### PR TITLE
replaced underscore in EO file name with doubled underscore in Java file name

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -57,7 +57,7 @@ SOFTWARE.
   </xsl:function>
   <xsl:function name="eo:clean" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
-    <xsl:value-of select="concat('EO', replace(replace(replace(replace($n, '-', '_'), '@', 'φ'), 'α', '_'), '\$', '\$EO'))"/>
+    <xsl:value-of select="concat('EO', replace(replace(replace(replace(replace($n, '_', '__'), '-', '_'), '@', 'φ'), 'α', '_'), '\$', '\$EO'))"/>
   </xsl:function>
   <xsl:function name="eo:suffix" as="xs:string">
     <xsl:param name="s1"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -28,6 +28,7 @@ SOFTWARE.
     underscore with doubled underscore. We need to find more elegant
     solution. For example, we can use camel case for names with underscore.
     For example, we can convert `foo_bar` to `fooBar`. Or something else.
+    The solution should be backward compatible.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="to-java" version="2.0">
   <xsl:import href="/org/eolang/parser/_datas.xsl"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -28,7 +28,6 @@ SOFTWARE.
     underscore with doubled underscore. We need to find more elegant
     solution. For example, we can use camel case for names with underscore.
     For example, we can convert `foo_bar` to `fooBar`. Or something else.
-    The solution should be backward compatible.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="to-java" version="2.0">
   <xsl:import href="/org/eolang/parser/_datas.xsl"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -22,6 +22,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
+<!--
+  @todo #1890:30m Change the behaviour of conversions for names
+    with underscore. Currently, the conversion is done by replacing
+    underscore with doubled underscore. We need to find more elegant
+    solution. For example, we can use camel case for names with underscore.
+    For example, we can convert `foo_bar` to `fooBar`. Or something else.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="to-java" version="2.0">
   <xsl:import href="/org/eolang/parser/_datas.xsl"/>
   <xsl:param name="disclaimer"/>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/underscore-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/underscore-to-java.yaml
@@ -1,0 +1,12 @@
+xsls:
+  - /org/eolang/parser/add-default-package.xsl
+  - /org/eolang/maven/pre/classes.xsl
+  - /org/eolang/maven/pre/attrs.xsl
+  - /org/eolang/maven/pre/data.xsl
+  - /org/eolang/maven/pre/to-java.xsl
+tests:
+  - /program/errors[count(*)=0]
+  - //java[contains(text(), 'public final class EOfoo__underscore extends PhDefault')]
+eo: |
+  [] > foo_underscore
+    * 1 2 (* 3 4) > @


### PR DESCRIPTION
Closes: #1890

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new XSL files and modifies existing ones to improve the conversion of names with underscores in the EO language to Java. It also includes a to-do note to find a more elegant solution for this conversion.

### Detailed summary
- Added `/org/eolang/parser/add-default-package.xsl`
- Added `/org/eolang/maven/pre/classes.xsl`
- Added `/org/eolang/maven/pre/attrs.xsl`
- Added `/org/eolang/maven/pre/data.xsl`
- Added `/org/eolang/maven/pre/to-java.xsl`
- Added `/program/errors[count(*)=0]` to tests
- Added `//java[contains(text(), 'public final class EOfoo__underscore extends PhDefault')]` to tests
- Modified `/org/eolang/maven/pre/to-java.xsl` to improve conversion of names with underscores to Java
- Added to-do note to find a more elegant solution for this conversion

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->