### PR TITLE
feat(#1842): directories numbering

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CompilationStep.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CompilationStep.java
@@ -1,0 +1,10 @@
+package org.eolang.maven;
+
+
+/**
+ Path outputDirectory();
+ */
+public interface CompilationStep {
+
+
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CompilationStep.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CompilationStep.java
@@ -1,10 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.maven;
 
-
 /**
- Path outputDirectory();
+ * The compilation step may generate artifacts or files on the filesystem.
+ *
+ * @since 0.30
+ * @todo #1842:90min We can add method 'outputDirectory()' in order to replace hardcoded static
+ *  variables like ParseMojo.DIR, ResolveMojo.DIR, OptimizeMojo.DIR, CopyMojo.DIR,
+ *  TranspileMojo.DIR, etc. The CompilationStep interface could also define other common behaviors
+ *  shared among different Mojos.
  */
-public interface CompilationStep {
-
-
+interface CompilationStep {
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -58,22 +58,23 @@ import org.eolang.parser.ParsingTrain;
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     threadSafe = true
 )
-public final class OptimizeMojo extends SafeMojo {
+public final class OptimizeMojo extends SafeMojo implements CompilationStep {
 
-    /**
-     * The directory where to place intermediary files.
-     */
-    public static final String STEPS = "02-steps";
 
     /**
      * The directory where to transpile to.
      */
-    public static final String DIR = "03-optimize";
+    public static final String DIR = "2-optimize";
 
     /**
      * Subdirectory for optimized cache.
      */
-    public static final String OPTIMIZED = "optimized";
+    static final String OPTIMIZED = "optimized";
+
+    /**
+     * The directory where to place intermediary files.
+     */
+    static final String STEPS = "2-optimization-steps";
 
     /**
      * Track optimization steps into intermediate XML files?

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -60,7 +60,6 @@ import org.eolang.parser.ParsingTrain;
 )
 public final class OptimizeMojo extends SafeMojo implements CompilationStep {
 
-
     /**
      * The directory where to transpile to.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -64,7 +64,7 @@ import org.xembly.Xembler;
     requiresDependencyResolution = ResolutionScope.COMPILE
 )
 @SuppressWarnings("PMD.ImmutableField")
-public final class ParseMojo extends SafeMojo implements CompilationStep{
+public final class ParseMojo extends SafeMojo implements CompilationStep {
 
     /**
      * Zero version.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -64,7 +64,7 @@ import org.xembly.Xembler;
     requiresDependencyResolution = ResolutionScope.COMPILE
 )
 @SuppressWarnings("PMD.ImmutableField")
-public final class ParseMojo extends SafeMojo {
+public final class ParseMojo extends SafeMojo implements CompilationStep{
 
     /**
      * Zero version.
@@ -74,7 +74,7 @@ public final class ParseMojo extends SafeMojo {
     /**
      * The directory where to parse to.
      */
-    public static final String DIR = "01-parse";
+    public static final String DIR = "1-parse";
 
     /**
      * Subdirectory for parsed cache.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -58,12 +58,12 @@ import org.eolang.maven.util.Rel;
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     threadSafe = true
 )
-public final class PullMojo extends SafeMojo {
+public final class PullMojo extends SafeMojo implements CompilationStep {
 
     /**
      * The directory where to process to.
      */
-    public static final String DIR = "04-pull";
+    public static final String DIR = "3-pull";
 
     /**
      * The Git hash to pull objects from, in objectionary.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -60,12 +60,12 @@ import org.eolang.maven.util.Walk;
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     threadSafe = true
 )
-public final class ResolveMojo extends SafeMojo {
+public final class ResolveMojo extends SafeMojo implements CompilationStep {
 
     /**
      * The directory where to resolve to.
      */
-    public static final String DIR = "06-resolve";
+    public static final String DIR = "4-resolve";
 
     /**
      * Skip artifact with the version 0.0.0.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -61,22 +61,22 @@ import org.eolang.parser.StUnhex;
     requiresDependencyResolution = ResolutionScope.COMPILE
 )
 @SuppressWarnings("PMD.LongVariable")
-public final class TranspileMojo extends SafeMojo {
-
-    /**
-     * Extension for compiled sources in XMIR format (XML).
-     */
-    public static final String EXT = "xmir";
+public final class TranspileMojo extends SafeMojo implements CompilationStep {
 
     /**
      * The directory where to transpile to.
      */
-    public static final String DIR = "06-transpile";
+    public static final String DIR = "6-transpile";
 
     /**
      * The directory where to put pre-transpile files.
      */
-    public static final String PRE = "05-pre";
+    private static final String PRE = "5-pre";
+
+    /**
+     * Extension for compiled sources in XMIR format (XML).
+     */
+    static final String EXT = "xmir";
 
     /**
      * Parsing train with XSLs.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -69,11 +69,6 @@ public final class TranspileMojo extends SafeMojo implements CompilationStep {
     public static final String DIR = "6-transpile";
 
     /**
-     * The directory where to put pre-transpile files.
-     */
-    private static final String PRE = "5-pre";
-
-    /**
      * Extension for compiled sources in XMIR format (XML).
      */
     static final String EXT = "xmir";
@@ -98,6 +93,11 @@ public final class TranspileMojo extends SafeMojo implements CompilationStep {
             "/org/eolang/maven/pre/to-java.xsl"
         )
     ).back().back();
+
+    /**
+     * The directory where to put pre-transpile files.
+     */
+    private static final String PRE = "5-pre";
 
     /**
      * Target directory.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -311,7 +311,7 @@ final class OptimizeMojoTest {
             "org/eolang/maven/set-warning-severity.xsl",
             maven.execute(ParseMojo.class)
                 .result()
-                .get("target/01-parse/foo/x/main.xmir")
+                .get("target/1-parse/foo/x/main.xmir")
         );
         Assertions.assertThrows(
             IllegalStateException.class,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -67,7 +67,7 @@ final class ResolveMojoTest {
             .set(AssembleMojo.ATTR_VERSION, "0.22.1");
         final Path target = temp.resolve("target");
         this.resolve(new DummyCentral(), foreign, target);
-        final Path path = temp.resolve("target/06-resolve/org.eolang/eo-runtime/-/0.7.0");
+        final Path path = temp.resolve("target/4-resolve/org.eolang/eo-runtime/-/0.7.0");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
         MatcherAssert.assertThat(
             path.resolve("eo-runtime-0.7.0.jar").toFile(),
@@ -92,7 +92,7 @@ final class ResolveMojoTest {
             .set(AssembleMojo.ATTR_VERSION, "0.22.1");
         final Path target = temp.resolve("target");
         this.resolve(new DummyCentral(), foreign, target);
-        final Path path = temp.resolve("target/06-resolve/org.eolang/eo-runtime/-/");
+        final Path path = temp.resolve("target/4-resolve/org.eolang/eo-runtime/-/");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
         MatcherAssert.assertThat(
             path,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -100,7 +100,7 @@ final class TranspileMojoTest {
             .execute(new FakeMaven.Transpile())
             .result();
         final Path java = res.get(this.compiled);
-        final Path xmir = res.get("target/06-transpile/foo/x/main.xmir");
+        final Path xmir = res.get("target/6-transpile/foo/x/main.xmir");
         MatcherAssert.assertThat(java.toFile(), FileMatchers.anExistingFile());
         MatcherAssert.assertThat(xmir.toFile(), FileMatchers.anExistingFile());
         MatcherAssert.assertThat(java.toFile().setLastModified(0L), Matchers.is(true));

--- a/eo-runtime/src/test/groovy/check-all-java-classes-compiled.groovy
+++ b/eo-runtime/src/test/groovy/check-all-java-classes-compiled.groovy
@@ -22,15 +22,44 @@
  * SOFTWARE.
  */
 
-/**
- * Entry point for running validation scripts.
- * To add new validation create new script in this folder and add it
- * to the list below.
- */
-[
-  'src/test/groovy/check-xsl-id.groovy',
-  'src/test/groovy/check-xsl-version.groovy'
-].each {
-  evaluate(new File(it))
-  println String.format('Verified with %s - OK', it)
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
+
+println 'Verify that all java classes were compiled successfully'
+Path binaries = basedir.toPath()
+  .resolve("target")
+  .resolve("classes")
+  .resolve("org")
+  .resolve("eolang");
+Path classes = basedir.toPath()
+  .resolve("src")
+  .resolve("main")
+  .resolve("java")
+  .resolve("org")
+  .resolve("eolang");
+Set<String> expected = Files.walk(classes)
+  .filter(it -> {
+    it.toString().endsWith(".java")
+  })
+  .map(Path::getFileName)
+  .map(Path::toString)
+  .map(it -> {
+    return it.replace(".java", ".class")
+  }).collect(Collectors.toSet())
+Set<String> actual = Files.walk(binaries)
+  .filter(it -> {
+    it.toString().endsWith(".class")
+  })
+  .map(Path::getFileName)
+  .map(Path::toString)
+  .collect(Collectors.toSet())
+if (!actual.containsAll(expected)) {
+  throw new IllegalStateException(
+    String.format(
+      "Not all classes are compiled\nExpected %s\nActual %s",
+      expected,
+      actual
+    )
+  )
 }

--- a/eo-runtime/src/test/groovy/check-folders-numbering.groovy
+++ b/eo-runtime/src/test/groovy/check-folders-numbering.groovy
@@ -4,7 +4,7 @@
  * Copyright (c) 2016-2023 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
+ * of this software and associated documentation directories (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
@@ -22,19 +22,19 @@
  * SOFTWARE.
  */
 
-target = basedir.toPath().resolve("target").resolve("eo").toFile()
-def files = target.listFiles(new FileFilter() {
+target = basedir.toPath().resolve("target").resolve("eo")
+def directories = target.toFile().listFiles(new FileFilter() {
   @Override
   boolean accept(final File pathname) {
     return pathname.isDirectory()
   }
 })
-assert 6 == files.size()
+assert 6 == directories.size()
 [
-  new File('1-parse', target),
-  new File('2-optimize', target),
-  new File('3-pull', target),
-  new File('4-resolve', target),
-  new File('5-pre', target),
-  new File('6-transpile', target),
-].each { assert files.contains(it) }
+  target.resolve('1-parse').toFile(),
+  target.resolve('2-optimize').toFile(),
+  target.resolve('3-pull').toFile(),
+  target.resolve('4-resolve').toFile(),
+  target.resolve('5-pre').toFile(),
+  target.resolve('6-transpile').toFile(),
+].each { assert directories.contains(it) }

--- a/eo-runtime/src/test/groovy/check-folders-numbering.groovy
+++ b/eo-runtime/src/test/groovy/check-folders-numbering.groovy
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 /**
  * The MIT License (MIT)
  *
@@ -23,18 +25,23 @@
  */
 
 target = basedir.toPath().resolve("target").resolve("eo")
-def directories = target.toFile().listFiles(new FileFilter() {
+List<File> directories = target.toFile().listFiles(new FileFilter() {
   @Override
   boolean accept(final File pathname) {
     return pathname.isDirectory()
   }
 })
-assert 6 == directories.size()
-[
-  target.resolve('1-parse').toFile(),
-  target.resolve('2-optimize').toFile(),
-  target.resolve('3-pull').toFile(),
-  target.resolve('4-resolve').toFile(),
-  target.resolve('5-pre').toFile(),
-  target.resolve('6-transpile').toFile(),
-].each { assert directories.contains(it) }
+List<File> allowed = [
+  '1-parse',
+  '2-optimize',
+  '3-pull',
+  '4-resolve',
+  '5-pre',
+  '6-transpile',
+].stream()
+  .map { target.resolve(it).toFile() }
+  .collect(Collectors.toList())
+
+assert allowed.containsAll(directories)
+
+true

--- a/eo-runtime/src/test/groovy/check-folders-numbering.groovy
+++ b/eo-runtime/src/test/groovy/check-folders-numbering.groovy
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-target = new File('eo-runtime/target/eo');
+target = basedir.toPath().resolve("target").resolve("eo").toFile()
 def files = target.listFiles(new FileFilter() {
   @Override
   boolean accept(final File pathname) {

--- a/eo-runtime/src/test/groovy/verify.groovy
+++ b/eo-runtime/src/test/groovy/verify.groovy
@@ -28,9 +28,13 @@
  * to the list below.
  */
 [
-  'src/test/groovy/check-folders-numbering.groovy',
-  'src/test/groovy/check-all-java-classes-compiled.groovy'
+  'check-folders-numbering.groovy',
+  'check-all-java-classes-compiled.groovy'
 ].each {
-  evaluate(new File(it, basedir))
+  evaluate(basedir.toPath()
+    .resolve("src")
+    .resolve("test")
+    .resolve("groovy")
+    .resolve(it).toFile())
   println String.format('Verified with %s - OK', it)
 }

--- a/eo-runtime/src/test/groovy/verify.groovy
+++ b/eo-runtime/src/test/groovy/verify.groovy
@@ -22,44 +22,15 @@
  * SOFTWARE.
  */
 
-import java.nio.file.Files
-import java.nio.file.Path
-import java.util.stream.Collectors
-
-println 'Verify that all java classes were compiled successfully'
-Path binaries = basedir.toPath()
-  .resolve("target")
-  .resolve("classes")
-  .resolve("org")
-  .resolve("eolang");
-Path classes = basedir.toPath()
-  .resolve("src")
-  .resolve("main")
-  .resolve("java")
-  .resolve("org")
-  .resolve("eolang");
-Set<String> expected = Files.walk(classes)
-  .filter(it -> {
-    it.toString().endsWith(".java")
-  })
-  .map(Path::getFileName)
-  .map(Path::toString)
-  .map(it -> {
-    return it.replace(".java", ".class")
-  }).collect(Collectors.toSet())
-Set<String> actual = Files.walk(binaries)
-  .filter(it -> {
-    it.toString().endsWith(".class")
-  })
-  .map(Path::getFileName)
-  .map(Path::toString)
-  .collect(Collectors.toSet())
-if (!actual.containsAll(expected)) {
-  throw new IllegalStateException(
-    String.format(
-      "Not all classes are compiled\nExpected %s\nActual %s",
-      expected,
-      actual
-    )
-  )
+/**
+ * Entry point for running validation scripts.
+ * To add new validation create new script in this folder and add it
+ * to the list below.
+ */
+[
+  'src/test/groovy/check-folders-numbering.groovy',
+  'src/test/groovy/check-all-java-classes-compiled.groovy'
+].each {
+  evaluate(new File(it, basedir))
+  println String.format('Verified with %s - OK', it)
 }

--- a/src/test/groovy/check-folders-numbering.groovy
+++ b/src/test/groovy/check-folders-numbering.groovy
@@ -1,5 +1,3 @@
-import groovy.io.FileType
-
 /**
  * The MIT License (MIT)
  *
@@ -36,7 +34,7 @@ assert 6 == files.size()
   new File('1-parse', target),
   new File('2-optimize', target),
   new File('3-pull', target),
-  new File('4-pre', target),
-  new File('5-resolve', target),
+  new File('4-resolve', target),
+  new File('5-pre', target),
   new File('6-transpile', target),
 ].each { assert files.contains(it) }

--- a/src/test/groovy/check-folders-numbering.groovy
+++ b/src/test/groovy/check-folders-numbering.groovy
@@ -1,3 +1,5 @@
+import groovy.io.FileType
+
 /**
  * The MIT License (MIT)
  *
@@ -22,18 +24,19 @@
  * SOFTWARE.
  */
 
-/**
- * Entry point for running validation scripts.
- * To add new validation create new script in this folder and add it
- * to the list below.
- */
+target = new File('eo-runtime/target/eo');
+def files = target.listFiles(new FileFilter() {
+  @Override
+  boolean accept(final File pathname) {
+    return pathname.isDirectory()
+  }
+})
+assert 6 == files.size()
 [
-  'src/test/groovy/check-folders-numbering.groovy',
-  'src/test/groovy/check-xsl-id.groovy',
-  'src/test/groovy/check-xsl-version.groovy'
-].each {
-  evaluate(new File(it))
-  println String.format('Verified with %s - OK', it)
-}
-
-
+  new File('1-parse', target),
+  new File('2-optimize', target),
+  new File('3-pull', target),
+  new File('4-pre', target),
+  new File('5-resolve', target),
+  new File('6-transpile', target),
+].each { assert files.contains(it) }


### PR DESCRIPTION
Here are the changes I've made:

1. Added an additional integration test to verify correct directory naming after `eo-runtime` compilation.
2. Renamed folders and updated numbering to align with correct order.
3. Renamed the test `eo-runtime/src/test/groovy/verify.groovy` to `eo-runtime/src/test/groovy/check-all-java-classes-compiled.groovy`. The entry point is now `eo-runtime/src/test/groovy/verify.groovy`.
4. Created a new `CompilationStep` interface. Please note the `@todo` comment in the code. While I'm unsure if it's the optimal solution, it is an improvement over the previous static variables used.

Closes: #1842 