### PR TITLE
fix(#1787): remove strange check that absent in logs

### DIFF
--- a/eo-maven-plugin/src/it/fibonacci/verify.groovy
+++ b/eo-maven-plugin/src/it/fibonacci/verify.groovy
@@ -63,7 +63,6 @@ private static boolean online() {
 String log = new File(basedir, 'build.log').text
 
 [
-  '--- eo-maven-plugin:',
   'org.eolang:eo-runtime:',
   ' unpacked to ',
   '6th Fibonacci number is 8',


### PR DESCRIPTION
Remove strange check that absent in Windows logs.

Closes: #1787 