### PR TITLE
refactor(#1723):  apply FakeMaven for SnippetTest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
@@ -52,9 +52,7 @@ public final class DemandMojo extends SafeMojo {
 
     @Override
     public void exec() {
-        for (final String obj : this.objects) {
-            this.scopedTojos().add(obj);
-        }
+        this.objects.forEach(this.scopedTojos()::add);
         Logger.info(
             this, "Added %d objects to foreign catalog at %s",
             this.objects.size(), new Rel(this.foreign)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -110,7 +110,7 @@ public final class FakeMaven {
      * @return The same maven instance.
      * @throws IOException If method can't save eo program to the workspace.
      */
-    public FakeMaven withProgram(final Input input) throws IOException{
+    public FakeMaven withProgram(final Input input) throws IOException {
         return this.withProgram(new UncheckedText(new TextOf(input)).asString());
     }
 
@@ -224,6 +224,7 @@ public final class FakeMaven {
         this.params.putIfAbsent("generateGraphFiles", true);
         this.params.putIfAbsent("generateDotFiles", true);
         this.params.putIfAbsent("generateDotFiles", true);
+        this.params.putIfAbsent("generatedDir", this.targetPath().resolve("generated").toFile());
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.allowedParams(mojo).entrySet()) {
             moja.with(entry.getKey(), entry.getValue());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -195,10 +195,6 @@ public final class FakeMaven {
         this.params.putIfAbsent("foreign", this.foreignPath().toFile());
         this.params.putIfAbsent("foreignFormat", "csv");
         this.params.putIfAbsent("project", new MavenProjectStub());
-        this.params.putIfAbsent(
-            "generatedDir",
-            this.workspace.absolute(Paths.get("generated")).toFile()
-        );
         final Path transpiled = Paths.get("transpiled");
         this.workspace.save(new TextOf(""), transpiled);
         this.params.putIfAbsent("transpiled", this.workspace.absolute(transpiled).toFile());
@@ -224,7 +220,7 @@ public final class FakeMaven {
         this.params.putIfAbsent("generateGraphFiles", true);
         this.params.putIfAbsent("generateDotFiles", true);
         this.params.putIfAbsent("generateDotFiles", true);
-        this.params.putIfAbsent("generatedDir", this.targetPath().resolve("generated").toFile());
+        this.params.putIfAbsent("generatedDir", this.generatedPath().toFile());
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.allowedParams(mojo).entrySet()) {
             moja.with(entry.getKey(), entry.getValue());
@@ -239,6 +235,14 @@ public final class FakeMaven {
      */
     public Path targetPath() {
         return this.workspace.absolute(Paths.get("target"));
+    }
+
+    /**
+     * Path to generated directory.
+     * @return Path to generated dir.
+     */
+    public Path generatedPath() {
+        return this.targetPath().resolve("generated");
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.cactoos.Input;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.maven.util.Home;
@@ -101,6 +102,16 @@ public final class FakeMaven {
      */
     public FakeMaven withHelloWorld() throws IOException {
         return this.withProgram("+package f", "[args] > main", "  (stdout \"Hello!\").print");
+    }
+
+    /**
+     * Adds eo program to a workspace.
+     * @param input Program as an input.
+     * @return The same maven instance.
+     * @throws IOException If method can't save eo program to the workspace.
+     */
+    public FakeMaven withProgram(final Input input) throws IOException{
+        return this.withProgram(new UncheckedText(new TextOf(input)).asString());
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -49,6 +49,7 @@ import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.IsEmpty;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
+import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Walk;
 import org.hamcrest.MatcherAssert;
@@ -160,55 +161,6 @@ final class SnippetTest {
             .with("objects", Collections.singletonList("org.eolang.bool"));
         maven.execute(RegisterMojo.class);
         maven.execute(DemandMojo.class);
-
-        final Path home = Paths.get(
-            System.getProperty(
-                "runtime.path",
-                Paths.get("").toAbsolutePath().resolve("eo-runtime").toString()
-            )
-        );
-        final OyFake objectionary = new OyFake(
-            name -> {
-                final Input res;
-                if (name.contains("collections")) {
-                    res = new ResourceOf(
-                        String.format("%s.eo", name.replace(".", "/"))
-                    );
-                } else {
-                    res = new InputOf(
-                        home.resolve(
-                            String.format(
-                                "src/main/eo/%s.eo",
-                                name.replace(".", "/")
-                            )
-                        )
-                    );
-                }
-                return res;
-            },
-            name -> {
-                final boolean res;
-                if (name.contains("collections")) {
-                    res = !new IsEmpty(
-                        new TextOf(
-                            new ResourceOf(
-                                String.format("%s.eo", name.replace(".", "/"))
-                            )
-                        )
-                    ).value();
-                } else {
-                    res = Files.exists(
-                        home.resolve(
-                            String.format(
-                                "src/main/eo/%s.eo",
-                                name.replace(".", "/")
-                            )
-                        )
-                    );
-                }
-                return res;
-            }
-        );
         new Moja<>(AssembleMojo.class)
             .with("ignoreTransitive", true)
             .with("outputDir", target.resolve("out").toFile())
@@ -216,7 +168,7 @@ final class SnippetTest {
             .with("foreign", foreign.toFile())
             .with("foreignFormat", "json")
             .with("placed", target.resolve("list").toFile())
-            .with("objectionary", objectionary)
+            .with("objectionary", SnippetTest.objectionary())
             .with("central", Central.EMPTY)
             .execute();
         final Path generated = target.resolve("generated");
@@ -275,6 +227,58 @@ final class SnippetTest {
             stdout
         );
         return 0;
+    }
+
+    private static Objectionary objectionary() {
+        final Path home = Paths.get(
+            System.getProperty(
+                "runtime.path",
+                Paths.get("").toAbsolutePath().resolve("eo-runtime").toString()
+            )
+        );
+        final OyFake objectionary = new OyFake(
+            name -> {
+                final Input res;
+                if (name.contains("collections")) {
+                    res = new ResourceOf(
+                        String.format("%s.eo", name.replace(".", "/"))
+                    );
+                } else {
+                    res = new InputOf(
+                        home.resolve(
+                            String.format(
+                                "src/main/eo/%s.eo",
+                                name.replace(".", "/")
+                            )
+                        )
+                    );
+                }
+                return res;
+            },
+            name -> {
+                final boolean res;
+                if (name.contains("collections")) {
+                    res = !new IsEmpty(
+                        new TextOf(
+                            new ResourceOf(
+                                String.format("%s.eo", name.replace(".", "/"))
+                            )
+                        )
+                    ).value();
+                } else {
+                    res = Files.exists(
+                        home.resolve(
+                            String.format(
+                                "src/main/eo/%s.eo",
+                                name.replace(".", "/")
+                            )
+                        )
+                    );
+                }
+                return res;
+            }
+        );
+        return objectionary;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -153,33 +153,24 @@ final class SnippetTest {
         new Home(src).save(code, Paths.get("code.eo"));
         final Path target = tmp.resolve("target");
         final Path foreign = target.resolve("eo-foreign.json");
-        final File value = src.toFile();
+        final Path generated = target.resolve("generated");
+
         final FakeMaven maven = new FakeMaven(tmp)
             .with("foreign", target.resolve("eo-foreign.json").toFile())
             .with("foreignFormat", "json")
-            .with("sourcesDir", value)
-            .with("objects", Collections.singletonList("org.eolang.bool"));
-        maven.execute(RegisterMojo.class);
-        maven.execute(DemandMojo.class);
-        new Moja<>(AssembleMojo.class)
-            .with("ignoreTransitive", true)
-            .with("outputDir", target.resolve("out").toFile())
-            .with("targetDir", target.toFile())
-            .with("foreign", foreign.toFile())
-            .with("foreignFormat", "json")
-            .with("placed", target.resolve("list").toFile())
+            .with("sourcesDir", src.toFile())
+            .with("objects", Collections.singletonList("org.eolang.bool"))
             .with("objectionary", SnippetTest.objectionary())
-            .with("central", Central.EMPTY)
-            .execute();
-        final Path generated = target.resolve("generated");
-        new Moja<>(TranspileMojo.class)
+
             .with("project", new MavenProjectStub())
             .with("targetDir", target.toFile())
             .with("generatedDir", generated.toFile())
-            .with("foreign", foreign.toFile())
             .with("transpiled", target.resolve("transpiled.csv").toFile())
-            .with("foreignFormat", "json")
-            .execute();
+            ;
+        maven.execute(RegisterMojo.class);
+        maven.execute(DemandMojo.class);
+        maven.execute(AssembleMojo.class);
+        maven.execute(TranspileMojo.class);
         final Path classes = target.resolve("classes");
         classes.toFile().mkdir();
         final String cpath = String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -50,7 +50,6 @@ import org.cactoos.text.IsEmpty;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.maven.objectionary.Objectionary;
-import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Walk;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -114,13 +113,15 @@ final class SnippetTest {
         );
         MatcherAssert.assertThat(
             String.format("'%s' returned wrong exit code", yml),
-            result, Matchers.equalTo(map.get("exit"))
+            result,
+            Matchers.equalTo(map.get("exit"))
         );
-        Logger.debug(this, "Stdout: \"%s\"", stdout.toString());
+        final String actual = new String(stdout.toByteArray(), StandardCharsets.UTF_8);
+        Logger.debug(this, "Stdout: \"%s\"", actual);
         for (final String ptn : (Iterable<String>) map.get("out")) {
             MatcherAssert.assertThat(
                 String.format("'%s' printed something wrong", yml),
-                new String(stdout.toByteArray(), StandardCharsets.UTF_8),
+                actual,
                 Matchers.matchesPattern(
                     Pattern.compile(ptn, Pattern.DOTALL | Pattern.MULTILINE)
                 )
@@ -155,7 +156,6 @@ final class SnippetTest {
             .with("sourcesDir", src.toFile())
             .with("objects", Collections.singletonList("org.eolang.bool"))
             .with("objectionary", SnippetTest.objectionary())
-
             .with("project", new MavenProjectStub())
             .with("generatedDir", generated.toFile())
             .with("transpiled", target.resolve("transpiled.csv").toFile());
@@ -163,10 +163,8 @@ final class SnippetTest {
         maven.execute(DemandMojo.class);
         maven.execute(AssembleMojo.class);
         maven.execute(TranspileMojo.class);
-
         final Path classes = target.resolve("classes");
-        classes.toFile().mkdir();
-        final String cpath = String.format(
+        final String classpath = String.format(
             ".%s%s",
             File.pathSeparatorChar,
             System.getProperty(
@@ -188,7 +186,7 @@ final class SnippetTest {
                     .map(Path::toString)
                     .collect(Collectors.joining(" ")),
                 classes,
-                cpath
+                classpath
             ),
             generated
         );
@@ -200,7 +198,7 @@ final class SnippetTest {
                         SnippetTest.jdkExecutable("java"),
                         "-Dfile.encoding=utf-8",
                         "-cp",
-                        cpath,
+                        classpath,
                         "org.eolang.Main"
                     ),
                     args

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -148,18 +148,15 @@ final class SnippetTest {
         final Output stdout
     ) throws Exception {
         final Path src = tmp.resolve("src");
-        new Home(src).save(code, Paths.get("code.eo"));
         final Path target = tmp.resolve("target");
         final Path generated = target.resolve("generated");
         final FakeMaven maven = new FakeMaven(tmp)
-            .with("foreign", target.resolve("eo-foreign.json").toFile())
-            .with("foreignFormat", "json")
+            .withProgram(code)
             .with("sourcesDir", src.toFile())
             .with("objects", Collections.singletonList("org.eolang.bool"))
             .with("objectionary", SnippetTest.objectionary())
 
             .with("project", new MavenProjectStub())
-            .with("targetDir", target.toFile())
             .with("generatedDir", generated.toFile())
             .with("transpiled", target.resolve("transpiled.csv").toFile());
         maven.execute(RegisterMojo.class);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -151,16 +152,15 @@ final class SnippetTest {
         new Home(src).save(code, Paths.get("code.eo"));
         final Path target = tmp.resolve("target");
         final Path foreign = target.resolve("eo-foreign.json");
-        new Moja<>(RegisterMojo.class)
+        final File value = src.toFile();
+        final FakeMaven maven = new FakeMaven(tmp)
             .with("foreign", target.resolve("eo-foreign.json").toFile())
             .with("foreignFormat", "json")
-            .with("sourcesDir", src.toFile())
-            .execute();
-        new Moja<>(DemandMojo.class)
-            .with("foreign", foreign.toFile())
-            .with("foreignFormat", "json")
-            .with("objects", new ListOf<>("org.eolang.bool"))
-            .execute();
+            .with("sourcesDir", value)
+            .with("objects", Collections.singletonList("org.eolang.bool"));
+        maven.execute(RegisterMojo.class);
+        maven.execute(DemandMojo.class);
+
         final Path home = Paths.get(
             System.getProperty(
                 "runtime.path",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -75,8 +75,6 @@ import org.yaml.snakeyaml.Yaml;
  * @todo #1107:30m Method `jdkExecutable` is duplicated in eo-runtime.
  *  Find a way to make it reusable (i.e making it part of
  *  VerboseProcess) and remove it from MainTest.
- * @todo #1723:30m Add FakeMojo support for SnippetTest. We have to reuse FakeMojo class in order
- *  to reduce code duplication and increase overall test code readability. {@link FakeMaven}.
  */
 @ExtendWith(OnlineCondition.class)
 final class SnippetTest {
@@ -225,7 +223,7 @@ final class SnippetTest {
                 Paths.get("").toAbsolutePath().resolve("eo-runtime").toString()
             )
         );
-        final OyFake objectionary = new OyFake(
+        return new OyFake(
             name -> {
                 final Input res;
                 if (name.contains("collections")) {
@@ -267,7 +265,6 @@ final class SnippetTest {
                 return res;
             }
         );
-        return objectionary;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -60,7 +60,7 @@ final class TranspileMojoTest {
     @BeforeEach
     void setUp() throws Exception {
         this.program = new TextOf(new ResourceOf("org/eolang/maven/mess.eo")).asString();
-        this.compiled = "generated/EOorg/EOeolang/EOexamples/EOmessTest.java";
+        this.compiled = "target/generated/EOorg/EOeolang/EOexamples/EOmessTest.java";
     }
 
     @ParameterizedTest
@@ -132,7 +132,7 @@ final class TranspileMojoTest {
             .withProgram(src)
             .execute(new FakeMaven.Transpile())
             .result();
-        final String java = "generated/EOorg/EOeolang/EOarray.java";
+        final String java = "target/generated/EOorg/EOeolang/EOarray.java";
         MatcherAssert.assertThat(
             res, Matchers.hasKey(java)
         );


### PR DESCRIPTION
I've tried to refactor `SnippetTest` by:

1. Applying `FakeMaven` (puzzle is removed too)
2. Introducing more methods `compileJava(), runJava(), objectionary(), classpath()` that help to understand what's going on.


#1723 