### PR TITLE
feat(#2126): Add more tests for `synthetic-references.xs` and `abstracts-float-up.xsl` transformations

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/converts-to-java-with-arrays-and-scopes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/converts-to-java-with-arrays-and-scopes.yaml
@@ -1,0 +1,73 @@
+# Current test shows optimization and transpilation chain for simple program.
+# The aim of this test is to check that entire pipeline with
+# synthetic-referenses.xsl transformation works as expected without creating
+# any warnings or errors.
+# Pay attention to synthetic-references.xsl and to-java.xsl transformations.
+xsls:
+  - /org/eolang/parser/errors/not-empty-atoms.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/errors/many-free-attributes.xsl
+  - /org/eolang/parser/errors/broken-aliases.xsl
+  - /org/eolang/parser/errors/duplicate-aliases.xsl
+  - /org/eolang/parser/errors/global-nonames.xsl
+  - /org/eolang/parser/errors/same-line-names.xsl
+  - /org/eolang/parser/errors/self-naming.xsl
+  - /org/eolang/parser/cti/cti-adds-errors.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/wrap-method-calls.xsl
+  - /org/eolang/parser/expand-qqs.xsl
+  - /org/eolang/parser/add-probes.xsl
+  - /org/eolang/parser/vars-float-up.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/parser/warnings/unsorted-metas.xsl
+  - /org/eolang/parser/warnings/incorrect-architect.xsl
+  - /org/eolang/parser/warnings/incorrect-home.xsl
+  - /org/eolang/parser/warnings/incorrect-version.xsl
+  - /org/eolang/parser/expand-aliases.xsl
+  - /org/eolang/parser/resolve-aliases.xsl
+  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/add-default-package.xsl
+  - /org/eolang/parser/errors/broken-refs.xsl
+  - /org/eolang/parser/errors/unknown-names.xsl
+  - /org/eolang/parser/errors/noname-attributes.xsl
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+  - /org/eolang/parser/warnings/duplicate-metas.xsl
+  - /org/eolang/parser/warnings/mandatory-package-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-home-meta.xsl
+  - /org/eolang/parser/warnings/mandatory-version-meta.xsl
+  - /org/eolang/parser/warnings/correct-package-meta.xsl
+  - /org/eolang/parser/errors/unused-aliases.xsl
+  - /org/eolang/parser/errors/data-objects.xsl
+  - /org/eolang/parser/warnings/unit-test-without-phi.xsl
+  - /org/eolang/parser/set-locators.xsl
+  - /org/eolang/parser/optimize/globals-to-abstracts.xsl
+  - /org/eolang/parser/optimize/remove-refs.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+  - /org/eolang/parser/add-refs.xsl
+  - /org/eolang/maven/pre/classes.xsl
+  - /org/eolang/maven/pre/package.xsl
+  - /org/eolang/maven/pre/tests.xsl
+  - /org/eolang/maven/pre/rename-tests-inners.xsl
+  - /org/eolang/maven/pre/attrs.xsl
+  - /org/eolang/maven/pre/varargs.xsl
+  - /org/eolang/maven/pre/data.xsl
+  - /org/eolang/maven/pre/to-java.xsl
+# @todo #2126:90min Found more than one target of object at the line.
+#  Processing terminated by xsl:message at line 358 in to-java.xsl
+#  When we fix the problem, we have to enable the following test.
+skip: true
+tests:
+  - /program/errors[count(*)=0]
+eo: |
+  +architect volodya.lombrozo@gmail.com
+  +home https://github.com/objectionary/eo
+  +tests
+  +package org.eolang
+  +version 0.0.0
+  
+  [] > main
+    * 0 (* 1 2) > arr
+    eq > @
+      * ((arr.at 1).at 1)
+      * 2

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
@@ -1,0 +1,98 @@
+xsls:
+  - /org/eolang/parser/wrap-method-calls.xsl
+  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/optimize/abstracts-float-up.xsl
+  - /org/eolang/parser/optimize/remove-levels.xsl
+tests:
+  - /program/errors[count(*)=0]
+  # 'main' object
+  - //o[@name='main']
+  - //o[@name='main']/o[@base='sibling' and @name='@']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$first' and @name='first' and count(o)=0]
+  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$second' and @name='second' and count(o)=0]
+  # 'main$t1$first' object
+  - //o[@name='main$t1$first' and count(o)=1]
+  - //o[@name='main$t1$first']/o[@base='int' and @name='@']
+  # 'main$t1$second' object
+  - //o[@name='main$t1$second' and count(o)=1]
+  - //o[@name='main$t1$second']/o[@base='int' and @name='@']
+# Currently the test converts the code from the snippet to:
+# Without synthetic references:
+# ____
+# [] > main
+#   tuple > arr
+#     0
+#     tuple
+#       1
+#       2
+#   eq > @
+#     tuple
+#       arr
+#       .at
+#         1
+#       .at
+#         1
+#     tuple
+#       2
+# ____
+# With synthetic references:
+# ____
+# [] > main
+#   tuple > arr
+#     0
+#     main$t0$generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128 > generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128
+#   eq > @
+#     tuple
+#       arr
+#       .at
+#         1
+#       .at
+#         1
+#     tuple
+#       2
+#
+# [] > main$t0$generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128
+#   tuple > org.eolang.scope-a5d6690a-1b51-4872-96f8-f4347eed3128
+#     1
+#     2
+#   org.eolang.scope-a5d6690a-1b51-4872-96f8-f4347eed3128 > @
+# ____
+# With WRAPPED METHOD CALLS and synthetic references
+# ____
+# [] > main
+#   tuple > arr
+#     0
+#     constant-array
+#   eq > @
+#     tuple
+#       second
+#         arr
+#     tuple
+#       2
+#
+# [] > constant-array
+#   tuple > local-element
+#     1
+#     2
+#   local-element > @
+#
+# [arr] > second
+#   .at > local-element
+#     first
+#       arr
+#     1
+#   local-element > @
+#
+# [arr] > first
+#   .at > local-element
+#     arr
+#     1
+#   local-element > @
+# ____
+eo: |
+  [] > main
+    * 0 (* 1 2) > arr
+    eq > @
+      * ((arr.at 1).at 1)
+      * 2

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
@@ -7,58 +7,30 @@ tests:
   - /program/errors[count(*)=0]
   # 'main' object
   - //o[@name='main']
-  - //o[@name='main']/o[@base='sibling' and @name='@']
-  - //o[@name='main']/o[@base='.eq' and @name='sibling']
-  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$first' and @name='first' and count(o)=0]
-  - //o[@name='main']/o[@base='.eq' and @name='sibling']/o[@base='main$t1$second' and @name='second' and count(o)=0]
-  # 'main$t1$first' object
-  - //o[@name='main$t1$first' and count(o)=1]
-  - //o[@name='main$t1$first']/o[@base='int' and @name='@']
-  # 'main$t1$second' object
-  - //o[@name='main$t1$second' and count(o)=1]
-  - //o[@name='main$t1$second']/o[@base='int' and @name='@']
+  - //o[@name='main']/o[@base='tuple' and @name='arr' and count(o)=2]/o[@base='int']
+  - //o[@name='main']/o[@base='tuple' and @name='arr' and count(o)=2]/o[not(@base='int')]
+  - //o[@name='main']/o[@base='eq' and @name='@' and count(o)=2]
+  - //o[@name='main']/o[@base='eq' and @name='@' and count(o)=2]/o[@base='tuple']/o/o[@base='arr']
+  - //o[@name='main']/o[@base='eq' and @name='@' and count(o)=2]/o[@base='tuple']/o[@base='int']
+  # The first generated object: 'constant-array' from the example below
+  - //o[@abstract and count(o)=2 and @name]
+  - //o[@abstract and count(o)=2 and @name]/o[@base='tuple' and count(o)=2]
+  - //o[@abstract and count(o)=2 and @name]/o[@base='tuple' and count(o)=2]/o[@base='int' and contains(text(), '1')]
+  - //o[@abstract and count(o)=2 and @name]/o[@base='tuple' and count(o)=2]/o[@base='int' and contains(text(), '2')]
+  - //o[@abstract and count(o)=2 and @name]/o[@name='@']
+  # The second generated object: 'second' from the example below
+  - //o[@abstract and count(o)=3 and @name]
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]/o/o[@base='arr']
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]/o[@base='int' and contains(text(), '1')]
+  - //o[@abstract and count(o)=3 and @name]/o[@name='@']
+  # The third generated object: 'first' from the example below
+  - //o[@abstract and count(o)=3 and @name]
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]/o[@base='arr']
+  - //o[@abstract and count(o)=3 and @name]/o[@base='.at' and count(o)=2]/o[@base='int' and contains(text(), '1')]
+  - //o[@abstract and count(o)=3 and @name]/o[@name='@']
 # Currently the test converts the code from the snippet to:
