### PR TITLE
OyFake moved

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.set.SetOf;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Online;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.set.SetOf;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -33,6 +33,7 @@ import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChRemote;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import org.cactoos.io.ResourceOf;
 import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.objectionary.Objectionary;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SkipTest.java
@@ -27,6 +27,7 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Online;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -50,6 +50,7 @@ import org.cactoos.text.IsEmpty;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.maven.objectionary.Objectionary;
+import org.eolang.maven.objectionary.OyFake;
 import org.eolang.maven.util.Walk;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyCachingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyCachingTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.io.InputOf;
 import org.cactoos.text.TextOf;
-import org.eolang.maven.OyFake;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFake.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFake.java
@@ -21,13 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.maven;
+package org.eolang.maven.objectionary;
 
 import com.jcabi.log.Logger;
 import org.cactoos.Func;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
-import org.eolang.maven.objectionary.Objectionary;
 
 /**
  * Objectionary with lambda-function Ctor-s for testing.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFallbackSwapTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyFallbackSwapTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.io.InputOf;
 import org.cactoos.text.TextOf;
-import org.eolang.maven.OyFake;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyIndexedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OyIndexedTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Collections;
 import org.cactoos.text.TextOf;
 import org.eolang.maven.OnlineCondition;
-import org.eolang.maven.OyFake;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `OyFake` class to the `org.eolang.maven.objectionary` package, and replaces all imports of the previous `OyFake` class with this new one. 

### Detailed summary
- Introduced `OyFake` to `org.eolang.maven.objectionary` package
- Replaced all imports of previous `OyFake` class with new one in all relevant files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->