### PR TITLE
#1563 clear error message for wrong attrs

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -210,22 +210,25 @@ public abstract class PhDefault implements Phi, Cloneable {
                 )
             );
         }
-        int idx;
-        for (idx = 0; idx < pos; ++idx) {
+        Attr attr = this.attr(this.order.get(0));
+        for (int idx = 0; idx <= pos; ++idx) {
             if (idx >= this.order.size()) {
                 throw new ExFailure(
                     String.format(
-                        "There are just %d attributes here, can't read the %d-th one",
-                        this.order.size(), pos
+                        "%s has just %d attribute(s), can't read the %d-th one",
+                        this,
+                        this.order.size(),
+                        pos
                     )
                 );
             }
             final String name = this.order.get(idx);
+            attr = this.attr(this.order.get(idx));
             if (this.attrs.get(name) instanceof AtVararg) {
                 break;
             }
         }
-        return this.attr(this.order.get(idx));
+        return attr;
     }
 
     @Override


### PR DESCRIPTION
closes #1563

Error message would be:
```
EOorg.EOeolang.EOerror$ExError: EOorg.EOeolang.EOstringν69="EOorg.EOeolang.EOcage.Writeν64 has just 1 attribute(s), can't read the 1-th one"SF
```