### PR TITLE
feat(#2175): Add more tests for abstracts-float-up and fix the bug

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/optimize/abstracts-float-up.xsl
@@ -88,7 +88,7 @@ SOFTWARE.
       <xsl:if test="$top/descendant-or-self::o[generate-id() = generate-id($current-ancestor)]">
         <xsl:for-each select="$current-ancestor/o[@name and generate-id() != generate-id($bottom)]">
           <xsl:variable name="copied" select="."/>
-          <xsl:if test="not($bottom/ancestor-or-self::o[generate-id() = generate-id($copied)])">
+          <xsl:if test="not($bottom/ancestor-or-self::o[generate-id() = generate-id($copied)]) and $bottom/descendant::o[@base=$copied/@name]">
             <xsl:copy-of select="$copied"/>
           </xsl:if>
         </xsl:for-each>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-abstract-parents.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-abstract-parents.yaml
@@ -1,0 +1,55 @@
+xsls:
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+tests:
+  - /program/errors[count(*)=0]
+  # 'main' object
+  - //o[@name='main']
+  - //o[@name='main']/o[@base='sibling' and @name='@']
+  - //o[@name='main']/o[not(@base) and @name='arg']
+  - //o[@name='main']/o[@base='main$sibling' and @name='sibling']
+  - //o[@name='main']/o[@base='main$sibling' and @name='sibling']/o[@base='arg' and not(@name)]
+  # 'main$sibling' object
+  - //o[@name='main$sibling' and count(o)=3]
+  - //o[@name='main$sibling']/o[not(@base) and @name='arg']
+  - //o[@name='main$sibling']/o[@base='main$sibling$first' and @name='first']
+  - //o[@name='main$sibling']/o[@base='main$sibling$first' and @name='first']/o[@base='arg' and not(@name)]
+  - //o[@name='main$sibling']/o[@base='main$sibling$second' and @name='second']
+  - //o[@name='main$sibling']/o[@base='main$sibling$second' and @name='second']/o[@base='arg' and not(@name)]
+  # 'main$sibling$first' object
+  - //o[@name='main$sibling$first' and count(o)=3]
+  - //o[@name='main$sibling$first']/o[@base='arg' and not(@name)]
+  - //o[@name='main$sibling$first']/o[@base='.one' and @name='@']
+  - //o[@name='main$sibling$first']/o[not(@base) and @name='arg']
+  # 'main$sibling$second' object
+  - //o[@name='main$sibling$second' and count(o)=3]
+  - //o[@name='main$sibling$second']/o[@base='arg' and not(@name)]
+  - //o[@name='main$sibling$second']/o[@base='.two' and @name='@']
+  - //o[@name='main$sibling$second']/o[not(@base) and @name='arg']
+# Currently the test converts the code from the snippet to:
+# ____
+# [arg] > main
+#   sibling > @
+#   main$sibling > sibling
+#     arg
+#
+# [arg] > main$sibling
+#   main$sibling$first > first
+#     arg
+#   main$sibling$second > second
+#     arg
+#
+# [arg] > main$sibling$first
+#   arg.one > @
+#
+# [] > main$sibling$second
+#   arg.two > @
+# ____
+eo: |
+  [arg] > main
+    sibling > @
+    [] > sibling
+      [] > first
+        arg.one > @
+      [] > second
+        arg.two > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-siblings.yaml
@@ -1,0 +1,45 @@
+xsls:
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+tests:
+  - /program/errors[count(*)=0]
+  # 'main' object
+  - //o[@name='main']
+  - //o[@name='main']/o[@base='sibling' and @name='@']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t2$first' and @name='first' and count(o)=1]
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t2$second' and @name='second' and count(o)=1]
+  # 'main$t1$first' object
+  - //o[@name='main$t2$first' and count(o)=3]
+  - //o[@name='main$t2$first']/o[@base='arg' and not(@name)]
+  - //o[@name='main$t2$first']/o[@base='.one' and @name='@']
+  - //o[@name='main$t2$first']/o[not(@base) and @name='arg']
+  # 'main$t1$second' object
+  - //o[@name='main$t2$second' and count(o)=3]
+  - //o[@name='main$t2$second']/o[@base='arg' and not(@name)]
+  - //o[@name='main$t2$second']/o[@base='.two' and @name='@']
+  - //o[@name='main$t2$first']/o[not(@base) and @name='arg']
+# Currently the test converts the code from the snippet to:
+# ____
+# [arg] > main
+#   sibling > @
+#   eq. > sibling
+#     main$t2$first > first
+#       arg
+#     main$t2$second > second
+#       arg
+#
+# [arg] > main$t2$first
+#   arg.one > @
+#
+# [] > main$t2$second
+#   arg.two > @
+# ____
+eo: |
+  [arg] > main
+    sibling > @
+    eq. > sibling
+      [] > first
+        arg.one > @
+      [] > second
+        arg.two > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arguments-and-siblings.yaml
@@ -9,16 +9,16 @@ tests:
   - //o[@name='main']/o[@base='.eq' and @name='sibling']
   - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t2$first' and @name='first' and count(o)=1]
   - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t2$second' and @name='second' and count(o)=1]
-  # 'main$t1$first' object
+  # 'main$t2$first' object
   - //o[@name='main$t2$first' and count(o)=3]
   - //o[@name='main$t2$first']/o[@base='arg' and not(@name)]
   - //o[@name='main$t2$first']/o[@base='.one' and @name='@']
   - //o[@name='main$t2$first']/o[not(@base) and @name='arg']
-  # 'main$t1$second' object
+  # 'main$t2$second' object
   - //o[@name='main$t2$second' and count(o)=3]
   - //o[@name='main$t2$second']/o[@base='arg' and not(@name)]
   - //o[@name='main$t2$second']/o[@base='.two' and @name='@']
-  - //o[@name='main$t2$first']/o[not(@base) and @name='arg']
+  - //o[@name='main$t2$second']/o[not(@base) and @name='arg']
 # Currently the test converts the code from the snippet to:
 # ____
 # [arg] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
@@ -21,9 +21,7 @@ tests:
 #   sibling > @
 #   eq. > sibling
 #     main$t1$first > first
-#       @   <-------------------- What is this?
 #     main$t1$second > second
-#       @   <-------------------- What is this?
 #
 # [] > main$t1$first
 #   1 > @
@@ -31,13 +29,6 @@ tests:
 # [] > main$t1$second
 #   2 > @
 # ____
-# @todo #2126:90min Fix problem with redundant objects.
-#  Enabling synthetic-attributes-with-to-java.yaml test case still fails.
-#  The possible reason is the wrong behaviour of abstracts-float-up.xsl
-#  or remove-levels.xsl transformations. As you can see from the comment above
-#  - we have strange argument @ that passes into main$t1$first and
-#  main$t1$second objects which is considered wrong and can cause some problems.
-skip: false
 eo: |
   [] > main
     sibling > @

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-siblings.yaml
@@ -37,7 +37,7 @@ tests:
 #  or remove-levels.xsl transformations. As you can see from the comment above
 #  - we have strange argument @ that passes into main$t1$first and
 #  main$t1$second objects which is considered wrong and can cause some problems.
-skip: true
+skip: false
 eo: |
   [] > main
     sibling > @


### PR DESCRIPTION
Add more tests for `abstracts-float-up.xsl` and fix the bug with redundant arguments.

Closes: #2175 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the EO parser by fixing a problem with redundant objects. It introduces changes to the `abstracts-float-up.xsl` and `remove-levels.xsl` transformations, and includes improvements to the corresponding test cases.

### Detailed summary
- Fix problem with redundant objects
- Update `abstracts-float-up.xsl` and `remove-levels.xsl` transformations
- Improve test cases for `redundant-levels-with-siblings.yaml`, `redundant-levels-with-arguments-and-siblings.yaml`, and `redundant-levels-with-arguments-and-abstract-parents.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->