### PR TITLE
concat method for arrays created

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/array.eo
@@ -130,3 +130,6 @@
               item
               x.at idx
       FALSE
+
+  # Returns the combined current and passed arrays
+  [arr] > concat /array

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOarray$EOconcat.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOarray$EOconcat.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Eugene Darashkevich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package EOorg.EOeolang;
+
+import org.eolang.AtComposite;
+import org.eolang.AtFree;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Param;
+import org.eolang.PhDefault;
+import org.eolang.PhWith;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+import java.util.Arrays;
+
+/**
+ * CONCAT.
+ *
+ * @since 1.0
+ */
+@XmirObject(oname = "array.concat")
+public class EOarray$EOconcat extends PhDefault {
+
+    /**
+     * Ctor.
+     * @param sigma Sigma
+     */
+    public EOarray$EOconcat(final Phi sigma) {
+        super(sigma);
+        this.add("arr", new AtFree());
+        this.add("φ", new AtComposite(this, rho -> {
+            final Phi[] first = new Param(rho).strong(Phi[].class);
+            final Phi[] second = new Dataized(rho.attr("arr").get()).take(Phi[].class);
+            final Phi[] result = Arrays.copyOf(first, first.length + second.length);
+            System.arraycopy(second, 0, result, first.length, second.length);
+            return new Data.ToPhi(result);
+        }));
+    }
+
+}
+

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -405,3 +405,47 @@
     $.is
       $.equal-to
         "Can't at() the 20th element of the array, there are just 4 of them"
+
+[] > concat-array-with-empty-array-1
+  * 1 2 3 > a
+  * > b
+  a.concat b > res
+  assert-that > @
+    res.length
+    $.equal-to 3
+
+[] > concat-array-with-empty-array-2
+  * > a
+  * 1 2 3 > b
+  a.concat b > res
+  assert-that > @
+    res.length
+    $.equal-to 3
+
+[] > concat-array-with-empty-array-3
+  * > a
+  * > b
+  a.concat b > res
+  assert-that > @
+    res.length
+    $.equal-to 0
+
+[] > concat-arrays
+  * 1 2 3 > a
+  * 100 200 > b
+  a.concat b > res
+  assert-that > @
+    plus.
+      res.at 2
+      res.at 4
+    $.equal-to 203
+
+[] > concat-three-arrays
+  * 0 1 2 > a
+  * 3 4 > b
+  * (* "five" "six") (* "siven") > c
+  a.concat (b.concat c) > res
+  assert-that > @
+    * (res.length) ((res.at 5).at 1)
+    $.equal-to
+      * 7 "six"


### PR DESCRIPTION
A method that implements array concatenation is added to arrays here.
The method is implemented in Java to get the running time linear from the size of the arrays. If implemented in EOLANG, the running time would be quadratic.