### PR TITLE
#1824 Make `+inf.times` and `-inf.times` work with multiple arguments

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -65,6 +65,9 @@
   [x] > gt /bool
 
   # Tests that $ ≥ x
+  # @todo #1824:30min. "float.gte nan", "float.lte nan", "int.gte nan" and
+  #  "int.lte nan" must be equal to FALSE. Need to add extra check if "x" is NaN
+  #  and relevant tests
   [x] > gte
     if. > @
       x.as-bytes.eq nan.as-bytes

--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -63,9 +63,6 @@
   [x] > gt /bool
 
   # Tests that $ ≥ x
-  # @todo #1824:30min. "float.gte nan", "float.lte nan", "int.gte nan" and
-  #  "int.lte nan" must be equal to FALSE. Need to add extra check if "x" is NaN
-  #  and relevant tests
   [x] > gte
     or. > @
       ^.eq x

--- a/eo-runtime/src/main/eo/org/eolang/nan.eo
+++ b/eo-runtime/src/main/eo/org/eolang/nan.eo
@@ -28,7 +28,7 @@
 
 # Not a number
 [] > nan
-  0.0.div 0.0 > @!
+  0.0.div 0.0 > @
 
   # Tests that $ = x
   [x] > eq

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -28,7 +28,7 @@
 
 # Negative infinity
 [] > negative-infinity
-  -1.0.div 0.0 > @!
+  -1.0.div 0.0 > @
 
   # Tests that $ = x
   [x] > eq

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -60,64 +60,139 @@
 
   # Multiplication of $ and x
   [x...] > times
-    x.at 0 > first!
+    positive-infinity > pos-inf!
+    0 > zero!
 
     # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
-    [num] > check-nan
+    [num] > is-nan
       not. > @
         num.eq num
 
-    if. > @
-      or.
-        check-nan first
-        first.eq 0.0
-        first.eq 0
-      nan
-      if.
-        first.eq ^
-        positive-infinity
-        ^
+    [term] > is-nan-or-zero
+      or. > @
+        is-nan
+          term > t!
+        t.eq -0.0
+        t.eq 0.0
+        t.eq 0
 
-  # Sum of $ and x
-  [x...] > plus
-    positive-infinity.as-bytes > pos-inf-as-bytes!
+    [term] > is-term-gt-zero
+      try > @
+        []
+          term.gt 0 > @
+        [e]
+          term.gt 0.0 > @
+        FALSE
 
-    [acc index terms check-term] > plus-rec
+    [acc-index-terms infs is-term-gt-zero] > times-rec
+      acc-index-terms.at 0 > acc!
+      acc-index-terms.at 1 > index!
+      acc-index-terms.at 2 > terms
+      infs.at 0 > neg-inf
+      infs.at 1 > pos-inf
+
       if. > @
         index.eq terms.length
         acc
         if.
-          check-term
+          or.
+            not.
+              eq.
+                terms.at index > term!
+                term
+            term.eq -0.0
+            term.eq 0.0
+            term.eq 0
+          nan
+          []
+            if. > @
+              acc.gt 0.0
+              times-rec
+                *
+                  if.
+                    is-term-gt-zero term > term-gt-zero
+                    acc
+                    neg-inf
+                  index.plus 1 > next-index
+                  terms
+                * neg-inf acc
+                is-term-gt-zero
+              times-rec
+                *
+                  if.
+                    term-gt-zero
+                    acc
+                    pos-inf
+                  next-index
+                  terms
+                * acc pos-inf
+                is-term-gt-zero
+
+    if. > @
+      eq.
+        x.length > terms-count!
+        zero
+      ^
+      if.
+        terms-count.gt 1
+        times-rec
+          * ^ zero x
+          * ^ pos-inf
+          is-term-gt-zero
+        if.
+          is-nan-or-zero
+            x.at zero > first!
+          nan
+          if.
+            is-term-gt-zero first
+            ^
+            pos-inf
+
+  # Sum of $ and x
+  [x...] > plus
+    positive-infinity.as-bytes > pos-inf-as-bytes!
+    0 > zero!
+
+    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
+    [num] > is-nan
+      not. > @
+        num.eq num
+
+    [term] > is-nan-or-pos-inf
+      or. > @
+        is-nan
+          term > t!
+        t.as-bytes.eq pos-inf-as-bytes
+
+    [acc index terms is-nan-or-pos-inf] > plus-rec
+      if. > @
+        index.eq terms.length
+        acc
+        if.
+          is-nan-or-pos-inf
             terms.at index
           nan
           plus-rec
             acc
             index.plus 1
             terms
