### PR TITLE
#1174 add ChPattern implementation

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -55,10 +55,10 @@ public final class PullMojo extends SafeMojo {
     /**
      * The Git hash to pull objects from, in objectionary.
      *
-     * @since 0.21.0
      * @todo #1174:90min The wrong naming. It isn't a `hash` - it's a `tag`.
      *   We have to rename that property. Also it's important to check if we don't break something
      *   by such a renaming.
+     * @since 0.21.0
      */
     @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.hash", required = true, defaultValue = "master")
@@ -91,6 +91,16 @@ public final class PullMojo extends SafeMojo {
     private Path offlineHashFile;
 
     /**
+     * Return hash by pattern.
+     * -DofflineHash=0.*.*:abc2sd3
+     * -DofflineHash=0.2.7:abc2sd3,0.2.8:s4se2fe
+     *
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "offlineHash")
+    private String offlineHash;
+
+    /**
      * The objectionary.
      */
     @SuppressWarnings("PMD.ImmutableField")
@@ -103,10 +113,12 @@ public final class PullMojo extends SafeMojo {
                 && !row.exists(AssembleMojo.ATTR_XMIR)
         );
         final CommitHash tag;
-        if (this.offlineHashFile == null) {
+        if (this.offlineHashFile == null && this.offlineHash == null) {
             tag = new ChRemote(this.hash);
-        } else {
+        } else if (this.offlineHash == null) {
             tag = new ChText(this.offlineHashFile, this.hash);
+        } else {
+            tag = new ChPattern(this.offlineHash, this.hash);
         }
         if (this.objectionary == null) {
             this.objectionary = new OyFallbackSwap(
@@ -195,5 +207,4 @@ public final class PullMojo extends SafeMojo {
         }
         return src;
     }
-
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChPatternTest.java
@@ -25,7 +25,6 @@ package org.eolang.maven;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -43,7 +42,6 @@ class ChPatternTest {
      * @param tag Tag
      * @param expected Expected Hash
      */
-    @Disabled
     @ParameterizedTest
     @CsvSource({
         "'0.*.*:abc2sd3', '0.0.0', abc2sd3",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -32,7 +32,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -106,7 +105,6 @@ final class PullMojoTest {
      * @param temp Temporary directory for test.
      */
     @Test
-    @Disabled
     void pullsUsingOfflineHash(@TempDir final Path temp) {
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");


### PR DESCRIPTION
Original issue: #1174.

Add implementation for `ChPattern` class. Allows to use the next patterns for mocking hashes:
```
 -DofflineHash=0.*.*:abc2sd3
 -DofflineHash=0.2.7:abc2sd3,0.2.8:s4se2fe
```
