### PR TITLE
#2213 Fixed `ForeignTojos.contains()` method and added test

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
@@ -128,7 +128,7 @@ public final class RegisterMojo extends SafeMojo {
                 );
             }
             final String name = unplace.make(file);
-            if (!this.scopedTojos().contains(name)) {
+            if (this.scopedTojos().contains(name)) {
                 Logger.debug(this, "EO source %s already registered", name);
                 continue;
             }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -185,7 +185,7 @@ public final class ForeignTojos implements Closeable {
      * @return True if the tojo exists.
      */
     public boolean contains(final String name) {
-        return this.select(tojo -> tojo.get(Attribute.ID.key()).equals(name)).isEmpty();
+        return !this.select(tojo -> tojo.get(Attribute.ID.key()).equals(name)).isEmpty();
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.tojos;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.eolang.maven.FakeMaven;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests from {@link ForeignTojos}.
+ *
+ * @since 0.29.5
+ */
+final class ForeignTojosTest {
+
+    /**
+     * Testable foreign tojos.
+     */
+    private ForeignTojos tojos;
+
+    @BeforeEach
+    void setUp(@TempDir final Path tmp) {
+        this.tojos = new ForeignTojos(() -> new FakeMaven(tmp).foreign());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "abs",
+        "org.eolang.int",
+        "QQ.io.stdout"
+    })
+    void contains(final String name) {
+        this.tojos.add(name);
+        MatcherAssert.assertThat(
+            this.tojos.contains(name),
+            Matchers.is(true)
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        this.tojos.close();
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -61,15 +61,29 @@ final class ForeignTojosTest {
 
     @ParameterizedTest
     @CsvSource({
-        "abs, abs, true",
-        "org.eolang.int, org.eolang.float, false",
-        "QQ.io.stdout, QQ.io.stdout, true"
+        "abs",
+        "org.eolang.int",
+        "QQ.io.stdout"
     })
-    void contains(final String name, final String check, final boolean contains) {
+    void contains(final String name) {
+        this.tojos.add(name);
+        MatcherAssert.assertThat(
+            this.tojos.contains(name),
+            Matchers.is(true)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "abs, sba",
+        "org.eolang.int, org.eolang.float",
+        "QQ.io.stdout, QQ.txt.sprintf"
+    })
+    void doesNotContain(final String name, final String check) {
         this.tojos.add(name);
         MatcherAssert.assertThat(
             this.tojos.contains(check),
-            Matchers.is(contains)
+            Matchers.is(false)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -79,10 +79,10 @@ final class ForeignTojosTest {
         "org.eolang.int, org.eolang.float",
         "QQ.io.stdout, QQ.txt.sprintf"
     })
-    void doesNotContain(final String name, final String check) {
-        this.tojos.add(name);
+    void doesNotContain(final String existing, final String considered) {
+        this.tojos.add(existing);
         MatcherAssert.assertThat(
-            this.tojos.contains(check),
+            this.tojos.contains(considered),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -46,6 +46,14 @@ final class ForeignTojosTest {
      */
     private ForeignTojos tojos;
 
+    /**
+     * Set up environment before each test.
+     *
+     * @param tmp Temporary dir.
+     * @todo #2213:60min Create an instance of ForeignTojos in memory.
+     *  It would be better to be able to create an instance of ForeignTojos in
+     *  memory for test purposes.
+     */
     @BeforeEach
     void setUp(@TempDir final Path tmp) {
         this.tojos = new ForeignTojos(() -> new FakeMaven(tmp).foreign());
@@ -53,15 +61,15 @@ final class ForeignTojosTest {
 
     @ParameterizedTest
     @CsvSource({
-        "abs",
-        "org.eolang.int",
-        "QQ.io.stdout"
+        "abs, abs, true",
+        "org.eolang.int, org.eolang.float, false",
+        "QQ.io.stdout, QQ.io.stdout, true"
     })
-    void contains(final String name) {
+    void contains(final String name, final String check, final boolean contains) {
         this.tojos.add(name);
         MatcherAssert.assertThat(
-            this.tojos.contains(name),
-            Matchers.is(true)
+            this.tojos.contains(check),
+            Matchers.is(contains)
         );
     }
 


### PR DESCRIPTION
Closes: #2213

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `RegisterMojo` class and adding tests for the `ForeignTojos` class. 

### Detailed summary
- In `RegisterMojo`, the condition in the `if` statement is reversed.
- In `ForeignTojos`, the `contains` method is modified to return the opposite result.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->