### PR TITLE
fix(#2196): check access before removing binaries

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -35,6 +35,7 @@ import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -261,6 +262,11 @@ public final class TranspileMojo extends SafeMojo {
         for (final Path binary : unexpected) {
             try {
                 Files.deleteIfExists(binary);
+            } catch (final AccessDeniedException ignore) {
+                Logger.warn(
+                    this, "Can't delete file %s due to access denied",
+                    binary
+                );
             } catch (final IOException cause) {
                 throw new IllegalStateException(
                     String.format("Can't delete file %s", binary),
@@ -268,6 +274,7 @@ public final class TranspileMojo extends SafeMojo {
                 );
             }
         }
+
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -252,6 +252,11 @@ public final class TranspileMojo extends SafeMojo {
      * generated sources. In other words, if generated-sources (or generated-test-sources) folder
      * has java classes, we expect that they will be only compiled from that folder.
      * @param java The list of java files.
+     * @todo #2169:30min Find the original cause of the problem with access denied.
+     *  The problem is that sometimes we can't remove the file due to access denied.
+     *  We need to find the original cause of the problem and fix it.
+     *  Then, just remove AccessDeniedException from the catch block.
+     *  For now, we just ignore the problem and log the warning.
      */
     private void cleanUpClasses(final Collection<? extends Path> java) {
         final Set<Path> unexpected = java.stream()
@@ -261,17 +266,10 @@ public final class TranspileMojo extends SafeMojo {
             .collect(Collectors.toSet());
         for (final Path binary : unexpected) {
             try {
-                if (TranspileMojo.canRemove(binary)) {
-                    Files.deleteIfExists(binary);
-                } else {
-                    Logger.warn(
-                        this, "Can't delete file %s due to access denied", binary
-                    );
-                }
+                Files.deleteIfExists(binary);
             } catch (final AccessDeniedException cause) {
-                throw new IllegalStateException(
-                    String.format("Fails during file [%s] deleting due to access denied", binary),
-                    cause
+                Logger.warn(
+                    this, "Can't delete file %s due to access denied", binary
                 );
             } catch (final IOException cause) {
                 throw new IllegalStateException(
@@ -280,19 +278,6 @@ public final class TranspileMojo extends SafeMojo {
                 );
             }
         }
-    }
-
-    /**
-     * Check if we can remove the file.
-     * @param file The file to check
-     * @return True if we can remove the file
-     * @todo #2169:30min Find the original cause of the problem with access denied.
-     *  The problem is that sometimes we can't remove the file due to access denied.
-     *  We need to find the original cause of the problem and fix it.
-     *  For now, we just ignore the problem and log the warning.
-     */
-    private static boolean canRemove(final Path file) {
-        return Files.isWritable(file.getParent());
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -264,7 +264,8 @@ public final class TranspileMojo extends SafeMojo {
                 Files.deleteIfExists(binary);
             } catch (final AccessDeniedException ignore) {
                 Logger.warn(
-                    this, "Can't delete file %s due to access denied",
+                    this,
+                    "Can't delete file %s due to access denied",
                     binary
                 );
             } catch (final IOException cause) {
@@ -274,7 +275,6 @@ public final class TranspileMojo extends SafeMojo {
                 );
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
Check access before removing binaries.

Closes: #2196

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with file deletion in the TranspileMojo class. The AccessDeniedException is caught and logged as a warning instead of throwing an exception. 

### Detailed summary
- Added import for AccessDeniedException
- Modified cleanUpClasses method to catch AccessDeniedException and log a warning message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->