### PR TITLE
Tagged binarizesWithoutErrors test as "Slow"

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -253,7 +253,7 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludedGroups>Slow</excludedGroups>
+          <excludedGroups>slow</excludedGroups>
           <argLine>@{argLine} -Xss${stack-size}</argLine>
           <systemPropertyVariables>
             <runtime.jar>${org.eolang:eo-runtime:jar}</runtime.jar>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -253,6 +253,7 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <excludedGroups>Slow</excludedGroups>
           <argLine>@{argLine} -Xss${stack-size}</argLine>
           <systemPropertyVariables>
             <runtime.jar>${org.eolang:eo-runtime:jar}</runtime.jar>
@@ -441,6 +442,13 @@ SOFTWARE.
                 <exclude>xml:/src/test/resources/META-INF/maven/plugin.xml
                 </exclude>
               </excludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludedGroups>""</excludedGroups>
             </configuration>
           </plugin>
           <plugin>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -448,7 +448,7 @@ SOFTWARE.
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludedGroups>""</excludedGroups>
+              <excludedGroups>nothing-to-exclude</excludedGroups>
             </configuration>
           </plugin>
           <plugin>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,6 +45,7 @@ final class BinarizeMojoTest {
      * @throws Exception If fails.
      */
     @Test
+    @Tag("Slow")
     @ExtendWith(CargoCondition.class)
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -45,7 +45,7 @@ final class BinarizeMojoTest {
      * @throws Exception If fails.
      */
     @Test
-    @Tag("Slow")
+    @Tag("slow")
     @ExtendWith(CargoCondition.class)
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;


### PR DESCRIPTION
Closes: #2091

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a JUnit tag and configures the `maven-surefire-plugin` to exclude slow tests. 

### Detailed summary
- Added `@Tag("slow")` to `BinarizeMojoTest`
- Configured `maven-surefire-plugin` to exclude slow tests in `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->