### PR TITLE
chore: Try to repair daily builds

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -5,7 +5,7 @@ on:
     - cron: '30 1 * * *'
 jobs:
   build:
-    runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -5,7 +5,7 @@ on:
     - cron: '30 1 * * *'
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
Currently, our daily build doesn't work, because it waits for runner. As was suggested in that [thread](https://stackoverflow.com/questions/70959954/error-waiting-for-a-runner-to-pick-up-this-job-using-github-actions#:~:text=If%20you%20misspell%20the%20requested,why%20we%20face%20this%20error.) we can specify runner concretely by using one of the "allowed" runners.
The full list of runners you can check right [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the operating systems used in the `build` job of the `.github/workflows/daily.yml` workflow.

### Detailed summary
- Changes the operating systems used in the `build` job from `ubuntu-latest` and `macos-latest` to `ubuntu-20.04`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->