### PR TITLE
refactor(#2141): abstracts-float-up.xsl

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
@@ -24,8 +24,8 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="abstracts-float-up" version="2.0">
   <!--
-  Here we take abstracts that stay inside other
-  abstracts and move them to highest level. This code:
+  Here, we extract abstracts that are nested within other abstracts
+  and relocate them to the highest level. Example:
 
   [a] > foo
     [] > test
@@ -42,6 +42,20 @@ SOFTWARE.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <!-- The eo:name-of function generates the name of the object based on its
+  ancestors. Example:
+
+  [] > another
+    eq. > @
+      [] > first
+        1 > @
+      [] > second
+        2 > @
+
+   Will generate the following names:
+   eo:name-of(first) = "another$t0$first"
+   eo:name-of(second) = "another$t0$second"
+  -->
   <xsl:function name="eo:name-of" as="xs:string">
     <xsl:param name="object" as="element()"/>
     <xsl:variable name="name">
@@ -66,6 +80,7 @@ SOFTWARE.
     </xsl:variable>
     <xsl:value-of select="$name"/>
   </xsl:function>
+  <!-- This is the strange function -->
   <xsl:function name="eo:vars">
     <xsl:param name="bottom" as="element()"/>
     <xsl:param name="top" as="element()"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
@@ -44,7 +44,7 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:function name="eo:name-of" as="xs:string">
     <xsl:param name="object" as="element()"/>
-    <xsl:variable name="n">
+    <xsl:variable name="name">
       <xsl:for-each select="$object/ancestor-or-self::o">
         <xsl:choose>
           <xsl:when test="eo:abstract(.) and not(@name)">
@@ -64,7 +64,7 @@ SOFTWARE.
         </xsl:if>
       </xsl:for-each>
     </xsl:variable>
-    <xsl:value-of select="$n"/>
+    <xsl:value-of select="$name"/>
   </xsl:function>
   <xsl:function name="eo:vars">
     <xsl:param name="bottom" as="element()"/>
@@ -81,13 +81,17 @@ SOFTWARE.
       </xsl:if>
     </xsl:for-each>
   </xsl:function>
-  <xsl:function name="eo:ancestors">
-    <xsl:param name="object" as="element()"/>
-    <xsl:for-each select="$object/ancestor-or-self::o[eo:abstract(.)]">
-      <xsl:sort data-type="number" select="position()" order="descending"/>
-      <xsl:copy-of select="."/>
-    </xsl:for-each>
-  </xsl:function>
+  <xsl:template match="//objects">
+    <xsl:copy>
+      <xsl:apply-templates select=".//o[eo:abstract(.)]" mode="top"/>
+      <xsl:apply-templates select="o[not(eo:abstract(.))]|@*"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
   <xsl:template match="o[eo:abstract(.)]">
     <xsl:element name="o">
       <xsl:apply-templates select="@* except @base except @abstract"/>
@@ -158,17 +162,6 @@ SOFTWARE.
           </xsl:element>
         </xsl:for-each>
       </xsl:for-each>
-    </xsl:copy>
-  </xsl:template>
-  <xsl:template match="//objects">
-    <xsl:copy>
-      <xsl:apply-templates select=".//o[eo:abstract(.)]" mode="top"/>
-      <xsl:apply-templates select="o[not(eo:abstract(.))]|@*"/>
-    </xsl:copy>
-  </xsl:template>
-  <xsl:template match="node()|@*">
-    <xsl:copy>
-      <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
@@ -80,14 +80,13 @@ SOFTWARE.
     </xsl:variable>
     <xsl:value-of select="$name"/>
   </xsl:function>
-  <!-- This is the strange function -->
   <xsl:function name="eo:vars">
     <xsl:param name="bottom" as="element()"/>
     <xsl:param name="top" as="element()"/>
     <xsl:for-each select="$bottom/ancestor::o">
-      <xsl:variable name="a" select="."/>
-      <xsl:if test="$top/descendant-or-self::o[generate-id() = generate-id($a)]">
-        <xsl:for-each select="$a/o[@name and generate-id() != generate-id($bottom)]">
+      <xsl:variable name="current-ancestor" select="."/>
+      <xsl:if test="$top/descendant-or-self::o[generate-id() = generate-id($current-ancestor)]">
+        <xsl:for-each select="$current-ancestor/o[@name and generate-id() != generate-id($bottom)]">
           <xsl:variable name="o" select="."/>
           <xsl:if test="not($bottom/ancestor-or-self::o[generate-id() = generate-id($o)])">
             <xsl:copy-of select="$o"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
@@ -14,6 +14,7 @@ tests:
   # 'another$t0$second' object
   - //o[@name='another$t0$second' and count(o)=1]
   - //o[@name='another$t0$second']/o[@base='2' and @name='@']
+skip: true
 # Currently the test converts the code from the snippet to:
 # ____
 #

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
@@ -14,7 +14,6 @@ tests:
   # 'another$t0$second' object
   - //o[@name='another$t0$second' and count(o)=1]
   - //o[@name='another$t0$second']/o[@base='2' and @name='@']
-skip: true
 # Currently the test converts the code from the snippet to:
 # ____
 #


### PR DESCRIPTION
Small refactoring of `abstracts-float-up.xsl` transformation:
1. Remove redundant code
2. Fix grammar mistakes in comments
3. Reorder some templates

Related to #2141 