### PR TITLE
solved the problem of parsing with copying an object with a method

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
@@ -105,6 +105,7 @@ method
     |
     VERTEX
   )
+  COPY?
   ;
 
 scope

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -269,6 +269,9 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
             ctx.getStart().getLine(),
             ctx.getStart().getCharPositionInLine()
         );
+        if (ctx.COPY() != null) {
+            this.objects.prop("copy", "");
+        }
         this.objects.prop("method", "");
         this.objects.prop("base", String.format(".%s", ctx.mtd.getText()));
         this.objects.leave();

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/copy.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/copy.yaml
@@ -1,0 +1,12 @@
+xsls: []
+tests:
+  - //objects[count(o)=1]
+  - //objects[count(.//o[@copy=''])=1]
+eo: |
+  [] > test
+    [] > book
+      "qwerty" > title
+    book.title' > copy-title
+    eq. > @
+      copy-title
+      "qwerty"

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -343,3 +343,11 @@
     assert-that
       b1.v
       $.equal-to 1
+
+[] > copy-object-with-dot
+  [] > book
+    "qwerty" > title
+  book.title' > copy-title
+  eq. > @
+    copy-title
+    "qwerty"


### PR DESCRIPTION
Closes: #1214

Now we can do this `obj.method' > copy` without parsing error