### PR TITLE
(#1084) - Specify encoding when creating `String` object

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/data.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/data.xsl
@@ -88,6 +88,7 @@ SOFTWARE.
                 <xsl:when test="@base='org.eolang.string'">
                   <xsl:text>new String(</xsl:text>
                   <xsl:value-of select="$array"/>
+                  <xsl:text>, java.nio.charset.StandardCharsets.UTF_8</xsl:text>
                   <xsl:text>)</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>

--- a/eo-runtime/src/test/eo/org/eolang/string-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/string-tests.eo
@@ -94,15 +94,12 @@
     "Hello, \u0434\u0440\u0443\u0433!\n"
     $.equal-to "Hello, друг!\n"
 
-# @todo #348:30min This test is broken on Windows.
-#  Probably default charset is not UTF-8.
-#  Fix the build and enable this test back.
-# [] > supports-escape-sequences-in-text
-#   assert-that > @
-#     """
-#     Hello, \u0434\u0440\u0443\u0433!\n
-#     """
-#     $.equal-to "Hello, друг!\n"
+[] > supports-escape-sequences-in-text
+  assert-that > @
+    """
+    Hello, \u0434\u0440\u0443\u0433!\n
+    """
+    $.equal-to "Hello, друг!\n"
 
 [] > preserves-indentation-in-text
   assert-that > @


### PR DESCRIPTION
Per #1084