-            check-term
-
-    [term] > check-term
-      term > t!
-      or. > @
-        not.
-          t.eq t
-        t.as-bytes.eq pos-inf-as-bytes
+            is-nan-or-pos-inf
 
     if. > @
       eq.
         x.length > terms-count!
-        0
+        zero
       ^
       if.
         terms-count.gt 1
         plus-rec
           ^
-          0
+          zero
           x
-          check-term
+          is-nan-or-pos-inf
         if.
-          check-term
-            x.at 0
+          is-nan-or-pos-inf
+            x.at zero
           nan
           ^
 
@@ -128,43 +203,48 @@
   # Difference between $ and x
   [x...] > minus
     ^.as-bytes > neg-inf-as-bytes!
+    0 > zero!
 
-    [acc index terms check-term] > minus-rec
+    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
+    [num] > is-nan
+      not. > @
+        num.eq num
+
+    [term] > is-nan-or-neg-inf
+      or. > @
+        is-nan
+          term > t!
+        t.as-bytes.eq neg-inf-as-bytes
+
+    [acc index terms is-nan-or-neg-inf] > minus-rec
       if. > @
         index.eq terms.length
         acc
         if.
-          check-term
+          is-nan-or-neg-inf
             terms.at index
           nan
           minus-rec
             acc
             index.plus 1
             terms
-            check-term
-
-    [term] > check-term
-      term > t!
-      or. > @
-        not.
-          t.eq t
-        t.as-bytes.eq neg-inf-as-bytes
+            is-nan-or-neg-inf
 
     if. > @
       eq.
         x.length > terms-count!
-        0
+        zero
       ^
       if.
         terms-count.gt 1
         minus-rec
           ^
-          0
+          zero
           x
-          check-term
+          is-nan-or-neg-inf
         if.
-          check-term
-            x.at 0
+          is-nan-or-neg-inf
+            x.at zero
           nan
           ^
 

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -84,7 +84,7 @@
           term.gt 0.0 > @
         FALSE
 
-    [acc-index-terms infs is-term-gt-zero] > times-rec
+    [acc-index-terms infs is-nan-or-zero is-term-gt-zero] > times-rec
       acc-index-terms.at 0 > acc!
       acc-index-terms.at 1 > index!
       acc-index-terms.at 2 > terms
@@ -95,14 +95,8 @@
         index.eq terms.length
         acc
         if.
-          or.
-            not.
-              eq.
-                terms.at index > term!
-                term
-            term.eq -0.0
-            term.eq 0.0
-            term.eq 0
+          is-nan-or-zero
+            terms.at index > term!
           nan
           []
             if. > @
@@ -115,7 +109,8 @@
                     neg-inf
                   index.plus 1 > next-index
                   terms
-                * neg-inf acc
+                infs
+                is-nan-or-zero
                 is-term-gt-zero
               times-rec
                 *
@@ -125,7 +120,8 @@
                     pos-inf
                   next-index
                   terms
-                * acc pos-inf
+                infs
+                is-nan-or-zero
                 is-term-gt-zero
 
     if. > @
@@ -138,6 +134,7 @@
         times-rec
           * ^ zero x
           * ^ pos-inf
+          is-nan-or-zero
           is-term-gt-zero
         if.
           is-nan-or-zero

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -28,7 +28,7 @@
 
 # Positive infinity
 [] > positive-infinity
-  1.0.div 0.0 > @!
+  1.0.div 0.0 > @
 
   # Tests that $ = x
   [x] > eq
@@ -59,70 +59,145 @@
         nan.as-bytes
 
   # Multiplication of $ and x
-  # @todo #1806:30min. Make positive-infinity.times and negative-infinity.times
-  #  worked with multiple arguments without using objects from eo-collections.
-  #  See positive-infinity.plus and negative-infinity.plus as an example
   [x...] > times
-    x.at 0 > first!
+    negative-infinity > neg-inf!
+    0 > zero!
 
     # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
-    [num] > check-nan
+    [num] > is-nan
       not. > @
         num.eq num
 
-    if. > @
-      or.
-        check-nan first
-        first.eq 0.0
-        first.eq 0
-      nan
-      if.
-        eq.
-          first
-          negative-infinity
-        first
-        ^
+    [term] > is-nan-or-zero
+      or. > @
+        is-nan
+          term > t!
+        t.eq -0.0
+        t.eq 0.0
+        t.eq 0
 
-  # Sum of $ and x
-  [x...] > plus
-    negative-infinity.as-bytes > neg-inf-as-bytes!
+    [term] > is-term-gt-zero
+      try > @
+        []
+          term.gt 0 > @
+        [e]
+          term.gt 0.0 > @
+        nop
 
