### PR TITLE
feat(#1904): move caching logic out of PlaceMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PlaceMojo.java
@@ -30,17 +30,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.io.InputOf;
 import org.cactoos.set.SetOf;
 import org.eolang.maven.tojos.PlacedTojo;
+import org.eolang.maven.tojos.PlacedTojosCached;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
 import org.eolang.maven.util.Walk;
@@ -86,6 +84,13 @@ public final class PlaceMojo extends SafeMojo {
      */
     @Parameter
     private Set<String> excludeBinaries = new SetOf<>();
+
+    /**
+     * Placed cached tojos.
+     * @since 0.30
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    private final PlacedTojosCached placedTojosCached = new PlacedTojosCached(this.placedTojos);
 
     @Override
     public void exec() throws IOException {
@@ -140,7 +145,6 @@ public final class PlaceMojo extends SafeMojo {
             .includes(this.includeBinaries)
             .excludes(this.excludeBinaries);
         int copied = 0;
-        final Map<String, PlacedTojo> cache = this.placedCache();
         for (final Path file : binaries) {
             final String path = file.toString().substring(dir.toString().length() + 1);
             if (path.startsWith(CopyMojo.DIR)) {
@@ -152,10 +156,8 @@ public final class PlaceMojo extends SafeMojo {
                 continue;
             }
             final Path target = this.outputDir.toPath().resolve(path);
-            final Collection<PlacedTojo> before = Stream.of(cache.get(target.toString()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-            if (!before.isEmpty() && !Files.exists(target)) {
+            final Optional<PlacedTojo> before = this.placedTojosCached.find(target);
+            if (before.isPresent() && !Files.exists(target)) {
                 Logger.info(
                     this,
                     "The file %s has been placed to %s, but now it's gone, re-placing",
@@ -163,37 +165,35 @@ public final class PlaceMojo extends SafeMojo {
                     new Rel(target)
                 );
             }
-            if (!before.isEmpty() && Files.exists(target)
+            if (before.isPresent() && Files.exists(target)
                 && target.toFile().length() == file.toFile().length()) {
                 Logger.debug(
                     this,
                     "The same file %s is already placed to %s maybe by %s, skipping",
                     new Rel(file), new Rel(target),
-                    before.iterator().next().dependency()
+                    before.get().dependency()
                 );
                 continue;
             }
-            if (!before.isEmpty() && Files.exists(target)
+            if (before.isPresent() && Files.exists(target)
                 && target.toFile().length() != file.toFile().length()) {
                 Logger.debug(
                     this,
                     "File %s (%d bytes) was already placed at %s (%d bytes!) by %s, replacing",
                     new Rel(file), file.toFile().length(),
                     new Rel(target), target.toFile().length(),
-                    before.iterator().next().dependency()
+                    before.get().dependency()
                 );
             }
-            if (!before.isEmpty() && Files.exists(target) && !before.iterator().next().unplaced()) {
+            if (before.isPresent() && Files.exists(target) && !before.get().unplaced()) {
                 continue;
             }
             new Home(this.outputDir.toPath()).save(new InputOf(file), Paths.get(path));
-            final String id = target.toString();
-            final PlacedTojo tojo = this.placedTojos.placeClass(
+            this.placedTojosCached.placeClass(
                 target,
                 target.toString().substring(this.outputDir.toString().length() + 1),
                 dep
             );
-            cache.putIfAbsent(id, tojo);
             ++copied;
         }
         if (copied > 0) {
@@ -208,24 +208,5 @@ public final class PlaceMojo extends SafeMojo {
             );
         }
         return copied;
-    }
-
-    /**
-     * Collect all binaries into a fast map for efficient search.
-     * @return Cached placed tojos.
-     * @todo #1894:30min Replace PlaceMojo#placedCache crutch with an appropriate solution from
-     *  Tojos library. The original problem is that Tojos has not so optimal reading mechanism
-     *  and it's not efficient to read row by row from tojos. You can check the progress
-     *  <a href="https://github.com/yegor256/tojos/issues/60">here</a>.
-     */
-    private Map<String, PlacedTojo> placedCache() {
-        return this.placedTojos.classes()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    PlacedTojo::identifier,
-                    row -> row
-                )
-            );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojosCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/PlacedTojosCached.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.tojos;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Placed tojos that cached in memory.
+ * After implementing the <a href="https://github.com/yegor256/tojos/issues/60">issue</a>
+ * the class will be removed.
+ * @since 0.30
+ */
+public final class PlacedTojosCached {
+
+    /**
+     * Delegate.
+     */
+    private final PlacedTojos origin;
+
+    /**
+     * Cached placed tojos.
+     */
+    private final Unchecked<Map<String, PlacedTojo>> cache;
+
+    /**
+     * Ctor.
+     * @param tojos Placed tojos.
+     */
+    public PlacedTojosCached(final PlacedTojos tojos) {
+        this.origin = tojos;
+        this.cache = new Unchecked<>(new Sticky<>(() -> PlacedTojosCached.placedCache(tojos)));
+    }
+
+    /**
+     * Find placed tojo by path.
+     * @param target Path.
+     * @return Placed tojo.
+     */
+    public Optional<PlacedTojo> find(final Path target) {
+        return Optional.ofNullable(this.cache.value().get(target.toString()));
+    }
+
+    /**
+     * Place class.
+     * @param target Path.
+     * @param related Related path.
+     * @param dep Dependency.
+     */
+    public void placeClass(final Path target, final String related, final String dep) {
+        final PlacedTojo tojo = this.origin.placeClass(target, related, dep);
+        this.cache.value().putIfAbsent(target.toString(), tojo);
+    }
+
+    /**
+     * Collect all binaries into a fast map for efficient search.
+     * @param tojos Placed tojos.
+     * @return Cached placed tojos.
+     * @todo #1894:30min Replace PlaceMojo#placedCache crutch with an appropriate solution from
+     *  Tojos library. The original problem is that Tojos has not so optimal reading mechanism
+     *  and it's not efficient to read row by row from tojos. You can check the progress
+     *  <a href="https://github.com/yegor256/tojos/issues/60">here</a>.
+     */
+    private static Map<String, PlacedTojo> placedCache(final PlacedTojos tojos) {
+        return tojos.classes()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    PlacedTojo::identifier,
+                    row -> row
+                )
+            );
+    }
+}


### PR DESCRIPTION
I started implementing #1904 and encountered a problem where I cannot refactor the `place` method due to tight coupling with the cache. Therefore, I have decided to temporarily move the cache to a separate class.