### PR TITLE
feat(#2141): Redundant objects

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
@@ -83,13 +83,13 @@ SOFTWARE.
   <xsl:function name="eo:vars">
     <xsl:param name="bottom" as="element()"/>
     <xsl:param name="top" as="element()"/>
-    <xsl:for-each select="$bottom/ancestor::o">
+    <xsl:for-each select="$bottom/ancestor::o[eo:abstract(.)]">
       <xsl:variable name="current-ancestor" select="."/>
       <xsl:if test="$top/descendant-or-self::o[generate-id() = generate-id($current-ancestor)]">
         <xsl:for-each select="$current-ancestor/o[@name and generate-id() != generate-id($bottom)]">
-          <xsl:variable name="o" select="."/>
-          <xsl:if test="not($bottom/ancestor-or-self::o[generate-id() = generate-id($o)])">
-            <xsl:copy-of select="$o"/>
+          <xsl:variable name="copied" select="."/>
+          <xsl:if test="not($bottom/ancestor-or-self::o[generate-id() = generate-id($copied)])">
+            <xsl:copy-of select="$copied"/>
           </xsl:if>
         </xsl:for-each>
       </xsl:if>
@@ -120,8 +120,8 @@ SOFTWARE.
       </xsl:attribute>
       <xsl:variable name="ancestors" select="ancestor-or-self::o[eo:abstract(.)]"/>
       <xsl:for-each select="1 to count($ancestors) - 1">
-        <xsl:variable name="level" select="position()"/>
-        <xsl:for-each select="eo:vars($ancestors[count($ancestors) - $level + 1], $ancestors[count($ancestors) - $level])">
+        <xsl:variable name="index" select="position()"/>
+        <xsl:for-each select="eo:vars($ancestors[count($ancestors) - $index + 1], $ancestors[count($ancestors) - $index])">
           <xsl:element name="o">
             <xsl:attribute name="as">
               <xsl:value-of select="@name"/>
@@ -130,7 +130,7 @@ SOFTWARE.
               <xsl:value-of select="@name"/>
             </xsl:attribute>
             <xsl:attribute name="level">
-              <xsl:value-of select="$level"/>
+              <xsl:value-of select="$index"/>
             </xsl:attribute>
           </xsl:element>
         </xsl:for-each>
@@ -159,14 +159,14 @@ SOFTWARE.
       </xsl:if>
       <xsl:apply-templates select="node()|@* except @name"/>
       <xsl:for-each select="1 to count($ancestors) - 1">
-        <xsl:variable name="level" select="position()"/>
-        <xsl:for-each select="eo:vars($ancestors[count($ancestors) - $level + 1], $ancestors[count($ancestors) - $level])">
+        <xsl:variable name="index" select="position()"/>
+        <xsl:for-each select="eo:vars($ancestors[count($ancestors) - $index + 1], $ancestors[count($ancestors) - $index])">
           <xsl:element name="o">
             <xsl:attribute name="name">
               <xsl:value-of select="@name"/>
             </xsl:attribute>
             <xsl:attribute name="level">
-              <xsl:value-of select="$level"/>
+              <xsl:value-of select="$index"/>
             </xsl:attribute>
             <xsl:attribute name="line">
               <xsl:value-of select="$o/@line"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/not-redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/not-redundant-levels.yaml
@@ -7,7 +7,6 @@ tests:
   - //o[@name='first']
   - //o[@name='first']/o[@base='first$second' and @name='second']
   - //o[@name='first']/o[@base='first$second' and @name='second']/o[@base='arg']
-  - //o[@name='first']/o[@base='first$second' and @name='second']/o[@base='arg']
   # 'first$second' object
   - //o[@name='first$second']
   - //o[@name='first$second']/o[@name='arg']
@@ -23,6 +22,6 @@ tests:
 #   arg.method > a
 # ____
 eo: |
-  [arg] > first
+  [arg arg2] > first
     [] > second
       arg.method > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/not-redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/not-redundant-levels.yaml
@@ -22,6 +22,6 @@ tests:
 #   arg.method > a
 # ____
 eo: |
-  [arg arg2] > first
+  [arg] > first
     [] > second
       arg.method > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
@@ -17,28 +17,6 @@ tests:
 skip: false
 # Currently the test converts the code from the snippet to:
 # ____
-#
-# [] > another
-#   eq. > @
-#     another$t0$first > first
-#       second
-#     another$t0$second > second
-#       first
-#
-# [second] > another$t0$first
-#   1 > @
-#
-# [first] > another$t0$second
-#   2 > @
-# ____
-# Which actually looks strange.
-
-# @todo #2131:90min Remove redundant objects and levels.
-#  It's better to remove redundant objects from the result code snippet.
-#  They create some problems in the future transformations.
-#  When the transformation is fixed we can enable the test.
-#  The test should convert the code from the snippet to the next:
-# ____
 # [] > another
 #   eq. > @
 #     another$t0$first > first

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
@@ -5,16 +5,16 @@ tests:
   - /program/errors[count(*)=0]
   # 'another' object
   - //o[@name='another']
-  - //o[@name='another']/o[@base='eq.' and @name='@']
-  - //o[@name='another']/o[@base='eq.' and @name='@']/o[@base='another$t0$first' and @name='first']
-  - //o[@name='another']/o[@base='eq.' and @name='@']/o[@base='another$t0$second' and @name='second']
+  - //o[@name='another']/o[@base='.eq' and @name='@']
+  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$first' and @name='first']
+  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$second' and @name='second']
   # 'another$t0$first' object
   - //o[@name='another$t0$first' and count(o)=1]
-  - //o[@name='another$t0$first']/o[@base='1' and @name='@']
+  - //o[@name='another$t0$first']/o[@base='int' and @name='@']
   # 'another$t0$second' object
   - //o[@name='another$t0$second' and count(o)=1]
-  - //o[@name='another$t0$second']/o[@base='2' and @name='@']
-skip: true
+  - //o[@name='another$t0$second']/o[@base='int' and @name='@']
+skip: false
 # Currently the test converts the code from the snippet to:
 # ____
 #

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels.yaml
@@ -14,7 +14,6 @@ tests:
   # 'another$t0$second' object
   - //o[@name='another$t0$second' and count(o)=1]
   - //o[@name='another$t0$second']/o[@base='int' and @name='@']
-skip: false
 # Currently the test converts the code from the snippet to:
 # ____
 # [] > another


### PR DESCRIPTION
Fix bug with creating redundant arguments for objects that float up.

Closes: #2141 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes redundant objects and levels, and optimizes XSLT templates. 

### Detailed summary
- Removed redundant objects from `redundant-levels.yaml` and `not-redundant-levels.yaml` test files.
- Optimized `abstracts-float-up.xsl` template.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->