### PR TITLE
feat(#1934): enable `HomeTest#throwsExceptionOnAbsolute` test

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/util/HomeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/util/HomeTest.java
@@ -35,7 +35,6 @@ import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,11 +44,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Test for {@link Home}.
  *
  * @since 0.22
- * @todo #1907:30m Enable HomeTest.throwsExceptionOnAbsolute().
- *  The test fails on Windows with no error thrown. It means
- *  that this test didn't throw IllegalArgumentException when we are
- *  trying to check existence of file in temporary directory.
- *  Possible reason is Home.onlyRelative() method.
  */
 final class HomeTest {
 
@@ -133,11 +127,10 @@ final class HomeTest {
     }
 
     @Test
-    @Disabled
     void throwsExceptionOnAbsolute(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> new Home(temp).exists(Paths.get("/tmp/file.txt"))
+            () -> new Home(temp).exists(temp.toAbsolutePath())
         );
     }
 }


### PR DESCRIPTION
Enable `HomeTest#throwsExceptionOnAbsolute()` test 

Closes: #1934 