### PR TITLE
feat(#1514) Throw an Exception if param doesn't fit to a Mojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
@@ -173,11 +173,12 @@ public final class Moja<T extends AbstractMojo> {
         } else {
             final Class<?> parent = clazz.getSuperclass();
             if (parent == null) {
-                Logger.warn(
-                    this,
-                    "Can't find '%s' in '%s'",
-                    name,
-                    mojo.getClass().getCanonicalName()
+                throw new IllegalStateException(
+                    String.format(
+                        "Can't find '%s' in '%s'",
+                        name,
+                        this.type.getCanonicalName()
+                    )
                 );
             } else {
                 this.initField(parent, mojo, entry);


### PR DESCRIPTION
I've returned back the logic with throwing an Exception in `Moja` if a corresponding field isn't found.
Now we check field presence right inside `FakeMaven`.  

Closes: #1514 