### PR TITLE
Refactor: add `TranspiledTojos`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -46,6 +46,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.eolang.maven.tojos.TranspiledTojos;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -202,10 +203,8 @@ abstract class SafeMojo extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
-    protected final Unchecked<Tojos> transpiledTojos = new Unchecked<>(
-        new Sticky<>(
-            () -> Catalogs.INSTANCE.make(this.transpiled.toPath(), this.transpiledFormat)
-        )
+    protected final TranspiledTojos transpiledTojos = new TranspiledTojos(
+        new Sticky<>(() -> Catalogs.INSTANCE.make(this.transpiled.toPath(), this.transpiledFormat))
     );
 
     /**
@@ -265,7 +264,7 @@ abstract class SafeMojo extends AbstractMojo {
                     SafeMojo.closeTojos(this.placedTojos.value());
                 }
                 if (this.transpiled != null) {
-                    SafeMojo.closeTojos(this.transpiledTojos.value());
+                    SafeMojo.closeTojos(this.transpiledTojos);
                 }
             }
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -27,7 +27,6 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.tojos.Tojo;
-import com.yegor256.tojos.Tojos;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.TrBulk;
 import com.yegor256.xsline.TrClasspath;
@@ -155,11 +154,7 @@ public final class TranspileMojo extends SafeMojo implements CompilationStep {
                 );
             } else {
                 final List<Path> paths = this.transpile(src, input, target);
-                for (final Path path : paths) {
-                    this.transpiledTojos.value()
-                        .add(String.valueOf(path))
-                        .set(AssembleMojo.ATTR_XMIR2, tojo.get(AssembleMojo.ATTR_XMIR2));
-                }
+                paths.forEach(p -> this.transpiledTojos.add(p, tojo.get(AssembleMojo.ATTR_XMIR2)));
                 saved += paths.size();
             }
         }
@@ -233,16 +228,7 @@ public final class TranspileMojo extends SafeMojo implements CompilationStep {
         );
         int count = 0;
         for (final Tojo exist : existed) {
-            final List<Tojo> removable = this.transpiledTojos.value().select(
-                row -> row.get(AssembleMojo.ATTR_XMIR2)
-                    .equals(exist.get(AssembleMojo.ATTR_XMIR2))
-            );
-            for (final Tojo remove : removable) {
-                final File file = new File(remove.get(Tojos.KEY));
-                if (file.delete()) {
-                    count += 1;
-                }
-            }
+            count += this.transpiledTojos.remove(exist.get(AssembleMojo.ATTR_XMIR2));
         }
         return count;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.tojos;
+
+import com.yegor256.tojos.Tojo;
+import com.yegor256.tojos.Tojos;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Transpiled tojos that keeps information about all transpiled files.
+ *
+ * @since 0.30
+ */
+public final class TranspiledTojos implements Closeable {
+
+    /**
+     * All tojos.
+     */
+    private final Unchecked<? extends Tojos> all;
+
+    /**
+     * The main public constructor.
+     * @param tojos Tojos source.
+     */
+    public TranspiledTojos(final Sticky<? extends Tojos> tojos) {
+        this(new Unchecked<>(tojos));
+    }
+
+    /**
+     * The main constructor.
+     * @param tojos Tojos source.
+     */
+    private TranspiledTojos(final Unchecked<? extends Tojos> tojos) {
+        this.all = tojos;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.all.value().close();
+    }
+
+    /**
+     * Add transpiled file to the list.
+     * @param transpiled Transpiled file.
+     * @param xmir Xmir2 file.
+     */
+    public void add(final Path transpiled, final String xmir) {
+        this.all.value().add(String.valueOf(transpiled)).set(Attribute.XMIR2.key(), xmir);
+    }
+
+    /**
+     * Remove all transpiled files by xmir.
+     * @param xmir Xmir2 file.
+     * @return Number of removed files.
+     */
+    public long remove(final String xmir) {
+        return this.findByXmir(xmir)
+            .stream()
+            .map(row -> row.get(Attribute.ID.key()))
+            .map(File::new)
+            .filter(File::delete)
+            .count();
+    }
+
+    /**
+     * Find all tojos by xmir.
+     * @param xmir Xmir2 file.
+     * @return List of tojos.
+     */
+    private List<Tojo> findByXmir(final String xmir) {
+        return this.all.value().select(row -> row.get(Attribute.XMIR2.key()).equals(xmir));
+    }
+
+    /**
+     * All possible attributes of transpiled tojos.
+     * It's convenient to keep them encapsulated.
+     *
+     * @since 0.30
+     */
+    private enum Attribute {
+        /**
+         * Id.
+         */
+        ID("id"),
+
+        /**
+         * Xmir2.
+         */
+        XMIR2("xmir2");
+
+        /**
+         * Attribute key in tojos file.
+         */
+        private final String key;
+
+        /**
+         * The main constructor.
+         * @param attribute Attribute key in tojos file.
+         */
+        Attribute(final String attribute) {
+            this.key = attribute;
+        }
+
+        /**
+         * Get attribute key.
+         * @return Attribute key.
+         */
+        String key() {
+            return this.key;
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/package-info.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Package for domain tojos.
+ * @since 0.30
+ * The same way as {@link org.eolang.maven.tojos.TranspiledTojos} we can implement
+ *  - placed tojos
+ *  - foreign tojos
+ *  By that we can achieve grater encapsulation and better readability.
+ */
+package org.eolang.maven.tojos;


### PR DESCRIPTION
I believe we have an encapsulation problem related to the `Tojos` that work with the `eo-foreign.cvs`, `placed.cvs`, or `transpiled.cvs` files. We are currently using attributes from those files in various parts of the program, which presents the following issues:

1. We are using strange `static` variables with oddly composed names in many different places (`ATTR_DISCOVERED_AT`, `ATTR_PLD_RELATED`, `ATTR_PLD_HASH`).
2. We are exposing the internals of `Tojos` and its attributes to foreign objects. This means that other objects dictate how `Tojos` should save its internals.

To address this issue, I suggest a simple refactoring, for example, for the transpiled `Tojos` (but the same refactoring could be applied to `eo-foreign.cvs` and `placed.cvs` as well). Here are the steps we can take:

1. Create a `TranspiledTojos` class that will encapsulate all behaviour related to transpiled `Tojos`.
2. Inside `TranspiledTojos`, define a set of attributes as an enum (instead of using `AssembleMojo.ATTR_XMIR2` and `Tojos.KEY`).

Please take a look at the code.