### PR TITLE
eo-runtime version in eo-maven-plugin was up to 0.29.5

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -38,7 +38,7 @@ SOFTWARE.
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
       <!-- This version is intentionally lower than the current version of the project -->
-      <version>0.29.3</version>
+      <version>0.29.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -113,7 +113,7 @@ final class SnippetTest {
             Matchers.allOf(
                 new Mapped<>(
                     ptn -> Matchers.matchesPattern(
-                        Pattern.compile(ptn, Pattern.DOTALL)
+                        Pattern.compile(ptn, Pattern.DOTALL | Pattern.MULTILINE)
                     ),
                     (Iterable<String>) map.get("out")
                 )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SnippetTest.java
@@ -113,7 +113,7 @@ final class SnippetTest {
             Matchers.allOf(
                 new Mapped<>(
                     ptn -> Matchers.matchesPattern(
-                        Pattern.compile(ptn, Pattern.DOTALL | Pattern.MULTILINE)
+                        Pattern.compile(ptn, Pattern.DOTALL)
                     ),
                     (Iterable<String>) map.get("out")
                 )

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/snippets/fibo.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/snippets/fibo.yaml
@@ -1,7 +1,7 @@
 exit: 0
 in: ""
 out:
-  - "\n---\ntrue\n"
+  - ".*true.*"
 args: [ "main" ]
 eo: |
   [args...] > main

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/snippets/fibo.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/snippets/fibo.yaml
@@ -1,7 +1,7 @@
 exit: 0
 in: ""
 out:
-  - ""
+  - "\n---\ntrue\n"
 args: [ "main" ]
 eo: |
   [args...] > main

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -39,7 +39,6 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Bridge between Java CLI and EO.
@@ -195,9 +194,7 @@ public final class Main {
         }
         Main.LOGGER.info(
             String.format(
-                "%s---%s%s",
-                System.lineSeparator(),
-                System.lineSeparator(),
+                "%n---%n%s",
                 new Dataized(app).take().toString()
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -195,7 +195,9 @@ public final class Main {
         }
         Main.LOGGER.info(
             String.format(
-                "%n---%n%s",
+                "%s---%s%s",
+                System.lineSeparator(),
+                System.lineSeparator(),
                 new Dataized(app).take().toString()
             )
         );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the eo-runtime version and makes changes to `fibo.yaml` and `Main.java` files.

### Detailed summary
- Updated `eo-runtime` version from `0.29.3` to `0.29.5`.
- In `fibo.yaml` file, changed the expected output by adding a regex pattern `".*true.*"`.
- In `eo-runtime/src/main/java/org/eolang/Main.java` file, removed unused import statement for `java.util.stream.Collectors`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->