### PR TITLE
feat(#1479): `FakeMaven` returns `HashMap` of results 

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -25,6 +25,7 @@ package org.eolang.maven;
 
 import com.yegor256.tojos.TjSmart;
 import com.yegor256.tojos.Tojo;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.maven.plugin.AbstractMojo;
 
@@ -196,14 +198,17 @@ public final class FakeMaven {
      * Creates of the result map with all files and folders that was created
      *  or compiled during mojo execution.
      *
-     * @return Map of "relative path" (key) - "absolute path" (value).
+     * @return Map of "relative UNIX path" (key) - "absolute path" (value).
      * @throws IOException If some problem with filesystem have happened.
      */
     private Map<String, Path> result() throws IOException {
         final Path root = this.workspace.absolute(Paths.get(""));
         return Files.walk(root).collect(
             Collectors.toMap(
-                p -> root.relativize(p).toString(),
+                p -> String.join(
+                    "/",
+                    root.relativize(p).toString().split(Pattern.quote(File.separator))
+                ),
                 Function.identity()
             )
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -87,6 +87,9 @@ public final class FakeMaven {
      * Set default the params for all mojos.
      *
      * @return The same maven instance.
+     * @todo 1479:90min The method withDefaults() has to be called right in the exec() method.
+     *  We should set default properties only if they aren't set using `with()` method. Also
+     *  it's important to remove withDefaults() method from tests.
      */
     public FakeMaven withDefaults() {
         this.params.put("targetDir", this.targetPath().toFile());
@@ -111,6 +114,9 @@ public final class FakeMaven {
      * Creates eo-foreign.* file.
      *
      * @return The same maven instance.
+     * @todo 1479:90min The method withEoForeign() has to be deleted. We can move the logic of
+     *  creation eo-foreign.* file into exec() function directly. Also it's important to remove the
+     *  method from tests.
      */
     public FakeMaven withEoForeign() {
         final Tojo tojo = Catalogs.INSTANCE.make(this.foreignPath())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -87,7 +87,7 @@ public final class FakeMaven {
      * Set default the params for all mojos.
      *
      * @return The same maven instance.
-     * @todo 1479:90min The method withDefaults() has to be called right in the exec() method.
+     * @todo #1479:90min The method withDefaults() has to be called right in the exec() method.
      *  We should set default properties only if they aren't set using `with()` method. Also
      *  it's important to remove withDefaults() method from tests.
      */
@@ -114,7 +114,7 @@ public final class FakeMaven {
      * Creates eo-foreign.* file.
      *
      * @return The same maven instance.
-     * @todo 1479:90min The method withEoForeign() has to be deleted. We can move the logic of
+     * @todo #1479:90min The method withEoForeign() has to be deleted. We can move the logic of
      *  creation eo-foreign.* file into exec() function directly. Also it's important to remove the
      *  method from tests.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -66,6 +66,7 @@ final class ParseMojoTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)
+                .withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
                 .withEoForeign()
                 .withDefaults()
                 .with("timeout", 0)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -23,11 +23,8 @@
  */
 package org.eolang.maven;
 
-import com.yegor256.tojos.TjSmart;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -108,23 +105,14 @@ final class ParseMojoTest {
     }
 
     @Test
-    void testCrashOnInvalidSyntax(@TempDir final Path temp)
-        throws Exception {
-        final Path src = temp.resolve("bar/src.eo");
-        new Home(temp).save("something < is wrong here", temp.relativize(src));
-        final Path foreign = temp.resolve("foreign-1");
-        Catalogs.INSTANCE.make(foreign)
-            .add("bar.src")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_EO, src.toString());
+    void testCrashOnInvalidSyntax(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new Moja<>(ParseMojo.class)
-                .with("targetDir", temp.resolve("target").toFile())
-                .with("foreign", foreign.toFile())
-                .with("cache", temp.resolve("cache/parsed"))
-                .with("foreignFormat", "csv")
-                .execute()
+            () -> new FakeMaven(temp)
+                .withProgram("something < is wrong here")
+                .withEoForeign()
+                .withDefaults()
+                .execute(ParseMojo.class)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -69,27 +69,14 @@ final class ParseMojoTest {
     }
 
     @Test
-    void failsOnTimeout(@TempDir final Path temp) throws Exception {
-        final Path src = temp.resolve("foo/x/main.eo");
-        final Path target = temp.resolve("target");
-        new Home(temp).save(
-            "+package f\n\n[args] > main\n  (stdout \"Hello!\").print\n",
-            temp.relativize(src)
-        );
-        final Path foreign = temp.resolve("eo-foreign.csv");
-        Catalogs.INSTANCE.make(foreign)
-            .add("foo.x.main")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_EO, src.toString());
+    void failsOnTimeout(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new Moja<>(ParseMojo.class)
+            () -> new FakeMaven(temp)
+                .withEoForeign()
+                .withDefaults()
                 .with("timeout", 0)
-                .with("targetDir", target.toFile())
-                .with("foreign", foreign.toFile())
-                .with("cache", temp.resolve("cache/parsed"))
-                .with("foreignFormat", "csv")
-                .execute()
+                .execute(ParseMojo.class)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -47,10 +47,7 @@ final class ParseMojoTest {
     void testSimpleParsing(@TempDir final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(
-            maven.withProgram(
-                    "+package f", "[args] > main",
-                    "  (stdout \"Hello!\").print"
-                )
+            maven.withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
                 .withDefaults()
                 .withEoForeign()
                 .execute(ParseMojo.class),
@@ -97,7 +94,7 @@ final class ParseMojoTest {
                     .withEoForeign()
                     .with("cache", cache)
                     .execute(ParseMojo.class)
-                    .get(String.format("%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT))
+                    .get(String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT))
             ).toString(),
             Matchers.equalTo(expected)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -106,38 +106,16 @@ final class ParseMojoTest {
 
     @Test
     void testCrashOnInvalidSyntax(@TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new FakeMaven(temp)
-                .withProgram("something < is wrong here")
-                .withEoForeign()
-                .withDefaults()
-                .execute(ParseMojo.class)
-        );
-    }
-
-    @Test
-    void testCrashesWithFileName(@TempDir final Path temp)
-        throws Exception {
-        final Path src = temp.resolve("bar/src.eo");
-        new Home(temp).save("something < is wrong here", temp.relativize(src));
-        final Path foreign = temp.resolve("foreign-1");
-        Catalogs.INSTANCE.make(foreign)
-            .add("bar.src")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_EO, src.toString());
-        final IllegalStateException exception = Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new Moja<>(ParseMojo.class)
-                .with("targetDir", temp.resolve("target").toFile())
-                .with("foreign", foreign.toFile())
-                .with("cache", temp.resolve("cache/parsed"))
-                .with("foreignFormat", "csv")
-                .execute()
-        );
         MatcherAssert.assertThat(
-            exception.getCause().getCause().getMessage(),
-            Matchers.containsString(String.format("Failed to parse %s", src))
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new FakeMaven(temp)
+                    .withProgram("something < is wrong here")
+                    .withEoForeign()
+                    .withDefaults()
+                    .execute(ParseMojo.class)
+            ).getCause().getCause().getMessage(),
+            Matchers.containsString("Failed to parse")
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -182,14 +182,14 @@ final class UnplaceMojoTest {
             .with("removeBinaries", new SetOf<>("**foo6.class"))
             .execute();
         final Path placed = temp.resolve("placed.csv");
-        MatcherAssert.assertThat(
-            Files.readString(placed).contains("false"),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            Files.readString(placed).contains("true"),
-            Matchers.is(true)
-        );
+//        MatcherAssert.assertThat(
+//            Files.readString(placed).contains("false"),
+//            Matchers.is(false)
+//        );
+//        MatcherAssert.assertThat(
+//            Files.readString(placed).contains("true"),
+//            Matchers.is(true)
+//        );
     }
 
     @Test
@@ -210,13 +210,13 @@ final class UnplaceMojoTest {
             .with("keepBinaries", new SetOf<>("**foo6.class"))
             .execute();
         final Path placed = temp.resolve("placed.csv");
-        MatcherAssert.assertThat(
-            Files.readString(placed).contains("false"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            Files.readString(placed).contains("true"),
-            Matchers.is(false)
-        );
+//        MatcherAssert.assertThat(
+//            Files.readString(placed).contains("false"),
+//            Matchers.is(true)
+//        );
+//        MatcherAssert.assertThat(
+//            Files.readString(placed).contains("true"),
+//            Matchers.is(false)
+//        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -182,14 +182,14 @@ final class UnplaceMojoTest {
             .with("removeBinaries", new SetOf<>("**foo6.class"))
             .execute();
         final Path placed = temp.resolve("placed.csv");
-//        MatcherAssert.assertThat(
-//            Files.readString(placed).contains("false"),
-//            Matchers.is(false)
-//        );
-//        MatcherAssert.assertThat(
-//            Files.readString(placed).contains("true"),
-//            Matchers.is(true)
-//        );
+        MatcherAssert.assertThat(
+            Files.readString(placed).contains("false"),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            Files.readString(placed).contains("true"),
+            Matchers.is(true)
+        );
     }
 
     @Test
@@ -210,13 +210,13 @@ final class UnplaceMojoTest {
             .with("keepBinaries", new SetOf<>("**foo6.class"))
             .execute();
         final Path placed = temp.resolve("placed.csv");
-//        MatcherAssert.assertThat(
-//            Files.readString(placed).contains("false"),
-//            Matchers.is(true)
-//        );
-//        MatcherAssert.assertThat(
-//            Files.readString(placed).contains("true"),
-//            Matchers.is(false)
-//        );
+        MatcherAssert.assertThat(
+            Files.readString(placed).contains("false"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            Files.readString(placed).contains("true"),
+            Matchers.is(false)
+        );
     }
 }


### PR DESCRIPTION
`FakeMaven.execute()` returns a map of all compiled or created files in working dir after mojo execution. The key of the map is a relative path as a `String` and the value of the map is an absolute path to the same file.
I've also rewrote all tests under `ParseMojoTest` in order to apply the new approach in practice. It looks amazing to me.

Except two things of course - ` .withDefaults()` and `.withEoForeign()` - they are redundant.

Closes: #1479 