### PR TITLE
#1382 Use ChText inside ChRemote

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
@@ -36,6 +36,10 @@ import org.cactoos.text.UncheckedText;
  * Hash of tag from objectionary.
  *
  * @since 0.26
+ * @todo #1382:90min We definitely have to split {@link org.eolang.maven.ChRemote} class to
+ *   a two different classes: ChRemote and ChCached - in that case we will able to remove
+ *   static methods and reuse ChCached somewhere else (not only in ChRemote).
+ *   After implementation of ChCached - it's important remove CACHE from ChRemote.
  */
 final class ChRemote implements CommitHash {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
@@ -107,6 +107,6 @@ final class ChRemote implements CommitHash {
      * @throws IOException if fails
      */
     private static Text load() throws IOException {
-        return new TextOf(new URL(ChRemote.HOME).openStream());
+        return new TextOf(new URL(ChRemote.HOME));
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
@@ -27,7 +27,6 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.net.URL;
 import org.cactoos.Text;
-import org.cactoos.io.InputOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 
@@ -108,6 +107,6 @@ final class ChRemote implements CommitHash {
      * @throws IOException if fails
      */
     private static Text load() throws IOException {
-        return new TextOf(new InputOf(new URL(ChRemote.HOME).openStream()));
+        return new TextOf(new URL(ChRemote.HOME).openStream());
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
@@ -25,7 +25,6 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import org.cactoos.Text;
 import org.cactoos.io.InputOf;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChRemote.java
@@ -109,7 +109,6 @@ final class ChRemote implements CommitHash {
      * @throws IOException if fails
      */
     private static Text load() throws IOException {
-        final InputStream ins = new URL(ChRemote.HOME).openStream();
-        return new TextOf(new InputOf(ins));
+        return new TextOf(new InputOf(new URL(ChRemote.HOME).openStream()));
     }
 }


### PR DESCRIPTION
I've used `ChText` inside `ChRemote`, but noticed that `ChRemote` have two responsibilities (get hashes by URL and caching) - puzzle was added for it.

Closes: #1382 