-# Without synthetic references:
-# ____
-# [] > main
-#   tuple > arr
-#     0
-#     tuple
-#       1
-#       2
-#   eq > @
-#     tuple
-#       arr
-#       .at
-#         1
-#       .at
-#         1
-#     tuple
-#       2
-# ____
-# With synthetic references:
-# ____
-# [] > main
-#   tuple > arr
-#     0
-#     main$t0$generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128 > generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128
-#   eq > @
-#     tuple
-#       arr
-#       .at
-#         1
-#       .at
-#         1
-#     tuple
-#       2
-#
-# [] > main$t0$generated-scope-a5d6690a-1b51-4872-96f8-f4347eed3128
-#   tuple > org.eolang.scope-a5d6690a-1b51-4872-96f8-f4347eed3128
-#     1
-#     2
-#   org.eolang.scope-a5d6690a-1b51-4872-96f8-f4347eed3128 > @
-# ____
-# With WRAPPED METHOD CALLS and synthetic references
 # ____
 # [] > main
 #   tuple > arr


### PR DESCRIPTION
Add more tests for `synthetic-references.xs` and `abstracts-float-up.xsl` transformations. 

Related to #2126.
___
We have the problem with `to-java.xsl` and `synthetic-references.xsl` transformations when they are applied together:
```
Processing terminated by xsl:message at line 358 in to-java.xsl
```
So, I've added tests to check that `synthetic-references.xs` and `abstracts-float-up.xsl` transformations work as expected. 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing and removing redundant levels in the code. It includes changes to the XSL files and adds new tests for error checking.

### Detailed summary
- Added new XSL files for optimizing and removing levels
- Added new tests for error checking
- Updated YAML files to include new XSL files and tests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->