### PR TITLE
rename `ChResolve` to `ChCompound`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -38,8 +38,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterator.Mapped;
 import org.cactoos.list.ListOf;
+import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.hash.ChNarrow;
-import org.eolang.maven.hash.ChResolve;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyFallbackSwap;
@@ -120,7 +120,7 @@ public final class ProbeMojo extends SafeMojo {
             row -> row.exists(AssembleMojo.ATTR_XMIR2)
                 && !row.exists(AssembleMojo.ATTR_PROBED)
         );
-        final CommitHash hash = new ChResolve(
+        final CommitHash hash = new ChCompound(
             this.offlineHashFile, this.offlineHash, this.tag
         );
         if (this.objectionary == null) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -34,8 +34,8 @@ import java.util.Collection;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.hash.ChNarrow;
-import org.eolang.maven.hash.ChResolve;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyCaching;
@@ -128,7 +128,7 @@ public final class PullMojo extends SafeMojo implements CompilationStep {
             row -> !row.exists(AssembleMojo.ATTR_EO)
                 && !row.exists(AssembleMojo.ATTR_XMIR)
         );
-        final CommitHash hash = new ChResolve(
+        final CommitHash hash = new ChCompound(
             this.offlineHashFile, this.offlineHash, this.tag
         );
         if (this.objectionary == null) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
@@ -35,9 +35,6 @@ import java.nio.file.Path;
  *  be used to change the behavior of an object.
  *  Need to use composable decorators to make this class
  *  not configurable.
- * @todo #1569:30min Need to rename this class to a more correct one.
- *  The correct one name will consist of prefix "Ch" and a noun or
- *  adjective.
  */
 public final class ChCompound implements CommitHash {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
@@ -39,7 +39,7 @@ import java.nio.file.Path;
  *  The correct one name will consist of prefix "Ch" and a noun or
  *  adjective.
  */
-public final class ChResolve implements CommitHash {
+public final class ChCompound implements CommitHash {
 
     /**
      * Read hashes from local file.
@@ -65,7 +65,7 @@ public final class ChResolve implements CommitHash {
      * @param text Hash by pattern
      * @param label The Git hash to pull objects from
      */
-    public ChResolve(final Path data, final String text, final String label) {
+    public ChCompound(final Path data, final String text, final String label) {
         this.file = data;
         this.hash = text;
         this.tag = label;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
-import org.eolang.maven.hash.ChResolve;
+import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.util.Home;
@@ -115,7 +115,7 @@ final class PullMojoTest {
             .with("foreign", foreign)
             .execute();
         final Objectionary objectionary = new OyRemote(
-            new ChResolve(null, null, "master")
+            new ChCompound(null, null, "master")
         );
         new Moja<>(ProbeMojo.class)
             .with("targetDir", target)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChCompoundTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChCompoundTest.java
@@ -37,16 +37,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link ChResolve}.
+ * Test case for {@link ChCompound}.
  * @since 0.28.14
  */
-final class ChResolveTest {
+final class ChCompoundTest {
 
     @Test
     @ExtendWith(OnlineCondition.class)
     void getsCommitHashValueFromRemoteTag() {
         MatcherAssert.assertThat(
-            new ChResolve(
+            new ChCompound(
                 null,
                 null,
                 "0.26.0"
@@ -58,7 +58,7 @@ final class ChResolveTest {
     @Test
     void getsCommitHashValueFromPattern() {
         MatcherAssert.assertThat(
-            new ChResolve(
+            new ChCompound(
                 null,
                 "master:m23ss3h,3.1.*:abc2sd3",
                 "master"
@@ -72,7 +72,7 @@ final class ChResolveTest {
         final Path file = temp.resolve("tags.txt");
         new Home().save(new ResourceOf("org/eolang/maven/commits/tags.txt"), file);
         MatcherAssert.assertThat(
-            new ChResolve(
+            new ChCompound(
                 file,
                 null,
                 "master"
@@ -86,7 +86,7 @@ final class ChResolveTest {
     void catchesAnExceptionWhenNoArguments() {
         Assertions.assertThrows(
             NullPointerException.class,
-            () -> new ChResolve(null, null, null).value()
+            () -> new ChCompound(null, null, null).value()
         );
     }
 


### PR DESCRIPTION
Rename class `ChResolve` to `ChCompound`
closes #1645
