### PR TITLE
feat(#1489): remove `withEoForeign` method

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -111,25 +111,6 @@ public final class FakeMaven {
     }
 
     /**
-     * Creates eo-foreign.* file.
-     *
-     * @return The same maven instance.
-     * @todo #1479:90min The method withEoForeign() has to be deleted. We can move the logic of
-     *  creation eo-foreign.* file into exec() function directly. Also it's important to remove the
-     *  method from tests.
-     */
-    public FakeMaven withEoForeign() {
-        final Tojo tojo = Catalogs.INSTANCE.make(this.foreignPath())
-            .add("foo.x.main");
-        tojo.set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_VERSION, "0.25.0");
-        for (final Map.Entry<String, Object> entry : this.attributes.entrySet()) {
-            tojo.set(entry.getKey(), entry.getValue());
-        }
-        return this;
-    }
-
-    /**
      * Sets tojo attribute.
      *
      * @param attribute Tojo attribute.
@@ -152,6 +133,13 @@ public final class FakeMaven {
     public <T extends AbstractMojo> Map<String, Path> execute(
         final Class<T> mojo
     ) throws IOException {
+        final Tojo tojo = Catalogs.INSTANCE.make(this.foreignPath())
+            .add("foo.x.main")
+            .set(AssembleMojo.ATTR_SCOPE, "compile")
+            .set(AssembleMojo.ATTR_VERSION, "0.25.0");
+        for (final Map.Entry<String, Object> entry : this.attributes.entrySet()) {
+            tojo.set(entry.getKey(), entry.getValue());
+        }
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.params.entrySet()) {
             moja.with(entry.getKey(), entry.getValue());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -49,7 +49,6 @@ final class ParseMojoTest {
         MatcherAssert.assertThat(
             maven.withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
                 .withDefaults()
-                .withEoForeign()
                 .execute(ParseMojo.class),
             Matchers.hasKey(
                 String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
@@ -67,7 +66,6 @@ final class ParseMojoTest {
             IllegalStateException.class,
             () -> new FakeMaven(temp)
                 .withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
-                .withEoForeign()
                 .withDefaults()
                 .with("timeout", 0)
                 .execute(ParseMojo.class)
@@ -92,7 +90,6 @@ final class ParseMojoTest {
                 maven.withProgram("invalid content")
                     .withTojoAttribute(AssembleMojo.ATTR_HASH, hash)
                     .withDefaults()
-                    .withEoForeign()
                     .with("cache", cache)
                     .execute(ParseMojo.class)
                     .get(String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT))
@@ -108,7 +105,6 @@ final class ParseMojoTest {
                 IllegalStateException.class,
                 () -> new FakeMaven(temp)
                     .withProgram("something < is wrong here")
-                    .withEoForeign()
                     .withDefaults()
                     .execute(ParseMojo.class)
             ).getCause().getCause().getMessage(),
@@ -122,7 +118,6 @@ final class ParseMojoTest {
             new FakeMaven(temp)
                 .withProgram("something < is wrong here")
                 .withDefaults()
-                .withEoForeign()
                 .with("failOnError", false)
                 .execute(ParseMojo.class),
             Matchers.not(


### PR DESCRIPTION
The redundant method `withEoForeign()` was removed from `FakeMaven`. 

Closes: #1489 