### PR TITLE
feat(#2077): fix problems with LogFormatTest

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -37,12 +37,23 @@ import org.junitpioneer.jupiter.StdOut;
 /**
  * Tests of the log4j logger messages format.
  *
+ * All log messages are written to System.out. System.out is a shared resource among all other
+ * threads.  For this reason, we run tests in this class in the same thread (disabling parallelism).
+ * This approach prevents log messages from other threads from interfering. Since all the tests in
+ * this class are relatively fast, it does not significantly impact overall performance.
+ * We disable parallelism by using the {@link Execution} annotation with
+ * {@link ExecutionMode#SAME_THREAD}. DO NOT REMOVE THAT ANNOTATION!
+ *
  * @since 0.28.11
  */
 @Execution(ExecutionMode.SAME_THREAD)
 class LogFormatTest {
 
-    private static final String FORMAT = "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...";
+    /**
+     * Expected log message format.
+     */
+    private static final String FORMAT =
+        "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...";
 
     @StdIo
     @Test

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -24,108 +24,55 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import org.apache.log4j.Appender;
-import org.apache.log4j.WriterAppender;
-import org.apache.log4j.spi.LoggingEvent;
+import java.util.Arrays;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
 
 /**
  * Tests of the log4j logger messages format.
  *
  * @since 0.28.11
  */
+@Execution(ExecutionMode.SAME_THREAD)
 class LogFormatTest {
 
+    private static final String FORMAT = "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...";
+
+    @StdIo
     @Test
-    @Timeout(5)
-    void printsFormattedMessage() {
-        final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getRootLogger();
-        final Appender appender = logger.getAppender("CONSOLE");
-        final MockAppender mock = new MockAppender(appender);
-        logger.addAppender(mock);
-        Logger.info(this, "Wake up, Neo...");
-        final String expected =
-            "^\\d{2}:\\d{2}:\\d{2} \\[INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...\\R";
+    void printsFormattedMessage(final StdOut out) {
+        final String message = "Wake up, Neo...";
+        Logger.info(this, message);
+        final Optional<String> log = Arrays.stream(out.capturedLines())
+            .filter(s -> s.contains(message))
+            .findFirst();
         MatcherAssert.assertThat(
-            String.format("Expected message '%s', but log was:\n '%s'", expected, mock.raw()),
-            mock.contains(expected),
+            String.format("Log message '%s' not found", message),
+            log.isPresent(),
             Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Expected message '%s', but log was:\n '%s'",
+                log.get(),
+                LogFormatTest.FORMAT
+            ),
+            log.get(),
+            Matchers.matchesPattern(LogFormatTest.FORMAT)
         );
     }
 
-    /**
-     * Mock log4j adapter that intercepts all log messages.
-     *
-     * @since 0.28.11
-     */
-    private static final class MockAppender extends WriterAppender {
-        /**
-         * Real appender.
-         */
-        private final Appender console;
-
-        /**
-         * Last log message event.
-         */
-        private final BlockingQueue<LoggingEvent> events;
-
-        /**
-         * The main constructor.
-         *
-         * @param console Real log4j appender that we want to replace.
-         */
-        private MockAppender(final Appender console) {
-            this.console = console;
-            this.events = new LinkedBlockingQueue<>();
-        }
-
-        @Override
-        public void append(final LoggingEvent event) {
-            this.events.add(event);
-            super.append(event);
-        }
-
-        /**
-         * Check if any log message matches the regex.
-         * @param regex The regex to match.
-         * @return True if any log message matches the regex.
-         */
-        private boolean contains(final String regex) {
-            try {
-                while (true) {
-                    if (this.last().matches(regex)) {
-                        return true;
-                    }
-                }
-            } catch (final InterruptedException interrupt) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(interrupt);
-            }
-        }
-
-        /**
-         * Get the last log message.
-         * @return The last log message.
-         * @throws InterruptedException If interrupted.
-         */
-        private String last() throws InterruptedException {
-            return this.console.getLayout().format(this.events.poll(5, TimeUnit.SECONDS));
-        }
-
-        /**
-         * Get all log messages as a single string.
-         * @return All log messages as a single string.
-         */
-        private String raw() {
-            return this.events.stream().map(LoggingEvent::getRenderedMessage)
-                .collect(Collectors.joining("\n"));
-        }
+    @Test
+    void matchesCorrectly() {
+        MatcherAssert.assertThat(
+            "16:02:08 [INFO] org.eolang.maven.LogFormatTest: Wake up, Neo...",
+            Matchers.matchesPattern(LogFormatTest.FORMAT)
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
@@ -57,9 +58,10 @@ class LogFormatTest {
 
     @StdIo
     @Test
-    void printsFormattedMessage(final StdOut out) {
+    void printsFormattedMessage(final StdOut out) throws IOException {
         final String message = "Wake up, Neo...";
         Logger.info(this, message);
+        out.flush();
         final Optional<String> log = Arrays.stream(out.capturedLines())
             .filter(s -> s.contains(message))
             .findFirst();


### PR DESCRIPTION
Simplify `LogFormatTest` and make it avoid concurrency problems.

Closes: #2077

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a test for the log4j logger messages format in the `eo-maven-plugin` module.

### Detailed summary
- Adds a test for the log4j logger messages format in the `eo-maven-plugin` module.
- Disables parallelism to prevent log messages from other threads from interfering.
- Uses `@StdOut` to capture log messages written to `System.out`.
- Adds `FORMAT` constant to match expected log message format.
- Adds `matchesCorrectly` test method to test the `FORMAT` constant.
- Removes `MockAppender` class and `printsFormattedMessage` test method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->