### PR TITLE
1096 malformed compilation input

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Collection;
 import org.cactoos.text.Joined;
@@ -93,15 +94,25 @@ public final class JavaFiles {
      */
     private static void saveJava(final XML java, final Path generated) throws IOException {
         final String type = java.xpath("@java-name").get(0);
-        final Path dest = new Place(type).make(
-            generated, "java"
-        );
-        new Save(
-            new Joined(
-                "",
-                java.xpath("java/text()")
-            ),
-            dest
-        ).save();
+        try {
+            final Path dest = new Place(type).make(
+                generated, "java"
+            );
+            new Save(
+                new Joined(
+                    "",
+                    java.xpath("java/text()")
+                ),
+                dest
+            ).save();
+        } catch (InvalidPathException ex) {
+            throw new IOException(
+                String.format(
+                    "Unable to save Java class `%s`. Check you system encoding. Expected `UTF-8`",
+                    type
+                ),
+                ex
+            );
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -105,7 +105,7 @@ public final class JavaFiles {
                 ),
                 dest
             ).save();
-        } catch (InvalidPathException ex) {
+        } catch (final InvalidPathException ex) {
             throw new IOException(
                 String.format(
                     "Unable to save Java class `%s`. Check you system encoding. Expected `UTF-8`",


### PR DESCRIPTION
#1096 Extend exception description.

After some analysis it turned out that to fixing the issue within eo-plugin is expensive: there is no single place to read/write Java file names. The paths (and class names) are referred within `foreign` as well.
Also non-ascii symbols are used in manually created classes in `eo-runtime` which makes it more difficult to fix as both `eo-runtime` and `eo-maven-plugin` need to be corrected at the same time (seems to be not possible at the moment due to integration tests dependency mechanism).