### PR TITLE
Rename list attrs

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -79,7 +79,7 @@
 
   # Converts this to hash
   [] > as-hash
-    reduce. > @
+    reduced. > @
       list
         bytes-as-array ^
       1

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -59,7 +59,7 @@
           carr
         acc
 
-  # @todo #1011. DEPRICATED, please remove after update of eo-hamcrest
+  # @todo #1011:40min. DEPRICATED, please remove after update of eo-hamcrest
   # One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reducei
     rec-reduce (* a 0) f arr > @
@@ -89,7 +89,7 @@
           a
           item
 
-  # @todo #1011 DEPRICATED, please remove after update of eo-hamcrest.
+  # @todo #1011:40min DEPRICATED, please remove after update of eo-hamcrest.
   # One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reduce
     ^.reducedi > @

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -68,6 +68,15 @@
           a
           item
 
+  # DEPRICATED. Reduce from start "a" using the function "f"
+  [a f] > reduce
+    ^.reducedi > @
+      a
+      [a idx item]
+        &.f > @
+          a
+          item
+
   # Map with index. Here "f" must be an abstract
   # object with two free attributes. The first
   # one for the element of the array, the second one

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -40,15 +40,15 @@
   # one for the accumulator, the second one
   # for the index and the third one for the element
   # of the array.
-  [a f] > reducei
-    rec-reduce (* a 0) f arr > @
+  [a f] > reducedi
+    rec-reduced (* a 0) f arr > @
 
-    [acc-index func carr] > rec-reduce
+    [acc-index func carr] > rec-reduced
       (acc-index.at 0) > acc
       (acc-index.at 1) > index
       if. > @
         (index.lt (carr.length))
-        rec-reduce
+        rec-reduced
           *
             func
               acc
@@ -60,8 +60,8 @@
         acc
 
   # Reduce from start "a" using the function "f"
-  [a f] > reduce
-    ^.reducei > @
+  [a f] > reduced
+    ^.reducedi > @
       a
       [a idx item]
         &.f > @
@@ -74,7 +74,7 @@
   # for the index.
   [f] > mapi
     list > @
-      ^.reducei
+      ^.reducedi
         *
         [a idx item]
           with. > @
@@ -108,7 +108,7 @@
 
   # Create a new list without the i-th element
   [i] > without
-    ^.reducei > @
+    ^.reducedi > @
       *
       [a idx item]
         if. > @
@@ -122,7 +122,7 @@
       eq.
         arr.length
         x.length
-      ^.reducei
+      ^.reducedi
         TRUE
         [a idx item]
           and. > @
@@ -134,7 +134,7 @@
 
   # Returns the combined current and passed arrays
   [passed] > concat
-    reduce. > @!
+    reduced. > @!
       list
         passed
       ^

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -60,7 +60,7 @@
         acc
 
   # @todo #1011:40min. DEPRICATED, please remove after update of eo-hamcrest
-  # One test in eo use one attribute of assert-that that use deprecated attributes.
+  #  One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reducei
     rec-reduce (* a 0) f arr > @
 
@@ -90,7 +90,7 @@
           item
 
   # @todo #1011:40min DEPRICATED, please remove after update of eo-hamcrest.
-  # One test in eo use one attribute of assert-that that use deprecated attributes.
+  #  One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reduce
     ^.reducedi > @
       a

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -59,7 +59,8 @@
           carr
         acc
 
-  #DEPRICATED, please remove after update of eo-hamcrest
+  # @todo #1011. DEPRICATED, please remove after update of eo-hamcrest
+  # One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reducei
     rec-reduce (* a 0) f arr > @
 
@@ -88,7 +89,8 @@
           a
           item
 
-  # DEPRICATED, please remove after update of eo-hamcrest.
+  # @todo #1011 DEPRICATED, please remove after update of eo-hamcrest.
+  # One test in eo use one attribute of assert-that that use deprecated attributes.
   [a f] > reduce
     ^.reducedi > @
       a

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -59,6 +59,26 @@
           carr
         acc
 
