### PR TITLE
check time of parallel option

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -273,6 +273,11 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+            </configurationParameters>
+          </properties>
           <argLine>@{argLine} -Xss${stack-size}</argLine>
           <systemPropertyVariables>
             <runtime.jar>${org.eolang:eo-runtime:jar}</runtime.jar>


### PR DESCRIPTION
Added parallel option to pom.xml

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a configuration property to enable parallel execution of JUnit 5 tests in the `eo-maven-plugin` pom.xml file.

### Detailed summary
- Added `junit.jupiter.execution.parallel.enabled = true` configuration property to `maven-surefire-plugin` in `eo-maven-plugin/pom.xml`.

<!-- end pr-codex -->