### PR TITLE
(#1060) - Allow `array` as a normal object

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/_datas.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_datas.xsl
@@ -32,4 +32,18 @@ SOFTWARE.
     <a>org.eolang.bool</a>
     <a>org.eolang.double</a>
   </xsl:variable>
+  <!--
+   @todo #1060:30m Avoid duplication with a better
+    condition check inside to-java.xslt.
+    Array can be constructed as raw data, and also
+    by .with method.
+  -->
+  <xsl:variable name="literal-objects" as="element()*">
+    <a>org.eolang.bytes</a>
+    <a>org.eolang.string</a>
+    <a>org.eolang.int</a>
+    <a>org.eolang.float</a>
+    <a>org.eolang.bool</a>
+    <a>org.eolang.double</a>
+  </xsl:variable>
 </xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/data-objects.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/data-objects.xsl
@@ -28,7 +28,7 @@ SOFTWARE.
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="//o[not(@data) and @base=$data-objects/text()]">
+      <xsl:for-each select="//o[not(@data) and @base=$literal-objects/text()]">
         <xsl:element name="error">
           <xsl:attribute name="check">
             <xsl:text>data-objects</xsl:text>

--- a/eo-runtime/src/main/eo/org/eolang/array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/array.eo
@@ -26,7 +26,14 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 
+# @todo #1060:30min The method .empty is not nessesary.
+#  Make the create of array possible just by using
+#  the object name, i.e `array > a` and remove this
+#  method.
 [] > array
+  # Create empty array
+  [] > empty
+    (*) > @
 
   # Obtain the length of the array.
   [] > length /int

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -182,3 +182,18 @@
     $.equal-to
       list
         * 1 2 3
+
+[] > gets-lengths-of-empty-array-keyword
+  assert-that > @
+    array.empty.length
+    $.equal-to 0
+
+[] > array-fluent-with-indented-keyword
+  array.empty
+  .with 1
+  .with 2
+  .with 3 > a
+  assert-that > @
+    list a
+    $.equal-to
+      list (* 1 2 3)

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -164,3 +164,21 @@
     $.equal-to
       list
         * 7 "six"
+
+[] > array-fluent-with
+  assert-that > @
+    ((((*).with 1).with 2).with 3)
+    $.equal-to
+      list
+        * 1 2 3
+
+[] > array-fluent-with-indented
+  (*)
+  .with 1
+  .with 2
+  .with 3 > a
+  assert-that > @
+    list a
+    $.equal-to
+      list
+        * 1 2 3


### PR DESCRIPTION
Per #1060 
- Remove `array` from `data-objects` 
- Add `array.empty` & tests
- Add todos