### PR TITLE
fix(vararg): fix bug for local objects called

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspilerCanonical.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspilerCanonical.java
@@ -84,6 +84,7 @@ final class TranspilerCanonical implements Transpiler {
                 new OutputTo(target),
                 new TargetSpy(place.make(this.pre, "")),
                 new ListOf<>(
+                    "org/eolang/maven/pre/called-objects.xsl",
                     "org/eolang/maven/pre/classes.xsl",
                     "org/eolang/maven/pre/junit.xsl",
                     "org/eolang/maven/pre/rename-junit-inners.xsl",

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/called-objects.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/called-objects.xsl
@@ -23,6 +23,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="pre-called-objects" version="2.0">
+  <!--
+    When we detect a call of an abstract object with
+    vararg as free attribute :
+    [] > test
+      [] > app
+        (f 1 2 3) > @
+      [args...] > f
+        args.length > @
+
+    We transform the vararg attribute to an array as below :
+    [] > test
+      [] > app
+        (f (* 1 2 3)) > @
+      [args...] > f
+        args.length > @
+  -->
   <xsl:output encoding="UTF-8"/>
   <xsl:template name="convert-vararg-to-array">
     <xsl:param name="called-obj"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/called-objects.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/called-objects.xsl
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Yegor Bugayenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="pre-called-objects" version="2.0">
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template name="convert-vararg-to-array">
+    <xsl:param name="called-obj"/>
+    <xsl:param name="free-args"/>
+    <xsl:choose>
+      <xsl:when test="count($free-args) &gt; 0 and count($called-obj/*) &gt;= count($free-args)">
+        <xsl:copy>
+          <xsl:apply-templates select="$called-obj/@*"/>
+          <xsl:for-each select="$free-args">
+            <xsl:variable name="pos" select="position()"/>
+            <xsl:choose>
+              <xsl:when test="not(@vararg)">
+                <xsl:variable name="arg" select="$called-obj/o[$pos]"/>
+                <xsl:element name="o">
+                  <xsl:apply-templates select="$arg/node()|$arg/@*"/>
+                </xsl:element>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:element name="o">
+                  <xsl:attribute name="base">
+                    <xsl:text>org.eolang.array</xsl:text>
+                  </xsl:attribute>
+                  <xsl:attribute name="data">
+                    <xsl:text>array</xsl:text>
+                  </xsl:attribute>
+                  <xsl:attribute name="line">
+                    <xsl:value-of select="$called-obj/@line"/>
+                  </xsl:attribute>
+                  <xsl:attribute name="unvaring"/>
+                  <xsl:for-each select="$called-obj/o[position() &gt;= $pos]">
+                    <xsl:copy>
+                      <xsl:apply-templates select="node()|@*"/>
+                    </xsl:copy>
+                  </xsl:for-each>
+                </xsl:element>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="o[@base and @ref and not(@atom) and not(@cut) and not(@ancestors) and not(@parent) and count(./*) &gt; 0]">
+    <xsl:variable name="called-obj" select="."/>
+    <xsl:call-template name="convert-vararg-to-array">
+      <xsl:with-param name="called-obj" select="$called-obj"/>
+      <xsl:with-param name="free-args" select="//objects/o[@line = $called-obj/@ref and @original-name = $called-obj/@base]/o[not(@base) and not(@level)]"/>
+    </xsl:call-template>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -286,11 +286,25 @@ SOFTWARE.
     </xsl:for-each>
     <xsl:value-of select="$indent"/>
     <xsl:value-of select="$name"/>
-    <xsl:text> = new PhWith(</xsl:text>
+    <xsl:choose>
+      <xsl:when test="../@unvaring">
+        <xsl:text> = new PhUnvar(new PhWith(</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text> = new PhWith(</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:value-of select="$name"/>
     <xsl:text>, "Δ", new Data.Value&lt;Phi[]&gt;(</xsl:text>
     <xsl:value-of select="$name"/>
-    <xsl:text>_a));</xsl:text>
+    <xsl:choose>
+      <xsl:when test="../@unvaring">
+        <xsl:text>_a)));</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>_a));</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:value-of select="eo:eol(0)"/>
   </xsl:template>
   <xsl:template match="o[not(@base) and @name]">

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -209,15 +209,11 @@
       h.write func
       h.@ "Jeff"
 
-# It's currently broken. Now we should resolve it first
-# before enabling it by uncommenting.
-# [] > app-that-calls-varargs-func
-#   [] > app
-#     [args...] > f
-#       1 > a
-#       2 > @
-#     (f 1 2 3).eq 2 > @
-#   app > output
-#   output.eq TRUE > @
-[] > app-that-calls-varargs-func
-  TRUE > @
+[] > app-that-calls-local-object-with-varargs-attr
+  [] > app
+    [args...] > f
+      1 > a
+      2 > @
+    (f 1 2 3).eq 2 > @
+  app > output
+  output.eq TRUE > @

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
@@ -39,17 +39,12 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests dataization of an EO app that calls a function
+ * Tests dataization of an EO app that calls an abject
  * with varargs.
  *
  * @since 0.22
- * @todo #414:30min Fix bug EO app calling a varargs func.
- *  We reproduced by a Java and EO tests, the bug with exception `You can't overwrite X`
- *  when EO app try to call a function that uses varargs as parameter. Now, we must fix it
- *  and enable test below and eo test {@code [] > calls-varargs-func} located in
- *  `runtime-tests.eo`.
  */
