### PR TITLE
fix(#1574) Add concurrency test that shows the problem 

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -193,14 +193,7 @@ public final class ParseMojo extends SafeMojo {
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl"})
     private void parse(final Tojo tojo) throws IOException {
-        String first;
-        try {
-            first = tojo.get(AssembleMojo.ATTR_EO);
-        } catch (final Exception ex) {
-            Logger.error(this, "Failed to parse %s: %[exception]s", tojo, ex);
-            throw ex;
-        }
-        final Path source = Paths.get(first);
+        final Path source = Paths.get(tojo.get(AssembleMojo.ATTR_EO));
         final String name = tojo.get(Tojos.KEY);
         final Footprint footprint;
         if (tojo.exists(AssembleMojo.ATTR_HASH)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -193,7 +193,14 @@ public final class ParseMojo extends SafeMojo {
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl"})
     private void parse(final Tojo tojo) throws IOException {
-        final Path source = Paths.get(tojo.get(AssembleMojo.ATTR_EO));
+        String first;
+        try {
+            first = tojo.get(AssembleMojo.ATTR_EO);
+        } catch (final Exception ex) {
+            Logger.error(this, "Failed to parse %s: %[exception]s", tojo, ex);
+            throw ex;
+        }
+        final Path source = Paths.get(first);
         final String name = tojo.get(Tojos.KEY);
         final Footprint footprint;
         if (tojo.exists(AssembleMojo.ATTR_HASH)) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.maven;
 
 import com.yegor256.tojos.Tojo;
@@ -26,7 +49,10 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class CatalogsConcurrencyTest {
 
-    final static int CORES = Runtime.getRuntime().availableProcessors();
+    /**
+     * Number of cores on the running system.
+     */
+    private static final int CORES = Runtime.getRuntime().availableProcessors();
 
     @Disabled
     @Test
@@ -35,17 +61,22 @@ class CatalogsConcurrencyTest {
         MatcherAssert.assertThat(
             new SumOf(
                 new Threads<>(
-                    CORES,
-                    IntStream.range(0, CORES)
+                    CatalogsConcurrencyTest.CORES,
+                    IntStream.range(0, CatalogsConcurrencyTest.CORES)
                         .mapToObj(i -> tojos.add(UUID.randomUUID().toString()))
                         .map(CatalogsConcurrencyTest::task)
                         .collect(Collectors.toList())
                 )
             ),
-            Matchers.equalTo(CORES)
+            Matchers.equalTo(CatalogsConcurrencyTest.CORES)
         );
     }
 
+    /**
+     * Task to be executed in parallel.
+     * @param tojo Tojo
+     * @return Scalar
+     */
     private static Scalar<Integer> task(final Tojo tojo) {
         return () -> {
             final String uuid = "uuid";
@@ -57,6 +88,4 @@ class CatalogsConcurrencyTest {
             return 1;
         };
     }
-
-
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
@@ -45,7 +45,8 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.29.0
  * @todo #1574:30min MonoTojo is not thread safe.
  *  It's not possible to use it in parallel. It should be fixed.
- *  After that, remove the @Disabled annotation from the test below.
+ *  When <a href="https://github.com/yegor256/tojos/issues/50"> the issue</a> will be fixed,
+ *  remove the @Disabled annotation from the test below.
  */
 class CatalogsConcurrencyTest {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsConcurrencyTest.java
@@ -1,0 +1,62 @@
+package org.eolang.maven;
+
+import com.yegor256.tojos.Tojo;
+import com.yegor256.tojos.Tojos;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.cactoos.Scalar;
+import org.cactoos.experimental.Threads;
+import org.cactoos.number.SumOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Concurrency tests for {@link Catalogs}.
+ * All tests in that class must be executed in parallel and in order to be sure that
+ * everything works fine it's important to run the tests many times.
+ * @since 0.29.0
+ * @todo #1574:30min MonoTojo is not thread safe.
+ *  It's not possible to use it in parallel. It should be fixed.
+ *  After that, remove the @Disabled annotation from the test below.
+ */
+class CatalogsConcurrencyTest {
+
+    final static int CORES = Runtime.getRuntime().availableProcessors();
+
+    @Disabled
+    @Test
+    void readsFromTojosConcurrently(@TempDir final Path tmp) {
+        final Tojos tojos = Catalogs.INSTANCE.make(tmp.resolve("foreign"), "json");
+        MatcherAssert.assertThat(
+            new SumOf(
+                new Threads<>(
+                    CORES,
+                    IntStream.range(0, CORES)
+                        .mapToObj(i -> tojos.add(UUID.randomUUID().toString()))
+                        .map(CatalogsConcurrencyTest::task)
+                        .collect(Collectors.toList())
+                )
+            ),
+            Matchers.equalTo(CORES)
+        );
+    }
+
+    private static Scalar<Integer> task(final Tojo tojo) {
+        return () -> {
+            final String uuid = "uuid";
+            tojo.set(uuid, UUID.randomUUID().toString());
+            tojo.get(uuid);
+            tojo.get(uuid);
+            tojo.get(uuid);
+            tojo.get(uuid);
+            return 1;
+        };
+    }
+
+
+}


### PR DESCRIPTION
Add concurrency test that shows the problem with concurrent reading/writing `MonoTojo` attributes. It's important enable test when https://github.com/yegor256/tojos/issues/50 will be finished. 

Test for #1574.