### PR TITLE
#808 warnings for unordered metas

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/withwarning.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/withwarning.eo
@@ -1,9 +1,9 @@
 # This is the header comment of this simple EO
 # program, to be ignored.
 
-+package org.eolang.examples
 +alias org.eolang.io.stdout
 +junit
++package org.eolang.examples
 
 [] > main
   [] > @

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -69,6 +69,7 @@ public final class ParsingTrain extends TrEnvelope {
         "/org/eolang/parser/wrap-method-calls.xsl",
         "/org/eolang/parser/vars-float-up.xsl",
         "/org/eolang/parser/add-refs.xsl",
+        "/org/eolang/parser/warnings/metas-unsorted.xsl",
         "/org/eolang/parser/expand-aliases.xsl",
         "/org/eolang/parser/resolve-aliases.xsl",
         "/org/eolang/parser/add-default-package.xsl",

--- a/eo-parser/src/main/resources/org/eolang/parser/warnings/metas-unsorted.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/warnings/metas-unsorted.xsl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Yegor Bugayenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="metas-sorted" version="2.0">
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template match="/program/errors">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:for-each select="/program/metas/meta">
+        <xsl:variable name="meta-text" select="concat(head, ' ', tail)"/>
+        <xsl:variable name="previous" select="(preceding-sibling::meta)[1]"/>
+        <xsl:variable name="sibling-text" select="concat($previous/head/text(), ' ', $previous/tail/text())"/>
+        <xsl:if test="$meta-text &lt; $sibling-text">
+          <xsl:element name="error">
+            <xsl:attribute name="check">
+              <xsl:text>metas-sorted</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="line">
+              <xsl:value-of select="@line"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Meta is out of order: "</xsl:text>
+            <xsl:value-of select="$meta-text"/>
+            <xsl:text>"</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/adds-default-package.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/adds-default-package.yaml
@@ -13,11 +13,11 @@ tests:
   - //o[@base='Q']
   - //o[@base='QQ']
 eo: |
-  +alias stdout org.eolang.io.stdout
-  +alias stdin org.eolang.io.stdin
-  +alias scanner org.eolang.txt.scanner
-  +foo Some other meta
   +alias foo
+  +alias scanner org.eolang.txt.scanner
+  +alias stdin org.eolang.io.stdin
+  +alias stdout org.eolang.io.stdout
+  +foo Some other meta
 
   [args] > main
     and

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-alias-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-alias-duplicates.yaml
@@ -2,12 +2,12 @@ xsls:
   - /org/eolang/parser/errors/duplicate-aliases.xsl
 tests:
   - /program/errors[count(error[@severity='error'])=1]
-  - /program/errors/error[@line='2']
+  - /program/errors/error[@line='3']
   - /program/metas/meta[head='alias' and tail='stdout org.eolang.io.stdout']
 eo: |
-  +alias stdout org.eolang.io.stdout
-  +alias stdout org.eolang.io.stdout
   +alias stding org.eolang.io.stdin
+  +alias stdout org.eolang.io.stdout
+  +alias stdout org.eolang.io.stdout
 
   [] > main
     (stdout "Hello, world!").print

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-broken-aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-broken-aliases.yaml
@@ -2,6 +2,9 @@ xsls:
   - /org/eolang/parser/errors/broken-aliases.xsl
 tests:
   - /program/errors[count(error[@severity='error'])=20]
+  - /program/errors/error[@line='1']
+  - /program/errors/error[@line='2']
+  - /program/errors/error[@line='7']
   - /program/errors/error[@line='8']
   - /program/errors/error[@line='9']
   - /program/errors/error[@line='10']
@@ -19,37 +22,34 @@ tests:
   - /program/errors/error[@line='22']
   - /program/errors/error[@line='23']
   - /program/errors/error[@line='24']
-  - /program/errors/error[@line='25']
-  - /program/errors/error[@line='26']
-  - /program/errors/error[@line='27']
 eo: |
-  +alias org.eolang.io.stdout
-  +alias caseInsensitive thiS.IS.2
-  +alias with-Dash-and-number-999 0.1.2
-  +alias i文件 this.is.legal2
-  +alias with-dash
-  +alias with-dash org.eolang.with-dash
-  +alias org.eolang.with-dash
-  +alias this is some mistake
+  +alias
   +alias FirstLetter Should.Be.Small
-  +alias the> symbol.is.not.allowed
-  +alias the< symbol.is.not.allowed
-  +alias the. symbol.is.not.allowed
-  +alias the[ symbol.is.not.allowed
-  +alias the] symbol.is.not.allowed
+  +alias caseInsensitive thiS.IS.2
+  +alias i文件 this.is.legal2
+  +alias org.eolang.io.stdout
+  +alias org.eolang.with-dash
+  +alias the  symbol.is.not.allowed
+  +alias the! symbol.is.not.allowed
+  +alias the" symbol.is.not.allowed
+  +alias the# symbol.is.not.allowed
+  +alias the$ symbol.is.not.allowed
+  +alias the& symbol.is.not.allowed
   +alias the( symbol.is.not.allowed
   +alias the) symbol.is.not.allowed
-  +alias the! symbol.is.not.allowed
-  +alias the: symbol.is.not.allowed
-  +alias the" symbol.is.not.allowed
-  +alias the@ symbol.is.not.allowed
-  +alias the^ symbol.is.not.allowed
-  +alias the$ symbol.is.not.allowed
-  +alias the# symbol.is.not.allowed
-  +alias the& symbol.is.not.allowed
+  +alias the. symbol.is.not.allowed
   +alias the/ symbol.is.not.allowed
-  +alias the  symbol.is.not.allowed
-  +alias
+  +alias the: symbol.is.not.allowed
+  +alias the< symbol.is.not.allowed
+  +alias the> symbol.is.not.allowed
+  +alias the@ symbol.is.not.allowed
+  +alias the[ symbol.is.not.allowed
+  +alias the] symbol.is.not.allowed
+  +alias the^ symbol.is.not.allowed
+  +alias this is some mistake
+  +alias with-Dash-and-number-999 0.1.2
+  +alias with-dash
+  +alias with-dash org.eolang.with-dash
 
   [] > main
     (stdout "Hello, world!").print

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-metas-unsorted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-metas-unsorted.yaml
@@ -1,0 +1,11 @@
+xsls:
+  - /org/eolang/parser/warnings/metas-unsorted.xsl
+tests:
+  - /program/errors[count(error[@severity='warning'])=1]
+  - /program/errors/error[@line='2']
+eo: |
+  +alias stdout org.eolang.io.stdout
+  +alias stding org.eolang.io.stdin
+
+  [] > main
+    (stdout "Hello, world!").print

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-unused-aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-unused-aliases.yaml
@@ -8,9 +8,9 @@ tests:
   - /program/errors/error[@line='3']
   - //o[@name='foo']
 eo: |
-  +alias org.eolang.io.stdout
-  +alias in org.eolang.io.stdin
   +alias err org.eolang.io.stderr
+  +alias in org.eolang.io.stdin
+  +alias org.eolang.io.stdout
 
   [x] > foo
     x.div in.nextInt > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/expands-aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/expands-aliases.yaml
@@ -5,8 +5,8 @@ tests:
   - //meta[head='alias' and tail='scanner org.eolang.txt.scanner' and part[1]='scanner' and part[2]='org.eolang.txt.scanner']
   - //meta[head='alias' and tail='stdin org.eolang.io.stdin' and part[1]='stdin' and part[2]='org.eolang.io.stdin']
 eo: |
-  +alias stdin org.eolang.io.stdin
   +alias org.eolang.txt.scanner
+  +alias stdin org.eolang.io.stdin
 
   [args] > main
     and

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
@@ -23,10 +23,10 @@ eo: |
   # sure all possible syntax scenarios can
   # be parsed by the ANTLR
 
-  +alias Test Test
   +alias org.example.foo
-  +foo
+  +alias Test Test
   +bar Some text
+  +foo
 
   500.43.@ > one
 

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/leap-year.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/leap-year.yaml
@@ -8,8 +8,8 @@ eo: |
   #
   # License is MIT
 
-  +alias org.eolang.io.stdout
   +alias org.eolang.io.stdin
+  +alias org.eolang.io.stdout
   +alias org.eolang.txt.scanner
 
   [args] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/resolves-aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/resolves-aliases.yaml
@@ -13,9 +13,9 @@ tests:
   - //o[@base='$']
   - //o[@base='^']
 eo: |
-  +alias stdout org.eolang.io.stdout
-  +alias stdin org.eolang.io.stdin
   +alias org.eolang.txt.scanner
+  +alias stdin org.eolang.io.stdin
+  +alias stdout org.eolang.io.stdout
   +foo Some other meta
 
   [args] > main


### PR DESCRIPTION
Introduced metas order check and corresponding warning.

**! Implementation Note !** 
`metas-unsorted.xsl` must be run before `expand-aliases.xsl` since alphabetical order cannot be controlled by developer in this case.