### PR TITLE
feat(#2017): Enable `BinarizeMojoTest` run in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ target/
 .recommenders
 .mvn/wrapper/maven-wrapper.jar
 .factorypath
-eo-maven-plugin/tests-repetition.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .recommenders
 .mvn/wrapper/maven-wrapper.jar
 .factorypath
+eo-maven-plugin/tests-repetition.sh

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -37,13 +37,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  * Test case for {@link BinarizeMojo}.
  *
  * @since 0.1
- * @todo #1996:30min Make BinarizeMojoTest run tests in parallel.
- *  Currently all tests in this class are executed in the same thread. This is done by the
- *  annotation @Execution(ExecutionMode.SAME_THREAD) on the class. This is a temporary solution
- *  because the class has some concurrency problems. We need to make the tests in this class run
- *  in parallel and then remove the annotation.
  */
-@Execution(ExecutionMode.SAME_THREAD)
 final class BinarizeMojoTest {
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link BinarizeMojo}.


### PR DESCRIPTION
I've tried to run `BinarizeMojoTest` in parallel many times (I even wrote the script to check) and I haven't found any problems. Thus, I just close the puzzle.

Close: #2017

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new line to .gitignore and removes some annotations from BinarizeMojoTest.java.

### Detailed summary
- Added a new line to .gitignore file.
- Removed @Execution and @ExecutionMode annotations from BinarizeMojoTest.java.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->