### PR TITLE
feat(#2080): Remove classes produced by dirty libraries

### DIFF
--- a/eo-maven-plugin/src/it/duplicate_classes/verify.groovy
+++ b/eo-maven-plugin/src/it/duplicate_classes/verify.groovy
@@ -36,15 +36,5 @@ def disjoint = Files.walk(testClasses).filter(Files::isRegularFile)
   return testClasses.relativize(it).toString()
 }.noneMatch { binaries.contains(it) }
 println "Compiled classes do not have duplicates: " + disjoint
-/**
- * @todo #2072:90min. Fix the bug with class intersection in the 'classes' and
- *  'test-classes' folders. Both folders should contain different unique
- *  classes. In other words, we should avoid duplicating class compilation for
- *  tests. The problem with duplicated sources in tests was fixed:
- *  <a href="https://github.com/objectionary/eo/pull/2076">here<a/>
- *  But we still have problems with duplicated classes downloaded from
- *  dependencies. Apparently, we might check ResolveMojo to find the problem
- *  cause. Once the bug is fixed, uncomment the following statement.
- */
-// assert disjoint
+assert disjoint
 return true

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -32,8 +32,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
+import org.eolang.maven.util.Home;
 import org.eolang.xax.XaxStory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -193,6 +195,24 @@ final class TranspileMojoTest {
             "Both class paths should not intersect and don't have to have common classes",
             intersection,
             Matchers.empty()
+        );
+    }
+
+    @Test
+    void transpilesAndCleansGarbageFromDirtyDependency(@TempDir final Path temp)
+        throws IOException {
+        final Path target = temp.resolve("target");
+        final Path sources = target.resolve("generated-sources");
+        final FakeMaven maven = new FakeMaven(temp);
+        final Path binary = Paths.get("classes", "EOf", "EOmain.class");
+        new Home(maven.targetPath()).save(new Randomized(), binary);
+        maven.with("generatedDir", sources.toFile())
+            .with("targetDir", target.resolve("eo").toFile())
+            .withHelloWorld()
+            .execute(new FakeMaven.Transpile());
+        MatcherAssert.assertThat(
+            maven.targetPath().resolve(binary).toFile(),
+            Matchers.not(FileMatchers.anExistingFile())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.1
  * @checkstyle LocalFinalVariableNameCheck (100 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class UnplaceMojoTest {
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceMojoTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -184,6 +186,55 @@ final class UnplaceMojoTest {
                 Matchers.containsString("false"),
                 Matchers.not(Matchers.containsString("true"))
             )
+        );
+    }
+
+    @Test
+    void unplacesWithRemoveBinaries(@TempDir final Path temp) throws Exception {
+        final Path target = Paths.get("target");
+        final Path source = target
+            .resolve("classes")
+            .resolve("EOorg")
+            .resolve("EOeolang")
+            .resolve("EOtxt")
+            .resolve("EOregexp.class");
+        final Path test = target
+            .resolve("test-classes")
+            .resolve("EOorg")
+            .resolve("EOeolang")
+            .resolve("EOtxt")
+            .resolve("EOregexp.class");
+        final Path remaining = target
+            .resolve("test-classes")
+            .resolve("EOorg")
+            .resolve("EOeolang")
+            .resolve("EOharmcrest")
+            .resolve("EOassert.class");
+        final Home workspace = new Home(temp);
+        workspace.save(UUID.randomUUID().toString(), source);
+        workspace.save(UUID.randomUUID().toString(), test);
+        workspace.save(UUID.randomUUID().toString(), remaining);
+        UnplaceMojoTest.placeClass(temp, temp.resolve(source));
+        final Path placed = UnplaceMojoTest.placeClass(temp, temp.resolve(test));
+        new FakeMaven(temp)
+            .with("placed", placed.toFile())
+            .with("removeBinaries", Collections.singleton("EOorg/EOeolang/EOtxt/**"))
+            .execute(UnplaceMojo.class)
+            .result();
+        MatcherAssert.assertThat(
+            String.format("Source class %s has not to be present", source),
+            temp.resolve(source).toFile(),
+            Matchers.not(FileMatchers.anExistingFile())
+        );
+        MatcherAssert.assertThat(
+            String.format("Test class %s has not to be present", test),
+            temp.resolve(test).toFile(),
+            Matchers.not(FileMatchers.anExistingFile())
+        );
+        MatcherAssert.assertThat(
+            String.format("Test class %s has to be present", remaining),
+            temp.resolve(remaining).toFile(),
+            FileMatchers.anExistingFile()
         );
     }
 


### PR DESCRIPTION
The PR is trying to fix problem produced by dirty libraries like [eo-strings](https://github.com/objectionary/eo-strings/issues/147) example. Some libraries by mistake can put ALL their compiled classes right into the final library jar, instead of only adding atoms. This can cause different runtime errors since the classpath will contain two classes with the same name:
- The first class file will be added from dirty library
- The second class with the same name will be compiled from the transpiled java file
     
 In order to prevent this, we remove all classes that have the java analog in the generated sources. In other words, if `generated-sources` (or `generated-test-sources`) folder has java classes, we expect that they will be only compiled from that folder.

Closes: #2080 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a bug with class intersection in the 'classes' and 'test-classes' folders. It also includes a new method to clean up dirty classes.

### Detailed summary
- Fixed the bug with class intersection in the 'classes' and 'test-classes' folders.
- Added a new method to clean up dirty classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->