### PR TITLE
versions configures

### DIFF
--- a/eo-maven-plugin/src/main/resources/META-INF/MANIFEST.MF
+++ b/eo-maven-plugin/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,1 @@
 EO-Maven-Version: ${project.version}
-EO-Version: ${project.version}

--- a/eo-maven-plugin/src/test/resources/META-INF/MANIFEST.MF
+++ b/eo-maven-plugin/src/test/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-EO-Version: ${project.version}

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -160,6 +160,8 @@ SOFTWARE.
             <index>true</index>
             <manifestEntries>
               <EO-Version>${project.version}</EO-Version>
+              <EO-Revision>${buildNumber}</EO-Revision>
+              <EO-Dob>${timestamp}</EO-Dob>
             </manifestEntries>
           </archive>
         </configuration>

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -94,6 +94,8 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
         this.dirs.add("program")
             .attr("name", this.name)
             .attr("version", Manifests.read("EO-Version"))
+            .attr("revision", Manifests.read("EO-Revision"))
+            .attr("dob", Manifests.read("EO-Dob"))
             .attr(
                 "time",
                 ZonedDateTime.now(ZoneOffset.UTC).format(

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -103,6 +103,8 @@ SOFTWARE.
     <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="time" type="xs:dateTime" use="required"/>
     <xs:attribute name="version" type="xs:string" use="required"/>
+    <xs:attribute name="revision" type="xs:string" use="required"/>
+    <xs:attribute name="dob" type="xs:dateTime" use="required"/>
     <xs:attribute name="source" type="xs:string"/>
   </xs:complexType>
   <xs:element name="program" type="program"/>

--- a/eo-parser/src/test/resources/META-INF/MANIFEST.MF
+++ b/eo-parser/src/test/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,3 @@
 EO-Version: ${project.version}
+EO-Revision: ${buildNumber}
+EO-Dob: ${timestamp}

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -201,7 +201,7 @@ public final class Main {
     }
 
     /**
-     * Read the version from resources and prints it.
+     * Read the version from resources and return it.
      * @return Version string
      * @throws IOException If fails
      */

--- a/eo-runtime/src/test/resources/META-INF/MANIFEST.MF
+++ b/eo-runtime/src/test/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-EO-Version: ${project.version}


### PR DESCRIPTION
I reconfigured `EO-*` attributes in all manifests. Now they are all in order.