### PR TITLE
feat(#1609): Use `Footprint` for generated `java` files.

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
+import org.cactoos.Text;
 import org.cactoos.text.Joined;
+import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
 
@@ -71,9 +73,8 @@ final class JavaFiles {
     public List<Path> save() throws IOException {
         final Collection<XML> nodes = new XMLDocument(this.source)
             .nodes("//class[java and not(@atom)]");
-        final List<Path> files = new ArrayList<>(0);
         for (final XML java : nodes) {
-            files.add(this.saveJava(java));
+            this.saveJava(java);
         }
         if (nodes.isEmpty()) {
             Logger.debug(
@@ -86,7 +87,7 @@ final class JavaFiles {
                 nodes.size(), new Rel(this.source), new Rel(this.dest)
             );
         }
-        return files;
+        return new FtDefault(this.dest).paths("java");
     }
 
     /**
@@ -95,13 +96,11 @@ final class JavaFiles {
      * @return Path to generated file
      * @throws IOException If fails
      */
-    private Path saveJava(final XML java) throws IOException {
-        final String type = java.xpath("@java-name").get(0);
-        final Path path = new Place(type).make(this.dest, "java");
-        new Home(this.dest).save(
-            new Joined("", java.xpath("java/text()")),
-            this.dest.relativize(path)
+    private void saveJava(final XML java) throws IOException {
+        new FtDefault(this.dest).save(
+            java.xpath("@java-name").get(0),
+            "java",
+            new Joined("", java.xpath("java/text()"))::asString
         );
-        return path;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -44,7 +44,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
 import org.eolang.parser.ParsingTrain;
@@ -217,9 +216,8 @@ public final class TranspileMojo extends SafeMojo {
             TranspileMojo.TRAIN,
             place.make(this.targetDir.toPath().resolve(TranspileMojo.PRE), "")
         );
-        final XML out = new Xsline(trn).pass(input);
         final Path dir = this.targetDir.toPath().resolve(TranspileMojo.DIR);
-        new Home(dir).save(out.toString(), dir.relativize(target));
+        new Home(dir).save(new Xsline(trn).pass(input).toString(), dir.relativize(target));
         return new JavaFiles(target, this.generatedDir.toPath()).save();
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -44,6 +44,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
 import org.eolang.parser.ParsingTrain;
@@ -191,7 +192,9 @@ public final class TranspileMojo extends SafeMojo {
      * @return List of Paths to generated java file
      * @throws IOException If any issues with I/O
      */
-    private List<Path> transpile(final Path src, final XML input,
+    private List<Path> transpile(
+        final Path src,
+        final XML input,
         final Path target
     ) throws IOException {
         final String name = input.xpath("/program/@name").get(0);
@@ -211,19 +214,13 @@ public final class TranspileMojo extends SafeMojo {
         }
         final Place place = new Place(name);
         final Train<Shift> trn = new SpyTrain(
-            TranspileMojo.TRAIN, place.make(
-            this.targetDir.toPath().resolve(TranspileMojo.PRE),
-            ""
-        )
+            TranspileMojo.TRAIN,
+            place.make(this.targetDir.toPath().resolve(TranspileMojo.PRE), "")
         );
         final XML out = new Xsline(trn).pass(input);
         final Path dir = this.targetDir.toPath().resolve(TranspileMojo.DIR);
-        new Home(dir)
-            .save(out.toString(), dir.relativize(target));
-        return new JavaFiles(
-            target,
-            this.generatedDir.toPath()
-        ).save();
+        new Home(dir).save(out.toString(), dir.relativize(target));
+        return new JavaFiles(target, this.generatedDir.toPath()).save();
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
@@ -52,9 +52,8 @@ public interface Footprint {
      */
     void save(String program, String ext, Scalar<String> content) throws IOException;
 
-
     /**
-     * Get all saved regular files as a list.
+     * Get list of saved regular files with ext.
      * @param ext File extension
      * @return List of files
      * @throws IOException In case of IO issues

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
@@ -53,5 +53,11 @@ public interface Footprint {
     void save(String program, String ext, Scalar<String> content) throws IOException;
 
 
-    List<Path> paths(String ext) throws IOException;
+    /**
+     * Get all saved regular files as a list.
+     * @param ext File extension
+     * @return List of files
+     * @throws IOException In case of IO issues
+     */
+    List<Path> list(String ext) throws IOException;
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/Footprint.java
@@ -24,6 +24,8 @@
 package org.eolang.maven.footprint;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import org.cactoos.Scalar;
 
 /**
@@ -48,6 +50,8 @@ public interface Footprint {
      * @param content File content
      * @throws IOException In case of IO issues
      */
-    void save(String program, String ext, Scalar<String> content)
-        throws IOException;
+    void save(String program, String ext, Scalar<String> content) throws IOException;
+
+
+    List<Path> paths(String ext) throws IOException;
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
@@ -105,8 +105,8 @@ public final class FtCached implements Footprint {
     }
 
     @Override
-    public List<Path> paths(final String ext) throws IOException {
-        return this.origin.paths(ext);
+    public List<Path> list(final String ext) throws IOException {
+        return this.origin.list(ext);
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.text.IoCheckedText;
@@ -37,7 +38,7 @@ import org.eolang.maven.util.Home;
 
 /**
  * Program footprint of EO compilation process.
- * <p/>The footprint optionally cached in {@link #cache} folder.
+ * <p>The footprint optionally cached in {@link #cache} folder.</p>
  * Caching is applied if {@link #hash} is not empty otherwise caching is ignored.
  *
  * @since 1.0
@@ -101,6 +102,11 @@ public final class FtCached implements Footprint {
             new Home(this.cache).save(text, this.path(program, ext));
         }
         this.origin.save(program, ext, () -> text);
+    }
+
+    @Override
+    public List<Path> paths(final String ext) throws IOException {
+        return this.origin.paths(ext);
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtDefault.java
@@ -24,7 +24,11 @@
 package org.eolang.maven.footprint;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.text.IoCheckedText;
@@ -35,7 +39,7 @@ import org.eolang.maven.util.Home;
 /**
  * Default implementation of a Footprint.
  * Program footprint of EO compilation process.
- * <p/>The footprint consists of file in {@link #main} folder
+ * <p>The footprint consists of file in {@link #main} folder</p>
  * @since 1.0
  */
 public final class FtDefault implements Footprint {
@@ -69,5 +73,19 @@ public final class FtDefault implements Footprint {
             new IoChecked<>(content).value(),
             this.main.relativize(new Place(program).make(this.main, ext))
         );
+    }
+
+    @Override
+    public List<Path> paths(final String ext) throws IOException {
+        final List<Path> res;
+        if (Files.exists(this.main)) {
+            res = Files.walk(this.main)
+                .filter(path -> path.toString().endsWith(ext))
+                .filter(Files::isRegularFile)
+                .collect(Collectors.toList());
+        } else {
+            res = Collections.emptyList();
+        }
+        return res;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtDefault.java
@@ -51,10 +51,10 @@ public final class FtDefault implements Footprint {
 
     /**
      * Ctor.
-     * @param main Main location.
+     * @param path Main location.
      */
-    public FtDefault(final Path main) {
-        this.main = main;
+    public FtDefault(final Path path) {
+        this.main = path;
     }
 
     @Override
@@ -76,12 +76,12 @@ public final class FtDefault implements Footprint {
     }
 
     @Override
-    public List<Path> paths(final String ext) throws IOException {
+    public List<Path> list(final String ext) throws IOException {
         final List<Path> res;
         if (Files.exists(this.main)) {
             res = Files.walk(this.main)
-                .filter(path -> path.toString().endsWith(ext))
                 .filter(Files::isRegularFile)
+                .filter(path -> path.toString().endsWith(ext))
                 .collect(Collectors.toList());
         } else {
             res = Collections.emptyList();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
@@ -25,7 +25,7 @@ package org.eolang.maven.footprint;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
+import org.cactoos.Scalar;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -36,26 +36,22 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 1.0
  */
 final class FtCachedTest {
+
+    /**
+     * Default content.
+     */
+    private static final Scalar<String> CONTENT = () -> "content";
+
     @Test
-    void testContentOfCachedFile(@TempDir final Path temp) throws Exception {
-        final String content = String.join(
-            "\n",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<program>",
-            "</program>"
-        );
-        new FtCached(
-            "abcde123",
-            temp.resolve("parsed"),
-            new FtDefault(temp.resolve("target"))
-        ).save("org.eolang.txt.text", "xmir", () -> content);
+    void loadsContentOfCachedFile(@TempDir final Path temp) throws Exception {
+        final Path target = temp.resolve("target");
+        final Path parsed = temp.resolve("parsed");
+        final Footprint cached = new FtCached("abcde123", parsed, new FtDefault(target));
+        final String program = "org.eolang.txt.format";
+        cached.save(program, "xmir", FtCachedTest.CONTENT);
         MatcherAssert.assertThat(
-            new FtCached(
-                "abcde123",
-                temp.resolve("parsed"),
-                new FtDefault(temp.resolve("target"))
-            ).load("org.eolang.txt.text", "xmir"),
-            Matchers.equalTo(content)
+            cached.load(program, "xmir"),
+            Matchers.equalTo(FtCachedTest.CONTENT.value())
         );
     }
 
@@ -63,11 +59,11 @@ final class FtCachedTest {
     void returnsListOfSavedFilesFromDelegate(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("target");
         final Footprint footprint = new FtCached(
-            UUID.randomUUID().toString(),
+            "abcde123",
             temp.resolve("parsed"),
             new FtDefault(target)
         );
-        footprint.save("prog", "xmir", () -> "content");
+        footprint.save("prog", "xmir", FtCachedTest.CONTENT);
         MatcherAssert.assertThat(
             footprint.list("xmir"),
             Matchers.hasItem(target.resolve("prog.xmir"))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
@@ -60,7 +60,7 @@ final class FtCachedTest {
     }
 
     @Test
-    void returnsListOfSavedFilesWithoutDirectory(@TempDir final Path temp) throws IOException {
+    void returnsListOfSavedFilesFromDelegate(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("target");
         final Footprint footprint = new FtCached(
             UUID.randomUUID().toString(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.maven.footprint;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -54,6 +56,21 @@ final class FtCachedTest {
                 new FtDefault(temp.resolve("target"))
             ).load("org.eolang.txt.text", "xmir"),
             Matchers.equalTo(content)
+        );
+    }
+
+    @Test
+    void returnsListOfSavedFilesWithoutDirectory(@TempDir final Path temp) throws IOException {
+        final Path target = temp.resolve("target");
+        final Footprint footprint = new FtCached(
+            UUID.randomUUID().toString(),
+            temp.resolve("parsed"),
+            new FtDefault(target)
+        );
+        footprint.save("prog", "xmir", () -> "content");
+        MatcherAssert.assertThat(
+            footprint.list("xmir"),
+            Matchers.hasItem(target.resolve("prog.xmir"))
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
@@ -48,8 +48,8 @@ final class FtDefaultTest {
     private static final Scalar<String> CONTENT = () -> "content";
 
     @Test
-    void testContentOfNoCacheFile(@TempDir final Path temp) throws Exception {
-        final String program = "org.eolang.txt.text";
+    void loadsContentOfNoCacheFile(@TempDir final Path temp) throws Exception {
+        final String program = "org.eolang.txt";
         final Path target = temp.resolve("target");
         new FtDefault(target).save(program, FtDefaultTest.XMIR, FtDefaultTest.CONTENT);
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
@@ -23,7 +23,11 @@
  */
 package org.eolang.maven.footprint;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Random;
+import java.util.UUID;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -48,6 +52,34 @@ final class FtDefaultTest {
             new FtDefault(temp.resolve("target"))
                 .load("org.eolang.txt.text", "xmir"),
             Matchers.equalTo(content)
+        );
+    }
+
+    @Test
+    void returnsListOfSavedFilesWithoutDirectory(@TempDir final Path temp) throws IOException {
+        final Footprint footprint = new FtDefault(temp);
+        footprint.save("org.eolang.a", "xmir", () -> UUID.randomUUID().toString());
+        footprint.save("org.eolang.b", "xmir", () -> UUID.randomUUID().toString());
+        footprint.save("org.eolang.c", "o", () -> UUID.randomUUID().toString());
+        footprint.save("org.eolang.dir.sub", "o", () -> UUID.randomUUID().toString());
+        final Path subfolder = temp.resolve("org").resolve("eolang");
+        MatcherAssert.assertThat(
+            footprint.list("xmir"),
+            Matchers.containsInAnyOrder(
+                subfolder.resolve("a.xmir"),
+                subfolder.resolve("b.xmir")
+            )
+        );
+        MatcherAssert.assertThat(
+            footprint.list("o"),
+            Matchers.containsInAnyOrder(
+                subfolder.resolve("c.o"),
+                subfolder.resolve("dir").resolve("sub.o")
+            )
+        );
+        MatcherAssert.assertThat(
+            footprint.list("dir"),
+            Matchers.empty()
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
@@ -25,9 +25,7 @@ package org.eolang.maven.footprint;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Random;
-import java.util.UUID;
+import org.cactoos.Scalar;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -38,30 +36,35 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 1.0
  */
 final class FtDefaultTest {
+
+    /**
+     * Default extension.
+     */
+    private static final String XMIR = "xmir";
+
+    /**
+     * Default content.
+     */
+    private static final Scalar<String> CONTENT = () -> "content";
+
     @Test
     void testContentOfNoCacheFile(@TempDir final Path temp) throws Exception {
-        final String content = String.join(
-            "\n",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<program>",
-            "</program>"
-        );
-        new FtDefault(temp.resolve("target"))
-            .save("org.eolang.txt.text", "xmir", () -> content);
+        final String program = "org.eolang.txt.text";
+        final Path target = temp.resolve("target");
+        new FtDefault(target).save(program, FtDefaultTest.XMIR, FtDefaultTest.CONTENT);
         MatcherAssert.assertThat(
-            new FtDefault(temp.resolve("target"))
-                .load("org.eolang.txt.text", "xmir"),
-            Matchers.equalTo(content)
+            new FtDefault(target).load(program, FtDefaultTest.XMIR),
+            Matchers.equalTo(FtDefaultTest.CONTENT.value())
         );
     }
 
     @Test
     void returnsListOfSavedFilesWithoutDirectory(@TempDir final Path temp) throws IOException {
         final Footprint footprint = new FtDefault(temp);
-        footprint.save("org.eolang.a", "xmir", () -> UUID.randomUUID().toString());
-        footprint.save("org.eolang.b", "xmir", () -> UUID.randomUUID().toString());
-        footprint.save("org.eolang.c", "o", () -> UUID.randomUUID().toString());
-        footprint.save("org.eolang.dir.sub", "o", () -> UUID.randomUUID().toString());
+        footprint.save("org.eolang.a", FtDefaultTest.XMIR, FtDefaultTest.CONTENT);
+        footprint.save("org.eolang.b", FtDefaultTest.XMIR, FtDefaultTest.CONTENT);
+        footprint.save("org.eolang.c", "o", FtDefaultTest.CONTENT);
+        footprint.save("org.eolang.dir.sub", "o", FtDefaultTest.CONTENT);
         final Path subfolder = temp.resolve("org").resolve("eolang");
         MatcherAssert.assertThat(
             footprint.list("xmir"),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
@@ -78,7 +78,7 @@ final class FtDefaultTest {
             )
         );
         MatcherAssert.assertThat(
-            footprint.list("dir"),
+            footprint.list("org"),
             Matchers.empty()
         );
     }


### PR DESCRIPTION
Use `Footprint` for generated `java` files inside `TranspileMojo`.

Closes: #1609 