### PR TITLE
removed Guava dependency and updated BinarizeMojo

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -244,7 +244,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+      <version>32.0.0-jre</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -242,12 +242,6 @@ SOFTWARE.
       <!-- version from parent POM -->
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.moandjiezana.toml</groupId>
       <artifactId>toml4j</artifactId>
       <version>0.7.2</version>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes a dependency on Google Guava and makes several changes to the `BinarizeMojo` class, including using `org.cactoos` instead of `com.google.common.io` and `com.jcabi.log.VerboseProcess` instead of `com.google.common.io.CharStreams`.

### Detailed summary
- Remove dependency on Google Guava from `pom.xml`
- Use `org.cactoos` instead of `com.google.common.io`
- Use `com.jcabi.log.VerboseProcess` instead of `com.google.common.io.CharStreams`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->