### PR TITLE
fixed paper according to the latest EO version

### DIFF
--- a/paper/sections/syntax.tex
+++ b/paper/sections/syntax.tex
@@ -162,8 +162,8 @@ second line and the \ff{>} symbol, while two spaces will break the syntax):
 [dx dy] > vector |$\label{ln:vector}$|
   sqrt. > length |$\label{ln:length}$|
     plus.
-      dx.pow 2
-      dy.pow 2 |$\label{ln:length-end}$| |$\label{ln:vector-end}$|
+      dx.times dx
+      dy.timex dy |$\label{ln:length-end}$| |$\label{ln:vector-end}$|
 \end{ffcode*}
 
 The code at \lref{comment} is a \emph{comment}.
@@ -178,7 +178,7 @@ The declaration of the attribute \ff{length} at \lrefs{length}{length-end}
 can be written in one line, using \emph{dot notation}:
 
 \begin{ffcode}
-((dx.pow 2).plus (dy.pow 2)).sqrt > length
+((dx.times dx).plus (dy.timex dy)).sqrt > length
 \end{ffcode}
 
 An \emph{inverse} dot notation is used in order to simplify
@@ -189,14 +189,14 @@ this expression in multiple lines without the usage of
 inverse notation, but it will look less readable:
 
 \begin{ffcode}
-dx.pow 2 |$\label{ln:dx-pow}$|
+dx.times dx |$\label{ln:dx-pow}$|
 .plus
-  dy.pow 2 |$\label{ln:dx-pow-2}$|
+  dy.timex dy |$\label{ln:dx-pow-2}$|
 .sqrt > length |$\label{ln:dx-pow-3}$|
 \end{ffcode}
 
-Here, \lref{dx-pow} is the application of the object \ff{dx.pow} with
-a new argument \ff{2}. Then, the next line is the object \ff{plus} taken
+Here, \lref{dx-pow} is the application of the object \ff{dx.times} with
+a new argument \ff{dx}. Then, the next line is the object \ff{plus} taken
 from the object created at the first line, using the dot notation. Then,
 \lref{dx-pow-2} is the argument passed to the object \ff{plus}.
 The code at \lref{dx-pow-3} takes the object \ff{sqrt} from the object constructed
@@ -248,13 +248,13 @@ this XML tree of elements and attributes:
   <o name="dy"/>
   <o name="length" base=".sqrt">
     <o base=".plus">
-      <o base=".pow">
+      <o base=".times">
         <o base="dx"/>
-        <o base="int" data="int">2</>
+        <o base="dx"/>
       </o>
-      <o base=".pow">
+      <o base=".times">
         <o base="dy"/>
-        <o base="int" data="int">2</>
+        <o base="dy"/>
       </o>
     </o>
   </o>


### PR DESCRIPTION
We've got a wrong EO syntax in syntax.tex when used `pow` object. This object not in `int` object anymore, so I decided to replace it by `times`.
Another approach - is to decorate `dx` and `dy` by `QQ.math.number` object