### PR TITLE
feat(#2015): Fix concurrency problem with `LogFormatTest`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ target/
 .recommenders
 .mvn/wrapper/maven-wrapper.jar
 .factorypath
-eo-maven-plugin/tests-repetition.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .recommenders
 .mvn/wrapper/maven-wrapper.jar
 .factorypath
+eo-maven-plugin/tests-repetition.sh

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -26,12 +26,12 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 import org.apache.log4j.Appender;
 import org.apache.log4j.WriterAppender;
 import org.apache.log4j.spi.LoggingEvent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,20 +46,18 @@ class LogFormatTest {
      */
     private MockAppender mock;
 
-    @BeforeEach
-    public void overrideLogAppender() {
+    @Test
+    void printsFormattedMessage() {
         final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getRootLogger();
         final Appender appender = logger.getAppender("CONSOLE");
         this.mock = new MockAppender(appender);
         logger.addAppender(this.mock);
-    }
-
-    @Test
-    void printsFormattedMessage() {
         Logger.info(this, "Wake up, Neo...");
+        final String expected = "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...\\R";
         MatcherAssert.assertThat(
+            String.format("Expected message '%s', but log was:\n '%s'", expected, this.mock.raw()),
             this.mock.containsMessage(
-                "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...\\R"
+                expected
             ),
             Matchers.is(true)
         );
@@ -106,6 +104,15 @@ class LogFormatTest {
             return this.events.stream().anyMatch(
                 event -> this.console.getLayout().format(event).matches(regex)
             );
+        }
+
+        /**
+         * Get all log messages as a single string.
+         * @return All log messages as a single string.
+         */
+        private String raw() {
+            return this.events.stream().map(LoggingEvent::getRenderedMessage)
+                .collect(Collectors.joining("\n"));
         }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -25,7 +25,7 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.log4j.Appender;
 import org.apache.log4j.WriterAppender;
 import org.apache.log4j.spi.LoggingEvent;
@@ -88,7 +88,7 @@ class LogFormatTest {
          */
         private MockAppender(final Appender console) {
             this.console = console;
-            this.events = new ConcurrentLinkedDeque<>();
+            this.events = new ConcurrentLinkedQueue<>();
         }
 
         @Override

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -55,7 +55,7 @@ class LogFormatTest {
             "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...\\R";
         MatcherAssert.assertThat(
             String.format("Expected message '%s', but log was:\n '%s'", expected, mock.raw()),
-            mock.containsMessage(expected),
+            mock.contains(expected),
             Matchers.is(true)
         );
     }
@@ -97,10 +97,10 @@ class LogFormatTest {
          * @param regex The regex to match.
          * @return True if any log message matches the regex.
          */
-        private boolean containsMessage(final String regex) {
+        private boolean contains(final String regex) {
             try {
                 while (true) {
-                    if (this.lastMessage().matches(regex)) {
+                    if (this.last().matches(regex)) {
                         return true;
                     }
                 }
@@ -115,7 +115,7 @@ class LogFormatTest {
          * @return The last log message.
          * @throws InterruptedException If interrupted.
          */
-        private String lastMessage() throws InterruptedException {
+        private String last() throws InterruptedException {
             return this.console.getLayout().format(this.events.poll(5, TimeUnit.SECONDS));
         }
 


### PR DESCRIPTION
Fix concurrency problem with `LogFormatTest` and remove the corresponding puzzle.

Closes: #2015

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new dependency and updates the test class `LogFormatTest` to use a `BlockingQueue` instead of an `AtomicReference` to store log events. It also replaces a disabled test with a timeout annotation.

### Detailed summary
- Added a new dependency
- Replaced `AtomicReference` with `BlockingQueue` in `MockAppender`
- Replaced a disabled test with a timeout annotation in `LogFormatTest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->