### PR TITLE
#1713 exclude packages from probes

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -60,7 +60,7 @@ final class ProbeMojoTest {
                     .foreignPath(),
                 "probed"
             ),
-            Matchers.equalTo("7")
+            Matchers.equalTo("5")
         );
     }
 

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -63,7 +63,8 @@ SOFTWARE.
         <xsl:apply-templates select="node()|@*"/>
         <xsl:for-each select="//o[starts-with(@base, '.')]">
           <xsl:variable name="p" select="eo:qualify(.)"/>
-          <xsl:if test="not(eo:contains-any-of($p, ('$', '^', '@','&lt;')))">
+          <xsl:variable name="c" select="string-length($p) - string-length(translate($p, '.', ''))"/>
+          <xsl:if test="not(eo:contains-any-of($p, ('$', '^', '@', '&lt;'))) and not(starts-with($p, '.')) and $c &gt; 1">
             <xsl:element name="meta">
               <xsl:attribute name="line">
                 <xsl:value-of select="@line"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-probes.yaml
@@ -1,9 +1,7 @@
 tests:
   - /program/errors[count(error)=0]
   - /program/sheets/sheet[contains(text(),'add-probes')]
-  - //metas[count(.//meta[head/text()='probe'])=8]
-  - //meta[head/text()='probe' and tail/text()='stdout.and' and part/text()='stdout.and']
-  - //meta[head/text()='probe' and tail/text()='Q.org' and part/text()='Q.org']
+  - //metas[count(.//meta[head/text()='probe'])=6]
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang' and part/text()='Q.org.eolang']
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt' and part/text()='Q.org.eolang.txt']
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt.sprintf' and part/text()='Q.org.eolang.txt.sprintf']


### PR DESCRIPTION
closes #1713

- excluded probes started with '.' (as it's an internal object)
- excluded probes with less than 3 elements (packages)

Performance impact (MacBook pro):
- overall build time: 9:30min -> 7:15min
- number of probes for `eo-runtime`: 218 -> 76