-    [acc index terms check-term] > plus-rec
+    # @todo #1824:30min. Pass "is-nan-or-zero" to "times-rec" here and in
+    #  negative-infinity. Now for some reason it's not possible to pass two or
+    #  more objects-functions to another object. To avoid code duplication
+    #  "is-nan-or-zero" object should be passed to "times-rec" as well as
+    #  "is-term-gt-zero"
+    [acc-index-terms infs is-term-gt-zero] > times-rec
+      acc-index-terms.at 0 > acc!
+      acc-index-terms.at 1 > index!
+      acc-index-terms.at 2 > terms
+      infs.at 0 > pos-inf
+      infs.at 1 > neg-inf
+
       if. > @
         index.eq terms.length
         acc
         if.
-          check-term
+          or.
+            not.
+              eq.
+                terms.at index > term!
+                term
+            term.eq -0.0
+            term.eq 0.0
+            term.eq 0
+          nan
+          []
+            if. > @
+              acc.gt 0.0
+              times-rec
+                *
+                  if.
+                    is-term-gt-zero term > term-gt-zero
+                    acc
+                    neg-inf
+                  index.plus 1
+                  terms
+                * acc neg-inf
+                is-term-gt-zero
+              times-rec
+                *
+                  if.
+                    term-gt-zero
+                    acc
+                    pos-inf
+                  index.plus 1
+                  terms
+                * pos-inf acc
+                is-term-gt-zero
+
+    if. > @
+      eq.
+        x.length > terms-count!
+        zero
+      ^
+      if.
+        terms-count.gt 1
+        times-rec
+          * ^ zero x
+          * ^ neg-inf
+          is-term-gt-zero
+        if.
+          is-nan-or-zero
+            x.at zero > first!
+          nan
+          if.
+            is-term-gt-zero first
+            ^
+            neg-inf
+
+  # Sum of $ and x
+  [x...] > plus
+    negative-infinity.as-bytes > neg-inf-as-bytes!
+    0 > zero!
+
+    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
+    [num] > is-nan
+      not. > @
+        num.eq num
+
+    [term] > is-nan-or-neg-inf
+      or. > @
+        is-nan
+          term > t!
+        t.as-bytes.eq neg-inf-as-bytes
+
+    [acc index terms is-nan-or-neg-inf] > plus-rec
+      if. > @
+        index.eq terms.length
+        acc
+        if.
+          is-nan-or-neg-inf
             terms.at index
           nan
           plus-rec
             acc
             index.plus 1
             terms
-            check-term
-
-    [term] > check-term
-      term > t!
-      or. > @
-        not.
-          t.eq t
-        t.as-bytes.eq neg-inf-as-bytes
+            is-nan-or-neg-inf
 
     if. > @
       eq.
         x.length > terms-count!
-        0
+        zero
       ^
       if.
         terms-count.gt 1
         plus-rec
           ^
-          0
+          zero
           x
-          check-term
+          is-nan-or-neg-inf
         if.
-          check-term
-            x.at 0
+          is-nan-or-neg-inf
+            x.at zero
           nan
           ^
 
@@ -131,48 +206,50 @@
     negative-infinity > @
 
   # Difference between $ and x
-  # @todo #1806:30min. Make positive-infinity.minus and negative-infinity.minus
-  #  worked with multiple arguments without using objects from eo-collections.
-  #  See positive-infinity.plus and negative-infinity.plus as an example
   [x...] > minus
     ^.as-bytes > pos-inf-as-bytes!
+    0 > zero!
 
-    [acc index terms check-term] > minus-rec
+    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
+    [num] > is-nan
+      not. > @
+        num.eq num
+
+    [term] > is-nan-or-pos-inf
+      or. > @
+        is-nan
+          term > t!
+        t.as-bytes.eq pos-inf-as-bytes
+
+    [acc index terms is-nan-or-pos-inf] > minus-rec
       if. > @
         index.eq terms.length
         acc
         if.
-          check-term
+          is-nan-or-pos-inf
             terms.at index
           nan
           minus-rec
             acc
             index.plus 1
             terms
-            check-term
-
-    [term] > check-term
-      term > t!
-      or. > @
-        not.
-          t.eq t
-        t.as-bytes.eq pos-inf-as-bytes
+            is-nan-or-pos-inf
 
     if. > @
       eq.
         x.length > terms-count!
-        0
+        zero
       ^
       if.
         terms-count.gt 1
         minus-rec
           ^
-          0
+          zero
           x
-          check-term
+          is-nan-or-pos-inf
         if.
