### PR TITLE
feat(#2144): Upgrade jtcop

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>
@@ -447,6 +449,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
+              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                    It is disabled in the whole eo-maven-plugin module because
+                    it requires lots of fixes simultaneously. We have to enable
+                    that rule and apply all required changes in order to make
+                    all jtcop checks to pass.
+              -->
               <exclusions>
                 <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -447,7 +447,7 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
                     It is disabled in the whole eo-maven-plugin module because
                     it requires lots of fixes simultaneously. We have to enable
                     that rule and apply all required changes in order to make

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -448,10 +448,10 @@ SOFTWARE.
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
               <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                    It is disabled in the whole eo-maven-plugin module because
-                    it requires lots of fixes simultaneously. We have to enable
-                    that rule and apply all required changes in order to make
-                    all jtcop checks to pass.
+                     It is disabled in the whole eo-maven-plugin module because
+                     it requires lots of fixes simultaneously. We have to enable
+                     that rule and apply all required changes in order to make
+                     all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -443,6 +443,17 @@ SOFTWARE.
               </excludes>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>com.github.volodya-lombrozo</groupId>
+            <artifactId>jtcop-maven-plugin</artifactId>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAllTestsHaveProductionClass
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>
@@ -447,11 +449,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                     It is disabled in the whole eo-maven-plugin module because
-                     it requires lots of fixes simultaneously. We have to enable
-                     that rule and apply all required changes in order to make
-                     all jtcop checks to pass.
+              <!--
+                @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                  It is disabled in the whole eo-maven-plugin module because
+                  it requires lots of fixes simultaneously. We have to enable
+                  that rule and apply all required changes in order to make
+                  all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>
@@ -246,6 +248,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
+              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                    It is disabled in the whole eo-parser module because it
+                    requires lots of fixes simultaneously. We have to enable
+                    that rule and apply all required changes in order to make
+                    all jtcop checks to pass.
+              -->
               <exclusions>
                 <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -246,7 +246,7 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
                     It is disabled in the whole eo-parser module because it
                     requires lots of fixes simultaneously. We have to enable
                     that rule and apply all required changes in order to make

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -246,11 +246,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                     It is disabled in the whole eo-parser module because it
-                     requires lots of fixes simultaneously. We have to enable
-                     that rule and apply all required changes in order to make
-                     all jtcop checks to pass.
+              <!--
+                @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                  It is disabled in the whole eo-parser module because it
+                  requires lots of fixes simultaneously. We have to enable
+                  that rule and apply all required changes in order to make
+                  all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -247,10 +247,10 @@ SOFTWARE.
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
               <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                    It is disabled in the whole eo-parser module because it
-                    requires lots of fixes simultaneously. We have to enable
-                    that rule and apply all required changes in order to make
-                    all jtcop checks to pass.
+                     It is disabled in the whole eo-parser module because it
+                     requires lots of fixes simultaneously. We have to enable
+                     that rule and apply all required changes in order to make
+                     all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -237,4 +237,24 @@ SOFTWARE.
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>qulice</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.volodya-lombrozo</groupId>
+            <artifactId>jtcop-maven-plugin</artifactId>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAllTestsHaveProductionClass
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -276,7 +276,7 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
                     It is disabled in the whole eo-runtime module because it
                     requires lots of fixes simultaneously. We have to enable
                     that rule and apply all required changes in order to make

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -276,11 +276,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
-              <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                     It is disabled in the whole eo-runtime module because it
-                     requires lots of fixes simultaneously. We have to enable
-                     that rule and apply all required changes in order to make
-                     all jtcop checks to pass.
+              <!--
+                @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                  It is disabled in the whole eo-runtime module because it
+                  requires lots of fixes simultaneously. We have to enable
+                  that rule and apply all required changes in order to make
+                  all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -277,10 +277,10 @@ SOFTWARE.
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
               <!-- @todo #2144:30min Enable RuleAllTestsHaveProductionClass rule.
-                    It is disabled in the whole eo-runtime module because it
-                    requires lots of fixes simultaneously. We have to enable
-                    that rule and apply all required changes in order to make
-                    all jtcop checks to pass.
+                     It is disabled in the whole eo-runtime module because it
+                     requires lots of fixes simultaneously. We have to enable
+                     that rule and apply all required changes in order to make
+                     all jtcop checks to pass.
               -->
               <exclusions>
                 <exclusion>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>
@@ -116,8 +114,7 @@ SOFTWARE.
            switches surefire communication channel from default to TCP/IP and solves the bug.
            More detailed: https://stackoverflow.com/questions/55272870/surefire-maven-plugin-corrupted-stdout-by-directly-writing-to-native-stream-in
            and https://maven.apache.org/surefire/maven-surefire-plugin/examples/process-communication.html-->
-          <forkNode
-                  implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
           <properties>
             <configurationParameters>
               junit.jupiter.execution.parallel.enabled = true

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -272,6 +272,17 @@ SOFTWARE.
               </excludes>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>com.github.volodya-lombrozo</groupId>
+            <artifactId>jtcop-maven-plugin</artifactId>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAllTestsHaveProductionClass
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>
@@ -114,7 +116,8 @@ SOFTWARE.
            switches surefire communication channel from default to TCP/IP and solves the bug.
            More detailed: https://stackoverflow.com/questions/55272870/surefire-maven-plugin-corrupted-stdout-by-directly-writing-to-native-stream-in
            and https://maven.apache.org/surefire/maven-surefire-plugin/examples/process-communication.html-->
-          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+          <forkNode
+                  implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
           <properties>
             <configurationParameters>
               junit.jupiter.execution.parallel.enabled = true
@@ -276,6 +279,12 @@ SOFTWARE.
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <configuration>
+              <!-- @todo: #2144:30min Enable RuleAllTestsHaveProductionClass rule.
+                    It is disabled in the whole eo-runtime module because it
+                    requires lots of fixes simultaneously. We have to enable
+                    that rule and apply all required changes in order to make
+                    all jtcop checks to pass.
+              -->
               <exclusions>
                 <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.9</version>
+            <version>0.1.14</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Upgrade `jtcop-maven-plugin` up to `0.1.14` version.

Closes: #2144

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `jtcop-maven-plugin` version and enables a rule that checks for the presence of production classes in tests. 

### Detailed summary
- Updated `jtcop-maven-plugin` version from `0.1.9` to `0.1.14`
- Enabled `RuleAllTestsHaveProductionClass` rule in `eo-runtime`, `eo-maven-plugin`, and `eo-parser` modules

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->