### PR TITLE
fix: revert `maven-compiler-plugin` back to the version `3.8.1`

### DIFF
--- a/eo-maven-plugin/src/it/fibonacci/pom.xml
+++ b/eo-maven-plugin/src/it/fibonacci/pom.xml
@@ -38,7 +38,7 @@ SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@ SOFTWARE.
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.8.1</version>
           <configuration combine.self="override">
             <source>8</source>
             <target>8</target>


### PR DESCRIPTION
Revert `maven-compiler-plugin` back to the version `3.8.1`.

The issue comes from that [PR](https://github.com/objectionary/eo/pull/1850).