### PR TITLE
Add Upper-case for Bool Objects

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo.xsl
@@ -132,7 +132,10 @@ SOFTWARE.
     <xsl:value-of select="text()"/>
     <xsl:text>"</xsl:text>
   </xsl:template>
-  <xsl:template match="o[@data and @data!='string' and @data!='array']" mode="head">
+  <xsl:template match="o[@data='bool']" mode="head">
+    <xsl:value-of select="upper-case(text())"/>
+  </xsl:template>
+  <xsl:template match="o[@data and @data!='string' and @data!='array' and @data!='bool']" mode="head">
     <xsl:value-of select="text()"/>
   </xsl:template>
   <xsl:template match="node()|@*">

--- a/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/idiomatic.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/idiomatic.eo
@@ -20,6 +20,7 @@
           *
             "Hello, друг"
             2.18
+            TRUE
       bar
         plus.
           n


### PR DESCRIPTION
Add Upper-case for Bool Objects when parsing from XMIR to EO.