-          check-term
-            x.at 0
+          is-nan-or-pos-inf
+            x.at zero
           nan
           ^
 

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -84,12 +84,7 @@
           term.gt 0.0 > @
         FALSE
 
-    # @todo #1824:30min. Pass "is-nan-or-zero" to "times-rec" here and in
-    #  negative-infinity. Now for some reason it's not possible to pass two or
-    #  more objects-functions to another object. To avoid code duplication
-    #  "is-nan-or-zero" object should be passed to "times-rec" as well as
-    #  "is-term-gt-zero"
-    [acc-index-terms infs is-term-gt-zero] > times-rec
+    [acc-index-terms infs is-nan-or-zero is-term-gt-zero] > times-rec
       acc-index-terms.at 0 > acc!
       acc-index-terms.at 1 > index!
       acc-index-terms.at 2 > terms
@@ -100,14 +95,8 @@
         index.eq terms.length
         acc
         if.
-          or.
-            not.
-              eq.
-                terms.at index > term!
-                term
-            term.eq -0.0
-            term.eq 0.0
-            term.eq 0
+          is-nan-or-zero
+            terms.at index > term!
           nan
           []
             if. > @
@@ -120,7 +109,8 @@
                     neg-inf
                   index.plus 1 > next-index
                   terms
-                * acc neg-inf
+                infs
+                is-nan-or-zero
                 is-term-gt-zero
               times-rec
                 *
@@ -130,7 +120,8 @@
                     pos-inf
                   next-index
                   terms
-                * pos-inf acc
+                infs
+                is-nan-or-zero
                 is-term-gt-zero
 
     if. > @
@@ -143,6 +134,7 @@
         times-rec
           * ^ zero x
           * ^ neg-inf
+          is-nan-or-zero
           is-term-gt-zero
         if.
           is-nan-or-zero

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -63,7 +63,7 @@
     negative-infinity > neg-inf!
     0 > zero!
 
-    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN
+    # here we use the rule "NaN != NaN is TRUE" to check if "num" is NaN.
     [num] > is-nan
       not. > @
         num.eq num

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -82,7 +82,7 @@
           term.gt 0 > @
         [e]
           term.gt 0.0 > @
-        nop
+        FALSE
 
     # @todo #1824:30min. Pass "is-nan-or-zero" to "times-rec" here and in
     #  negative-infinity. Now for some reason it's not possible to pass two or
@@ -118,7 +118,7 @@
                     is-term-gt-zero term > term-gt-zero
                     acc
                     neg-inf
-                  index.plus 1
+                  index.plus 1 > next-index
                   terms
                 * acc neg-inf
                 is-term-gt-zero
@@ -128,7 +128,7 @@
                     term-gt-zero
                     acc
                     pos-inf
-                  index.plus 1
+                  next-index
                   terms
                 * pos-inf acc
                 is-term-gt-zero

--- a/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
@@ -185,6 +185,12 @@
       negative-infinity.times 0.0
     $.equal-to nan.as-bytes
 
+[] > negative-infinity-times-neg-float-zero
+  assert-that > @
+    as-bytes.
+      negative-infinity.times -0.0
+    $.equal-to nan.as-bytes
+
 [] > negative-infinity-times-int-zero
   assert-that > @
     as-bytes.
@@ -223,16 +229,59 @@
     $.equal-to neg-inf
 
 [] > negative-infinity-times-negative-float
-  negative-infinity > neg-inf!
   assert-that > @
-    neg-inf.times -42.5
-    $.equal-to neg-inf
+    negative-infinity.times -42.5
+    $.equal-to positive-infinity
 
 [] > negative-infinity-times-negative-int
+  assert-that > @
+    negative-infinity.times -42
+    $.equal-to positive-infinity
+
+[] > negative-infinity-times-multiple-positive-numbers
   negative-infinity > neg-inf!
   assert-that > @
-    neg-inf.times -42
+    neg-inf.times 25 11.2 51
     $.equal-to neg-inf
