### PR TITLE
feat(#1939): Fix problem with recursive update of a map

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhConst.java
+++ b/eo-runtime/src/main/java/org/eolang/PhConst.java
@@ -87,9 +87,14 @@ public final class PhConst implements Phi {
 
     @Override
     public Attr attr(final String name) {
-        return this.cached.computeIfAbsent(
-            name, x -> new AtConst(this.origin.attr(name), this)
-        );
+        final Attr ret;
+        if (this.cached.containsKey(name)) {
+            ret = this.cached.get(name);
+        } else {
+            ret = new AtConst(this.origin.attr(name), this);
+            this.cached.put(name, ret);
+        }
+        return ret;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ SOFTWARE.
     <!-- This is required for later correct replacement of argLine -->
     <argLine/>
     <!-- This is the size of the stack, which you can modify from command line -->
-    <stack-size>1M</stack-size>
+    <stack-size>8M</stack-size>
     <sonar.projectKey>com.objectionary:${project.name}</sonar.projectKey>
     <sonar.organization>objectionary</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ SOFTWARE.
     <!-- This is required for later correct replacement of argLine -->
     <argLine/>
     <!-- This is the size of the stack, which you can modify from command line -->
-    <stack-size>16M</stack-size>
+    <stack-size>1M</stack-size>
     <sonar.projectKey>com.objectionary:${project.name}</sonar.projectKey>
     <sonar.organization>objectionary</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Fix flaky test by replacing `computeIfAbsent` method with a plain old java approach.

We can't modify the map inside of `computeIfAbsent` lambda. You can write more about it [here](https://stackoverflow.com/questions/19278443/how-do-i-use-the-new-computeifabsent-function) and [here](https://stackoverflow.com/questions/28840047/recursive-concurrenthashmap-computeifabsent-call-never-terminates-bug-or-fea) 

Closes: #1939 