### PR TITLE
feat(#2126):  abstracts-float-up.xsl and remove-levels.xsl still have problems

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
@@ -60,7 +60,7 @@ xsls:
 #  line and pos attributes.
 #  Processing terminated by xsl:message at line 358 in to-java.xsl
 #  When we fix the problem, we have to enable the following test.
-skip: false
+skip: true
 tests:
   - /program/errors[count(*)=0]
 eo: |

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
@@ -60,7 +60,7 @@ xsls:
 #  line and pos attributes.
 #  Processing terminated by xsl:message at line 358 in to-java.xsl
 #  When we fix the problem, we have to enable the following test.
-skip: true
+skip: false
 tests:
   - /program/errors[count(*)=0]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
@@ -3,17 +3,18 @@ xsls:
   - /org/eolang/parser/optimize/remove-levels.xsl
 tests:
   - /program/errors[count(*)=0]
-  # 'another' object
-  - //o[@name='another']
-  - //o[@name='another']/o[@base='.eq' and @name='@']
-  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$first' and @name='first']
-  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$second' and @name='second']
-  # 'another$t0$first' object
-  - //o[@name='another$t0$first' and count(o)=1]
-  - //o[@name='another$t0$first']/o[@base='int' and @name='@']
-  # 'another$t0$second' object
-  - //o[@name='another$t0$second' and count(o)=1]
-  - //o[@name='another$t0$second']/o[@base='int' and @name='@']
+  # 'main' object
+  - //o[@name='main']
+  - //o[@name='main']/o[@base='sibling' and @name='@']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$first' and @name='first' and count(o)=0]
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$second' and @name='second' and count(o)=0]
+  # 'main$t1$first' object
+  - //o[@name='main$t1$first' and count(o)=1]
+  - //o[@name='main$t1$first']/o[@base='int' and @name='@']
+  # 'main$t1$second' object
+  - //o[@name='main$t1$second' and count(o)=1]
+  - //o[@name='main$t1$second']/o[@base='int' and @name='@']
 # Currently the test converts the code from the snippet to:
 # ____
 # [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
@@ -1,0 +1,41 @@
+xsls:
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+tests:
+  - /program/errors[count(*)=0]
+  # 'another' object
+  - //o[@name='another']
+  - //o[@name='another']/o[@base='.eq' and @name='@']
+  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$first' and @name='first']
+  - //o[@name='another']/o[@base='.eq' and @name='@']/o[@base='another$t0$second' and @name='second']
+  # 'another$t0$first' object
+  - //o[@name='another$t0$first' and count(o)=1]
+  - //o[@name='another$t0$first']/o[@base='int' and @name='@']
+  # 'another$t0$second' object
+  - //o[@name='another$t0$second' and count(o)=1]
+  - //o[@name='another$t0$second']/o[@base='int' and @name='@']
+# Currently the test converts the code from the snippet to:
+# ____
+# [] > main
+#   sibling > @
+#   eq. > sibling
+#     main$t1$first > first
+#       @   <-------------------- What is this?
+#     main$t1$second > second
+#       @   <-------------------- What is this?
+#
+# [] > main$t1$first
+#   1 > @
+#
+# [] > main$t1$second
+#   2 > @
+# ____
+
+eo: |
+  [] > main
+    sibling > @
+    eq. > sibling
+      [] > first
+        1 > @
+      [] > second
+        2 > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
@@ -31,6 +31,12 @@ tests:
 # [] > main$t1$second
 #   2 > @
 # ____
+# @todo #2126:90min Fix problem with redundant objects.
+#  Enabling synthetic-attributes-with-to-java.yaml test case still fails.
+#  The possible reason is the wrong behaviour of abstracts-float-up.xsl
+#  or remove-levels.xsl transformations. As you can see from the comment above
+#  - we have strange argument @ that passes into main$t1$first and
+#  main$t1$second objects which is considered wrong and can cause some problems.
 
 eo: |
   [] > main


### PR DESCRIPTION
Add test that emphasises the problem with  `abstracts-float-up.xsl` and `remove-levels.xsl` transformations.
I was trying to enable `synthetic-attributes-with-to-java.yaml` test, but it still fails, so it is the possible cause of the error.

Related to #2126 