+
+[] > negative-infinity-times-two-negative-numbers
+  negative-infinity > neg-inf!
+  assert-that > @
+    neg-inf.times -11.2 -5
+    $.equal-to neg-inf
+
+[] > negative-infinity-times-three-negative-numbers
+  assert-that > @
+    negative-infinity.times -11.2 -5 -3
+    $.equal-to positive-infinity
+
+[] > negative-infinity-times-multiple-numbers-with-nan
+  nan > not-a-number!
+  assert-that > @
+    (negative-infinity.times -25 not-a-number 51).as-bytes
+    $.equal-to not-a-number.as-bytes
+
+[] > negative-infinity-times-multiple-numbers-with-float-zero
+  assert-that > @
+    (negative-infinity.times -25 0.0 51).as-bytes
+    $.equal-to nan.as-bytes
+
+[] > negative-infinity-times-multiple-numbers-with-neg-float-zero
+  assert-that > @
+    (negative-infinity.times -25 -0.0 51).as-bytes
+    $.equal-to nan.as-bytes
+
+[] > negative-infinity-times-multiple-numbers-with-int-zero
+  assert-that > @
+    (negative-infinity.times -25 0 51).as-bytes
+    $.equal-to nan.as-bytes
+
+[] > negative-infinity-times-multiple-infinites
+  negative-infinity > neg-inf!
+  positive-infinity > pos-inf!
+  assert-that > @
+    neg-inf.times pos-inf neg-inf pos-inf pos-inf
+    $.equal-to pos-inf
 
 # Plus
 [] > negative-infinity-plus-nan

--- a/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
@@ -185,6 +185,12 @@
       positive-infinity.times 0.0
     $.equal-to nan.as-bytes
 
+[] > positive-infinity-times-neg-float-zero
+  assert-that > @
+    as-bytes.
+      positive-infinity.times -0.0
+    $.equal-to nan.as-bytes
+
 [] > positive-infinity-times-int-zero
   assert-that > @
     as-bytes.
@@ -260,12 +266,17 @@
     (positive-infinity.times -25 0.0 51).as-bytes
     $.equal-to nan.as-bytes
 
+[] > positive-infinity-times-multiple-numbers-with-neg-float-zero
+  assert-that > @
+    (positive-infinity.times -25 -0.0 51).as-bytes
+    $.equal-to nan.as-bytes
+
 [] > positive-infinity-times-multiple-numbers-with-int-zero
   assert-that > @
     (positive-infinity.times -25 0 51).as-bytes
     $.equal-to nan.as-bytes
 
-[] > positive-infinity-times-multiple-numbers-with-infinites
+[] > positive-infinity-times-multiple-infinites
   positive-infinity > pos-inf!
   negative-infinity > neg-inf!
   assert-that > @

--- a/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
@@ -223,16 +223,54 @@
     $.equal-to pos-inf
 
 [] > positive-infinity-times-negative-float
-  positive-infinity > pos-inf!
   assert-that > @
-    pos-inf.times -42.5
-    $.equal-to pos-inf
+    positive-infinity.times -42.5
+    $.equal-to negative-infinity
 
 [] > positive-infinity-times-negative-int
+  assert-that > @
+    positive-infinity.times -42
+    $.equal-to negative-infinity
+
+[] > positive-infinity-times-multiple-positive-numbers
   positive-infinity > pos-inf!
   assert-that > @
-    pos-inf.times -42
+    pos-inf.times 25 11.2 51
     $.equal-to pos-inf
+
+[] > positive-infinity-times-two-negative-numbers
+  positive-infinity > pos-inf!
+  assert-that > @
+    pos-inf.times -11.2 -5
+    $.equal-to pos-inf
+
+[] > positive-infinity-times-three-negative-numbers
+  assert-that > @
+    positive-infinity.times -11.2 -5 -3
+    $.equal-to negative-infinity
+
+[] > positive-infinity-times-multiple-numbers-with-nan
+  nan > not-a-number!
+  assert-that > @
+    (positive-infinity.times -25 not-a-number 51).as-bytes
+    $.equal-to not-a-number.as-bytes
+
+[] > positive-infinity-times-multiple-numbers-with-float-zero
+  assert-that > @
+    (positive-infinity.times -25 0.0 51).as-bytes
+    $.equal-to nan.as-bytes
+
+[] > positive-infinity-times-multiple-numbers-with-int-zero
+  assert-that > @
+    (positive-infinity.times -25 0 51).as-bytes
+    $.equal-to nan.as-bytes
+
+[] > positive-infinity-times-multiple-numbers-with-infinites
+  positive-infinity > pos-inf!
+  negative-infinity > neg-inf!
+  assert-that > @
+    pos-inf.times neg-inf pos-inf neg-inf neg-inf
+    $.equal-to neg-inf
 
 # Plus
 [] > positive-infinity-plus-nan


### PR DESCRIPTION
Closes: #1824 

What's done:
- Made `positive-infinity.times` work with multiple arguments
- Made `negative-infinity.times` work with multiple arguments
- Removed caching of `@` in `positive-infinity`, `negative-infinity` and `nan` because it causes `StackOverflow`
- `plus` and `minus` in infinities were refactored. Now they have the same code style
- Added tests
- Added `todo` for future optimization