### PR TITLE
#1437: fast fix of the problem with tests for the new plugin version `0.28.11`

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -85,10 +85,10 @@ final class ResolveMojoTest {
             .set(AssembleMojo.ATTR_VERSION, "0.22.1");
         final Path target = temp.resolve("target");
         this.resolve(new DummyCentral(), foreign, target);
-        final Path path = temp.resolve("target/06-resolve/org.eolang/eo-runtime/-/0.28.10");
+        final Path path = temp.resolve("target/06-resolve/org.eolang/eo-runtime/-/0.28.11");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
         MatcherAssert.assertThat(
-            path.resolve("eo-runtime-0.28.10.jar").toFile(),
+            path.resolve("eo-runtime-0.28.11.jar").toFile(),
             FileMatchers.anExistingFile()
         );
     }


### PR DESCRIPTION
Fast fix of tests for the new plugin version `0.28.11`, after that fix all pipelines will work fine.

Closes: #1437 