### PR TITLE
Fixed readme in eo-maven-plugin

### DIFF
--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -126,7 +126,7 @@ mvn -U clean install
 
 If you want to build your project or run your tests which use eo-maven-plugin, you can change stack size for your purposes by stack-size option:
 
-```
-mvn clean install -Pqulice -D.stack-size=1M
+```shell
+mvn clean install -Pqulice -Dstack-size=1M
 ```
 where 1M is size of stack. By default stack-size = 256M in eo-maven-plugin, maximum size is 1G.


### PR DESCRIPTION
I just noticed that there is small mistake in description of readme. Now it is OK