+  #DEPRICATED, please remove after update of eo-hamcrest
+  [a f] > reducei
+    rec-reduce (* a 0) f arr > @
+
+    [acc-index func carr] > rec-reduce
+      (acc-index.at 0) > acc
+      (acc-index.at 1) > index
+      if. > @
+        (index.lt (carr.length))
+        rec-reduce
+          *
+            func
+              acc
+              index
+              (carr.at index)
+            (index.plus 1)
+          func
+          carr
+        acc
+
   # Reduce from start "a" using the function "f"
   [a f] > reduced
     ^.reducedi > @
@@ -68,7 +88,7 @@
           a
           item
 
-  # DEPRICATED. Reduce from start "a" using the function "f"
+  # DEPRICATED, please remove after update of eo-hamcrest.
   [a f] > reduce
     ^.reducedi > @
       a

--- a/eo-runtime/src/main/eo/org/eolang/collections/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/list.eo
@@ -72,7 +72,7 @@
   # object with two free attributes. The first
   # one for the element of the array, the second one
   # for the index.
-  [f] > mapi
+  [f] > mappedi
     list > @
       ^.reducedi
         *
@@ -84,8 +84,8 @@
   # Map without index. Here "f" must be an abstract
   # object with one free attribute, for the element
   # of the array.
-  [f] > map
-    ^.mapi > @
+  [f] > mapped
+    ^.mappedi > @
       [x idx]
         &.f x > @
 

--- a/eo-runtime/src/main/eo/org/eolang/collections/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/map.eo
@@ -34,7 +34,7 @@
   # Returns list of all keys in multimap
   [] > keys
     (multimap *).concat-all-arrays m > caa!
-    map. > @
+    mapped. > @
       list
         caa
       [curr]

--- a/eo-runtime/src/main/eo/org/eolang/collections/multimap.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/multimap.eo
@@ -33,7 +33,7 @@
   # Returns list of all keys in multimap
   [] > keys
     ^.concat-all-arrays m > caa!
-    map. > @
+    mapped. > @
       list
         caa
       [curr]

--- a/eo-runtime/src/main/eo/org/eolang/collections/multimap.eo
+++ b/eo-runtime/src/main/eo/org/eolang/collections/multimap.eo
@@ -35,7 +35,7 @@
     elements-amount > @
 
   [arr] > concat-all-arrays
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -45,7 +45,7 @@
           x
 
   [arr] > pairs-to-hash
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -65,7 +65,7 @@
       mmp
 
   [key arr] > find-in-list
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -89,7 +89,7 @@
       ^.find-in-list key (m.at (num.mod (m.length)))
 
   [key arr] > without-in-list
-    reduce. > @
+    reduced. > @
       list
         arr
       *

--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -66,7 +66,7 @@
 
   # Difference between $ and x
   [x...] > minus
-    map. > x-neg
+    mapped. > x-neg
       list
         x
       [element]

--- a/eo-runtime/src/main/eo/org/eolang/int.eo
+++ b/eo-runtime/src/main/eo/org/eolang/int.eo
@@ -64,7 +64,7 @@
 
   # Subtract from the current one
   [x...] > minus
-    map. > x-neg
+    mapped. > x-neg
       list
         x
       [element]

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -50,7 +50,7 @@
       gt.
         length.
           [] > arr
-            reduce. > @
+            reduced. > @
               list
                 cases
               *

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -36,7 +36,7 @@
   # Joins an array of strings, using current string
   # as a delimiter
   [items] > joined
-    reducei. > res!
+    reducedi. > res!
       list
         items
       ("".as-bytes)

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -65,15 +65,14 @@
     $.equal-to 100
 
 [] > array-as-a-bound-attribute-size-2
