### PR TITLE
imperative goto usage

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -193,6 +193,19 @@
           x
     $.equal-to 3
 
+[] > while-without-last-dataization
+  memory 0 > x
+  assert-that > @
+    seq
+      while.
+        x.lt 2
+        [i]
+          x.write (x.plus 1) > @
+      .@
+      .<
+      x
+    $.equal-to 2
+
 [] > last-while-dataization-object-with-false-condition
   memory 3 > x
   assert-that > @

--- a/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
@@ -42,9 +42,11 @@
               i.lt 10
               g.backward
               TRUE
+      .@
+      .<
       stdout "Finished!"
       i
-    $.equal-to 11
+    $.equal-to 10
 
 [] > goto-jumps-forward
   [x] > div

--- a/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
@@ -42,6 +42,23 @@
               i.lt 10
               g.backward
               TRUE
+      stdout "Finished!"
+      i
+    $.equal-to 11
+
+[] > goto-jumps-backwards-without-last-datization
+  memory 0 > i
+  assert-that > @
+    seq
+      i.write 1
+      goto
+        [g]
+          seq > @
+            i.write (i.plus 1)
+            if.
+              i.lt 10
+              g.backward
+              TRUE
       .@
       .<
       stdout "Finished!"


### PR DESCRIPTION
This is an example of how `goto` and `while` can be used in imperative way