### PR TITLE
feat(#2188): Print xmir as eo in logs

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/CheckPack.java
@@ -98,6 +98,7 @@ public final class CheckPack {
         }
         if (!failures.isEmpty()) {
             Logger.info(this, "Broken XML:\n%s", out);
+            Logger.info(this, "Broken EO:\n%s", new XMIR(out).toEO());
         }
         return failures;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -120,10 +120,13 @@ public final class ParsingTrain extends TrEnvelope {
         super(
             new TrLambda(
                 new TrFast(
-                    new TrLogged(
-                        new TrClasspath<>(sheets).back(),
-                        ParsingTrain.class,
-                        Level.FINEST
+                    new TrLambda(
+                        new TrLogged(
+                            new TrClasspath<>(sheets).back(),
+                            ParsingTrain.class,
+                            Level.FINEST
+                        ),
+                        StEoLogged::new
                     )
                 ),
                 shift -> new StSequence(

--- a/eo-parser/src/main/java/org/eolang/parser/StEoLogged.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StEoLogged.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.parser;
 
 import com.jcabi.log.Logger;
@@ -5,15 +28,36 @@ import com.jcabi.xml.XML;
 import com.yegor256.xsline.Shift;
 import java.util.function.Consumer;
 
+/**
+ * Shift that logs the EO representation of the XML before throwing an exception.
+ *
+ * @since 0.30
+ */
 final class StEoLogged implements Shift {
 
+    /**
+     * Origin shift.
+     */
     private final Shift origin;
+
+    /**
+     * Logger.
+     */
     private final Consumer<? super String> logger;
 
+    /**
+     * Ctor.
+     * @param shift Origin shift
+     */
     StEoLogged(final Shift shift) {
         this(shift, message -> Logger.error(StEoLogged.class, message));
     }
 
+    /**
+     * Ctor.
+     * @param origin Origin shift
+     * @param logger Logger
+     */
     StEoLogged(final Shift origin, final Consumer<? super String> logger) {
         this.origin = origin;
         this.logger = logger;
@@ -25,6 +69,7 @@ final class StEoLogged implements Shift {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public XML apply(final int position, final XML xml) {
         try {
             return this.origin.apply(position, xml);

--- a/eo-parser/src/main/java/org/eolang/parser/StEoLogged.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StEoLogged.java
@@ -1,0 +1,72 @@
+package org.eolang.parser;
+
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import java.util.logging.Level;
+
+public class StEoLogged implements Shift {
+
+    private final Shift origin;
+    private final Object target;
+    private final Level level;
+
+    public StEoLogged(final Shift origin) {
+        this(origin, StEoLogged.class, Level.INFO);
+    }
+
+    public StEoLogged(final Shift origin, final Object target, final Level level) {
+        this.origin = origin;
+        this.target = target;
+        this.level = level;
+    }
+
+    @Override
+    public String uid() {
+        return this.origin.uid();
+    }
+
+    @Override
+    public XML apply(final int position, final XML xml) {
+        final XML out;
+        try {
+            if (Logger.isEnabled(this.level, this.target)) {
+                final String before = xml.toString();
+                out = this.origin.apply(position, xml);
+                final String after = out.toString();
+                if (before.equals(after)) {
+                    Logger.log(
+                        this.level,
+                        this.target,
+                        "Shift #%d via '%s' made no changes",
+                        position, this.uid()
+                    );
+                } else {
+                    Logger.log(
+                        this.level,
+                        this.target,
+                        "Shift #%d via '%s' produced (%d->%d chars):\n%s<EOF>",
+                        position,
+                        this.uid(),
+                        before.length(),
+                        after.length(),
+                        after
+                            .replace("\n", "\\n\n")
+                            .replace("\t", "\\t\t")
+                            .replace("\r", "\\r\r")
+                    );
+                }
+            } else {
+                out = this.origin.apply(position, xml);
+            }
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final RuntimeException ex) {
+            Logger.error(this.target, "The error happened here:%n%s", xml);
+            throw new IllegalArgumentException(
+                String.format("Shift '%s' failed", this.origin),
+                ex
+            );
+        }
+        return out;
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
@@ -123,6 +123,4 @@ class StEoLoggedTest {
             return new ArrayList<>(this.captured);
         }
     }
-
-
 }

--- a/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
@@ -1,0 +1,128 @@
+package org.eolang.parser;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.StFailure;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.Consumer;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StEoLogged}.
+ *
+ * @since 0.30
+ */
+class StEoLoggedTest {
+
+    @Test
+    void hasTheSameUid() {
+        final StUnhex origin = new StUnhex();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect, that the uid() calculation will be delegated to the origin: %s",
+                origin
+            ),
+            new StEoLogged(origin).uid(),
+            Matchers.equalTo(origin.uid())
+        );
+    }
+
+    @Test
+    void delegatesWithoutException() {
+        final FakeLog log = new FakeLog();
+        MatcherAssert.assertThat(
+            "We expect that shift will successfully generate output xml",
+            new StEoLogged(new StUnhex(), log).apply(1, StEoLoggedTest.example()),
+            Matchers.notNullValue()
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that logs will be empty, but was %s",
+                log.all()
+            ),
+            log.empty(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void printsMessageWithEoIfExceptionIsThrown() {
+        final FakeLog log = new FakeLog();
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new StEoLogged(new StFailure(), log).apply(1, StEoLoggedTest.example()),
+            "We expect that shift will throw an exception, but it didn't"
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that logs will contain the eo representation of the xml, but was %s",
+                log.all()
+            ),
+            log.last(),
+            Matchers.containsString(
+                String.join(
+                    "\n",
+                    "[] > main",
+                    "  TRUE > x",
+                    "  FALSE > y"
+                )
+            )
+        );
+    }
+
+    private static XML example() {
+        return new XMLDocument(
+            String.join(
+                "\n",
+                "<program>",
+                "  <errors/>",
+                "  <sheets/>",
+                "  <objects>",
+                "    <o abstract=\"\" line=\"1\" name=\"main\" pos=\"0\">",
+                "      <o base=\"bool\" data=\"bytes\" line=\"2\" name=\"x\" pos=\"2\">01</o>",
+                "      <o base=\"bool\" data=\"bytes\" line=\"3\" name=\"y\" pos=\"2\">00</o>",
+                "    </o>",
+                "  </objects>",
+                "</program>"
+            )
+        );
+    }
+
+    private static class FakeLog implements Consumer<String> {
+
+        private final Queue<String> captured;
+
+        FakeLog() {
+            this(new LinkedList<>());
+        }
+
+        private FakeLog(final Queue<String> captured) {
+            this.captured = captured;
+        }
+
+        @Override
+        public void accept(final String message) {
+            this.captured.add(message);
+        }
+
+        String last() {
+            return this.captured.remove();
+        }
+
+        boolean empty() {
+            return this.captured.isEmpty();
+        }
+
+        Collection<String> all() {
+            return new ArrayList<>(this.captured);
+        }
+    }
+
+
+}

--- a/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.parser;
 
 import com.jcabi.xml.XML;
@@ -76,6 +99,18 @@ class StEoLoggedTest {
         );
     }
 
+    /**
+     * Example xml.
+     * <p>
+     * {@code
+     * [] > main
+     *   TRUE > x
+     *   FALSE > y
+     * }
+     * </p>
+     *
+     * @return XML
+     */
     private static XML example() {
         return new XMLDocument(
             String.join(
@@ -94,14 +129,30 @@ class StEoLoggedTest {
         );
     }
 
-    private static class FakeLog implements Consumer<String> {
+    /**
+     * Fake log.
+     * <p>Used for testing purposes.</p>
+     *
+     * @since 0.30
+     */
+    private static final class FakeLog implements Consumer<String> {
 
+        /**
+         * Captured messages.
+         */
         private final Queue<String> captured;
 
-        FakeLog() {
+        /**
+         * Ctor.
+         */
+        private FakeLog() {
             this(new LinkedList<>());
         }
 
+        /**
+         * Ctor.
+         * @param captured Captured messages
+         */
         private FakeLog(final Queue<String> captured) {
             this.captured = captured;
         }
@@ -111,15 +162,27 @@ class StEoLoggedTest {
             this.captured.add(message);
         }
 
-        String last() {
+        /**
+         * Get last captured message.
+         * @return Captured message
+         */
+        private String last() {
             return this.captured.remove();
         }
 
-        boolean empty() {
+        /**
+         * Check if captured messages are empty.
+         * @return True if empty, false otherwise
+         */
+        private boolean empty() {
             return this.captured.isEmpty();
         }
 
-        Collection<String> all() {
+        /**
+         * Get all captured messages.
+         * @return Captured messages
+         */
+        private Collection<String> all() {
             return new ArrayList<>(this.captured);
         }
     }


### PR DESCRIPTION
Print `xmir` as `eo` in logs when an exception happens.

Closes: #2188 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new feature to the codebase. 

### Detailed summary
- Added a new class `StEoLogged` that logs the EO representation of XML before throwing an exception.
- Created a test case for `StEoLogged` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->