### PR TITLE
feat(#2139): Make OptimizeMojoTest#optimizesIfExpired more stable

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -110,7 +110,6 @@ public final class OptimizeMojo extends SafeMojo {
     private boolean failOnWarning;
 
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void exec() throws IOException {
         final Collection<ForeignTojo> sources = this.scopedTojos().withXmir();
         final Optimization common = this.optimization();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -61,7 +61,7 @@ final class OptimizeMojoTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/packs/", glob = "**.yaml")
-    void checksPacks(final String pack) throws Exception {
+    void checksPacks(final String pack) throws IOException {
         final CheckPack check = new CheckPack(pack);
         if (check.skip()) {
             Assumptions.abort(
@@ -75,7 +75,7 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void skipsAlreadyOptimized(@TempDir final Path temp) throws Exception {
+    void skipsAlreadyOptimized(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .withHelloWorld()
             .execute(new FakeMaven.Optimize());
@@ -101,13 +101,14 @@ final class OptimizeMojoTest {
                 String.format("target/%s/foo/x/main.%s", OptimizeMojo.DIR, TranspileMojo.EXT)
             );
         final long start = System.currentTimeMillis();
-        if (!tgt.toFile().setLastModified(start - TimeUnit.SECONDS.toMillis(10L))) {
+        final long old = start - TimeUnit.SECONDS.toMillis(10L);
+        if (!tgt.toFile().setLastModified(old)) {
             Assertions.fail(String.format("The last modified attribute can't be set for %s", tgt));
         }
         maven.execute(OptimizeMojo.class);
         MatcherAssert.assertThat(
             tgt.toFile().lastModified(),
-            Matchers.greaterThan(start)
+            Matchers.greaterThan(old)
         );
     }
 
@@ -152,7 +153,7 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void savesOptimizedResultsToCache(@TempDir final Path temp) throws Exception {
+    void savesOptimizedResultsToCache(@TempDir final Path temp) throws IOException {
         final Path cache = temp.resolve("cache");
         final String hash = "abcdef1";
         new FakeMaven(temp)
@@ -169,7 +170,7 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void optimizesSuccessfully(@TempDir final Path temp) throws Exception {
+    void optimizesSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final Map<String, Path> res = maven
             .withHelloWorld()
@@ -222,7 +223,7 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void failsOnErrorFlag(@TempDir final Path temp) throws Exception {
+    void failsOnErrorFlag(@TempDir final Path temp) throws IOException {
         MatcherAssert.assertThat(
             new FakeMaven(temp)
                 .withProgram(
@@ -258,7 +259,7 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void stopsOnCritical(@TempDir final Path temp) throws Exception {
+    void stopsOnCritical(@TempDir final Path temp) throws IOException {
         MatcherAssert.assertThat(
             new XMLDocument(
                 new FakeMaven(temp)


### PR DESCRIPTION
Make OptimizeMojoTest#optimizesIfExpired more stable and specify concrete exceptions (`Exception` -> `IOException`).

Closes: #2139 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the `OptimizeMojo` class in the `eo-maven-plugin` by replacing the `Exception` type with `IOException`, which is more specific. It also includes some code refactoring and improvements in the test suite.

### Detailed summary
- Replaced `Exception` with `IOException` in `OptimizeMojo` and `OptimizeMojoTest`
- Refactored and improved code in `OptimizeMojo`
- Improved test coverage in `OptimizeMojoTest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->