### PR TITLE
vertex as attribute

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
@@ -188,7 +188,11 @@ head
     NAME
     COPY?
     |
-    NAME
+    (
+      NAME
+      |
+      VERTEX
+    )
     DOT
     |
     data

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -336,6 +336,8 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
             this.objects.prop("data", "array");
         } else if (ctx.RHO() != null) {
             base = "^";
+        } else if (ctx.VERTEX() != null) {
+            base = "<";
         } else if (ctx.ROOT() != null) {
             base = "Q";
         } else if (ctx.HOME() != null) {

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
@@ -36,6 +36,8 @@ eo: |
       $.plus.@ 5.< > i
       third:foo > x...!
         $:^
+        <.
+          z
         f 12 false
           (((t' 22) r:t 8.54 "yes".< "\t").print 88 0x1f):hey TRUE.< FALSE > a!
             # This object is also very good

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -141,6 +141,14 @@
       45-1F-E7.<.eq (45-1F-E7.<)
     $.equal-to TRUE
 
+[] > take-vertex-as-vertical-attribute
+  assert-that > @
+    eq.
+      <.
+        42
+      42.<
+    $.equal-to TRUE
+
 [] > negative-object-vertices
   [x] > a
   assert-that > @


### PR DESCRIPTION
Now it's possible to use `<` as attribute name in vertical notation.