### PR TITLE
#1602 Adding grammar for object versioning

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
@@ -131,6 +131,9 @@ scope
 application
   :
   head
+  version
+  |
+  head
   htail?
   |
   application
@@ -212,6 +215,12 @@ head
   )
   ;
 
+version
+  :
+  BAR
+  VERSION
+  ;
+
 has
   :
   COLON
@@ -266,6 +275,7 @@ RB: ')';
 AT: '@';
 RHO: '^';
 HASH: '#';
+BAR: '|';
 
 fragment INDENT:
     SPACE SPACE
@@ -315,6 +325,7 @@ FLOAT: (PLUS | MINUS)? [0-9]+ DOT [0-9]+ EXPONENT?;
 HEX: '0x' [0-9a-fA-F]+;
 
 NAME: [a-z][\p{Letter}\p{General_Category=Decimal_Number}_-]*;
+VERSION: [0-9]+ DOT [0-9]+ DOT [0-9]+;
 
 fragment TEXT_MARK: '"""';
 TEXT:

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -375,7 +375,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterVersion(ProgramParser.VersionContext ctx) {
+    public void enterVersion(final ProgramParser.VersionContext ctx) {
         this.objects.enter();
         if (ctx.VERSION() != null) {
             this.objects.prop("version", ctx.VERSION().getText());
@@ -383,7 +383,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     }
 
     @Override
-    public void exitVersion(ProgramParser.VersionContext ctx) {
+    public void exitVersion(final ProgramParser.VersionContext ctx) {
         this.objects.leave();
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -375,6 +375,19 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     }
 
     @Override
+    public void enterVersion(ProgramParser.VersionContext ctx) {
+        this.objects.enter();
+        if (ctx.VERSION() != null) {
+            this.objects.prop("version", ctx.VERSION().getText());
+        }
+    }
+
+    @Override
+    public void exitVersion(ProgramParser.VersionContext ctx) {
+        this.objects.leave();
+    }
+
+    @Override
     public void enterHas(final ProgramParser.HasContext ctx) {
         this.objects.enter();
         final String has;

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -48,7 +48,7 @@ import org.xembly.Directives;
  * @checkstyle CyclomaticComplexityCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals", "PMD.ExcessivePublicCount"})
 public final class XeListener implements ProgramListener, Iterable<Directive> {
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
@@ -1,0 +1,16 @@
+xsls: []
+tests:
+  - //o[@base='func0' and @version='3.4.5' and @name='x']
+  - //o[@base='func1' and @version='1.2.3']
+  - //o[@base='func2' and not(@version)]
+  - //o[@base='func3' and @version='3.2.1']
+  - //o[@base='func4' and @version='10.20.30']
+eo: |
+  [] > main
+    func0|3.4.5 > x
+    func1|1.2.3
+      1
+    func2 2
+    func3|3.2.1
+    .method
+      func4|10.20.30

--- a/eo-parser/src/test/resources/org/eolang/parser/typos/version-with-inline-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/typos/version-with-inline-application.yaml
@@ -1,0 +1,4 @@
+line: 2
+eo: |
+  [args] > app
+    stdout|1.2.3 42


### PR DESCRIPTION
Ref: #1602

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `version` keyword to EO language and improves the EO parser. 

### Detailed summary
- Added `version` keyword to the EO language
- Improved EO parser to support the new `version` keyword
- Updated tests to include new syntax
- Minor code refactoring in `XeListener` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->