### PR TITLE
feat(#2126): Enable `synthetic-attributes-with-to-java.yaml` test

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
@@ -53,14 +53,6 @@ xsls:
   - /org/eolang/maven/pre/varargs.xsl
   - /org/eolang/maven/pre/data.xsl
   - /org/eolang/maven/pre/to-java.xsl
-# @todo #2122:90min Found more than one target of object at the line.
-#  The test below throws exception during the execution of the entire
-#  pipeline. The problem is in the synthetic-references.xsl transformation.
-#  The transformation adds new objects to the program, probably with incorrect
-#  line and pos attributes.
-#  Processing terminated by xsl:message at line 358 in to-java.xsl
-#  When we fix the problem, we have to enable the following test.
-skip: true
 tests:
   - /program/errors[count(*)=0]
 eo: |


### PR DESCRIPTION
Enable `synthetic-attributes-with-to-java.yaml` test.

Closes: #2126

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a problem with the synthetic-references.xsl transformation that causes exceptions during the execution of the entire pipeline. The test related to this issue is currently skipped. 

### Detailed summary
- Removed `/org/eolang/maven/pre/data.xsl` and `/org/eolang/maven/pre/to-java.xsl` from the resource file.
- Added a comment regarding the issue with the synthetic-references.xsl transformation.
- Skipped the test `/program/errors[count(*)=0]` due to the mentioned issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->