### PR TITLE
Fail on Sonar results

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,4 +29,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn --batch-mode -DskipTests -Dinvoker.skip verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true
-        

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,4 +28,5 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn --batch-mode -DskipTests -Dinvoker.skip verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn --batch-mode -DskipTests -Dinvoker.skip verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true
+        


### PR DESCRIPTION
closes #1897

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `-Dsonar.qualitygate.wait=true` flag to the SonarCloud workflow in the `.github/workflows/sonar.yml` file.

### Detailed summary
- Added the `-Dsonar.qualitygate.wait=true` flag to the `mvn` command in the SonarCloud workflow.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->