### PR TITLE
maven compiler plugin update version ignored by renovate bot

### DIFF
--- a/eo-maven-plugin/src/it/fibonacci/pom.xml
+++ b/eo-maven-plugin/src/it/fibonacci/pom.xml
@@ -45,7 +45,7 @@ SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@ SOFTWARE.
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.8.1</version>
           <configuration combine.self="override">
             <source>8</source>
             <target>8</target>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "ignoreDeps": ["maven-compiler-plugin"]
 }


### PR DESCRIPTION
#1585

What is done:

- changed maven compiler plugin version
- added ignoring rule for this dependency to renovate bot