### PR TITLE
added broken-refs test

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/packs/broken-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/broken-refs.yaml
@@ -1,0 +1,11 @@
+xsls:
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/errors/broken-refs.xsl
+tests:
+  - /program/errors[count(*)=0]
+  - //o[@base='a' and @line='3' and @ref='2']
+  - //o[@base='a' and @line='3' and @ref!='']
+eo: |
+  [] > app
+    42 > a
+    a.plus 1 > @


### PR DESCRIPTION
Closes: #1683

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new XSL files and test cases to handle broken references in EO code. It also includes a new EO code example. 

### Detailed summary
- Added `/org/eolang/parser/add-refs.xsl` file
- Added `/org/eolang/parser/errors/broken-refs.xsl` file
- Added `/program/errors[count(*)=0]` test case
- Added `//o[@base='a' and @line='3' and @ref='2']` test case
- Added `//o[@base='a' and @line='3' and @ref!='']` test case
- Added new EO code example: `[] > app\n42 > a\na.plus 1 > @`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->