### PR TITLE
standardized UTF-8 for console Java I/O according to `JEP 400: UTF-8 by Default`

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [11, 17]
+        java: [11, 17, 18]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -199,7 +199,9 @@ final class SnippetTest {
                 new Joined<String>(
                     new ListOf<>(
                         SnippetTest.jdkExecutable("java"),
-                        "-Dfile.encoding=utf-8",
+                        "-Dfile.encoding=UTF-8",
+                        "-Dsun.stdout.encoding=UTF-8",
+                        "-Dsun.stderr.encoding=UTF-8",
                         "-cp",
                         SnippetTest.classpath(),
                         "org.eolang.Main"

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -125,7 +125,9 @@ final class MainTest {
     private static String exec(final String... cmds) throws Exception {
         final Collection<String> args = new LinkedList<>();
         args.add(MainTest.jdkExecutable("java"));
-        args.add("-Dfile.encoding=utf-8");
+        args.add("-Dfile.encoding=UTF-8");
+        args.add("-Dsun.stdout.encoding=UTF-8");
+        args.add("-Dsun.stderr.encoding=UTF-8");
         args.add("-cp");
         args.add(System.getProperty("java.class.path"));
         args.add(Main.class.getCanonicalName());
@@ -143,7 +145,13 @@ final class MainTest {
             ).value();
         }
         return new String(stdout.toByteArray(), StandardCharsets.UTF_8)
-            .replaceFirst("Picked up .*\n", "");
+            .replaceFirst(
+                String.format(
+                    "Picked up .*%s",
+                    System.lineSeparator()
+                ),
+                ""
+            );
     }
 
     /**


### PR DESCRIPTION

Closes: #992 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Java 18 to the matrix of operating systems and Java versions tested, and updates encoding settings for consistency.

### Detailed summary
- Adds Java 18 to the matrix of operating systems and Java versions tested
- Updates encoding settings for consistency in `SnippetTest.java` and `MainTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->