### PR TITLE
suggestion  to avoid `ram.ram-slice.slice` object

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ram.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ram.eo
@@ -27,10 +27,6 @@
 +version 0.0.0
 
 # Random-access memory (RAM).
-# @todo #684:30min We need to add ram.ram-slice.slice object
-#  here. This object would return ram-slice object and get
-#  two parameters: position and size, same as in ram.slice
-#  object. And will allow us to make a chain of slice objects.
 [size] > ram
   # Write bytes from position.
   [position data] > write /true

--- a/eo-runtime/src/test/eo/org/eolang/ram-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/ram-tests.eo
@@ -76,3 +76,17 @@
       as-string.
         (r.slice 0 10).slice 0 10
     $.equal-to "12345-----"
+
+[] > slice-chain
+  ram 1024 > r
+  [] > cut-hello
+    seq > @
+      write.
+        r.slice 200 13 > s
+        "Hello, world!".as-bytes
+      s.slice 0 5
+      .slice 0 4
+      .slice 0 1
+  assert-that > @
+    cut-hello
+    $.equal-to "H"


### PR DESCRIPTION
#945

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new test cases and functionality to the `eo-runtime/src/test/eo/org/eolang/ram-tests.eo` file and removes a to-do item from the `eo-runtime/src/main/eo/org/eolang/ram.eo` file.

### Detailed summary
- Added test cases for new functionality:
  - `slice-chain`
  - `ram 1024`
  - `cut-hello`
  - `s.slice 0 5`
  - `.slice 0 4`
  - `.slice 0 1`
  - `assert-that`
- Removed to-do item for `ram.ram-slice.slice` object from `eo-runtime/src/main/eo/org/eolang/ram.eo` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->