### PR TITLE
#1602 Independent versioning

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
@@ -135,7 +135,8 @@ public final class RegisterMojo extends SafeMojo {
             this.scopedTojos()
                 .add(name)
                 .withSource(file.toAbsolutePath())
-                .withVersion(ParseMojo.ZERO);
+                .withVersion(ParseMojo.ZERO)
+                .withVer(ParseMojo.ZERO);
             Logger.debug(this, "EO source %s registered", name);
         }
         Logger.info(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -281,4 +281,22 @@ public final class ForeignTojo {
     public String scope() {
         return this.delegate.get(ForeignTojos.Attribute.SCOPE.key());
     }
+
+    /**
+     * Temporary version.
+     * @param ver The version.
+     * @return The tojo itself.
+     */
+    public ForeignTojo withVer(final String ver) {
+        this.delegate.set(ForeignTojos.Attribute.VER.key(), ver);
+        return this;
+    }
+
+    /**
+     * Return the temporary version of the tojo.
+     * @return The version.
+     */
+    public String ver() {
+        return this.delegate.get(ForeignTojos.Attribute.VER.key());
+    }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -301,7 +301,12 @@ public final class ForeignTojos implements Closeable {
         /**
          * Hash.
          */
-        HASH("hash");
+        HASH("hash"),
+
+        /**
+         * Ver.
+         */
+        VER("ver");
 
         /**
          * Attribute name.

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -378,7 +378,7 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
     public void enterVersion(final ProgramParser.VersionContext ctx) {
         this.objects.enter();
         if (ctx.VERSION() != null) {
-            this.objects.prop("version", ctx.VERSION().getText());
+            this.objects.prop("ver", ctx.VERSION().getText());
         }
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
@@ -1,10 +1,10 @@
 xsls: []
 tests:
-  - //o[@base='func0' and @version='3.4.5' and @name='x']
-  - //o[@base='func1' and @version='1.2.3']
-  - //o[@base='func2' and not(@version)]
-  - //o[@base='func3' and @version='3.2.1']
-  - //o[@base='func4' and @version='10.20.30']
+  - //o[@base='func0' and @ver='3.4.5' and @name='x']
+  - //o[@base='func1' and @ver='1.2.3']
+  - //o[@base='func2' and not(@ver)]
+  - //o[@base='func3' and @ver='3.2.1']
+  - //o[@base='func4' and @ver='10.20.30']
 eo: |
   [] > main
     func0|3.4.5 > x


### PR DESCRIPTION
Ref: #1602

In order to continue developing object versioning independently without breaking main pipeline extra fields "ver" were introduced that will be replaced in the future

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new attribute "ver" and updating related code to support versioning in the EO language. 

### Detailed summary
- Added a new attribute "ver" in the `ForeignTojos` class.
- Updated code in `XeListener` to use the "ver" attribute instead of "version".
- Updated code in `RegisterMojo` to include the "ver" attribute.
- Updated test cases in `versions.yaml` to use the "ver" attribute instead of "version".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->