### PR TITLE
#1223 Tests for `OptimizeMojo` caching

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -77,6 +77,11 @@ public final class OptimizeMojo extends SafeMojo {
     public static final String DIR = "03-optimize";
 
     /**
+     * Subdirectory for optimized cache.
+     */
+    public static final String OPTIMIZED = "optimized";
+
+    /**
      * Parsing train with XSLs.
      *
      * @implNote The list of applied XSLs is adjusted during execution.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -137,9 +137,10 @@ final class OptimizeMojoTest {
      *
      * @param temp Temporary test directory.
      * @throws Exception if unexpected error happened.
-     * @todo #1223:90min remove '@Disabled' annotation when caching of already optimized xmir files
-     *  will be implemented. Also don't forget to remove '@Disabled' annotation from the
-     *  'savesOptimizedResultsToCache' test that is placed below.
+     * @todo #1223:90min Implement caching for optimization step. After implementation don't forget
+     *  to remove '@Disabled' annotation from the next tests:
+     *  - 'getsAlreadyOptimizedResultsFromCache'
+     *  - 'savesOptimizedResultsToCache'
      */
     @Test
     @Disabled

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -35,9 +35,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -126,6 +129,104 @@ final class OptimizeMojoTest {
         MatcherAssert.assertThat(
             tgt.toFile().lastModified(),
             Matchers.greaterThan(start)
+        );
+    }
+
+    /**
+     * Test case for #1223.
+     *
+     * @param temp Temporary test directory.
+     * @throws Exception if unexpected error happened.
+     * @todo #1223:90min remove '@Disabled' annotation when caching of already optimized xmir files
+     *  will be implemented. Also don't forget to remove '@Disabled' annotation from the
+     *  'savesOptimizedResultsToCache' test that is placed below.
+     */
+    @Test
+    @Disabled
+    void getsAlreadyOptimizedResultsFromCache(@TempDir final Path temp) throws Exception {
+        final Path src = temp.resolve("foo/main.eo");
+        new Home(temp).save(
+            "+package f\n\n[args] > main\n  (stdout \"Hello!\").print > @\n",
+            src
+        );
+        final Path target = temp.resolve("target");
+        final Path foreign = temp.resolve("eo-foreign.json");
+        final Path cache = temp.resolve("cache");
+        final TextOf cached = new TextOf(
+            new ResourceOf("org/eolang/maven/optimize/main.xml")
+        );
+        final String hash = "abcdef1";
+        new Home(cache).save(
+            cached,
+            Paths.get(OptimizeMojo.OPTIMIZED)
+                .resolve(hash)
+                .resolve("foo/main.xmir")
+        );
+        Catalogs.INSTANCE.make(foreign, "json")
+            .add("foo.main")
+            .set(AssembleMojo.ATTR_SCOPE, "compile")
+            .set(AssembleMojo.ATTR_HASH, hash)
+            .set(AssembleMojo.ATTR_EO, src.toString());
+        new Moja<>(ParseMojo.class)
+            .with("targetDir", target.toFile())
+            .with("foreign", foreign.toFile())
+            .with("foreignFormat", "json")
+            .with("cache", temp.resolve("cache/parsed"))
+            .execute();
+        new Moja<>(OptimizeMojo.class)
+            .with("targetDir", target.toFile())
+            .with("foreign", foreign.toFile())
+            .with("trackOptimizationSteps", true)
+            .with("foreignFormat", "json")
+            .with("cache", cache)
+            .execute();
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                new Home(target).load(
+                    Paths.get(
+                        String.format("%s/foo/main.%s", OptimizeMojo.DIR, TranspileMojo.EXT)
+                    )
+                ).asBytes()
+            ),
+            Matchers.is(new XMLDocument(cached.asString()))
+        );
+    }
+
+    @Test
+    @Disabled
+    void savesOptimizedResultsToCache(@TempDir final Path temp) throws Exception {
+        final Path src = temp.resolve("foo/main.eo");
+        new Home(temp).save(
+            "+package f\n\n[args] > main\n  (stdout \"Hello!\").print > @\n",
+            src
+        );
+        final Path target = temp.resolve("target");
+        final Path foreign = temp.resolve("eo-foreign.json");
+        final Path cache = temp.resolve("cache");
+        final String hash = "abcdef1";
+        Catalogs.INSTANCE.make(foreign, "json")
+            .add("foo.main")
+            .set(AssembleMojo.ATTR_SCOPE, "compile")
+            .set(AssembleMojo.ATTR_HASH, hash)
+            .set(AssembleMojo.ATTR_EO, src.toString());
+        new Moja<>(ParseMojo.class)
+            .with("targetDir", target.toFile())
+            .with("foreign", foreign.toFile())
+            .with("foreignFormat", "json")
+            .with("cache", temp.resolve("cache/parsed"))
+            .execute();
+        new Moja<>(OptimizeMojo.class)
+            .with("targetDir", target.toFile())
+            .with("foreign", foreign.toFile())
+            .with("trackOptimizationSteps", true)
+            .with("foreignFormat", "json")
+            .with("cache", cache)
+            .execute();
+        MatcherAssert.assertThat(
+            cache.resolve(OptimizeMojo.OPTIMIZED)
+                .resolve(hash)
+                .resolve("foo/main.xmir").toFile(),
+            FileMatchers.anExistingFile()
         );
     }
 
