### PR TITLE
#1352 `Home` redesign. Usages refactoring.

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopyMojo.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.regex.Pattern;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -100,11 +101,11 @@ public final class CopyMojo extends SafeMojo {
         final Path target = this.outputDir.toPath().resolve(CopyMojo.DIR);
         final Collection<Path> sources = new Walk(this.sourcesDir.toPath());
         for (final Path src : sources) {
-            new Home().save(
+            new Home(target).save(
                 CopyMojo.REPLACE
                     .matcher(new UncheckedText(new TextOf(new InputOf(src))).asString())
                     .replaceAll(String.format("$1:%s$2", this.version)),
-                target.resolve(
+                Paths.get(
                     src.toAbsolutePath().toString().substring(
                         this.sourcesDir.toPath().toAbsolutePath().toString().length() + 1
                     )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DepDirs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DepDirs.java
@@ -60,7 +60,7 @@ final class DepDirs extends ListEnvelope<String> {
      */
     private static List<String> list(final Path dir) throws IOException {
         final List<String> names = new LinkedList<>();
-        if (new Home().exists(dir)) {
+        if (Files.exists(Home.clean(dir))) {
             final String home = dir.toAbsolutePath().toString();
             names.addAll(
                 Files.find(dir, 4, (t, u) -> true)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FileHash.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FileHash.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.cactoos.bytes.BytesOf;
@@ -53,7 +54,7 @@ final class FileHash {
     @Override
     public String toString() {
         final String hash;
-        if (new Home().exists(this.file)) {
+        if (Files.exists(Home.clean(this.file))) {
             hash = Arrays.toString(
                 new UncheckedBytes(
                     new Md5DigestOf(new InputOf(new BytesOf(this.file)))

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FtCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FtCached.java
@@ -110,8 +110,8 @@ final class FtCached implements Footprint {
             text = this.load(program, ext);
         } else {
             text = new IoChecked<>(content).value();
-            new Home().save(text, cached);
+            new Home(this.cache).save(text, this.cache.relativize(cached));
         }
-        new Home().save(text, target);
+        new Home(this.main).save(text, this.main.relativize(target));
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FtDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FtDefault.java
@@ -61,10 +61,9 @@ final class FtDefault implements Footprint {
     @Override
     public void save(final String program, final String ext, final Scalar<String> content)
         throws IOException {
-        final Path target = new Place(program).make(this.main, ext);
         new Home(this.main).save(
             new IoChecked<>(content).value(),
-            this.main.relativize(target)
+            this.main.relativize(new Place(program).make(this.main, ext))
         );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FtDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FtDefault.java
@@ -61,9 +61,10 @@ final class FtDefault implements Footprint {
     @Override
     public void save(final String program, final String ext, final Scalar<String> content)
         throws IOException {
-        new Home().save(
+        final Path target = new Place(program).make(this.main, ext);
+        new Home(this.main).save(
             new IoChecked<>(content).value(),
-            new Place(program).make(this.main, ext)
+            this.main.relativize(target)
         );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
@@ -337,20 +337,22 @@ public final class GmiMojo extends SafeMojo {
         if (Logger.isTraceEnabled(this)) {
             Logger.trace(this, "GMIs:\n%s", instructions);
         }
-        new Home().save(instructions, gmi);
+        new Home(gmi.getParent()).save(instructions, gmi.getParent().relativize(gmi));
         if (this.generateGmiXmlFiles) {
-            new Home().save(
+            final Path sibling = gmi.resolveSibling(String.format("%s.xml", gmi.getFileName()));
+            new Home(sibling.getParent()).save(
                 after.toString(),
-                gmi.resolveSibling(String.format("%s.xml", gmi.getFileName()))
+                sibling.getParent().relativize(sibling)
             );
         }
         if (this.generateXemblyFiles) {
             final String xembly = new Xsline(GmiMojo.TO_XEMBLY)
                 .pass(after)
                 .xpath("/xembly/text()").get(0);
-            new Home().save(
+            final Path sibling = gmi.resolveSibling(String.format("%s.xe", gmi.getFileName()));
+            new Home(sibling.getParent()).save(
                 xembly,
-                gmi.resolveSibling(String.format("%s.xe", gmi.getFileName()))
+                sibling.getParent().relativize(sibling)
             );
             this.makeGraph(xembly, gmi);
         }
@@ -380,9 +382,12 @@ public final class GmiMojo extends SafeMojo {
                         .append(dirs)
                 ).domQuietly()
             );
-            new Home().save(
+            final Path sibling = gmi.resolveSibling(
+                String.format("%s.graph.xml", gmi.getFileName())
+            );
+            new Home(sibling.getParent()).save(
                 graph.toString(),
-                gmi.resolveSibling(String.format("%s.graph.xml", gmi.getFileName()))
+                sibling.getParent().relativize(sibling)
             );
             if (Logger.isTraceEnabled(this)) {
                 Logger.trace(this, "Graph:\n%s", graph.toString());
@@ -404,9 +409,10 @@ public final class GmiMojo extends SafeMojo {
             if (Logger.isTraceEnabled(this)) {
                 Logger.trace(this, "Dot:\n%s", dot);
             }
-            new Home().save(
+            final Path sibling = gmi.resolveSibling(String.format("%s.dot", gmi.getFileName()));
+            new Home(sibling.getParent()).save(
                 dot,
-                gmi.resolveSibling(String.format("%s.dot", gmi.getFileName()))
+                sibling.getParent().relativize(sibling)
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -45,6 +45,8 @@ import org.cactoos.scalar.LengthOf;
  * Base location for files.
  *
  * @since 0.27
+ * @todo #1352:30min Prohibit absolute paths in methods `save`, `load`, `exists`.
+ *  Throw an exception in case absolut path is given for these methods.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class Home {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -208,7 +208,8 @@ final class Home {
      * @param path Path
      * @return Clean path
      * @todo #1352:30min Move utility `clean` method out of `Home` class. Create
-     *  maybe separate class for this. Update all usages of this method.
+     *  maybe separate class for this. Consider removing this method at all as
+     *  it seems does nothing useful. Update all usages of this method.
      */
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static Path clean(final Path path) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -42,7 +42,7 @@ import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.LengthOf;
 
 /**
- * Class for saving and loading files.
+ * Base location for files.
  *
  * @since 0.27
  */
@@ -73,15 +73,16 @@ final class Home {
      * Saving input.
      *
      * @param input Input
-     * @param path Path to file
+     * @param path Cwd-relative path to file
      * @throws IOException If fails
      */
     public void save(final Input input, final Path path) throws IOException {
-        final File dir = path.toFile().getParentFile();
+        final Path target = this.absolute(path);
+        final File dir = target.toFile().getParentFile();
         if (dir.mkdirs()) {
             Logger.debug(
                 this, "Directory created: %s",
-                this.rel(path.getParent())
+                this.rel(target.getParent())
             );
         }
         try {
@@ -89,19 +90,19 @@ final class Home {
                 new LengthOf(
                     new TeeInput(
                         input,
-                        new OutputTo(path)
+                        new OutputTo(target)
                     )
                 )
             ).value();
             Logger.debug(
                 Home.class, "File %s saved (%d bytes)",
-                this.rel(path), bytes
+                target, bytes
             );
         } catch (final IOException ex) {
             throw new IOException(
                 String.format(
                     "Failed while trying to save to %s",
-                    this.rel(path)
+                    target
                 ),
                 ex
             );
@@ -112,7 +113,7 @@ final class Home {
      * Saving string.
      *
      * @param str String
-     * @param path Path to file
+     * @param path Cwd-relative path to file
      * @throws IOException If fails
      */
     public void save(final String str, final Path path) throws IOException {
@@ -123,7 +124,7 @@ final class Home {
      * Saving text.
      *
      * @param txt Text
-     * @param path Path to file
+     * @param path Cwd-relative path to file
      * @throws IOException If fails
      */
     public void save(final Text txt, final Path path) throws IOException {
@@ -134,7 +135,7 @@ final class Home {
      * Saving stream.
      *
      * @param stream Input stream
-     * @param path Path to file
+     * @param path Cwd-relative path to file
      * @throws IOException If fails
      */
     public void save(final InputStream stream, final Path path) throws IOException {
@@ -145,7 +146,7 @@ final class Home {
      * Saving bytes.
      *
      * @param bytes Byte array
-     * @param path Path to file
+     * @param path Cwd-relative path to file
      * @throws IOException If fails
      */
     public void save(final byte[] bytes, final Path path) throws IOException {
@@ -155,8 +156,14 @@ final class Home {
     /**
      * Make relative name from path.
      *
-     * @param file The path of the file or dir
+     * @param file Absolute path to a file or dir
      * @return Relative name to CWD
+     * @todo #1352:30min Make `rel` method strictly relative to base.
+     *  In most cases `rel` is used with empty `Home()` and given absolute path
+     *  which is not part of it. So it just returns absolute path.
+     *  Throw an exception in case give path is not sub-path of a base.
+     *  Along with that revise all usages of this method and replace applicable
+     *  with just `Path.relativize` or plain local vars.
      */
     public String rel(final Path file) {
         String path = file.toAbsolutePath().toString();
@@ -174,33 +181,46 @@ final class Home {
     /**
      * Check if exists.
      *
-     * @param path Path
+     * @param path Cwd-relative path to file
      * @return True if exists
      */
     public boolean exists(final Path path) {
-        return Files.exists(this.path(path));
+        return Files.exists(this.absolute(Home.clean(path)));
     }
 
     /**
      * Load bytes from file by path.
      *
-     * @param path Path to the file
+     * @param path Cwd-relative path to file
      * @return Bytes of file
      * @throws IOException if method can't find the file by path or
      *  if some exception happens during reading the file
      */
     public Bytes load(final Path path) throws IOException {
-        return new BytesOf(Files.readAllBytes(this.path(path)));
+        return new BytesOf(Files.readAllBytes(this.absolute(Home.clean(path))));
     }
 
     /**
-     * Path modification.
+     * Clean path.
      *
      * @param path Path
-     * @return Modified path (without bad symbols)
+     * @return Clean path
+     * @todo #1352:30min Move utility `clean` method out of `Home` class. Create
+     *  maybe separate class for this. Update all usages of this method.
      */
-    private static Path path(final Path path) {
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static Path clean(final Path path) {
         final byte[] bytes = path.toString().getBytes(StandardCharsets.UTF_8);
         return Paths.get(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Absolute path to a file.
+     *
+     * @param path Cwd-relative path to file
+     * @return Absolute path
+     */
+    private Path absolute(final Path path) {
+        return this.cwd.resolve(path);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -24,7 +24,6 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -80,8 +79,7 @@ final class Home {
      */
     public void save(final Input input, final Path path) throws IOException {
         final Path target = this.absolute(path);
-        final File dir = target.toFile().getParentFile();
-        if (dir.mkdirs()) {
+        if (target.toFile().getParentFile().mkdirs()) {
             Logger.debug(
                 this, "Directory created: %s",
                 this.rel(target.getParent())

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -100,12 +100,12 @@ final class JavaFiles {
             final Path dest = new Place(type).make(
                 generated, "java"
             );
-            new Home().save(
+            new Home(generated).save(
                 new Joined(
                     "",
                     java.xpath("java/text()")
                 ),
-                dest
+                generated.relativize(dest)
             );
             return dest;
         } catch (final InvalidPathException ex) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import com.yegor256.tojos.Tojo;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.regex.Pattern;
@@ -50,13 +51,13 @@ public final class MarkMojo extends SafeMojo {
     @SuppressWarnings({ "PMD.GuardLogStatement", "PMD.PrematureDeclaration" })
     public void exec() throws IOException {
         final Path home = this.targetDir.toPath().resolve(ResolveMojo.DIR);
-        if (new Home().exists(home)) {
+        if (Files.exists(home)) {
             final Collection<String> deps = new DepDirs(home);
             int found = 0;
             for (final String dep : deps) {
                 final Path dir = home.resolve(dep);
                 final Path sub = dir.resolve(CopyMojo.DIR);
-                if (!new Home().exists(sub)) {
+                if (!Files.exists(sub)) {
                     continue;
                 }
                 final String ver = dep.split(Pattern.quote(File.separator))[3];

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -273,7 +273,10 @@ public final class OptimizeMojo extends SafeMojo {
         final Path target = place.make(
             this.targetDir.toPath().resolve(OptimizeMojo.DIR), TranspileMojo.EXT
         );
-        new Home().save(xml.toString(), target);
+        new Home(this.targetDir.toPath()).save(
+            xml.toString(),
+            this.targetDir.toPath().relativize(target)
+        );
         Logger.debug(
             this, "Optimized %s (program:%s) to %s",
             new Home().rel(file), name, new Home().rel(target)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
@@ -28,7 +28,9 @@ import com.yegor256.tojos.Tojo;
 import com.yegor256.tojos.Tojos;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -101,7 +103,7 @@ public final class PlaceMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Path home = this.targetDir.toPath().resolve(ResolveMojo.DIR);
-        if (new Home().exists(home)) {
+        if (Files.exists(home)) {
             final Collection<String> deps = new DepDirs(home);
             int copied = 0;
             for (final String dep : deps) {
@@ -164,7 +166,7 @@ public final class PlaceMojo extends SafeMojo {
                 row -> row.get(Tojos.KEY).equals(target.toString())
                     && "class".equals(row.get(PlaceMojo.ATTR_KIND))
             );
-            if (!before.isEmpty() && !new Home().exists(target)) {
+            if (!before.isEmpty() && !Files.exists(target)) {
                 Logger.info(
                     this,
                     "The file %s has been placed to %s, but now it's gone, re-placing",
@@ -172,7 +174,7 @@ public final class PlaceMojo extends SafeMojo {
                     new Home().rel(target)
                 );
             }
-            if (!before.isEmpty() && new Home().exists(target)
+            if (!before.isEmpty() && Files.exists(target)
                 && target.toFile().length() == file.toFile().length()) {
                 Logger.debug(
                     this,
@@ -182,7 +184,7 @@ public final class PlaceMojo extends SafeMojo {
                 );
                 continue;
             }
-            if (!before.isEmpty() && new Home().exists(target)
+            if (!before.isEmpty() && Files.exists(target)
                 && target.toFile().length() != file.toFile().length()) {
                 Logger.debug(
                     this,
@@ -192,7 +194,7 @@ public final class PlaceMojo extends SafeMojo {
                     before.iterator().next().get(PlaceMojo.ATTR_ORIGIN)
                 );
             }
-            new Home().save(new InputOf(file), target);
+            new Home(this.outputDir.toPath()).save(new InputOf(file), Paths.get(path));
             this.placedTojos.value().add(target.toString())
                 .set(PlaceMojo.ATTR_KIND, "class")
                 .set(PlaceMojo.ATTR_HASH, new FileHash(target))

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -153,8 +153,9 @@ public final class PullMojo extends SafeMojo {
      * @throws IOException If fails
      */
     private Path pull(final String name) throws IOException {
+        final Path dir = this.targetDir.toPath().resolve(PullMojo.DIR);
         final Path src = new Place(name).make(
-            this.targetDir.toPath().resolve(PullMojo.DIR), "eo"
+            dir, "eo"
         );
         if (src.toFile().exists() && !this.overWrite) {
             Logger.debug(
@@ -162,9 +163,9 @@ public final class PullMojo extends SafeMojo {
                 name, new Home().rel(src)
             );
         } else {
-            new Home().save(
+            new Home(dir).save(
                 this.objectionary.get(name),
-                src
+                dir.relativize(src)
             );
             Logger.debug(
                 this, "The sources of the object '%s' pulled to %s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -28,6 +28,7 @@ import com.jcabi.xml.XMLDocument;
 import com.yegor256.tojos.Tojo;
 import com.yegor256.tojos.Tojos;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -112,7 +113,7 @@ public final class ResolveMojo extends SafeMojo {
                 .resolve(dep.getArtifactId())
                 .resolve(classifier)
                 .resolve(dep.getVersion());
-            if (new Home().exists(dest)) {
+            if (Files.exists(dest)) {
                 Logger.debug(
                     this, "Dependency %s already resolved to %s",
                     coords, new Home().rel(dest)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SpyTrain.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SpyTrain.java
@@ -31,6 +31,7 @@ import com.yegor256.xsline.TrEnvelope;
 import com.yegor256.xsline.TrLambda;
 import com.yegor256.xsline.Train;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Train that spies.
@@ -55,11 +56,9 @@ final class SpyTrain extends TrEnvelope {
                         shift::uid,
                         (pos, xml) -> {
                             final String log = shift.uid().replaceAll("[^a-z0-9]", "-");
-                            new Home().save(
+                            new Home(dir).save(
                                 xml.toString(),
-                                dir.resolve(
-                                    String.format("%02d-%s.xml", pos, log)
-                                )
+                                Paths.get(String.format("%02d-%s.xml", pos, log))
                             );
                             if (Logger.isDebugEnabled(SpyTrain.class)) {
                                 Logger.debug(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -209,7 +209,9 @@ public final class TranspileMojo extends SafeMojo {
             )
         );
         final XML out = new Xsline(trn).pass(input);
-        new Home().save(out.toString(), target);
+        final Path dir = this.targetDir.toPath().resolve(TranspileMojo.DIR);
+        new Home(dir)
+            .save(out.toString(), dir.relativize(target));
         return new JavaFiles(
             target,
             this.generatedDir.toPath()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -247,7 +247,7 @@ public final class UnplaceMojo extends SafeMojo {
     private static boolean delete(final Path file) throws IOException {
         Path dir = file.getParent();
         boolean deleted = false;
-        if (new Home().exists(file)) {
+        if (Files.exists(file)) {
             Files.delete(file);
             deleted = true;
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnspileMojo.java
@@ -137,7 +137,7 @@ public final class UnspileMojo extends SafeMojo {
             name.replaceAll("\\.class$", ".java")
         );
         boolean deleted = false;
-        if (new Home().exists(java)) {
+        if (Files.exists(java)) {
             Files.delete(file);
             Logger.debug(
                 this, "Deleted %s since %s is present",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
@@ -121,7 +121,7 @@ final class Walk extends ListEnvelope<Path> {
      */
     private static List<Path> list(final Path dir) throws IOException {
         final List<Path> files = new LinkedList<>();
-        if (new Home().exists(dir)) {
+        if (Files.exists(dir)) {
             files.addAll(
                 Files.walk(dir)
                     .filter(file -> !file.toFile().isDirectory())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.io.InputOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -41,14 +42,14 @@ final class AssembleMojoTest {
     @Test
     void assemblesTogether(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("src");
-        new Home().save(
+        new Home(src).save(
             String.join(
                 "\n",
                 "+alias stdout org.eolang.io.stdout",
                 "",
                 "[x] > main\n  (stdout \"Hello!\" x).print\n"
             ),
-            src.resolve("main.eo")
+            Paths.get("main.eo")
         );
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)
@@ -73,8 +74,8 @@ final class AssembleMojoTest {
             )
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.%s",
                         ParseMojo.DIR, TranspileMojo.EXT
@@ -88,7 +89,7 @@ final class AssembleMojoTest {
     @Test
     void assemblesNotFailWithFailOnErrorFlag(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("src");
-        new Home().save(
+        new Home(src).save(
             String.join(
                 "\n",
                 "+alias stdout org.eolang.io.stdout",
@@ -96,9 +97,9 @@ final class AssembleMojoTest {
                 "",
                 "[x] < wrong>\n  (stdout \"Hello!\" x).print\n"
             ),
-            src.resolve("wrong.eo")
+            Paths.get("wrong.eo")
         );
-        new Home().save(
+        new Home(src).save(
             String.join(
                 "\n",
                 "+alias stdout org.eolang.io.stdout",
@@ -106,7 +107,7 @@ final class AssembleMojoTest {
                 "",
                 "[x] > main\n  (stdout \"Hello!\" x).print\n"
             ),
-            src.resolve("main.eo")
+            Paths.get("main.eo")
         );
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)
@@ -132,8 +133,8 @@ final class AssembleMojoTest {
             )
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.%s",
                         ParseMojo.DIR, TranspileMojo.EXT
@@ -143,8 +144,8 @@ final class AssembleMojoTest {
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/main.%s",
                         ParseMojo.DIR, TranspileMojo.EXT

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.io.InputOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -61,14 +62,14 @@ class CleanMojoTest {
     @Test
     void fullCompilingLifecycleSuccessfully(@TempDir final Path temp) throws IOException {
         final Path src = temp.resolve("src");
-        new Home().save(
+        new Home(src).save(
             String.join(
                 "\n",
                 "+alias stdout org.eolang.io.stdout",
                 "",
                 "[x] > main\n  (stdout \"Hello!\" x).print\n"
             ),
-            src.resolve("main.eo")
+            Paths.get("main.eo")
         );
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CopyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CopyMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -41,9 +42,9 @@ final class CopyMojoTest {
     void copiesSources(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("src");
         final Path classes = temp.resolve("classes");
-        new Home().save(
+        new Home(src).save(
             "+rt foo:0.0.0\n\n[args] > main\n  \"0.0.0\" > @\n",
-            src.resolve("foo/main.eo")
+            Paths.get("foo/main.eo")
         );
         final String ver = "1.1.1";
         new Moja<>(CopyMojo.class)
@@ -53,11 +54,11 @@ final class CopyMojoTest {
             .execute();
         final Path out = classes.resolve("EO-SOURCES/foo/main.eo");
         MatcherAssert.assertThat(
-            new Home().exists(out),
+            new Home(classes).exists(classes.relativize(out)),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new TextOf(new Home().load(out)).asString(),
+            new TextOf(new Home(classes).load(classes.relativize(out))).asString(),
             Matchers.allOf(
                 Matchers.containsString("+rt foo:"),
                 Matchers.containsString("0.0.0"),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DepDirsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DepDirsTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,10 +41,10 @@ final class DepDirsTest {
 
     @Test
     void findsDirs(@TempDir final Path temp) throws IOException {
-        new Home().save("", temp.resolve("a/b/c/f/test.txt"));
-        new Home().save("", temp.resolve("a/b/f.txt"));
-        new Home().save("", temp.resolve("test/f.txt"));
-        new Home().save("", temp.resolve("a/g"));
+        new Home(temp).save("", Paths.get("a/b/c/f/test.txt"));
+        new Home(temp).save("", Paths.get("a/b/f.txt"));
+        new Home(temp).save("", Paths.get("test/f.txt"));
+        new Home(temp).save("", Paths.get("a/g"));
         MatcherAssert.assertThat(
             new DepDirs(temp),
             Matchers.contains(String.format("a%sb%1$sc%1$sf", File.separator))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -82,7 +82,7 @@ final class DiscoverMojoTest {
 
     private void saveProgram(final Path temp, final Input code) throws IOException {
         final Path program = temp.resolve("program.eo");
-        new Home().save(code, program);
+        new Home(temp).save(code, temp.relativize(program));
         Catalogs.INSTANCE.make(temp.resolve(DiscoverMojoTest.EO_FOREIGN), "json")
             .add("foo.src")
             .set(AssembleMojo.ATTR_SCOPE, "compile")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FileHashTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FileHashTest.java
@@ -40,7 +40,7 @@ final class FileHashTest {
     @Test
     void readsFromExistingFile(@TempDir final Path temp) throws IOException {
         final Path path = temp.resolve("1.txt");
-        new Home().save("hey, you", path);
+        new Home(temp).save("hey, you", temp.relativize(path));
         MatcherAssert.assertThat(
             new FileHash(path).toString(),
             Matchers.startsWith("[-26, 1, -29, 113, ")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/GmiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/GmiMojoTest.java
@@ -143,7 +143,7 @@ final class GmiMojoTest {
     private static XML toGraph(final String code, final String inclusion) throws IOException {
         final Path temp = Files.createTempDirectory("eo");
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(code, src);
+        new Home(temp).save(code, temp.relativize(src));
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
         Catalogs.INSTANCE.make(foreign)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
@@ -23,14 +23,12 @@
  */
 package org.eolang.maven;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -71,7 +69,7 @@ final class HomeTest {
 
     @Test
     void existsTest(@TempDir final Path temp) throws IOException {
-        HomeTest.write(temp.resolve("file.txt"), "any content");
+        Files.write(temp.resolve("file.txt"), "any content".getBytes());
         MatcherAssert.assertThat(
             new Home(temp).exists(Paths.get("file.txt")),
             Matchers.is(true)
@@ -82,7 +80,7 @@ final class HomeTest {
     void existsInDirTest(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("dir/subdir/file.txt");
         target.getParent().toFile().mkdirs();
-        HomeTest.write(target, "any content");
+        Files.write(target, "any content".getBytes());
         MatcherAssert.assertThat(
             new Home(temp.resolve("dir")).exists(Paths.get("subdir/file.txt")),
             Matchers.is(true)
@@ -143,21 +141,5 @@ final class HomeTest {
             new TextOf(home.load(subfolder)),
             Matchers.equalTo(new TextOf(content))
         );
-    }
-
-    /**
-     * Write file content.
-     * @param target Path to a file
-     * @param content Content
-     * @throws IOException In case I/O exceptions.
-     */
-    private static void write(final Path target, final String content) throws IOException {
-        final BufferedWriter file = Files.newBufferedWriter(
-            target,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.WRITE
-        );
-        file.write(content);
-        file.close();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
@@ -23,12 +23,14 @@
  */
 package org.eolang.maven;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.cactoos.Bytes;
+import java.nio.file.StandardOpenOption;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -52,7 +54,7 @@ final class HomeTest {
     void saves(final int size, @TempDir final Path temp) throws IOException {
         final Path resolve = temp.resolve("1.txt");
         final String content = new UncheckedText(new Randomized(size)).asString();
-        new Home().save(content, resolve);
+        new Home(temp).save(content, resolve);
         MatcherAssert.assertThat(
             new UncheckedText(new TextOf(resolve)).asString(),
             Matchers.is(content)
@@ -69,18 +71,20 @@ final class HomeTest {
 
     @Test
     void existsTest(@TempDir final Path temp) throws IOException {
-        new Home().save("any content", temp.resolve("file.txt"));
+        HomeTest.write(temp.resolve("file.txt"), "any content");
         MatcherAssert.assertThat(
-            new Home().exists(temp.resolve("file.txt")),
+            new Home(temp).exists(Paths.get("file.txt")),
             Matchers.is(true)
         );
     }
 
     @Test
     void existsInDirTest(@TempDir final Path temp) throws IOException {
-        new Home(Paths.get("dir")).save("any content", temp.resolve("file.txt"));
+        final Path target = temp.resolve("dir/subdir/file.txt");
+        target.getParent().toFile().mkdirs();
+        HomeTest.write(target, "any content");
         MatcherAssert.assertThat(
-            new Home(Paths.get("dir")).exists(temp.resolve("file.txt")),
+            new Home(temp.resolve("dir")).exists(Paths.get("subdir/file.txt")),
             Matchers.is(true)
         );
     }
@@ -90,9 +94,9 @@ final class HomeTest {
         final String filename = "文件名.txt";
         final byte[] bytes = filename.getBytes(StandardCharsets.UTF_16BE);
         final String decoded = new String(bytes, StandardCharsets.UTF_16BE);
-        new Home(Paths.get("directory")).save("any content", temp.resolve(decoded));
+        new Home(Paths.get("directory")).save("any content", Paths.get(decoded));
         MatcherAssert.assertThat(
-            new Home(Paths.get("directory")).exists(temp.resolve(filename)),
+            new Home(Paths.get("directory")).exists(Paths.get(filename)),
             Matchers.is(true)
         );
     }
@@ -102,29 +106,58 @@ final class HomeTest {
         final String filename = "EOorg/EOeolang/EOmath/EOnan$EOas_int$EO@";
         final byte[] bytes = filename.getBytes("CP1252");
         final String decoded = new String(bytes, "CP1252");
-        new Home(Paths.get("directory")).save("any content", temp.resolve(decoded));
+        new Home(Paths.get("directory")).save("any content", Paths.get(decoded));
         MatcherAssert.assertThat(
-            new Home(Paths.get("directory")).exists(temp.resolve(filename)),
+            new Home(Paths.get("directory")).exists(Paths.get(filename)),
             Matchers.is(true)
         );
     }
 
     @Test
     void loadBytesFromExistingFile(@TempDir final Path temp) throws IOException {
-        final Home home = new Home();
-        final String filename = "foo";
+        final Home home = new Home(temp);
         final String content = "bar";
-        final Path subfolder = temp.resolve("subfolder").resolve(filename);
+        final Path subfolder = Paths.get("subfolder").resolve("foo.txt");
         home.save(content, subfolder);
-        final Bytes bytes = home.load(subfolder);
-        final TextOf text = new TextOf(bytes);
-        MatcherAssert.assertThat(text, Matchers.equalTo(new TextOf(content)));
+        MatcherAssert.assertThat(
+            new TextOf(home.load(subfolder)),
+            Matchers.equalTo(new TextOf(content))
+        );
     }
 
     @Test
     void loadFromAbsentFile(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            NoSuchFileException.class,
+            () -> new Home(temp).load(temp.resolve("nonexistent"))
+        );
+    }
+
+    @Test
+    void savesToCwd() throws IOException {
         final Home home = new Home();
-        final Path absent = temp.resolve("nonexistent");
-        Assertions.assertThrows(NoSuchFileException.class, () -> home.load(absent));
+        final String content = "bar";
+        final Path subfolder = Paths.get("subfolder").resolve("foo.txt");
+        home.save(content, subfolder);
+        MatcherAssert.assertThat(
+            new TextOf(home.load(subfolder)),
+            Matchers.equalTo(new TextOf(content))
+        );
+    }
+
+    /**
+     * Write file content.
+     * @param target Path to a file
+     * @param content Content
+     * @throws IOException In case I/O exceptions.
+     */
+    private static void write(final Path target, final String content) throws IOException {
+        final BufferedWriter file = Files.newBufferedWriter(
+            target,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE
+        );
+        file.write(content);
+        file.close();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -39,9 +40,9 @@ final class MarkMojoTest {
     @Test
     void extendForeignWithNewObjects(@TempDir final Path temp) throws Exception {
         final Path bins = temp.resolve(ResolveMojo.DIR);
-        new Home().save(
+        new Home(bins).save(
             "hi",
-            bins.resolve(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR))
+            Paths.get(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR))
         );
         final Path foreign = temp.resolve("placed.json");
         new Moja<>(MarkMojo.class)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -32,6 +32,7 @@ import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Xsline;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
@@ -51,9 +52,9 @@ final class OptimizeMojoTest {
     @Test
     void skipsAlreadyOptimized(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(
+        new Home(temp).save(
             "+package f\n\n[args] > main\n  (stdout \"Hello!\").print > @\n",
-            src
+            temp.relativize(src)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");
@@ -90,9 +91,9 @@ final class OptimizeMojoTest {
     @Test
     void optimizesIfExpired(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(
+        new Home(temp).save(
             "+package f\n\n[args] > main\n  (stdout \"Hello!\").print > @\n",
-            src
+            temp.relativize(src)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");
@@ -131,9 +132,9 @@ final class OptimizeMojoTest {
     @Test
     void testSimpleOptimize(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(
+        new Home(temp).save(
             "+package f\n\n[args] > main\n  (stdout \"Hello!\").print > @\n",
-            src
+            temp.relativize(src)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");
@@ -154,16 +155,16 @@ final class OptimizeMojoTest {
             .with("foreignFormat", "csv")
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format("%s/foo/main/00-not-empty-atoms.xml", OptimizeMojo.STEPS)
                 )
             ),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format("%s/foo/main.%s", OptimizeMojo.DIR, TranspileMojo.EXT)
                 )
             ),
@@ -174,7 +175,7 @@ final class OptimizeMojoTest {
     @Test
     void testOptimizeWithFailOnErrorFlag(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(
+        new Home(temp).save(
             String.join(
                 "\n",
                 "+package f",
@@ -182,7 +183,7 @@ final class OptimizeMojoTest {
                 "[args] > main",
                 "  (stdout \"Hello!\").print > @\n"
             ),
-            src
+            temp.relativize(src)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");
@@ -215,7 +216,7 @@ final class OptimizeMojoTest {
     @Test
     void testOptimizedFail(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/main.eo");
-        new Home().save(
+        new Home(temp).save(
             String.join(
                 "\n",
                 "+package f",
@@ -223,7 +224,7 @@ final class OptimizeMojoTest {
                 "[args] > main",
                 "  (stdout \"Hello!\").print > @\n"
             ),
-            src
+            temp.relativize(src)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");
@@ -250,7 +251,10 @@ final class OptimizeMojoTest {
     @Test
     void testFailOnWarning(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo.src.eo");
-        new Home().save(new ResourceOf("org/eolang/maven/withwarning.eo"), src);
+        new Home(temp).save(
+            new ResourceOf("org/eolang/maven/withwarning.eo"),
+            temp.relativize(src)
+        );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
         Catalogs.INSTANCE.make(foreign)
@@ -293,6 +297,6 @@ final class OptimizeMojoTest {
                             new ResourceOf(xsl).stream()
                         )))
         ).pass(new XMLDocument(xml));
-        new Home().save(output.toString(), xml);
+        new Home(xml.getParent()).save(output.toString(), xml.getParent().relativize(xml));
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import com.yegor256.tojos.TjSmart;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -47,9 +48,9 @@ final class ParseMojoTest {
     void testSimpleParsing(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/x/main.eo");
         final Path target = temp.resolve("target");
-        new Home().save(
+        new Home(temp).save(
             "+package f\n\n[args] > main\n  (stdout \"Hello!\").print\n",
-            src
+            temp.relativize(src)
         );
         final Path foreign = temp.resolve("eo-foreign.csv");
         Catalogs.INSTANCE.make(foreign)
@@ -63,8 +64,8 @@ final class ParseMojoTest {
             .with("foreignFormat", "csv")
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format("%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
                 )
             ),
@@ -82,9 +83,9 @@ final class ParseMojoTest {
     void testSimpleParsingCached(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("foo/x/main.eo");
         final Path target = temp.resolve("target");
-        new Home().save(
+        new Home(temp).save(
             "invalid content",
-            src
+            temp.relativize(src)
         );
         final Path foreign = temp.resolve("eo-foreign.csv");
         new FtCached(
@@ -110,8 +111,8 @@ final class ParseMojoTest {
             .with("cache", temp.resolve("parsed"))
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format("%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
                 )
             ),
@@ -129,7 +130,7 @@ final class ParseMojoTest {
     void testCrashOnInvalidSyntax(@TempDir final Path temp)
         throws Exception {
         final Path src = temp.resolve("bar/src.eo");
-        new Home().save("something < is wrong here", src);
+        new Home(temp).save("something < is wrong here", temp.relativize(src));
         final Path foreign = temp.resolve("foreign-1");
         Catalogs.INSTANCE.make(foreign)
             .add("bar.src")
@@ -150,7 +151,7 @@ final class ParseMojoTest {
     void testCrashesWithFileName(@TempDir final Path temp)
         throws Exception {
         final Path src = temp.resolve("bar/src.eo");
-        new Home().save("something < is wrong here", src);
+        new Home(temp).save("something < is wrong here", temp.relativize(src));
         final Path foreign = temp.resolve("foreign-1");
         Catalogs.INSTANCE.make(foreign)
             .add("bar.src")
@@ -173,9 +174,9 @@ final class ParseMojoTest {
         throws Exception {
         final Path src = temp.resolve("foo/x/main.eo");
         final Path target = temp.resolve("target");
-        new Home().save(
+        new Home(temp).save(
             "something < is wrong here",
-            src
+            temp.relativize(src)
         );
         final Path foreign = temp.resolve("eo-foreign");
         Catalogs.INSTANCE.make(foreign)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import com.yegor256.tojos.Tojos;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -42,24 +43,24 @@ final class PlaceMojoTest {
     void placesBinaries(@TempDir final Path temp) throws Exception {
         final Path bins = temp.resolve(ResolveMojo.DIR);
         final Path classes = temp.resolve("classes");
-        new Home().save("x1", bins.resolve("foo/hello/-/0.1/EObar/x.bin"));
-        new Home().save("x2", bins.resolve("foo/hello/-/0.1/org/eolang/f/x.a.class"));
-        new Home().save("x3", bins.resolve("foo/hello/-/0.1/org/eolang/t.txt"));
+        new Home(bins).save("x1", Paths.get("foo/hello/-/0.1/EObar/x.bin"));
+        new Home(bins).save("x2", Paths.get("foo/hello/-/0.1/org/eolang/f/x.a.class"));
+        new Home(bins).save("x3", Paths.get("foo/hello/-/0.1/org/eolang/t.txt"));
         new Moja<>(PlaceMojo.class)
             .with("targetDir", temp.toFile())
             .with("outputDir", classes.toFile())
             .with("placed", temp.resolve("placed.json").toFile())
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(classes.resolve("EObar/x.bin")),
+            new Home(classes).exists(Paths.get("EObar/x.bin")),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new Home().exists(classes.resolve("org/eolang/f/x.a.class")),
+            new Home(classes).exists(classes.resolve("org/eolang/f/x.a.class")),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new Home().exists(classes.resolve("org/eolang/t.txt")),
+            new Home(classes).exists(classes.resolve("org/eolang/t.txt")),
             Matchers.is(true)
         );
     }
@@ -69,9 +70,9 @@ final class PlaceMojoTest {
         final Path bins = temp.resolve(ResolveMojo.DIR);
         final Path classes = temp.resolve("classes");
         final Path placed = temp.resolve("placed.json");
-        new Home().save("x1", bins.resolve("foo/hello/-/0.1/EObar/x.bin"));
-        new Home().save("x1", classes.resolve("EObar/x.bin"));
-        new Home().save("x2", bins.resolve("foo/hello/-/0.1/org/eolang/f/x.a.class"));
+        new Home(bins).save("x1", Paths.get("foo/hello/-/0.1/EObar/x.bin"));
+        new Home(classes).save("x1", Paths.get("EObar/x.bin"));
+        new Home(bins).save("x2", Paths.get("foo/hello/-/0.1/org/eolang/f/x.a.class"));
         new Moja<>(PlaceMojo.class)
             .with("targetDir", temp.toFile())
             .with("outputDir", classes.toFile())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.io.InputOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -55,8 +56,8 @@ final class PullMojoTest {
             )
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.eo",
                         PullMojo.DIR

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -25,6 +25,7 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -42,14 +43,14 @@ final class ResolveMojoTest {
     @Test
     void testSimpleResolve(@TempDir final Path temp) throws Exception {
         final Path src = temp.resolve("src");
-        new Home().save(
+        new Home(src).save(
             String.format(
                 "%s\n%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:jar-with-dependencies:0.7.0",
                 "+rt jvm org.eolang:eo-sys:jar-with-dependencies:0.0.5",
                 "[] > foo /int"
             ),
-            src.resolve("foo.eo")
+            Paths.get("foo.eo")
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -81,22 +82,22 @@ final class ResolveMojoTest {
     @Test
     void testConflictingDependencies(@TempDir final Path temp) throws IOException {
         final Path first = temp.resolve("src/foo1.src");
-        new Home().save(
+        new Home(temp).save(
             String.format(
                 "%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:0.22.1",
                 "[] > foo /int"
             ),
-            first
+            temp.relativize(first)
         );
         final Path second = temp.resolve("src/foo2.src");
-        new Home().save(
+        new Home(temp).save(
             String.format(
                 "%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:0.22.0",
                 "[] > foo /int"
             ),
-            second
+            temp.relativize(second)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -141,22 +142,22 @@ final class ResolveMojoTest {
     @Test
     void testConflictingDependenciesNoFail(@TempDir final Path temp) throws IOException {
         final Path first = temp.resolve("src/foo1.src");
-        new Home().save(
+        new Home(temp).save(
             String.format(
                 "%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:jar-with-dependencies:0.22.1",
                 "[] > foo /int"
             ),
-            first
+            temp.relativize(first)
         );
         final Path second = temp.resolve("src/foo2.src");
-        new Home().save(
+        new Home(temp).save(
             String.format(
                 "%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:jar-with-dependencies:0.22.0",
                 "[] > foo /int"
             ),
-            second
+            temp.relativize(second)
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.io.InputOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -44,8 +45,8 @@ class SkipTest {
         final Path target = temp.resolve("target");
         this.executePullMojo(temp, target, false);
         MatcherAssert.assertThat(
-            new Home().exists(
-                target.resolve(
+            new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.eo",
                         PullMojo.DIR
@@ -61,8 +62,8 @@ class SkipTest {
         final Path target = temp.resolve("target");
         this.executePullMojo(temp, target, true);
         MatcherAssert.assertThat(
-            !new Home().exists(
-                target.resolve(
+            !new Home(target).exists(
+                Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.eo",
                         PullMojo.DIR
@@ -79,7 +80,7 @@ class SkipTest {
         this.executeCopyMojo(temp, classes, true);
         final Path out = classes.resolve("EO-SOURCES/foo/main.eo");
         MatcherAssert.assertThat(
-            !new Home().exists(out),
+            !new Home(classes).exists(classes.relativize(out)),
             Matchers.is(true)
         );
     }
@@ -90,7 +91,7 @@ class SkipTest {
         this.executeCopyMojo(temp, classes, false);
         final Path out = classes.resolve("EO-SOURCES/foo/main.eo");
         MatcherAssert.assertThat(
-            new Home().exists(out),
+            new Home(classes).exists(classes.relativize(out)),
             Matchers.is(true)
         );
     }
@@ -123,9 +124,9 @@ class SkipTest {
         final boolean skip
     ) throws IOException {
         final Path src = temp.resolve("src");
-        new Home().save(
+        new Home(src).save(
             "+rt foo:0.0.0\n\n[args] > main\n  \"0.0.0\" > @\n",
-            src.resolve("foo/main.eo")
+            Paths.get("foo/main.eo")
         );
         final String ver = "1.1.1";
         new Moja<>(CopyMojo.class)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -140,7 +140,7 @@ final class SnippetTest {
     private static int run(final Path tmp, final Input code, final List<String> args,
         final Input stdin, final Output stdout) throws Exception {
         final Path src = tmp.resolve("src");
-        new Home().save(code, src.resolve("code.eo"));
+        new Home(src).save(code, Paths.get("code.eo"));
         final Path target = tmp.resolve("target");
         final Path foreign = target.resolve("eo-foreign.json");
         new Moja<>(RegisterMojo.class)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
@@ -50,7 +51,7 @@ final class TranspileMojoTest {
         throws Exception {
         final Input source = new ResourceOf("org/eolang/maven/mess.eo");
         final Path src = temp.resolve("foo.src.eo");
-        new Home().save(source, src);
+        new Home(temp).save(source, temp.relativize(src));
         final Path target = temp.resolve("target");
         final Path generated = temp.resolve("generated");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -81,7 +82,7 @@ final class TranspileMojoTest {
         final Path java = generated.resolve("EOorg/EOeolang/EOexamples/EOmessTest.java");
         MatcherAssert.assertThat(
             String.format("The file \"%s\" wasn't created", java),
-            new Home().exists(java),
+            new Home(temp).exists(temp.relativize(java)),
             Matchers.is(true)
         );
         final long before = java.toFile().lastModified();
@@ -106,7 +107,7 @@ final class TranspileMojoTest {
         throws Exception {
         final Input source = new ResourceOf("org/eolang/maven/mess.eo");
         final Path src = temp.resolve("foo.src.eo");
-        new Home().save(source, src);
+        new Home(temp).save(source, temp.relativize(src));
         final Path target = temp.resolve("target");
         final Path generated = temp.resolve("generated");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -138,14 +139,14 @@ final class TranspileMojoTest {
         final Path java = generated.resolve("EOorg/EOeolang/EOexamples/EOmessTest.java");
         MatcherAssert.assertThat(
             String.format("The file \"%s\" wasn't created", java),
-            new Home().exists(java),
+            new Home(temp).exists(temp.relativize(java)),
             Matchers.is(true)
         );
         Assertions.assertTrue(java.toFile().setLastModified(0L));
         final Path xmir = target.resolve("06-transpile")
             .resolve("foo")
             .resolve("src.xmir");
-        Assertions.assertTrue(new Home().exists(xmir));
+        Assertions.assertTrue(new Home(temp).exists(temp.relativize(xmir)));
         Assertions.assertTrue(xmir.toFile().setLastModified(0L));
         new Moja<>(TranspileMojo.class)
             .with("project", new MavenProjectStub())
@@ -167,7 +168,7 @@ final class TranspileMojoTest {
         throws Exception {
         final Input source = new ResourceOf("org/eolang/maven/mess.eo");
         final Path src = temp.resolve("foo.src.eo");
-        new Home().save(source, src);
+        new Home(temp).save(source, temp.relativize(src));
         final Path target = temp.resolve("target");
         final Path generated = temp.resolve("generated");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -198,14 +199,14 @@ final class TranspileMojoTest {
         final Path java = generated.resolve("EOorg/EOeolang/EOexamples/EOmessTest.java");
         MatcherAssert.assertThat(
             String.format("The file \"%s\" wasn't created", java),
-            new Home().exists(java),
+            new Home(temp).exists(temp.relativize(java)),
             Matchers.is(true)
         );
         Assertions.assertTrue(java.toFile().setLastModified(0L));
         final Path xmir = target.resolve("06-transpile")
             .resolve("foo")
             .resolve("src.xmir");
-        Assertions.assertTrue(new Home().exists(xmir));
+        Assertions.assertTrue(new Home(temp).exists(temp.relativize(xmir)));
         new Moja<>(TranspileMojo.class)
             .with("project", new MavenProjectStub())
             .with("targetDir", target.toFile())
@@ -236,7 +237,7 @@ final class TranspileMojoTest {
     void testRealCompilation(@TempDir final Path temp)
         throws Exception {
         final Path src = Paths.get("../eo-runtime/src/main/eo/org/eolang/array.eo");
-        Assumptions.assumeTrue(new Home().exists(src));
+        Assumptions.assumeTrue(Files.exists(src));
         final String java = this.compile(
             temp,
             new InputOf(src),
@@ -259,7 +260,7 @@ final class TranspileMojoTest {
         final String file
     ) throws Exception {
         final Path src = temp.resolve("foo.src.eo");
-        new Home().save(code, src);
+        new Home(temp).save(code, temp.relativize(src));
         final Path target = temp.resolve("target");
         final Path generated = temp.resolve("generated");
         final Path foreign = temp.resolve("eo-foreign.json");
@@ -291,7 +292,7 @@ final class TranspileMojoTest {
         final Path java = generated.resolve(file);
         MatcherAssert.assertThat(
             String.format("The file \"%s\" wasn't created", java),
-            new Home().exists(java),
+            Files.exists(java),
             Matchers.is(true)
         );
         return java;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -110,8 +110,7 @@ final class UnplaceMojoTest {
     @Test
     void testKeepBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo5.class");
-        final Home home = new Home(temp);
-        home.save("testKeepBinaries", temp.relativize(foo));
+        new Home(temp).save("testKeepBinaries", temp.relativize(foo));
         final Path pparent = foo.getParent().getParent();
         final Path list = temp.resolve("placed.csv");
         Catalogs.INSTANCE.make(list)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.set.SetOf;
@@ -46,14 +47,15 @@ final class UnplaceMojoTest {
     @Test
     void testCleaning(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo.class");
-        new Home().save("...", foo);
+        final Home home = new Home(temp);
+        home.save("...", temp.relativize(foo));
         final Path pparent = foo.getParent().getParent();
         final Path foo2 = temp.resolve("a/b/c/foo2.class");
-        new Home().save("...", foo2);
+        home.save("...", temp.relativize(foo2));
         final Path foo3 = temp.resolve("a/b/c/d/foo3.class");
-        new Home().save("...", foo3);
+        home.save("...", temp.relativize(foo3));
         final Path foo4 = temp.resolve("a/b/c/e/foo4.class");
-        new Home().save("...", foo4);
+        home.save("...", temp.relativize(foo4));
         final Path list = temp.resolve("placed.csv");
         Catalogs.INSTANCE.make(list)
             .add(foo.toString())
@@ -84,23 +86,23 @@ final class UnplaceMojoTest {
             .with("placedFormat", "csv")
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(foo),
+            Files.exists(foo),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            new Home().exists(foo2),
+            Files.exists(foo2),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            new Home().exists(foo3),
+            Files.exists(foo3),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            new Home().exists(foo4),
+            Files.exists(foo4),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            new Home().exists(Paths.get(String.valueOf(pparent))),
+            Files.exists(Paths.get(String.valueOf(pparent))),
             Matchers.is(false)
         );
     }
@@ -108,7 +110,8 @@ final class UnplaceMojoTest {
     @Test
     void testKeepBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo5.class");
-        new Home().save("testKeepBinaries", foo);
+        final Home home = new Home(temp);
+        home.save("testKeepBinaries", temp.relativize(foo));
         final Path pparent = foo.getParent().getParent();
         final Path list = temp.resolve("placed.csv");
         Catalogs.INSTANCE.make(list)
@@ -123,11 +126,11 @@ final class UnplaceMojoTest {
             .with("keepBinaries", new SetOf<>("**foo5.class"))
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(foo),
+            Files.exists(foo),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new Home().exists(Paths.get(String.valueOf(pparent))),
+            Files.exists(Paths.get(String.valueOf(pparent))),
             Matchers.is(true)
         );
     }
@@ -135,7 +138,8 @@ final class UnplaceMojoTest {
     @Test
     void testKeepRemoveBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo6.class");
-        new Home().save("testKeepRemoveBinaries", foo);
+        final Home home = new Home(temp);
+        home.save("testKeepRemoveBinaries", temp.relativize(foo));
         final Path pparent = foo.getParent().getParent();
         final Path list = temp.resolve("placed.csv");
         Catalogs.INSTANCE.make(list)
@@ -151,11 +155,11 @@ final class UnplaceMojoTest {
             .with("removeBinaries", new SetOf<>("**foo6.class"))
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(foo),
+            Files.exists(temp.relativize(foo)),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            new Home().exists(Paths.get(String.valueOf(pparent))),
+            Files.exists(Paths.get(String.valueOf(pparent))),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnspileMojoTest.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.maven;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -38,18 +40,18 @@ final class UnspileMojoTest {
 
     @Test
     void testCleaning(@TempDir final Path temp) throws Exception {
-        final Path generated = temp.resolve("generated");
-        final Path classes = temp.resolve("classes");
-        final Path foo = classes.resolve("a/b/c/foo.class");
-        new Home().save("abc", foo);
-        new Home().save("xxx", generated.resolve("a/b/c/foo.java"));
-        new Home().save("cde", classes.resolve("foo.txt"));
+        final Path generated = Paths.get("generated");
+        final Path classes = Paths.get("classes");
+        final Path foo = Paths.get("a/b/c/foo.class");
+        new Home(temp).save("abc", foo);
+        new Home(temp).save("xxx", generated.resolve("a/b/c/foo.java"));
+        new Home(temp).save("cde", classes.resolve("foo.txt"));
         new Moja<>(UnspileMojo.class)
             .with("generatedDir", generated.toFile())
             .with("classesDir", classes.toFile())
             .execute();
         MatcherAssert.assertThat(
-            new Home().exists(foo),
+            Files.exists(foo),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WalkTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WalkTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,8 +40,8 @@ final class WalkTest {
 
     @Test
     void findsFiles(@TempDir final Path temp) throws Exception {
-        new Home().save("", temp.resolve("foo/hello/0.1/EObar/x.bin"));
-        new Home().save("", temp.resolve("EOxxx/bar"));
+        new Home(temp).save("", Paths.get("foo/hello/0.1/EObar/x.bin"));
+        new Home(temp).save("", Paths.get("EOxxx/bar"));
         MatcherAssert.assertThat(
             new Walk(temp).includes(new ListOf<>("EO**/*")),
             Matchers.iterableWithSize(1)


### PR DESCRIPTION
#1352 `Home` redesign.
Quite a few changes are made. 
Base change is in `Home` class: key methods are changed to use relative path to the base. 
Method `rel` is left as is (it's purpose under question).

Changes are made to all classes which use `Home` to supply relative paths instead of absolute ones. For this purpose in a number of places the following pattern is used for conversion from full path to relative: `full_path.getParent().relativize(full_path)`