### PR TITLE
#1338 added number of threads used in thread executor within exec() method

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -103,10 +103,8 @@ public final class ParseMojo extends SafeMojo {
      * Number of parallel threads.
      * @checkstyle MemberNameCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.threads", defaultValue = "4")
     private int threads = 4;
-
 
     @Override
     public void exec() throws IOException {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -100,7 +100,7 @@ public final class ParseMojo extends SafeMojo {
     private boolean failOnError = true;
 
     /**
-     * Default threads number.
+     * Number of parallel threads.
      * @checkstyle MemberNameCheck (7 lines)
      */
     @SuppressWarnings("PMD.ImmutableField")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -101,8 +101,8 @@ public final class ParseMojo extends SafeMojo {
 
     /**
      * Number of parallel threads.
-     * @checkstyle MemberNameCheck (7 lines)
      */
+    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.threads", defaultValue = "4")
     private int threads = 4;
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -99,6 +99,15 @@ public final class ParseMojo extends SafeMojo {
         defaultValue = "true")
     private boolean failOnError = true;
 
+    /**
+     * Default threads number.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @SuppressWarnings("PMD.ImmutableField")
+    @Parameter(property = "eo.threads", defaultValue = "4")
+    private int threads = 4;
+
+
     @Override
     public void exec() throws IOException {
         final Collection<Tojo> tojos = this.scopedTojos().select(
@@ -142,7 +151,7 @@ public final class ParseMojo extends SafeMojo {
                 }
             );
         try {
-            Executors.newFixedThreadPool(4)
+            Executors.newFixedThreadPool(this.threads)
                 .invokeAll(tasks)
                 .forEach(
                     completed -> {


### PR DESCRIPTION
[#1338](https://github.com/objectionary/eo/issues/1338) added number of threads used in thread executor within exec() method