@@ -274,12 +375,12 @@ final class OptimizeMojoTest {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> new Moja<>(OptimizeMojo.class)
-            .with("targetDir", target.toFile())
-            .with("foreign", foreign.toFile())
-            .with("foreignFormat", "csv")
-            .with("failOnError", false)
-            .with("failOnWarning", true)
-            .execute()
+                .with("targetDir", target.toFile())
+                .with("foreign", foreign.toFile())
+                .with("foreignFormat", "csv")
+                .with("failOnError", false)
+                .with("failOnWarning", true)
+                .execute()
         );
     }
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program>
+    <errors/>
+    <objects>
+        <o abstract=""
+           line="3"
+           name="main"
+           original-name="main"
+           pos="0">
+            <o line="3" name="args" pos="1"/>
+            <o base=".print" line="4" name="@" pos="19">
+                <o base="org.eolang.stdout" line="4" pos="3">
+                    <o base="org.eolang.string" data="string" line="4" pos="10">
+                        Dummy
+                    </o>
+                </o>
+            </o>
+        </o>
+    </objects>
+</program>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
 <program>
   <errors/>
   <objects>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/optimize/main.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <program>
-    <errors/>
-    <objects>
-        <o abstract=""
-           line="3"
-           name="main"
-           original-name="main"
-           pos="0">
-            <o line="3" name="args" pos="1"/>
-            <o base=".print" line="4" name="@" pos="19">
-                <o base="org.eolang.stdout" line="4" pos="3">
-                    <o base="org.eolang.string" data="string" line="4" pos="10">
-                        Dummy
-                    </o>
-                </o>
-            </o>
+  <errors/>
+  <objects>
+    <o abstract="" line="3" name="main" original-name="main" pos="0">
+      <o line="3" name="args" pos="1"/>
+      <o base=".print" line="4" name="@" pos="19">
+        <o base="org.eolang.stdout" line="4" pos="3">
+          <o base="org.eolang.string" data="string" line="4" pos="10">
+            Dummy
+          </o>
         </o>
-    </objects>
+      </o>
+    </o>
+  </objects>
 </program>


### PR DESCRIPTION
I've added several tests for the future `OptimiseMojo` caching:
1) We expect that `OptimizeMojo` will get `xmir` file from the cache (`getsAlreadyOptimizedResultsFromCache`)
2) We expect that `OptimizeMojo` will create a file in the cache if an optimisation result is absent in the cache (`savesOptimizedResultsToCache`)

Original issue: #1223