### PR TITLE
fix: flaky LogFormatTest

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -264,6 +264,13 @@ SOFTWARE.
             <runtime.jar>${org.eolang:eo-runtime:jar}</runtime.jar>
             <runtime.path>${project.basedir}/../eo-runtime</runtime.path>
           </systemPropertyVariables>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+              junit.jupiter.execution.parallel.mode.default = concurrent
+              junit.jupiter.execution.parallel.mode.classes.default = concurrent
+            </configurationParameters>
+          </properties>
         </configuration>
       </plugin>
       <plugin>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LogFormatTest.java
@@ -88,6 +88,12 @@ class LogFormatTest {
         );
     }
 
+    /**
+     * Since logging is usually asynchronous, we need to wait for the message to appear in the
+     * output. Moreover, logging system can take extra time to initialize.
+     * @param out Standard output
+     * @return Logged message
+     */
     private static String waitForMessage(final StdOut out) {
         try {
             return Executors.newSingleThreadExecutor().submit(


### PR DESCRIPTION
We still continue to get failed pipelines, because `LogFormatTest` fails time to time. Looks like the reason in initialisation of the SL4J. What happens exactly:
1) We start our test
2) SL4J starts initialisation
3) Our test sends message to SL4J
4) Since SL4J is still in process of initialising - it does nothing
5) Our test fails 
6) SL4J prints our message (Message [replay](https://www.slf4j.org/codes.html#replay))

Proves from logs:
```
SLF4J: Class path contains multiple SLF4J providers.
[261](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:262)
SLF4J: Found provider [org.slf4j.reload4j.Reload4jServiceProvider@2c8e37a1]
[262](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:263)
SLF4J: Found provider [MavenSlf4j()]
[263](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:264)
SLF4J: See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
[264](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:265)
Error:  Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.175 s <<< FAILURE! - in org.eolang.maven.LogFormatTest
[265](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:266)
Error:  org.eolang.maven.LogFormatTest.printsFormattedMessage(StdOut)  Time elapsed: 0.124 s  <<< FAILURE!
....
SLF4J: Actual provider is of type [org.slf4j.reload4j.Reload4jServiceProvider@2c8e37a1]
[337](https://github.com/objectionary/eo/actions/runs/5091132648/jobs/9150778675#step:5:338)
SLF4J: A number (1) of logging calls during the initialization phase have been intercepted and are
SLF4J: now being replayed. These are subject to the filtering rules of the underlying logging system.
org.eolang.maven.LogFormatTest: Wake up, Neo...
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds parallel execution to JUnit tests and improves logging in the `eo-maven-plugin`.

### Detailed summary
- Added `junit.jupiter.execution.parallel.enabled = true` and `junit.jupiter.execution.parallel.mode.default = concurrent` to enable parallel execution of JUnit tests.
- Added `junit.jupiter.execution.parallel.mode.classes.default = concurrent` to run test classes concurrently.
- Improved logging in `LogFormatTest.java` by waiting for the message to appear in the output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->