### PR TITLE
redundant method removed

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
@@ -29,11 +29,9 @@ package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
-import org.eolang.Data;
 import org.eolang.ExAbstract;
 import org.eolang.ExFailure;
 import org.eolang.PhDefault;
-import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
 
@@ -68,24 +66,6 @@ public final class EOerror extends PhDefault {
                     throw new ExError(enclosure);
                 }
             )
-        );
-    }
-
-    /**
-     * Ctor.
-     *
-     * <p>Use this method to build a new error object. Don't use the
-     * constructor here. This factory method is much more convenient.</p>
-     *
-     * @param format Message format string, similar to {@link String#format(String, Object...)}
-     * @param params Parameters, which will be passed to the formatter
-     * @return The error object
-     */
-    public static Phi make(final String format, final Object... params) {
-        return new PhWith(
-            new EOerror(Phi.Φ),
-            "α",
-            new Data.ToPhi(String.format(format, params))
         );
     }
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
@@ -27,7 +27,10 @@
  */
 package EOorg.EOeolang;
 
+import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.PhWith;
+import org.eolang.Phi;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +46,11 @@ public final class EOerrorTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> new Dataized(
-                EOerror.make("intentional error")
+                new PhWith(
+                    new EOerror(Phi.Φ),
+                    "α",
+                    new Data.ToPhi("intentional error")
+                )
             ).take()
         );
     }


### PR DESCRIPTION
We used this method only once and only inside a test of itself. I think, it's redundant.