### PR TITLE
feat(#1226): Check `eo-maven-plugin` version during caching 

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -157,6 +157,9 @@ public final class ParseMojo extends SafeMojo implements CompilationStep {
      *
      * @param tojo The tojo
      * @throws IOException If fails
+     * @todo #1226:30min new FtCached(hash, cache, origin) should be replaced with a new constructor
+     *  that uses the current eo-maven-plugin version - new FtCached(CacheVersion, cache, origin).
+     *  This will allow us to invalidate the cache when the plugin version changes.
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl"})
     private void parse(final Tojo tojo) throws IOException {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
@@ -29,11 +29,14 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Version of the eo-maven-plugin cache.
- * The version consists of two main components: the version of the eo-maven-plugin
- * and the hash of tag from the objectionary/home.
- * CacheVersion could be also not cacheable, if the version of the eo-maven-plugin is development
- * see {@link CacheVersion#NOT_CACHEABLE} versions.
+ * Version of the cache.
+ * The version consists of two main components:
+ *  1) Base, which is maven-style version string
+ *  2) Hash string, containing git hash.
+ * The two parts define the cacheable location by method {@link #path}.
+ * If base is empty or contains '0.0.0' or 'SNAPSHOT' (see {@link CacheVersion#NOT_CACHEABLE}
+ * versions) the version is considered non-cacheable.
+ *
  * @since 0.30
  */
 final class CacheVersion {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
@@ -29,8 +29,11 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Cache version.
- *
+ * Version of the eo-maven-plugin cache.
+ * The version consists of two main components: the version of the eo-maven-plugin
+ * and the hash of tag from the objectionary/home.
+ * CacheVersion could be also not cacheable, if the version of the eo-maven-plugin is development
+ * see {@link CacheVersion#NOT_CACHEABLE} versions.
  * @since 0.30
  */
 final class CacheVersion {
@@ -41,19 +44,24 @@ final class CacheVersion {
     private static final String[] NOT_CACHEABLE = {"0.0.0", "SNAPSHOT"};
 
     /**
-     * Version of the eo-maven-plugin.
+     * Version of the eo-maven-plugin which currently builds a program.
+     * Version could be:
+     *  - 0.0.0 - if the version is not set in the pom.xml
+     *  - 0.30.0 - if the version is set in the pom.xml
+     *  - 1.0-SNAPSHOT - if the not stable development version is set in the pom.xml
+     *  By some reason, the version could also be empty.
      */
     private final String version;
 
     /**
-     * Hash of the object.
+     * Hash of tag from the objectionary/home.
      */
     private final String hash;
 
     /**
      * Ctor.
-     * @param ver Version of the eo-maven-plugin
-     * @param hsh Hash of the object
+     * @param ver Version of the eo-maven-plugin which currently builds a program.
+     * @param hsh Hash of the objectionary tag.
      */
     CacheVersion(final String ver, final String hsh) {
         this.version = ver;
@@ -75,7 +83,7 @@ final class CacheVersion {
      * Get cache path.
      * @return Path.
      */
-    Path cache() {
+    Path path() {
         return Paths.get(Objects.toString(this.version, ""))
             .resolve(Objects.toString(this.hash, ""));
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.footprint;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Cache version.
+ *
+ * @since 0.30
+ */
+final class CacheVersion {
+
+    /**
+     * Not cacheable versions.
+     */
+    private static final String[] NOT_CACHEABLE = {"0.0.0", "SNAPSHOT"};
+    /**
+     * Version of the eo-maven-plugin.
+     */
+    private final String version;
+
+    /**
+     * Hash of the object.
+     */
+    private final String hash;
+
+    /**
+     * Ctor.
+     * @param ver Version of the eo-maven-plugin
+     * @param hsh Hash of the object
+     */
+    CacheVersion(final String ver, final String hsh) {
+        this.version = ver;
+        this.hash = hsh;
+    }
+
+    /**
+     * Checks if the version is cacheable.
+     * @return True if cacheable, false otherwise.
+     */
+    boolean cacheable() {
+        return Objects.nonNull(this.hash)
+            && !this.hash.isEmpty()
+            && (Objects.isNull(this.version)
+            || Arrays.stream(CacheVersion.NOT_CACHEABLE).noneMatch(this.version::contains));
+    }
+
+    /**
+     * Get cache path.
+     * @return Path.
+     */
+    Path cache() {
+        return Paths.get(Objects.toString(this.version, ""))
+            .resolve(Objects.toString(this.hash, ""));
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/CacheVersion.java
@@ -39,6 +39,7 @@ final class CacheVersion {
      * Not cacheable versions.
      */
     private static final String[] NOT_CACHEABLE = {"0.0.0", "SNAPSHOT"};
+
     /**
      * Version of the eo-maven-plugin.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
@@ -151,6 +151,6 @@ public final class FtCached implements Footprint {
      * @return Path
      */
     private Path path(final String program, final String ext) {
-        return new Place(program).make(this.version.cache(), ext);
+        return new Place(program).make(this.version.path(), ext);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/footprint/FtCached.java
@@ -61,7 +61,7 @@ public final class FtCached implements Footprint {
 
     /**
      * Ctor.
-     * @param hash Version tag
+     * @param hash Version tag or hash
      * @param cache Cache root
      * @param origin Origin
      */
@@ -70,27 +70,24 @@ public final class FtCached implements Footprint {
         final Path cache,
         final Footprint origin
     ) {
-        this("", hash, cache, origin);
+        this(new CacheVersion("", hash), cache, origin);
     }
 
     /**
      * Ctor.
-     * @param ver Version of eo-maven-plugin
-     * @param hash Version hash
+     * @param ver Version
      * @param cache Cache root
      * @param origin Origin
      */
-    private FtCached(
-        final String ver,
-        final String hash,
+    FtCached(
+        final CacheVersion ver,
         final Path cache,
         final Footprint origin
     ) {
-        this.version = new CacheVersion(ver, hash);
+        this.version = ver;
         this.cache = cache;
         this.origin = origin;
     }
-
 
     @Override
     public String load(final String program, final String ext) throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
@@ -63,11 +63,11 @@ class CacheVersionTest {
 
     @ParameterizedTest
     @CsvSource({
-        "0.0.0, abcdefg, 0.0.0/abcdefg",
-        "2.0-SNAPSHOT, abcdefg, 2.0-SNAPSHOT/abcdefg",
-        "1.0-SNAPSHOT, abcdefg, 1.0-SNAPSHOT/abcdefg",
-        "SNAPSHOT, abcdefg, SNAPSHOT/abcdefg",
-        "0.1.0, abcdefg, 0.1.0/abcdefg",
+        "0.0.0, abcdefg, 0.0.0|abcdefg",
+        "2.0-SNAPSHOT, abcdefg, 2.0-SNAPSHOT|abcdefg",
+        "1.0-SNAPSHOT, abcdefg, 1.0-SNAPSHOT|abcdefg",
+        "SNAPSHOT, abcdefg, SNAPSHOT|abcdefg",
+        "0.1.0, abcdefg, 0.1.0|abcdefg",
         "'', abcdefg, abcdefg",
         "'', master, master",
         "'','', ''",
@@ -82,7 +82,7 @@ class CacheVersionTest {
     ) {
         MatcherAssert.assertThat(
             new CacheVersion(version, hash).cache(),
-            Matchers.equalTo(Paths.get(expected.replaceAll("/", File.separator)))
+            Matchers.equalTo(Paths.get(expected.replace("|", File.separator)))
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
@@ -81,7 +81,7 @@ class CacheVersionTest {
         final String expected
     ) {
         MatcherAssert.assertThat(
-            new CacheVersion(version, hash).cache(),
+            new CacheVersion(version, hash).path(),
             Matchers.equalTo(Paths.get(expected.replace("|", File.separator)))
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.maven.footprint;
 
 import java.io.File;
@@ -7,6 +30,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+/**
+ * Test cases for {@link CacheVersion}.
+ *
+ * @since 0.30
+ */
 class CacheVersionTest {
 
     @ParameterizedTest
@@ -20,7 +48,7 @@ class CacheVersionTest {
         "0.1.0, abcdefg, true",
         "'', abcdefg, true",
         "'', master, true",
-        "'null', master, true",
+        "'null', master, true"
     })
     void checksIfVersionIsCacheable(
         final String version,
@@ -45,7 +73,7 @@ class CacheVersionTest {
         "'','', ''",
         ",, ''",
         "'',, ''",
-        ",,''",
+        ",,''"
     })
     void returnsCorrectCachePath(
         final String version,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/CacheVersionTest.java
@@ -1,0 +1,60 @@
+package org.eolang.maven.footprint;
+
+import java.io.File;
+import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CacheVersionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "0.0.0, abcdefg, false",
+        "2.0-SNAPSHOT, abcdefg, false",
+        "1.0-SNAPSHOT, abcdefg, false",
+        "SNAPSHOT, abcdefg, false",
+        "'','', false",
+        "0.1.0, '', false",
+        "0.1.0, abcdefg, true",
+        "'', abcdefg, true",
+        "'', master, true",
+        "'null', master, true",
+    })
+    void checksIfVersionIsCacheable(
+        final String version,
+        final String hash,
+        final boolean expected
+    ) {
+        MatcherAssert.assertThat(
+            new CacheVersion(version, hash).cacheable(),
+            Matchers.is(expected)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0.0.0, abcdefg, 0.0.0/abcdefg",
+        "2.0-SNAPSHOT, abcdefg, 2.0-SNAPSHOT/abcdefg",
+        "1.0-SNAPSHOT, abcdefg, 1.0-SNAPSHOT/abcdefg",
+        "SNAPSHOT, abcdefg, SNAPSHOT/abcdefg",
+        "0.1.0, abcdefg, 0.1.0/abcdefg",
+        "'', abcdefg, abcdefg",
+        "'', master, master",
+        "'','', ''",
+        ",, ''",
+        "'',, ''",
+        ",,''",
+    })
+    void returnsCorrectCachePath(
+        final String version,
+        final String hash,
+        final String expected
+    ) {
+        MatcherAssert.assertThat(
+            new CacheVersion(version, hash).cache(),
+            Matchers.equalTo(Paths.get(expected.replaceAll("/", File.separator)))
+        );
+    }
+}


### PR DESCRIPTION
Added `CacheVersion` class that encapsulates the logic of choosing whether `eo-maven-plugin` version is cacheable or not.

Closes: #1226 