### PR TITLE
#2018: Enable test depending on cargo installed.

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -50,13 +50,9 @@ final class BinarizeMojoTest {
      * BinarizeMojo can binarize without errors.
      * @param temp Temporary directory.
      * @throws Exception If fails.
-     * @todo #1989:30min Enable BinarizeMojoTest.binarizesWithoutErrors() test. The test is disabled
-     *  because it fails on systems that don't hava install rust. We have to invent a way to check
-     *  installed rust on the system before running that test. The logic is similar to
-     *  {@link org.eolang.maven.OnlineCondition}.
      */
     @Test
-    @Disabled
+    @ExtendWith(CargoCondition.class)
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CargoCondition.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CargoCondition.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.eolang.maven;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit's extension to skip a test if there is no cargo.
+ *
+ * @since 0.30
+ */
+public final class CargoCondition implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(
+        final ExtensionContext context) {
+        final ConditionEvaluationResult ret;
+        final boolean exists = Stream.of(
+            System.getenv("PATH").split(Pattern.quote(File.pathSeparator))
+            )
+            .map(Paths::get)
+            .anyMatch(path -> Files.exists(path.resolve("cargo")));
+        if (exists) {
+            ret = ConditionEvaluationResult.enabled("Cargo is installed");
+        } else {
+            ret = ConditionEvaluationResult.disabled("There is not cargo here");
+        }
+        return ret;
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CargoCondition.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CargoCondition.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * JUnit's extension to skip a test if there is no cargo.
+ * Cargo is a build system for rust so it is required for rust inserts.
  *
  * @since 0.30
  */


### PR DESCRIPTION
Closes #2018 
Implemented `cargo` installed condition.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a JUnit extension to skip tests if cargo is not installed. It also enables a previously disabled test case.

### Detailed summary
- Added `CargoCondition` JUnit extension
- Enabled previously disabled `binarizesWithoutErrors` test case

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->