### PR TITLE
feat(#1493). Add `<error>` to `XMIR` if redundant parentheses are found.

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
+++ b/eo-parser/src/main/java/org/eolang/parser/RedundantParentheses.java
@@ -27,13 +27,14 @@ import com.jcabi.log.Logger;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * The class that checks redundant parentheses for object expression.
  *
  * @since 0.28.12
  */
-final class RedundantParentheses implements Consumer<String> {
+final class RedundantParentheses implements Predicate<String> {
 
     /**
      * The callback that will be called in case if redundant parentheses is found.
@@ -44,7 +45,7 @@ final class RedundantParentheses implements Consumer<String> {
      * Constructor with default reaction that writes warning to the log.
      */
     RedundantParentheses() {
-        this(s -> Logger.warn("%s contains redundant parentheses", s));
+        this(s -> Logger.warn("Redundant parentheses", s));
     }
 
     /**
@@ -54,13 +55,6 @@ final class RedundantParentheses implements Consumer<String> {
      */
     RedundantParentheses(final Consumer<String> reaction) {
         this.reaction = reaction;
-    }
-
-    @Override
-    public void accept(final String expression) {
-        if (RedundantParentheses.test(expression)) {
-            this.reaction.accept(expression);
-        }
     }
 
     /**
@@ -75,7 +69,7 @@ final class RedundantParentheses implements Consumer<String> {
      * @param expression Raw object expression from parser.
      * @return True if the expression contains redundant parentheses.
      */
-    private static boolean test(final String expression) {
+    public boolean test(final String expression) {
         final Deque<Character> stack = new ArrayDeque<>();
         boolean res = false;
         for (final char symbol : RedundantParentheses.expressionChars(expression)) {
@@ -97,6 +91,9 @@ final class RedundantParentheses implements Consumer<String> {
         }
         if (stack.isEmpty()) {
             res = true;
+        }
+        if (res) {
+            this.reaction.accept(expression);
         }
         return res;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -28,7 +28,6 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Consumer;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -74,7 +73,7 @@ public final class Syntax {
     /**
      * Checks redundant parentheses.
      */
-    private final Consumer<String> redundancy;
+    private final RedundantParentheses redundancy;
 
     /**
      * Ctor.
@@ -106,7 +105,7 @@ public final class Syntax {
         final String nme,
         final Input ipt,
         final Output tgt,
-        final Consumer<String> redundancy
+        final RedundantParentheses redundancy
     ) {
         this.name = nme;
         this.input = ipt;

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -115,6 +115,11 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
         this.dirs
             .attr("ms", (System.nanoTime() - this.start) / (1000L * 1000L))
             .up();
+        dirs.xpath("/program/errors")
+            .push()
+            .add("error")
+            .attr("line", "10")
+            .attr("severity", "warning");
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -81,11 +81,6 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     private final RedundantParentheses check;
 
     /**
-     * Found error directives.
-     */
-    private final Directives errors;
-
-    /**
      * Ctor.
      * @param name Tha name of it
      * @param check The strategy to check eo expressions for redundant parentheses.
@@ -93,7 +88,6 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     public XeListener(final String name, final RedundantParentheses check) {
         this.name = name;
         this.dirs = new Directives();
-        this.errors = new Directives();
         this.objects = new Objects.ObjXembly();
         this.start = System.nanoTime();
         this.check = check;
@@ -119,8 +113,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     public void exitProgram(final ProgramParser.ProgramContext ctx) {
         this.dirs
             .attr("ms", (System.nanoTime() - this.start) / (1000L * 1000L))
-            .up()
-            .append(this.errors);
+            .up();
     }
 
     @Override
@@ -188,12 +181,13 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
             }
             final String text = application.getText();
             if (this.check.test(text)) {
-                this.errors.xpath("/program/errors")
+                this.dirs.push()
+                    .xpath("/program/errors")
                     .add("error")
                     .attr("line", ctx.getStart().getLine())
                     .attr("severity", "warning")
                     .set(String.format("'%s' contains redundant parentheses", text))
-                    .up();
+                    .pop();
             }
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/redundency/redundent-parentheses.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/redundency/redundent-parentheses.yaml
@@ -1,0 +1,8 @@
+tests:
+  - /program/errors[count(error)=1]
+  - //error[@severity='warning' and @line=4 and text()="'(1.plus 2)' contains redundant parentheses"]
+eo: |
+  +package a.b.c
+
+  [] > x
+    (1.plus 2) > y


### PR DESCRIPTION
The `</error>` with `severity=warning` was added to `XMIR` if redundant parentheses are found.

Closes: #1493 