### PR TITLE
2197 cache rust

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -206,6 +206,12 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.12.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <version>2.0.7</version>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -209,7 +209,6 @@ SOFTWARE.
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.12.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -85,10 +85,16 @@ public final class BinarizeMojo extends SafeMojo {
         new Moja<>(BinarizeParseMojo.class).copy(this).execute();
         for (final File project: targetDir.toPath().resolve("Lib").toFile().listFiles()) {
             if (project.isDirectory() && project.toPath().resolve("Cargo.toml").toFile().exists()) {
-                build(project);
+                this.build(project);
             }
         }
     }
+
+    /**
+     * Builds cargo project.
+     * @param project Path to the project.
+     * @throws IOException If any issues with IO.
+     */
     private void build(final File project) throws IOException {
         final File target = project.toPath().resolve("target").toFile();
         final File cached = cache

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -47,6 +47,10 @@ import org.eolang.maven.rust.BuildFailureException;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
+ * @todo #2197: 45min Update cached rust insert if it was changed.
+ *  Now it copies cargo project to cache directory in the end of every
+ *  compilation. It is better to copy the project only if it was changed
+ *  with the last compilation.
  */
 @Mojo(
     name = "binarize",
@@ -77,14 +81,16 @@ public final class BinarizeMojo extends SafeMojo {
     public void exec() throws IOException {
         new Moja<>(BinarizeParseMojo.class).copy(this).execute();
         final Path dest = targetDir.toPath().resolve("Lib");
-        // cp .eo/Lib/target to Lib/target
         final File cached = cache.resolve("Lib").resolve("target").toFile();
         if (cached.exists()) {
-            Logger.info(this,
-                String.format("Copying %s to %s"),
-                cached,
-                dest.resolve("target").toString()
-                );
+            Logger.info(
+                this,
+                String.format(
+                    "Copying %s to %s",
+                    cached,
+                    dest.resolve("target")
+                )
+            );
             FileUtils.copyDirectory(
                 cached,
                 dest.resolve("target").toFile()
@@ -126,7 +132,14 @@ public final class BinarizeMojo extends SafeMojo {
                 )
             );
         } else {
-            // cp Lib/target .eo/Lib/target
+            Logger.info(
+                this,
+                String.format(
+                    "Update cached %s with %s",
+                    cached,
+                    dest.resolve("target").toFile()
+                )
+            );
             FileUtils.copyDirectory(dest.resolve("target").toFile(), cached);
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -80,24 +80,25 @@ public final class BinarizeMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         new Moja<>(BinarizeParseMojo.class).copy(this).execute();
-        final Path dest = targetDir.toPath().resolve("Lib");
-        final File cached = cache.resolve("Lib").toFile();
+        final Path project = targetDir.toPath().resolve("Lib");
+        final File target = project.resolve("target").toFile();
+        final File cached = cache.resolve("Lib").resolve("target").toFile();
         if (cached.exists()) {
             Logger.info(
                 this,
                 String.format(
                     "Copying %s to %s",
                     cached,
-                    dest
+                    target
                 )
             );
             FileUtils.copyDirectory(
                 cached,
-                dest.toFile()
+                target
             );
         }
         final ProcessBuilder builder = new ProcessBuilder("cargo", "build")
-            .directory(dest.toFile());
+            .directory(project.toFile());
         Logger.info(this, "Building rust project..");
         final Process building = builder.start();
         try {
@@ -107,7 +108,7 @@ public final class BinarizeMojo extends SafeMojo {
             throw new BuildFailureException(
                 String.format(
                     "Interrupted while building %s",
-                    dest.toAbsolutePath()
+                    project.toAbsolutePath()
                 ),
                 exception
             );
@@ -118,10 +119,10 @@ public final class BinarizeMojo extends SafeMojo {
                 String.format(
                     "Cargo building succeeded, update cached %s with %s",
                     cached,
-                    dest.toFile()
+                    target
                 )
             );
-            FileUtils.copyDirectory(dest.toFile(), cached);
+            FileUtils.copyDirectory(project.toFile(), cached);
         } else {
             Logger.error(this, "There was an error in compilation");
             final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
@@ -137,8 +138,8 @@ public final class BinarizeMojo extends SafeMojo {
             }
             throw new BuildFailureException(
                 String.format(
-                    "Failed to build cargo project with dest = %s",
-                    dest.toAbsolutePath()
+                    "Failed to build cargo project with destination = %s",
+                    project.toAbsolutePath()
                 )
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -47,7 +47,7 @@ import org.eolang.maven.rust.BuildFailureException;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
- * @todo #2197: 45min Update cached rust insert if it was changed.
+ * @todo #2197:45min Update cached rust insert if it was changed.
  *  Now it copies cargo project to cache directory in the end of every
  *  compilation. It is better to copy the project only if it was changed
  *  with the last compilation.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.commons.io.FileUtils;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.OutputTo;
 import org.cactoos.io.TeeInput;
@@ -76,6 +77,19 @@ public final class BinarizeMojo extends SafeMojo {
     public void exec() throws IOException {
         new Moja<>(BinarizeParseMojo.class).copy(this).execute();
         final Path dest = targetDir.toPath().resolve("Lib");
+        // cp .eo/Lib/target to Lib/target
+        final File cached = cache.resolve("Lib").resolve("target").toFile();
+        if (cached.exists()) {
+            Logger.info(this,
+                String.format("Copying %s to %s"),
+                cached,
+                dest.resolve("target").toString()
+                );
+            FileUtils.copyDirectory(
+                cached,
+                dest.resolve("target").toFile()
+            );
+        }
         final ProcessBuilder builder = new ProcessBuilder("cargo", "build")
             .directory(dest.toFile());
         Logger.info(this, "Building rust project..");
@@ -111,6 +125,9 @@ public final class BinarizeMojo extends SafeMojo {
                     dest.toAbsolutePath()
                 )
             );
+        } else {
+            // cp Lib/target .eo/Lib/target
+            FileUtils.copyDirectory(dest.resolve("target").toFile(), cached);
         }
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -115,10 +115,10 @@ public final class BinarizeMojo extends SafeMojo {
                 target
             );
         }
-        final ProcessBuilder builder = new ProcessBuilder("cargo", "build")
-            .directory(project);
         Logger.info(this, "Building rust project..");
-        final Process building = builder.start();
+        final Process building = new ProcessBuilder("cargo", "build")
+            .directory(project)
+            .start();
         try {
             building.waitFor();
         } catch (final InterruptedException exception) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -27,9 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
-
-import org.cactoos.map.MapOf;
-import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -90,7 +90,7 @@ final class BinarizeMojoTest {
             .result();
         MatcherAssert.assertThat(
             res,
-            Matchers.hasKey(Paths.get(".cache").resolve("Lib").toString())
+            Matchers.hasValue(temp.resolve(".cache").resolve("Lib"))
         );
         Assertions.assertDoesNotThrow(
             () -> maven.execute(new FakeMaven.Binarize())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -26,6 +26,12 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+
+import org.cactoos.map.MapOf;
+import org.eolang.maven.util.Home;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -78,9 +84,17 @@ final class BinarizeMojoTest {
     void binarizesAgainQuickly(@TempDir final Path temp) throws IOException {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {
-            maven = new FakeMaven(temp)
-                .withProgram(Paths.get("src/test/resources/org/eolang/maven/simple-rust.eo"))
+            maven = new FakeMaven(
+                new Home(temp), new MapOf("cache", temp.resolve(".cache"))
+            ).withProgram(Paths.get("src/test/resources/org/eolang/maven/simple-rust.eo"));
         }
+        final Map<String, Path> res = maven
+            .execute(new FakeMaven.Binarize())
+            .result();
+        MatcherAssert.assertThat(
+            res,
+            Matchers.hasKey(Paths.get(".cache").resolve("Lib").toString())
+        );
         Assertions.assertDoesNotThrow(
             () -> maven.execute(new FakeMaven.Binarize())
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -78,7 +78,7 @@ final class BinarizeMojoTest {
 
     @Test
     @Tag("slow")
-    void binarizesAgainQuickly(@TempDir final Path temp) throws IOException {
+    void savesToCache(@TempDir final Path temp) throws IOException {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {
             maven = new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -72,4 +72,17 @@ final class BinarizeMojoTest {
             () -> maven.execute(new FakeMaven.Binarize())
         );
     }
+
+    @Test
+    @Tag("slow")
+    void binarizesAgainQuickly(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven;
+        synchronized (BinarizeMojoTest.class) {
+            maven = new FakeMaven(temp)
+                .withProgram(Paths.get("src/test/resources/org/eolang/maven/simple-rust.eo"))
+        }
+        Assertions.assertDoesNotThrow(
+            () -> maven.execute(new FakeMaven.Binarize())
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -84,9 +84,9 @@ final class BinarizeMojoTest {
     void binarizesAgainQuickly(@TempDir final Path temp) throws IOException {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {
-            maven = new FakeMaven(
-                new Home(temp), new MapOf("cache", temp.resolve(".cache"))
-            ).withProgram(Paths.get("src/test/resources/org/eolang/maven/simple-rust.eo"));
+            maven = new FakeMaven(temp)
+                .with("cache", temp.resolve(".cache"))
+                .withProgram(Paths.get("src/test/resources/org/eolang/maven/simple-rust.eo"));
         }
         final Map<String, Path> res = maven
             .execute(new FakeMaven.Binarize())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -52,6 +52,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.Input;
+import org.cactoos.map.MapOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.maven.tojos.ForeignTojos;
@@ -95,6 +96,25 @@ public final class FakeMaven {
     private final AtomicInteger current;
 
     /**
+     * Ctor.
+     * @param workspace Workspace.
+     * @param params Params.
+     * @param attributes Attributes.
+     * @param current Current.
+     */
+    public FakeMaven(
+        final Home workspace,
+        final Map<String, Object> params,
+        final Map<ForeignTojos.Attribute, Object> attributes,
+        final AtomicInteger current
+    ) {
+        this.workspace = workspace;
+        this.params = params;
+        this.attributes = attributes;
+        this.current = current;
+    }
+
+    /**
      * The main constructor.
      *
      * @param workspace Test temporary directory.
@@ -104,6 +124,15 @@ public final class FakeMaven {
         this.params = new HashMap<>();
         this.attributes = new HashMap<>();
         this.current = new AtomicInteger(0);
+    }
+
+    public FakeMaven(final Home workspace, final Map<String, Object> params) {
+        this(
+            workspace,
+            new MapOf<>("cache", workspace.absolute(Paths.get("eo")).resolve("cache")),
+            new HashMap<>(),
+            new AtomicInteger(0)
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -52,7 +52,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.Input;
-import org.cactoos.map.MapOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.maven.tojos.ForeignTojos;
@@ -96,50 +95,15 @@ public final class FakeMaven {
     private final AtomicInteger current;
 
     /**
-     * Ctor.
-     * @param workspace Workspace.
-     * @param params Params.
-     * @param attributes Attributes.
-     * @param current Current.
-     */
-    public FakeMaven(
-        final Home workspace,
-        final Map<String, Object> params,
-        final Map<ForeignTojos.Attribute, Object> attributes,
-        final AtomicInteger current
-    ) {
-        this.workspace = workspace;
-        this.params = params;
-        this.attributes = attributes;
-        this.current = current;
-    }
-
-    /**
      * The main constructor.
      *
      * @param workspace Test temporary directory.
      */
     public FakeMaven(final Path workspace) {
-        this(
-            new Home(workspace),
-            new HashMap<>(),
-            new HashMap<>(),
-            new AtomicInteger(0)
-        );
-    }
-
-    /**
-     * Ctor.
-     * @param workspace
-     * @param params
-     */
-    public FakeMaven(final Home workspace, final Map<String, Object> params) {
-        this(
-            workspace,
-            params,
-            new HashMap<>(),
-            new AtomicInteger(0)
-        );
+        this.workspace = new Home(workspace);
+        this.params = new HashMap<>();
+        this.attributes = new HashMap<>();
+        this.current = new AtomicInteger(0);
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -120,16 +120,23 @@ public final class FakeMaven {
      * @param workspace Test temporary directory.
      */
     public FakeMaven(final Path workspace) {
-        this.workspace = new Home(workspace);
-        this.params = new HashMap<>();
-        this.attributes = new HashMap<>();
-        this.current = new AtomicInteger(0);
+        this(
+            new Home(workspace),
+            new HashMap<>(),
+            new HashMap<>(),
+            new AtomicInteger(0)
+        );
     }
 
+    /**
+     * Ctor.
+     * @param workspace
+     * @param params
+     */
     public FakeMaven(final Home workspace, final Map<String, Object> params) {
         this(
             workspace,
-            new MapOf<>("cache", workspace.absolute(Paths.get("eo")).resolve("cache")),
+            params,
             new HashMap<>(),
             new AtomicInteger(0)
         );


### PR DESCRIPTION
Closes: #2197
Rust caching. 
Saves `cargo project`'s target folder to `.eo/`. 
Copies it to local folder in the next compilation.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the EO Maven Plugin by adding a new dependency and making changes to the BinarizeMojo class. 

### Detailed summary
- Added `commons-io` dependency to `pom.xml`
- Added imports and test methods to `BinarizeMojoTest.java`
- Updated `BinarizeMojo.java` with new `import` and changes to the `build` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->