### PR TITLE
(#1086) - Use type inference & remove `java-type` attribute

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/data.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/data.xsl
@@ -38,39 +38,6 @@ SOFTWARE.
           <xsl:value-of select="@data"/>
         </xsl:attribute>
         <xsl:element name="value">
-          <xsl:attribute name="java-type">
-            <xsl:choose>
-              <xsl:when test="@data='bytes'">
-                <xsl:choose>
-                  <xsl:when test="@base='org.eolang.string'">
-                    <xsl:text>String</xsl:text>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:text>byte[]</xsl:text>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:when>
-              <xsl:when test="@data='string'">
-                <xsl:text>String</xsl:text>
-              </xsl:when>
-              <xsl:when test="@data='float'">
-                <xsl:text>Double</xsl:text>
-              </xsl:when>
-              <xsl:when test="@data='int'">
-                <xsl:text>Long</xsl:text>
-              </xsl:when>
-              <xsl:when test="@data='bool'">
-                <xsl:text>Boolean</xsl:text>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:message terminate="yes">
-                  <xsl:text>Unknown data type "</xsl:text>
-                  <xsl:value-of select="@data"/>
-                  <xsl:text>"</xsl:text>
-                </xsl:message>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:attribute>
           <xsl:choose>
             <xsl:when test="@data='bytes'">
               <xsl:variable name="array">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -569,9 +569,7 @@ SOFTWARE.
     <xsl:value-of select="$name"/>
     <xsl:text> = new PhWith(</xsl:text>
     <xsl:value-of select="$name"/>
-    <xsl:text>, "Δ", new Data.Value&lt;</xsl:text>
-    <xsl:value-of select="@java-type"/>
-    <xsl:text>&gt;(</xsl:text>
+    <xsl:text>, "Δ", new Data.Value&lt;&gt;(</xsl:text>
     <xsl:value-of select="text()"/>
     <xsl:text>));</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -49,12 +49,6 @@ import org.xembly.Directives;
  *  After that update this todo. When all data types
  *  are stored as bytes, remove data attribute from XML
  *  and XSLT templates.
- * @todo #348:30min Avoid using Java types in XSLT
- *  processing. data.xslt and to-java.xslt use
- *  java-type attribute. This attribute is redundant
- *  and can be replaced by type inference. This
- *  change will ease the task off removing data
- *  attribute above.
  */
 @SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
 public final class XeListener implements ProgramListener, Iterable<Directive> {


### PR DESCRIPTION
Per #1086 
- Remove unnecessary type parameter from `data.xsl` & `to-java.xsl`