### PR TITLE
#1724 Make `eo-runtrime` independent of `eo-collections`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/bool.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bool.eo
@@ -61,10 +61,3 @@
       ^
       01-
       00-
-
-  # Converts this to hash
-  [] > as-hash
-    if. > @
-      ^
-      1231
-      1237

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.bytes-as-array
-+alias org.eolang.collections.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -78,20 +78,6 @@
   [] > as-bytes
     ^ > @
 
-  # Converts this to hash
-  [] > as-hash
-    reduced. > @
-      list
-        bytes-as-array ^
-      1
-      [a b]
-        plus. > @
-          times.
-            31
-            a
-          as-int.
-            (0.as-bytes.and b).right 54
-
   # Concatenation of two byte sequences:
   # the current and the provided one,
   # as a new sequence

--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -103,12 +103,3 @@
 
   # Converts this to bytes
   [] > as-bytes /bytes
-
-  # Converts this to hash
-  [] > as-hash
-    as-int. > @
-      xor.
-        as-bytes
-        right.
-          as-bytes
-          32

--- a/eo-runtime/src/main/eo/org/eolang/int.eo
+++ b/eo-runtime/src/main/eo/org/eolang/int.eo
@@ -101,12 +101,3 @@
 
   # Converts this to bytes
   [] > as-bytes /bytes
-
-  # Converts this to hash
-  [] > as-hash
-    as-int. > @
-      xor.
-        as-bytes
-        right.
-          as-bytes
-          32

--- a/eo-runtime/src/main/eo/org/eolang/string.eo
+++ b/eo-runtime/src/main/eo/org/eolang/string.eo
@@ -39,10 +39,5 @@
   # Turn it into bytes.
   [] > as-bytes /bytes
 
-  # Converts this to hash
-  [] > as-hash
-    as-hash. > @
-      ^.as-bytes
-
   # Takes a piece of a string as another string
   [start len] > slice /string

--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -171,17 +171,6 @@
       TRUE
     $.equal-to TRUE
 
-[] > hash-equals-the-value
-  assert-that > @
-    and.
-      eq.
-        1231
-        TRUE.as-hash
-      eq.
-        1237
-        FALSE.as-hash
-    $.equal-to TRUE
-
 [] > last-while-dataization-object
   memory 0 > x
   assert-that > @

--- a/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
@@ -374,17 +374,6 @@
       $.equal-to
         "hello world"
 
-[] > bytes-hashes-equals
-  assert-that > @
-    05-5E-78.as-hash
-    $.equal-to
-      05-5E-78.as-hash
-
-[] > bytes-as-hash-value
-  assert-that > @
-    01.as-hash
-    $.equal-to 1
-
 [] > xor-as-int
   assert-that > @
     (2397719729.as-bytes.xor (4294967295.as-bytes)).as-int
@@ -444,10 +433,3 @@
   assert-that > @
     ((-4294967296).as-bytes.or (1.as-bytes)).as-int
     $.equal-to -4294967295
-
-[] > bytes-hashes-remain-same
-  assert-that > @
-    01-02-03-04.as-hash
-    $.equal-to
-      923521
-

--- a/eo-runtime/src/test/eo/org/eolang/float-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/float-tests.eo
@@ -496,11 +496,5 @@
     3.1415926.as-bytes
     $.equal-to 3.1415926
 
-[] > similar-values-have-similar-hash
-  assert-that > @
-    (3.1415926).as-hash
-    $.equal-to
-      (3.1415926).as-hash
-
 [] > inline-float-computation
   ((4.0).plus (5.7)).eq (9.7) > @

--- a/eo-runtime/src/test/eo/org/eolang/int-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/int-tests.eo
@@ -285,30 +285,6 @@
     42.as-bytes
     $.equal-to 42
 
-[] > as-hash-equals-to-similar-values
-  assert-that > @
-    42.as-hash
-    $.equal-to
-      42.as-hash
-
-# We can have collisions, so in this test just check if values not similar
-[] > as-hash-have-different-hashes
-  seq > @
-    stdout
-      sprintf
-        "%d %d %d\n"
-        41.as-hash
-        42.as-hash
-        43.as-hash
-    TRUE
-
-[] > as-hash-not-equal
-  assert-that > @
-    41.as-hash
-    $.not
-      $.equal-to
-        42.as-hash
-
 [] > sum-up-several-arguments
   assert-that > @
     1982

--- a/eo-runtime/src/test/eo/org/eolang/int-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/int-tests.eo
@@ -21,8 +21,6 @@
 # SOFTWARE.
 
 +alias org.eolang.hamcrest.assert-that
-+alias org.eolang.io.stdout
-+alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/string-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/string-tests.eo
@@ -128,12 +128,6 @@
     """
     $.equal-to "a\n b\n  c"
 
-[] > similar-strings-generate-similar-hashes
-  assert-that > @
-    "hello".as-hash
-    $.equal-to
-      "hello".as-hash
-
 [] > compares-two-strings
   assert-that > @
     eq.


### PR DESCRIPTION
Closes: #1724

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds and removes some functions in several files of the eo-runtime. It also includes some test files. The changes are focused on adding and removing functions that convert data types and calculate hashes.

### Detailed summary
- Removed `as-hash` function from `bool.eo`, `int.eo`, `float.eo`, and `string.eo`
- Removed `slice` function from `string.eo`
- Added `as-bytes` function to `string.eo` and `bytes.eo`
- Added `similar-strings-generate-similar-hashes` function to `string-tests.eo`
- Added `compares-two-strings` function to `string-tests.eo`
- Added `similar-values-have-similar-hash` function to `float-tests.eo`
- Added `inline-float-computation` function to `float-tests.eo`
- Added `hash-equals-the-value` function to `bool-tests.eo`
- Added `last-while-dataization-object` function to `bool-tests.eo`
- Added `bytes-hashes-equals` function to `bytes-tests.eo`
- Added `bytes-as-hash-value` function to `bytes-tests.eo`
- Added `xor-as-int` function to `bytes-tests.eo`
- Removed `bytes-hashes-remain-same` function from `bytes-tests.eo`
- Removed `as-hash-equals-to-similar-values` function from `int-tests.eo`
- Removed `as-hash-have-different-hashes` and `as-hash-not-equal` functions from `int-tests.eo`
- Added `sum-up-several-arguments` function to `int-tests.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->