### PR TITLE
adds test for checking cage for infinite loop

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/cage-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cage-tests.eo
@@ -163,4 +163,13 @@
         cb.z
         cb.z.plus 40
 
-
+[] > infinite-loop-check
+  cage 0 > x
+  cage 0 > tmp
+  [value] > pyint
+    [y] > add
+      pyint (value.plus (y.value)) > @
+  seq > @
+    x.write (pyint 0)
+    tmp.write (x.add (pyint 1))
+    tmp.value.eq 1


### PR DESCRIPTION
Closes: #914 

I added failed test to `cage-tests.eo` and it passed. So, I believe we can close this issue 