### PR TITLE
enabled `compares-two-foreign-objects` test

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -307,9 +307,6 @@
       foo.y.<
     $.equal-to TRUE
 
-# @todo #1502:30min For some reason this test doesn't work any more,
-#  after I changed the algorithm inside WHILE atom. Can't figure out
-#  why it doesn't work, let's find out and enable this test back again.
 [] > compares-two-foreign-objects
   nop > @
     assert-that


### PR DESCRIPTION
Closes: #1505

<!-- start pr-codex -->

---

## PR-Codex overview
This PR aims to fix a failing test in the `eo-runtime` module. 

### Detailed summary
- Removed a TODO comment about a failing test in `eo-runtime-tests.eo`
- The test was failing because of a change in the algorithm inside a `WHILE` atom.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->