### PR TITLE
#881 checkstyle fixed

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
@@ -54,18 +54,20 @@ public class EOfloat$EOdiv extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "float.div",
-                    "x",
-                    Double.class,
-                    (acc, x) -> acc / x,
-                    x -> {
-                        String msg = "";
-                        if (x.equals(0.0)) {
-                            msg = "division by zero is infinity";
-                        }
-                        return msg;
-                    }
+                new ExprReduce<Double>(
+                     "x",
+                     (acc, x) -> acc / x,
+                     new ExprReduce.Args(
+                           Double.class,
+                             x -> {
+                                 String msg = "";
+                                 if (x.equals(0.0)) {
+                                     msg = "division by zero is infinity";
+                                 }
+                                 return msg;
+                             },
+                             "float.div"
+                      )
                 )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
@@ -55,19 +55,19 @@ public class EOfloat$EOdiv extends PhDefault {
             new AtComposite(
                 this,
                 new ExprReduce<Double>(
-                     "x",
-                     (acc, x) -> acc / x,
-                     new ExprReduce.Args(
-                           Double.class,
-                             x -> {
-                                 String msg = "";
-                                 if (x.equals(0.0)) {
-                                     msg = "division by zero is infinity";
-                                 }
-                                 return msg;
-                             },
-                             "float.div"
-                      )
+                    "x",
+                    (acc, x) -> acc / x,
+                    new ExprReduce.Args(
+                        Double.class,
+                        x -> {
+                            String msg = "";
+                            if (x.equals(0.0)) {
+                                msg = "division by zero is infinity";
+                            }
+                            return msg;
+                        },
+                        "float.div"
+                    )
                 )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
@@ -54,11 +54,14 @@ public class EOfloat$EOplus extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "float.plus",
-                    "x",
-                    Double.class,
-                    Double::sum
+                new ExprReduce<Double>(
+                        "x",
+                        Double::sum,
+                        new ExprReduce.Args(
+                                Double.class,
+                                x -> "",
+                                "float.plus"
+                        )
                 )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
@@ -55,13 +55,13 @@ public class EOfloat$EOplus extends PhDefault {
             new AtComposite(
                 this,
                 new ExprReduce<Double>(
-                        "x",
-                        Double::sum,
-                        new ExprReduce.Args(
-                                Double.class,
-                                x -> "",
-                                "float.plus"
-                        )
+                    "x",
+                    Double::sum,
+                    new ExprReduce.Args(
+                        Double.class,
+                        x -> "",
+                        "float.plus"
+                    )
                 )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
@@ -55,13 +55,13 @@ public class EOfloat$EOtimes extends PhDefault {
             new AtComposite(
                 this,
                     new ExprReduce<Double>(
-                            "x",
-                            (acc, x) -> acc * x,
-                            new ExprReduce.Args(
-                                    Double.class,
-                                    x -> "",
-                                    "float.times"
-                            )
+                        "x",
+                        (acc, x) -> acc * x,
+                        new ExprReduce.Args(
+                            Double.class,
+                            x -> "",
+                            "float.times"
+                        )
                     )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
@@ -54,12 +54,15 @@ public class EOfloat$EOtimes extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "float.times",
-                    "x",
-                    Double.class,
-                    (acc, x) -> acc * x
-                )
+                    new ExprReduce<Double>(
+                            "x",
+                            (acc, x) -> acc * x,
+                            new ExprReduce.Args(
+                                    Double.class,
+                                    x -> "",
+                                    "float.times"
+                            )
+                    )
             )
         );
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
@@ -59,19 +59,21 @@ public class EOint$EOdiv extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "int.div",
-                    "x",
-                    Long.class,
-                    (acc, x) -> acc / x,
-                    x -> {
-                        String msg = "";
-                        if (x.equals(0L)) {
-                            msg = "division by zero is infinity";
-                        }
-                        return msg;
-                    }
-                )
+                    new ExprReduce<Long>(
+                            "x",
+                            (acc, x) -> acc / x,
+                            new ExprReduce.Args(
+                                    Long.class,
+                                    x -> {
+                                        String msg = "";
+                                        if (x.equals(0L)) {
+                                            msg = "division by zero is infinity";
+                                        }
+                                        return msg;
+                                    },
+                                    "int.div"
+                            )
+                    )
             )
         );
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
@@ -59,21 +59,21 @@ public class EOint$EOdiv extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                    new ExprReduce<Long>(
-                            "x",
-                            (acc, x) -> acc / x,
-                            new ExprReduce.Args(
-                                    Long.class,
-                                    x -> {
-                                        String msg = "";
-                                        if (x.equals(0L)) {
-                                            msg = "division by zero is infinity";
-                                        }
-                                        return msg;
-                                    },
-                                    "int.div"
-                            )
+                new ExprReduce<Long>(
+                    "x",
+                    (acc, x) -> acc / x,
+                    new ExprReduce.Args(
+                        Long.class,
+                        x -> {
+                            String msg = "";
+                            if (x.equals(0L)) {
+                                msg = "division by zero is infinity";
+                            }
+                            return msg;
+                        },
+                        "int.div"
                     )
+                )
             )
         );
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
@@ -58,12 +58,15 @@ public class EOint$EOplus extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "int.plus",
-                    "x",
-                    Long.class,
-                    Long::sum
-                )
+                    new ExprReduce<Long>(
+                            "x",
+                            Long::sum,
+                            new ExprReduce.Args(
+                                    Long.class,
+                                    x -> "",
+                                    "int.plus"
+                            )
+                    )
             )
         );
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
@@ -59,13 +59,13 @@ public class EOint$EOplus extends PhDefault {
             new AtComposite(
                 this,
                     new ExprReduce<Long>(
-                            "x",
-                            Long::sum,
-                            new ExprReduce.Args(
-                                    Long.class,
-                                    x -> "",
-                                    "int.plus"
-                            )
+                        "x",
+                        Long::sum,
+                        new ExprReduce.Args(
+                            Long.class,
+                            x -> "",
+                            "int.plus"
+                        )
                     )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
@@ -55,13 +55,13 @@ public class EOint$EOtimes extends PhDefault {
             new AtComposite(
                 this,
                     new ExprReduce<Long>(
-                            "x",
-                            (acc, x) -> acc * x,
-                            new ExprReduce.Args(
-                                    Long.class,
-                                    x -> "",
-                                    "int.times"
-                            )
+                        "x",
+                        (acc, x) -> acc * x,
+                        new ExprReduce.Args(
+                            Long.class,
+                            x -> "",
+                            "int.times"
+                        )
                     )
             )
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
@@ -54,12 +54,15 @@ public class EOint$EOtimes extends PhDefault {
             "φ",
             new AtComposite(
                 this,
-                new ExprReduce<>(
-                    "int.times",
-                    "x",
-                    Long.class,
-                    (acc, x) -> acc * x
-                )
+                    new ExprReduce<Long>(
+                            "x",
+                            (acc, x) -> acc * x,
+                            new ExprReduce.Args(
+                                    Long.class,
+                                    x -> "",
+                                    "int.times"
+                            )
+                    )
             )
         );
     }

--- a/eo-runtime/src/main/java/org/eolang/ExprReduce.java
+++ b/eo-runtime/src/main/java/org/eolang/ExprReduce.java
@@ -23,24 +23,24 @@
  */
 package org.eolang;
 
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
 
 /**
  * Builds a phi performing reduction operation on varargs parameter.
- * <br/>The expression iterates over varargs (including rho)
- * one by one performing provided reduction operation.
- * Type checking is done for each vararg.
  * <p/>Definition example:
  * <code><pre>
  *     final VarargExpr&lt;Long&gt; expr = new VarargExpr<>(
- *         "plus",
  *         "x",
- *         Long.class,
- *         Long::sum,
+ *         new ExrpReduce.Args(
+ *             "plus",
+ *             Long.class,
+ *             Long::sum,
+ *             x -> ""
+ *         )
  *     );
  * </pre></code>
  * @param <T> Type of arguments
@@ -58,15 +58,18 @@ public final class ExprReduce<T> implements Expr {
      */
     private final BinaryOperator<T> reduction;
 
+    /**
+     * Arguments parsing class.
+     */
     private final Args<T> arguments;
+
     /**
      * Ctor.
      *
-     * @param oper Operation name
      * @param param Name of parameter with varargs
-     * @param type Type of varargs
      * @param reduction Reduction operation on consecutive varags
-     * @param validation Validation function
+     * @param arguments Arguments storing and parsing object
+     * @since 1.0
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public ExprReduce(
@@ -81,11 +84,29 @@ public final class ExprReduce<T> implements Expr {
 
     @Override
     public Phi get(final Phi rho) {
-        Optional<T> acc = this.arguments.get(rho, this.param).stream().reduce(this.reduction);
+        final Optional<T> acc = this.arguments.get(rho, this.param).stream().reduce(this.reduction);
         return new Data.ToPhi(acc.get());
     }
 
-    public static class Args<T>{
+    /**
+     * Extracts and validates args.
+     * <br/>The expression iterates over varargs (including rho)
+     * one by one performing provided reduction operation.
+     * Type checking is done for each vararg.
+     * <p/>Definition example:
+     * <code><pre>
+     *     final VarargExpr&lt;Long&gt; args = new Args<>(
+     *         "plus",
+     *         Long.class,
+     *         Long::sum,
+     *         x -> ""
+     *
+     *     );
+     * </pre></code>
+     * @param <T> Type of arguments
+     * @since 1.0
+     */
+    public static final class Args<T> {
 
         /**
          * Varargs type.
@@ -102,40 +123,49 @@ public final class ExprReduce<T> implements Expr {
          */
         private final String oper;
 
+        /**
+         * Ctor.
+         *
+         * @param type Type of parameter with varargs
+         * @param validation Validation operation on varargs
+         * @param oper Operation that that should be used with varargs
+         * @checkstyle ParameterNumberCheck (10 lines)
+         */
         public Args(
             final Class<T> type,
             final Function<T, String> validation,
             final String oper
-        ){
+        ) {
             this.type = type;
             this.validation = validation;
             this.oper = oper;
         }
 
-        public List<T> get(Phi rho, String param){
-            T acc = new Param(rho).strong(this.type);
-            List<T> ls = new ArrayList<>();
-            ls.add(acc);
+        @Override
+        public List<T> get(final Phi rho, final String param) {
+            final T acc = new Param(rho).strong(this.type);
             final Phi[] args = new Param(rho, param).strong(Phi[].class);
+            final List<T> list = new ArrayList<>(args.length + 1);
+            list.add(acc);
             for (int idx = 0; idx < args.length; ++idx) {
                 final Object val = new Dataized(args[idx]).take();
                 if (!val.getClass().getCanonicalName().equals(this.type.getCanonicalName())) {
                     throw new ExFailure(
-                            "The %dth argument of '%s' is not a(n) %s: %s",
-                            idx + 1, this.oper, this.type.getSimpleName(), val
+                        "The %dth argument of '%s' is not a(n) %s: %s",
+                        idx + 1, this.oper, this.type.getSimpleName(), val
                     );
                 }
                 final T typed = this.type.cast(val);
                 final String msg = this.validation.apply(typed);
                 if (!msg.isEmpty()) {
                     throw new ExFailure(
-                            "The %dth argument of '%s' is invalid: %s",
-                            idx + 1, this.oper, msg
+                        "The %dth argument of '%s' is invalid: %s",
+                        idx + 1, this.oper, msg
                     );
                 }
-                ls.add(typed);
+                list.add(typed);
             }
-            return ls;
+            return list;
         }
 
     }

--- a/eo-runtime/src/main/java/org/eolang/ExprReduce.java
+++ b/eo-runtime/src/main/java/org/eolang/ExprReduce.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
  *         )
  *     );
  * </pre></code>
- * @param <T> Type of arguments
+ * @param <T> Type of arguments that are going to be reduced
  * @since 1.0
  */
 public final class ExprReduce<T> implements Expr {
@@ -70,7 +70,6 @@ public final class ExprReduce<T> implements Expr {
      * @param reduction Reduction operation on consecutive varags
      * @param arguments Arguments storing and parsing object
      * @since 1.0
-     * @checkstyle ParameterNumberCheck (10 lines)
      */
     public ExprReduce(
         final String param,
@@ -103,7 +102,7 @@ public final class ExprReduce<T> implements Expr {
      *
      *     );
      * </pre></code>
-     * @param <T> Type of arguments
+     * @param <T> Type of arguments that are going to be reduced
      * @since 1.0
      */
     public static final class Args<T> {
@@ -129,7 +128,6 @@ public final class ExprReduce<T> implements Expr {
          * @param type Type of parameter with varargs
          * @param validation Validation operation on varargs
          * @param oper Operation that that should be used with varargs
-         * @checkstyle ParameterNumberCheck (10 lines)
          */
         public Args(
             final Class<T> type,
@@ -141,7 +139,13 @@ public final class ExprReduce<T> implements Expr {
             this.oper = oper;
         }
 
-        @Override
+        /**
+         * Ctor.
+         *
+         * @param rho Rho argument that is parsed
+         * @param param Name of parameter with varargs
+         * @return Returns the list of parsed and validated values
+         */
         public List<T> get(final Phi rho, final String param) {
             final T acc = new Param(rho).strong(this.type);
             final Phi[] args = new Param(rho, param).strong(Phi[].class);

--- a/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
@@ -35,14 +35,14 @@ import org.junit.jupiter.api.Test;
 class ExprReduceTest {
     @Test
     void exprTest() throws Exception {
-        final ExprReduce<Long> expr = new ExprReduce<Long>(
-              "x",
-              Long::sum,
-              new ExprReduce.Args(
-                      Long.class,
-                      x -> "",
-                      "plus"
-              )
+        final ExprReduce expr = new ExprReduce<Long>(
+            "x",
+            Long::sum,
+            new ExprReduce.Args(
+                Long.class,
+                x -> "",
+                "plus"
+            )
         );
         Phi phi = new Data.ToPhi(100L);
         phi = phi.attr("plus").get();
@@ -57,14 +57,14 @@ class ExprReduceTest {
 
     @Test
     void wrongTypeTest() {
-        final ExprReduce<Long> expr = new ExprReduce<Long>(
-                "x",
-                Long::sum,
-                new ExprReduce.Args(
-                        Long.class,
-                        x -> "",
-                        "plus"
-                )
+        final ExprReduce expr = new ExprReduce<Long>(
+            "x",
+            Long::sum,
+            new ExprReduce.Args(
+                Long.class,
+                x -> "",
+                "plus"
+            )
         );
         Phi phi = new Data.ToPhi(100L);
         phi = phi.attr("plus").get();

--- a/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
@@ -35,11 +35,14 @@ import org.junit.jupiter.api.Test;
 class ExprReduceTest {
     @Test
     void exprTest() throws Exception {
-        final ExprReduce<Long> expr = new ExprReduce<>(
-            "plus",
-            "x",
-            Long.class,
-            Long::sum
+        final ExprReduce<Long> expr = new ExprReduce<Long>(
+              "x",
+              Long::sum,
+              new ExprReduce.Args(
+                      Long.class,
+                      x -> "",
+                      "plus"
+              )
         );
         Phi phi = new Data.ToPhi(100L);
         phi = phi.attr("plus").get();
@@ -54,11 +57,14 @@ class ExprReduceTest {
 
     @Test
     void wrongTypeTest() {
-        final ExprReduce<Long> expr = new ExprReduce<>(
-            "plus",
-            "x",
-            Long.class,
-            Long::sum
+        final ExprReduce<Long> expr = new ExprReduce<Long>(
+                "x",
+                Long::sum,
+                new ExprReduce.Args(
+                        Long.class,
+                        x -> "",
+                        "plus"
+                )
         );
         Phi phi = new Data.ToPhi(100L);
         phi = phi.attr("plus").get();


### PR DESCRIPTION
@mximp in this version I changed all as required, but still have one problem, `Args.get()` accepts two attributes. This happens because `param` is inaccessible from the `Args` class because it's static. In addition, `param` can't be used as an attribute of `Args,` because in this case `Args` object will have 4 attributes, and checkstyle will appear again. The only solution I see is that `Args` need to be non-static objects, but in this case, we can't call a constructor like this `new ExprReduce.Arg(...)`.