### PR TITLE
feat(#1488): remove `withDefaults` method from `FakeMaven`

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -84,21 +84,6 @@ public final class FakeMaven {
     }
 
     /**
-     * Set default the params for all mojos.
-     *
-     * @return The same maven instance.
-     * @todo #1479:90min The method withDefaults() has to be called right in the exec() method.
-     *  We should set default properties only if they aren't set using `with()` method. Also
-     *  it's important to remove withDefaults() method from tests.
-     */
-    public FakeMaven withDefaults() {
-        this.params.put("targetDir", this.targetPath().toFile());
-        this.params.put("foreign", this.foreignPath().toFile());
-        this.params.put("foreignFormat", "csv");
-        return this;
-    }
-
-    /**
      * Sets parameter for execution.
      *
      * @param param Parameter name
@@ -140,6 +125,9 @@ public final class FakeMaven {
         for (final Map.Entry<String, Object> entry : this.attributes.entrySet()) {
             tojo.set(entry.getKey(), entry.getValue());
         }
+        this.params.putIfAbsent("targetDir", this.targetPath().toFile());
+        this.params.putIfAbsent("foreign", this.foreignPath().toFile());
+        this.params.putIfAbsent("foreignFormat", "csv");
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.params.entrySet()) {
             moja.with(entry.getKey(), entry.getValue());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -48,7 +48,6 @@ final class ParseMojoTest {
         final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(
             maven.withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
-                .withDefaults()
                 .execute(ParseMojo.class),
             Matchers.hasKey(
                 String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
@@ -66,7 +65,6 @@ final class ParseMojoTest {
             IllegalStateException.class,
             () -> new FakeMaven(temp)
                 .withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print")
-                .withDefaults()
                 .with("timeout", 0)
                 .execute(ParseMojo.class)
         );
@@ -89,7 +87,6 @@ final class ParseMojoTest {
             new TextOf(
                 maven.withProgram("invalid content")
                     .withTojoAttribute(AssembleMojo.ATTR_HASH, hash)
-                    .withDefaults()
                     .with("cache", cache)
                     .execute(ParseMojo.class)
                     .get(String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT))
@@ -105,7 +102,6 @@ final class ParseMojoTest {
                 IllegalStateException.class,
                 () -> new FakeMaven(temp)
                     .withProgram("something < is wrong here")
-                    .withDefaults()
                     .execute(ParseMojo.class)
             ).getCause().getCause().getMessage(),
             Matchers.containsString("Failed to parse")
@@ -117,7 +113,6 @@ final class ParseMojoTest {
         MatcherAssert.assertThat(
             new FakeMaven(temp)
                 .withProgram("something < is wrong here")
-                .withDefaults()
                 .with("failOnError", false)
                 .execute(ParseMojo.class),
             Matchers.not(


### PR DESCRIPTION
The `withDefaults` method was removed from `FakeMaven`.

Closes: #1488 