### PR TITLE
#2161 Enabling "sparse decoration" transformation

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -280,7 +280,7 @@ final class OptimizeMojoTest {
                     .result()
                     .get(
                         String.format(
-                            "target/%s/foo/x/main/25-duplicate-names.xml",
+                            "target/%s/foo/x/main/26-duplicate-names.xml",
                             OptimizeMojo.STEPS
                         )
                     )

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -64,12 +64,6 @@ public final class ParsingTrain extends TrEnvelope {
      *  When the problem is fixed, we should enable synthetic-references.xsl transformation
      *  by adding it to the SHEETS array between remove-aliases.xsl and add-default-package.xsl
      *  transformations.
-     *
-     * @todo #2109:30min Enable sparse-decoration.xsl transformation.
-     *  Currently sparse-decoration.xsl transformations is disabled because
-     *  it breaks some integration tests for unknown reason. Need to put
-     *  the transformation right before warnings/unsorted-metas.xsl
-     *  transformation and make sure build works.
      */
     private static final String[] SHEETS = {
         "/org/eolang/parser/errors/not-empty-atoms.xsl",

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -87,6 +87,7 @@ public final class ParsingTrain extends TrEnvelope {
         "/org/eolang/parser/add-probes.xsl",
         "/org/eolang/parser/vars-float-up.xsl",
         "/org/eolang/parser/add-refs.xsl",
+        "/org/eolang/parser/warnings/sparse-decoration.xsl",
         "/org/eolang/parser/warnings/unsorted-metas.xsl",
         "/org/eolang/parser/warnings/incorrect-architect.xsl",
         "/org/eolang/parser/warnings/incorrect-home.xsl",

--- a/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
@@ -27,7 +27,7 @@ SOFTWARE.
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="//o[@abstract and count(o)=1 and count(o[@name='@' and (@abstract or count(o)=0)])=1]">
+      <xsl:for-each select="//o[@abstract and count(o)=1 and count(o[@name='@' and not(@base='^') and (@abstract or count(o)=0)])=1]">
         <xsl:element name="error">
           <xsl:attribute name="check">
             <xsl:text>sparse-decoration</xsl:text>

--- a/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
@@ -38,7 +38,7 @@ SOFTWARE.
           <xsl:attribute name="severity">
             <xsl:text>warning</xsl:text>
           </xsl:attribute>
-          <xsl:text>Sparse decoration is not prohibited</xsl:text>
+          <xsl:text>Sparse decoration is prohibited</xsl:text>
         </xsl:element>
       </xsl:for-each>
     </xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/warnings/sparse-decoration.xsl
@@ -38,7 +38,7 @@ SOFTWARE.
           <xsl:attribute name="severity">
             <xsl:text>warning</xsl:text>
           </xsl:attribute>
-          <xsl:text>Sparse objects are prohibited</xsl:text>
+          <xsl:text>Sparse decoration is not prohibited</xsl:text>
         </xsl:element>
       </xsl:for-each>
     </xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-sparse-decoration.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-sparse-decoration.yaml
@@ -1,11 +1,12 @@
 xsls:
   - /org/eolang/parser/warnings/sparse-decoration.xsl
 tests:
-  - /program/errors[count(error[@severity='warning'])=4]
+  - /program/errors[count(error[@severity='warning'])=5]
   - /program/errors/error[@line='3']
   - /program/errors/error[@line='6']
   - /program/errors/error[@line='18']
   - /program/errors/error[@line='19']
+  - /program/errors/error[@line='27']
 eo: |
   5 > five
 
@@ -27,3 +28,17 @@ eo: |
   [] > decorates-abstract
     [] > @
       five > @
+
+  [] > decorates-parent
+    ^ > @
+
+  [] > try-example
+    try
+      []
+        5 > @
+      []
+        error "Error" > @
+      nop
+
+  [args...] > nop
+    TRUE > @

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -192,9 +192,6 @@
           nan
           ^
 
-  # Negation of $
-  positive-infinity > neg
-
   # Difference between $ and x
   [x...] > minus
     ^.as-bytes > neg-inf-as-bytes!

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -98,31 +98,30 @@
           is-nan-or-zero
             terms.at index > term!
           nan
-          []
-            if. > @
-              acc.gt 0.0
-              times-rec
-                *
-                  if.
-                    is-term-gt-zero term > term-gt-zero
-                    acc
-                    neg-inf
-                  index.plus 1 > next-index
-                  terms
-                infs
-                is-nan-or-zero
-                is-term-gt-zero
-              times-rec
-                *
-                  if.
-                    term-gt-zero
-                    acc
-                    pos-inf
-                  next-index
-                  terms
-                infs
-                is-nan-or-zero
-                is-term-gt-zero
+          if.
+            acc.gt 0.0
+            times-rec
+              *
+                if.
+                  is-term-gt-zero term > term-gt-zero
+                  acc
+                  neg-inf
+                index.plus 1 > next-index
+                terms
+              infs
+              is-nan-or-zero
+              is-term-gt-zero
+            times-rec
+              *
+                if.
+                  term-gt-zero
+                  acc
+                  pos-inf
+                next-index
+                terms
+              infs
+              is-nan-or-zero
+              is-term-gt-zero
 
     if. > @
       eq.
@@ -194,8 +193,7 @@
           ^
 
   # Negation of $
-  [] > neg
-    positive-infinity > @
+  positive-infinity > neg
 
   # Difference between $ and x
   [x...] > minus
@@ -285,31 +283,30 @@
           is-nan-or-infinite
             terms.at index > term!
           nan
-          []
-            if. > @
-              acc.gt 0.0
-              div-rec
-                *
-                  if.
-                    is-term-gte-zero term > term-gte-zero
-                    acc
-                    neg-inf
-                  index.plus 1 > next-index
-                  terms
-                infs
-                is-nan-or-infinite
-                is-term-gte-zero
-              div-rec
-                *
-                  if.
-                    term-gte-zero
-                    acc
-                    pos-inf
-                  next-index
-                  terms
-                infs
-                is-nan-or-infinite
-                is-term-gte-zero
+          if.
+            acc.gt 0.0
+            div-rec
+              *
+                if.
+                  is-term-gte-zero term > term-gte-zero
+                  acc
+                  neg-inf
+                index.plus 1 > next-index
+                terms
+              infs
+              is-nan-or-infinite
+              is-term-gte-zero
+            div-rec
+              *
+                if.
+                  term-gte-zero
+                  acc
+                  pos-inf
+                next-index
+                terms
+              infs
+              is-nan-or-infinite
+              is-term-gte-zero
 
     if. > @
       eq.

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -98,31 +98,30 @@
           is-nan-or-zero
             terms.at index > term!
           nan
-          []
-            if. > @
-              acc.gt 0.0
-              times-rec
-                *
-                  if.
-                    is-term-gt-zero term > term-gt-zero
-                    acc
-                    neg-inf
-                  index.plus 1 > next-index
-                  terms
-                infs
-                is-nan-or-zero
-                is-term-gt-zero
-              times-rec
-                *
-                  if.
-                    term-gt-zero
-                    acc
-                    pos-inf
-                  next-index
-                  terms
-                infs
-                is-nan-or-zero
-                is-term-gt-zero
+          if.
+            acc.gt 0.0
+            times-rec
+              *
+                if.
+                  is-term-gt-zero term > term-gt-zero
+                  acc
+                  neg-inf
+                index.plus 1 > next-index
+                terms
+              infs
+              is-nan-or-zero
+              is-term-gt-zero
+            times-rec
+              *
+                if.
+                  term-gt-zero
+                  acc
+                  pos-inf
+                next-index
+                terms
+              infs
+              is-nan-or-zero
+              is-term-gt-zero
 
     if. > @
       eq.
@@ -194,8 +193,7 @@
           ^
 
   # Negation of $
-  [] > neg
-    negative-infinity > @
+  negative-infinity > neg
 
   # Difference between $ and x
   [x...] > minus
@@ -285,31 +283,30 @@
           is-nan-or-infinite
             terms.at index > term!
           nan
-          []
-            if. > @
-              acc.gt 0.0
-              div-rec
-                *
-                  if.
-                    is-term-gte-zero term > term-gte-zero
-                    acc
-                    neg-inf
-                  index.plus 1 > next-index
-                  terms
-                infs
-                is-nan-or-infinite
-                is-term-gte-zero
-              div-rec
-                *
-                  if.
-                    term-gte-zero
-                    acc
-                    pos-inf
-                  next-index
-                  terms
-                infs
-                is-nan-or-infinite
-                is-term-gte-zero
+          if.
+            acc.gt 0.0
+            div-rec
+              *
+                if.
+                  is-term-gte-zero term > term-gte-zero
+                  acc
+                  neg-inf
+                index.plus 1 > next-index
+                terms
+              infs
+              is-nan-or-infinite
+              is-term-gte-zero
+            div-rec
+              *
+                if.
+                  term-gte-zero
+                  acc
+                  pos-inf
+                next-index
+                terms
+              infs
+              is-nan-or-infinite
+              is-term-gte-zero
 
     if. > @
       eq.

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -192,9 +192,6 @@
           nan
           ^
 
-  # Negation of $
-  negative-infinity > neg
-
   # Difference between $ and x
   [x...] > minus
     ^.as-bytes > pos-inf-as-bytes!


### PR DESCRIPTION
Closes: #2109

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to the code in order to fix a bug related to duplicate names and sparse decoration warnings.

### Detailed summary:
- Changed the file path in `OptimizeMojoTest.java` from `25-duplicate-names.xml` to `26-duplicate-names.xml`.
- Updated the number of warnings in the `catches-sparse-decoration.yaml` file from 4 to 5.
- Added a new error at line 27 in the `catches-sparse-decoration.yaml` file.
- Made changes to the `sparse-decoration.xsl` file to update the error message from "Sparse objects are prohibited" to "Sparse decoration is prohibited".
- Added the `sparse-decoration.xsl` file to the `SHEETS` array in the `ParsingTrain.java` file.
- Made changes to the `negative-infinity.eo` and `positive-infinity.eo` files to update the formatting and structure of the code.
- Removed the `neg` object from the `negative-infinity.eo` file.
- Updated the comments in the `ParsingTrain.java` file to reflect the changes made to the code.
- Made changes to the `eo-runtime` files to update the formatting and structure of the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->