### PR TITLE
feat(#1167): Add more tests for synthetic-attributes transformation

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -22,8 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                id="synthetic-references" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
   <!--
   Process alias attribute.
   @todo #1167:90m synthetic-attributes. Add more tests with methods.

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -22,16 +22,22 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                id="synthetic-references" version="2.0">
   <!--
   Process alias attribute.
-  @todo #1145:30m This stylesheet just removes alias attribute.
-   A proper processing would be
-   1) move object one level above
-   2) add a synthetic name to its attributes
-   3) put the alias in place of actual object.
-   Continue to work on that issue,
-   until synthetic-attributes.yaml passes.
+  @todo #1167:90m synthetic-attributes. Add more tests with methods.
+   The current number of tests is not enough to implement
+   synthetic-references.xsl transformation.
+   We also have to add tests that checks XMIR with "methods".
+   Something like "((foo 1).with 2).with 3"
+   Then we have to continue to work on that issue,
+   until the next tests pass:
+    synthetic-attributes.yaml
+    synthetic-attributes-double-scope.yaml
+    synthetic-attributes-many-arguments.yaml
+    synthetic-attributes-nested.yaml
+    synthetic-attributes-without-scope.yaml
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@alias]">

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
@@ -1,0 +1,18 @@
+xsls:
+  - /org/eolang/parser/synthetic-references.xsl
+skip: true
+tests:
+  - //o[@base='foo' and count(o)=2]
+  - //o[@base='bar' and count(o)=2]
+  - //o[@base='foobar' and count(o)=2]
+eo: |
+  [] > aliases
+    [x y] > foo
+      42 > @
+    [z k] > bar
+      43 > @
+    [i j] > foobar
+      44 > @
+    eq. > @
+      foobar (foo 1 2) (bar 3 4)
+      44

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
@@ -2,12 +2,12 @@ xsls:
   - /org/eolang/parser/synthetic-references.xsl
 skip: true
 tests:
-  - //o[@base='foo' and count(o)=1]
+  - //o[@base='foo' and count(o)=3]
 eo: |
   [] > aliases
-    [x] > foo
-      [y] > @
+    [x y z] > foo
+      [k] > @
         42 > @
     eq. > @
-      (foo 1) 2
+      (foo 1 2 3) 4
       42

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
@@ -1,0 +1,18 @@
+xsls:
+  - /org/eolang/parser/synthetic-references.xsl
+skip: true
+tests:
+  - //o[@base='foo' and count(o)=2]
+  - //o[@base='bar' and count(o)=2]
+  - //o[@base='foobar' and count(o)=2]
+eo: |
+  [] > aliases
+    [x y] > foo
+      42 > @
+    [z k] > bar
+      43 > @
+    [i j] > foobar
+      44 > @
+    eq. > @
+      foobar (foo (bar 1 2) 3) 4
+      44

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
@@ -2,12 +2,12 @@ xsls:
   - /org/eolang/parser/synthetic-references.xsl
 skip: true
 tests:
-  - //o[@base='foo' and count(o)=1]
+  - //o[@base='foo' and count(o)=2]
 eo: |
   [] > aliases
-    [x] > foo
-      [y] > @
+    [x y] > foo
+      [z] > @
         42 > @
     eq. > @
-      (foo 1) 2
+      foo 1 2
       42


### PR DESCRIPTION
I've started to implement issue #1167 (the original issue is #415) and realized that the solution requires consideration of several additional cases, which also need to be tested. Therefore, I've added these cases as tests and included a new puzzle.

Closes: #1167

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new tests and a to-do list to the `synthetic-references.xsl` stylesheet. 

### Detailed summary
- Added new tests for `synthetic-attributes.yaml`
- Added new tests for `synthetic-attributes-double-scope.yaml`
- Added new tests for `synthetic-attributes-many-arguments.yaml`
- Added new tests for `synthetic-attributes-nested.yaml`
- Added new tests for `synthetic-attributes-without-scope.yaml`
- Added a to-do list for the `synthetic-references.xsl` stylesheet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->