### PR TITLE
#1844 Fixed `float.gte` and `float.lte` to get FALSE in `0.0.gte -0.0` and `0.0.lte -0.0`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -55,22 +55,18 @@
 
   # Tests that $ ≤ x
   [x] > lte
-    if. > @
-      x.as-bytes.eq nan.as-bytes
-      FALSE
-      not.
-        ^.gt x
+    or. > @
+      ^.eq x
+      ^.lt x
 
   # Tests that $ > x
   [x] > gt /bool
 
   # Tests that $ ≥ x
   [x] > gte
-    if. > @
-      x.as-bytes.eq nan.as-bytes
-      FALSE
-      not.
-        ^.lt x
+    or. > @
+      ^.eq x
+      ^.gt x
 
   # Multiplication of $ and x
   [x...] > times /float

--- a/eo-runtime/src/test/eo/org/eolang/float-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/float-tests.eo
@@ -138,6 +138,62 @@
       0.0
     $.equal-to TRUE
 
+[] > zero-not-equal-to-neg-zero
+  assert-that > @
+    0.0
+    $.not
+      $.equal-to -0.0
+
+[] > neg-zero-not-equal-to-zero
+  assert-that > @
+    -0.0
+    $.not
+      $.equal-to 0.0
+
+[] > zero-not-greater-that-neg-zero
+  assert-that > @
+    0.0
+    $.not
+      $.greater-than -0.0
+
+[] > neg-zero-not-greater-that-zero
+  assert-that > @
+    -0.0
+    $.not
+      $.greater-than 0.0
+
+[] > zero-not-less-that-neg-zero
+  assert-that > @
+    0.0
+    $.not
+      $.less-than -0.0
+
+[] > neg-zero-not-less-that-zero
+  assert-that > @
+    -0.0
+    $.not
+      $.less-than 0.0
+
+[] > zero-not-gte-neg-zero
+  assert-that > @
+    0.0.gte -0.0
+    $.equal-to FALSE
+
+[] > neg-zero-not-gte-zero
+  assert-that > @
+    -0.0.gte 0.0
+    $.equal-to FALSE
+
+[] > zero-not-lte-neg-zero
+  assert-that > @
+    0.0.lte -0.0
+    $.equal-to FALSE
+
+[] > neg-zero-not-lte-zero
+  assert-that > @
+    -0.0.lte 0.0
+    $.equal-to FALSE
+
 [] > float-zero-not-eq-to-int-zero
   assert-that > @
     eq.


### PR DESCRIPTION
Closes: #1844 

What's done:
- Fixed `float.gte` and `float.lte`
- Added specific tests with `0.0` and `-0.0`