### PR TITLE
`PlacedTojos` refactoring

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.io.InputOf;
 import org.cactoos.set.SetOf;
+import org.eolang.maven.tojos.PlacedTojo;
 import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
@@ -61,31 +62,6 @@ import org.eolang.maven.util.Walk;
 )
 @SuppressWarnings({"PMD.ImmutableField", "PMD.AvoidDuplicateLiterals"})
 public final class PlaceMojo extends SafeMojo {
-
-    /**
-     * Attr in CSV.
-     */
-    static final String ATTR_PLD_RELATED = "related";
-
-    /**
-     * Attr in CSV.
-     */
-    static final String ATTR_PLD_KIND = "kind";
-
-    /**
-     * Attr in CSV.
-     */
-    static final String ATTR_PLD_HASH = "hash";
-
-    /**
-     * Where the binary is coming from (JAR name).
-     */
-    static final String ATTR_PLD_DEP = "dependency";
-
-    /**
-     * Attr in CSV.
-     */
-    static final String ATTR_PLD_UNPLACED = "unplaced";
 
     /**
      * Output.
@@ -121,7 +97,7 @@ public final class PlaceMojo extends SafeMojo {
             final Collection<String> deps = new DepDirs(home);
             int copied = 0;
             for (final String dep : deps) {
-                final Collection<Tojo> before = this.placedTojos.dependencyJar(dep);
+                final Collection<Tojo> before = this.placedTojos.findJar(dep);
                 if (!before.isEmpty()) {
                     Logger.info(this, "Found placed binaries from %s", dep);
                 }
@@ -167,7 +143,7 @@ public final class PlaceMojo extends SafeMojo {
             .includes(this.includeBinaries)
             .excludes(this.excludeBinaries);
         int copied = 0;
-        final Map<String, Tojo> cache = this.placedCache();
+        final Map<String, PlacedTojo> cache = this.placedCache();
         for (final Path file : binaries) {
             final String path = file.toString().substring(dir.toString().length() + 1);
             if (path.startsWith(CopyMojo.DIR)) {
@@ -179,7 +155,7 @@ public final class PlaceMojo extends SafeMojo {
                 continue;
             }
             final Path target = this.outputDir.toPath().resolve(path);
-            final Collection<Tojo> before = Stream.of(cache.get(target.toString()))
+            final Collection<PlacedTojo> before = Stream.of(cache.get(target.toString()))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
             if (!before.isEmpty() && !Files.exists(target)) {
@@ -196,7 +172,7 @@ public final class PlaceMojo extends SafeMojo {
                     this,
                     "The same file %s is already placed to %s maybe by %s, skipping",
                     new Rel(file), new Rel(target),
-                    before.iterator().next().get(PlaceMojo.ATTR_PLD_DEP)
+                    before.iterator().next().dependency()
                 );
                 continue;
             }
@@ -207,7 +183,7 @@ public final class PlaceMojo extends SafeMojo {
                     "File %s (%d bytes) was already placed at %s (%d bytes!) by %s, replacing",
                     new Rel(file), file.toFile().length(),
                     new Rel(target), target.toFile().length(),
-                    before.iterator().next().get(PlaceMojo.ATTR_PLD_DEP)
+                    before.iterator().next().dependency()
                 );
             }
             if (!before.isEmpty() && Files.exists(target) && PlacedTojos.isNotUnplaced(before)) {
@@ -215,7 +191,7 @@ public final class PlaceMojo extends SafeMojo {
             }
             new Home(this.outputDir.toPath()).save(new InputOf(file), Paths.get(path));
             final String id = target.toString();
-            final Tojo tojo = this.placedTojos.addClass(
+            final PlacedTojo tojo = this.placedTojos.placeClass(
                 target,
                 target.toString().substring(this.outputDir.toString().length() + 1),
                 dep
@@ -245,9 +221,10 @@ public final class PlaceMojo extends SafeMojo {
      *  and it's not efficient to read row by row from tojos. You can check the progress
      *  <a href="https://github.com/yegor256/tojos/issues/60">here</a>.
      */
-    private Map<String, Tojo> placedCache() {
-        return this.placedTojos.allClasses()
+    private Map<String, PlacedTojo> placedCache() {
+        return this.placedTojos.classes()
             .stream()
+            .map(PlacedTojo::new)
             .collect(
                 Collectors.toMap(
                     row -> row.get(Tojos.KEY),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -189,7 +189,7 @@ abstract class SafeMojo extends AbstractMojo {
     );
 
     /**
-     * Placed tojos
+     * Placed tojos.
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -46,6 +46,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.tojos.TranspiledTojos;
 import org.slf4j.impl.StaticLoggerBinder;
 
@@ -188,14 +189,12 @@ abstract class SafeMojo extends AbstractMojo {
     );
 
     /**
-     * Cached placed tojos.
+     * Placed tojos
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
-    protected final Unchecked<Tojos> placedTojos = new Unchecked<>(
-        new Sticky<>(
-            () -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedFormat)
-        )
+    protected final PlacedTojos placedTojos = new PlacedTojos(
+        new Sticky<>(() -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedFormat))
     );
 
     /**
@@ -261,7 +260,7 @@ abstract class SafeMojo extends AbstractMojo {
                     SafeMojo.closeTojos(this.tojos.value());
                 }
                 if (this.placed != null) {
-                    SafeMojo.closeTojos(this.placedTojos.value());
+                    SafeMojo.closeTojos(this.placedTojos);
                 }
                 if (this.transpiled != null) {
                     SafeMojo.closeTojos(this.transpiledTojos);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnplaceMojo.java
@@ -24,7 +24,6 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import com.yegor256.tojos.Tojos;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -97,7 +96,7 @@ public final class UnplaceMojo extends SafeMojo {
             .map(PlacedTojo::dependency)
             .collect(Collectors.toSet());
         this.placedTojos.jars().stream()
-            .filter(dep -> used.contains(dep.id()))
+            .filter(dep -> used.contains(dep.identifier()))
             .forEach(PlacedTojo::unplace);
     }
 
@@ -145,7 +144,7 @@ public final class UnplaceMojo extends SafeMojo {
         int unplaced = 0;
         for (final PlacedTojo tojo : all) {
             final String related = tojo.related();
-            final Path path = Paths.get(tojo.id());
+            final Path path = Paths.get(tojo.identifier());
             final String hash = new FileHash(path).toString();
             if (!tojo.sameHash(hash)) {
                 if (hash.isEmpty()) {
@@ -200,7 +199,7 @@ public final class UnplaceMojo extends SafeMojo {
         int remained = 0;
         for (final PlacedTojo tojo : tojos) {
             final String related = tojo.related();
-            final Path path = Paths.get(tojo.id());
+            final Path path = Paths.get(tojo.identifier());
             if (!this.keepBinaries.isEmpty()
                 && UnplaceMojo.inside(related, this.keepBinaries)) {
                 remained += 1;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojo.java
@@ -1,0 +1,51 @@
+package org.eolang.maven.tojos;
+
+import com.yegor256.tojos.Tojo;
+
+public class PlacedTojo implements Tojo {
+
+    private final Tojo origin;
+
+    public PlacedTojo(final Tojo tojo) {
+        this.origin = tojo;
+    }
+
+    public String id() {
+        return this.origin.get(PlacedTojos.Attribute.ID.key());
+    }
+
+    public String dependency() {
+        return this.origin.get(PlacedTojos.Attribute.DEPENDENCY.key());
+    }
+
+    public String related() {
+        return this.origin.get(PlacedTojos.Attribute.RELATED.key());
+    }
+
+    public boolean sameHash(final String hash) {
+        return this.origin.get(PlacedTojos.Attribute.HASH.key()).equals(hash);
+    }
+
+    public void unplace() {
+        this.origin.set(PlacedTojos.Attribute.UNPLACED.key(), "true");
+    }
+
+    public String unplaced() {
+        return this.origin.get(PlacedTojos.Attribute.UNPLACED.key());
+    }
+
+    @Override
+    public boolean exists(final String key) {
+        return this.origin.exists(key);
+    }
+
+    @Override
+    public String get(final String key) {
+        return this.origin.get(key);
+    }
+
+    @Override
+    public Tojo set(final String key, final Object value) {
+        return this.origin.set(key, value);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojo.java
@@ -1,51 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.maven.tojos;
 
 import com.yegor256.tojos.Tojo;
 
-public class PlacedTojo implements Tojo {
+/**
+ * Placed tojo.
+ *
+ * @since 0.30
+ */
+public final class PlacedTojo {
 
+    /**
+     * The delegate.
+     */
     private final Tojo origin;
 
-    public PlacedTojo(final Tojo tojo) {
+    /**
+     * Ctor.
+     * @param tojo The delegate.
+     */
+    PlacedTojo(final Tojo tojo) {
         this.origin = tojo;
     }
 
-    public String id() {
+    /**
+     * The tojo id.
+     * @return The id.
+     */
+    public String identifier() {
         return this.origin.get(PlacedTojos.Attribute.ID.key());
     }
 
+    /**
+     * The placed tojo dependency.
+     * @return The dependency.
+     */
     public String dependency() {
         return this.origin.get(PlacedTojos.Attribute.DEPENDENCY.key());
     }
 
+    /**
+     * The placed tojo related file path.
+     * @return The related file path.
+     */
     public String related() {
         return this.origin.get(PlacedTojos.Attribute.RELATED.key());
     }
 
+    /**
+     * Check if the tojo has the same hash.
+     * @param hash The hash to check.
+     * @return True if the hash is the same.
+     */
     public boolean sameHash(final String hash) {
         return this.origin.get(PlacedTojos.Attribute.HASH.key()).equals(hash);
     }
 
+    /**
+     * Mark the tojo as unplaced.
+     */
     public void unplace() {
         this.origin.set(PlacedTojos.Attribute.UNPLACED.key(), "true");
     }
 
-    public String unplaced() {
-        return this.origin.get(PlacedTojos.Attribute.UNPLACED.key());
+    /**
+     * Check if the tojo is a class.
+     * @return True if the tojo is a class.
+     */
+    public boolean isClass() {
+        return "class".equals(this.origin.get(PlacedTojos.Attribute.KIND.key()));
     }
 
-    @Override
-    public boolean exists(final String key) {
-        return this.origin.exists(key);
+    /**
+     * Check if the tojo is a jar.
+     * @return True if the tojo is a jar.
+     */
+    public boolean isJar() {
+        return "jar".equals(this.origin.get(PlacedTojos.Attribute.KIND.key()));
     }
 
-    @Override
-    public String get(final String key) {
-        return this.origin.get(key);
+    /**
+     * Check if the tojo is placed.
+     * @return True if the tojo is placed.
+     */
+    public boolean placed() {
+        return !this.unplaced();
     }
 
-    @Override
-    public Tojo set(final String key, final Object value) {
-        return this.origin.set(key, value);
+    /**
+     * Check if the tojo is unplaced.
+     * @return True if the tojo is unplaced.
+     */
+    public boolean unplaced() {
+        return this.origin.exists(PlacedTojos.Attribute.UNPLACED.key())
+            && "true".equals(this.origin.get(PlacedTojos.Attribute.UNPLACED.key()));
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojos.java
@@ -1,0 +1,103 @@
+package org.eolang.maven.tojos;
+
+import com.yegor256.tojos.Tojo;
+import com.yegor256.tojos.Tojos;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+import org.eolang.maven.util.FileHash;
+
+/**
+ * PlacedTojos encapsulates tojos logic and keeps short information about all placed files.
+ *
+ * @since 0.30
+ */
+public class PlacedTojos implements Closeable {
+
+    /**
+     * All tojos.
+     */
+    private final Unchecked<? extends Tojos> all;
+
+    public PlacedTojos(final Sticky<? extends Tojos> tojos) {
+        this(new Unchecked<>(tojos));
+    }
+
+    private PlacedTojos(final Unchecked<? extends Tojos> tojos) {
+        this.all = tojos;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.all.value().close();
+    }
+
+    public Collection<Tojo> dependencyJar(final String dep) {
+        return this.all.value().select(
+            row -> row.get(Tojos.KEY).equals(dep)
+                && "jar".equals(row.get(Attribute.KIND.key()))
+        );
+    }
+
+    public Collection<Tojo> allClasses() {
+        return this.all.value().select(row -> "class".equals(row.get(Attribute.KIND.key())));
+    }
+
+    public Collection<Tojo> allJars() {
+        return this.all.value().select(row -> "jar".equals(row.get(Attribute.KIND.key())));
+    }
+
+    public void addDependency(final String dep) {
+        this.all.value().add(dep).set(Attribute.KIND.key(), "jar");
+    }
+
+    public Tojo addClass(final Path target, final String related, final String dep) {
+        final String id = target.toString();
+        return this.all.value().add(id)
+            .set(Attribute.KIND.key(), "class")
+            .set(Attribute.HASH.key(), new FileHash(target))
+            .set(Attribute.RELATED.key(), related)
+            .set(Attribute.DEPENDENCY.key(), dep)
+            .set(Attribute.UNPLACED.key(), "false");
+    }
+
+    public boolean isEmpty() {
+        return this.all.value().select(row -> true).isEmpty();
+    }
+
+    /**
+     * Check whether tojos was not unplaced.
+     * @param before Tojos.
+     * @return True if not unplaced.
+     */
+    public static boolean isNotUnplaced(final Iterable<? extends Tojo> before) {
+        final Tojo tojo = before.iterator().next();
+        return tojo.exists(Attribute.UNPLACED.key())
+            && "false".equals(tojo.get(Attribute.UNPLACED.key()));
+    }
+
+
+    private enum Attribute {
+
+        ID("id"),
+        KIND("kind"),
+        DEPENDENCY("dependency"),
+        HASH("hash"),
+        RELATED("related"),
+        UNPLACED("unplaced"),
+        ;
+
+        private final String key;
+
+        Attribute(final String key) {
+            this.key = key;
+        }
+
+        String key() {
+            return this.key;
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -50,6 +50,7 @@ import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.Input;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
+import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.util.Home;
 
 /**
@@ -197,12 +198,13 @@ public final class FakeMaven {
      * @param binary Binary as class file or jar.
      * @return The same maven instance.
      */
-    FakeMaven withPlacedBinary(final String binary) {
+    FakeMaven withPlacedBinary(final Path binary) {
         this.placed()
-            .add(binary)
-            .set(PlaceMojo.ATTR_PLD_DEP, "test.jar")
-            .set(PlaceMojo.ATTR_PLD_UNPLACED, "false")
-            .set(PlaceMojo.ATTR_PLD_KIND, binary.substring(binary.lastIndexOf('.') + 1));
+            .placeClass(binary, "", "test.jar");
+//            .add(binary)
+//            .set(PlaceMojo.ATTR_PLD_DEP, "test.jar")
+//            .set(PlaceMojo.ATTR_PLD_UNPLACED, "false")
+//            .set(PlaceMojo.ATTR_PLD_KIND, binary.substring(binary.lastIndexOf('.') + 1));
         return this;
     }
 
@@ -287,8 +289,8 @@ public final class FakeMaven {
      *
      * @return TjSmart of the current placed.json file.
      */
-    TjSmart placed() {
-        return new TjSmart(
+    PlacedTojos placed() {
+        return new PlacedTojos(
             Catalogs.INSTANCE.make(this.workspace.absolute(Paths.get("placed.json")))
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -199,12 +199,7 @@ public final class FakeMaven {
      * @return The same maven instance.
      */
     FakeMaven withPlacedBinary(final Path binary) {
-        this.placed()
-            .placeClass(binary, "", "test.jar");
-//            .add(binary)
-//            .set(PlaceMojo.ATTR_PLD_DEP, "test.jar")
-//            .set(PlaceMojo.ATTR_PLD_UNPLACED, "false")
-//            .set(PlaceMojo.ATTR_PLD_KIND, binary.substring(binary.lastIndexOf('.') + 1));
+        this.placed().placeClass(binary, "", "test.jar");
         return this;
     }
 
@@ -290,9 +285,7 @@ public final class FakeMaven {
      * @return TjSmart of the current placed.json file.
      */
     PlacedTojos placed() {
-        return new PlacedTojos(
-            Catalogs.INSTANCE.make(this.workspace.absolute(Paths.get("placed.json")))
-        );
+        return new PlacedTojos(this.workspace.absolute(Paths.get("placed.json")));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceMojoTest.java
@@ -103,7 +103,7 @@ final class PlaceMojoTest {
         MatcherAssert.assertThat(
             new FakeMaven(temp)
                 .withPlacedBinary(
-                    temp.resolve(PlaceMojoTest.TARGET_CLASSES).resolve(binary).toString()
+                    temp.resolve(PlaceMojoTest.TARGET_CLASSES).resolve(binary)
                 )
                 .execute(PlaceMojo.class)
                 .result()
@@ -121,10 +121,8 @@ final class PlaceMojoTest {
         PlaceMojoTest.saveBinary(temp, content, binary);
         PlaceMojoTest.saveAlreadyPlacedBinary(temp, "old content", binary);
         final Path path = PlaceMojoTest.pathToPlacedBinary(temp, binary);
-        final FakeMaven maven = new FakeMaven(temp).withPlacedBinary(path.toString());
-        maven.placed().select(all -> true).forEach(
-            tojo -> tojo.set(PlaceMojo.ATTR_PLD_UNPLACED, "true")
-        );
+        final FakeMaven maven = new FakeMaven(temp).withPlacedBinary(path);
+        maven.placed().unplaceAll();
         MatcherAssert.assertThat(
             maven.execute(PlaceMojo.class).result(),
             Matchers.hasValue(path)
@@ -196,7 +194,7 @@ final class PlaceMojoTest {
             new ContainsFile("**/eo-runtime-*.jar")
         );
         MatcherAssert.assertThat(
-            maven.placed().select(tojo -> "jar".equals(tojo.get(PlaceMojo.ATTR_PLD_KIND))).size(),
+            maven.placed().jars().size(),
             Matchers.is(1)
         );
     }
@@ -213,8 +211,7 @@ final class PlaceMojoTest {
             Matchers.not(new ContainsFile("**/eo-runtime-*.jar"))
         );
         MatcherAssert.assertThat(
-            maven.placed()
-                .select(tojo -> "jar".equals(tojo.get(PlaceMojo.ATTR_PLD_KIND))).isEmpty(),
+            maven.placed().jars().isEmpty(),
             Matchers.is(true)
         );
     }
@@ -226,9 +223,6 @@ final class PlaceMojoTest {
         final String old = "some old content";
         PlaceMojoTest.saveBinary(temp, old, binary);
         maven.execute(PlaceMojo.class).result();
-        maven.placed().select(all -> true).forEach(
-            tojo -> tojo.set(PlaceMojo.ATTR_PLD_UNPLACED, "false")
-        );
         PlaceMojoTest.saveBinary(temp, "new content", binary);
         maven.execute(PlaceMojo.class).result();
         MatcherAssert.assertThat(
@@ -245,9 +239,7 @@ final class PlaceMojoTest {
         maven.execute(PlaceMojo.class).result();
         final String updated = "with some new content";
         PlaceMojoTest.saveBinary(temp, updated, binary);
-        maven.placed().select(all -> true).forEach(
-            tojo -> tojo.set(PlaceMojo.ATTR_PLD_UNPLACED, "true")
-        );
+        maven.placed().unplaceAll();
         maven.execute(PlaceMojo.class).result();
         MatcherAssert.assertThat(
             new TextOf(PlaceMojoTest.pathToPlacedBinary(temp, binary)).asString(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.maven;
 
-import com.yegor256.tojos.Tojo;
-import com.yegor256.tojos.Tojos;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -87,7 +85,7 @@ final class UnplaceMojoTest {
         UnplaceMojoTest.placeClass(temp, UnplaceMojoTest.clazz(temp));
         UnplaceMojoTest.placeJar(temp, UnplaceMojoTest.DEFAULT_JAR);
         final Path placed = UnplaceMojoTest.placeClass(temp, UnplaceMojoTest.clazz(temp));
-        final List<PlacedTojo> tojos = new PlacedTojos(placed).all();
+        final List<PlacedTojo> tojos = new PlacedTojos(placed).allBinaries();
         new FakeMaven(temp)
             .with("placed", placed.toFile())
             .execute(UnplaceMojo.class);
@@ -96,7 +94,7 @@ final class UnplaceMojoTest {
             Matchers.equalTo(5)
         );
         MatcherAssert.assertThat(
-            tojos.stream().allMatch(tojo -> tojo.unplaced().equals("true")),
+            tojos.stream().allMatch(PlacedTojo::unplaced),
             Matchers.is(true)
         );
     }
@@ -109,7 +107,7 @@ final class UnplaceMojoTest {
         final String other = "other-jar";
         UnplaceMojoTest.placeJar(temp, other);
         final Path placed = UnplaceMojoTest.placeClass(temp, UnplaceMojoTest.clazz(temp));
-        final List<PlacedTojo> tojos = new PlacedTojos(placed).all();
+        final List<PlacedTojo> tojos = new PlacedTojos(placed).allBinaries();
         new FakeMaven(temp)
             .with("placed", placed.toFile())
             .execute(UnplaceMojo.class);
@@ -119,8 +117,8 @@ final class UnplaceMojoTest {
         );
         MatcherAssert.assertThat(
             tojos.stream()
-                .filter(tojo -> tojo.id().equals(other))
-                .allMatch(tojo -> tojo.unplaced().equals("false")),
+                .filter(tojo -> tojo.identifier().equals(other))
+                .allMatch(PlacedTojo::placed),
             Matchers.is(true)
         );
     }
@@ -197,9 +195,7 @@ final class UnplaceMojoTest {
      */
     private static Path placeClass(final Path temp, final Path clazz) {
         final Path placed = UnplaceMojoTest.placedFile(temp);
-        new PlacedTojos(
-            () -> Catalogs.INSTANCE.make(placed)
-        ).placeClass(
+        new PlacedTojos(placed).placeClass(
             clazz,
             temp.relativize(clazz).toString(),
             UnplaceMojoTest.DEFAULT_JAR
@@ -214,9 +210,7 @@ final class UnplaceMojoTest {
      * @return Path to the placed tojos file.
      */
     private static void placeJar(final Path temp, final String name) {
-        new PlacedTojos(
-            () -> Catalogs.INSTANCE.make(UnplaceMojoTest.placedFile(temp))
-        ).placeJar(name);
+        new PlacedTojos(UnplaceMojoTest.placedFile(temp)).placeJar(name);
     }
 
     /**


### PR DESCRIPTION
I've provided refactoring for `placed` tojos. The main aim is encapsulation of tojo attributes. For that reason two classes were added:
- `PlacedTojos`
- `PlacedTojo`   
This PR is quite important for the future implementation of the next issues:
- https://github.com/objectionary/eo/issues/1928
- https://github.com/objectionary/eo/issues/1904

Similar to https://github.com/objectionary/eo/pull/1859