### PR TITLE
#1386: Get latest `eo-runtime` dependency version from Maven

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
@@ -42,7 +42,7 @@ final class DcsWithRuntime implements Dependencies {
     /**
      * Dependency downloaded by HTTP from Maven Central.
      */
-    private static final Unchecked<Dependency> FROM_MAVEN = fromMaven();
+    private static final Unchecked<Dependency> MAVEN_DEPENDENCY = DcsWithRuntime.mavenDependency();
 
     /**
      * All dependencies.
@@ -60,7 +60,7 @@ final class DcsWithRuntime implements Dependencies {
      * @param delegate Dependencies delegate.
      */
     DcsWithRuntime(final Dependencies delegate) {
-        this(delegate, DcsWithRuntime.FROM_MAVEN);
+        this(delegate, DcsWithRuntime.MAVEN_DEPENDENCY);
     }
 
     /**
@@ -88,7 +88,7 @@ final class DcsWithRuntime implements Dependencies {
      *
      * @return Runtime dependency from Maven Central.
      */
-    private static Unchecked<Dependency> fromMaven() {
+    private static Unchecked<Dependency> mavenDependency() {
         final String url = String.format(
             "https://repo.maven.apache.org/maven2/%s/maven-metadata.xml",
             "org/eolang/eo-runtime"

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
@@ -40,14 +40,14 @@ import org.cactoos.scalar.Unchecked;
 final class DcsWithRuntime implements Dependencies {
 
     /**
-     * Dependency downloaded by HTTP from Maven Central.
-     */
-    static final Unchecked<Dependency> FROM_MAVEN = fromMaven();
-
-    /**
      * Hardcoded dependency.
      */
     static final Unchecked<Dependency> HARDCODED = DcsWithRuntime.dependency("0.28.10");
+
+    /**
+     * Dependency downloaded by HTTP from Maven Central.
+     */
+    private static final Unchecked<Dependency> FROM_MAVEN = fromMaven();
 
     /**
      * All dependencies.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
@@ -50,7 +50,7 @@ final class DcsWithRuntime implements Dependencies {
     private final Dependencies delegate;
 
     /**
-     * Runtime dependency source.
+     * Supplier of the eo-runtime dependency.
      */
     private final Unchecked<Dependency> supplied;
 
@@ -67,7 +67,7 @@ final class DcsWithRuntime implements Dependencies {
      * The main constructor.
      *
      * @param delegate Dependencies delegate.
-     * @param supplied Runtime dependency source.
+     * @param supplied Supplier of the eo-runtime dependency.
      */
     DcsWithRuntime(final Dependencies delegate, final Unchecked<Dependency> supplied) {
         this.delegate = delegate;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
@@ -40,11 +40,6 @@ import org.cactoos.scalar.Unchecked;
 final class DcsWithRuntime implements Dependencies {
 
     /**
-     * Hardcoded dependency.
-     */
-    static final Unchecked<Dependency> HARDCODED = DcsWithRuntime.dependency("0.28.10");
-
-    /**
      * Dependency downloaded by HTTP from Maven Central.
      */
     private static final Unchecked<Dependency> FROM_MAVEN = fromMaven();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsWithRuntime.java
@@ -52,7 +52,7 @@ final class DcsWithRuntime implements Dependencies {
     /**
      * Runtime dependency source.
      */
-    private final Unchecked<Dependency> source;
+    private final Unchecked<Dependency> supplied;
 
     /**
      * Constructor.
@@ -67,18 +67,18 @@ final class DcsWithRuntime implements Dependencies {
      * The main constructor.
      *
      * @param delegate Dependencies delegate.
-     * @param source Runtime dependency source.
+     * @param supplied Runtime dependency source.
      */
-    DcsWithRuntime(final Dependencies delegate, final Unchecked<Dependency> source) {
+    DcsWithRuntime(final Dependencies delegate, final Unchecked<Dependency> supplied) {
         this.delegate = delegate;
-        this.source = source;
+        this.supplied = supplied;
     }
 
     @Override
     public Iterator<Dependency> iterator() {
         final ListOf<Dependency> all = new ListOf<>(this.delegate);
         if (all.stream().noneMatch(new RuntimeDependencyEquality())) {
-            all.add(this.source.value());
+            all.add(this.supplied.value());
         }
         return all.iterator();
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.util.Collections;
 import org.apache.maven.model.Dependency;
 import org.cactoos.scalar.LengthOf;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ class DcsWithRuntimeTest {
     void addsHardcodedVersionOfRuntimeDependency() throws Exception {
         final DcsWithRuntime dependencies = new DcsWithRuntime(
             dependencies(),
-            DcsWithRuntime.HARDCODED
+            new Unchecked<>(DcsWithRuntimeTest::dependency)
         );
         MatcherAssert.assertThat(
             new LengthOf(dependencies).value(),
@@ -61,12 +62,14 @@ class DcsWithRuntimeTest {
     }
 
     private static Dependencies dependencies() {
-        return () -> {
-            final Dependency dependency = new Dependency();
-            dependency.setGroupId("org.eolang");
-            dependency.setArtifactId("eo-collections");
-            dependency.setVersion("0.1.0");
-            return Collections.singleton(dependency).iterator();
-        };
+        return Collections.singleton(dependency())::iterator;
+    }
+
+    private static Dependency dependency() {
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId("org.eolang");
+        dependency.setArtifactId("eo-collections");
+        dependency.setVersion("0.1.0");
+        return dependency;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import java.util.Collections;
+import org.apache.maven.model.Dependency;
+import org.cactoos.scalar.LengthOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link org.eolang.maven.DcsWithRuntime}.
+ *
+ * @since 0.28.11
+ */
+class DcsWithRuntimeTest {
+
+    @Test
+    void addsHardcodedVersionOfRuntimeDependency() throws Exception {
+        final DcsWithRuntime dependencies = new DcsWithRuntime(
+            dependencies(),
+            DcsWithRuntime.HARDCODED
+        );
+        MatcherAssert.assertThat(
+            new LengthOf(dependencies).value(),
+            Matchers.equalTo(2L)
+        );
+    }
+
+    @Test
+    void addsRemoteVersionOfRuntimeDependency() throws Exception {
+        final DcsWithRuntime dependencies = new DcsWithRuntime(
+            dependencies(),
+            DcsWithRuntime.FROM_MAVEN
+        );
+        MatcherAssert.assertThat(
+            new LengthOf(dependencies).value(),
+            Matchers.equalTo(2L)
+        );
+    }
+
+    private static Dependencies dependencies() {
+        return () -> {
+            final Dependency dependency = new Dependency();
+            dependency.setGroupId("org.eolang");
+            dependency.setArtifactId("eo-collections");
+            dependency.setVersion("0.1.0");
+            return Collections.singleton(dependency).iterator();
+        };
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DcsWithRuntimeTest.java
@@ -52,8 +52,7 @@ class DcsWithRuntimeTest {
     @Test
     void addsRemoteVersionOfRuntimeDependency() throws Exception {
         final DcsWithRuntime dependencies = new DcsWithRuntime(
-            dependencies(),
-            DcsWithRuntime.FROM_MAVEN
+            dependencies()
         );
         MatcherAssert.assertThat(
             new LengthOf(dependencies).value(),


### PR DESCRIPTION
Get latest `eo-runtime` dependency version from Maven.

Closes: #1386 