### PR TITLE
Extract `objects` construction

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Objects.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Objects.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Object tree.
+ * @since 0.1
+ */
+interface Objects extends Iterable<Directive> {
+
+    /**
+     * Start new object.
+     * @param line At line.
+     * @param pos At position.
+     */
+    void start(int line, int pos);
+
+    /**
+     * Add data.
+     * @param data Data.
+     */
+    void data(String data);
+
+    /**
+     * Property.
+     * @param key Key.
+     * @param value Value.
+     */
+    void prop(String key, Object value);
+
+    /**
+     * Enter last object.
+     */
+    void enter();
+
+    /**
+     * Leave current object.
+     */
+    void leave();
+
+    /**
+     * Xembly object tree.
+     * @since 0.1
+     */
+    final class ObjXembly implements Objects {
+
+        /**
+         * Collected directives.
+         */
+        private final Directives dirs = new Directives();
+
+        @Override
+        public void start(final int line, final int pos) {
+            this.dirs.add("o");
+            this.prop("line", line);
+            this.prop("pos", pos);
+        }
+
+        @Override
+        public void data(final String data) {
+            this.dirs.set(data);
+        }
+
+        @Override
+        public void prop(final String key, final Object type) {
+            this.dirs.attr(key, type);
+        }
+
+        @Override
+        public void enter() {
+            this.dirs.xpath("o[last()]").strict(1);
+        }
+
+        @Override
+        public void leave() {
+            this.dirs.up();
+        }
+
+        @Override
+        public Iterator<Directive> iterator() {
+            return this.dirs.iterator();
+        }
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -25,6 +25,7 @@ package org.eolang.parser;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.List;
 import org.antlr.v4.runtime.ANTLRErrorListener;
@@ -45,6 +46,7 @@ import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
 import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
+import org.xembly.Xembler;
 
 /**
  * Syntax parser, from EO to XMIR, using ANTLR4.
@@ -118,7 +120,7 @@ public final class Syntax {
         parser.addErrorListener(errors);
         final XeListener xel = new XeListener(this.name);
         new ParseTreeWalker().walk(xel, parser.program());
-        final XML dom = xel.xml();
+        final XML dom = new XMLDocument(new Xembler(xel).domQuietly());
         new Schema(dom).check();
         Logger.debug(this, "Raw XML:\n%s", dom.toString());
         new Unchecked<>(

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.Xembler;
+
+/**
+ * Test for {@link Objects}.
+ * @since 0.1
+ * @checkstyle MagicNumberCheck (1000 lines)
+ */
+final class ObjectsTest {
+
+    @Test
+    void oneObject() {
+        final Objects objs = new Objects.ObjXembly();
+        objs.start(9, 10);
+        objs.prop("x", "y");
+        objs.data("xxx");
+        objs.leave();
+        MatcherAssert.assertThat(
+            new XMLDocument(new Xembler(objs).domQuietly()),
+            XhtmlMatchers.hasXPaths(
+                "/o",
+                "/o[@line='9']",
+                "/o[@pos='10']",
+                "/o[@x='y']",
+                "/o[text()='xxx']"
+            )
+        );
+    }
+
+    @Test
+    void nestedObjects() {
+        final Objects objs = new Objects.ObjXembly();
+        objs.start(1, 2);
+        objs.start(3, 4);
+        objs.prop("x", "y");
+        objs.data("yyy");
+        objs.leave();
+        objs.leave();
+        MatcherAssert.assertThat(
+            new XMLDocument(new Xembler(objs).domQuietly()),
+            XhtmlMatchers.hasXPaths(
+                "/o",
+                "/o/o[text()='yyy']"
+            )
+        );
+    }
+
+    @Test
+    void entersPrevios() {
+        final Objects objs = new Objects.ObjXembly();
+        objs.start(5, 6);
+        objs.start(7, 8);
+        objs.leave();
+        objs.leave();
+        objs.enter();
+        objs.prop("z", "a");
+        MatcherAssert.assertThat(
+            new XMLDocument(new Xembler(objs).domQuietly()),
+            XhtmlMatchers.hasXPaths(
+                "/o/o",
+                "/o[@z='a']"
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
Attempt to reduce mutable state inside `XeListener` and isolate `<objects>` creation. 