### PR TITLE
#1174 Test for offline hash parameter in PullMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChPattern.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChPattern.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+/**
+ * Commit Hash pattern.
+ *
+ * Returns hash values by particular pattern:
+ * -DofflineHash=0.*.*:abc2sd3
+ * -DofflineHash=0.2.7:abc2sd3,0.2.8:s4se2fe
+ *
+ * @since 0.28.11
+ */
+final class ChPattern implements CommitHash {
+
+    /**
+     * Pattern like *.*.* or 'master'.
+     */
+    private final String pattern;
+
+    /**
+     * Particular tag to match.
+     */
+    private final String tag;
+
+    /**
+     * The main constructor.
+     *
+     * @param pattern Pattern like *.*.* or 'master'.
+     * @param tag Particular tag to match.
+     */
+    ChPattern(
+        final String pattern,
+        final String tag
+    ) {
+        this.pattern = pattern;
+        this.tag = tag;
+    }
+
+    @Override
+    public String value() {
+        return this.pattern + this.tag;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChPattern.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChPattern.java
@@ -31,6 +31,11 @@ package org.eolang.maven;
  * -DofflineHash=0.2.7:abc2sd3,0.2.8:s4se2fe
  *
  * @since 0.28.11
+ * @todo #1174:90min Add implementation for {@link org.eolang.maven.ChPattern} class.
+ *   Now it has dummy behaviour. When {@link org.eolang.maven.ChPattern} will be finished we
+ *   can remove '@Disabled' annotation from the next tests:
+ *   - org.eolang.maven.PullMojoTest#pullsUsingOfflineHash(Path)
+ *   - org.eolang.maven.ChPatternTest#returnsCorrectHashByPattern(String, String, String)
  */
 final class ChPattern implements CommitHash {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link org.eolang.maven.ChPattern}.
+ *
+ * @since 0.28.11
+ */
+class ChPatternTest {
+
+    @Disabled
+    @ParameterizedTest
+    @CsvSource({
+        "'0.*.*:abc2sd3', '0.0.0', abc2sd3",
+        "'*.*.*:abc2sd3', '2.2.2', abc2sd3",
+        "'0.*.*:abc2sd3', '1.0.0', ''",
+        "'0.*.*:m23ss3h', '0.1.2', 'm23ss3h'",
+        "'0.*.*:m23ss3h,1.*.*:abc2sd3', '0.1.2', 'm23ss3h'",
+        "'0.*.*:m23ss3h, 1.*.*:abc2sd3', '0.1.2', 'm23ss3h'",
+        "'0.*.*:m23ss3h,1.*.*:abc2sd3', '1.1.2', 'abc2sd3'",
+        "'0.*.*:m23ss3h,3.*.*:abc2sd3', '2.1.2', ''",
+        "'3.*.*:m23ss3h,3.1.*:abc2sd3', '3.1.2', 'abc2sd3'",
+        "'3.1.2:m23ss3h,3.1.*:abc2sd3', '3.1.2', 'm23ss3h'",
+        "'master:m23ss3h,3.1.*:abc2sd3', 'master', 'm23ss3h'",
+        "'master:m23ss3h,composite-tag:abc2sd3', 'composite-tag', 'abc2sd3'"
+    })
+    void returnsCorrectHashByPattern(
+        final String pattern,
+        final String tag,
+        final String expected
+    ) {
+        MatcherAssert.assertThat(new ChPattern(pattern, tag).value(), Matchers.equalTo(expected));
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
@@ -42,9 +42,6 @@ class ChPatternTest {
      * @param pattern Pattern
      * @param tag Tag
      * @param expected Expected Hash
-     * @todo #1174:90min Add implementation for {@link org.eolang.maven.ChPattern} class.
-     *  Now it has dummy behaviour. When {@link org.eolang.maven.ChPattern} will be finished we
-     *  can remove '@Disabled' annotation from that test.
      */
     @Disabled
     @ParameterizedTest

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
@@ -36,6 +36,16 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 class ChPatternTest {
 
+    /**
+     * Get hash by tag using pattern test.
+     *
+     * @param pattern Pattern
+     * @param tag Tag
+     * @param expected Expected Hash
+     * @todo #1174:90min Add implementation for {@link org.eolang.maven.ChPattern} class.
+     *  Now it has dummy behaviour. When {@link org.eolang.maven.ChPattern} will be finished we
+     *  can remove '@Disabled' annotation from that test.
+     */
     @Disabled
     @ParameterizedTest
     @CsvSource({

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -100,6 +100,14 @@ final class PullMojoTest {
         );
     }
 
+    /**
+     * Offline hash test.
+     *
+     * @param temp Temporary directory for test.
+     * @todo #1174:90min Add implementation for {@link org.eolang.maven.ChPattern} class.
+     *  Now it has dummy behaviour. When {@link org.eolang.maven.ChPattern} will be finished we
+     *  can remove '@Disabled' annotation from that test.
+     */
     @Test
     @Disabled
     void pullsUsingOfflineHash(@TempDir final Path temp) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -104,9 +104,6 @@ final class PullMojoTest {
      * Offline hash test.
      *
      * @param temp Temporary directory for test.
-     * @todo #1174:90min Add implementation for {@link org.eolang.maven.ChPattern} class.
-     *  Now it has dummy behaviour. When {@link org.eolang.maven.ChPattern} will be finished we
-     *  can remove '@Disabled' annotation from that test.
      */
     @Test
     @Disabled

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -32,6 +32,7 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,18 +43,23 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class PullMojoTest {
 
+    /**
+     * Default format of eo-foreign.json for all tests.
+     */
+    private static final String FOREIGN_FORMAT = "json";
+
     @Test
     void testSimplePull(@TempDir final Path temp) {
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
-        Catalogs.INSTANCE.make(foreign, "json")
+        Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)
             .add("org.eolang.io.stdout")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
             .set(AssembleMojo.ATTR_VERSION, "*.*.*");
         new Moja<>(PullMojo.class)
             .with("targetDir", target.toFile())
             .with("foreign", foreign.toFile())
-            .with("foreignFormat", "json")
+            .with("foreignFormat", PullMojoTest.FOREIGN_FORMAT)
             .with("objectionary", this.dummy())
             .execute();
         MatcherAssert.assertThat(
@@ -77,20 +83,43 @@ final class PullMojoTest {
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
-        Catalogs.INSTANCE.make(foreign, "json")
+        Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)
             .add("org.eolang.io.stdout")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
             .set(AssembleMojo.ATTR_VERSION, "*.*.*");
         new Moja<>(PullMojo.class)
             .with("targetDir", target.toFile())
             .with("foreign", foreign.toFile())
-            .with("foreignFormat", "json")
+            .with("foreignFormat", PullMojoTest.FOREIGN_FORMAT)
             .with("objectionary", this.dummy())
             .with("offlineHashFile", temp.resolve("tags.txt"))
             .execute();
         MatcherAssert.assertThat(
             new LinkedList<>(new MnJson(foreign).read()).getFirst().get("hash"),
             Matchers.equalTo("mmmmmmm")
+        );
+    }
+
+    @Test
+    @Disabled
+    void pullsUsingOfflineHash(@TempDir final Path temp) {
+        final Path target = temp.resolve("target");
+        final Path foreign = temp.resolve("eo-foreign.json");
+        Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)
+            .add("org.eolang.io.stdout")
+            .set(AssembleMojo.ATTR_SCOPE, "compile")
+            .set(AssembleMojo.ATTR_VERSION, "*.*.*");
+        new Moja<>(PullMojo.class)
+            .with("targetDir", target.toFile())
+            .with("foreign", foreign.toFile())
+            .with("foreignFormat", PullMojoTest.FOREIGN_FORMAT)
+            .with("objectionary", this.dummy())
+            .with("hash", "1.0.0")
+            .with("offlineHash", "*.*.*:abcdefg")
+            .execute();
+        MatcherAssert.assertThat(
+            new LinkedList<>(new MnJson(foreign).read()).getFirst().get("hash"),
+            Matchers.equalTo("abcdefg")
         );
     }
 


### PR DESCRIPTION
I've added the test for `PullMojo` and `offlineHash`. 
After implementation I'll remove the `@Disabled` annotation.

Original issue: #1174. It's not a final PR.