### PR TITLE
feat(#1940): Parallel TranspileMojo execution

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -39,7 +39,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -162,22 +161,6 @@ public final class TranspileMojo extends SafeMojo {
     }
 
     /**
-     * Transpile with careful exception handling.
-     * @param tojo Tojo that should be transpiled.
-     * @return Number of transpiled files.
-     */
-    private long transpileSafety(final ForeignTojo tojo) {
-        try {
-            return this.transpile(tojo);
-        } catch (final IOException exception) {
-            throw new TranspileException(
-                String.format("Can't transpile tojo %s", tojo.identifier()),
-                exception
-            );
-        }
-    }
-
-    /**
      * Transpile.
      * @param tojo Tojo that should be transpiled.
      * @return Number of transpiled files.
@@ -265,20 +248,5 @@ public final class TranspileMojo extends SafeMojo {
             sum += this.transpiledTojos.remove(path);
         }
         return sum;
-    }
-
-    /**
-     * Exception during transpilation phase.
-     * @since 0.31
-     */
-    private final class TranspileException extends RuntimeException {
-        /**
-         * Constructor.
-         * @param message Exception context message.
-         * @param cause The cause of the exception.
-         */
-        TranspileException(final String message, final Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -130,32 +130,32 @@ public final class TranspileMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Collection<ForeignTojo> sources = this.scopedTojos().withSecondXmir();
-        int saved = 0;
-        for (final ForeignTojo tojo : sources) {
-            final Path file = tojo.xmirSecond();
-            final XML input = new XMLDocument(file);
-            final String name = input.xpath("/program/@name").get(0);
-            final Place place = new Place(name);
-            final Path target = place.make(
-                this.targetDir.toPath().resolve(TranspileMojo.DIR),
-                TranspileMojo.EXT
-            );
-            final Path src = tojo.source();
-            if (
-                target.toFile().exists()
-                    && target.toFile().lastModified() >= file.toFile().lastModified()
-                    && target.toFile().lastModified() >= src.toFile().lastModified()
-            ) {
-                Logger.info(
-                    this, "XMIR %s (%s) were already transpiled to %s",
-                    new Rel(file), name, new Rel(target)
-                );
-            } else {
-                final List<Path> paths = this.transpile(src, input, target);
-                paths.forEach(p -> this.transpiledTojos.add(p, file));
-                saved += paths.size();
-            }
-        }
+//        for (final ForeignTojo tojo : sources) {
+//            final Path file = tojo.xmirSecond();
+//            final XML input = new XMLDocument(file);
+//            final String name = input.xpath("/program/@name").get(0);
+//            final Place place = new Place(name);
+//            final Path target = place.make(
+//                this.targetDir.toPath().resolve(TranspileMojo.DIR),
+//                TranspileMojo.EXT
+//            );
+//            final Path src = tojo.source();
+//            if (
+//                target.toFile().exists()
+//                    && target.toFile().lastModified() >= file.toFile().lastModified()
+//                    && target.toFile().lastModified() >= src.toFile().lastModified()
+//            ) {
+//                Logger.info(
+//                    this, "XMIR %s (%s) were already transpiled to %s",
+//                    new Rel(file), name, new Rel(target)
+//                );
+//            } else {
+//                final List<Path> paths = this.transpile(src, input, target);
+//                paths.forEach(p -> this.transpiledTojos.add(p, file));
+//                saved += paths.size();
+//            }
+//        }
+        final long saved = sources.parallelStream().mapToLong(this::transpileSafety).sum();
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %s",
             sources.size(), saved, new Rel(this.generatedDir)
@@ -174,6 +174,43 @@ public final class TranspileMojo extends SafeMojo {
                 new Rel(this.generatedDir)
             );
         }
+    }
+
+    private long transpileSafety(final ForeignTojo tojo) {
+        try {
+            return this.transpile(tojo);
+        } catch (final IOException exception) {
+            throw new TranspileException("CONTEXT NEEDED", exception);
+        }
+    }
+
+    private int transpile(final ForeignTojo tojo) throws IOException {
+        final int saved;
+        final Path file = tojo.xmirSecond();
+        final XML input = new XMLDocument(file);
+        final String name = input.xpath("/program/@name").get(0);
+        final Place place = new Place(name);
+        final Path target = place.make(
+            this.targetDir.toPath().resolve(TranspileMojo.DIR),
+            TranspileMojo.EXT
+        );
+        final Path src = tojo.source();
+        if (
+            target.toFile().exists()
+                && target.toFile().lastModified() >= file.toFile().lastModified()
+                && target.toFile().lastModified() >= src.toFile().lastModified()
+        ) {
+            Logger.info(
+                this, "XMIR %s (%s) were already transpiled to %s",
+                new Rel(file), name, new Rel(target)
+            );
+            saved = 0;
+        } else {
+            final List<Path> paths = this.transpile(src, input, target);
+            paths.forEach(p -> this.transpiledTojos.add(p, file));
+            saved = paths.size();
+        }
+        return saved;
     }
 
     /**
@@ -225,5 +262,12 @@ public final class TranspileMojo extends SafeMojo {
             .map(ForeignTojo::xmirSecond)
             .mapToLong(this.transpiledTojos::remove)
             .sum();
+    }
+
+
+    private final class TranspileException extends RuntimeException {
+        TranspileException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -239,14 +239,10 @@ public final class TranspileMojo extends SafeMojo {
      * @return Count of removed files
      */
     private long removeTranspiled(final Path src) {
-        final List<Path> all = this.scopedTojos()
+        return this.scopedTojos()
             .withSource(src).stream()
             .map(ForeignTojo::xmirSecond)
-            .collect(Collectors.toList());
-        long sum = 0;
-        for (final Path path : all) {
-            sum += this.transpiledTojos.remove(path);
-        }
-        return sum;
+            .mapToLong(this.transpiledTojos::remove)
+            .sum();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
@@ -29,7 +29,9 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 
@@ -103,9 +105,15 @@ public final class TranspiledTojos implements Closeable {
      * @return List of tojos.
      */
     private List<Tojo> findByXmir(final Path second) {
-        return this.all.value().select(
-            row -> row.get(Attribute.XMIR2.key()).equals(second.toString())
-        );
+        final List<Tojo> result;
+        if (this.all.value() == null) {
+            result = Collections.emptyList();
+        } else {
+            result = this.all.value().select(
+                row -> row.get(Attribute.XMIR2.key()).equals(second.toString())
+            );
+        }
+        return result;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -139,6 +140,24 @@ final class TranspileMojoTest {
         MatcherAssert.assertThat(
             new TextOf(res.get(java)).asString(),
             Matchers.containsString("class EOtuple")
+        );
+    }
+
+    @Test
+    void transpilesSeveralEoProgramsInParallel(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final int programs = 30;
+        for (int prog = 0; prog < programs; ++prog) {
+            maven.withProgram(this.program);
+        }
+        maven.execute(new FakeMaven.Transpile()).result();
+        MatcherAssert.assertThat(
+            Files.list(maven.generatedPath()
+                .resolve("EOorg")
+                .resolve("EOeolang")
+                .resolve("EOexamples")
+            ).count(),
+            Matchers.equalTo(4L)
         );
     }
 }


### PR DESCRIPTION
Make TranspileMojo work in parallel by using several available threads.

Entire build time on my local laptop: before = 02:51 min , after = 2:10 min

Closes: #1940

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for parallel transpilation of multiple EO programs, improving performance. It also adds object locking to prevent concurrency issues and uses a threading library to parallelize the transpilation process.

### Detailed summary
- Added support for parallel transpilation of multiple EO programs
- Added object locking to prevent concurrency issues
- Used a threading library to parallelize the transpilation process

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->