### PR TITLE
paper suggestions

### DIFF
--- a/paper/sections/calculus.tex
+++ b/paper/sections/calculus.tex
@@ -138,7 +138,7 @@ in the brackets. For example, the object at \lref{point-copy} may be written as
 \begin{equation}\label{eq:point}
 \begin{split}
 & \ff{point}(\ff{x} \mapsto \ff{5}, \ff{y} \mapsto \ff{-3}).\ff{distance}(\br
-& \quad \ff{p} \mapsto \ff{point}(\ff{x} \mapsto \ff{13}, \ff{y} \mapsto \ff{3.9}) \br
+& \quad \ff{to} \mapsto \ff{point}(\ff{x} \mapsto \ff{13}, \ff{y} \mapsto \ff{3.9}) \br
 & ),
 \end{split}
 \end{equation}
@@ -199,8 +199,8 @@ For example:
 & x \mapsto \llbracket y \mapsto \llbracket \rrbracket \rrbracket \br
 & x.y.\rho = x \br
 & z \mapsto \llbracket t \mapsto x.y \rrbracket \br
-& z.t.\rho = z \br
-& z.t.\sigma = x.
+& z.t.\rho = x \br
+& z.t.\sigma = z.
 \end{split}
 \end{equation}
 


### PR DESCRIPTION
Here I suggest two changes in paper:
1) Changed `point` parameter name, because of this:
```
distance.
  point
    5:x
    -3:y
  point:to
    13:x
    3.9:y
```
2) The second one is about sigma and rho