### PR TITLE
Added removing empty folders in UnplaceMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -26,8 +26,11 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import com.yegor256.tojos.Tojo;
 import com.yegor256.tojos.Tojos;
+
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,9 +50,9 @@ import org.cactoos.set.SetOf;
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
 @Mojo(
-    name = "unplace",
-    defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
-    threadSafe = true
+        name = "unplace",
+        defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+        threadSafe = true
 )
 @SuppressWarnings("PMD.ImmutableField")
 public final class UnplaceMojo extends SafeMojo {
@@ -61,9 +64,9 @@ public final class UnplaceMojo extends SafeMojo {
      * @since 0.11.0
      */
     @Parameter(
-        property = "eo.placed",
-        required = true,
-        defaultValue = "${project.build.directory}/eo/placed.csv"
+            property = "eo.placed",
+            required = true,
+            defaultValue = "${project.build.directory}/eo/placed.csv"
     )
     private File placed;
 
@@ -98,8 +101,8 @@ public final class UnplaceMojo extends SafeMojo {
             this.placeThem();
         } else {
             Logger.info(
-                this, "The list of placed binaries is absent: %s",
-                Save.rel(this.placed.toPath())
+                    this, "The list of placed binaries is absent: %s",
+                    Save.rel(this.placed.toPath())
             );
         }
     }
@@ -111,7 +114,7 @@ public final class UnplaceMojo extends SafeMojo {
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public void placeThem() throws IOException {
         final Collection<Tojo> tojos = new Catalog(
-            this.placed.toPath(), this.placedFormat
+                this.placed.toPath(), this.placedFormat
         ).make().select(t -> "class".equals(t.get(PlaceMojo.ATTR_KIND)));
         int deleted = 0;
         if (!this.keepBinaries.isEmpty()) {
@@ -120,23 +123,23 @@ public final class UnplaceMojo extends SafeMojo {
         deleted += this.killThem(tojos);
         if (tojos.isEmpty()) {
             Logger.info(
-                this, "No binaries were placed into %s, nothing to uplace",
-                Save.rel(this.placed.toPath())
+                    this, "No binaries were placed into %s, nothing to uplace",
+                    Save.rel(this.placed.toPath())
             );
         } else if (deleted == 0) {
             Logger.info(
-                this, "No binaries out of %d deleted in %s",
-                tojos.size(), Save.rel(this.placed.toPath())
+                    this, "No binaries out of %d deleted in %s",
+                    tojos.size(), Save.rel(this.placed.toPath())
             );
         } else if (deleted == tojos.size()) {
             Logger.info(
-                this, "All %d binari(es) deleted, which were found in %s",
-                tojos.size(), Save.rel(this.placed.toPath())
+                    this, "All %d binari(es) deleted, which were found in %s",
+                    tojos.size(), Save.rel(this.placed.toPath())
             );
         } else {
             Logger.info(
-                this, "Just %d binari(es) out of %d deleted in %s",
-                deleted, tojos.size(), Save.rel(this.placed.toPath())
+                    this, "Just %d binari(es) out of %d deleted in %s",
+                    deleted, tojos.size(), Save.rel(this.placed.toPath())
             );
         }
     }
@@ -158,10 +161,10 @@ public final class UnplaceMojo extends SafeMojo {
                     continue;
                 }
                 Logger.info(
-                    this,
-                    // @checkstyle LineLength (1 line)
-                    "The binary %s looks different, but its unplacing is mandatory as 'mandatoryUnplace' option specifies",
-                    related
+                        this,
+                        // @checkstyle LineLength (1 line)
+                        "The binary %s looks different, but its unplacing is mandatory as 'mandatoryUnplace' option specifies",
+                        related
                 );
             }
             UnplaceMojo.delete(path);
@@ -184,24 +187,25 @@ public final class UnplaceMojo extends SafeMojo {
             final String related = tojo.get(PlaceMojo.ATTR_RELATED);
             final Path path = Paths.get(tojo.get(Tojos.KEY));
             if (!this.keepBinaries.isEmpty()
-                && UnplaceMojo.inside(related, this.keepBinaries)) {
+                    && UnplaceMojo.inside(related, this.keepBinaries)) {
                 remained += 1;
                 continue;
             }
+            System.out.println("PATH: "+ path);
             UnplaceMojo.delete(path);
             deleted += 1;
             Logger.debug(
-                this,
-                // @checkstyle LineLength (1 line)
-                "The binary %s is removed since it doesn't match 'selectivelyPlace' list of globs",
-                related
+                    this,
+                    // @checkstyle LineLength (1 line)
+                    "The binary %s is removed since it doesn't match 'selectivelyPlace' list of globs",
+                    related
             );
         }
         Logger.info(
-            this,
-            // @checkstyle LineLength (1 line)
-            "Because of 'selectivelyPlace' list of globs: %d files remained and %d deleted",
-            remained, deleted
+                this,
+                // @checkstyle LineLength (1 line)
+                "Because of 'selectivelyPlace' list of globs: %d files remained and %d deleted",
+                remained, deleted
         );
         return deleted;
     }
@@ -231,7 +235,7 @@ public final class UnplaceMojo extends SafeMojo {
      */
     private static boolean matches(final String related, final String glob) {
         return FileSystems.getDefault().getPathMatcher(
-            String.format("glob:%s", glob)
+                String.format("glob:%s", glob)
         ).matches(Paths.get(related));
     }
 
@@ -241,14 +245,25 @@ public final class UnplaceMojo extends SafeMojo {
      * @throws IOException If fails
      */
     private static void delete(final Path file) throws IOException {
-        final Path dir = file.getParent();
+        Path dir = file.getParent();
+        String[] files = new File(dir.toString()).list();
+        System.out.println("List of files: " + dir);
+        for (String f : files) {
+            System.out.println("- " + f);
+        }
+
         Files.delete(file);
-        if (!Files.newDirectoryStream(dir).iterator().hasNext()) {
-            Files.delete(dir);
+
+        System.out.println("deleted: path = " + file + "\n");
+
+        while (!Files.newDirectoryStream(dir).iterator().hasNext()) {
+            Path curdir = dir;
+            dir = curdir.getParent();
+            Files.delete(curdir);
             Logger.debug(
-                UnplaceMojo.class,
-                "Empty directory deleted too: %s",
-                Save.rel(dir)
+                    UnplaceMojo.class,
+                    "Empty directory deleted too: %s",
+                    Save.rel(dir)
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -26,11 +26,8 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import com.yegor256.tojos.Tojo;
 import com.yegor256.tojos.Tojos;
-
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,9 +47,9 @@ import org.cactoos.set.SetOf;
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
 @Mojo(
-        name = "unplace",
-        defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
-        threadSafe = true
+    name = "unplace",
+    defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+    threadSafe = true
 )
 @SuppressWarnings("PMD.ImmutableField")
 public final class UnplaceMojo extends SafeMojo {
@@ -64,9 +61,9 @@ public final class UnplaceMojo extends SafeMojo {
      * @since 0.11.0
      */
     @Parameter(
-            property = "eo.placed",
-            required = true,
-            defaultValue = "${project.build.directory}/eo/placed.csv"
+        property = "eo.placed",
+        required = true,
+        defaultValue = "${project.build.directory}/eo/placed.csv"
     )
     private File placed;
 
@@ -101,8 +98,8 @@ public final class UnplaceMojo extends SafeMojo {
             this.placeThem();
         } else {
             Logger.info(
-                    this, "The list of placed binaries is absent: %s",
-                    Save.rel(this.placed.toPath())
+                this, "The list of placed binaries is absent: %s",
+                Save.rel(this.placed.toPath())
             );
         }
     }
@@ -114,7 +111,7 @@ public final class UnplaceMojo extends SafeMojo {
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public void placeThem() throws IOException {
         final Collection<Tojo> tojos = new Catalog(
-                this.placed.toPath(), this.placedFormat
+            this.placed.toPath(), this.placedFormat
         ).make().select(t -> "class".equals(t.get(PlaceMojo.ATTR_KIND)));
         int deleted = 0;
         if (!this.keepBinaries.isEmpty()) {
@@ -123,23 +120,23 @@ public final class UnplaceMojo extends SafeMojo {
         deleted += this.killThem(tojos);
         if (tojos.isEmpty()) {
             Logger.info(
-                    this, "No binaries were placed into %s, nothing to uplace",
-                    Save.rel(this.placed.toPath())
+                this, "No binaries were placed into %s, nothing to uplace",
+                Save.rel(this.placed.toPath())
             );
         } else if (deleted == 0) {
             Logger.info(
-                    this, "No binaries out of %d deleted in %s",
-                    tojos.size(), Save.rel(this.placed.toPath())
+                this, "No binaries out of %d deleted in %s",
+                tojos.size(), Save.rel(this.placed.toPath())
             );
         } else if (deleted == tojos.size()) {
             Logger.info(
-                    this, "All %d binari(es) deleted, which were found in %s",
-                    tojos.size(), Save.rel(this.placed.toPath())
+                this, "All %d binari(es) deleted, which were found in %s",
+                tojos.size(), Save.rel(this.placed.toPath())
             );
         } else {
             Logger.info(
-                    this, "Just %d binari(es) out of %d deleted in %s",
-                    deleted, tojos.size(), Save.rel(this.placed.toPath())
+                this, "Just %d binari(es) out of %d deleted in %s",
+                deleted, tojos.size(), Save.rel(this.placed.toPath())
             );
         }
     }
@@ -161,10 +158,10 @@ public final class UnplaceMojo extends SafeMojo {
                     continue;
                 }
                 Logger.info(
-                        this,
-                        // @checkstyle LineLength (1 line)
-                        "The binary %s looks different, but its unplacing is mandatory as 'mandatoryUnplace' option specifies",
-                        related
+                    this,
+                    // @checkstyle LineLength (1 line)
+                    "The binary %s looks different, but its unplacing is mandatory as 'mandatoryUnplace' option specifies",
+                    related
                 );
             }
             UnplaceMojo.delete(path);
@@ -187,25 +184,24 @@ public final class UnplaceMojo extends SafeMojo {
             final String related = tojo.get(PlaceMojo.ATTR_RELATED);
             final Path path = Paths.get(tojo.get(Tojos.KEY));
             if (!this.keepBinaries.isEmpty()
-                    && UnplaceMojo.inside(related, this.keepBinaries)) {
+                && UnplaceMojo.inside(related, this.keepBinaries)) {
                 remained += 1;
                 continue;
             }
-            System.out.println("PATH: "+ path);
             UnplaceMojo.delete(path);
             deleted += 1;
             Logger.debug(
-                    this,
-                    // @checkstyle LineLength (1 line)
-                    "The binary %s is removed since it doesn't match 'selectivelyPlace' list of globs",
-                    related
+                this,
+                // @checkstyle LineLength (1 line)
+                "The binary %s is removed since it doesn't match 'selectivelyPlace' list of globs",
+                related
             );
         }
         Logger.info(
-                this,
-                // @checkstyle LineLength (1 line)
-                "Because of 'selectivelyPlace' list of globs: %d files remained and %d deleted",
-                remained, deleted
+            this,
+            // @checkstyle LineLength (1 line)
+            "Because of 'selectivelyPlace' list of globs: %d files remained and %d deleted",
+            remained, deleted
         );
         return deleted;
     }
@@ -235,7 +231,7 @@ public final class UnplaceMojo extends SafeMojo {
      */
     private static boolean matches(final String related, final String glob) {
         return FileSystems.getDefault().getPathMatcher(
-                String.format("glob:%s", glob)
+            String.format("glob:%s", glob)
         ).matches(Paths.get(related));
     }
 
@@ -246,24 +242,15 @@ public final class UnplaceMojo extends SafeMojo {
      */
     private static void delete(final Path file) throws IOException {
         Path dir = file.getParent();
-        String[] files = new File(dir.toString()).list();
-        System.out.println("List of files: " + dir);
-        for (String f : files) {
-            System.out.println("- " + f);
-        }
-
         Files.delete(file);
-
-        System.out.println("deleted: path = " + file + "\n");
-
         while (!Files.newDirectoryStream(dir).iterator().hasNext()) {
-            Path curdir = dir;
+            final Path curdir = dir;
             dir = curdir.getParent();
             Files.delete(curdir);
             Logger.debug(
-                    UnplaceMojo.class,
-                    "Empty directory deleted too: %s",
-                    Save.rel(dir)
+                UnplaceMojo.class,
+                "Empty directory deleted too: %s",
+                Save.rel(dir)
             );
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -45,45 +45,68 @@ public final class UnplaceMojoTest {
 
     @Test
     public void testCleaning(@TempDir final Path temp) throws Exception {
-        // final Path dir = temp.resolve("aa/bb/cb/dir");  // it does not create folder
         final Path foo = temp.resolve("a/b/c/foo.class");
-        new File(temp + "/a/b/c/dir").mkdirs();
-        new File(temp + "/aa/b/c/d/e/dir").mkdirs();
-        new File(temp + "/aaa/b/c/dir/subdir").mkdirs();
+        new Save("...", foo).save();
+        Path pparent = foo.getParent().getParent();  // a/b
 
-        new Save("abc", foo).save();
+        final Path foo2 = temp.resolve("a/b/c/foo2.class");
+        new Save("...", foo2).save();
+
+        final Path foo3 = temp.resolve("a/b/c/d/foo3.class");
+        new Save("...", foo3).save();
+
+        final Path foo4 = temp.resolve("a/b/c/e/foo4.class");
+        new Save("...", foo4).save();
+
+
         final Path list = temp.resolve("placed.json");
-<<<<<<< HEAD
         new MonoTojos(new Csv(list)).add(foo.toString())
-            .set("kind", "class")
-            .set(PlaceMojo.ATTR_RELATED, "---")
-            .set("hash", new FileHash(foo));
-=======
-        new MonoTojos(new Csv(list)).add(foo.toString());
-        new MonoTojos(new Csv(list)).add(temp + "/a/b/c/dir");
-        new MonoTojos(new Csv(list)).add(temp + "/aa/b/c/d/e/dir");
-        new MonoTojos(new Csv(list)).add(temp + "/aaa/b/c/dir/subdir");
->>>>>>> 2c3f253f52e6fe64245a056e6c1671426bdbb275
+                .set("kind", "class")
+                .set(PlaceMojo.ATTR_RELATED, "---")
+                .set("hash", new FileHash(foo));
+
+        new MonoTojos(new Csv(list)).add(foo2.toString())
+                .set("kind", "class")
+                .set(PlaceMojo.ATTR_RELATED, "---")
+                .set("hash", new FileHash(foo2));
+
+        new MonoTojos(new Csv(list)).add(foo3.toString())
+                .set("kind", "class")
+                .set(PlaceMojo.ATTR_RELATED, "---")
+                .set("hash", new FileHash(foo3));
+
+        new MonoTojos(new Csv(list)).add(foo4.toString())
+                .set("kind", "class")
+                .set(PlaceMojo.ATTR_RELATED, "---")
+                .set("hash", new FileHash(foo4));
+
         new Moja<>(UnplaceMojo.class)
-            .with("placed", list.toFile())
-            .with("placedFormat", "csv")
-            .execute();
+                .with("placed", list.toFile())
+                .with("placedFormat", "csv")
+                .execute();
+
         MatcherAssert.assertThat(
-            Files.exists(foo),
-            Matchers.is(false)
+                Files.exists(foo),
+                Matchers.is(false)
+        );
+
+        MatcherAssert.assertThat(
+                Files.exists(foo2),
+                Matchers.is(false)
+        );
+
+        MatcherAssert.assertThat(
+                Files.exists(foo3),
+                Matchers.is(false)
+        );
+
+        MatcherAssert.assertThat(
+                Files.exists(foo4),
+                Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            Files.exists(Paths.get(temp + "/a/b/c/dir")),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            Files.exists(Paths.get(temp + "/aa/b/c/d/e/dir")),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            Files.exists(Paths.get(temp + "/aaa/b/c/dir")),  // It fails (should it?)
-            Matchers.is(false)
+                Files.exists(Paths.get(String.valueOf(pparent))),
+                Matchers.is(false)
         );
     }
-
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -25,12 +25,9 @@ package org.eolang.maven;
 
 import com.yegor256.tojos.Csv;
 import com.yegor256.tojos.MonoTojos;
-
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,73 +37,62 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link UnplaceMojo}.
  *
  * @since 0.1
+ * @checkstyle LocalFinalVariableNameCheck (100 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class UnplaceMojoTest {
 
     @Test
     public void testCleaning(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo.class");
         new Save("...", foo).save();
-        Path pparent = foo.getParent().getParent();  // a/b
-
+        final Path pparent = foo.getParent().getParent();
         final Path foo2 = temp.resolve("a/b/c/foo2.class");
         new Save("...", foo2).save();
-
         final Path foo3 = temp.resolve("a/b/c/d/foo3.class");
         new Save("...", foo3).save();
-
         final Path foo4 = temp.resolve("a/b/c/e/foo4.class");
         new Save("...", foo4).save();
-
-
         final Path list = temp.resolve("placed.json");
         new MonoTojos(new Csv(list)).add(foo.toString())
-                .set("kind", "class")
-                .set(PlaceMojo.ATTR_RELATED, "---")
-                .set("hash", new FileHash(foo));
-
+            .set("kind", "class")
+            .set(PlaceMojo.ATTR_RELATED, "---")
+            .set("hash", new FileHash(foo));
         new MonoTojos(new Csv(list)).add(foo2.toString())
-                .set("kind", "class")
-                .set(PlaceMojo.ATTR_RELATED, "---")
-                .set("hash", new FileHash(foo2));
-
+            .set("kind", "class")
+            .set(PlaceMojo.ATTR_RELATED, "---")
+            .set("hash", new FileHash(foo2));
         new MonoTojos(new Csv(list)).add(foo3.toString())
-                .set("kind", "class")
-                .set(PlaceMojo.ATTR_RELATED, "---")
-                .set("hash", new FileHash(foo3));
-
+            .set("kind", "class")
+            .set(PlaceMojo.ATTR_RELATED, "---")
+            .set("hash", new FileHash(foo3));
         new MonoTojos(new Csv(list)).add(foo4.toString())
-                .set("kind", "class")
-                .set(PlaceMojo.ATTR_RELATED, "---")
-                .set("hash", new FileHash(foo4));
-
+            .set("kind", "class")
+            .set(PlaceMojo.ATTR_RELATED, "---")
+            .set("hash", new FileHash(foo4));
         new Moja<>(UnplaceMojo.class)
-                .with("placed", list.toFile())
-                .with("placedFormat", "csv")
-                .execute();
-
+            .with("placed", list.toFile())
+            .with("placedFormat", "csv")
+            .execute();
         MatcherAssert.assertThat(
-                Files.exists(foo),
-                Matchers.is(false)
-        );
-
-        MatcherAssert.assertThat(
-                Files.exists(foo2),
-                Matchers.is(false)
-        );
-
-        MatcherAssert.assertThat(
-                Files.exists(foo3),
-                Matchers.is(false)
-        );
-
-        MatcherAssert.assertThat(
-                Files.exists(foo4),
-                Matchers.is(false)
+            Files.exists(foo),
+            Matchers.is(false)
         );
         MatcherAssert.assertThat(
-                Files.exists(Paths.get(String.valueOf(pparent))),
-                Matchers.is(false)
+            Files.exists(foo2),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            Files.exists(foo3),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            Files.exists(foo4),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            Files.exists(Paths.get(String.valueOf(pparent))),
+            Matchers.is(false)
         );
     }
 }


### PR DESCRIPTION
@yegor256 I fixed objectionary/eo#873
Problem (at least one of them) appeared because we didn't remove empty parent folders. For example if we placed `a/b/c/smth.class` and then removed `smth.class` only `c` was removed too. I added cycle in `UnplaceMojo.delete()` and it now removes `a/b` too. I reproduced it in `UnplaceMojoTest`. If we replace `while` with `if` test fails. 
Please check it and merge