### PR TITLE
Hotfix for failed cyclic dependency

### DIFF
--- a/eo-maven-plugin/src/it/fibonacci/pom.xml
+++ b/eo-maven-plugin/src/it/fibonacci/pom.xml
@@ -34,18 +34,11 @@ SOFTWARE.
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <name>Fibonacci Numbers Calculator</name>
-  <dependencies>
-    <dependency>
-      <groupId>org.eolang</groupId>
-      <artifactId>eo-runtime</artifactId>
-      <version>@project.version@</version>
-    </dependency>
-  </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>


### PR DESCRIPTION
Remove cyclic dependency and downgrade `maven-compiler-plugin` version.
Hotfix for: https://github.com/objectionary/eo/pull/1592#issuecomment-1359202227