### PR TITLE
feat(#1682): use specific version for xcop-action

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@1.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: g4s8/xcop-action@1.0
+      - uses: g4s8/xcop-action@1.1


### PR DESCRIPTION
Use specific version (`1.1`) for `xcop-action`. 

https://github.com/g4s8/xcop-action/issues/4#issuecomment-1382703615 :
>@volodya-lombrozo try using some stable version to avoid docker building in GH actions, e.g. g4s8/xcop-action@1.0 instead of g4s8/xcop-action@master


Closes: #1682 