### PR TITLE
Update ReadMe

### DIFF
--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -9,19 +9,23 @@ Here is a simple program that gets a year from command line and tells you
 whether it's leap or not:
 
 ```eo
++alias org.eolang.txt.sprintf
++alias org.eolang.io.stdout
++alias org.eolang.txt.text
++alias org.eolang.math.number
+
 [args...] > main
   [y] > leap
     or. > @
       and.
-        eq. (mod. y 4) 0
-        not. (eq. (mod. y 100) 0)
-      eq. (mod. y 400) 0
-  QQ.io.stdout > @
-    QQ.txt.sprintf
+        eq. (mod. (number y) 4) 0
+        not. (eq. (mod. (number y) 100) 0)
+      eq. (mod. (number y) 400) 0
+  stdout > @
+    sprintf
       "%d is %sa leap year!"
-      (args.get 0).as-int > year!
+      (text (args.at 0)).as-int > year!
       if. (leap year:y) "" "not "
-
 ```
 
 In order to compile this program, put it into `src/main/eo/main.eo` and then
@@ -32,6 +36,14 @@ create a file `pom.xml` with this content (it's just a sample):
   [...]
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>

--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -9,22 +9,17 @@ Here is a simple program that gets a year from command line and tells you
 whether it's leap or not:
 
 ```eo
-+alias org.eolang.txt.sprintf
-+alias org.eolang.io.stdout
-+alias org.eolang.txt.text
-+alias org.eolang.math.number
-
 [args...] > main
   [y] > leap
     or. > @
       and.
-        eq. (mod. (number y) 4) 0
-        not. (eq. (mod. (number y) 100) 0)
-      eq. (mod. (number y) 400) 0
-  stdout > @
-    sprintf
+        eq. (mod. (QQ.math.number y) 4) 0
+        not. (eq. (mod. (QQ.math.number y) 100) 0)
+      eq. (mod. (QQ.math.number y) 400) 0
+  QQ.io.stdout > @
+    QQ.txt.sprintf
       "%d is %sa leap year!"
-      (text (args.at 0)).as-int > year!
+      (QQ.txt.text (args.at 0)).as-int > year!
       if. (leap year:y) "" "not "
 ```
 


### PR DESCRIPTION
According to #1399. There are some errors with building:
```
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```
And code is not relevant. Now it is fixed