### PR TITLE
test(#1366): Fix tests names and add `test-naming-conventions` plugin

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 class CleanMojoTest {
 
     @Test
-    void execSuccessfully(@TempDir final Path temp) throws IOException {
+    void cleansSuccessfully(@TempDir final Path temp) throws IOException {
         final Path dir = Files.createDirectories(temp.resolve("target"));
         final Path out = Files.createDirectories(dir.resolve("child"));
         final Path small = Files.createDirectories(out.resolve("child.eo"));
@@ -60,7 +60,7 @@ class CleanMojoTest {
     }
 
     @Test
-    void fullCompilingLifecycleSuccessfully(@TempDir final Path temp) throws IOException {
+    void makesFullCompilingLifecycleSuccessfully(@TempDir final Path temp) throws IOException {
         final Path src = temp.resolve("src");
         new Home(src).save(
             String.join(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class MarkMojoTest {
 
     @Test
-    void extendForeignWithNewObjects(@TempDir final Path temp) throws Exception {
+    void extendsForeignWithNewObjects(@TempDir final Path temp) throws Exception {
         final Path bins = temp.resolve(ResolveMojo.DIR);
         new Home(bins).save(
             "hi",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -59,7 +59,7 @@ final class OptimizeMojoTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/packs/", glob = "**.yaml")
-    void testPacks(final String pack) throws Exception {
+    void checksPacks(final String pack) throws Exception {
         MatcherAssert.assertThat(
             new CheckPack(pack).failures(),
             Matchers.empty()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class ParseMojoTest {
 
     @Test
-    void testSimpleParsing(@TempDir final Path temp) throws Exception {
+    void parsesSuccessfully(@TempDir final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(
             maven.withHelloWorld()
@@ -77,7 +77,7 @@ final class ParseMojoTest {
     }
 
     @Test
-    void testSimpleParsingCached(@TempDir final Path temp) throws Exception {
+    void parsesWithCache(@TempDir final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp);
         final Path cache = temp.resolve("cache");
         final String expected = new UncheckedText(
@@ -103,7 +103,7 @@ final class ParseMojoTest {
     }
 
     @Test
-    void testCrashOnInvalidSyntax(@TempDir final Path temp) {
+    void crashesOnInvalidSyntax(@TempDir final Path temp) {
         MatcherAssert.assertThat(
             Assertions.assertThrows(
                 IllegalStateException.class,
@@ -116,7 +116,7 @@ final class ParseMojoTest {
     }
 
     @Test
-    void testDoNotCrashesWithFailOnError(@TempDir final Path temp) throws Exception {
+    void doesNotCrashesWithFailOnError(@TempDir final Path temp) throws Exception {
         MatcherAssert.assertThat(
             new FakeMaven(temp)
                 .withProgram("something < is wrong here")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -50,7 +50,7 @@ final class PullMojoTest {
     private static final String FOREIGN_FORMAT = "json";
 
     @Test
-    void testSimplePull(@TempDir final Path temp) throws IOException {
+    void pullsSuccessfully(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("target");
         final Path foreign = temp.resolve("eo-foreign.json");
         Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class RegisterMojoTest {
 
     @Test
-    void registerOkNames(@TempDir final Path temp) throws IOException {
+    void registersOkNames(@TempDir final Path temp) throws IOException {
         new Home(temp).save(
             new ResourceOf("org/eolang/maven/file-name/abc-def.eo"),
             Paths.get("src/eo/org/eolang/maven/abc-def.eo")
@@ -77,7 +77,7 @@ final class RegisterMojoTest {
     }
 
     @Test
-    void noFailureWhenNoStrictNames(@TempDir final Path temp) throws IOException {
+    void doesNotFailWhenNoStrictNames(@TempDir final Path temp) throws IOException {
         new Home(temp).save(
             new ResourceOf("org/eolang/maven/file-name/.abc.eo"),
             Paths.get("src/eo/org/eolang/maven/.abc.eo")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class ResolveMojoTest {
 
     @Test
-    void resolveWithSingleDependency(@TempDir final Path temp) throws Exception {
+    void resolvesWithSingleDependency(@TempDir final Path temp) throws Exception {
         final Path foo = Paths.get("src").resolve("foo.eo");
         new Home(temp).save(
             String.format(
@@ -73,7 +73,7 @@ final class ResolveMojoTest {
     }
 
     @Test
-    void resolveWithoutAnyDependencies(@TempDir final Path temp) throws IOException {
+    void resolvesWithoutAnyDependencies(@TempDir final Path temp) throws IOException {
         final Path foo = Paths.get("src").resolve("sum.eo");
         final Home home = new Home(temp);
         home.save(
@@ -144,7 +144,7 @@ final class ResolveMojoTest {
      * @throws IOException In case of I/O issues.
      */
     @Test
-    void testConflictingDependencies(@TempDir final Path temp) throws IOException {
+    void resolvesWithConflictingDependencies(@TempDir final Path temp) throws IOException {
         final Path first = temp.resolve("src/foo1.src");
         new Home(temp).save(
             String.format(
@@ -205,7 +205,7 @@ final class ResolveMojoTest {
     }
 
     @Test
-    void testConflictingDependenciesNoFail(@TempDir final Path temp) throws IOException {
+    void resolvesWithConflictingDependenciesNoFail(@TempDir final Path temp) throws IOException {
         final Path first = temp.resolve("src/foo1.src");
         new Home(temp).save(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 class SkipTest {
 
     @Test
-    void testExecutedPullMojo(@TempDir final Path temp) throws IOException {
+    void executesPullMojo(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("target");
         this.executePullMojo(temp, target, false);
         MatcherAssert.assertThat(
@@ -59,7 +59,7 @@ class SkipTest {
     }
 
     @Test
-    void testSkippedPullMojo(@TempDir final Path temp) {
+    void skipsPullMojo(@TempDir final Path temp) {
         final Path target = temp.resolve("target");
         this.executePullMojo(temp, target, true);
         MatcherAssert.assertThat(
@@ -76,7 +76,7 @@ class SkipTest {
     }
 
     @Test
-    void testSkippedCopyMojo(@TempDir final Path temp) throws IOException {
+    void skipsCopyMojo(@TempDir final Path temp) throws IOException {
         final Path classes = temp.resolve("classes");
         this.executeCopyMojo(temp, classes, true);
         final Path out = classes.resolve("EO-SOURCES/foo/main.eo");
@@ -87,7 +87,7 @@ class SkipTest {
     }
 
     @Test
-    void testExecutedCopyMojo(@TempDir final Path temp) throws IOException {
+    void executesCopyMojo(@TempDir final Path temp) throws IOException {
         final Path classes = temp.resolve("classes");
         this.executeCopyMojo(temp, classes, false);
         final Path out = classes.resolve("EO-SOURCES/foo/main.eo");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoTest.java
@@ -58,7 +58,7 @@ final class SodgMojoTest {
 
     @Test
     @Disabled
-    void bigSlowTest() throws Exception {
+    void convertsToGraph() throws Exception {
         final StringBuilder program = new StringBuilder(1000);
         for (int idx = 0; idx < 40; ++idx) {
             for (int spc = 0; spc < idx; ++spc) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -65,7 +65,7 @@ final class TranspileMojoTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/pre/", glob = "**.yaml")
-    void testPreStylesheets(final String yaml) {
+    void createsPreStylesheets(final String yaml) {
         MatcherAssert.assertThat(
             new XaxStory(yaml),
             Matchers.is(true)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -49,7 +49,7 @@ final class UnplaceMojoTest {
     private static final String ATTR_KIND_CLASS = "class";
 
     @Test
-    void testCleaning(@TempDir final Path temp) throws Exception {
+    void cleans(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo.class");
         final Home home = new Home(temp);
         home.save("...", temp.relativize(foo));
@@ -112,7 +112,7 @@ final class UnplaceMojoTest {
     }
 
     @Test
-    void testKeepBinaries(@TempDir final Path temp) throws Exception {
+    void keepsBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo5.class");
         new Home(temp).save("testKeepBinaries", temp.relativize(foo));
         final Path pparent = foo.getParent().getParent();
@@ -139,7 +139,7 @@ final class UnplaceMojoTest {
     }
 
     @Test
-    void testKeepRemoveBinaries(@TempDir final Path temp) throws Exception {
+    void keepsRemoveBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo6.class");
         final Home home = new Home(temp);
         home.save("testKeepRemoveBinaries", temp.relativize(foo));
@@ -168,7 +168,7 @@ final class UnplaceMojoTest {
     }
 
     @Test
-    void testUnplaceRemoveBinaries(@TempDir final Path temp) throws Exception {
+    void unplacesRemoveBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo6.class");
         new Home().save("testUnplaceRemoveBinaries", foo);
         final Path list = temp.resolve("placed.csv");
@@ -196,7 +196,7 @@ final class UnplaceMojoTest {
     }
 
     @Test
-    void testUnplaceKeepBinaries(@TempDir final Path temp) throws Exception {
+    void unplacesKeepBinaries(@TempDir final Path temp) throws Exception {
         final Path foo = temp.resolve("a/b/c/foo6.class");
         new Home().save("testUnplaceKeepBinaries", foo);
         final Path list = temp.resolve("placed.csv");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnspileMojoTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class UnspileMojoTest {
 
     @Test
-    void testCleaning(@TempDir final Path temp) throws Exception {
+    void cleans(@TempDir final Path temp) throws Exception {
         final Path generated = Paths.get("generated");
         final Path classes = Paths.get("classes");
         final Path foo = Paths.get("a/b/c/foo.class");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChRemoteTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class ChRemoteTest {
 
     @Test
-    void testCommitHashTag() {
+    void getsCommitHashTag() {
         final String hash = new ChRemote("0.26.0").value();
         MatcherAssert.assertThat(
             hash,
@@ -48,7 +48,7 @@ final class ChRemoteTest {
     }
 
     @Test
-    void testCommitHashOldTag() {
+    void getsCommitHashOldTag() {
         final String hash = new ChRemote("0.23.19").value();
         MatcherAssert.assertThat(
             hash,
@@ -57,7 +57,7 @@ final class ChRemoteTest {
     }
 
     @Test
-    void testCommitHashException() {
+    void throwsCommitHashException() {
         Assertions.assertThrows(
             ChText.NotFound.class,
             () -> new ChRemote("nonsense").value()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFallbackSwapTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFallbackSwapTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class OyFallbackSwapTest {
     @Test
-    void testFallbackNoSwapOy() throws Exception {
+    void getsWithFallbackNoSwapOy() throws Exception {
         MatcherAssert.assertThat(
             new TextOf(
                 new OyFallbackSwap(
@@ -53,7 +53,7 @@ class OyFallbackSwapTest {
     }
 
     @Test
-    void testFallbackSwapOyFail() throws Exception {
+    void getsWithFallbackSwapOyFail() throws Exception {
         MatcherAssert.assertThat(
             new TextOf(
                 new OyFallbackSwap(
@@ -71,7 +71,7 @@ class OyFallbackSwapTest {
     }
 
     @Test
-    void testFallbackSwapOy() throws Exception {
+    void getsWithFallbackSwapOy() throws Exception {
         MatcherAssert.assertThat(
             new TextOf(
                 new OyFallbackSwap(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/util/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/util/HomeTest.java
@@ -60,7 +60,7 @@ final class HomeTest {
     }
 
     @Test
-    void existsTest(@TempDir final Path temp) throws IOException {
+    void exists(@TempDir final Path temp) throws IOException {
         Files.write(temp.resolve("file.txt"), "any content".getBytes());
         MatcherAssert.assertThat(
             new Home(temp).exists(Paths.get("file.txt")),
@@ -69,7 +69,7 @@ final class HomeTest {
     }
 
     @Test
-    void existsInDirTest(@TempDir final Path temp) throws IOException {
+    void existsInDir(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("dir/subdir/file.txt");
         target.getParent().toFile().mkdirs();
         Files.write(target, "any content".getBytes());
@@ -80,7 +80,7 @@ final class HomeTest {
     }
 
     @Test
-    void existsInDirDifferentEncryptionTest(@TempDir final Path temp) throws IOException {
+    void existsInDirDifferentEncryption(@TempDir final Path temp) throws IOException {
         final String filename = "文件名.txt";
         final byte[] bytes = filename.getBytes(StandardCharsets.UTF_16BE);
         final String decoded = new String(bytes, StandardCharsets.UTF_16BE);
@@ -93,7 +93,7 @@ final class HomeTest {
     }
 
     @Test
-    void existsInDirWithSpecialSymbolsTest(@TempDir final Path temp) throws IOException {
+    void existsInDirWithSpecialSymbols(@TempDir final Path temp) throws IOException {
         final String filename = "EOorg/EOeolang/EOmath/EOnan$EOas_int$EO@";
         final byte[] bytes = filename.getBytes("CP1252");
         final String decoded = new String(bytes, "CP1252");
@@ -106,7 +106,7 @@ final class HomeTest {
     }
 
     @Test
-    void loadBytesFromExistingFile(@TempDir final Path temp) throws IOException {
+    void loadsBytesFromExistingFile(@TempDir final Path temp) throws IOException {
         final Home home = new Home(temp);
         final String content = "bar";
         final Path subfolder = temp.resolve("subfolder").resolve("foo.txt");
@@ -118,7 +118,7 @@ final class HomeTest {
     }
 
     @Test
-    void loadFromAbsentFile(@TempDir final Path temp) {
+    void loadsFromAbsentFile(@TempDir final Path temp) {
         Assertions.assertThrows(
             NoSuchFileException.class,
             () -> new Home(temp).load(temp.resolve("nonexistent"))

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
 final class ObjectsTest {
 
     @Test
-    void oneObject() {
+    void parsesOneObject() {
         final Objects objs = new Objects.ObjXembly();
         objs.start(9, 10);
         objs.prop("x", "y");
@@ -55,7 +55,7 @@ final class ObjectsTest {
     }
 
     @Test
-    void nestedObjects() {
+    void parsesNestedObjects() {
         final Objects objs = new Objects.ObjXembly();
         objs.start(1, 2);
         objs.start(3, 4);
@@ -73,7 +73,7 @@ final class ObjectsTest {
     }
 
     @Test
-    void entersPrevios() {
+    void parsesObjectsWithEnteringPrevious() {
         final Objects objs = new Objects.ObjXembly();
         objs.start(5, 6);
         objs.start(7, 8);

--- a/eo-parser/src/test/java/org/eolang/parser/PacksTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/PacksTest.java
@@ -53,7 +53,7 @@ final class PacksTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/parser/xax/", glob = "**.yml")
-    void testXslStylesheets(final String yaml) {
+    void createsXaxStoryWithXslStylesheets(final String yaml) {
         MatcherAssert.assertThat(
             new XaxStory(yaml),
             Matchers.is(true)

--- a/eo-parser/src/test/java/org/eolang/parser/SyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SyntaxTest.java
@@ -105,7 +105,7 @@ final class SyntaxTest {
         "a b c > x\n  x ^ > @",
         "[] > x\n  x ^ > @"
     })
-    void shouldBeParsable(final String code) {
+    void parsesSuccessfully(final String code) {
         final Syntax syntax = new Syntax(
             "test-2",
             new InputOf(code),

--- a/eo-parser/src/test/java/org/eolang/parser/TyposTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TyposTest.java
@@ -43,7 +43,7 @@ final class TyposTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/parser/typos/", glob = "**.yaml")
-    void testPacks(final String yml) throws Exception {
+    void checksPacks(final String yml) throws Exception {
         final Yaml yaml = new Yaml();
         final Map<String, Object> map = yaml.load(yml);
         try {

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOandTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOandTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 public final class EOboolEOandTest {
 
     @Test
-    public void logicallyJoinsTwoValues() {
+    public void joinsTwoValuesLogically() {
         final Phi left = new Data.ToPhi(true);
         final Phi right = new Data.ToPhi(false);
         final Phi and = left.attr("and").get();

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
@@ -126,7 +126,7 @@ public final class EOboolEOwhileTest {
     }
 
     @Test
-    public void complexBooleanToggle() {
+    public void dataizesComplexBooleanToggle() {
         final Phi parent = new Parent(Phi.Φ);
         final Phi toggle = new PhMethod(parent, "toggle");
         new Dataized(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 public final class EObytesEOconcatTest {
 
     @Test
-    public void concatBytes() {
+    public void concatenatesBytes() {
         final Phi current = new EOstring$EOas_bytes(new Data.ToPhi("привет "));
         final Phi provided = new EOstring$EOas_bytes(new Data.ToPhi("mr. ㄤㄠ!"));
         final Phi phi = new PhMethod(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 public final class EOcageTest {
 
     @Test
-    public void simpleWriteAndRead() {
+    public void writesAndReads() {
         final Phi cage = new EOcage(Phi.Φ);
         EOcageTest.writeTo(cage, new Data.ToPhi(1L));
         MatcherAssert.assertThat(
@@ -57,7 +57,7 @@ public final class EOcageTest {
     }
 
     @Test
-    public void emptyCageHasIdentity() {
+    public void checksThatEmptyCageHasIdentity() {
         final Phi cage = new EOcage(Phi.Φ);
         MatcherAssert.assertThat(
             new Dataized(cage.attr("ν").get()).take(Long.class),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOmallocTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 class EOheapEOmallocTest {
 
     @Test
-    public void allocateMemory() {
+    public void allocatesMemory() {
         final Phi heap = new PhWith(new EOheap(Phi.Φ), 0, new Data.ToPhi(100L));
         final Phi pointer = new PhWith(
             new PhMethod(heap, "malloc"),
@@ -76,7 +76,7 @@ class EOheapEOmallocTest {
     }
 
     @Test
-    public void checkMallocPointer() {
+    public void checksMallocPointer() {
         final long size = 20L;
         final Phi heap = new PhWith(new EOheap(Phi.Φ), 0, new Data.ToPhi(100L));
         final Phi pointer = new PhWith(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOpointerEOblockTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOpointerEOblockTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 public final class EOheapEOpointerEOblockTest {
 
     @Test
-    public void writesToHeap() {
+    public void writesBytesIntoHeap() {
         final Phi heap = new PhWith(new EOheap(Phi.Φ), 0, new Data.ToPhi(100L));
         final Phi pointer = new PhWith(
             new PhMethod(heap, "pointer"),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdinTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdinTest.java
@@ -81,7 +81,7 @@ public final class EOstdinTest {
 
     @StdIo("this is a test input!")
     @Test
-    public void nextLineOneLineTest(final StdIn stdin) {
+    public void dataizesNextLineOneLine(final StdIn stdin) {
         final String expected = "this is a test input!";
         final Phi phi = new PhMethod(new PhCopy(new EOstdin(Phi.Φ)), "next-line");
         final String actual = new Dataized(phi).take(String.class);
@@ -93,7 +93,7 @@ public final class EOstdinTest {
 
     @StdIo("this is a testing input!")
     @Test
-    public void stdinOneLineTest(final StdIn stdin) {
+    public void dataizesStdinOneLine(final StdIn stdin) {
         final String expected = "this is a testing input!".concat(System.lineSeparator());
         final Phi phi = new PhCopy(new EOstdin(Phi.Φ));
         final String actual = new Dataized(phi).take(String.class);
@@ -105,7 +105,7 @@ public final class EOstdinTest {
 
     @StdIo({"this is a test input!", "another line", "yet another line"})
     @Test
-    public void nextLineMultiLineTest(final StdIn stdin) {
+    public void dataizesNextLineMultiLine(final StdIn stdin) {
         final String expected = "this is a test input!";
         final Phi phi = new PhMethod(new PhCopy(new EOstdin(Phi.Φ)), "next-line");
         final String actual = new Dataized(phi).take(String.class);
@@ -117,7 +117,7 @@ public final class EOstdinTest {
 
     @StdIo("")
     @Test
-    public void nextLineEmptyTest(final StdIn stdin) {
+    public void dataizesNextLineEmpty(final StdIn stdin) {
         final Phi phi = new PhMethod(new PhCopy(new EOstdin(Phi.Φ)), "next-line");
         final EOerror.ExError error = Assertions.assertThrows(
             EOerror.ExError.class,
@@ -133,7 +133,7 @@ public final class EOstdinTest {
 
     @StdIo("")
     @Test
-    public void stdinEmptyTest(final StdIn stdin) {
+    public void dataizesEmptyStdin(final StdIn stdin) {
         final String expected = "";
         final Phi phi = new PhCopy(new EOstdin(Phi.Φ));
         final String actual = new Dataized(phi).take(String.class);
@@ -145,7 +145,7 @@ public final class EOstdinTest {
 
     @StdIo({"this is a test input!", "another line", "yet another line"})
     @Test
-    public void stdinMultiLineTest(final StdIn stdin) {
+    public void dataizesStdinMultiLine(final StdIn stdin) {
         final String first = "this is a test input!".concat(System.lineSeparator());
         final String second = "another line".concat(System.lineSeparator());
         final String third = "yet another line".concat(System.lineSeparator());
@@ -159,7 +159,7 @@ public final class EOstdinTest {
 
     @StdIo({"first", "second", "third"})
     @Test
-    public void stdinfewOneLineTest(final StdIn stdin) {
+    public void dataizesStdinFewOneLine(final StdIn stdin) {
         final String first = "\u0066\u0069\u0072\u0073\u0074";
         final String second = "\u0073\u0065\u0063\u006F\u006E\u0064";
         final String third = "\u0074\u0068\u0069\u0072\u0064";
@@ -185,7 +185,7 @@ public final class EOstdinTest {
 
     @StdIo({"first", "", "third"})
     @Test
-    public void stdinEmptyLineBetweenNonEmpty(final StdIn stdin) {
+    public void dataizesStdinEmptyLineBetweenNonEmpty(final StdIn stdin) {
         final String first = "\u0066\u0069\u0072\u0073\u0074";
         final String third = "\u0074\u0068\u0069\u0072\u0064";
         Phi phi = new PhMethod(new PhCopy(new EOstdin(Phi.Φ)), "next-line");

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
@@ -50,7 +50,7 @@ public final class EOmemoryTest {
     private static final String WRITE = "write";
 
     @Test
-    public void writeAfterCopy() {
+    public void writesAfterCopy() {
         final Phi first = new EOmemory(Phi.Φ);
         final Phi second = first.copy();
         second.attr(0).put(new Data.ToPhi(1L));
@@ -120,7 +120,7 @@ public final class EOmemoryTest {
     }
 
     @Test
-    public void makeCorrectCopy() {
+    public void makesCorrectCopy() {
         final Phi mem = new EOmemory(Phi.Φ);
         final Phi text = new Data.ToPhi(1L);
         final Phi write = mem.attr(EOmemoryTest.WRITE).get();

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOram_sliceTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOram_sliceTest.java
@@ -54,7 +54,7 @@ public final class EOram_sliceTest {
         "10, 5, hello, 5, 5, hello",
         "13, 0, hello world, 6, 5, world"
     })
-    void ramSlice(
+    void makesRamSlice(
         final long total,
         final int wrt,
         final String data,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOas_bytesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOas_bytesTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public final class EOstringEOas_bytesTest {
 
     @Test
-    public void stringToBytes() {
+    public void convertsStringToBytes() {
         final Phi str = new Data.ToPhi("Hello, друг!");
         final Phi phi = new EOstring$EOas_bytes(str);
         MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOsliceTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOsliceTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public final class EOstringEOsliceTest {
 
     @Test
-    public void sliceString() {
+    public void slicesString() {
         final Phi str = new Data.ToPhi("строка ㄤㄠ");
         final Phi phi = new PhWith(
             new PhWith(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 public final class HeapsTest {
 
     @Test
-    public void mallocAndFreeWork() {
+    public void performsMallocAndFreeWork() {
         final Phi heap = new EOheap(Phi.Φ);
         final int pointer = Heaps.INSTANCE.malloc(heap, 100);
         MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 final class BytesOfTest {
 
     @Test
-    void notWorks() {
+    void negatesSeveralTimes() {
         final String text = "abc";
         final Bytes bytes = new BytesOf(text);
         MatcherAssert.assertThat(
@@ -48,7 +48,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void notWorksNumeric() {
+    void negatesOnce() {
         final Bytes bytes = new BytesOf(-128L);
         MatcherAssert.assertThat(
             bytes.not(),
@@ -57,7 +57,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void andWorks() {
+    void checksAnd() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
             bytes.and(bytes.not()),
@@ -66,7 +66,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void orWorks() {
+    void checksOr() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
             bytes.or(bytes.not()),
@@ -75,7 +75,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void xorWorks() {
+    void checksXor() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
             bytes.xor(new BytesOf(-512L)),
@@ -84,7 +84,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void asNumberLong() {
+    void checksAsNumberLong() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
             bytes.asNumber(Long.class),
@@ -93,7 +93,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void underflowForLong() {
+    void checksUnderflowForLong() {
         final Bytes bytes = new BytesOf("A");
         Assertions.assertThrows(
             UnsupportedOperationException.class,
@@ -111,7 +111,7 @@ final class BytesOfTest {
         "0xFF000000,  24, 0x000000FF",
         "0x000000FF,   8, 0x00000000"
     })
-    void shiftWorks(final long num, final int bits, final long expected) {
+    void checksShift(final long num, final int bits, final long expected) {
         final Bytes bytes = new BytesOf(num);
         MatcherAssert.assertThat(
             bytes.shift(bits).asNumber(Long.class),
@@ -131,7 +131,7 @@ final class BytesOfTest {
         "0xFFFFFF80,   3, 0xFFFFFFF0",
         "0xFFFFFC00,   3, 0xFFFFFF80"
     })
-    void sshiftWorks(final long num, final int bits, final long expected) {
+    void checksShifts(final long num, final int bits, final long expected) {
         final Bytes bytes = new BytesOf((int) num);
         final int actual = bytes.sshift(bits).asNumber(Integer.class);
         MatcherAssert.assertThat(
@@ -141,7 +141,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void sshiftDoesNotSupportRightShift() {
+    void doesNotSupportRightShift() {
         final Bytes bytes = new BytesOf(Integer.MAX_VALUE);
         Assertions.assertThrows(
             UnsupportedOperationException.class,

--- a/eo-runtime/src/test/java/org/eolang/CachedPhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CachedPhiTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 final class CachedPhiTest {
 
     @Test
-    void simpleCaching() {
+    void caches() {
         final AtomicInteger count = new AtomicInteger(0);
         final CachedPhi cphi = new CachedPhi();
         final Supplier<Phi> sup = () -> {
@@ -54,7 +54,7 @@ final class CachedPhiTest {
     }
 
     @Test
-    void recursiveCaching() {
+    void cachesRecursive() {
         final AtomicInteger count = new AtomicInteger(3);
         final CachedPhi cphi = new CachedPhi();
         final AtomicReference<Supplier<Phi>> sup = new AtomicReference<>();

--- a/eo-runtime/src/test/java/org/eolang/DataizedLogLevelTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedLogLevelTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 final class DataizedLogLevelTest {
 
     @Test
-    void shortLogs() throws InterruptedException {
+    void printsShortLogs() throws InterruptedException {
         final Logger log = Logger.getLogger(Dataized.class.getName());
         final Level before = log.getLevel();
         log.setLevel(Level.ALL);
@@ -86,7 +86,7 @@ final class DataizedLogLevelTest {
     }
 
     @Test
-    void longLogs() throws InterruptedException {
+    void printsLongLogs() throws InterruptedException {
         final Logger log = Logger.getLogger(Dataized.class.getName());
         final Level before = log.getLevel();
         log.setLevel(Level.ALL);

--- a/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class ExInterruptedTest {
 
     @Test
-    void rightException() {
+    void throwsRightException() {
         final EOthrow phi = new EOthrow(new Data.ToPhi(true));
         Assertions.assertThrows(
             ExInterrupted.class,

--- a/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExprReduceTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
  */
 class ExprReduceTest {
     @Test
-    void exprTest() throws Exception {
+    void reducesExpr() {
         final ExprReduce expr = new ExprReduce<Long>(
             "x",
             Long::sum,
@@ -56,7 +56,7 @@ class ExprReduceTest {
     }
 
     @Test
-    void wrongTypeTest() {
+    void reducesWithWrongType() {
         final ExprReduce expr = new ExprReduce<Long>(
             "x",
             Long::sum,

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -64,7 +64,7 @@ public final class MainTest {
     }
 
     @Test
-    public void jvmFullRun() throws Exception {
+    public void executesJvmFullRun() throws Exception {
         MatcherAssert.assertThat(
             MainTest.exec("--verbose", "org.eolang.io.stdout", "Hello, dude!"),
             Matchers.allOf(
@@ -77,7 +77,7 @@ public final class MainTest {
     }
 
     @Test
-    public void jvmFullRunWithError() throws Exception {
+    public void executesJvmFullRunWithError() throws Exception {
         MatcherAssert.assertThat(
             MainTest.exec("--verbose", "org.eolang.io.stdout"),
             Matchers.containsString("Error at \"EOorg.EOeolang.EOio.EOstdout#text\" attribute")
@@ -85,7 +85,7 @@ public final class MainTest {
     }
 
     @Test
-    public void objectNotFoundException() throws Exception {
+    public void executesWithObjectNotFoundException() throws Exception {
         MatcherAssert.assertThat(
             MainTest.exec("unavailable-name"),
             Matchers.containsString("Can not find 'unavailable-name' object")

--- a/eo-runtime/src/test/java/org/eolang/PhConstTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhConstTest.java
@@ -69,7 +69,7 @@ final class PhConstTest {
     }
 
     @Test
-    void onceEvenIfCopied() {
+    void dataizesOnceEvenIfCopied() {
         final Dummy dummy = new Dummy("child");
         final Phi child = new PhMethod(new PhConst(dummy), "child");
         new Dataized(child).take(Long.class);
@@ -79,7 +79,7 @@ final class PhConstTest {
     }
 
     @Test
-    void simpleRandomToConst() {
+    void dataizesSimpleRandomToConst() {
         final Phi rnd = new PhConstTest.Rnd(Phi.Φ);
         MatcherAssert.assertThat(
             new Dataized(rnd).take(Double.class),
@@ -95,7 +95,7 @@ final class PhConstTest {
     }
 
     @Test
-    void negRandomToConst() {
+    void dataizesNegRandomToConst() {
         final Phi cnst = new PhConst(new PhConstTest.Rnd(Phi.Φ));
         final double first = new Dataized(
             cnst.attr("neg").get()
@@ -107,7 +107,7 @@ final class PhConstTest {
     }
 
     @Test
-    void randomToConst() {
+    void dataizesRandomToConst() {
         final Phi rnd = new PhConst(new PhConstTest.Rnd(Phi.Φ));
         final Phi eql = rnd.attr("eq").get();
         eql.attr(0).put(rnd);
@@ -118,7 +118,7 @@ final class PhConstTest {
     }
 
     @Test
-    void doesntAllowAttributesOfDecorateeToBeSet() {
+    void doesNotAllowAttributesOfDecorateeToBeSet() {
         final Phi phi = new Boom();
         Assertions.assertThrows(
             ExUnset.class,
@@ -156,7 +156,7 @@ final class PhConstTest {
     }
 
     @Test
-    void keepConstMultiLayers() {
+    void keepsConstMultiLayers() {
         final Phi phi = new PhWith(
             new Envelope(Phi.Φ),
             0,

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -145,7 +145,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void recursiveCachingOfPhi() {
+    void cachesPhiRecursively() {
         final Phi phi = new PhDefaultTest.RecursivePhi(Phi.Φ);
         PhDefaultTest.RecursivePhi.count = 3;
         MatcherAssert.assertThat(
@@ -155,7 +155,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void recursiveCachingOfPhiViaNew() {
+    void cachesPhiViaNewRecursively() {
         final Phi phi = new PhDefaultTest.RecursivePhiViaNew(Phi.Φ);
         PhDefaultTest.RecursivePhiViaNew.count = 3;
         MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
@@ -44,7 +44,7 @@ final class PhMethodTest {
     }
 
     @Test
-    void safeToString() {
+    void convertsSafeToString() {
         MatcherAssert.assertThat(
             new PhMethod(Phi.Φ, "hello").toString(),
             Matchers.endsWith(".hello")
@@ -63,7 +63,7 @@ final class PhMethodTest {
     }
 
     @Test
-    void calculatesToLocalJustOnce() {
+    void calculatesLocalJustOnce() {
         final Dummy dummy = new Dummy(Phi.Φ);
         final Phi phi = new PhMethod(dummy, "foo");
         final int total = 10;
@@ -74,7 +74,7 @@ final class PhMethodTest {
     }
 
     @Test
-    void calculatesThroughPhiOnce() {
+    void calculatesPhiOnce() {
         final Dummy dummy = new Dummy(Phi.Φ);
         final Phi phi = new PhMethod(dummy, "neg");
         new Dataized(phi).take();
@@ -82,7 +82,7 @@ final class PhMethodTest {
     }
 
     @Test
-    void calculatesThroughPhiManyTimes() {
+    void calculatesPhiManyTimes() {
         final Dummy dummy = new Dummy(Phi.Φ);
         final Phi phi = new PhMethod(dummy, "neg");
         final int total = 10;

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -84,7 +84,7 @@ final class PhiTest {
     }
 
     @Test
-    void locationTest() {
+    void getsLocation() {
         MatcherAssert.assertThat(
             new PhWith(
                 new PhLocated(

--- a/eo-runtime/src/test/java/org/eolang/VerticesTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerticesTest.java
@@ -67,7 +67,7 @@ final class VerticesTest {
      * values.
      */
     @Test
-    void vtxConcurrencyTest() {
+    void performsVtxOperationsConcurrently() {
         final Set<Integer> hashes = ConcurrentHashMap.newKeySet();
         final Vertices vtx = new Vertices();
         final int threads = 1000;

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.jcabi</groupId>
@@ -319,6 +321,19 @@ SOFTWARE.
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>com.github.volodya-lombrozo</groupId>
+            <artifactId>test-naming-conventions</artifactId>
+            <version>0.1.2</version>
+            <executions>
+              <execution>
+                <id>check-tests-names</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
I've added `test-naming-conventions` [plugin](https://github.com/volodya-lombrozo/test-naming-conventions/blob/main/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java) and fixed all tests names in the project.

Closes: #1366 