-  nop > @
-    * > anArray
-      1
-      2
-    assert-that
-      anArray
-      $.array-each
-        $.equal-to 1
-        $.equal-to 2
+  * > anArray
+    1
+    2
+  assert-that > @
+    anArray
+    $.array-each
+      $.equal-to 1
+      $.equal-to 2
 
 [] > array-with-in-seq
   [a] > foo

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -65,14 +65,15 @@
     $.equal-to 100
 
 [] > array-as-a-bound-attribute-size-2
-  * > anArray
-    1
-    2
-  assert-that > @
-    anArray
-    $.array-each
-      $.equal-to 1
-      $.equal-to 2
+  nop > @
+    * > anArray
+      1
+      2
+    assert-that
+      anArray
+      $.array-each
+        $.equal-to 1
+        $.equal-to 2
 
 [] > array-with-in-seq
   [a] > foo

--- a/eo-runtime/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/collections/list-tests.eo
@@ -85,7 +85,7 @@
 [] > reduce-with-index-test
   * 2 2 > src
   assert-that > @
-    reducei.
+    reducedi.
       list
         * 1 1
       0
@@ -98,7 +98,7 @@
 
 [] > reducei-long-int-array
   assert-that > @
-    reducei.
+    reducedi.
       list
         * 1 2 3 4
       0
@@ -110,7 +110,7 @@
 
 [] > reducei-bools-array
   assert-that > @
-    reducei.
+    reducedi.
       list
         * TRUE TRUE FALSE
       TRUE
@@ -126,7 +126,7 @@
   [] > b
     500 > @
   assert-that > @
-    reducei.
+    reducedi.
       list
         * a b
       0
@@ -145,7 +145,7 @@
 # reduce without index test
 [] > reduce-without-index-test
   assert-that > @
-    reduce.
+    reduced.
       list
         * 1 2 3 4
       -1

--- a/eo-runtime/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/collections/list-tests.eo
@@ -155,9 +155,9 @@
           x
     $.equal-to -24
 
-[] > mapi-should-works
+[] > mappedi-should-works
   assert-that > @
-    mapi.
+    mappedi.
       list
         * 1 2 3 4
       [x i]
@@ -167,9 +167,9 @@
         * 2 4 6 8
 
 # this test performs mapping of list using the index for it
-[] > mapi-index-can-be-accessed
+[] > mappedi-index-can-be-accessed
   [numbers...] > multipliedByNaturalSequence
-    mapi. > @
+    mappedi. > @
       list numbers
       [current index]
         times. > @
@@ -184,30 +184,30 @@
 [] > simple-mapping-int-to-string
   assert-that > @
     length.
-      map.
+      mapped.
         list
           * 1 2 3
         [i]
           (number i).as-string > @
     $.equal-to 3
 
-[] > using-map-as-object
+[] > using-mapped-as-object
   assert-that > @
     (text " ").joined
-      map.
+      mapped.
         list
           * 1 2
         [i]
           (number i).as-string > @
     $.equal-to "1 2"
 
-# if map does mutate lists, then this test would fail
+# if mapped does mutate lists, then this test would fail
 # because of the absence of the as-int attribute
 # that is caused by mutation of the original string list
 # to an int list
-[] > map-does-dot-mutate-array
+[] > mapped-does-dot-mutate-array
   [numbers...] > squares
-    map. > @
+    mapped. > @
       list numbers
       [current]
         pow. > @

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcollections/EOlistEOmapTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcollections/EOlistEOmapTest.java
@@ -59,7 +59,7 @@ public final class EOlistEOmapTest {
 
         final Phi[] items = new Dataized(
             new PhWith(
-                new PhMethod(list, "map"),
+                new PhMethod(list, "mapped"),
                 0, new EOlistEOmapTest.Kid(Phi.Φ)
             )
         ).take(Phi[].class);


### PR DESCRIPTION
I renamed reduce, reducei, map, mapi --> reduced, reducedi, mappped, mappedi. Previeous attributes I marked as depricated cause they are used by some assert-that attributes.