-final class EODataizeAppCallsVarargsFuncTest {
+final class EOAppCallsObjectWithVarargsAttrTest {
 
     @Test
     public void dataizesEOappThatCallsVarargsFunc() {

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
@@ -43,6 +43,10 @@ import org.junit.jupiter.api.Test;
  * with varargs.
  *
  * @since 0.22
+ * @todo #534:30min Vararg: fix bug readonly attribute for external objects.
+ *  We resolved bug for local object with vararg as free attribute. We need now to
+ *  fix bug for external ones. To resolve it, we should firstly know the free attributes
+ *  of these external objects.
  */
 final class EOAppCallsObjectWithVarargsAttrTest {
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOAppCallsObjectWithVarargsAttrTest.java
@@ -31,11 +31,11 @@ import org.eolang.Dataized;
 import org.eolang.PhCopy;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
+import org.eolang.PhUnvar;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,13 +52,12 @@ import org.junit.jupiter.api.Test;
 final class EODataizeAppCallsVarargsFuncTest {
 
     @Test
-    @Disabled
     public void dataizesEOappThatCallsVarargsFunc() {
         MatcherAssert.assertThat(
             new Dataized(
                 new EOappThatCallsVarargsFunc(Phi.Φ)
-            ).take(Long.class),
-            Matchers.is(2L)
+            ).take(Boolean.class),
+            Matchers.is(true)
         );
     }
 
@@ -79,10 +78,19 @@ final class EODataizeAppCallsVarargsFuncTest {
                     new AtComposite(
                         this,
                         (rho) -> {
-                            Phi fvar = new PhCopy(new Fvarargs(rho));
-                            fvar = new PhWith(fvar, 0, new Data.ToPhi(1L));
-                            fvar = new PhWith(fvar, 1, new Data.ToPhi(2L));
-                            fvar = new PhWith(fvar, 2, new Data.ToPhi(3L));
+                            final Phi fvar = new PhWith(
+                                new PhCopy(new Fvarargs(rho)),
+                                0,
+                                new PhUnvar(
+                                    new Data.ToPhi(
+                                        new Phi[] {
+                                            new Data.ToPhi(1L),
+                                            new Data.ToPhi(2L),
+                                            new Data.ToPhi(3L)
+                                        }
+                                    )
+                                )
+                            );
                             return new PhWith(
                                 new PhCopy(new PhMethod(fvar, "eq")), 0, new Data.ToPhi(2L)
                             );

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -31,7 +31,6 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -75,86 +74,5 @@ public final class DataizedTest {
                 Matchers.not(Matchers.containsString("\n"))
             )
         );
-    }
-
-    /**
-     * Try to datarize an EO app that calls a varargs func.
-     * @todo #414:30min Fix bug execute an EO program calling a varargs func.
-     *  We reproduced by a test bug during execution with exception `You can't overwrite X`
-     *  when EO app try to call a function that uses varargs as parameter. Now, we must fix it
-     *  and disable the test (test below).
-     */
-    @Test
-    @Disabled
-    public void datarizesEOappCallingVarargsFunc() {
-        MatcherAssert.assertThat(
-            new Dataized(
-                new EOappCallingVarargsFunc(Phi.Φ)
-            ).take(Long.class),
-            Matchers.is(2L)
-        );
-    }
-
-    /**
-     * Main program sample.
-     * {@code
-     *  [] > app
-     *    (f 1 2 3).eq 2 > @
-     * }
-     * @since 0.22
-     */
-    private static class EOappCallingVarargsFunc extends PhDefault {
-        public EOappCallingVarargsFunc(Phi sigma) {
-            super(sigma);
-            this.add(
-                "φ",
-                new AtOnce(
-                    new AtComposite(
-                        this,
-                        (rho) -> {
-                            Phi fvar = new PhCopy(new DataizedTest.Fvarargs(rho));
-                            Phi var1 = new Data.ToPhi(1L);
-                            Phi var2 = new Data.ToPhi(2L);
-                            Phi var3 = new Data.ToPhi(3L);
-                            Phi fvard = new PhWith(fvar, 0, var1);
-                            fvard = new PhWith(fvard, 1, var2);
-                            fvard = new PhWith(fvard, 2, var3);
-                            return new PhWith(
-                                new PhCopy(new PhMethod(fvard, "eq")), 0, new Data.ToPhi(2L)
-                            );
-                        }
-                    )
-                )
-            );
-        }
-    }
-
-    /**
-     * Varargs function sample.
-     * {@code
-     *  [args] > f
-     *    1 > a
-     *    2 > @
-     * }
-     * @since 0.22
-     */
-    @SuppressWarnings("unchecked")
-    private static class Fvarargs extends PhDefault {
-        public Fvarargs(final Phi sigma) {
-            super(sigma);
-            this.add("args", new AtVararg());
-            this.add(
-                "a",
-                new AtOnce(
-                    new AtComposite(this, (rho) -> new Data.ToPhi(1L))
-                )
-            );
-            this.add(
-                "φ",
-                new AtOnce(
-                    new AtComposite(this, (rho) -> new Data.ToPhi(2L))
-                )
-            );
-        }
     }
 }


### PR DESCRIPTION
We fix here bug about readonly attribute when calling a local object with vararg as free attribute.
We added a puzzle to fix the case of external object called with vararg as free attribute.

Ref: #534 