### PR TITLE
feat(#1989): remove `ATTR_DISCOVERED` and `ATTR_DOSCOVERED_AT` attributes

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -85,12 +85,6 @@ public final class AssembleMojo extends SafeMojo {
     public static final String ATTR_DISCOVERED = "discovered";
 
     /**
-     * Where this object was discovered.
-     */
-    @SuppressWarnings("PMD.LongVariable")
-    public static final String ATTR_DISCOVERED_AT = "discovered-at";
-
-    /**
      * Tojo ATTR.
      */
     public static final String ATTR_PROBED = "probed";

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -37,6 +37,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.maven.objectionary.Objectionary;
+import org.eolang.maven.tojos.ForeignTojos;
 
 /**
  * Pull all necessary EO XML files from Objectionary and parse them all.
@@ -78,11 +79,6 @@ public final class AssembleMojo extends SafeMojo {
      * Absolute location of SODG file.
      */
     public static final String ATTR_SODG = "sodg";
-
-    /**
-     * Tojo ATTR.
-     */
-    public static final String ATTR_DISCOVERED = "discovered";
 
     /**
      * Tojo ATTR.
@@ -293,7 +289,7 @@ public final class AssembleMojo extends SafeMojo {
             AssembleMojo.ATTR_EO,
             AssembleMojo.ATTR_XMIR,
             AssembleMojo.ATTR_XMIR2,
-            AssembleMojo.ATTR_DISCOVERED,
+            ForeignTojos.Attribute.DISCOVERED.key(),
             AssembleMojo.ATTR_PROBED,
         };
         final Collection<String> parts = new LinkedList<>();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -26,11 +26,9 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import com.yegor256.tojos.Tojo;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.TreeSet;
@@ -62,10 +60,10 @@ public final class DiscoverMojo extends SafeMojo {
             final Path src = tojo.xmirSecond();
             final Collection<String> names = this.discover(src);
             for (final String name : names) {
-                this.scopedTojos().addForeign(name).discoveredAt(src);
+                this.scopedTojos().addForeign(name).withDiscoveredAt(src);
                 discovered.add(name);
             }
-            tojo.discovered(names.size());
+            tojo.withDiscovered(names.size());
         }
         if (tojos.isEmpty()) {
             if (this.scopedTojos().select(row -> true).isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -148,7 +148,7 @@ public final class ProbeMojo extends SafeMojo {
                 }
                 ++count;
                 final ForeignTojo ftojo = this.scopedTojos().addForeign(name);
-                ftojo.discoveredAt(src);
+                ftojo.withDiscoveredAt(src);
                 probed.add(name);
             }
             tojo.set(AssembleMojo.ATTR_HASH, new ChNarrow(hash).value());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -46,6 +46,7 @@ import org.eolang.maven.objectionary.OyFallbackSwap;
 import org.eolang.maven.objectionary.OyHome;
 import org.eolang.maven.objectionary.OyIndexed;
 import org.eolang.maven.objectionary.OyRemote;
+import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Online;
 import org.eolang.maven.util.Rel;
 
@@ -146,11 +147,8 @@ public final class ProbeMojo extends SafeMojo {
                     continue;
                 }
                 ++count;
-                final Tojo ftojo = this.scopedTojos().add(name);
-                if (!ftojo.exists(AssembleMojo.ATTR_VERSION)) {
-                    ftojo.set(AssembleMojo.ATTR_VERSION, "*.*.*");
-                }
-                ftojo.set(AssembleMojo.ATTR_DISCOVERED_AT, src);
+                final ForeignTojo ftojo = this.scopedTojos().addForeign(name);
+                ftojo.discoveredAt(src);
                 probed.add(name);
             }
             tojo.set(AssembleMojo.ATTR_HASH, new ChNarrow(hash).value());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -95,6 +95,7 @@ public final class ForeignTojo {
     /**
      * Set the jar.
      * @param coordinates The coordinates of jar.
+     * @return The tojo itself.
      */
     public ForeignTojo withJar(final Coordinates coordinates) {
         this.delegate.set(ForeignTojos.Attribute.JAR.key(), coordinates.toString());
@@ -104,6 +105,7 @@ public final class ForeignTojo {
     /**
      * Set the discovered size.
      * @param size The size.
+     * @return The tojo itself.
      */
     public ForeignTojo withDiscovered(final int size) {
         this.delegate.set(ForeignTojos.Attribute.DISCOVERED.key(), Integer.valueOf(size));
@@ -113,6 +115,7 @@ public final class ForeignTojo {
     /**
      * Set the discovered at.
      * @param path The path where was discovered.
+     * @return The tojo itself.
      */
     public ForeignTojo withDiscoveredAt(final Path path) {
         if (!this.delegate.exists(ForeignTojos.Attribute.VERSION.key())) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -26,7 +26,6 @@ package org.eolang.maven.tojos;
 import com.yegor256.tojos.Tojo;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.eolang.maven.AssembleMojo;
 import org.eolang.maven.Coordinates;
 
 /**
@@ -97,26 +96,29 @@ public final class ForeignTojo {
      * Set the jar.
      * @param coordinates The coordinates of jar.
      */
-    public void withJar(final Coordinates coordinates) {
+    public ForeignTojo withJar(final Coordinates coordinates) {
         this.delegate.set(ForeignTojos.Attribute.JAR.key(), coordinates.toString());
+        return this;
     }
 
     /**
      * Set the discovered size.
      * @param size The size.
      */
-    public void discovered(final int size) {
+    public ForeignTojo withDiscovered(final int size) {
         this.delegate.set(ForeignTojos.Attribute.DISCOVERED.key(), Integer.valueOf(size));
+        return this;
     }
 
     /**
      * Set the discovered at.
      * @param path The path where was discovered.
      */
-    public void discoveredAt(final Path path) {
+    public ForeignTojo withDiscoveredAt(final Path path) {
         if (!this.delegate.exists(ForeignTojos.Attribute.VERSION.key())) {
             this.delegate.set(ForeignTojos.Attribute.VERSION.key(), "*.*.*");
         }
         this.delegate.set(ForeignTojos.Attribute.DISCOVERED_AT.key(), path);
+        return this;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -26,6 +26,7 @@ package org.eolang.maven.tojos;
 import com.yegor256.tojos.Tojo;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.eolang.maven.AssembleMojo;
 import org.eolang.maven.Coordinates;
 
 /**
@@ -98,5 +99,24 @@ public final class ForeignTojo {
      */
     public void withJar(final Coordinates coordinates) {
         this.delegate.set(ForeignTojos.Attribute.JAR.key(), coordinates.toString());
+    }
+
+    /**
+     * Set the discovered size.
+     * @param size The size.
+     */
+    public void discovered(final int size) {
+        this.delegate.set(ForeignTojos.Attribute.DISCOVERED.key(), Integer.valueOf(size));
+    }
+
+    /**
+     * Set the discovered at.
+     * @param path The path where was discovered.
+     */
+    public void discoveredAt(final Path path) {
+        if (!this.delegate.exists(ForeignTojos.Attribute.VERSION.key())) {
+            this.delegate.set(ForeignTojos.Attribute.VERSION.key(), "*.*.*");
+        }
+        this.delegate.set(ForeignTojos.Attribute.DISCOVERED_AT.key(), path);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
-import org.eolang.maven.AssembleMojo;
 
 /**
  * Foreign tojos.
@@ -83,6 +82,16 @@ public final class ForeignTojos implements Tojos {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Add a foreign tojo.
+     * Similar to {@link ForeignTojos#add(String)}, but returns {@link ForeignTojo}.
+     * @param name The name of the tojo.
+     * @return The tojo.
+     */
+    public ForeignTojo addForeign(final String name) {
+        return new ForeignTojo(this.add(name));
+    }
+
     @Override
     public Tojo add(final String name) {
         final Tojo tojo = this.tojos.value().add(name);
@@ -96,7 +105,7 @@ public final class ForeignTojos implements Tojos {
     public List<Tojo> select(final Predicate<Tojo> filter) {
         return this.tojos.value().select(
             t -> filter.test(t)
-                && (t.get(AssembleMojo.ATTR_SCOPE).equals(this.scope) || "test".equals(this.scope)
+                && (t.get(Attribute.SCOPE.key()).equals(this.scope) || "test".equals(this.scope)
             )
         );
     }
@@ -111,6 +120,16 @@ public final class ForeignTojos implements Tojos {
             .select(
                 row -> row.exists(Attribute.XMIR_2.key())
                     && row.get(Attribute.EO.key()).equals(eobj.toString())
+            ).stream()
+            .map(ForeignTojo::new)
+            .collect(Collectors.toList());
+    }
+
+
+    public Collection<ForeignTojo> isNotDiscoveredYet() {
+        return tojos.value()
+            .select(
+                row -> row.exists(Attribute.XMIR_2.key()) && !row.exists(Attribute.DISCOVERED.key())
             ).stream()
             .map(ForeignTojo::new)
             .collect(Collectors.toList());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -55,6 +55,14 @@ public final class ForeignTojos implements Tojos {
     /**
      * Ctor.
      * @param scalar Scalar
+     */
+    public ForeignTojos(final Scalar<Tojos> scalar) {
+        this(scalar, "compile");
+    }
+
+    /**
+     * Ctor.
+     * @param scalar Scalar
      * @param scope Scope
      */
     public ForeignTojos(final Scalar<Tojos> scalar, final String scope) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -133,9 +133,12 @@ public final class ForeignTojos implements Tojos {
             .collect(Collectors.toList());
     }
 
-
+    /**
+     * Get the tojos that are not discovered yet.
+     * @return The tojos.
+     */
     public Collection<ForeignTojo> isNotDiscoveredYet() {
-        return tojos.value()
+        return this.tojos.value()
             .select(
                 row -> row.exists(Attribute.XMIR_2.key()) && !row.exists(Attribute.DISCOVERED.key())
             ).stream()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -46,6 +47,7 @@ final class BinarizeMojoTest {
      * @throws Exception If fails.
      */
     @Test
+    @Disabled
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -47,7 +46,6 @@ final class BinarizeMojoTest {
      * @throws Exception If fails.
      */
     @Test
-    @Disabled
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {


### PR DESCRIPTION
Remove `ATTR_DISCOVERED` and `ATTR_DOSCOVERED_AT` attributes.

Partly solves the issue #1989

<!-- start pr-codex -->

---

## PR-Codex overview
This PR includes changes in `AssembleMojo`, `DiscoverMojo`, `ProbeMojo`, `ForeignTojo`, `ForeignTojos`, and `ResolveMojoTest`. Changes include adding a new import statement, removing certain constants, adding new methods to `ForeignTojo`, and `ForeignTojos`, and modifying existing methods.

<!-- end pr-codex -->