### PR TITLE
2011 rust name by location

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -40,7 +40,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -194,30 +193,6 @@ public final class BinarizeParseMojo extends SafeMojo {
             );
         }
         return result;
-    }
-
-    /**
-     * Uniquely converts the loc into the name for jni function.
-     * @param loc Location attribute of the rust insert.
-     * @return Name for function.
-     */
-    private static String name(final String loc) {
-        final String prefix = "f";
-        final int word = 4;
-        final int capacity = prefix.length() + loc.length() + word * loc.length();
-        final StringBuilder out = new StringBuilder(
-            capacity
-        );
-        out.append(prefix).append(loc.toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "o"));
-        for (final char chr: loc.toCharArray()) {
-            out.append(
-                String.format(
-                    "%04x",
-                    (int) chr
-                )
-            );
-        }
-        return out.toString();
     }
 
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -116,8 +116,7 @@ public final class BinarizeParseMojo extends SafeMojo {
                     .map(BinarizeParseMojo::unhex)
                     .collect(Collectors.toList());
                 final String function = names.name(
-                    code,
-                    String.join(", ", dependencies)
+                    node.xpath("@code_loc").get(0)
                 );
                 final String filename = String.format(
                     "%s%s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -92,14 +92,6 @@ public final class BinarizeParseMojo extends SafeMojo {
     ).back().back();
 
     /**
-     * Cache directory.
-     * @checkstyle MemberNameCheck (7 lines)
-     */
-    @Parameter(property = "eo.cache")
-    @SuppressWarnings("PMD.ImmutableField")
-    private Path cache = Paths.get(System.getProperty("user.home")).resolve(".eo");
-
-    /**
      * Target directory.
      * @checkstyle MemberNameCheck (7 lines)
      */
@@ -116,7 +108,7 @@ public final class BinarizeParseMojo extends SafeMojo {
             row -> row.exists(AssembleMojo.ATTR_XMIR2)
         );
         final Project project = new Project(targetDir.toPath().resolve("Lib"));
-        final Names names = new Names(this.cache);
+        final Names names = new Names(targetDir.toPath());
         for (final Tojo tojo : sources) {
             final Path file = Paths.get(tojo.get(AssembleMojo.ATTR_XMIR2));
             final XML input = new XMLDocument(file);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -109,7 +109,7 @@ public final class BinarizeParseMojo extends SafeMojo {
             final XML input = new XMLDocument(file);
             final List<XML> nodes = this.addRust(input).nodes("/program/rusts/rust");
             for (final XML node: nodes) {
-                final String code = unhex(node.xpath("@code").get(0));
+                final String code = BinarizeParseMojo.unhex(node.xpath("@code").get(0));
                 final List<String> dependencies =
                     node.xpath("./dependencies/dependency/@name")
                     .stream()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -37,7 +37,10 @@ import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.util.Home;
 
 /**
- * Uniquely converts the insert into the name for jni function.
+ * The class for storing and assigning names to
+ * rust inserts by its location.
+ * It loads names base when is created and needs to
+ * be saved for using in other process.
  * @since 0.30
  */
 public final class Names {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -68,9 +68,8 @@ public final class Names {
     /**
      * Ctor.
      * @param target Directory where to serialize names.
-     * @throws IOException If any issues with IO.
      */
-    public Names(final Path target) throws IOException {
+    public Names(final Path target) {
         this.dest = target.resolve("names");
         this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
         this.all = Names.checked(this.dest);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -43,7 +43,7 @@ import org.eolang.maven.util.Home;
 /**
  * The class for storing and assigning names to
  * rust inserts by its location.
- * It loads names base when is created and needs to
+ * It loads names base from target and needs to
  * be saved for using in other process.
  * @since 0.30
  */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -39,7 +39,7 @@ import org.eolang.maven.util.Home;
 
 /**
  * Uniquely converts the insert into the name for jni function.
- * @since 0.29
+ * @since 0.30
  */
 public final class Names {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -161,7 +161,17 @@ public final class Names {
                 )
             )
         )) {
-            return (ConcurrentHashMap<String, String>) map.readObject();
+            final Object result = map.readObject();
+            if (result.getClass() != ConcurrentHashMap.class) {
+                throw new ClassCastException(
+                    String.format(
+                        "Object inside %s has wrong class %s",
+                        src,
+                        result.getClass()
+                    )
+                );
+            }
+            return (ConcurrentHashMap<String, String>) result;
         } catch (final ClassNotFoundException exc) {
             throw new IllegalArgumentException(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -21,11 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package org.eolang.maven.rust_project;
 
+import com.sun.tools.javac.util.Pair;
 import java.io.ByteArrayInputStream;
-import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -34,8 +34,12 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
-import com.sun.tools.javac.util.Pair;
 import org.eolang.maven.util.Home;
+
+/**
+ * Uniquely converts the loc into the name for jni function.
+ * @since 0.29
+ */
 public final class Names {
 
     /**
@@ -44,37 +48,38 @@ public final class Names {
      */
     private final Path dest;
 
+    /**
+     * All names.
+     */
     private final ConcurrentHashMap<String, String> all;
 
+    /**
+     * Prefix for the name.
+     */
     private final String prefix;
 
     /**
-     * Ctor
+     * Ctor.
      * @param target Directory where to serialize names.
      * @throws IOException If any issues with IO.
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public Names(final Path target) throws IOException {
-        this.dest = target;
+        this.dest = target.resolve("names.txt");
         this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
-        if (this.dest.resolve("names.txt").toFile().exists()) {
-            try {
-                this.all = load(target.resolve("names.txt"));
-            } catch (ClassNotFoundException exc) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        "File %s contains invalid data",
-                        this.dest
-                    ),
-                    exc
-                );
-            }
-        }
-        else {
+        if (this.dest.toFile().exists()) {
+            this.all = this.load(this.dest);
+        } else {
             this.all = new ConcurrentHashMap<>();
         }
     }
 
+    /**
+     * Assign the new name to the function.
+     * @param code Code of the function.
+     * @param dependencies Function dependencies.
+     * @return The name.
+     */
     public String name(final String code, final String dependencies) {
         return this.all.computeIfAbsent(
             new Pair<>(code, dependencies).toString(),
@@ -86,14 +91,43 @@ public final class Names {
         );
     }
 
+    /**
+     * Saves the function to name dispatching table.
+     * @throws IOException If any issues with IO.
+     */
     public void save() throws IOException {
-        Files.createDirectories(this.dest);
-        new ObjectOutputStream(new FileOutputStream(this.dest.resolve("names.txt").toFile())).writeObject(this.all);
+        Files.createDirectories(this.dest.getParent());
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(this.all);
+        oos.close();
+        new Home(this.dest.getParent()).save(
+            Base64.getEncoder().encodeToString(baos.toByteArray()),
+            this.dest.getFileName()
+        );
     }
 
-    private static ConcurrentHashMap<String, String> load(final Path src) throws IOException, ClassNotFoundException {
+    /**
+     * Loads the table.
+     * @param src Path where to install from.
+     * @return The map.
+     * @throws IOException If any issues with IO.
+     */
+    private static ConcurrentHashMap<String, String> load(final Path src) throws IOException {
         final String content = String.valueOf(new Home(src.getParent()).load(src.getFileName()));
-        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(content)));
-        return (ConcurrentHashMap<String, String>) ois.readObject();
+        final ObjectInputStream ois = new ObjectInputStream(
+            new ByteArrayInputStream(Base64.getDecoder().decode(content))
+        );
+        try {
+            return (ConcurrentHashMap<String, String>) ois.readObject();
+        } catch (final ClassNotFoundException exc) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "File %s contains invalid data",
+                    src
+                ),
+                exc
+            );
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -73,21 +73,7 @@ public final class Names {
     public Names(final Path target) throws IOException {
         this.dest = target.resolve("names");
         this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
-        this.all = new IoChecked<>(
-            new Sticky<>(
-                new Synced<>(
-                    () -> {
-                        final ConcurrentHashMap<String, String> result;
-                        if (Files.exists(this.dest)) {
-                            result = Names.load(this.dest);
-                        } else {
-                            result = new ConcurrentHashMap<>();
-                        }
-                        return result;
-                    }
-                )
-            )
-        );
+        this.all = Names.checked(this.dest);
     }
 
     /**
@@ -131,6 +117,29 @@ public final class Names {
         new Home(this.dest.getParent()).save(
             new String(Base64.getEncoder().encode(baos.toByteArray())),
             this.dest.getFileName()
+        );
+    }
+
+    /**
+     * Prestructor to initialize this.all.
+     * @param dest Directory where to load from.
+     * @return Names map.
+     */
+    private static IoChecked<ConcurrentHashMap<String, String>> checked(final Path dest) {
+        return new IoChecked<>(
+            new Sticky<>(
+                new Synced<>(
+                    () -> {
+                        final ConcurrentHashMap<String, String> result;
+                        if (Files.exists(dest)) {
+                            result = Names.load(dest);
+                        } else {
+                            result = new ConcurrentHashMap<>();
+                        }
+                        return result;
+                    }
+                )
+            )
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -69,7 +69,7 @@ public final class Names {
         this.dest = target.resolve("names");
         this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
         if (this.dest.toFile().exists()) {
-            this.all = load(this.dest);
+            this.all = Names.load(this.dest);
         } else {
             this.all = new ConcurrentHashMap<>();
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -68,7 +68,7 @@ public final class Names {
     public Names(final Path target) throws IOException {
         this.dest = target.resolve("names");
         this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
-        if (this.dest.toFile().exists()) {
+        if (Files.exists(this.dest)) {
             this.all = Names.load(this.dest);
         } else {
             this.all = new ConcurrentHashMap<>();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -175,7 +175,7 @@ public final class Names {
     /**
      * Loads the table.
      * @param src Path where to install from.
-     * @return The map.
+     * @return The map .
      * @throws IOException If any issues with IO.
      */
     @SuppressWarnings("unchecked")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -149,20 +149,19 @@ public final class Names {
      * @return The map.
      * @throws IOException If any issues with IO.
      */
+    @SuppressWarnings("unchecked")
     private static ConcurrentHashMap<String, String> load(final Path src) throws IOException {
-        try {
-            return (ConcurrentHashMap<String, String>) (
-                new ObjectInputStream(
-                    new ByteArrayInputStream(
-                        Base64.getDecoder().decode(
-                            new FtDefault(src.getParent()).load(
-                                src.getFileName().toString(),
-                                ""
-                            )
-                        )
+        try (ObjectInputStream map = new ObjectInputStream(
+            new ByteArrayInputStream(
+                Base64.getDecoder().decode(
+                    new FtDefault(src.getParent()).load(
+                        src.getFileName().toString(),
+                        ""
                     )
                 )
-            ).readObject();
+            )
+        )) {
+            return (ConcurrentHashMap<String, String>) map.readObject();
         } catch (final ClassNotFoundException exc) {
             throw new IllegalArgumentException(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -1,0 +1,57 @@
+package org.eolang.maven.rust_project;
+
+import com.sun.tools.javac.util.Pair;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+public class Names {
+
+    /**
+     * Cache directory.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    private final Path dest;
+
+    private final ConcurrentHashMap<String, String> all;
+
+    public Names(final Path cache) throws IOException {
+        this.dest = cache.resolve("binarize");
+        if (this.dest.resolve("names.txt").toFile().exists()) {
+            try {
+                this.all = (ConcurrentHashMap<String, String>) (new ObjectInputStream(new FileInputStream(cache.resolve("names.txt").toFile()))).readObject();
+            } catch (ClassNotFoundException exc) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "File %s contains invalid data",
+                        this.dest
+                    ),
+                    exc
+                );
+            }
+        }
+        else {
+            this.all = new ConcurrentHashMap<>();
+        }
+    }
+
+    public String name(final String code, final String dependencies) {
+        return this.all.computeIfAbsent(
+            new Pair<>(code, dependencies).toString(),
+            (key) -> String.format(
+                "f%d",
+                this.all.size()
+            )
+        );
+    }
+
+    public void save() throws IOException {
+        Files.createDirectories(this.dest);
+        new ObjectOutputStream(new FileOutputStream(this.dest.resolve("name.txt").toFile())).writeObject(this.all);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
-import org.cactoos.list.ListOf;
 import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.util.Home;
 
@@ -83,7 +82,7 @@ public final class Names {
      */
     public String name(final String code, final String dependencies) {
         return this.all.computeIfAbsent(
-            new ListOf<>(code, dependencies).toString(),
+            String.format("code: %s, dependencies: %s", code, dependencies),
             key -> String.format(
                 "%s%d",
                 this.prefix,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -113,12 +113,15 @@ public final class Names {
      * @throws IOException If any issues with IO.
      */
     private static ConcurrentHashMap<String, String> load(final Path src) throws IOException {
-        final String content = new FtDefault(src.getParent()).load(
-            src.getFileName().toString(),
-            ""
-        );
         final ObjectInputStream ois = new ObjectInputStream(
-            new ByteArrayInputStream(Base64.getDecoder().decode(content))
+            new ByteArrayInputStream(
+                Base64.getDecoder().decode(
+                    new FtDefault(src.getParent()).load(
+                        src.getFileName().toString(),
+                        ""
+                    )
+                )
+            )
         );
         try {
             return (ConcurrentHashMap<String, String>) ois.readObject();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -76,7 +76,7 @@ public final class Names {
 
     /**
      * Assign the new name to the function.
-     * @param loc Location of insert.
+     * @param loc Location of the insert.
      * @return The name.
      */
     public String name(final String loc) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -1,30 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.eolang.maven.rust_project;
 
-import com.sun.tools.javac.util.Pair;
-
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
-public class Names {
+import com.sun.tools.javac.util.Pair;
+import org.eolang.maven.util.Home;
+public final class Names {
 
     /**
-     * Cache directory.
+     * Target directory.
      * @checkstyle MemberNameCheck (7 lines)
      */
     private final Path dest;
 
     private final ConcurrentHashMap<String, String> all;
 
-    public Names(final Path cache) throws IOException {
-        this.dest = cache.resolve("binarize");
+    private final String prefix;
+
+    /**
+     * Ctor
+     * @param target Directory where to serialize names.
+     * @throws IOException If any issues with IO.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public Names(final Path target) throws IOException {
+        this.dest = target;
+        this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
         if (this.dest.resolve("names.txt").toFile().exists()) {
             try {
-                this.all = (ConcurrentHashMap<String, String>) (new ObjectInputStream(new FileInputStream(cache.resolve("names.txt").toFile()))).readObject();
+                this.all = load(target.resolve("names.txt"));
             } catch (ClassNotFoundException exc) {
                 throw new IllegalArgumentException(
                     String.format(
@@ -43,8 +78,9 @@ public class Names {
     public String name(final String code, final String dependencies) {
         return this.all.computeIfAbsent(
             new Pair<>(code, dependencies).toString(),
-            (key) -> String.format(
-                "f%d",
+            key -> String.format(
+                "%s%d",
+                this.prefix,
                 this.all.size()
             )
         );
@@ -52,6 +88,12 @@ public class Names {
 
     public void save() throws IOException {
         Files.createDirectories(this.dest);
-        new ObjectOutputStream(new FileOutputStream(this.dest.resolve("name.txt").toFile())).writeObject(this.all);
+        new ObjectOutputStream(new FileOutputStream(this.dest.resolve("names.txt").toFile())).writeObject(this.all);
+    }
+
+    private static ConcurrentHashMap<String, String> load(final Path src) throws IOException, ClassNotFoundException {
+        final String content = String.valueOf(new Home(src.getParent()).load(src.getFileName()));
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(content)));
+        return (ConcurrentHashMap<String, String>) ois.readObject();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -113,18 +113,19 @@ public final class Names {
      * @throws IOException If any issues with IO.
      */
     private static ConcurrentHashMap<String, String> load(final Path src) throws IOException {
-        final ObjectInputStream ois = new ObjectInputStream(
-            new ByteArrayInputStream(
-                Base64.getDecoder().decode(
-                    new FtDefault(src.getParent()).load(
-                        src.getFileName().toString(),
-                        ""
+        try {
+            return (ConcurrentHashMap<String, String>) (
+                new ObjectInputStream(
+                    new ByteArrayInputStream(
+                        Base64.getDecoder().decode(
+                            new FtDefault(src.getParent()).load(
+                                src.getFileName().toString(),
+                                ""
+                            )
+                        )
                     )
                 )
-            )
-        );
-        try {
-            return (ConcurrentHashMap<String, String>) ois.readObject();
+            ).readObject();
         } catch (final ClassNotFoundException exc) {
             throw new IllegalArgumentException(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -104,6 +104,35 @@ public final class Names {
         );
     }
 
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof Names)) {
+            return false;
+        }
+        final Names names = (Names) object;
+        try {
+            return this.dest.equals(names.dest)
+                && this.prefix.equals(names.prefix)
+                && this.all.value().equals(names.all.value());
+        } catch (final IOException exc) {
+            throw new IllegalArgumentException(
+                "Cannot load map correctly",
+                exc
+            );
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * this.dest.hashCode()
+            + 829 * this.prefix.hashCode()
+            + 9719 * this.all.hashCode();
+    }
+
     /**
      * Saves the function to name dispatching table.
      * @throws IOException If any issues with IO.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -114,7 +115,7 @@ public final class Names {
         oos.writeObject(this.all.value());
         oos.flush();
         new Home(this.dest.getParent()).save(
-            new String(Base64.getEncoder().encode(baos.toByteArray())),
+            new String(Base64.getEncoder().encode(baos.toByteArray()), StandardCharsets.UTF_8),
             this.dest.getFileName()
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -76,13 +76,12 @@ public final class Names {
 
     /**
      * Assign the new name to the function.
-     * @param code Code of the function.
-     * @param dependencies Function dependencies.
+     * @param loc Location of insert.
      * @return The name.
      */
-    public String name(final String code, final String dependencies) {
+    public String name(final String loc) {
         return this.all.computeIfAbsent(
-            String.format("code: %s, dependencies: %s", code, dependencies),
+            loc,
             key -> String.format(
                 "%s%d",
                 this.prefix,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java
@@ -175,7 +175,7 @@ public final class Names {
     /**
      * Loads the table.
      * @param src Path where to install from.
-     * @return The map .
+     * @return The map.
      * @throws IOException If any issues with IO.
      */
     @SuppressWarnings("unchecked")

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/add_rust/add_rust.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/add_rust/add_rust.xsl
@@ -37,8 +37,11 @@ SOFTWARE.
               <xsl:attribute name="code">
                 <xsl:value-of select="text()"/>
               </xsl:attribute>
-              <xsl:attribute name="loc">
+              <xsl:attribute name="insert_loc">
                 <xsl:value-of select="../attribute(loc)"/>
+              </xsl:attribute>
+              <xsl:attribute name="code_loc">
+                <xsl:value-of select="attribute(loc)"/>
               </xsl:attribute>
               <dependencies>
                 <xsl:for-each select="following-sibling::o/o">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/add_rust/add_rust.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/add_rust/add_rust.xsl
@@ -37,9 +37,6 @@ SOFTWARE.
               <xsl:attribute name="code">
                 <xsl:value-of select="text()"/>
               </xsl:attribute>
-              <xsl:attribute name="insert_loc">
-                <xsl:value-of select="../attribute(loc)"/>
-              </xsl:attribute>
               <xsl:attribute name="code_loc">
                 <xsl:value-of select="attribute(loc)"/>
               </xsl:attribute>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
@@ -58,7 +58,9 @@ final class BinarizeParseMojoTest {
             .result();
         final String rust = String.format(
             "target/binarize/codes/%s0.rs",
-            temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x")
+            temp.resolve("target").toString()
+                .toLowerCase(Locale.ENGLISH)
+                .replaceAll("[^a-z0-9]", "x")
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(rust)
@@ -87,7 +89,9 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
-        final String prefix = temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
+        final String prefix = temp.resolve("target").toString()
+            .toLowerCase(Locale.ENGLISH)
+            .replaceAll("[^a-z0-9]", "x");
         final String one = String.format(
             "target/binarize/codes/%s0.rs",
             prefix
@@ -139,7 +143,9 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
-        final String prefix = temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
+        final String prefix = temp.resolve("target").toString()
+            .toLowerCase(Locale.ENGLISH)
+            .replaceAll("[^a-z0-9]", "x");
         final String cargo = "target/Lib/Cargo.toml";
         final String lib = "target/Lib/src/lib.rs";
         final String module = String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
@@ -25,6 +25,7 @@ package org.eolang.maven;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.Map;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
@@ -56,8 +57,8 @@ final class BinarizeParseMojoTest {
             .execute(new FakeMaven.BinarizeParse())
             .result();
         final String rust = String.format(
-            "target/binarize/codes/%s.rs",
-            "f0"
+            "target/binarize/codes/%s0.rs",
+            temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x")
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(rust)
@@ -86,13 +87,14 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
+        final String prefix = temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
         final String one = String.format(
-            "target/binarize/codes/%s.rs",
-            "f0"
+            "target/binarize/codes/%s0.rs",
+            prefix
         );
         final String two = String.format(
-            "target/binarize/codes/%s.rs",
-            "f1"
+            "target/binarize/codes/%s1.rs",
+            prefix
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(one)
@@ -137,11 +139,12 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
+        final String prefix = temp.resolve("target").toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
         final String cargo = "target/Lib/Cargo.toml";
         final String lib = "target/Lib/src/lib.rs";
         final String module = String.format(
-            "target/Lib/src/%s.rs",
-            "f1"
+            "target/Lib/src/%s1.rs",
+            prefix
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(cargo)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
@@ -57,7 +57,7 @@ final class BinarizeParseMojoTest {
             .result();
         final String rust = String.format(
             "target/binarize/codes/%s.rs",
-            "fooorgoeolangocustomocreatesoobjector03a6002e006f00720067002e0065006f006c0061006e0067002e0063007500730074006f006d002e0063007200650061007400650073002d006f0062006a006500630074002e0072"
+            "f0"
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(rust)
@@ -88,11 +88,11 @@ final class BinarizeParseMojoTest {
             .result();
         final String one = String.format(
             "target/binarize/codes/%s.rs",
-            "fooorgoeolangocustomohellooworldo1or03a6002e006f00720067002e0065006f006c0061006e0067002e0063007500730074006f006d002e00680065006c006c006f002d0077006f0072006c0064002d0031002e0072"
+            "f0"
         );
         final String two = String.format(
             "target/binarize/codes/%s.rs",
-            "fooorgoeolangocustomohellooworldo2or03a6002e006f00720067002e0065006f006c0061006e0067002e0063007500730074006f006d002e00680065006c006c006f002d0077006f0072006c0064002d0032002e0072"
+            "f1"
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(one)
@@ -141,7 +141,7 @@ final class BinarizeParseMojoTest {
         final String lib = "target/Lib/src/lib.rs";
         final String module = String.format(
             "target/Lib/src/%s.rs",
-            "fooorgoeolangocustomocreatesoobjector03a6002e006f00720067002e0065006f006c0061006e0067002e0063007500730074006f006d002e0063007200650061007400650073002d006f0062006a006500630074002e0072"
+            "f1"
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(cargo)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -26,7 +26,6 @@ package org.eolang.maven.rust_project;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -73,9 +72,8 @@ final class NamesTest {
         );
         before.save();
         final Names after = new Names(temp);
-        final ListIterator<String> iterator = locations.listIterator(locations.size());
-        while (iterator.hasPrevious()) {
-            final String loc = iterator.previous();
+        for (int iter = locations.size() - 1; iter >= 0; --iter) {
+            final String loc = locations.get(iter);
             MatcherAssert.assertThat(
                 functions.get(loc),
                 Matchers.equalTo(after.name(loc))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.rust_project;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link Names}.
+ *
+ * @since 0.1
+ */
+final class NamesTest {
+    @Test
+    void solvesSameHashes(@TempDir final Path temp) throws IOException {
+        final Names dispatcher = new Names(temp);
+        final String one = "AaAaAa";
+        final String two = "AaAaBB";
+        MatcherAssert.assertThat(
+            one.hashCode(),
+            Matchers.equalTo(two.hashCode())
+        );
+        MatcherAssert.assertThat(
+            dispatcher.name(one, ""),
+            Matchers.not(
+                dispatcher.name(two, "")
+            )
+        );
+    }
+
+    @Test
+    void recoversNames(@TempDir final Path temp) throws IOException {
+        final List<String> codes = IntStream.range(0, 1000)
+            .mapToObj(String::valueOf)
+            .collect(Collectors.toList());
+        final String dependency = "dependency";
+        final Names before = new Names(temp);
+        final Map<String, String> functions = new HashMap<>();
+        for (final String code: codes) {
+            functions.put(code, before.name(code, dependency));
+        }
+        MatcherAssert.assertThat(
+            codes.size(),
+            Matchers.equalTo(functions.size())
+        );
+        before.save();
+        final Names after = new Names(temp);
+        final ListIterator<String> iterator = codes.listIterator(codes.size());
+        while (iterator.hasPrevious()) {
+            final String code = iterator.previous();
+            MatcherAssert.assertThat(
+                functions.get(code),
+                Matchers.equalTo(after.name(code, dependency))
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -64,7 +64,7 @@ final class NamesTest {
             .collect(Collectors.toList());
         final Names before = new Names(temp);
         final Map<String, String> functions = locations.stream().collect(
-            Collectors.toMap(loc -> loc, loc -> before.name(loc))
+            Collectors.toMap(loc -> loc, before::name)
         );
         MatcherAssert.assertThat(
             locations.size(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -57,6 +57,13 @@ final class NamesTest {
         );
     }
 
+    /**
+     * The goal is to check that `after` is built according to `before`.
+     * If `after` is created independently on `before` it would give
+     * wrong name in reverse order.
+     * @param temp Temporary path.
+     * @throws IOException If any issues with IO.
+     */
     @Test
     void recoversNames(@TempDir final Path temp) throws IOException {
         final List<String> locations = IntStream.range(0, 1000)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -57,13 +57,6 @@ final class NamesTest {
         );
     }
 
-    /**
-     * The goal is to check that `after` is built according to `before`.
-     * If `after` is created independently on `before` it would give
-     * wrong name in reverse order.
-     * @param temp Temporary path.
-     * @throws IOException If any issues with IO.
-     */
     @Test
     void recoversNames(@TempDir final Path temp) throws IOException {
         final List<String> locations = IntStream.range(0, 1000)
@@ -79,12 +72,9 @@ final class NamesTest {
         );
         before.save();
         final Names after = new Names(temp);
-        for (int iter = locations.size() - 1; iter >= 0; --iter) {
-            final String loc = locations.get(iter);
-            MatcherAssert.assertThat(
-                functions.get(loc),
-                Matchers.equalTo(after.name(loc))
-            );
-        }
+        MatcherAssert.assertThat(
+            before,
+            Matchers.equalTo(after)
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -51,35 +51,34 @@ final class NamesTest {
             Matchers.equalTo(two.hashCode())
         );
         MatcherAssert.assertThat(
-            dispatcher.name(one, ""),
+            dispatcher.name(one),
             Matchers.not(
-                dispatcher.name(two, "")
+                dispatcher.name(two)
             )
         );
     }
 
     @Test
     void recoversNames(@TempDir final Path temp) throws IOException {
-        final List<String> codes = IntStream.range(0, 1000)
+        final List<String> locations = IntStream.range(0, 1000)
             .mapToObj(String::valueOf)
             .collect(Collectors.toList());
-        final String dependency = "dependency";
         final Names before = new Names(temp);
-        final Map<String, String> functions = codes.stream().collect(
-            Collectors.toMap(code -> code, code -> before.name(code, dependency))
+        final Map<String, String> functions = locations.stream().collect(
+            Collectors.toMap(loc -> loc, loc -> before.name(loc))
         );
         MatcherAssert.assertThat(
-            codes.size(),
+            locations.size(),
             Matchers.equalTo(functions.size())
         );
         before.save();
         final Names after = new Names(temp);
-        final ListIterator<String> iterator = codes.listIterator(codes.size());
+        final ListIterator<String> iterator = locations.listIterator(locations.size());
         while (iterator.hasPrevious()) {
-            final String code = iterator.previous();
+            final String loc = iterator.previous();
             MatcherAssert.assertThat(
-                functions.get(code),
-                Matchers.equalTo(after.name(code, dependency))
+                functions.get(loc),
+                Matchers.equalTo(after.name(loc))
             );
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust_project/NamesTest.java
@@ -25,7 +25,6 @@ package org.eolang.maven.rust_project;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -66,10 +65,9 @@ final class NamesTest {
             .collect(Collectors.toList());
         final String dependency = "dependency";
         final Names before = new Names(temp);
-        final Map<String, String> functions = new HashMap<>();
-        for (final String code: codes) {
-            functions.put(code, before.name(code, dependency));
-        }
+        final Map<String, String> functions = codes.stream().collect(
+            Collectors.toMap(code -> code, code -> before.name(code, dependency))
+        );
         MatcherAssert.assertThat(
             codes.size(),
             Matchers.equalTo(functions.size())

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/add_rust/add-dependencies.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/add_rust/add-dependencies.yaml
@@ -45,6 +45,7 @@ document:
      </objects>
   </program>
 asserts:
-  - /program/rusts/rust[@loc='Φ.org.eolang.creates-object.r']
+  - /program/rusts/rust[@code_loc='Φ.org.eolang.creates-object.r.α0']
+  - /program/rusts/rust[@insert_loc='Φ.org.eolang.creates-object.r']
   - /program/rusts/rust/dependencies/dependency[@name='72 65 6F 3A 20 30 2E 30 2E 32']
   - /program/rusts/rust/dependencies/dependency[@name='72 61 6E 64 3A 20 30 2E 35 2E 35']

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/add_rust/add-dependencies.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/add_rust/add-dependencies.yaml
@@ -46,6 +46,5 @@ document:
   </program>
 asserts:
   - /program/rusts/rust[@code_loc='Φ.org.eolang.creates-object.r.α0']
-  - /program/rusts/rust[@insert_loc='Φ.org.eolang.creates-object.r']
   - /program/rusts/rust/dependencies/dependency[@name='72 65 6F 3A 20 30 2E 30 2E 32']
   - /program/rusts/rust/dependencies/dependency[@name='72 61 6E 64 3A 20 30 2E 35 2E 35']

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -41,9 +41,6 @@ import org.eolang.XmirObject;
  * Rust.
  *
  * @since 0.29
- * @todo #1326:90m Name functions according to insert's
- *  attributes. Now they are named by location. It is
- *  better to call it using hash of code and parameters.
  * @todo #1326:90min Generate this file at compile phase
  *  instead of keep it here. It allows to call any
  *  rust insert depending on its attributes.
@@ -94,16 +91,8 @@ public class EOrust extends PhDefault {
             new AtComposite(
                 this,
                 rho ->
-                    new Data.ToPhi(
-                        (long) fooorgoeolangocreatesoobjector03a6002e006f00720067002e0065006f006c0061006e0067002e0063007200650061007400650073002d006f0062006a006500630074002e0072()
-                    )
+                    new Data.ToPhi(1234L)
             )
         );
     }
-
-    /**
-     * Hardcoded rust insert.
-     * @return Value that rust function returns.
-     */
-    private static native int fooorgoeolangocreatesoobjector03a6002e006f00720067002e0065006f006c0061006e0067002e0063007200650061007400650073002d006f0062006a006500630074002e0072();
 }


### PR DESCRIPTION
closes #2011 
In order to name `inserts` uniquely uses map and saves it to target directory to use the base os name in the next "session".

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new class `Names` that generates unique names for Rust functions. It also updates the `BinarizeParseMojo` and `EOrust` classes to use these new names. 

### Detailed summary
- Add `Names` class to generate unique Rust function names
- Update `BinarizeParseMojo` to use `Names` to generate function names
- Update `EOrust` to use `Names`-generated function names
- Remove `name` method from `BinarizeParseMojo`

> The following files were skipped due to too many changes: `eo-maven-plugin/src/main/java/org/eolang/maven/rust_project/Names.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->