### PR TITLE
refactor(#2227): Refactor ForeignTojos Attribute

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -78,7 +77,6 @@ public final class ForeignTojos implements Closeable {
     public void close() throws IOException {
         this.tojos.value().close();
     }
-
 
     /**
      * Add a foreign tojo.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -77,6 +78,7 @@ public final class ForeignTojos implements Closeable {
     public void close() throws IOException {
         this.tojos.value().close();
     }
+
 
     /**
      * Add a foreign tojo.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -236,7 +236,7 @@ public final class ForeignTojos implements Closeable {
     /**
      * Foreign tojo attributes.
      */
-    public enum Attribute {
+    enum Attribute {
 
         /**
          * Tojo id.
@@ -294,11 +294,6 @@ public final class ForeignTojos implements Closeable {
         SCOPE("scope"),
 
         /**
-         * Transpiled.
-         */
-        TRANSPILED("transpiled"),
-
-        /**
          * Hash.
          */
         HASH("hash"),
@@ -325,7 +320,7 @@ public final class ForeignTojos implements Closeable {
          * Get the attribute name.
          * @return The attribute name.
          */
-        public String key() {
+        String key() {
             return this.key;
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -24,7 +24,6 @@
 package org.eolang.maven;
 
 import com.yegor256.tojos.TjSmart;
-import com.yegor256.tojos.Tojo;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -98,7 +97,6 @@ public final class FakeMaven {
     public FakeMaven(final Path workspace) {
         this.workspace = new Home(workspace);
         this.params = new HashMap<>();
-        this.attributes = new HashMap<>();
         this.current = new AtomicInteger(0);
     }
 
@@ -295,7 +293,7 @@ public final class FakeMaven {
     }
 
     /**
-     * Specify hash for all foreign tojos
+     * Specify hash for all foreign tojos.
      * @param hash Commit hash
      * @return The same maven instance.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -84,11 +84,6 @@ public final class FakeMaven {
     private final Map<String, Object> params;
 
     /**
-     * Attributes for eo.foreign.* and eo.external.*.
-     */
-    private final Map<ForeignTojos.Attribute, Object> attributes;
-
-    /**
      * Current program number.
      * We can save several programs in workspace and each program has it's own number
      * started from 0.
@@ -157,8 +152,6 @@ public final class FakeMaven {
      * @throws java.io.IOException If some problem with filesystem have happened.
      */
     public <T extends AbstractMojo> FakeMaven execute(final Class<T> mojo) throws IOException {
-        this.fillUp(this.foreign().select(all -> true));
-        this.fillUp(this.external().select(all -> true));
         this.params.putIfAbsent("targetDir", this.targetPath().toFile());
         this.params.putIfAbsent("foreign", this.foreignPath().toFile());
         this.params.putIfAbsent("external", this.externalPath().toFile());
@@ -464,25 +457,6 @@ public final class FakeMaven {
      */
     private Path externalPath() {
         return this.workspace.absolute(Paths.get("eo-external.csv"));
-    }
-
-    /**
-     * Fill up given tojos by the attributes.
-     * @param tojos Tojos to fill up.
-     * @todo #1602:30min Move the method to ForeignTojos if possible.
-     *  Let's treat ForeignTojos as an object (not as a collection of data)
-     *  and give it a chance to fulfill itself. It knows better how to do so.
-     *  ForeignTojo in current implementation does not have method set() so
-     *  we either need to implement it or just stay with the method here in
-     *  FakeMaven class.
-     */
-    private void fillUp(final List<Tojo> tojos) {
-        for (final Tojo tojo : tojos) {
-            for (final Map.Entry<ForeignTojos.Attribute, Object> entry
-                : this.attributes.entrySet()) {
-                tojo.set(entry.getKey().key(), entry.getValue());
-            }
-        }
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -54,6 +54,7 @@ import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.Input;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
+import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.util.Home;
@@ -301,14 +302,12 @@ public final class FakeMaven {
     }
 
     /**
-     * Sets tojo attribute.
-     *
-     * @param attribute Tojo attribute.
-     * @param value Attribute value.
+     * Specify hash for all foreign tojos
+     * @param hash Commit hash
      * @return The same maven instance.
      */
-    FakeMaven withTojoAttribute(final ForeignTojos.Attribute attribute, final Object value) {
-        this.attributes.put(attribute, value);
+    FakeMaven allTojosWithHash(final CommitHash hash) {
+        this.foreignTojos().all().forEach(tojo -> tojo.withHash(hash));
         return this;
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -138,7 +138,7 @@ final class OptimizeMojoTest {
         new FakeMaven(temp)
             .withHelloWorld()
             .with("cache", cache)
-            .withTojoAttribute(ForeignTojos.Attribute.HASH, hash)
+            .allTojosWithHash(() -> hash)
             .execute(new FakeMaven.Optimize());
         MatcherAssert.assertThat(
             new XMLDocument(
@@ -163,7 +163,7 @@ final class OptimizeMojoTest {
         new FakeMaven(temp)
             .withHelloWorld()
             .with("cache", cache)
-            .withTojoAttribute(ForeignTojos.Attribute.HASH, hash)
+            .allTojosWithHash(() -> hash)
             .execute(new FakeMaven.Optimize());
         MatcherAssert.assertThat(
             cache.resolve(OptimizeMojo.OPTIMIZED)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -43,7 +43,6 @@ import net.sf.saxon.TransformerFactoryImpl;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
-import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.util.Home;
 import org.eolang.parser.CheckPack;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -98,12 +98,18 @@ final class ParseMojoTest {
             cache.resolve(ParseMojo.PARSED),
             new FtDefault(maven.targetPath())
         ).save("foo.x.main", "xmir", () -> expected);
+        final String actual = String.format(
+            "target/%s/foo/x/main.%s",
+            ParseMojo.DIR,
+            TranspileMojo.EXT
+        );
         MatcherAssert.assertThat(
+            String.format("We expect that that %s is taken from the cache, but it didn't", actual),
             new TextOf(
                 maven.allTojosWithHash(hash)
                     .execute(new FakeMaven.Parse())
                     .result()
-                    .get(String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT))
+                    .get(actual)
             ).toString(),
             Matchers.equalTo(expected)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -38,8 +38,6 @@ import org.eolang.maven.footprint.FtDefault;
 import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.CommitHash;
-import org.eolang.maven.tojos.ForeignTojo;
-import org.eolang.maven.tojos.ForeignTojos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -35,6 +35,7 @@ import org.cactoos.text.UncheckedText;
 import org.eolang.maven.footprint.CacheVersion;
 import org.eolang.maven.footprint.FtCached;
 import org.eolang.maven.footprint.FtDefault;
+import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.CommitHash;
@@ -91,7 +92,7 @@ final class ParseMojoTest {
         final String expected = new UncheckedText(
             new TextOf(new ResourceOf("org/eolang/maven/main.xmir"))
         ).asString();
-        final CommitHash hash = new ChNarrow(new ChRemote("0.25.0"));
+        final CommitHash hash = new ChCached(new ChNarrow(new ChRemote("0.25.0")));
         new FtCached(
             new CacheVersion(FakeMaven.pluginVersion(), hash.value()),
             cache.resolve(ParseMojo.PARSED),


### PR DESCRIPTION
What has been done:
1. Removed `attributes` from `FakeMaven`
2. Removed `fillUp()` method from `FakeMaven`
3. Added the `allTojosWithHash()` method to set `hash` for all tojos for all tests
4. Removed the unsused attribute: `ForeignTojos.Attribute.TRANSPILED`

Closes: #2227

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the code by removing unused imports, enum values, and methods. 

### Detailed summary
- Removed unused imports in the `OptimizeMojoTest` and `ParseMojoTest` classes.
- Removed unused enum values and methods in the `Attribute` enum in the `ForeignTojos` class.
- Removed unused methods and attributes in the `FakeMaven` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->