### PR TITLE
refactor(#1598): Make `ResolveMojo` more testable

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DcsEachWithoutTransitive.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DcsEachWithoutTransitive.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import java.util.Iterator;
+import java.util.Objects;
+import org.apache.maven.model.Dependency;
+import org.cactoos.Func;
+import org.cactoos.iterable.Filtered;
+import org.cactoos.iterable.Mapped;
+
+/**
+ * Dependencies without transitive dependencies.
+ *
+ * @since 0.29.0
+ * @todo #1589:30min Add fine grained tests for DcsEachWithoutTransitive. It's important to add new
+ *  unit tests for different cases including dome garbage inputs.
+ */
+final class DcsEachWithoutTransitive implements Iterable<Dependency> {
+
+    /**
+     * Original dependencies.
+     */
+    private final Iterable<Dependency> delegate;
+
+    /**
+     * Strategy to get transitive dependencies for a particular dependency.
+     */
+    private final Func<? super Dependency, ? extends Iterable<Dependency>> transitive;
+
+    /**
+     * Ctor.
+     * @param dependencies Dependencies
+     * @param strategy Strategy
+     */
+    DcsEachWithoutTransitive(
+        final Iterable<Dependency> dependencies,
+        final Func<? super Dependency, ? extends Iterable<Dependency>> strategy
+    ) {
+        this.delegate = dependencies;
+        this.transitive = strategy;
+    }
+
+    @Override
+    public Iterator<Dependency> iterator() {
+        return new Mapped<>(
+            dependency -> {
+                final Iterable<Dependency> transitives = new Filtered<>(
+                    dep -> !DcsEachWithoutTransitive.eqTo(dep, dependency)
+                        && DcsEachWithoutTransitive.isRuntimeRequired(dep)
+                        && !ResolveMojo.isRuntime(dep),
+                    this.transitive.apply(dependency)
+                );
+                final String list = String.join(
+                    ", ",
+                    new Mapped<>(
+                        dep -> new Coordinates(dep).toString(),
+                        transitives
+                    )
+                );
+                if (!list.isEmpty()) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "%s contains transitive dependencies: [%s]",
+                            dependency, list
+                        )
+                    );
+                }
+                return dependency;
+            },
+            this.delegate
+        ).iterator();
+    }
+
+    /**
+     * Compare with NULL-safety.
+     * @param left Left
+     * @param right Right
+     * @return TRUE if they are equal
+     */
+    private static boolean eqTo(final Dependency left, final Dependency right) {
+        return Objects.equals(
+            Objects.toString(left.getClassifier(), ""),
+            Objects.toString(right.getClassifier(), "")
+        )
+            && Objects.equals(left.getArtifactId(), right.getArtifactId())
+            && Objects.equals(left.getGroupId(), right.getGroupId());
+    }
+
+    /**
+     * Check if dependency is not needed at runtime.
+     * @param dep Maven dependency
+     * @return True if it's not needed at runtime
+     */
+    private static boolean isRuntimeRequired(final Dependency dep) {
+        return dep.getScope() == null
+            || dep.getScope().isEmpty()
+            || "runtime".equals(dep.getScope())
+            || "compiled".equals(dep.getScope());
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -180,10 +180,6 @@ public final class ResolveMojo extends SafeMojo {
      * Find all deps for all Tojos.
      *
      * @return List of them
-     * @todo #1595:30 Make method 'deps' testable. For now it's not possible to test
-     *  'ignoreTransitive=false' branch because it's hard to mock all required fields.
-     *  Maybe we should provide a chance to mock all dependencies related to maven or
-     *  even extract new classes.
      */
     private Collection<Dependency> deps() {
         Iterable<Dependency> deps = new DcsDefault(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -30,8 +30,6 @@ import java.util.Collections;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.Func;
-import org.cactoos.io.ResourceOf;
-import org.cactoos.text.TextOf;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -145,7 +143,8 @@ final class ResolveMojoTest {
         final FakeMaven maven = new FakeMaven(temp);
         maven.withHelloWorld()
             .with("ignoreTransitive", false)
-            .with("transitiveDependenciesStrategy",
+            .with(
+                "transitiveStrategy",
                 (Func<Dependency, Iterable<Dependency>>) ignore -> Collections.emptyList()
             )
             .execute(new FakeMaven.Resolve());
@@ -171,9 +170,11 @@ final class ResolveMojoTest {
                     "[] > foo /int"
                 )
                 .with("ignoreTransitive", false)
-                .with("transitiveDependenciesStrategy",
+                .with(
+                    "transitiveStrategy",
                     (Func<Dependency, Iterable<Dependency>>) ignore -> Collections.singleton(
-                        dependency)
+                        dependency
+                    )
                 )
                 .execute(new FakeMaven.Resolve())
         );


### PR DESCRIPTION
1. Added new class `DcsEachWithoutTransitive`
2. Most of the logic related to transitive dependencies detection moved into `DcsEachWithoutTransitive`
3. Added parameter `transitiveStrategy` in order to test transitive dependencies (see new tests in `ResolveMojoTest`)

Closes: #1598 