### PR TITLE
#1602 Added syntax to use versions with fullname object

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
@@ -140,6 +140,11 @@ application
   method
   htail?
   |
+  application
+  method
+  version
+  suffix?
+  |
   scope
   htail?
   |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/versions.yaml
@@ -5,6 +5,8 @@ tests:
   - //o[@base='func2' and not(@ver)]
   - //o[@base='func3' and @ver='3.2.1']
   - //o[@base='func4' and @ver='10.20.30']
+  - //o[@base='.stdout' and @ver='1.28.5']
+  - //o[@base='.sprintf' and @ver='0.28.5' and @name='y']
 eo: |
   [] > main
     func0|3.4.5 > x
@@ -14,3 +16,6 @@ eo: |
     func3|3.2.1
     .method
       func4|10.20.30
+    QQ.io.stdout|1.28.5
+      QQ.txt.sprintf|0.28.5 > y
+        "Hello world"


### PR DESCRIPTION
Ref: #1602 

Added new syntax to be able to use versions with fullname object like `QQ.io.stdout` 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of two functions and adding two new functions. 

### Detailed summary
- Updated version of function `func3` to `3.2.1`
- Updated version of function `func4` to `10.20.30`
- Added new function `QQ.io.stdout` with version `1.28.5`
- Added new function `QQ.txt.sprintf` with version `0.28.5` and name `y`
- Added the string "Hello world"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->