### PR TITLE
feat(#1678): Check reserved chars in `add-probes.xsl`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -183,7 +183,7 @@ public final class ProbeMojo extends SafeMojo {
             new Mapped<>(
                 ProbeMojo::noPrefix,
                 new Filtered<>(
-                    obj -> !obj.isEmpty() && ProbeMojo.missesReservedChars(obj),
+                    obj -> !obj.isEmpty(),
                     new XMLDocument(file).xpath(
                         "//metas/meta[head/text() = 'probe']/tail/text()"
                     )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -136,6 +136,7 @@ public final class ProbeMojo extends SafeMojo {
         for (final Tojo tojo : tojos) {
             final Path src = Paths.get(tojo.get(AssembleMojo.ATTR_XMIR2));
             final Collection<String> names = this.probes(src);
+            Logger.info(this, "Probing %s objects ", names);
             int count = 0;
             for (final String name : names) {
                 if (!this.objectionary.contains(name)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -191,12 +191,10 @@ public final class ProbeMojo extends SafeMojo {
             )
         ).forEach(
             obj -> {
-                if (!ProbeMojo.hasReservedChars(obj)) {
-                    if (obj.length() > 1 && "Q.".equals(obj.substring(0, 2))) {
-                        ret.add(obj.substring(2));
-                    } else {
-                        ret.add(obj);
-                    }
+                if (obj.length() > 1 && "Q.".equals(obj.substring(0, 2))) {
+                    ret.add(obj.substring(2));
+                } else {
+                    ret.add(obj);
                 }
             }
         );
@@ -212,19 +210,6 @@ public final class ProbeMojo extends SafeMojo {
             );
         }
         return ret;
-    }
-
-    /**
-     * Checks if String has reserved symbols.
-     *
-     * @param str String
-     * @return True if found
-     * @todo #1395:30min Need to add the logic of "hasReservedChars" method to
-     *  add-probes.xsl". After that, the method in this class need to be removed.
-     */
-    private static boolean hasReservedChars(final String str) {
-        return Stream.of("<", ">", "$", "*", "?", ":", "\"", "|", "^", "@")
-            .anyMatch(str::contains);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -97,11 +97,19 @@ public final class ParsingTrain extends TrEnvelope {
      */
     @SuppressWarnings("unchecked")
     public ParsingTrain() {
+        this(ParsingTrain.SHEETS);
+    }
+
+    /**
+     * Ctor.
+     * @param sheets Sheets
+     */
+    ParsingTrain(final String... sheets) {
         super(
             new TrLambda(
                 new TrFast(
                     new TrLogged(
-                        new TrClasspath<>(ParsingTrain.SHEETS).back(),
+                        new TrClasspath<>(sheets).back(),
                         ParsingTrain.class,
                         Level.FINEST
                     )

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -22,10 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:eo="https://www.eolang.org"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema" id="add-probes"
-                version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="add-probes" version="2.0">
   <!--
   For every object which starts with '.' add probe meta
   with fully qualified name of the object.
@@ -46,8 +43,7 @@ SOFTWARE.
   <xsl:function name="eo:contains-any-of" as="xs:boolean">
     <xsl:param name="original" as="xs:string"/>
     <xsl:param name="chars" as="xs:string*"/>
-    <xsl:sequence
-            select="some $char in $chars satisfies contains($original, $char)"/>
+    <xsl:sequence select="some $char in $chars satisfies contains($original, $char)"/>
   </xsl:function>
   <xsl:function name="eo:qualify" as="xs:string">
     <xsl:param name="e" as="element()"/>
@@ -88,8 +84,7 @@ SOFTWARE.
     </xsl:variable>
     <xsl:apply-templates select="$mts"/>
   </xsl:template>
-  <xsl:template
-          match="meta[head/text() = 'probe' and tail/text() = following::meta/tail/text()]"/>
+  <xsl:template match="meta[head/text() = 'probe' and tail/text() = following::meta/tail/text()]"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -67,7 +67,7 @@ SOFTWARE.
         <xsl:apply-templates select="node()|@*"/>
         <xsl:for-each select="//o[starts-with(@base, '.')]">
           <xsl:variable name="probe" select="eo:qualify(.)"/>
-          <xsl:if test="not(eo:contains-any-of($probe, ('&lt;', '&gt;', '$', '*', '?', ':', '\', '|', '^', '@')))">
+          <xsl:if test="not(eo:contains-any-of($probe, ('$', '^', '@')))">
             <xsl:element name="meta">
               <xsl:attribute name="line">
                 <xsl:value-of select="@line"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -63,7 +63,7 @@ SOFTWARE.
         <xsl:apply-templates select="node()|@*"/>
         <xsl:for-each select="//o[starts-with(@base, '.')]">
           <xsl:variable name="p" select="eo:qualify(.)"/>
-          <xsl:if test="not(eo:contains-any-of($p, ('$', '^', '@')))">
+          <xsl:if test="not(eo:contains-any-of($p, ('$', '^', '@','&lt;')))">
             <xsl:element name="meta">
               <xsl:attribute name="line">
                 <xsl:value-of select="@line"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -62,8 +62,8 @@ SOFTWARE.
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
         <xsl:for-each select="//o[starts-with(@base, '.')]">
-          <xsl:variable name="probe" select="eo:qualify(.)"/>
-          <xsl:if test="not(eo:contains-any-of($probe, ('$', '^', '@')))">
+          <xsl:variable name="p" select="eo:qualify(.)"/>
+          <xsl:if test="not(eo:contains-any-of($p, ('$', '^', '@')))">
             <xsl:element name="meta">
               <xsl:attribute name="line">
                 <xsl:value-of select="@line"/>
@@ -72,10 +72,10 @@ SOFTWARE.
                 <xsl:text>probe</xsl:text>
               </xsl:element>
               <xsl:element name="tail">
-                <xsl:value-of select="$probe"/>
+                <xsl:value-of select="$p"/>
               </xsl:element>
               <xsl:element name="part">
-                <xsl:value-of select="$probe"/>
+                <xsl:value-of select="$p"/>
               </xsl:element>
             </xsl:element>
           </xsl:if>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
@@ -1,5 +1,6 @@
 tests:
   - /program/errors[count(error)=0]
+  - /program/sheets/sheet[contains(text(),'add-probes')]
   - //metas[count(.//meta[head/text()='probe'])=8]
   - //meta[head/text()='probe' and tail/text()='stdout.and']
   - //meta[head/text()='probe' and tail/text()='Q.org']

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
@@ -2,14 +2,14 @@ tests:
   - /program/errors[count(error)=0]
   - /program/sheets/sheet[contains(text(),'add-probes')]
   - //metas[count(.//meta[head/text()='probe'])=8]
-  - //meta[head/text()='probe' and tail/text()='stdout.and']
-  - //meta[head/text()='probe' and tail/text()='Q.org']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt.sprintf']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine.start']
+  - //meta[head/text()='probe' and tail/text()='stdout.and' and part/text()='stdout.and']
+  - //meta[head/text()='probe' and tail/text()='Q.org' and part/text()='Q.org']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang' and part/text()='Q.org.eolang']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt' and part/text()='Q.org.eolang.txt']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt.sprintf' and part/text()='Q.org.eolang.txt.sprintf']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car' and part/text()='Q.org.eolang.car']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine' and part/text()='Q.org.eolang.car.engine']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine.start' and part/text()='Q.org.eolang.car.engine.start']
 eo: |
   +package org.eolang.custom
   
@@ -27,3 +27,9 @@ eo: |
           n
           fibonacci n > f
       TRUE
+
+    [i] > other
+      stdout > @
+        sprintf
+          "%i"
+    $.other 1 > one

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
@@ -12,14 +12,14 @@ tests:
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine.start' and part/text()='Q.org.eolang.car.engine.start']
 eo: |
   +package org.eolang.custom
-  
+
   [] > app
     QQ.txt.sprintf > @
       "Hello, world!\n"
     start. > a
       engine.
         QQ.car
-  
+
     and. > fib
       stdout
         sprintf
@@ -33,3 +33,8 @@ eo: |
         sprintf
           "%i"
     $.other 1 > one
+
+    memory 0 > price
+    [p] > set-price
+      ^.price.write p > @
+


### PR DESCRIPTION
1. Added check for "reserved" characters in `add-probes.xsl`
2. Also only some characters were left ('$', '^', '@', '<'), since other can't be declared in `base` attribute (I can be mistaken here, please correct me if I'm wrong)
3. Added some checks to `add-probes.yaml` pack test.

Closes: #1700 