### PR TITLE
#1602 Copy of `ForeignTojos`for independent object versioning

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -195,6 +195,7 @@ public final class AssembleMojo extends SafeMojo {
             this.central = new Central(this.project, this.session, this.manager);
         }
         String before = this.tojos.status();
+        String extbefore = this.extTojos.status();
         int cycle = 0;
         final Moja<?>[] mojas = {
             new Moja<>(ParseMojo.class),
@@ -212,17 +213,23 @@ public final class AssembleMojo extends SafeMojo {
                 moja.copy(this).execute();
             }
             final String after = this.tojos.status();
+            final String extafter = this.extTojos.status();
             ++cycle;
             if (Logger.isInfoEnabled(this)) {
                 Logger.info(
                     this, "Assemble cycle #%d (%s -> %s), took %[nano]s",
                     cycle, before, after, System.nanoTime() - start
                 );
+                Logger.info(
+                    this, "External assemble cycle #%d (%s -> %s), took %[nano]s",
+                    cycle, extbefore, extafter, System.nanoTime() - start
+                );
             }
             if (after.equals(before)) {
                 break;
             }
             before = after;
+            extbefore = extafter;
         }
         Logger.info(
             this, "%d assemble cycle(s) produced some new object(s): %s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DemandMojo.java
@@ -52,7 +52,12 @@ public final class DemandMojo extends SafeMojo {
 
     @Override
     public void exec() {
-        this.objects.forEach(this.scopedTojos()::add);
+        this.objects.forEach(
+            object -> {
+                this.scopedTojos().add(object);
+                this.extTojos.add(object);
+            }
+        );
         Logger.info(
             this, "Added %d objects to foreign catalog at %s",
             this.objects.size(), new Rel(this.foreign)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -55,6 +55,7 @@ public final class DiscoverMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Collection<ForeignTojo> tojos = this.scopedTojos().notDiscovered();
+        final Collection<ForeignTojo> external = this.extTojos.notDiscovered();
         final Collection<String> discovered = new HashSet<>(1);
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
@@ -64,6 +65,7 @@ public final class DiscoverMojo extends SafeMojo {
                 discovered.add(name);
             }
             tojo.withDiscovered(names.size());
+            external.iterator().next().withDiscovered(names.size());
         }
         if (tojos.isEmpty()) {
             if (this.scopedTojos().size() == 0) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.TreeSet;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -55,17 +56,18 @@ public final class DiscoverMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Collection<ForeignTojo> tojos = this.scopedTojos().notDiscovered();
-        final Collection<ForeignTojo> external = this.extTojos.notDiscovered();
+        final Iterator<ForeignTojo> external = this.extTojos.notDiscovered().iterator();
         final Collection<String> discovered = new HashSet<>(1);
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
             final Collection<String> names = this.discover(src);
             for (final String name : names) {
                 this.scopedTojos().add(name).withDiscoveredAt(src);
+                this.extTojos.add(name).withDiscoveredAt(src);
                 discovered.add(name);
             }
             tojo.withDiscovered(names.size());
-            external.iterator().next().withDiscovered(names.size());
+            external.next().withDiscovered(names.size());
         }
         if (tojos.isEmpty()) {
             if (this.scopedTojos().size() == 0) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -29,6 +29,7 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -43,7 +44,6 @@ import org.eolang.maven.optimization.OptSpy;
 import org.eolang.maven.optimization.OptTrain;
 import org.eolang.maven.optimization.Optimization;
 import org.eolang.maven.tojos.ForeignTojo;
-import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
 import org.eolang.parser.ParsingTrain;
@@ -113,16 +113,16 @@ public final class OptimizeMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         final Collection<ForeignTojo> sources = this.scopedTojos().withXmir();
-        final Optimization common = this.optimization();
-        final Iterable<ForeignTojo> external = new Filtered<>(
+        final Iterator<ForeignTojo> external = new Filtered<>(
             ForeignTojo::notOptimized,
             this.extTojos.withXmir()
-        );
+        ).iterator();
+        final Optimization common = this.optimization();
         final int total = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    tojo -> this.task(tojo, external.iterator().next(), common),
+                    tojo -> this.task(tojo, external.next(), common),
                     new Filtered<>(
                         ForeignTojo::notOptimized,
                         sources

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -114,7 +115,7 @@ public final class ProbeMojo extends SafeMojo {
         }
         final Collection<String> probed = new HashSet<>(1);
         final Collection<ForeignTojo> tojos = this.scopedTojos().unprobed();
-        final Collection<ForeignTojo> external = this.extTojos.unprobed();
+        final Iterator<ForeignTojo> external = this.extTojos.unprobed().iterator();
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
             final Collection<String> names = this.probes(src);
@@ -127,14 +128,13 @@ public final class ProbeMojo extends SafeMojo {
                     continue;
                 }
                 ++count;
-                this.scopedTojos()
-                    .add(name)
-                    .withDiscoveredAt(src);
+                this.scopedTojos().add(name).withDiscoveredAt(src);
+                this.extTojos.add(name).withDiscoveredAt(src);
                 probed.add(name);
             }
             final CommitHash narrow = new ChNarrow(hash);
             tojo.withHash(narrow).withProbed(count);
-            external.iterator().next().withHash(narrow).withProbed(count);
+            external.next().withHash(narrow).withProbed(count);
         }
         if (tojos.isEmpty()) {
             if (this.scopedTojos().size() == 0) {
@@ -192,6 +192,7 @@ public final class ProbeMojo extends SafeMojo {
      * Trim Q prefix.
      * Q.a.b.c -> a.b
      * a.b.c -> a.b.c
+     *
      * @param obj Full object name
      * @return Trimmed object name
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -114,6 +114,7 @@ public final class ProbeMojo extends SafeMojo {
         }
         final Collection<String> probed = new HashSet<>(1);
         final Collection<ForeignTojo> tojos = this.scopedTojos().unprobed();
+        final Collection<ForeignTojo> external = this.extTojos.unprobed();
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
             final Collection<String> names = this.probes(src);
@@ -131,7 +132,9 @@ public final class ProbeMojo extends SafeMojo {
                     .withDiscoveredAt(src);
                 probed.add(name);
             }
-            tojo.withHash(new ChNarrow(hash)).withProbed(count);
+            final CommitHash narrow = new ChNarrow(hash);
+            tojo.withHash(narrow).withProbed(count);
+            external.iterator().next().withHash(narrow).withProbed(count);
         }
         if (tojos.isEmpty()) {
             if (this.scopedTojos().size() == 0) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Iterator;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -122,9 +123,12 @@ public final class PullMojo extends SafeMojo {
             );
         }
         final Collection<ForeignTojo> tojos = this.scopedTojos().withoutSources();
+        final Iterator<ForeignTojo> external = this.extTojos.withoutSources().iterator();
         for (final ForeignTojo tojo : tojos) {
-            tojo.withSource(this.pull(tojo.identifier()).toAbsolutePath())
-                .withHash(new ChNarrow(hash));
+            final Path pulled = this.pull(tojo.identifier()).toAbsolutePath();
+            final CommitHash narrow = new ChNarrow(hash);
+            tojo.withSource(pulled).withHash(narrow);
+            external.next().withSource(pulled).withHash(narrow);
         }
         Logger.info(
             this, "%d program(s) pulled from %s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
@@ -137,6 +137,10 @@ public final class RegisterMojo extends SafeMojo {
                 .withSource(file.toAbsolutePath())
                 .withVersion(ParseMojo.ZERO)
                 .withVer(ParseMojo.ZERO);
+            this.externalTojos
+                .add(name)
+                .withSource(file.toAbsolutePath())
+                .withVersion(ParseMojo.ZERO);
             Logger.debug(this, "EO source %s registered", name);
         }
         Logger.info(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/RegisterMojo.java
@@ -137,7 +137,7 @@ public final class RegisterMojo extends SafeMojo {
                 .withSource(file.toAbsolutePath())
                 .withVersion(ParseMojo.ZERO)
                 .withVer(ParseMojo.ZERO);
-            this.externalTojos
+            this.extTojos
                 .add(name)
                 .withSource(file.toAbsolutePath())
                 .withVersion(ParseMojo.ZERO);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -206,6 +206,7 @@ public final class ResolveMojo extends SafeMojo {
     private Collection<Dependency> deps() {
         Iterable<Dependency> deps = new DcsDefault(
             this.scopedTojos(),
+            this.extTojos,
             this.discoverSelf,
             this.skipZeroVersions
         );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -90,6 +90,10 @@ abstract class SafeMojo extends AbstractMojo {
     )
     protected File foreign;
 
+    /**
+     * File with external "tojos".
+     * @checkstyle VisibilityModifierCheck (10 lines)
+     */
     @Parameter(
         property = "eo.external",
         required = true,
@@ -206,7 +210,7 @@ abstract class SafeMojo extends AbstractMojo {
      * Copy of foreign tojos for object versioning implementation.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
-    protected final ForeignTojos externalTojos = new ForeignTojos(
+    protected final ForeignTojos extTojos = new ForeignTojos(
         () -> Catalogs.INSTANCE.make(this.external.toPath(), this.foreignFormat),
         () -> this.scope
     );
@@ -283,7 +287,7 @@ abstract class SafeMojo extends AbstractMojo {
                     SafeMojo.closeTojos(this.tojos);
                 }
                 if (this.external != null) {
-                    SafeMojo.closeTojos(this.externalTojos);
+                    SafeMojo.closeTojos(this.extTojos);
                 }
                 if (this.placed != null) {
                     SafeMojo.closeTojos(this.placedTojos);
@@ -308,7 +312,7 @@ abstract class SafeMojo extends AbstractMojo {
      * Exec it.
      * @throws IOException If fails
      */
-    abstract void exec() throws IOException;
+    abstract void exec() throws Exception;
 
     /**
      * Runs exec command with timeout if needed.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -208,6 +208,7 @@ abstract class SafeMojo extends AbstractMojo {
 
     /**
      * Copy of foreign tojos for object versioning implementation.
+     * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     protected final ForeignTojos extTojos = new ForeignTojos(
@@ -240,6 +241,13 @@ abstract class SafeMojo extends AbstractMojo {
     @SuppressWarnings("PMD.ImmutableField")
     private boolean skip;
 
+    /**
+     * Execute it.
+     * @throws MojoFailureException If fails during build
+     * @throws MojoExecutionException If fails during execution
+     * @checkstyle NoJavadocForOverriddenMethodsCheck (10 lines)
+     * @checkstyle CyclomaticComplexityCheck (70 lines)
+     */
     @Override
     public final void execute() throws MojoFailureException, MojoExecutionException {
         StaticLoggerBinder.getSingleton().setMavenLog(this.getLog());
@@ -312,7 +320,7 @@ abstract class SafeMojo extends AbstractMojo {
      * Exec it.
      * @throws IOException If fails
      */
-    abstract void exec() throws Exception;
+    abstract void exec() throws IOException;
 
     /**
      * Runs exec command with timeout if needed.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -90,6 +90,13 @@ abstract class SafeMojo extends AbstractMojo {
     )
     protected File foreign;
 
+    @Parameter(
+        property = "eo.external",
+        required = true,
+        defaultValue = "${project.build.directory}/eo-external.csv"
+    )
+    protected File external;
+
     /**
      * Format of "foreign" file ("json" or "csv").
      * @checkstyle MemberNameCheck (7 lines)
@@ -196,6 +203,15 @@ abstract class SafeMojo extends AbstractMojo {
     );
 
     /**
+     * Copy of foreign tojos for object versioning implementation.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    protected final ForeignTojos externalTojos = new ForeignTojos(
+        () -> Catalogs.INSTANCE.make(this.external.toPath(), this.foreignFormat),
+        () -> this.scope
+    );
+
+    /**
      * Placed tojos.
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
@@ -265,6 +281,9 @@ abstract class SafeMojo extends AbstractMojo {
             } finally {
                 if (this.foreign != null) {
                     SafeMojo.closeTojos(this.tojos);
+                }
+                if (this.external != null) {
+                    SafeMojo.closeTojos(this.externalTojos);
                 }
                 if (this.placed != null) {
                     SafeMojo.closeTojos(this.placedTojos);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
@@ -51,6 +51,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -351,6 +352,7 @@ public final class SodgMojo extends SafeMojo {
             );
         }
         final Collection<ForeignTojo> tojos = this.scopedTojos().withOptimized();
+        final Iterator<ForeignTojo> external = this.extTojos.withOptimized().iterator();
         final Path home = this.targetDir.toPath().resolve(SodgMojo.DIR);
         int total = 0;
         int instructions = 0;
@@ -377,6 +379,7 @@ public final class SodgMojo extends SafeMojo {
             final int extra = this.render(xmir, sodg);
             instructions += extra;
             tojo.withSodg(sodg.toAbsolutePath());
+            external.next().withSodg(sodg.toAbsolutePath());
             Logger.info(
                 this, "SODG for %s saved to %s (%d instructions)",
                 name, new Rel(sodg), extra

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/dependencies/DcsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/dependencies/DcsDefault.java
@@ -51,6 +51,11 @@ public final class DcsDefault implements Iterable<Dependency> {
     private final ForeignTojos tojos;
 
     /**
+     * List of external tojos.
+     */
+    private final ForeignTojos external;
+
+    /**
      * Discover self too.
      */
     private final boolean discover;
@@ -71,7 +76,25 @@ public final class DcsDefault implements Iterable<Dependency> {
         final boolean self,
         final boolean skip
     ) {
+        this(tjs, tjs, self, skip);
+    }
+
+    /**
+     * Ctor.
+     * @param tjs Tojos
+     * @param ext External tojos
+     * @param self Self
+     * @param skip Skip
+     * @checkstyle ParameterNumberCheck (8 lines)
+     */
+    public DcsDefault(
+        final ForeignTojos tjs,
+        final ForeignTojos ext,
+        final boolean self,
+        final boolean skip
+    ) {
         this.tojos = tjs;
+        this.external = ext;
         this.discover = self;
         this.skip = skip;
     }
@@ -79,6 +102,7 @@ public final class DcsDefault implements Iterable<Dependency> {
     @Override
     public Iterator<Dependency> iterator() {
         final Collection<ForeignTojo> list = this.tojos.dependencies();
+        final Iterator<ForeignTojo> ext = this.external.dependencies().iterator();
         Logger.debug(
             this, "%d suitable tojo(s) found out of %d",
             list.size(), this.tojos.size()
@@ -114,7 +138,9 @@ public final class DcsDefault implements Iterable<Dependency> {
                 new Coordinates(dep)
             );
             deps.add(dep);
-            tojo.withJar(new Coordinates(dep));
+            final Coordinates coordinates = new Coordinates(dep);
+            tojo.withJar(coordinates);
+            ext.next().withJar(coordinates);
         }
         return deps.iterator();
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -57,6 +57,7 @@ final class AssembleMojoTest {
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("sourcesDir", src.toFile())
             .with("includeSources", new SetOf<>("**.eo"))
@@ -65,6 +66,7 @@ final class AssembleMojoTest {
             .with("outputDir", temp.resolve("out").toFile())
             .with("targetDir", target.toFile())
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("placed", temp.resolve("list").toFile())
             .with("cache", temp.resolve("cache/parsed"))
@@ -120,6 +122,7 @@ final class AssembleMojoTest {
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("sourcesDir", src.toFile())
             .with("includeSources", new SetOf<>("**.eo"))
@@ -128,6 +131,7 @@ final class AssembleMojoTest {
             .with("outputDir", temp.resolve("out").toFile())
             .with("targetDir", target.toFile())
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("placed", temp.resolve("list").toFile())
             .with("cache", temp.resolve("cache/parsed"))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -168,5 +168,4 @@ final class AssembleMojoTest {
             Matchers.is(true)
         );
     }
-
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CleanMojoTest.java
@@ -77,6 +77,7 @@ class CleanMojoTest {
         final Path target = temp.resolve("target");
         new Moja<>(RegisterMojo.class)
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("sourcesDir", src.toFile())
             .with("includeSources", new SetOf<>("**.eo"))
@@ -85,6 +86,7 @@ class CleanMojoTest {
             .with("outputDir", temp.resolve("out").toFile())
             .with("targetDir", target.toFile())
             .with("foreign", temp.resolve("eo-foreign.json").toFile())
+            .with("external", temp.resolve("eo-external.json").toFile())
             .with("foreignFormat", "json")
             .with("placed", temp.resolve("list").toFile())
             .with("cache", temp.resolve("cache/parsed"))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -89,4 +89,30 @@ final class DiscoverMojoTest {
             Matchers.is(true)
         );
     }
+
+    @Test
+    void comparesStatusOfForeignAndExternalTojosAfterDiscovering(
+        @TempDir final Path tmp) throws IOException {
+        final FakeMaven maven = new FakeMaven(tmp);
+        maven.withHelloWorld().execute(new FakeMaven.Discover());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
+    @Test
+    void comparesStatusOfForeignAndExternalTojosAfterDiscoveringManyPrograms(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final int count = 20;
+        for (int idx = 0; idx < count; ++idx) {
+            maven.withHelloWorld();
+        }
+        maven.execute(new FakeMaven.Discover());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -320,7 +320,7 @@ public final class FakeMaven {
      * Sets tojo attribute.
      *
      * @param attribute Tojo attribute.
-     * @param value     Attribute value.
+     * @param value Attribute value.
      * @return The same maven instance.
      */
     FakeMaven withTojoAttribute(final ForeignTojos.Attribute attribute, final Object value) {
@@ -337,6 +337,11 @@ public final class FakeMaven {
         return this.workspace.absolute(Paths.get("eo-foreign.csv"));
     }
 
+    /**
+     * Path to 'eo-external.*' file after all changes.
+     *
+     * @return Path to eo-external.* file.
+     */
     Path externalPath() {
         return this.workspace.absolute(Paths.get("eo-external.csv"));
     }
@@ -468,7 +473,7 @@ public final class FakeMaven {
     /**
      * Looks for all declared fields for mojo and its parents.
      *
-     * @param mojo   Mojo or mojo parent.
+     * @param mojo Mojo or mojo parent.
      * @param fields Already collected fields.
      * @return All mojo and mojo parent fields.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -60,8 +60,11 @@ final class MarkMojoTest {
         MarkMojoTest.source(temp);
         final FakeMaven maven = new FakeMaven(temp);
         final ForeignTojos foreign = maven.foreignTojos();
-        foreign.add("foo.bar")
-            .withVersion("*.*.*");
+        final ForeignTojos external = maven.externalTojos();
+        final String name = "foo.bar";
+        final String version = "*.*.*";
+        foreign.add(name).withVersion(version);
+        external.add(name).withVersion(version);
         maven.execute(MarkMojo.class);
         MatcherAssert.assertThat(
             foreign.all().iterator().next().version(),
@@ -70,6 +73,23 @@ final class MarkMojoTest {
         MatcherAssert.assertThat(
             foreign.size(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterMarking(@TempDir final Path temp) throws IOException {
+        MarkMojoTest.source(temp);
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.execute(MarkMojo.class);
+        final ForeignTojos foreign = maven.foreignTojos();
+        final ForeignTojos external = maven.externalTojos();
+        MatcherAssert.assertThat(
+            foreign.status(),
+            Matchers.equalTo(external.status())
+        );
+        MatcherAssert.assertThat(
+            foreign.all().iterator().next().version(),
+            Matchers.equalTo(external.all().iterator().next().version())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -116,6 +116,32 @@ final class OptimizeMojoTest {
         );
     }
 
+    @Test
+    void comparesForeignAndExternalTojosAfterOptimization(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.withHelloWorld().execute(new FakeMaven.Optimize());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterOptimizationManyFiles(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final int count = 20;
+        for (int idx = 0; idx < count; ++idx) {
+            maven.withHelloWorld();
+        }
+        maven.execute(new FakeMaven.Optimize());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
     /**
      * Test case for #1223.
      *

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -184,6 +184,32 @@ final class ParseMojoTest {
         }
     }
 
+    @Test
+    void comparesStatusOfForeignAndExternalTojosAfterParsing(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.withHelloWorld().execute(new FakeMaven.Parse());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
+    @Test
+    void comparesStatusOfForeignAndExternalTojosAfterParsingManyPrograms(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final int count = 20;
+        for (int idx = 0; idx < count; ++idx) {
+            maven.withHelloWorld();
+        }
+        maven.execute(new FakeMaven.Parse());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
     /**
      * The mojo that does nothing, but executes infinitely.
      * @since 0.29

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -122,6 +122,34 @@ final class ProbeMojoTest {
         );
     }
 
+    @Test
+    void comparesForeignAndExternalTojosAfterProbing(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("objectionary", new Objectionary.Fake())
+            .withProgram(ProbeMojoTest.program())
+            .execute(new FakeMaven.Probe());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterProbingManyPrograms(
+        @TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("objectionary", new Objectionary.Fake());
+        final int count = 20;
+        for (int program = 0; program < count; ++program) {
+            maven.withProgram(ProbeMojoTest.program());
+        }
+        maven.execute(new FakeMaven.Probe());
+        MatcherAssert.assertThat(
+            maven.foreignTojos().status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
+
     private static String program() {
         return new UncheckedText(
             new TextOf(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -32,6 +32,7 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyRemote;
+import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -51,9 +52,14 @@ final class PullMojoTest {
     @Test
     void pullsSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
+        final String object = "org.eolang.io.stdout";
+        final String version = "*.*.*";
         maven.foreignTojos()
-            .add("org.eolang.io.stdout")
-            .withVersion("*.*.*");
+            .add(object)
+            .withVersion(version);
+        maven.externalTojos()
+            .add(object)
+            .withVersion(version);
         maven.with("objectionary", new Objectionary.Fake())
             .with("skip", false)
             .execute(PullMojo.class);
@@ -67,6 +73,46 @@ final class PullMojoTest {
                 )
             ),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterPulling(@TempDir final Path tmp) throws IOException {
+        final FakeMaven maven = new FakeMaven(tmp)
+            .with("objectionary", new Objectionary.Fake())
+            .with("skip", false);
+        final String name = "org.eolang.io.stdout";
+        final String version = "*.*.*";
+        final ForeignTojos tojos = maven.foreignTojos();
+        final ForeignTojos external = maven.externalTojos();
+        tojos.add(name).withVersion(version);
+        external.add(name).withVer(version);
+        maven.execute(new FakeMaven.Pull());
+        MatcherAssert.assertThat(
+            external.status(),
+            Matchers.equalTo(external.status())
+        );
+    }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterPullingManyObjects(
+        @TempDir final Path tmp) throws IOException {
+        final FakeMaven maven = new FakeMaven(tmp)
+            .with("objectionary", new Objectionary.Fake())
+            .with("skip", false);
+        final String name = "org.eolang.io.stdout";
+        final String version = "*.*.*";
+        final ForeignTojos tojos = maven.foreignTojos();
+        final ForeignTojos external = maven.externalTojos();
+        final int count = 20;
+        for (int idx = 0; idx < count; ++idx) {
+            tojos.add(name + idx).withVersion(version);
+            external.add(name + idx).withVersion(version);
+        }
+        maven.execute(new FakeMaven.Pull());
+        MatcherAssert.assertThat(
+            tojos.status(),
+            Matchers.equalTo(external.status())
         );
     }
 
@@ -108,9 +154,14 @@ final class PullMojoTest {
             Paths.get("tags.txt")
         );
         final FakeMaven maven = new FakeMaven(temp);
+        final String object = "org.eolang.io.stdout";
+        final String version = "*.*.*";
         maven.foreignTojos()
-            .add("org.eolang.io.stdout")
-            .withVersion("*.*.*");
+            .add(object)
+            .withVersion(version);
+        maven.externalTojos()
+            .add(object)
+            .withVersion(version);
         maven.with("objectionary", new Objectionary.Fake())
             .with("offlineHashFile", temp.resolve("tags.txt"))
             .with("skip", false)
@@ -129,9 +180,14 @@ final class PullMojoTest {
     @Test
     void pullsUsingOfflineHash(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
+        final String object = "org.eolang.io.stdout";
+        final String version = "*.*.*";
         maven.foreignTojos()
-            .add("org.eolang.io.stdout")
-            .withVersion("*.*.*");
+            .add(object)
+            .withVersion(version);
+        maven.externalTojos()
+            .add(object)
+            .withVersion(version);
         maven.with("objectionary", new Objectionary.Fake())
             .with("tag", "1.0.0")
             .with("offlineHash", "*.*.*:abcdefg")
@@ -146,10 +202,17 @@ final class PullMojoTest {
     @Test
     void skipsPullMojo(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
+        final String object = "org.eolang.io.stdout";
+        final String version = "*.*.*";
+        final String scope = "complie";
         maven.foreignTojos()
-            .add("org.eolang.io.stdout")
-            .withScope("compile")
-            .withVersion("*.*.*");
+            .add(object)
+            .withVersion(version)
+            .withScope(scope);
+        maven.externalTojos()
+            .add(object)
+            .withVersion(version)
+            .withScope(scope);
         maven.with("skip", true)
             .with("objectionary", new Objectionary.Fake())
             .execute(PullMojo.class);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -249,4 +249,31 @@ final class ResolveMojoTest {
             new ContainsFile("**/eo-runtime-*.jar")
         );
     }
+
+    @Test
+    void comparesForeignAndExternalTojosAfterResolving(@TempDir final Path tmp) throws IOException {
+        final FakeMaven maven = new FakeMaven(tmp)
+            .withProgram(
+                String.format(
+                    "%s\n\n%s",
+                    "+rt jvm org.eolang:eo-runtime:0.7.0",
+                    "[] > foo /int"
+                )
+            ).execute(new FakeMaven.Resolve());
+        final Path path = tmp.resolve("target/4-resolve/org.eolang/eo-runtime/-/0.7.0");
+        MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
+        MatcherAssert.assertThat(
+            path.resolve("eo-runtime-0.7.0.jar").toFile(),
+            FileMatchers.anExistingFile()
+        );
+        final ForeignTojos tojos = maven.foreignTojos();
+        MatcherAssert.assertThat(
+            tojos.size(),
+            Matchers.greaterThan(0)
+        );
+        MatcherAssert.assertThat(
+            tojos.status(),
+            Matchers.equalTo(maven.externalTojos().status())
+        );
+    }
 }


### PR DESCRIPTION
Ref: #1602 

What's done:
- Created one more `ForeignTojos` with name `external` that copies `foreign` one
- The tojos were added to all Mojos used in parsing and compilation pipeline
- Tests with checking equality of foreign and external tojos were added

The reason: the tojos were added to implement the feature on object versioning independentely. Main tojos file (eo-foreign.*) is not affected -> main build pipeline is not break.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of external dependencies in the code. 

### Detailed summary
- The `ResolveMojo` now includes the `extTojos` list in the `DcsDefault` constructor.
- The `RegisterMojo` now adds the `name` to the `extTojos` list.
- The `DemandMojo` now adds `object` to both the `scopedTojos` and `extTojos` lists.
- The `SodgMojo` now iterates over the `extTojos` list and adds the `sodg` to each element.
- The `CleanMojoTest`, `DiscoverMojoTest`, `OptimizeMojoTest`, `ParseMojoTest`, `ProbeMojoTest`, `ResolveMojoTest` classes now include tests that compare the status of `foreignTojos` and `externalTojos` after various operations.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/main/java/org/eolang/maven/dependencies/DcsDefault.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->