### PR TITLE
feat(#1989): Remove `ATTR_*` from `AssembleMojo`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -60,11 +60,6 @@ public final class AssembleMojo extends SafeMojo {
     /**
      * Tojo ATTR.
      */
-    public static final String ATTR_EO = "eo";
-
-    /**
-     * Tojo ATTR.
-     */
     public static final String ATTR_VERSION = "version";
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -63,11 +63,6 @@ public final class AssembleMojo extends SafeMojo {
     public static final String ATTR_VERSION = "version";
 
     /**
-     * Tojo ATTR.
-     */
-    public static final String ATTR_SCOPE = "scope";
-
-    /**
      * Output.
      * @checkstyle MemberNameCheck (7 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -40,9 +40,6 @@ import org.eolang.maven.objectionary.Objectionary;
  * Pull all necessary EO XML files from Objectionary and parse them all.
  *
  * @since 0.1
- * @todo #1969:90min Remove all ATTR_* constants from AssembleMojo class.
- *  We have to replace all hardcoded ATTR_* attributes with corresponding methods from ForeignTojos
- *  and ForeignTojo classes. It will increase maintainability of the code.
  */
 @Mojo(
     name = "assemble",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -58,11 +58,6 @@ public final class AssembleMojo extends SafeMojo {
     public static final String IR_EXTENSION = "xmir";
 
     /**
-     * Tojo ATTR.
-     */
-    public static final String ATTR_VERSION = "version";
-
-    /**
      * Output.
      * @checkstyle MemberNameCheck (7 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -263,4 +263,14 @@ public final class ForeignTojo {
         this.delegate.set(ForeignTojos.Attribute.VERSION.key(), ver);
         return this;
     }
+
+    /**
+     * Set the scope.
+     * @param scope The scope.
+     * @return The tojo itself.
+     */
+    public ForeignTojo withScope(final String scope) {
+        this.delegate.set(ForeignTojos.Attribute.SCOPE.key(), scope);
+        return this;
+    }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -171,6 +171,14 @@ public final class ForeignTojos implements Closeable {
     }
 
     /**
+     * Get all tojos as a collection.
+     * @return Collection of tojos.
+     */
+    public Collection<ForeignTojo> all() {
+        return this.select(all -> true);
+    }
+
+    /**
      * Check if the tojos contains a foreign tojo with name.
      * @param name The name of the tojo.
      * @return True if the tojo exists.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -369,11 +369,11 @@ public final class FakeMaven {
             String.format("foo/x/main%s.eo", FakeMaven.suffix(this.current.get()))
         );
         this.workspace.save(content, path);
-        this.foreign()
-            .add(String.format("foo.x.main%s", suffix(this.current.get())))
-            .set(AssembleMojo.ATTR_SCOPE, "compile")
-            .set(AssembleMojo.ATTR_VERSION, "0.25.0")
-            .set(AssembleMojo.ATTR_EO, this.workspace.absolute(path));
+        this.foreignTojos()
+            .add(String.format("foo.x.main%s", FakeMaven.suffix(this.current.get())))
+            .withScope("compile")
+            .withVersion("0.25.0")
+            .withSource(this.workspace.absolute(path));
         this.current.incrementAndGet();
         return this;
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -598,7 +598,7 @@ public final class FakeMaven {
     }
 
     /**
-     * Discovery pipeline
+     * Discovery pipeline.
      *
      * @since 0.31
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -596,4 +596,21 @@ public final class FakeMaven {
             ).iterator();
         }
     }
+
+    /**
+     * Discovery pipeline
+     *
+     * @since 0.31
+     */
+    static final class Discover implements Iterable<Class<? extends AbstractMojo>> {
+
+        @Override
+        public Iterator<Class<? extends AbstractMojo>> iterator() {
+            return Arrays.<Class<? extends AbstractMojo>>asList(
+                ParseMojo.class,
+                OptimizeMojo.class,
+                DiscoverMojo.class
+            ).iterator();
+        }
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -45,10 +46,11 @@ final class MarkMojoTest {
         final FakeMaven maven = new FakeMaven(temp);
         maven.execute(MarkMojo.class);
         MatcherAssert.assertThat(
-            maven.foreign()
-                .select(all -> true)
+            maven.foreignTojos()
+                .all()
                 .iterator()
-                .next().get(AssembleMojo.ATTR_VERSION),
+                .next()
+                .version(),
             Matchers.equalTo("0.1.8")
         );
     }
@@ -57,24 +59,25 @@ final class MarkMojoTest {
     void updatesVersionIfItExists(@TempDir final Path temp) throws IOException {
         MarkMojoTest.source(temp);
         final FakeMaven maven = new FakeMaven(temp);
-        maven.foreign().add("foo.bar").set(AssembleMojo.ATTR_VERSION, "*.*.*");
+        final ForeignTojos foreign = maven.foreignTojos();
+        foreign.add("foo.bar")
+            .withVersion("*.*.*");
         maven.execute(MarkMojo.class);
         MatcherAssert.assertThat(
-            maven.foreign()
-                .select(all -> true)
-                .iterator()
-                .next()
-                .get(AssembleMojo.ATTR_VERSION),
+            foreign.all().iterator().next().version(),
             Matchers.equalTo("0.1.8")
         );
         MatcherAssert.assertThat(
-            maven.foreign().select(all -> true).size(),
+            foreign.size(),
             Matchers.equalTo(1)
         );
     }
 
     private static void source(final Path temp) throws IOException {
         new Home(temp.resolve("target").resolve(ResolveMojo.DIR))
-            .save("hi", Paths.get(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR)));
+            .save(
+                "hi",
+                Paths.get(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR))
+            );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -75,9 +75,6 @@ final class MarkMojoTest {
 
     private static void source(final Path temp) throws IOException {
         new Home(temp.resolve("target").resolve(ResolveMojo.DIR))
-            .save(
-                "hi",
-                Paths.get(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR))
-            );
+            .save("hi", Paths.get(String.format("foo/hello/-/0.1.8/%s/foo/bar.eo", CopyMojo.DIR)));
     }
 }


### PR DESCRIPTION
The final PR related to #1989.
Remove all usages of `ATTR_*` from `AssembleMojo`.

Close: #1989 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new methods to the `ForeignTojo` class and uses them to replace hardcoded attributes in the `AssembleMojo` class. It also adds a new method to the `ForeignTojos` class and updates some test files. 

### Detailed summary
- Added `withScope` method to `ForeignTojo` class.
- Added `withVersion` method to `ForeignTojo` class.
- Replaced hardcoded attributes with corresponding methods in `AssembleMojo` class.
- Added `all` method to `ForeignTojos` class.
- Updated `MarkMojoTest`, `DiscoverMojoTest`, and `SkipTest` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->