### PR TITLE
Add tests for dup attributes

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/fix-missed-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/fix-missed-names.xsl
@@ -36,7 +36,7 @@ SOFTWARE.
         <xsl:variable name="p" select="ancestor::*[o[@parent and @original-name=$o/@base]][1]"/>
         <xsl:choose>
           <xsl:when test="$p">
-            <xsl:variable name="x" select="$p/o[@original-name=$o/@base]"/>
+            <xsl:variable name="x" select="$p/o[@original-name=$o/@base][1]"/>
             <xsl:value-of select="$x/@name"/>
           </xsl:when>
           <xsl:otherwise>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/float-up-same-attrs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/float-up-same-attrs.yaml
@@ -1,0 +1,31 @@
+xsls:
+  - /org/eolang/parser/optimize/remove-refs.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+  - /org/eolang/parser/add-refs.xsl
+tests:
+  - /program[count(.//o[@base='build' and not(@ref)])=2]
+  - /program/objects[count(o[@original-name='build'])=2]
+eo: |
+  [] > hello
+    [f s] > calc
+      plus. > @
+        f.next
+        s.next
+  
+    seq > @
+      QQ.io.stdout
+        QQ.txt.sprintf
+          "Result is %d\n"
+          calc
+            []
+              [x] > build
+                x.plus 1 > @
+                build (@.plus 1) > next
+              build 1 > @
+            []
+              [y] > build
+                y.plus 2 > @
+                build (@.plus 2) > next
+              build 2 > @
+      TRUE

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
@@ -1,0 +1,31 @@
+xsls:
+  - /org/eolang/parser/optimize/remove-refs.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/optimize/fix-missed-names.xsl
+tests:
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=2]
+eo: |
+  [] > hello
+    [f s] > calc
+      plus. > @
+        f.next
+        s.next
+  
+    seq > @
+      QQ.io.stdout
+        QQ.txt.sprintf
+          "Result is %d\n"
+          calc
+            []
+              [x] > build
+                x.plus 1 > @
+                build (@.plus 1) > next
+              build 1 > @
+            []
+              [y] > build
+                y.plus 2 > @
+                build (@.plus 2) > next
+              build 2 > @
+      TRUE

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
@@ -4,14 +4,9 @@ xsls:
   - /org/eolang/parser/optimize/remove-levels.xsl
   - /org/eolang/parser/add-refs.xsl
   - /org/eolang/parser/optimize/fix-missed-names.xsl
-# @todo #1807:60min Enable fix-name tests.
-#  The logic needs to be implemented to correctly handle same-name
-#  attributes: objects should reference different corresponding bases.
-#  The below test cases should pass.
-skip: true
 tests:
-  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build'])=1]
-  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a1$build'])=1]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build'] and @name='next')=1]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a1$build'] and @name='next')=1]
 eo: |
   [] > hello
     [f s] > calc

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
@@ -5,7 +5,7 @@ xsls:
   - /org/eolang/parser/add-refs.xsl
   - /org/eolang/parser/optimize/fix-missed-names.xsl
 tests:
-  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=3]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=2]
 eo: |
   [] > hello
     [f s] > calc

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
@@ -5,7 +5,7 @@ xsls:
   - /org/eolang/parser/add-refs.xsl
   - /org/eolang/parser/optimize/fix-missed-names.xsl
 tests:
-  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=2]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=3]
 eo: |
   [] > hello
     [f s] > calc

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml
@@ -4,8 +4,14 @@ xsls:
   - /org/eolang/parser/optimize/remove-levels.xsl
   - /org/eolang/parser/add-refs.xsl
   - /org/eolang/parser/optimize/fix-missed-names.xsl
+# @todo #1807:60min Enable fix-name tests.
+#  The logic needs to be implemented to correctly handle same-name
+#  attributes: objects should reference different corresponding bases.
+#  The below test cases should pass.
+skip: true
 tests:
-  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build hello$t1$t2$t2$t1$a1$build'])=2]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a0$build'])=1]
+  - //objects[count(.//o[@base='hello$t1$t2$t2$t1$a1$build'])=1]
 eo: |
   [] > hello
     [f s] > calc

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -434,3 +434,22 @@
     Hello
     """
     $.equal-to "Hello\n\nHello"
+
+[] > correctly-handles-same-name-attrs
+  [f s] > calc
+    plus. > @
+      f.next
+      s.next
+  assert-that > @
+    calc
+      []
+        [x] > build
+          x.plus 1 > @
+          build (@.plus 1) > next
+        build 1 > @
+      []
+        [y] > build
+          y.plus 2 > @
+          build (@.plus 2) > next
+        build 2 > @
+    $.equal-to 12


### PR DESCRIPTION
Related to #1807.

Adding two XSL tests proving current (broken) logic of cooperative execution of `abstracts-float-up.xsl` and `fix-missed-names.xsl`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a fix to the `eo-parser` module to handle missed names and includes tests to ensure correct behavior. 

### Detailed summary
- Added `fix-missed-names.xsl` to `eo-parser/src/main/resources/org/eolang/parser/optimize/`
- Added tests to `eo-runtime/src/test/eo/org/eolang/runtime-tests.eo`
- Added tests to `eo-parser/src/test/resources/org/eolang/parser/packs/float-up-same-attrs.yaml`
- Added tests to `eo-parser/src/test/resources/org/eolang/parser/packs/optimize/fix-names-with-duplicates.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->