### PR TITLE
fix(#1508): Remove Java 8 from GitHub runners

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [8, 11, 17]
+        java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ SOFTWARE.
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[1.8,)</version>
+                    <version>[11,)</version>
                   </requireJavaVersion>
                 </rules>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ SOFTWARE.
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[11,)</version>
+                    <version>[1.8,)</version>
                   </requireJavaVersion>
                 </rules>
               </configuration>


### PR DESCRIPTION
1) first of all, I've tried to reduce Java version for `maven-enforcer-plugin` in order to make all GitHub actions pass. It doesn't help, because  incompatibilities with `org.antlr:antlr4-maven-plugin:4.11.1` (see details in comments)
2) Since we have decided to [move to Java 11](https://github.com/objectionary/eo/issues/1481), I don't see the reason why we have to run our pipelines using Java 8.

Closes : #1508 