### PR TITLE
test: Add test for entire transpilation pipeline and  synthetic-references.xsl transformation

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -46,6 +46,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,8 +62,14 @@ final class OptimizeMojoTest {
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/packs/", glob = "**.yaml")
     void checksPacks(final String pack) throws Exception {
+        final CheckPack check = new CheckPack(pack);
+        if (check.skip()) {
+            Assumptions.abort(
+                String.format("%s is not ready", pack)
+            );
+        }
         MatcherAssert.assertThat(
-            new CheckPack(pack).failures(),
+            check.failures(),
             Matchers.empty()
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -268,7 +268,7 @@ final class OptimizeMojoTest {
                     .result()
                     .get(
                         String.format(
-                            "target/%s/foo/x/main/26-duplicate-names.xml",
+                            "target/%s/foo/x/main/25-duplicate-names.xml",
                             OptimizeMojo.STEPS
                         )
                     )

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
@@ -1,0 +1,77 @@
+# Current test shows optimization and transpilation chain for simple program.
+# The aim of this test is to check that entire pipeline with
+# synthetic-referenses.xsl transformation works as expected without creating
+# any warnings or errors.
+# Pay attention to synthetic-references.xsl and to-java.xsl transformations.
+xsls:
+  - /org/eolang/parser/errors/not-empty-atoms.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/errors/many-free-attributes.xsl
+  - /org/eolang/parser/errors/broken-aliases.xsl
+  - /org/eolang/parser/errors/duplicate-aliases.xsl
+  - /org/eolang/parser/errors/global-nonames.xsl
+  - /org/eolang/parser/errors/same-line-names.xsl
+  - /org/eolang/parser/errors/self-naming.xsl
+  - /org/eolang/parser/cti/cti-adds-errors.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/wrap-method-calls.xsl
+  - /org/eolang/parser/expand-qqs.xsl
+  - /org/eolang/parser/add-probes.xsl
+  - /org/eolang/parser/vars-float-up.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/warnings/unsorted-metas.xsl
+  - /org/eolang/parser/warnings/incorrect-architect.xsl
+  - /org/eolang/parser/warnings/incorrect-home.xsl
+  - /org/eolang/parser/warnings/incorrect-version.xsl
+  - /org/eolang/parser/expand-aliases.xsl
+  - /org/eolang/parser/resolve-aliases.xsl
+  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/add-default-package.xsl
+  - /org/eolang/parser/errors/broken-refs.xsl
+  - /org/eolang/parser/errors/unknown-names.xsl
+  - /org/eolang/parser/errors/noname-attributes.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/warnings/duplicate-metas.xsl
+  - /org/eolang/parser/warnings/mandatory-package-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-home-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-version-meta.xsl
+  - /org/eolang/parser/warnings/correct-package-meta.xsl
+  - /org/eolang/parser/errors/unused-aliases.xsl
+  - /org/eolang/parser/errors/data-objects.xsl
+  - /org/eolang/parser/warnings/unit-test-without-phi.xsl
+  - /org/eolang/parser/set-locators.xsl
+  - /org/eolang/parser/optimize/globals-to-abstracts.xsl
+  - /org/eolang/parser/optimize/remove-refs.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/maven/pre/classes.xsl
+  - /org/eolang/maven/pre/package.xsl
+  - /org/eolang/maven/pre/tests.xsl
+  - /org/eolang/maven/pre/rename-tests-inners.xsl
+  - /org/eolang/maven/pre/attrs.xsl
+  - /org/eolang/maven/pre/varargs.xsl
+  - /org/eolang/maven/pre/data.xsl
+  - /org/eolang/maven/pre/to-java.xsl
+# @todo #2110:90min Found more than one target of object at the line.
+#  The test below throws exception during the execution of the entire
+#  pipeline. The problem is in the synthetic-references.xsl transformation.
+#  The transformation adds new objects to the program, probably with incorrect
+#  line and pos attributes.
+#  Processing terminated by xsl:message at line 358 in to-java.xsl
+#  When we fix the problem, we have to enable the following test.
+skip: true
+tests:
+  - /program/errors[count(*)=0]
+eo: |
+  +architect volodya.lombrozo@gmail.com
+  +home https://github.com/objectionary/eo
+  +tests
+  +package org.eolang
+  +version 0.0.0
+  
+  [] > method
+    * 1 (* "one" "two") 3 > res
+    eq > @
+      * (res.length) ((res.at 1).at 1)
+      * 3 "two"

--- a/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
@@ -96,7 +96,7 @@ public final class CheckPack {
                 failures.add(xpath);
             }
         }
-        if (!failures.isEmpty()) {
+        if (!failures.isEmpty() || true) {
             Logger.info(this, "Broken XML:\n%s", out);
         }
         return failures;

--- a/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
@@ -96,7 +96,7 @@ public final class CheckPack {
                 failures.add(xpath);
             }
         }
-        if (!failures.isEmpty() || true) {
+        if (!failures.isEmpty()) {
             Logger.info(this, "Broken XML:\n%s", out);
         }
         return failures;

--- a/eo-parser/src/main/java/org/eolang/parser/Objects.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Objects.java
@@ -26,10 +26,7 @@ package org.eolang.parser;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -74,6 +71,10 @@ interface Objects extends Iterable<Directive> {
      */
     void alias();
 
+    /**
+     * Mark current object as last inside the scope.
+     * Last object that relates to the alias.
+     */
     void closeAlias();
 
     /**
@@ -123,17 +124,12 @@ interface Objects extends Iterable<Directive> {
             this.dirs.up();
         }
 
-        private final AtomicInteger next = new AtomicInteger(1);
-        private final Random random = new Random();
-
-
         @Override
         public void alias() {
             this.aliases.push(
                 String.format(
-                    "%s-scope-%s",
-                    Math.abs(this.random.nextInt(100)),
-                    this.next.getAndIncrement()
+                    "scope-%s",
+                    UUID.randomUUID()
                 )
             );
         }
@@ -141,7 +137,6 @@ interface Objects extends Iterable<Directive> {
         @Override
         public void closeAlias() {
             this.aliases.remove();
-            this.next.decrementAndGet();
         }
 
         @Override

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -53,6 +53,17 @@ public final class ParsingTrain extends TrEnvelope {
 
     /**
      * Sheets in the right order.
+     *
+     * @todo #2110:90min Enable synthetic-references.xsl transformation.
+     *  Currently, synthetic-references.xsl transformation is disabled because
+     *  it breaks the integration tests in eo-maven-plugin.
+     *  The problem is that the transformation breaks add-refs.xsl transformation and
+     *  to-java.xsl transformation. The reason is that synthetic-references.xsl transformation
+     *  adds new objects without @line and @pos attributes which are required by add-refs.xsl
+     *  and to-java.xsl transformations.
+     *  When the problem is fixed, we should enable synthetic-references.xsl transformation
+     *  by adding it to the SHEETS array between remove-aliases.xsl and add-default-package.xsl
+     *  transformations.
      */
     private static final String[] SHEETS = {
         "/org/eolang/parser/errors/not-empty-atoms.xsl",
@@ -76,7 +87,6 @@ public final class ParsingTrain extends TrEnvelope {
         "/org/eolang/parser/warnings/incorrect-version.xsl",
         "/org/eolang/parser/expand-aliases.xsl",
         "/org/eolang/parser/resolve-aliases.xsl",
-        "/org/eolang/parser/synthetic-references.xsl",
         "/org/eolang/parser/add-default-package.xsl",
         "/org/eolang/parser/errors/broken-refs.xsl",
         "/org/eolang/parser/errors/unknown-names.xsl",

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -324,7 +324,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
 
     @Override
     public void exitScope(final ProgramParser.ScopeContext ctx) {
-        // This method is created by ANTLR and can't be removed
+        this.objects.closeAlias();
     }
 
     @Override

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -64,6 +64,12 @@ SOFTWARE.
         <xsl:attribute name="name">
           <xsl:text>@</xsl:text>
         </xsl:attribute>
+        <xsl:attribute name="line">
+          <xsl:value-of select="@line"/>
+        </xsl:attribute>
+        <xsl:attribute name="pos">
+          <xsl:value-of select="@pos"/>
+        </xsl:attribute>
         <xsl:apply-templates select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
       </xsl:element>
     </xsl:element>

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -40,10 +40,35 @@ SOFTWARE.
   listed above (skip=false).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="o[@alias]">
-    <xsl:copy>
-      <xsl:apply-templates select="node()|@* except @alias"/>
-    </xsl:copy>
+  <xsl:template match="o[@alias and count(child::o) &gt; 1]">
+    <xsl:element name="o">
+      <xsl:attribute name="abstract"/>
+      <xsl:attribute name="line">
+        <xsl:value-of select="@line"/>
+      </xsl:attribute>
+      <xsl:attribute name="pos">
+        <xsl:value-of select="@pos"/>
+      </xsl:attribute>
+      <xsl:variable name="curr" select="@alias"/>
+      <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:attribute name="name">
+          <xsl:text>org.eolang.</xsl:text>
+          <xsl:value-of select="@alias"/>
+        </xsl:attribute>
+        <xsl:apply-templates select="child::o[contains(@alias, $curr)]"/>
+      </xsl:copy>
+      <xsl:element name="o">
+        <xsl:attribute name="base">
+          <xsl:text>org.eolang.</xsl:text>
+          <xsl:value-of select="@alias"/>
+        </xsl:attribute>
+        <xsl:attribute name="name">
+          <xsl:text>@</xsl:text>
+        </xsl:attribute>
+        <xsl:apply-templates select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
+      </xsl:element>
+    </xsl:element>
   </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -22,7 +22,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                id="synthetic-references" version="2.0">
   <!--
   Process alias attribute.
   @todo #2093:90m synthetic-attributes. Solution for synthetic-references.xsl.
@@ -42,14 +43,18 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@alias and count(child::o) &gt; 1]">
     <xsl:element name="o">
+      <xsl:variable name="curr" select="@alias"/>
       <xsl:attribute name="abstract"/>
+      <xsl:attribute name="name">
+        generated-
+        <xsl:value-of select="$curr"/>
+      </xsl:attribute>
       <xsl:attribute name="line">
         <xsl:value-of select="@line"/>
       </xsl:attribute>
       <xsl:attribute name="pos">
         <xsl:value-of select="@pos"/>
       </xsl:attribute>
-      <xsl:variable name="curr" select="@alias"/>
       <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:attribute name="name">
@@ -66,7 +71,8 @@ SOFTWARE.
         <xsl:attribute name="name">
           <xsl:text>@</xsl:text>
         </xsl:attribute>
-        <xsl:apply-templates select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
+        <xsl:apply-templates
+                select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
       </xsl:element>
     </xsl:element>
   </xsl:template>

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -25,19 +25,14 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
   <!--
   Process alias attribute.
-  @todo #2093:90m synthetic-attributes. Solution for synthetic-references.xsl.
-   Implement the proper solution for synthetic-references.xsl.
-   Currently we have enough tests that cover all important cases of that
-   feature:
-    synthetic-attributes.yaml
-    synthetic-attributes-double-scope.yaml
-    synthetic-attributes-many-arguments.yaml
-    synthetic-attributes-nested.yaml
-    synthetic-attributes-without-scope.yaml
-    synthetic-attributes-with-doubled-methods.yaml
-    synthetic-attributes-with-nested-methods.yaml
-  When the task will be implemented we have to enable all the tests that
-  listed above (skip=false).
+  @todo #2110:90m Rename synthetic-attributes to synthetic-scopes.
+    We call all attributes in the transformation as "aliases".
+    (you can read more about the original issue and why it is named so right
+    <a href="https://github.com/objectionary/eo/issues/415">here</a>.)
+    which is quite confusing and conflicts with the concept of aliases as
+    foreign references. We should rename the transformation to "scopes" or
+    "synthetic-scopes" and rename the "aliases" attributes in that stylesheet
+    accordingly.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@alias and count(child::o) &gt; 1]">

--- a/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/synthetic-references.xsl
@@ -22,8 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                id="synthetic-references" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
   <!--
   Process alias attribute.
   @todo #2093:90m synthetic-attributes. Solution for synthetic-references.xsl.
@@ -46,8 +45,7 @@ SOFTWARE.
       <xsl:variable name="curr" select="@alias"/>
       <xsl:attribute name="abstract"/>
       <xsl:attribute name="name">
-        generated-
-        <xsl:value-of select="$curr"/>
+        <xsl:value-of select="concat('generated-',$curr)"/>
       </xsl:attribute>
       <xsl:attribute name="line">
         <xsl:value-of select="@line"/>
@@ -71,8 +69,7 @@ SOFTWARE.
         <xsl:attribute name="name">
           <xsl:text>@</xsl:text>
         </xsl:attribute>
-        <xsl:apply-templates
-                select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
+        <xsl:apply-templates select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
       </xsl:element>
     </xsl:element>
   </xsl:template>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/aliases.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/aliases.yaml
@@ -1,6 +1,6 @@
 xsls: []
 tests:
-  - //objects[count(.//o[@alias])=2]
+  - //objects[count(.//o[@alias])=3]
 eo: |
   [] > aliases
     a (b (c d))

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
@@ -1,6 +1,5 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-double-scope.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
   - //o[@base='foo' and count(o)=3]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-many-arguments.yaml
@@ -1,6 +1,5 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='foo' and count(o)=3]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
@@ -1,6 +1,5 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-nested.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
@@ -1,67 +1,56 @@
+# Current test shows optimization chain for simple program.
+# The aim of this test is to check that all synthetic attributes are added
+# correctly and further optimization chain works as expected without creating
+# any warnings or errors.
+# Pay attention to synthetic-references.xsl and add-refs.xsl transformations.
 xsls:
-    - /org/eolang/parser/errors/not-empty-atoms.xsl
-    - /org/eolang/parser/critical-errors/duplicate-names.xsl
-    - /org/eolang/parser/errors/many-free-attributes.xsl
-    - /org/eolang/parser/errors/broken-aliases.xsl
-    - /org/eolang/parser/errors/duplicate-aliases.xsl
-    - /org/eolang/parser/errors/global-nonames.xsl
-    - /org/eolang/parser/errors/same-line-names.xsl
-    - /org/eolang/parser/errors/self-naming.xsl
-    - /org/eolang/parser/cti/cti-adds-errors.xsl
-    - /org/eolang/parser/add-refs.xsl
-    - /org/eolang/parser/wrap-method-calls.xsl
-    - /org/eolang/parser/expand-qqs.xsl
-    - /org/eolang/parser/add-probes.xsl
-    - /org/eolang/parser/vars-float-up.xsl
-    - /org/eolang/parser/add-refs.xsl
-    - /org/eolang/parser/warnings/unsorted-metas.xsl
-    - /org/eolang/parser/warnings/incorrect-architect.xsl
-    - /org/eolang/parser/warnings/incorrect-home.xsl
-    - /org/eolang/parser/warnings/incorrect-version.xsl
-    - /org/eolang/parser/expand-aliases.xsl
-    - /org/eolang/parser/resolve-aliases.xsl
-    - /org/eolang/parser/synthetic-references.xsl
-    - /org/eolang/parser/add-default-package.xsl
-    - /org/eolang/parser/errors/broken-refs.xsl
-    - /org/eolang/parser/errors/unknown-names.xsl
-    - /org/eolang/parser/errors/noname-attributes.xsl
-    - /org/eolang/parser/critical-errors/duplicate-names.xsl
-    - /org/eolang/parser/warnings/duplicate-metas.xsl
-    - /org/eolang/parser/warnings/mandatory-package-meta.xsl
-    - /org/eolang/parser/warnings/mandatory-home-meta.xsl
-    - /org/eolang/parser/warnings/mandatory-version-meta.xsl
-    - /org/eolang/parser/warnings/correct-package-meta.xsl
-    - /org/eolang/parser/errors/unused-aliases.xsl
-    - /org/eolang/parser/errors/data-objects.xsl
-    - /org/eolang/parser/warnings/unit-test-without-phi.xsl
-    - /org/eolang/parser/set-locators.xsl
-    - /org/eolang/parser/optimize/globals-to-abstracts.xsl
-    - /org/eolang/parser/optimize/remove-refs.xsl
-    - /org/eolang/parser/optimize/abstracts-float-up.xsl
-    - /org/eolang/parser/optimize/remove-levels.xsl
-    - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/errors/not-empty-atoms.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/errors/many-free-attributes.xsl
+  - /org/eolang/parser/errors/broken-aliases.xsl
+  - /org/eolang/parser/errors/duplicate-aliases.xsl
+  - /org/eolang/parser/errors/global-nonames.xsl
+  - /org/eolang/parser/errors/same-line-names.xsl
+  - /org/eolang/parser/errors/self-naming.xsl
+  - /org/eolang/parser/cti/cti-adds-errors.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/wrap-method-calls.xsl
+  - /org/eolang/parser/expand-qqs.xsl
+  - /org/eolang/parser/add-probes.xsl
+  - /org/eolang/parser/vars-float-up.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/warnings/unsorted-metas.xsl
+  - /org/eolang/parser/warnings/incorrect-architect.xsl
+  - /org/eolang/parser/warnings/incorrect-home.xsl
+  - /org/eolang/parser/warnings/incorrect-version.xsl
+  - /org/eolang/parser/expand-aliases.xsl
+  - /org/eolang/parser/resolve-aliases.xsl
+  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/add-default-package.xsl
+  - /org/eolang/parser/errors/broken-refs.xsl
+  - /org/eolang/parser/errors/unknown-names.xsl
+  - /org/eolang/parser/errors/noname-attributes.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/warnings/duplicate-metas.xsl
+  - /org/eolang/parser/warnings/mandatory-package-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-home-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-version-meta.xsl
+  - /org/eolang/parser/warnings/correct-package-meta.xsl
+  - /org/eolang/parser/errors/unused-aliases.xsl
+  - /org/eolang/parser/errors/data-objects.xsl
+  - /org/eolang/parser/warnings/unit-test-without-phi.xsl
+  - /org/eolang/parser/set-locators.xsl
+  - /org/eolang/parser/optimize/globals-to-abstracts.xsl
+  - /org/eolang/parser/optimize/remove-refs.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+  - /org/eolang/parser/add-refs.xsl
+skip: false
 tests:
   - /program/errors[count(*)=0]
 eo: |
-  +alias org.eolang.collections.list
-  +alias org.eolang.hamcrest.assert-that
-  +architect yegor256@gmail.com
-  +home https://github.com/objectionary/eo
-  +tests
-  +package org.eolang
-  +version 0.0.0
-
-  [] > concat-three-tuples
-    * 0 1 2 > a
-    * 3 4 > b
-    * (* "five" "six") (* "siven") > c
-    concat. > res
-      list a
-      concat.
-        list b
-        c
-    assert-that > @
-      * (res.length) ((res.at 5).at 1)
-      $.equal-to
-        list
-          * 7 "six"
+  [] > method
+    * 1 (* "one" "two") 3 > res
+    eq > @
+      * (res.length) ((res.at 1).at 1)
+      * 3 "two"

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
@@ -1,0 +1,67 @@
+xsls:
+    - /org/eolang/parser/errors/not-empty-atoms.xsl
+    - /org/eolang/parser/critical-errors/duplicate-names.xsl
+    - /org/eolang/parser/errors/many-free-attributes.xsl
+    - /org/eolang/parser/errors/broken-aliases.xsl
+    - /org/eolang/parser/errors/duplicate-aliases.xsl
+    - /org/eolang/parser/errors/global-nonames.xsl
+    - /org/eolang/parser/errors/same-line-names.xsl
+    - /org/eolang/parser/errors/self-naming.xsl
+    - /org/eolang/parser/cti/cti-adds-errors.xsl
+    - /org/eolang/parser/add-refs.xsl
+    - /org/eolang/parser/wrap-method-calls.xsl
+    - /org/eolang/parser/expand-qqs.xsl
+    - /org/eolang/parser/add-probes.xsl
+    - /org/eolang/parser/vars-float-up.xsl
+    - /org/eolang/parser/add-refs.xsl
+    - /org/eolang/parser/warnings/unsorted-metas.xsl
+    - /org/eolang/parser/warnings/incorrect-architect.xsl
+    - /org/eolang/parser/warnings/incorrect-home.xsl
+    - /org/eolang/parser/warnings/incorrect-version.xsl
+    - /org/eolang/parser/expand-aliases.xsl
+    - /org/eolang/parser/resolve-aliases.xsl
+    - /org/eolang/parser/synthetic-references.xsl
+    - /org/eolang/parser/add-default-package.xsl
+    - /org/eolang/parser/errors/broken-refs.xsl
+    - /org/eolang/parser/errors/unknown-names.xsl
+    - /org/eolang/parser/errors/noname-attributes.xsl
+    - /org/eolang/parser/critical-errors/duplicate-names.xsl
+    - /org/eolang/parser/warnings/duplicate-metas.xsl
+    - /org/eolang/parser/warnings/mandatory-package-meta.xsl
+    - /org/eolang/parser/warnings/mandatory-home-meta.xsl
+    - /org/eolang/parser/warnings/mandatory-version-meta.xsl
+    - /org/eolang/parser/warnings/correct-package-meta.xsl
+    - /org/eolang/parser/errors/unused-aliases.xsl
+    - /org/eolang/parser/errors/data-objects.xsl
+    - /org/eolang/parser/warnings/unit-test-without-phi.xsl
+    - /org/eolang/parser/set-locators.xsl
+    - /org/eolang/parser/optimize/globals-to-abstracts.xsl
+    - /org/eolang/parser/optimize/remove-refs.xsl
+    - /org/eolang/parser/optimize/abstracts-float-up.xsl
+    - /org/eolang/parser/optimize/remove-levels.xsl
+    - /org/eolang/parser/add-refs.xsl
+tests:
+  - /program/errors[count(*)=0]
+eo: |
+  +alias org.eolang.collections.list
+  +alias org.eolang.hamcrest.assert-that
+  +architect yegor256@gmail.com
+  +home https://github.com/objectionary/eo
+  +tests
+  +package org.eolang
+  +version 0.0.0
+
+  [] > concat-three-tuples
+    * 0 1 2 > a
+    * 3 4 > b
+    * (* "five" "six") (* "siven") > c
+    concat. > res
+      list a
+      concat.
+        list b
+        c
+    assert-that > @
+      * (res.length) ((res.at 5).at 1)
+      $.equal-to
+        list
+          * 7 "six"

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
@@ -45,7 +45,13 @@ xsls:
   - /org/eolang/parser/optimize/abstracts-float-up.xsl
   - /org/eolang/parser/optimize/remove-levels.xsl
   - /org/eolang/parser/add-refs.xsl
-skip: false
+# @todo #2110:90min Missing @line attribute after synthetic-attributes.xsl.
+#  We have to fix the problem with missing @line attribute after
+#  synthetic-attributes.xsl transformation. The problem is that
+#  synthetic-attributes.xsl transformation doesn't copy @line attribute from
+#  the original object.
+#  When we fix the problem, we have to enable the following test.
+skip: true
 tests:
   - /program/errors[count(*)=0]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-add-refs.yaml
@@ -45,16 +45,15 @@ xsls:
   - /org/eolang/parser/optimize/abstracts-float-up.xsl
   - /org/eolang/parser/optimize/remove-levels.xsl
   - /org/eolang/parser/add-refs.xsl
-# @todo #2110:90min Missing @line attribute after synthetic-attributes.xsl.
-#  We have to fix the problem with missing @line attribute after
-#  synthetic-attributes.xsl transformation. The problem is that
-#  synthetic-attributes.xsl transformation doesn't copy @line attribute from
-#  the original object.
-#  When we fix the problem, we have to enable the following test.
-skip: true
 tests:
   - /program/errors[count(*)=0]
 eo: |
+  +architect volodya.lombrozo@gmail.com
+  +home https://github.com/objectionary/eo
+  +tests
+  +package org.eolang
+  +version 0.0.0
+  
   [] > method
     * 1 (* "one" "two") 3 > res
     eq > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-doubled-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-doubled-methods.yaml
@@ -1,9 +1,9 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
-  - //o[@base='.foo' and count(o[@base='.bar'])=2]
+  - //o[@base='.foo' and count(o[@abstract]/o[@base='.bar'])=2]
   - //o[@base='.bar' and count(o)=2]
 eo: |
   [] > aliases

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-doubled-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-doubled-methods.yaml
@@ -1,7 +1,6 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='.foo' and count(o[@abstract]/o[@base='.bar'])=2]
   - //o[@base='.bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-nested-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-nested-methods.yaml
@@ -1,11 +1,11 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
-  - //o[@base='.with']/o[@base='.with']/o[@base='.with']/o[@base='foobar']
-  - //o[@base='.with']/o[@base='.with']/o[@base='.with' and count(o)=2]
-  - //o[@base='.with']/o[@base='.with' and count(o)=2]
+  - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with']/o[@base='foobar']
+  - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with' and count(o)=3]
+  - //o[@base='.with']/o[@abstract]/o[@base='.with' and count(o)=2]
   - //o[@base='.with' and count(o)=2]
 eo: |
   [] > aliases
@@ -16,8 +16,8 @@ eo: |
       [x] > with
         foo > @
     [] > foobar
-      [z] > with
+      [z d] > with
         bar > @
     eq. > @
-      ((foobar.with 1).with 2).with 3
+      ((foobar.with 1 2).with 3).with 4
       42

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-nested-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-with-nested-methods.yaml
@@ -1,7 +1,6 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with']/o[@base='foobar']
   - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with' and count(o)=3]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes-without-scope.yaml
@@ -1,6 +1,5 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='foo' and count(o)=2]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes.yaml
@@ -1,6 +1,5 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: false
 tests:
   - //o[@base='foo' and count(o)=1]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/synthetic-attributes.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/synthetic-references.xsl
-skip: true
+skip: false
 tests:
   - //o[@base='foo' and count(o)=1]
 eo: |


### PR DESCRIPTION
Enable `synthetic-attributes-with-add-refs.yaml` test and add one more test for `synthetic-references.xsl` and `add-refs.xsl` transformations that reveal the problem with "Found more than one target of object at the line" after `synthetic-references.xsl` transformation. 