### PR TITLE
makes-deep-object-recursively depth decreases

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -84,7 +84,7 @@
 
 [] > makes-deep-object-recursively
   assert-that > @
-    x 10
+    x 5
     $.equal-to 0
   [i] > x
     if. > @


### PR DESCRIPTION
We very often got an error due to stack overflow on this test, now the recursion depth has been reduced.