### PR TITLE
feat(#1547): add `PlaceMojo` test that place `eo-runtime` classes

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -197,6 +197,13 @@ public final class FakeMaven {
         this.params.putIfAbsent("ignoreVersionConflict", false);
         this.params.putIfAbsent("ignoreTransitive", true);
         this.params.putIfAbsent("central", new DummyCentral());
+        final Path placed = Paths.get("placed.json");
+        this.params.putIfAbsent("placed", this.workspace.absolute(placed).toFile());
+        this.params.putIfAbsent("placedFormat", "json");
+        this.params.putIfAbsent(
+            "outputDir",
+            this.workspace.absolute(Paths.get("target").resolve("classes")).toFile()
+        );
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.allowedParams(mojo).entrySet()) {
             moja.with(entry.getKey(), entry.getValue());
@@ -229,6 +236,17 @@ public final class FakeMaven {
     public TjSmart foreign() {
         return new TjSmart(
             Catalogs.INSTANCE.make(this.foreignPath())
+        );
+    }
+
+    /**
+     * Tojo for placed.json file.
+     *
+     * @return TjSmart of the current placed.json file.
+     */
+    public TjSmart placed() {
+        return new TjSmart(
+            Catalogs.INSTANCE.make(this.workspace.absolute(Paths.get("placed.json")))
         );
     }
 
@@ -386,6 +404,24 @@ public final class FakeMaven {
                 ParseMojo.class,
                 OptimizeMojo.class,
                 ResolveMojo.class
+            ).iterator();
+        }
+    }
+
+    /**
+     * Plan all eo dependencies full pipeline.
+     *
+     * @since 0.29.0
+     */
+    static final class Place implements Iterable<Class<? extends AbstractMojo>> {
+
+        @Override
+        public Iterator<Class<? extends AbstractMojo>> iterator() {
+            return Arrays.<Class<? extends AbstractMojo>>asList(
+                ParseMojo.class,
+                OptimizeMojo.class,
+                ResolveMojo.class,
+                PlaceMojo.class
             ).iterator();
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import com.yegor256.tojos.Tojos;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -89,6 +90,29 @@ final class PlaceMojoTest {
         MatcherAssert.assertThat(
             Files.exists(classes.resolve("org/eolang/f/x.a.class")),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * Test case for {@link PlaceMojo#execute()}.
+     * Since for tests we are using {@link org.eolang.maven.DummyCentral}, then instead of unpacking
+     * of classes from jar it just copies the jar itself to target/classes folder.
+     *
+     * @param temp Temporary directory
+     * @throws IOException If fails
+     */
+    @Test
+    void placesAllEoRuntimeClasses(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        MatcherAssert.assertThat(
+            maven.withHelloWorld()
+                .execute(new FakeMaven.Place())
+                .result().get("target/classes"),
+            new ContainsFile("**/eo-runtime-*.jar")
+        );
+        MatcherAssert.assertThat(
+            maven.placed().select(tojo -> "jar".equals(tojo.get(PlaceMojo.ATTR_PLD_KIND))).size(),
+            Matchers.equalTo(1)
         );
     }
 


### PR DESCRIPTION
Add test that proves that all classes from `eo-runtime` library will be added to `target/classes` directory automatically. Correlates with #1547 