### PR TITLE
#1230 introduce multithreading for parsing

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -32,6 +32,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -47,6 +53,8 @@ import org.xembly.Xembler;
  * Parse EO to XML.
  *
  * @since 0.1
+ * @todo #1230:30min Make number of threads in parsing executor configurable
+ *  via mojo parameter. Default value should be 4.
  */
 @Mojo(
     name = "parse",
@@ -96,30 +104,78 @@ public final class ParseMojo extends SafeMojo {
         final Collection<Tojo> tojos = this.scopedTojos().select(
             row -> row.exists(AssembleMojo.ATTR_EO)
         );
-        int total = 0;
-        for (final Tojo tojo : tojos) {
-            if (tojo.exists(AssembleMojo.ATTR_XMIR)) {
-                final Path xmir = Paths.get(tojo.get(AssembleMojo.ATTR_XMIR));
-                final Path src = Paths.get(tojo.get(AssembleMojo.ATTR_EO));
-                if (xmir.toFile().lastModified() >= src.toFile().lastModified()) {
-                    Logger.debug(
-                        this, "Already parsed %s to %s (it's newer than the source)",
-                        tojo.get(Tojos.KEY), new Home().rel(xmir)
+        final Set<Callable<Object>> tasks = new HashSet<>(0);
+        final AtomicInteger total = new AtomicInteger(0);
+        tojos.stream()
+            .map(SynchronizedTojo::new)
+            .forEach(
+                tojo -> {
+                    if (tojo.exists(AssembleMojo.ATTR_XMIR)) {
+                        final Path xmir = Paths.get(tojo.get(AssembleMojo.ATTR_XMIR));
+                        final Path src = Paths.get(tojo.get(AssembleMojo.ATTR_EO));
+                        if (xmir.toFile().lastModified() >= src.toFile().lastModified()) {
+                            Logger.debug(
+                                this, "Already parsed %s to %s (it's newer than the source)",
+                                tojo.get(Tojos.KEY), new Home().rel(xmir)
+                            );
+                            return;
+                        }
+                    }
+                    tasks.add(
+                        Executors.callable(
+                            () -> {
+                                try {
+                                    this.parse(tojo);
+                                    total.incrementAndGet();
+                                } catch (final IOException ex) {
+                                    throw new IllegalStateException(
+                                        String.format(
+                                            "Unable to parse %s",
+                                            tojo.get(Tojos.KEY)
+                                        ),
+                                        ex
+                                    );
+                                }
+                            }
+                        )
                     );
-                    continue;
                 }
-            }
-            this.parse(tojo);
-            ++total;
+            );
+        try {
+            Executors.newFixedThreadPool(4)
+                .invokeAll(tasks)
+                .forEach(
+                    completed -> {
+                        try {
+                            completed.get();
+                        } catch (final InterruptedException ex) {
+                            Thread.currentThread().interrupt();
+                        } catch (final ExecutionException ex) {
+                            throw new IllegalArgumentException(
+                                ex.getCause().getMessage(),
+                                ex
+                            );
+                        }
+                    }
+                );
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                String.format(
+                    "Interrupted while waiting for %d parsing to finish",
+                    total.get()
+                ),
+                ex
+            );
         }
-        if (total == 0) {
+        if (total.get() == 0) {
             if (tojos.isEmpty()) {
                 Logger.info(this, "No .eo sources need to be parsed to XMIRs");
             } else {
                 Logger.info(this, "No .eo sources parsed to XMIRs");
             }
         } else {
-            Logger.info(this, "Parsed %d .eo sources to XMIRs", total);
+            Logger.info(this, "Parsed %d .eo sources to XMIRs", total.get());
         }
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -53,8 +53,12 @@ import org.xembly.Xembler;
  * Parse EO to XML.
  *
  * @since 0.1
- * @todo #1230:30min Make number of threads in parsing executor configurable
- *  via mojo parameter. Default value should be 4.
+ * @todo #1230:30min Make number of threads used in thread executor within {@link #exec()} method
+ *  configurable via mojo parameter `threads`. Default value should be 4.
+ * @todo #1230:30min Replace usage of custom {@link SynchronizedTojo} with
+ *  implementation from Tojo framework once completed in
+ *  <a href="https://github.com/yegor256/tojos/issues/16">#16</a>. Custom implementation
+ *  can be removed after replacement.
  */
 @Mojo(
     name = "parse",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -55,10 +55,6 @@ import org.xembly.Xembler;
  * @since 0.1
  * @todo #1230:30min Make number of threads used in thread executor within {@link #exec()} method
  *  configurable via mojo parameter `threads`. Default value should be 4.
- * @todo #1230:30min Replace usage of custom {@link SynchronizedTojo} with
- *  implementation from Tojo framework once completed in
- *  <a href="https://github.com/yegor256/tojos/issues/16">#16</a>. Custom implementation
- *  can be removed after replacement.
  */
 @Mojo(
     name = "parse",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SynchronizedTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SynchronizedTojo.java
@@ -28,6 +28,10 @@ import com.yegor256.tojos.Tojo;
 /**
  * Thread-safe version of tojo. Synchronizes on global single lock within JVM.
  * @since 1.0
+ * @todo #1230:30min Replace this custom {@link SynchronizedTojo} with
+ *  implementation from Tojo framework once completed in
+ *  <a href="https://github.com/yegor256/tojos/issues/16">#16</a>. This class
+ *  should be removed and all usages updated accordingly.
  */
 final class SynchronizedTojo implements Tojo {
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SynchronizedTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SynchronizedTojo.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import com.yegor256.tojos.Tojo;
+
+/**
+ * Thread-safe version of tojo. Synchronizes on global single lock within JVM.
+ * @since 1.0
+ */
+final class SynchronizedTojo implements Tojo {
+    /**
+     * Lock object.
+     */
+    private static final Object LOCK = SynchronizedTojo.class;
+
+    /**
+     * Origin tojo.
+     */
+    private final Tojo origin;
+
+    /**
+     * Ctor.
+     * @param origin Tojo
+     */
+    SynchronizedTojo(final Tojo origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public boolean exists(final String key) {
+        synchronized (SynchronizedTojo.LOCK) {
+            return this.origin.exists(key);
+        }
+    }
+
+    @Override
+    public String get(final String key) {
+        synchronized (SynchronizedTojo.LOCK) {
+            return this.origin.get(key);
+        }
+    }
+
+    @Override
+    public Tojo set(final String key, final Object value) {
+        synchronized (SynchronizedTojo.LOCK) {
+            return this.origin.set(key, value);
+        }
+    }
+}


### PR DESCRIPTION
#1230 Introduced multithreading for parsing.

Fixed thread pool is used as executor. 
Synchronized `Tojo` implementation is provided to make _Foreign catalog_ file access safe.

Since parsing takes not that much time overall performance gain for Fibonacci app with 4 threads constitutes 2-3 seconds.