### PR TITLE
2157 Vertices

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -251,7 +251,7 @@ public interface Data<T> {
         public Value(final T value) {
             super(Phi.Φ);
             this.val = value;
-            this.vertex = PhDefault.VTX.get().best(value);
+            this.vertex = PhDefault.VTX.best(value);
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -50,7 +50,7 @@ public abstract class PhDefault implements Phi, Cloneable {
     /**
      * Vertices.
      */
-    protected static final ThreadLocal<Vertices> VTX = ThreadLocal.withInitial(Vertices::new);
+    protected static final Vertices VTX = new Vertices();
 
     /**
      * Logger.
@@ -107,7 +107,7 @@ public abstract class PhDefault implements Phi, Cloneable {
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public PhDefault(final Phi sigma) {
-        this.vertex = PhDefault.VTX.get().next();
+        this.vertex = PhDefault.VTX.next();
         this.attrs = new HashMap<>(0);
         this.order = new ArrayList<>(0);
         this.add("ρ", new AtSimple(sigma));
@@ -179,7 +179,7 @@ public abstract class PhDefault implements Phi, Cloneable {
     public final Phi copy() {
         try {
             final PhDefault copy = (PhDefault) this.clone();
-            copy.vertex = PhDefault.VTX.get().next();
+            copy.vertex = PhDefault.VTX.next();
             copy.cached = new CachedPhi();
             final Map<String, Attr> map = new HashMap<>(this.attrs.size());
             for (final Map.Entry<String, Attr> ent : this.attrs.entrySet()) {

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -71,7 +71,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    public void phiAreUniqueInDynamic() {
+    public void createsDifferentPhiInParallel() {
         final int threads = 1500;
         final Set<PhDefault> objects = ConcurrentHashMap.newKeySet();
         new Threads<>(

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -71,7 +71,7 @@ final class PhDefaultTest {
 
     @Test
     void createsDifferentPhiInParallel() {
-        final int threads = 1500;
+        final int threads = 100;
         final Set<PhDefault> objects = ConcurrentHashMap.newKeySet();
         new Threads<>(
             threads,
@@ -80,8 +80,8 @@ final class PhDefaultTest {
             ).limit(threads).collect(Collectors.toList())
         ).forEach(objects::add);
         MatcherAssert.assertThat(
-            objects.size(),
-            Matchers.equalTo(threads)
+            objects,
+            Matchers.hasSize(threads)
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -26,17 +26,16 @@ package org.eolang;
 import EOorg.EOeolang.EOstring;
 import EOorg.EOeolang.EOstring$EOlength;
 import EOorg.EOeolang.EOtxt.EOsprintf;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.Scalar;
 import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Test case for {@link PhDefault}.
@@ -71,13 +70,13 @@ final class PhDefaultTest {
     }
 
     @Test
-    public void createsDifferentPhiInParallel() {
+    void createsDifferentPhiInParallel() {
         final int threads = 1500;
         final Set<PhDefault> objects = ConcurrentHashMap.newKeySet();
         new Threads<>(
             threads,
             Stream.generate(
-                () -> (Scalar<PhDefault>) () -> (new EOstring$EOlength(Phi.Φ))
+                () -> (Scalar<PhDefault>) () -> new EOstring$EOlength(Phi.Φ)
             ).limit(threads).collect(Collectors.toList())
         ).forEach(objects::add);
         MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -24,11 +24,19 @@
 package org.eolang;
 
 import EOorg.EOeolang.EOstring;
+import EOorg.EOeolang.EOstring$EOlength;
 import EOorg.EOeolang.EOtxt.EOsprintf;
+import org.cactoos.Scalar;
+import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Test case for {@link PhDefault}.
@@ -59,6 +67,22 @@ final class PhDefaultTest {
         MatcherAssert.assertThat(
             new Dataized(phi.attr("ν").get()).take(Long.class),
             Matchers.greaterThan(0L)
+        );
+    }
+
+    @Test
+    public void phiUniqueHashesInDynamic() {
+        final int threads = 1500;
+        final Set<PhDefault> hashes = ConcurrentHashMap.newKeySet();
+        new Threads<>(
+            threads,
+            Stream.generate(
+                () -> (Scalar<PhDefault>) () -> (new EOstring$EOlength(Phi.Φ))
+            ).limit(threads).collect(Collectors.toList())
+        ).forEach(hashes::add);
+        MatcherAssert.assertThat(
+            hashes.size(),
+            Matchers.equalTo(threads)
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -71,17 +71,17 @@ final class PhDefaultTest {
     }
 
     @Test
-    public void phiUniqueHashesInDynamic() {
+    public void phiAreUniqueInDynamic() {
         final int threads = 1500;
-        final Set<PhDefault> hashes = ConcurrentHashMap.newKeySet();
+        final Set<PhDefault> objects = ConcurrentHashMap.newKeySet();
         new Threads<>(
             threads,
             Stream.generate(
                 () -> (Scalar<PhDefault>) () -> (new EOstring$EOlength(Phi.Φ))
             ).limit(threads).collect(Collectors.toList())
-        ).forEach(hashes::add);
+        ).forEach(objects::add);
         MatcherAssert.assertThat(
-            hashes.size(),
+            objects.size(),
             Matchers.equalTo(threads)
         );
     }


### PR DESCRIPTION
Closes: #2157

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the performance of the EO language by replacing ThreadLocal with a ConcurrentHashMap to allow parallelism. 

### Detailed summary
- Replaced ThreadLocal with ConcurrentHashMap to allow parallelism.
- Updated PhDefault and Data classes to use the new ConcurrentHashMap.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->