### PR TITLE
feat(#1989): Remove `ATTR_*` from `PullMojoTest`

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -60,7 +60,7 @@ import org.eolang.maven.util.Home;
  * NOT thread-safe.
  * @since 0.28.12
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.CouplingBetweenObjects"})
 @NotThreadSafe
 public final class FakeMaven {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -567,4 +567,23 @@ public final class FakeMaven {
             ).iterator();
         }
     }
+
+    /**
+     * Pull full pipeline.
+     *
+     * @since 0.31
+     */
+    static final class Pull implements Iterable<Class<? extends AbstractMojo>> {
+
+        @Override
+        public Iterator<Class<? extends AbstractMojo>> iterator() {
+            return Arrays.<Class<? extends AbstractMojo>>asList(
+                ParseMojo.class,
+                OptimizeMojo.class,
+                DiscoverMojo.class,
+                ProbeMojo.class,
+                PullMojo.class
+            ).iterator();
+        }
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -195,6 +195,16 @@ public final class FakeMaven {
     }
 
     /**
+     * Foreign tojos for eo-foreign.* file.
+     * @return Foreign tojos.
+     */
+    ForeignTojos foreignTojos() {
+        return new ForeignTojos(
+            () -> Catalogs.INSTANCE.make(this.foreignPath())
+        );
+    }
+
+    /**
      * Sets placed tojo attribute.
      *
      * @param binary Binary as class file or jar.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -75,7 +75,8 @@ final class PullMojoTest {
             new ChCompound(null, null, "master")
         );
         new FakeMaven(temp)
-            .withProgram("+package org.eolang.custom",
+            .withProgram(
+                "+package org.eolang.custom",
                 "",
                 "[] > main",
                 "  QQ.io.stdout > @",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -23,21 +23,17 @@
  */
 package org.eolang.maven;
 
+import com.yegor256.tojos.MnCsv;
 import com.yegor256.tojos.MnJson;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
-import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
-import org.cactoos.text.TextOf;
 import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyRemote;
-import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
-import org.eolang.maven.util.Online;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -116,21 +112,16 @@ final class PullMojoTest {
             new ResourceOf("org/eolang/maven/commits/tags.txt"),
             Paths.get("tags.txt")
         );
-        final Path target = temp.resolve("target");
-        final Path foreign = temp.resolve("eo-foreign.json");
-        Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.foreign()
             .add("org.eolang.io.stdout")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
             .set(AssembleMojo.ATTR_VERSION, "*.*.*");
-        new Moja<>(PullMojo.class)
-            .with("targetDir", target.toFile())
-            .with("foreign", foreign.toFile())
-            .with("foreignFormat", PullMojoTest.FOREIGN_FORMAT)
-            .with("objectionary", this.dummy())
+        maven.with("objectionary", this.dummy())
             .with("offlineHashFile", temp.resolve("tags.txt"))
-            .execute();
+            .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            new LinkedList<>(new MnJson(foreign).read()).getFirst().get("hash"),
+            new LinkedList<>(new MnCsv(maven.foreignPath()).read()).getFirst().get("hash"),
             Matchers.equalTo("mmmmmmm")
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -35,6 +35,7 @@ import org.cactoos.text.TextOf;
 import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyRemote;
+import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Online;
 import org.hamcrest.MatcherAssert;
@@ -59,20 +60,15 @@ final class PullMojoTest {
 
     @Test
     void pullsSuccessfully(@TempDir final Path temp) throws IOException {
-        final Path target = temp.resolve("target");
-        final Path foreign = temp.resolve("eo-foreign.json");
-        Catalogs.INSTANCE.make(foreign, PullMojoTest.FOREIGN_FORMAT)
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.foreign()
             .add("org.eolang.io.stdout")
             .set(AssembleMojo.ATTR_SCOPE, "compile")
             .set(AssembleMojo.ATTR_VERSION, "*.*.*");
-        new Moja<>(PullMojo.class)
-            .with("targetDir", target.toFile())
-            .with("foreign", foreign.toFile())
-            .with("foreignFormat", PullMojoTest.FOREIGN_FORMAT)
-            .with("objectionary", this.dummy())
-            .execute();
+        maven.with("objectionary", this.dummy())
+            .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            new Home(target).exists(
+            new Home(temp.resolve("target")).exists(
                 Paths.get(
                     String.format(
                         "%s/org/eolang/io/stdout.eo",
@@ -80,12 +76,11 @@ final class PullMojoTest {
                     )
                 )
             ),
-            Matchers.is(new Online().value())
+            Matchers.is(true)
         );
     }
 
     @Test
-    @ExtendWith(OnlineCondition.class)
     void pullsFromProbes(@TempDir final Path temp) throws IOException {
         final Path program = temp.resolve("program.eo");
         new Home(temp).save(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -48,19 +48,13 @@ import org.junit.jupiter.api.io.TempDir;
 @ExtendWith(OnlineCondition.class)
 final class PullMojoTest {
 
-    /**
-     * Default format of eo-foreign.json for all tests.
-     */
-    private static final String FOREIGN_FORMAT = "json";
-
     @Test
     void pullsSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
-        maven.foreign()
+        maven.foreignTojos()
             .add("org.eolang.io.stdout")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_VERSION, "*.*.*");
-        maven.with("objectionary", this.dummy())
+            .withVersion("*.*.*");
+        maven.with("objectionary", new OyFake())
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
             new Home(temp.resolve("target")).exists(
@@ -112,11 +106,10 @@ final class PullMojoTest {
             Paths.get("tags.txt")
         );
         final FakeMaven maven = new FakeMaven(temp);
-        maven.foreign()
+        maven.foreignTojos()
             .add("org.eolang.io.stdout")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_VERSION, "*.*.*");
-        maven.with("objectionary", this.dummy())
+            .withVersion("*.*.*");
+        maven.with("objectionary", new OyFake())
             .with("offlineHashFile", temp.resolve("tags.txt"))
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
@@ -133,11 +126,10 @@ final class PullMojoTest {
     @Test
     void pullsUsingOfflineHash(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
-        maven.foreign()
+        maven.foreignTojos()
             .add("org.eolang.io.stdout")
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_VERSION, "*.*.*");
-        maven.with("objectionary", this.dummy())
+            .withVersion("*.*.*");
+        maven.with("objectionary", new OyFake())
             .with("tag", "1.0.0")
             .with("offlineHash", "*.*.*:abcdefg")
             .execute(PullMojo.class);
@@ -146,14 +138,4 @@ final class PullMojoTest {
             Matchers.equalTo("abcdefg")
         );
     }
-
-    /**
-     * Dummy Objectionary.
-     *
-     * @return Dummy Objectionary.
-     */
-    private Objectionary dummy() {
-        return new OyFake();
-    }
-
 }


### PR DESCRIPTION
Remove `ATTR_*` from `PullMojoTest`.

Partly closes the #1989 issue.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new method to the `FakeMaven` class and simplifies some test code. 

### Detailed summary
- Added `foreignTojos()` method to `FakeMaven` class for creating foreign tojos
- Removed unused imports
- Simplified test code by using `FakeMaven` instance instead of `Moja` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->