### PR TITLE
feat(#485): Check redundant parentheses

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
+++ b/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * The class that checks redundant parentheses for object expression.
+ *
+ * @since 0.28.12
+ */
+final class RedundantParentheses {
+
+    /**
+     * Raw object expression from parser. Examples:
+     *  1.plus 2 > x
+     *  "Text" > y
+     *  (1.plus 2).plus 3
+     */
+    private final String expression;
+
+    /**
+     * The main constructor.
+     *
+     * @param expression Object expression.
+     */
+    RedundantParentheses(final String expression) {
+        this.expression = expression;
+    }
+
+    /**
+     * Checks if the expression contains redundant parentheses.
+     * @throws org.eolang.parser.RedundantParentheses.RedundantParenthesesException if the
+     *  expression contains redundant parentheses.
+     */
+    void check() {
+        final Deque<Character> stack = new ArrayDeque<>();
+        for (final char symbol : this.expressionChars()) {
+            if (symbol == ')') {
+                boolean operation = false;
+                char current = stack.pop();
+                while (current != '(') {
+                    if (current == '.' || current == ' ' || current == '-') {
+                        operation = true;
+                    }
+                    current = stack.pop();
+                }
+                if (!operation) {
+                    throw new RedundantParenthesesException();
+                }
+            } else {
+                stack.push(symbol);
+            }
+        }
+        if (stack.isEmpty()) {
+            throw new RedundantParenthesesException();
+        }
+    }
+
+    /**
+     * Clears raw expression from text literals and returns it as an array of chars.
+     *
+     * @return Expression as an array of chars.
+     */
+    private char[] expressionChars() {
+        return this.expression.replaceAll(
+            "\"(.|\\s)*?\"|\"\"\"(.|\\s)*?\"\"\"",
+            "literal"
+        ).toCharArray();
+    }
+
+    /**
+     * The exception that is thrown if redundant parentheses are found.
+     *
+     * @since 0.28.12
+     */
+    private final class RedundantParenthesesException extends IllegalStateException {
+        /**
+         * The default constructor.
+         */
+        private RedundantParenthesesException() {
+            super(
+                String.format(
+                    "%s contains redundant parentheses",
+                    RedundantParentheses.this.expression
+                )
+            );
+        }
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
+++ b/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
@@ -65,11 +65,14 @@ final class RedundantParentheses implements Consumer<String> {
 
     /**
      * Checks if the expression contains redundant parentheses.
-     *
-     * @param expression Raw object expression from parser. Examples:
+     * Examples of expressions to check:
+     * <pre>{@code
      *  1.plus 2 > x
      *  "Text" > y
      *  (1.plus 2).plus 3
+     * }
+     * </pre>
+     * @param expression Raw object expression from parser.
      * @return True if the expression contains redundant parentheses.
      */
     private static boolean test(final String expression) {

--- a/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
+++ b/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
@@ -26,9 +26,7 @@ package org.eolang.parser;
 import com.jcabi.log.Logger;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 /**
  * The class that checks redundant parentheses for object expression.
@@ -43,9 +41,9 @@ final class RedundantParentheses implements Consumer<String> {
     private final Consumer<String> reaction;
 
     /**
-     * Constructor with default reaction - writing warning to the log.
+     * Constructor with default reaction that writes warning to the log.
      */
-    public RedundantParentheses() {
+    RedundantParentheses() {
         this(s -> Logger.warn("%s contains redundant parentheses", s));
     }
 
@@ -59,9 +57,9 @@ final class RedundantParentheses implements Consumer<String> {
     }
 
     @Override
-    public void accept(final String s) {
-        if (RedundantParentheses.test(s)) {
-            reaction.accept(s);
+    public void accept(final String expression) {
+        if (RedundantParentheses.test(expression)) {
+            this.reaction.accept(expression);
         }
     }
 
@@ -70,11 +68,11 @@ final class RedundantParentheses implements Consumer<String> {
      *
      * @param expression Raw object expression from parser. Examples:
      *  1.plus 2 > x
-     * "Text" > y
+     *  "Text" > y
      *  (1.plus 2).plus 3
      * @return True if the expression contains redundant parentheses.
      */
-    private static boolean test(String expression) {
+    private static boolean test(final String expression) {
         final Deque<Character> stack = new ArrayDeque<>();
         boolean res = false;
         for (final char symbol : RedundantParentheses.expressionChars(expression)) {
@@ -102,7 +100,7 @@ final class RedundantParentheses implements Consumer<String> {
 
     /**
      * Clears raw expression from text literals and returns it as an array of chars.
-     *
+     * @param expression Raw experession
      * @return Expression as an array of chars.
      */
     private static char[] expressionChars(final String expression) {

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -72,7 +72,7 @@ public final class Syntax {
     private final Output target;
 
     /**
-     * Checks redundant parentheses if true.
+     * Checks redundant parentheses.
      */
     private final Consumer<String> redundancy;
 
@@ -99,7 +99,7 @@ public final class Syntax {
      * @param nme The name of it
      * @param ipt Input text
      * @param tgt Target
-     * @param redundancy Flag to check redundant parentheses
+     * @param redundancy Check for redundant parentheses
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public Syntax(
@@ -150,7 +150,7 @@ public final class Syntax {
         parser.removeErrorListeners();
         parser.addErrorListener(errors);
         final XeListener xel;
-        xel = new XeListener(this.name, redundancy);
+        xel = new XeListener(this.name, this.redundancy);
         new ParseTreeWalker().walk(xel, parser.program());
         final XML dom = new XMLDocument(new Xembler(xel).domQuietly());
         new Schema(dom).check();

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -71,16 +71,46 @@ public final class Syntax {
     private final Output target;
 
     /**
+     * Checks redundant parentheses if true.
+     */
+    private final boolean redundancy;
+
+    /**
      * Ctor.
      *
      * @param nme The name of it
      * @param ipt Input text
      * @param tgt Target
+     * @todo #485:90min The {@link org.eolang.parser.Syntax} by default doesn't check redundant
+     *  parentheses because some objects from objectioanry already contain redundancy parentheses
+     *  in their code that causes exceptions during parsing if
+     *  {@link org.eolang.parser.Syntax#redundancy} is true. By that reason it's important to
+     *  fix all redundancy parentheses in the objectionary. Then we will be able to remove
+     *  'redundancy' flag and check all eo programs for redundant parentheses by default.
      */
     public Syntax(final String nme, final Input ipt, final Output tgt) {
+        this(nme, ipt, tgt, false);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param nme The name of it
+     * @param ipt Input text
+     * @param tgt Target
+     * @param redundancy Flag to check redundant parentheses
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public Syntax(
+        final String nme,
+        final Input ipt,
+        final Output tgt,
+        final boolean redundancy
+    ) {
         this.name = nme;
         this.input = ipt;
         this.target = tgt;
+        this.redundancy = redundancy;
     }
 
     /**
@@ -96,7 +126,8 @@ public final class Syntax {
             public void syntaxError(final Recognizer<?, ?> recognizer,
                 final Object symbol, final int line,
                 final int position, final String msg,
-                final RecognitionException error) {
+                final RecognitionException error
+            ) {
                 throw new ParsingException(
                     String.format(
                         "[%d:%d] %s: \"%s\"",
@@ -117,7 +148,12 @@ public final class Syntax {
         );
         parser.removeErrorListeners();
         parser.addErrorListener(errors);
-        final XeListener xel = new XeListener(this.name);
+        final XeListener xel;
+        if (this.redundancy) {
+            xel = new XeListener(this.name, s -> new RedundantParentheses(s).check());
+        } else {
+            xel = new XeListener(this.name);
+        }
         new ParseTreeWalker().walk(xel, parser.program());
         final XML dom = new XMLDocument(new Xembler(xel).domQuietly());
         new Schema(dom).check();

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -149,8 +149,7 @@ public final class Syntax {
         );
         parser.removeErrorListeners();
         parser.addErrorListener(errors);
-        final XeListener xel;
-        xel = new XeListener(this.name, this.redundancy);
+        final XeListener xel = new XeListener(this.name, this.redundancy);
         new ParseTreeWalker().walk(xel, parser.program());
         final XML dom = new XMLDocument(new Xembler(xel).domQuietly());
         new Schema(dom).check();

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -32,7 +32,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -52,7 +52,7 @@ import org.xembly.Directives;
  *  are stored as bytes, remove data attribute from XML
  *  and XSLT templates.
  */
-@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 public final class XeListener implements ProgramListener, Iterable<Directive> {
 
     /**
@@ -167,7 +167,13 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
 
     @Override
     public void enterObject(final ProgramParser.ObjectContext ctx) {
-        // This method is created by ANTLR and can't be removed
+        if (ctx.application() != null) {
+            ProgramParser.ApplicationContext application = ctx.application();
+            if (application.suffix() != null) {
+                application = application.application();
+            }
+            new RedundantParentheses(application.getText()).check();
+        }
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -32,6 +32,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;
@@ -80,18 +81,6 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
      * Redundancy checker.
      */
     private final Consumer<String> redundancy;
-
-    /**
-     * Ctor.
-     * @param name Tha name of it
-     */
-    public XeListener(final String name) {
-        this(
-            name,
-            s -> {
-            }
-        );
-    }
 
     /**
      * Ctor.

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -79,19 +79,19 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     /**
      * Redundancy checker.
      */
-    private final Consumer<String> redundancy;
+    private final Consumer<String> check;
 
     /**
      * Ctor.
      * @param name Tha name of it
-     * @param redundancy The strategy to check eo expressions for redundant parentheses.
+     * @param check The strategy to check eo expressions for redundant parentheses.
      */
-    public XeListener(final String name, final Consumer<String> redundancy) {
+    public XeListener(final String name, final Consumer<String> check) {
         this.name = name;
         this.dirs = new Directives();
         this.objects = new Objects.ObjXembly();
         this.start = System.nanoTime();
-        this.redundancy = redundancy;
+        this.check = check;
     }
 
     @Override
@@ -180,7 +180,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
             if (application.suffix() != null) {
                 application = application.application();
             }
-            this.redundancy.accept(application.getText());
+            this.check.accept(application.getText());
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.StringJoiner;
+import java.util.function.Consumer;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;
@@ -76,14 +77,33 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     private final long start;
 
     /**
-     * Ctor.
-     * @param nme Tha name of it
+     * Redundancy checker.
      */
-    public XeListener(final String nme) {
-        this.name = nme;
+    private final Consumer<String> redundancy;
+
+    /**
+     * Ctor.
+     * @param name Tha name of it
+     */
+    public XeListener(final String name) {
+        this(
+            name,
+            s -> {
+            }
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param name Tha name of it
+     * @param redundancy The strategy to check eo expressions for redundant parentheses.
+     */
+    public XeListener(final String name, final Consumer<String> redundancy) {
+        this.name = name;
         this.dirs = new Directives();
         this.objects = new Objects.ObjXembly();
         this.start = System.nanoTime();
+        this.redundancy = redundancy;
     }
 
     @Override
@@ -172,7 +192,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
             if (application.suffix() != null) {
                 application = application.application();
             }
-            new RedundantParentheses(application.getText()).check();
+            this.redundancy.accept(application.getText());
         }
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.cactoos.io.InputOf;
+import org.cactoos.io.OutputTo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test cases for checking of redundant parentheses.
+ * The {@link org.eolang.parser.Syntax} object is used in order to check all possible expressions
+ * and situations.
+ *
+ * @since 0.28.12
+ */
+class RedundantParenthesesTest {
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void checksIfBracketsIsNotRedundant(
+        final String program,
+        final boolean correct
+    ) throws IOException {
+        final Syntax syntax = new Syntax(
+            "foo",
+            new InputOf(program),
+            new OutputTo(new ByteArrayOutputStream())
+        );
+        if (correct) {
+            syntax.parse();
+        } else {
+            Assertions.assertThrows(IllegalStateException.class, syntax::parse);
+        }
+    }
+
+    static Stream<Arguments> testCases() {
+        return Stream.of(
+            Arguments.of("[] > foo\n  1.add (a.add 5) 4 > x", true),
+            Arguments.of("[] > foo\n  add. 1 (a.add 5) > x", true),
+            Arguments.of("[] > foo\n  add. 1 2 3 4 > x", true),
+            Arguments.of("[] > foo\n  add. 1 2 3 4", true),
+            Arguments.of("[] > foo\n  add 1 2 3 4", true),
+            Arguments.of("[] > foo\n  1.add 4 > x", true),
+            Arguments.of("[] > foo\n  (add 1).add 2", true),
+            Arguments.of("[] > foo\n  1.add (1.add (1.add (1.add 1))) > x", true),
+            Arguments.of("[] > foo\n  (1.add 1).add (1.add 1) > x", true),
+            Arguments.of("[] > foo\n  add > x\n    1\n    1\n", true),
+            Arguments.of("[] > foo\n  1.with-text \"(text) with parentheses a(n)...\" > x", true),
+            Arguments.of("[] > foo\n  \"=(\" > x", true),
+            Arguments.of("[] > foo\n  \"=)\" > x", true),
+            Arguments.of("[] > foo\n  \")\" > x", true),
+            Arguments.of("[] > foo\n  \"(-_-)\" > x", true),
+            Arguments.of("[] > foo\n  \"Hello\".<.eq (\"Hello\".<)\n", true),
+            Arguments.of("[] > foo\n  \"\"\"\n(-_-)\n\"\"\" > x", true),
+            Arguments.of("[] > foo\n  add (-4) (-5)", true),
+            Arguments.of("[] > foo\n  (1.add (a.add 5) (4)) > x", false),
+            Arguments.of("[] > foo\n  (1.add (a.add 5) 4) > x", false),
+            Arguments.of("[] > foo\n  (1.add (a.add 5) 4)", false),
+            Arguments.of("[] > foo\n  1.add (5) > x", false),
+            Arguments.of("[] > foo\n  (1.add 4) > x", false),
+            Arguments.of("[] > foo\n  (1.add 4)", false),
+            Arguments.of("[] > foo\n  ((1.add 1)) > x", false),
+            Arguments.of("[] > foo\n  1.add 1 > x\n  (1.add 1)", false),
+            Arguments.of("[] > foo\n  1.add 1 > x\n  (1.add 1) > y", false),
+            Arguments.of("[] > foo\n  add > x\n    (1)\n    (1)\n", false)
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
@@ -51,7 +51,8 @@ class RedundantParenthesesTest {
         final Syntax syntax = new Syntax(
             "foo",
             new InputOf(program),
-            new OutputTo(new ByteArrayOutputStream())
+            new OutputTo(new ByteArrayOutputStream()),
+            true
         );
         if (correct) {
             syntax.parse();

--- a/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
@@ -52,7 +52,12 @@ class RedundantParenthesesTest {
             "foo",
             new InputOf(program),
             new OutputTo(new ByteArrayOutputStream()),
-            true
+            new RedundantParentheses(
+                s -> {
+                    throw new IllegalStateException(
+                        String.format("%s contains redundant parentheses", s));
+                }
+            )
         );
         if (correct) {
             syntax.parse();

--- a/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RedundantParenthesesTest.java
@@ -55,7 +55,8 @@ class RedundantParenthesesTest {
             new RedundantParentheses(
                 s -> {
                     throw new IllegalStateException(
-                        String.format("%s contains redundant parentheses", s));
+                        String.format("%s contains redundant parentheses", s)
+                    );
                 }
             )
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/adds-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/adds-refs.yaml
@@ -17,10 +17,10 @@ tests:
   - //o[@base='first' and @line='17' and @ref='1']
 eo: |
   [x a] > first
-    (stdout x)
+    stdout x
     second > hello
       third > x
-        (stdout "Hi")
+        stdout "Hi"
       one
         x
         two

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/aliases.yaml
@@ -1,6 +1,6 @@
 xsls: []
 tests:
-  - //objects[count(.//o[@alias])=4]
+  - //objects[count(.//o[@alias])=2]
 eo: |
   [] > aliases
-    (a (b (c (d))))
+    a (b (c d))

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-same-line-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-same-line-name.yaml
@@ -6,4 +6,4 @@ tests:
   - /program/objects/o[@name='first']/o[@name='x']
 eo: |
   [x] > first
-    (a > x (b > x))
+    a > x (b > x)

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/anonymous-more.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/anonymous-more.yaml
@@ -10,7 +10,7 @@ eo: |
 
   (dir "/tmp").walk
     *
-      ([f] (f.is-dir > @))
+      [f] (f.is-dir > @)
 
   (dir "/tmp").walk
-    * ([f] (f.is-dir > @))
+    * [f] (f.is-dir > @)

--- a/eo-runtime/src/main/eo/org/eolang/array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/array.eo
@@ -33,7 +33,7 @@
 [] > array
   # Create empty array
   [] > empty
-    (*) > @
+    * > @
 
   # Obtain the length of the array.
   [] > length /int

--- a/eo-runtime/src/test/eo/org/eolang/array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/array-tests.eo
@@ -42,7 +42,7 @@
 [] > empty-array-length
   [elements...] > arr
   assert-that > @
-    (arr).elements.length
+    arr.elements.length
     $.equal-to 0
 
 # check that array.length works properly for non-empty arrays
@@ -167,13 +167,13 @@
 
 [] > array-fluent-with
   assert-that > @
-    ((((*).with 1).with 2).with 3)
+    ((*.with 1).with 2).with 3
     $.equal-to
       list
         * 1 2 3
 
 [] > array-fluent-with-indented
-  (*)
+  *
   .with 1
   .with 2
   .with 3 > a

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -127,7 +127,7 @@
     seq
       f0.write 0
       f1.write 1
-      f2.write ((f0).plus (f1))
+      f2.write (f0.plus f1)
       f1.write f2
       TRUE
     $.equal-to TRUE
@@ -241,7 +241,7 @@
     [args...] > f
       1 > a
       2 > @
-    (f 1 2 3) > @
+    f 1 2 3 > @
   app > output
   assert-that > @
     output


### PR DESCRIPTION
Simple checker is implemented that validates object expressions inside `XeListener` for existing of redundant parentheses. Also some number of tests were added in order to prove the implementation.

Closes #485 