### PR TITLE
#1377: Don't use `Home.rel()` for logging

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Central.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Central.java
@@ -118,7 +118,7 @@ public final class Central implements BiConsumer<Dependency, Path> {
         Logger.info(
             this, "%s:%s:%s:%s unpacked to %s",
             dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getVersion(),
-            new Home().rel(path)
+            path
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CleanMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CleanMojo.java
@@ -48,7 +48,7 @@ public class CleanMojo extends SafeMojo {
             Logger.debug(
                 this,
                 "Directory '%s' doesn't exist",
-                new Home().rel(this.targetDir.toPath())
+                this.targetDir.toPath()
             );
             return;
         }
@@ -56,7 +56,7 @@ public class CleanMojo extends SafeMojo {
             Logger.info(
                 this,
                 "Deleted all files in: '%s'",
-                new Home().rel(this.targetDir.toPath())
+                this.targetDir.toPath()
             );
         }
     }
@@ -79,7 +79,7 @@ public class CleanMojo extends SafeMojo {
             Logger.debug(
                 this,
                 "'%s' purged",
-                new Home().rel(dir.toPath())
+                dir.toPath()
             );
         }
         return state;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopyMojo.java
@@ -115,13 +115,14 @@ public final class CopyMojo extends SafeMojo {
         if (sources.isEmpty()) {
             Logger.warn(
                 this, "No sources copied from %s to %s",
-                new Home().rel(this.sourcesDir.toPath()), new Home().rel(target)
+                this.sourcesDir.toPath(),
+                target
             );
         } else {
             Logger.info(
                 this, "%d source(s) copied from %s to %s",
-                sources.size(), new Home().rel(this.sourcesDir.toPath()),
-                new Home().rel(target)
+                sources.size(), this.sourcesDir.toPath(),
+                target
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
@@ -56,7 +56,7 @@ public final class DemandMojo extends SafeMojo {
         }
         Logger.info(
             this, "Added %d objects to foreign catalog at %s",
-            this.objects.size(), new Home().rel(this.foreign.toPath())
+            this.objects.size(), this.foreign.toPath()
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -127,12 +127,12 @@ public final class DiscoverMojo extends SafeMojo {
         if (names.isEmpty()) {
             Logger.debug(
                 this, "Didn't find any foreign objects in %s",
-                new Home().rel(file)
+                file
             );
         } else {
             Logger.debug(
                 this, "Found %d foreign objects in %s: %s",
-                names.size(), new Home().rel(file), names
+                names.size(), file, names
             );
         }
         return names;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
@@ -254,7 +254,7 @@ public final class GmiMojo extends SafeMojo {
             if (gmi.toFile().lastModified() >= xmir.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already converted %s to %s (it's newer than the source)",
-                    name, new Home().rel(gmi)
+                    name, gmi
                 );
                 continue;
             }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java
@@ -263,7 +263,7 @@ public final class GmiMojo extends SafeMojo {
             tojo.set(AssembleMojo.ATTR_GMI, gmi.toAbsolutePath().toString());
             Logger.info(
                 this, "GMI for %s saved to %s (%d instructions)",
-                name, new Home().rel(gmi), extra
+                name, gmi, extra
             );
             ++total;
         }
@@ -276,7 +276,7 @@ public final class GmiMojo extends SafeMojo {
         } else {
             Logger.info(
                 this, "Converted %d .xmir to GMIs, saved to %s, %d instructions",
-                total, new Home().rel(home), instructions
+                total, home, instructions
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -82,7 +82,7 @@ final class Home {
         if (target.toFile().getParentFile().mkdirs()) {
             Logger.debug(
                 this, "Directory created: %s",
-                this.rel(target.getParent())
+                target.getParent()
             );
         }
         try {
@@ -188,22 +188,6 @@ final class Home {
     public static Path clean(final Path path) {
         final byte[] bytes = path.toString().getBytes(StandardCharsets.UTF_8);
         return Paths.get(new String(bytes, StandardCharsets.UTF_8));
-    }
-
-    /**
-     * Make relative name from path.
-     *
-     * @param file Absolute path to a file or dir
-     * @return Relative name to CWD
-     */
-    String rel(final Path file) {
-        if (file.toAbsolutePath().startsWith(this.cwd.toAbsolutePath())) {
-            return String.format("./%s", this.cwd.relativize(file));
-        } else {
-            throw new IllegalArgumentException(
-                String.format("'%s' not under the '%s' folder", file, this.cwd)
-            );
-        }
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -154,22 +154,6 @@ final class Home {
     }
 
     /**
-     * Make relative name from path.
-     *
-     * @param file Absolute path to a file or dir
-     * @return Relative name to CWD
-     */
-    public String rel(final Path file) {
-        if (file.toAbsolutePath().startsWith(this.cwd.toAbsolutePath())) {
-            return String.format("./%s", this.cwd.relativize(file));
-        } else {
-            throw new IllegalArgumentException(
-                String.format("'%s' not under the '%s' folder", file, this.cwd)
-            );
-        }
-    }
-
-    /**
      * Check if exists.
      *
      * @param path Cwd-relative path to file
@@ -204,6 +188,22 @@ final class Home {
     public static Path clean(final Path path) {
         final byte[] bytes = path.toString().getBytes(StandardCharsets.UTF_8);
         return Paths.get(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Make relative name from path.
+     *
+     * @param file Absolute path to a file or dir
+     * @return Relative name to CWD
+     */
+    String rel(final Path file) {
+        if (file.toAbsolutePath().startsWith(this.cwd.toAbsolutePath())) {
+            return String.format("./%s", this.cwd.relativize(file));
+        } else {
+            throw new IllegalArgumentException(
+                String.format("'%s' not under the '%s' folder", file, this.cwd)
+            );
+        }
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Home.java
@@ -158,24 +158,15 @@ final class Home {
      *
      * @param file Absolute path to a file or dir
      * @return Relative name to CWD
-     * @todo #1352:30min Make `rel` method strictly relative to base.
-     *  In most cases `rel` is used with empty `Home()` and given absolute path
-     *  which is not part of it. So it just returns absolute path.
-     *  Throw an exception in case give path is not sub-path of a base.
-     *  Along with that revise all usages of this method and replace applicable
-     *  with just `Path.relativize` or plain local vars.
      */
     public String rel(final Path file) {
-        String path = file.toAbsolutePath().toString();
-        if (path.equals(this.cwd.toString())) {
-            path = "./";
-        } else if (path.startsWith(this.cwd.toString())) {
-            path = String.format(
-                "./%s",
-                path.substring(this.cwd.toString().length() + 1)
+        if (file.toAbsolutePath().startsWith(this.cwd.toAbsolutePath())) {
+            return String.format("./%s", this.cwd.relativize(file));
+        } else {
+            throw new IllegalArgumentException(
+                String.format("'%s' not under the '%s' folder", file, this.cwd)
             );
         }
-        return path;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -73,7 +73,7 @@ final class JavaFiles {
         if (nodes.isEmpty()) {
             Logger.debug(
                 this, "No .java files generated from %s",
-                new Home().rel(this.source)
+                this.source
             );
         } else {
             for (final XML java : nodes) {
@@ -81,7 +81,7 @@ final class JavaFiles {
             }
             Logger.info(
                 this, "Generated %d .java file(s) from %s to %s",
-                nodes.size(), new Home().rel(this.source), new Home().rel(this.dest)
+                nodes.size(), this.source, this.dest
             );
         }
         return files;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
@@ -97,7 +97,7 @@ public final class MarkMojo extends SafeMojo {
         }
         Logger.info(
             this, "Found %d sources in %s, %d program(s) registered with version %s",
-            sources.size(), new Home(targetDir.toPath()).rel(dir), done, version
+            sources.size(), dir, done, version
         );
         return done;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
@@ -97,7 +97,7 @@ public final class MarkMojo extends SafeMojo {
         }
         Logger.info(
             this, "Found %d sources in %s, %d program(s) registered with version %s",
-            sources.size(), new Home().rel(dir), done, version
+            sources.size(), new Home(targetDir.toPath()).rel(dir), done, version
         );
         return done;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -55,10 +55,9 @@ import org.eolang.parser.ParsingTrain;
 /**
  * Optimize XML files.
  *
- * @since 0.1
- *
  * @todo #1336:30min Make a number of threads in `exec()` method configurable
- *   via mojo parameter `threads`. Default value should be set to 4.
+ * via mojo parameter `threads`. Default value should be set to 4.
+ * @since 0.1
  */
 @Mojo(
     name = "optimize",
@@ -79,14 +78,15 @@ public final class OptimizeMojo extends SafeMojo {
 
     /**
      * Parsing train with XSLs.
+     *
      * @implNote The list of applied XSLs is adjusted during execution.
-     *  <br>Separate instance of the train is used of each optimization
-     *  thread since {@link com.jcabi.xml.XSLDocument}, which is used under
-     *  the hood in {@link TrClasspath}, is not thread-safe.
+     * <br>Separate instance of the train is used of each optimization
+     * thread since {@link com.jcabi.xml.XSLDocument}, which is used under
+     * the hood in {@link TrClasspath}, is not thread-safe.
      * @todo #1336:30min Replace creation of new `Train` instances for each
-     *   parsing task to a single `Train&gtShift&lt TRAIN`, once `TrClasspath`
-     *   is thread-safe (solved by
-     *   <a href="https://github.com/jcabi/jcabi-xml/issues/185"/>).
+     * parsing task to a single `Train&gtShift&lt TRAIN`, once `TrClasspath`
+     * is thread-safe (solved by
+     * <a href="https://github.com/jcabi/jcabi-xml/issues/185"/>).
      */
     private static final Unchecked<Train<Shift>> TRAIN = new Unchecked<>(
         () -> new TrFast(
@@ -107,6 +107,7 @@ public final class OptimizeMojo extends SafeMojo {
 
     /**
      * Track optimization steps into intermediate XML files?
+     *
      * @checkstyle MemberNameCheck (7 lines)
      * @since 0.24.0
      */
@@ -116,6 +117,7 @@ public final class OptimizeMojo extends SafeMojo {
 
     /**
      * Whether we should fail on error.
+     *
      * @checkstyle MemberNameCheck (7 lines)
      * @since 0.23.0
      */
@@ -127,6 +129,7 @@ public final class OptimizeMojo extends SafeMojo {
 
     /**
      * Whether we should fail on warn.
+     *
      * @checkstyle MemberNameCheck (10 lines)
      */
     @SuppressWarnings("PMD.ImmutableField")
@@ -154,7 +157,8 @@ public final class OptimizeMojo extends SafeMojo {
                         if (tgt.toFile().lastModified() >= src.toFile().lastModified()) {
                             Logger.debug(
                                 this, "Already optimized %s to %s",
-                                new Home().rel(src), new Home().rel(tgt)
+                                new Home(targetDir.toPath()).rel(src),
+                                new Home(targetDir.toPath()).rel(tgt)
                             );
                             return;
                         }
@@ -253,7 +257,7 @@ public final class OptimizeMojo extends SafeMojo {
             trn = new SpyTrain(trn, dir);
             Logger.debug(
                 this, "Optimization steps will be tracked to %s",
-                new Home().rel(dir)
+                new Home(targetDir.toPath()).rel(dir)
             );
         }
         return new Xsline(trn).pass(new XMLDocument(file));
@@ -270,16 +274,20 @@ public final class OptimizeMojo extends SafeMojo {
     private Path make(final XML xml, final Path file) throws IOException {
         final String name = new XMLDocument(file).xpath("/program/@name").get(0);
         final Place place = new Place(name);
+        final Path dir = this.targetDir.toPath();
         final Path target = place.make(
-            this.targetDir.toPath().resolve(OptimizeMojo.DIR), TranspileMojo.EXT
+            dir.resolve(OptimizeMojo.DIR), TranspileMojo.EXT
         );
-        new Home(this.targetDir.toPath()).save(
+        new Home(dir).save(
             xml.toString(),
-            this.targetDir.toPath().relativize(target)
+            dir.relativize(target)
         );
         Logger.debug(
-            this, "Optimized %s (program:%s) to %s",
-            new Home().rel(file), name, new Home().rel(target)
+            this,
+            "Optimized %s (program:%s) to %s",
+            new Home(dir).rel(file),
+            name,
+            new Home(dir).rel(target)
         );
         return target;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -157,8 +157,8 @@ public final class OptimizeMojo extends SafeMojo {
                         if (tgt.toFile().lastModified() >= src.toFile().lastModified()) {
                             Logger.debug(
                                 this, "Already optimized %s to %s",
-                                new Home(targetDir.toPath()).rel(src),
-                                new Home(targetDir.toPath()).rel(tgt)
+                                src,
+                                tgt
                             );
                             return;
                         }
@@ -257,7 +257,7 @@ public final class OptimizeMojo extends SafeMojo {
             trn = new SpyTrain(trn, dir);
             Logger.debug(
                 this, "Optimization steps will be tracked to %s",
-                new Home(targetDir.toPath()).rel(dir)
+                dir
             );
         }
         return new Xsline(trn).pass(new XMLDocument(file));
@@ -280,14 +280,14 @@ public final class OptimizeMojo extends SafeMojo {
         );
         new Home(dir).save(
             xml.toString(),
-            dir.relativize(target)
+            target
         );
         Logger.debug(
             this,
             "Optimized %s (program:%s) to %s",
-            new Home(dir).rel(file),
+            file,
             name,
-            new Home(dir).rel(target)
+            target
         );
         return target;
     }
@@ -302,5 +302,4 @@ public final class OptimizeMojo extends SafeMojo {
         final List<XML> errors = xml.nodes("/program/errors/error");
         return errors.isEmpty() || this.failOnError;
     }
-
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -56,7 +56,7 @@ import org.eolang.parser.ParsingTrain;
  * Optimize XML files.
  *
  * @todo #1336:30min Make a number of threads in `exec()` method configurable
- * via mojo parameter `threads`. Default value should be set to 4.
+ *  via mojo parameter `threads`. Default value should be set to 4.
  * @since 0.1
  */
 @Mojo(
@@ -84,9 +84,9 @@ public final class OptimizeMojo extends SafeMojo {
      * thread since {@link com.jcabi.xml.XSLDocument}, which is used under
      * the hood in {@link TrClasspath}, is not thread-safe.
      * @todo #1336:30min Replace creation of new `Train` instances for each
-     * parsing task to a single `Train&gtShift&lt TRAIN`, once `TrClasspath`
-     * is thread-safe (solved by
-     * <a href="https://github.com/jcabi/jcabi-xml/issues/185"/>).
+     *  parsing task to a single `Train&gtShift&lt TRAIN`, once `TrClasspath`
+     *  is thread-safe (solved by
+     *  <a href="https://github.com/jcabi/jcabi-xml/issues/185"/>).
      */
     private static final Unchecked<Train<Shift>> TRAIN = new Unchecked<>(
         () -> new TrFast(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyHome.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyHome.java
@@ -67,7 +67,7 @@ final class OyHome implements Objectionary {
     public String toString() {
         return String.format(
             "%s (%s)",
-            new Home().rel(this.home), this.version
+            this.home, this.version
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -116,7 +116,7 @@ public final class ParseMojo extends SafeMojo {
                         if (xmir.toFile().lastModified() >= src.toFile().lastModified()) {
                             Logger.debug(
                                 this, "Already parsed %s to %s (it's newer than the source)",
-                                tojo.get(Tojos.KEY), new Home().rel(xmir)
+                                tojo.get(Tojos.KEY), new Home(targetDir.toPath()).rel(xmir)
                             );
                             return;
                         }
@@ -250,7 +250,7 @@ public final class ParseMojo extends SafeMojo {
         tojo.set(AssembleMojo.ATTR_XMIR, target.toAbsolutePath().toString());
         Logger.debug(
             this, "Parsed %s to %s",
-            new Home().rel(source), new Home().rel(target)
+            source, target
         );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -116,7 +116,7 @@ public final class ParseMojo extends SafeMojo {
                         if (xmir.toFile().lastModified() >= src.toFile().lastModified()) {
                             Logger.debug(
                                 this, "Already parsed %s to %s (it's newer than the source)",
-                                tojo.get(Tojos.KEY), new Home(targetDir.toPath()).rel(xmir)
+                                tojo.get(Tojos.KEY), xmir
                             );
                             return;
                         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
@@ -131,7 +131,7 @@ public final class PlaceMojo extends SafeMojo {
         } else {
             Logger.info(
                 this, "The directory is absent, nothing to place: %s",
-                new Home().rel(home)
+                home
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
@@ -157,7 +157,7 @@ public final class PlaceMojo extends SafeMojo {
                 Logger.debug(
                     this,
                     "File %s is not a binary, but a source, won't place it",
-                    new Home().rel(file)
+                    file
                 );
                 continue;
             }
@@ -170,8 +170,8 @@ public final class PlaceMojo extends SafeMojo {
                 Logger.info(
                     this,
                     "The file %s has been placed to %s, but now it's gone, re-placing",
-                    new Home().rel(file),
-                    new Home().rel(target)
+                    file,
+                    target
                 );
             }
             if (!before.isEmpty() && Files.exists(target)
@@ -179,7 +179,7 @@ public final class PlaceMojo extends SafeMojo {
                 Logger.debug(
                     this,
                     "The same file %s is already placed to %s maybe by %s, skipping",
-                    new Home().rel(file), new Home().rel(target),
+                    file, target,
                     before.iterator().next().get(PlaceMojo.ATTR_ORIGIN)
                 );
                 continue;
@@ -189,8 +189,8 @@ public final class PlaceMojo extends SafeMojo {
                 Logger.debug(
                     this,
                     "File %s (%d bytes) was already placed at %s (%d bytes!) by %s, replacing",
-                    new Home().rel(file), file.toFile().length(),
-                    new Home().rel(target), target.toFile().length(),
+                    file, file.toFile().length(),
+                    target, target.toFile().length(),
                     before.iterator().next().get(PlaceMojo.ATTR_ORIGIN)
                 );
             }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -193,7 +193,7 @@ public final class PullMojo extends SafeMojo {
         if (src.toFile().exists() && !this.overWrite) {
             Logger.debug(
                 this, "The object '%s' already pulled to %s (and 'overWrite' is false)",
-                name, new Home().rel(src)
+                name, src
             );
         } else {
             new Home(dir).save(
@@ -202,7 +202,7 @@ public final class PullMojo extends SafeMojo {
             );
             Logger.debug(
                 this, "The sources of the object '%s' pulled to %s",
-                name, new Home().rel(src)
+                name, src
             );
         }
         return src;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
@@ -116,8 +116,9 @@ public final class RegisterMojo extends SafeMojo {
         }
         Logger.info(
             this, "Registered %d EO sources from %s to %s, included %s, excluded %s",
-            sources.size(), new Home().rel(this.sourcesDir.toPath()),
-            new Home().rel(this.foreign.toPath()),
+            sources.size(),
+            this.sourcesDir.toPath(),
+            this.foreign.toPath(),
             this.includeSources, this.excludeSources
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Rel.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Rel.java
@@ -77,10 +77,11 @@ final class Rel {
     public String toString() {
         String path = this.other.toAbsolutePath().toString();
         if (path.equals(this.base.toString())) {
-            path = "./";
+            path = String.format(".%s", File.separator);
         } else if (path.startsWith(this.base.toString())) {
             path = String.format(
-                "./%s",
+                ".%s%s",
+                File.separator,
                 path.substring(this.base.toString().length() + 1)
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -126,7 +126,7 @@ public final class ResolveMojo extends SafeMojo {
             if (Files.exists(dest)) {
                 Logger.debug(
                     this, "Dependency %s already resolved to %s",
-                    coords, new Home().rel(dest)
+                    coords, dest
                 );
                 continue;
             }
@@ -275,7 +275,7 @@ public final class ResolveMojo extends SafeMojo {
             throw new IllegalStateException(
                 String.format(
                     "Too many (%d) dependencies at %s",
-                    coords.size(), new Home().rel(file)
+                    coords.size(), file
                 )
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -144,7 +144,7 @@ public final class TranspileMojo extends SafeMojo {
             ) {
                 Logger.info(
                     this, "XMIR %s (%s) were already transpiled to %s",
-                    new Home().rel(file), name, new Home().rel(target)
+                    file, name, target
                 );
             } else {
                 final List<Path> paths = this.transpile(src, input, target);
@@ -158,20 +158,20 @@ public final class TranspileMojo extends SafeMojo {
         }
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %s",
-            sources.size(), saved, new Home().rel(this.generatedDir.toPath())
+            sources.size(), saved, this.generatedDir.toPath()
         );
         if (this.addSourcesRoot) {
             this.project.addCompileSourceRoot(this.generatedDir.getAbsolutePath());
             Logger.info(
                 this, "The directory added to Maven 'compile-source-root': %s",
-                new Home().rel(this.generatedDir.toPath())
+                this.generatedDir.toPath()
             );
         }
         if (this.addTestSourcesRoot) {
             this.project.addTestCompileSourceRoot(this.generatedDir.getAbsolutePath());
             Logger.info(
                 this, "The directory added to Maven 'test-compile-source-root': %s",
-                new Home().rel(this.generatedDir.toPath())
+                this.generatedDir.toPath()
             );
         }
     }
@@ -192,13 +192,14 @@ public final class TranspileMojo extends SafeMojo {
             Logger.debug(
                 this,
                 "Removed %d Java files for %s",
-                removed, new Home().rel(src)
+                removed,
+                src
             );
         } else {
             Logger.debug(
                 this,
                 "No Java files removed for %s",
-                new Home().rel(src)
+                src
             );
         }
         final Place place = new Place(name);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -97,22 +97,22 @@ public final class UnplaceMojo extends SafeMojo {
         if (tojos.isEmpty()) {
             Logger.info(
                 this, "No binaries were placed into %s, nothing to uplace",
-                new Home().rel(this.placed.toPath())
+                this.placed.toPath()
             );
         } else if (deleted == 0) {
             Logger.info(
                 this, "No binaries out of %d deleted in %s",
-                tojos.size(), new Home().rel(this.placed.toPath())
+                tojos.size(), this.placed.toPath()
             );
         } else if (deleted == tojos.size()) {
             Logger.info(
                 this, "All %d binari(es) deleted, which were found in %s",
-                tojos.size(), new Home().rel(this.placed.toPath())
+                tojos.size(), this.placed.toPath()
             );
         } else {
             Logger.info(
                 this, "Just %d binari(es) out of %d deleted in %s",
-                deleted, tojos.size(), new Home().rel(this.placed.toPath())
+                deleted, tojos.size(), this.placed.toPath()
             );
         }
     }
@@ -158,12 +158,12 @@ public final class UnplaceMojo extends SafeMojo {
                 unplaced += 1;
                 Logger.debug(
                     this, "Binary %s of %s deleted",
-                    new Home().rel(path), tojo.get(PlaceMojo.ATTR_ORIGIN)
+                    path, tojo.get(PlaceMojo.ATTR_ORIGIN)
                 );
             } else {
                 Logger.debug(
                     this, "Binary %s of %s already deleted",
-                    new Home().rel(path), tojo.get(PlaceMojo.ATTR_ORIGIN)
+                    path, tojo.get(PlaceMojo.ATTR_ORIGIN)
                 );
             }
         }
@@ -258,7 +258,7 @@ public final class UnplaceMojo extends SafeMojo {
             Logger.debug(
                 UnplaceMojo.class,
                 "Empty directory deleted too: %s",
-                new Home().rel(dir)
+                dir
             );
         }
         return deleted;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -75,7 +75,7 @@ public final class UnplaceMojo extends SafeMojo {
         if (this.placedTojos.value().select(r -> true).isEmpty()) {
             Logger.info(
                 this, "The list of placed binaries is absent: %s",
-                new Home().rel(this.placed.toPath())
+                this.placed.toPath()
             );
         } else {
             this.placeThem();
@@ -197,7 +197,7 @@ public final class UnplaceMojo extends SafeMojo {
             } else {
                 Logger.debug(
                     this, "Binary %s of %s already deleted",
-                    new Home().rel(path), tojo.get(PlaceMojo.ATTR_ORIGIN)
+                    path, tojo.get(PlaceMojo.ATTR_ORIGIN)
                 );
             }
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnspileMojo.java
@@ -98,17 +98,17 @@ public final class UnspileMojo extends SafeMojo {
         if (all.isEmpty()) {
             Logger.warn(
                 this, "No .class files in %s including %s, nothing to unspile",
-                new Home().rel(this.classesDir.toPath()), this.includes
+                this.classesDir.toPath(), this.includes
             );
         } else if (unspiled == 0) {
             Logger.info(
                 this, "No .class files out of %d deleted in %s including %s",
-                all.size(), new Home().rel(this.classesDir.toPath()), this.includes
+                all.size(), this.classesDir.toPath(), this.includes
             );
         } else {
             Logger.info(
                 this, "Deleted %d .class files out of %d in %s",
-                unspiled, all.size(), new Home().rel(this.classesDir.toPath())
+                unspiled, all.size(), this.classesDir.toPath()
             );
         }
     }
@@ -141,13 +141,13 @@ public final class UnspileMojo extends SafeMojo {
             Files.delete(file);
             Logger.debug(
                 this, "Deleted %s since %s is present",
-                new Home().rel(file), new Home().rel(java)
+                file, java
             );
             deleted = true;
         } else {
             Logger.debug(
                 this, "Not deleted %s since %s is absent",
-                new Home().rel(file), new Home().rel(java)
+                file, java
             );
         }
         return deleted;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -57,33 +56,6 @@ final class HomeTest {
         MatcherAssert.assertThat(
             new UncheckedText(new TextOf(resolve)).asString(),
             Matchers.is(content)
-        );
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "'file.txt', './file.txt'",
-        "'dir/file.txt', './dir/file.txt'",
-        "'long/path/to/file.txt', './long/path/to/file.txt'",
-        "'../file.txt', './../file.txt'",
-        "'./file.txt', './file.txt'"
-    })
-    void returnsRelativePathOfCurrentWorkingDirectory(
-        final String file,
-        final String expected,
-        @TempDir final Path temp
-    ) {
-        MatcherAssert.assertThat(
-            new Home(temp).rel(temp.resolve(file)),
-            Matchers.is(expected)
-        );
-    }
-
-    @Test
-    void throwsExceptionIfRelPathNotInCurrentWorkingDir(@TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> new Home(temp).rel(Paths.get("/not/in/home"))
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -59,11 +60,30 @@ final class HomeTest {
         );
     }
 
-    @Test
-    void returnsRelativePathOfCurrentWorkingDirectory(@TempDir final Path temp) {
+    @ParameterizedTest
+    @CsvSource({
+        "'file.txt', './file.txt'",
+        "'dir/file.txt', './dir/file.txt'",
+        "'long/path/to/file.txt', './long/path/to/file.txt'",
+        "'../file.txt', './../file.txt'",
+        "'./file.txt', './file.txt'"
+    })
+    void returnsRelativePathOfCurrentWorkingDirectory(
+        final String file,
+        final String expected,
+        @TempDir final Path temp
+    ) {
         MatcherAssert.assertThat(
-            new Home(temp.resolve("dir")).rel(temp.resolve("dir/file.txt")),
-            Matchers.is("./file.txt")
+            new Home(temp).rel(temp.resolve(file)),
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void throwsExceptionIfRelPathNotInCurrentWorkingDir(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Home(temp).rel(Paths.get("/not/in/home"))
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HomeTest.java
@@ -92,9 +92,10 @@ final class HomeTest {
         final String filename = "文件名.txt";
         final byte[] bytes = filename.getBytes(StandardCharsets.UTF_16BE);
         final String decoded = new String(bytes, StandardCharsets.UTF_16BE);
-        new Home(Paths.get("directory")).save("any content", Paths.get(decoded));
+        final Path directory = temp.resolve("directory");
+        new Home(directory).save("any content", Paths.get(decoded));
         MatcherAssert.assertThat(
-            new Home(Paths.get("directory")).exists(Paths.get(filename)),
+            new Home(directory).exists(Paths.get(filename)),
             Matchers.is(true)
         );
     }
@@ -104,9 +105,10 @@ final class HomeTest {
         final String filename = "EOorg/EOeolang/EOmath/EOnan$EOas_int$EO@";
         final byte[] bytes = filename.getBytes("CP1252");
         final String decoded = new String(bytes, "CP1252");
-        new Home(Paths.get("directory")).save("any content", Paths.get(decoded));
+        final Path directory = temp.resolve("directory");
+        new Home(directory).save("any content", Paths.get(decoded));
         MatcherAssert.assertThat(
-            new Home(Paths.get("directory")).exists(Paths.get(filename)),
+            new Home(directory).exists(Paths.get(filename)),
             Matchers.is(true)
         );
     }
@@ -115,7 +117,7 @@ final class HomeTest {
     void loadBytesFromExistingFile(@TempDir final Path temp) throws IOException {
         final Home home = new Home(temp);
         final String content = "bar";
-        final Path subfolder = Paths.get("subfolder").resolve("foo.txt");
+        final Path subfolder = temp.resolve("subfolder").resolve("foo.txt");
         home.save(content, subfolder);
         MatcherAssert.assertThat(
             new TextOf(home.load(subfolder)),
@@ -128,18 +130,6 @@ final class HomeTest {
         Assertions.assertThrows(
             NoSuchFileException.class,
             () -> new Home(temp).load(temp.resolve("nonexistent"))
-        );
-    }
-
-    @Test
-    void savesToCwd() throws IOException {
-        final Home home = new Home();
-        final String content = "bar";
-        final Path subfolder = Paths.get("subfolder").resolve("foo.txt");
-        home.save(content, subfolder);
-        MatcherAssert.assertThat(
-            new TextOf(home.load(subfolder)),
-            Matchers.equalTo(new TextOf(content))
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -224,7 +224,7 @@ final class OptimizeMojoTest {
                 "[args] > main",
                 "  (stdout \"Hello!\").print > @\n"
             ),
-            temp.relativize(src)
+            src
         );
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.csv");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
@@ -65,7 +65,7 @@ class RelTest {
                 Paths.get("/a/b/c"),
                 Paths.get("/d/e/f")
             ).toString(),
-            Matchers.is(Paths.get("/d/e/f").toString())
+            Matchers.is(Paths.get("/d/e/f").toAbsolutePath().toString())
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,7 @@ class RelTest {
     ) {
         MatcherAssert.assertThat(
             new Rel(temp, temp.resolve(file)).toString(),
-            Matchers.is(expected)
+            Matchers.is(Paths.get(expected).toString())
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RelTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -54,6 +55,17 @@ class RelTest {
         MatcherAssert.assertThat(
             new Rel(temp, temp.resolve(file)).toString(),
             Matchers.is(Paths.get(expected).toString())
+        );
+    }
+
+    @Test
+    void returnsAbsolutePathIfBaseAndOtherFromDifferentHierarchies() {
+        MatcherAssert.assertThat(
+            new Rel(
+                Paths.get("/a/b/c"),
+                Paths.get("/d/e/f")
+            ).toString(),
+            Matchers.is(Paths.get("/d/e/f").toString())
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -25,6 +25,7 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
@@ -42,8 +43,8 @@ final class ResolveMojoTest {
 
     @Test
     void resolveWithSingleDependency(@TempDir final Path temp) throws Exception {
-        final Path foo = temp.resolve("src").resolve("foo.eo");
-        new Home().save(
+        final Path foo = Paths.get("src").resolve("foo.eo");
+        new Home(temp).save(
             String.format(
                 "%s\n\n%s",
                 "+rt jvm org.eolang:eo-runtime:0.7.0",
@@ -55,7 +56,7 @@ final class ResolveMojoTest {
         Catalogs.INSTANCE.make(foreign, "json")
             .add("foo.eo")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_EO, foo.toString())
+            .set(AssembleMojo.ATTR_EO, temp.resolve(foo))
             .set(AssembleMojo.ATTR_VERSION, "0.22.1");
         final Path target = temp.resolve("target");
         this.resolve(new DummyCentral(), foreign, target);
@@ -69,8 +70,9 @@ final class ResolveMojoTest {
 
     @Test
     void resolveWithoutAnyDependencies(@TempDir final Path temp) throws IOException {
-        final Path foo = temp.resolve("src").resolve("sum.eo");
-        new Home().save(
+        final Path foo = Paths.get("src").resolve("sum.eo");
+        final Home home = new Home(temp);
+        home.save(
             "[a b] > sum\n  plus. > @\n    a\n    b",
             foo
         );
@@ -79,7 +81,7 @@ final class ResolveMojoTest {
             .add("sum")
             .set(AssembleMojo.ATTR_DISCOVERED, "0")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_EO, foo.toString())
+            .set(AssembleMojo.ATTR_EO, temp.resolve(foo))
             .set(AssembleMojo.ATTR_VERSION, "0.22.1");
         final Path target = temp.resolve("target");
         this.resolve(new DummyCentral(), foreign, target);


### PR DESCRIPTION
In the most cases we used `new Home().rel(fullPath)` statement without using constructor,  it means that the statement just returned `fullPath` as is, without any changes. 
According with the puzzle, we decided to throw exception if `fullPath` doesn't have common parent directories with `Home.cwd` (see tests and implementation). It means that I had two options:
1) Remove `new Home().rel(fullPath)` statements and use `fullPath` instead - (the logic don't change in that case). And it makes sense, because in logs it's better to see the full path instead of related path (at least it useful for debugging to see the real full path). 
2) Use something like `new Home(workdir).rel(fullPath)`, but we don't have `workdir` and adding it to all classes would be much longer comparing with (1) and the benefits are questionable.
___
by that reason I've decided to go by the (1) way. After implementation - I've noticed that `Home.rel` doesn't using anywhere. By that reason I removed it at all.

Closes: #1377
