### PR TITLE
feat(#1990): Rename XMIR_2 to OPTIMIZED

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -103,8 +103,8 @@ public final class BinarizeParseMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Project project = new Project(this.targetDir.toPath().resolve("Lib"));
-        for (final ForeignTojo tojo : this.scopedTojos().withSecondXmir()) {
-            final Path file = tojo.xmirSecond();
+        for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
+            final Path file = tojo.optimized();
             final XML input = new XMLDocument(file);
             final List<XML> nodes = this.addRust(input).nodes("/program/rusts/rust");
             for (final XML node: nodes) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -57,7 +57,7 @@ public final class DiscoverMojo extends SafeMojo {
         final Collection<ForeignTojo> tojos = this.scopedTojos().notDiscovered();
         final Collection<String> discovered = new HashSet<>(1);
         for (final ForeignTojo tojo : tojos) {
-            final Path src = tojo.xmirSecond();
+            final Path src = tojo.optimized();
             final Collection<String> names = this.discover(src);
             for (final String name : names) {
                 this.scopedTojos().add(name).withDiscoveredAt(src);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -167,7 +167,7 @@ public final class OptimizeMojo extends SafeMojo {
             final XML optimized = this.optimization(tojo, common)
                 .apply(new XMLDocument(src));
             if (this.shouldPass(optimized)) {
-                tojo.withXmirSecond(this.make(optimized, src).toAbsolutePath());
+                tojo.withOptimized(this.make(optimized, src).toAbsolutePath());
             }
             return 1;
         };

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -132,7 +132,7 @@ public final class ProbeMojo extends SafeMojo {
         final Collection<String> probed = new HashSet<>(1);
         final Collection<ForeignTojo> tojos = this.scopedTojos().unprobed();
         for (final ForeignTojo tojo : tojos) {
-            final Path src = tojo.xmirSecond();
+            final Path src = tojo.optimized();
             final Collection<String> names = this.probes(src);
             if (!names.isEmpty()) {
                 Logger.info(this, "Probing object(s): %s", names);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
@@ -350,7 +350,7 @@ public final class SodgMojo extends SafeMojo {
                 "Setting generateDotFiles and not setting generateGraphFiles has no effect because .dot files require .graph files"
             );
         }
-        final Collection<ForeignTojo> tojos = this.scopedTojos().withSecondXmir();
+        final Collection<ForeignTojo> tojos = this.scopedTojos().withOptimized();
         final Path home = this.targetDir.toPath().resolve(SodgMojo.DIR);
         int total = 0;
         int instructions = 0;
@@ -366,7 +366,7 @@ public final class SodgMojo extends SafeMojo {
                 continue;
             }
             final Path sodg = new Place(name).make(home, "sodg");
-            final Path xmir = tojo.xmirSecond();
+            final Path xmir = tojo.optimized();
             if (sodg.toFile().lastModified() >= xmir.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already converted %s to %s (it's newer than the source)",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -129,10 +129,10 @@ public final class TranspileMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        final Collection<ForeignTojo> sources = this.scopedTojos().withSecondXmir();
+        final Collection<ForeignTojo> sources = this.scopedTojos().withOptimized();
         int saved = 0;
         for (final ForeignTojo tojo : sources) {
-            final Path file = tojo.xmirSecond();
+            final Path file = tojo.optimized();
             final XML input = new XMLDocument(file);
             final String name = input.xpath("/program/@name").get(0);
             final Place place = new Place(name);
@@ -222,7 +222,7 @@ public final class TranspileMojo extends SafeMojo {
     private long removeTranspiled(final Path src) {
         return this.scopedTojos()
             .withSource(src).stream()
-            .map(ForeignTojo::xmirSecond)
+            .map(ForeignTojo::optimized)
             .mapToLong(this.transpiledTojos::remove)
             .sum();
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -69,11 +69,11 @@ public final class ForeignTojo {
     }
 
     /**
-     * The tojo xmir2.
-     * @return The xmir2.
+     * The tojo optimized xmir.
+     * @return The optimized xmir.
      */
-    public Path xmirSecond() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.XMIR_2.key()));
+    public Path optimized() {
+        return Paths.get(this.delegate.get(ForeignTojos.Attribute.OPTIMIZED.key()));
     }
 
     /**
@@ -120,8 +120,8 @@ public final class ForeignTojo {
     public boolean notOptimized() {
         final Path src = this.xmir();
         boolean res = true;
-        if (this.delegate.exists(ForeignTojos.Attribute.XMIR_2.key())) {
-            final Path tgt = this.xmirSecond();
+        if (this.delegate.exists(ForeignTojos.Attribute.OPTIMIZED.key())) {
+            final Path tgt = this.optimized();
             if (tgt.toFile().lastModified() >= src.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already optimized %s to %s",
@@ -205,12 +205,12 @@ public final class ForeignTojo {
     }
 
     /**
-     * Set the xmir2.
-     * @param xmir The xmir2.
+     * Set the optimized xmir.
+     * @param xmir The optimized xmir.
      * @return The tojo itself.
      */
-    public ForeignTojo withXmirSecond(final Path xmir) {
-        this.delegate.set(ForeignTojos.Attribute.XMIR_2.key(), xmir.toString());
+    public ForeignTojo withOptimized(final Path xmir) {
+        this.delegate.set(ForeignTojos.Attribute.OPTIMIZED.key(), xmir.toString());
         return this;
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -96,7 +96,7 @@ public final class ForeignTojos implements Closeable {
      */
     public Collection<ForeignTojo> notDiscovered() {
         return this.select(
-            row -> row.exists(Attribute.XMIR_2.key()) && !row.exists(Attribute.DISCOVERED.key())
+            row -> row.exists(Attribute.OPTIMIZED.key()) && !row.exists(Attribute.DISCOVERED.key())
         );
     }
 
@@ -127,7 +127,7 @@ public final class ForeignTojos implements Closeable {
      */
     public Collection<ForeignTojo> withSource(final Path source) {
         return this.select(
-            row -> row.exists(Attribute.XMIR_2.key())
+            row -> row.exists(Attribute.OPTIMIZED.key())
                 && row.get(Attribute.EO.key()).equals(source.toString())
         );
     }
@@ -152,11 +152,11 @@ public final class ForeignTojos implements Closeable {
     }
 
     /**
-     * Get the tojos that have corresponding xmir_2.
+     * Get the tojos that have corresponding optimized xmir.
      * @return The tojos.
      */
-    public Collection<ForeignTojo> withSecondXmir() {
-        return this.select(row -> row.exists(Attribute.XMIR_2.key()));
+    public Collection<ForeignTojo> withOptimized() {
+        return this.select(row -> row.exists(Attribute.OPTIMIZED.key()));
     }
 
     /**
@@ -165,7 +165,7 @@ public final class ForeignTojos implements Closeable {
      */
     public Collection<ForeignTojo> unprobed() {
         return this.select(
-            row -> row.exists(Attribute.XMIR_2.key())
+            row -> row.exists(Attribute.OPTIMIZED.key())
                 && !row.exists(Attribute.PROBED.key())
         );
     }
@@ -203,7 +203,7 @@ public final class ForeignTojos implements Closeable {
         final Attribute[] attrs = {
             Attribute.EO,
             Attribute.XMIR,
-            Attribute.XMIR_2,
+            Attribute.OPTIMIZED,
             Attribute.DISCOVERED,
             Attribute.PROBED,
         };
@@ -259,12 +259,9 @@ public final class ForeignTojos implements Closeable {
         XMIR("xmir"),
 
         /**
-         * Tojo xmir2 file.
-         * @todo #1969:30min Add more meaningful name for the xmir2 attribute.
-         *  I believe that instead of xmir2 we have to invent something more meaningful and
-         *  change all related methods and parameters that use xmir2 abbreviation.
+         * Path to the optimized xmir file.
          */
-        XMIR_2("xmir2"),
+        OPTIMIZED("optimized"),
 
         /**
          * Absolute location of SODG file.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
@@ -77,19 +77,19 @@ public final class TranspiledTojos implements Closeable {
     /**
      * Add transpiled file to the list.
      * @param transpiled Transpiled file.
-     * @param second Xmir2 file.
+     * @param optimized Optimized xmir file.
      */
-    public void add(final Path transpiled, final Path second) {
-        this.all.value().add(String.valueOf(transpiled)).set(Attribute.XMIR2.key(), second);
+    public void add(final Path transpiled, final Path optimized) {
+        this.all.value().add(String.valueOf(transpiled)).set(Attribute.OPTIMIZED.key(), optimized);
     }
 
     /**
      * Remove all transpiled files by xmir.
-     * @param second Xmir2 file.
+     * @param optimized Optimized xmir file.
      * @return Number of removed files.
      */
-    public long remove(final Path second) {
-        return this.findByXmir(second)
+    public long remove(final Path optimized) {
+        return this.findByOptimized(optimized)
             .stream()
             .map(row -> row.get(Attribute.ID.key()))
             .map(File::new)
@@ -98,13 +98,13 @@ public final class TranspiledTojos implements Closeable {
     }
 
     /**
-     * Find all tojos by xmir.
-     * @param second Xmir2 file.
+     * Find all tojos by optimized xmir.
+     * @param optimized Optimized xmir file.
      * @return List of tojos.
      */
-    private List<Tojo> findByXmir(final Path second) {
+    private List<Tojo> findByOptimized(final Path optimized) {
         return this.all.value().select(
-            row -> row.get(Attribute.XMIR2.key()).equals(second.toString())
+            row -> row.get(Attribute.OPTIMIZED.key()).equals(optimized.toString())
         );
     }
 
@@ -121,9 +121,9 @@ public final class TranspiledTojos implements Closeable {
         ID("id"),
 
         /**
-         * Xmir2.
+         * Optimized xmir.
          */
-        XMIR2("xmir2");
+        OPTIMIZED("optimized");
 
         /**
          * Attribute key in tojos file.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/TranspiledTojos.java
@@ -87,7 +87,8 @@ public final class TranspiledTojos implements Closeable {
      */
     public void add(final Path transpiled, final Path optimized) {
         synchronized (this.lock) {
-            this.all.value().add(String.valueOf(transpiled)).set(Attribute.OPTIMIZED.key(),
+            this.all.value().add(String.valueOf(transpiled)).set(
+                Attribute.OPTIMIZED.key(),
                 optimized
             );
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/TranspiledTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/TranspiledTojosTest.java
@@ -92,7 +92,7 @@ final class TranspiledTojosTest {
 
     @Test
     void adds() {
-        this.tojos.add(this.transpiled.get(0), Paths.get("first.xmir2"));
+        this.tojos.add(this.transpiled.get(0), Paths.get("first.optimized.xmir"));
         MatcherAssert.assertThat(
             this.original.select(all -> true),
             Matchers.hasSize(1)
@@ -101,9 +101,9 @@ final class TranspiledTojosTest {
 
     @Test
     void removesExistingTranspiledFiles() {
-        final Path first = Paths.get("1.xmir2");
-        final Path second = Paths.get("2.xmir2");
-        this.tojos.add(this.transpiled.get(0), Paths.get("0.xmir2"));
+        final Path first = Paths.get("1.optimized.xmir");
+        final Path second = Paths.get("2.optimized.xmir");
+        this.tojos.add(this.transpiled.get(0), Paths.get("0.optimized.xmir"));
         this.tojos.add(this.transpiled.get(1), first);
         this.tojos.add(this.transpiled.get(2), second);
         MatcherAssert.assertThat(


### PR DESCRIPTION
Rename `XMIR_2` to `OPTIMIZED`.

Closes: #1990

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the naming of a file in the eo-maven-plugin and updates the corresponding references to it. 

### Detailed summary
- Renames `xmir2` to `optimized` in `ForeignTojo` and related classes
- Updates all references to `xmir2` to `optimized` in `OptimizeMojo`, `ProbeMojo`, `DiscoverMojo`, `BinarizeParseMojo`, `SodgMojo`, `TranspileMojo`, `TranspiledTojos`, and `ForeignTojos`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->