### PR TITLE
#2208: Parallel compiling

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -81,7 +81,7 @@ public final class BinarizeMojo extends SafeMojo {
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    project -> () -> apply(project),
+                    project -> () -> this.apply(project),
                     targetDir.toPath().resolve("Lib").toFile().listFiles()
                 )
             )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -82,12 +82,17 @@ public final class BinarizeMojo extends SafeMojo {
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
                     project -> () -> {
-                        if (project.isDirectory() && project.toPath().resolve("Cargo.toml").toFile().exists()) {
+                        final int built;
+                        if (
+                            project.isDirectory() &&
+                                project.toPath().resolve("Cargo.toml").toFile().exists()
+                        ) {
                             this.build(project);
-                            return 1;
+                            built = 1;
                         } else {
-                            return 0;
+                            built = 0;
                         }
+                        return built;
                     },
                     targetDir.toPath().resolve("Lib").toFile().listFiles()
                 )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -81,19 +81,7 @@ public final class BinarizeMojo extends SafeMojo {
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    project -> () -> {
-                        final int built;
-                        if (
-                            project.isDirectory()
-                                && project.toPath().resolve("Cargo.toml").toFile().exists()
-                        ) {
-                            this.build(project);
-                            built = 1;
-                        } else {
-                            built = 0;
-                        }
-                        return built;
-                    },
+                    project -> () -> apply(project),
                     targetDir.toPath().resolve("Lib").toFile().listFiles()
                 )
             )
@@ -105,13 +93,33 @@ public final class BinarizeMojo extends SafeMojo {
     }
 
     /**
+     * Builds the project if it is a directory.
+     * @param project File to build.
+     * @return Number of projects were built, i.e. 0 or 1.
+     * @throws IOException If any issues with IO
+     */
+    private int apply(final File project) throws IOException {
+        final int built;
+        if (
+            project.isDirectory()
+                && project.toPath().resolve("Cargo.toml").toFile().exists()
+        ) {
+            this.build(project);
+            built = 1;
+        } else {
+            built = 0;
+        }
+        return built;
+    }
+
+    /**
      * Builds cargo project.
      * @param project Path to the project.
      * @throws IOException If any issues with IO.
      */
     private void build(final File project) throws IOException {
         final File target = project.toPath().resolve("target").toFile();
-        final File cached = cache
+        final File cached = this.cache
             .resolve("Lib")
             .resolve(project.getName())
             .resolve("target").toFile();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -84,8 +84,8 @@ public final class BinarizeMojo extends SafeMojo {
                     project -> () -> {
                         final int built;
                         if (
-                            project.isDirectory() &&
-                                project.toPath().resolve("Cargo.toml").toFile().exists()
+                            project.isDirectory()
+                                && project.toPath().resolve("Cargo.toml").toFile().exists()
                         ) {
                             this.build(project);
                             built = 1;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -77,7 +77,7 @@ public final class BinarizeMojo extends SafeMojo {
     @Override
     public void exec() throws IOException {
         new Moja<>(BinarizeParseMojo.class).copy(this).execute();
-        int total = new SumOf(
+        final int total = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(


### PR DESCRIPTION
Closes #2208 
Added concurrency to rust compilation.
Removed redundant `VerboseProcess.waitfor()` since `stdout` method already wait for its finish.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the build process of cargo projects in the BinarizeMojo class. 

### Detailed summary
- Added parallel compilation of cargo projects using Threads and SumOf classes from the cactoos library.
- Added a method to check if a project is valid by checking if it is a directory and if it contains a Cargo.toml file.
- Updated the build() method to use the new valid() method and removed the unnecessary waitFor() call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->