### PR TITLE
checked as-bytes conversion to EO

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
@@ -1,0 +1,4 @@
+[] > app
+  QQ.io.stdout > @
+    QQ.txt.sprintf "result is %d\n"
+      -1.times 228

--- a/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
@@ -1,4 +1,4 @@
 [] > app
   QQ.io.stdout > @
-    QQ.txt.sprintf "result is %d\n"
+    QQ.txt.sprintf "result is  %d\n"
       -1.times 228

--- a/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/xmir-samples/times.eo
@@ -1,4 +1,4 @@
 [] > app
   QQ.io.stdout > @
-    QQ.txt.sprintf "result is  %d\n"
+    QQ.txt.sprintf "result is %d\n"
       -1.times 228


### PR DESCRIPTION
Closes: #1243

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a test case for the `times` method in the `eo-parser` module.

### Detailed summary
- Added a new test file `times.eo` in the `eo-parser/src/test/resources/org/eolang/parser/xmir-samples` directory.
- Defined an `app` object that uses the `times` method with `-1` as the argument.
- Redirected the output of the program to `QQ.io.stdout`.
- Used `QQ.txt.sprintf` to format the output string.
- The output string includes the result of the `times` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->