### PR TITLE
#992 added tests for handling encoding

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -24,7 +24,11 @@
 package org.eolang;
 
 import com.jcabi.log.VerboseProcess;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -119,6 +123,58 @@ final class MainTest {
         MatcherAssert.assertThat(
             MainTest.exec("unavailable-name"),
             Matchers.containsString("Can not find 'unavailable-name' object")
+        );
+    }
+
+    @Test
+    void readsStreamCorrectly() throws IOException {
+        final BufferedReader reader = new BufferedReader(
+            Channels.newReader(
+                Channels.newChannel(
+                    new ByteArrayInputStream(
+                        ">> ··\uD835\uDD38('text' for EOorgEOio.EOstdoutν2) ➜ ΦSFN".getBytes(
+                            StandardCharsets.UTF_8
+                        )
+                    )
+                ),
+                StandardCharsets.UTF_8
+            )
+        );
+        MatcherAssert.assertThat(
+            reader.readLine().length(),
+            Matchers.greaterThan(0)
+        );
+    }
+
+    @Test
+    void readsSimpleStreamCorrectly() throws IOException {
+        final BufferedReader reader = new BufferedReader(
+            Channels.newReader(
+                Channels.newChannel(
+                    new ByteArrayInputStream(
+                        "abc".getBytes(
+                            StandardCharsets.UTF_8
+                        )
+                    )
+                ),
+                StandardCharsets.UTF_8
+            )
+        );
+        MatcherAssert.assertThat(
+            reader.readLine().length(),
+            Matchers.greaterThan(1)
+        );
+    }
+
+    @Test
+    void readsBytesCorrectly() {
+        MatcherAssert.assertThat(
+            new ByteArrayInputStream(
+                "··\uD835\uDD38➜Φ".getBytes(
+                    StandardCharsets.UTF_8
+                )
+            ).read(),
+            Matchers.greaterThan(0)
         );
     }
 


### PR DESCRIPTION
Increases functional test coverage for #992


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds tests for reading streams and bytes in `MainTest.java`.

### Detailed summary
- Added `readsStreamCorrectly` test for reading streams.
- Added `readsSimpleStreamCorrectly` test for reading simple streams.
- Added `readsBytesCorrectly` test for reading bytes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->