### PR TITLE
feat(#2119): rename synthetic-reference.xsl -> scopes.xsl

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/converts-to-java-with-arrays-and-scopes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/converts-to-java-with-arrays-and-scopes.yaml
@@ -2,7 +2,7 @@
 # The aim of this test is to check that entire pipeline with
 # synthetic-referenses.xsl transformation works as expected without creating
 # any warnings or errors.
-# Pay attention to synthetic-references.xsl and to-java.xsl transformations.
+# Pay attention to scopes.xsl and to-java.xsl transformations.
 xsls:
   - /org/eolang/parser/errors/not-empty-atoms.xsl
   - /org/eolang/parser/critical-errors/duplicate-names.xsl
@@ -25,7 +25,7 @@ xsls:
   - /org/eolang/parser/warnings/incorrect-version.xsl
   - /org/eolang/parser/expand-aliases.xsl
   - /org/eolang/parser/resolve-aliases.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
   - /org/eolang/parser/add-default-package.xsl
   - /org/eolang/parser/errors/broken-refs.xsl
   - /org/eolang/parser/errors/unknown-names.xsl

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/synthetic-attributes-with-to-java.yaml
@@ -2,7 +2,7 @@
 # The aim of this test is to check that entire pipeline with
 # synthetic-referenses.xsl transformation works as expected without creating
 # any warnings or errors.
-# Pay attention to synthetic-references.xsl and to-java.xsl transformations.
+# Pay attention to scopes.xsl and to-java.xsl transformations.
 xsls:
   - /org/eolang/parser/errors/not-empty-atoms.xsl
   - /org/eolang/parser/critical-errors/duplicate-names.xsl
@@ -25,7 +25,7 @@ xsls:
   - /org/eolang/parser/warnings/incorrect-version.xsl
   - /org/eolang/parser/expand-aliases.xsl
   - /org/eolang/parser/resolve-aliases.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
   - /org/eolang/parser/add-default-package.xsl
   - /org/eolang/parser/errors/broken-refs.xsl
   - /org/eolang/parser/errors/unknown-names.xsl

--- a/eo-parser/src/main/java/org/eolang/parser/Objects.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Objects.java
@@ -67,15 +67,15 @@ interface Objects extends Iterable<Directive> {
     void leave();
 
     /**
-     * Mark next object for aliasing.
+     * Mark next object for scoping.
      */
-    void alias();
+    void scope();
 
     /**
      * Mark current object as last inside the scope.
-     * Last object that relates to the alias.
+     * Last object that relates to the scope.
      */
-    void closeAlias();
+    void closeScope();
 
     /**
      * Xembly object tree.
@@ -91,16 +91,15 @@ interface Objects extends Iterable<Directive> {
         /**
          * Generated aliases.
          */
-        private final Deque<String> aliases = new LinkedList<>();
+        private final Deque<String> scopes = new LinkedList<>();
 
         @Override
         public void start(final int line, final int pos) {
             this.dirs.add("o");
             this.prop("line", line);
             this.prop("pos", pos);
-            if (!this.aliases.isEmpty()) {
-                final String alias = String.join("-", this.aliases);
-                this.prop("alias", alias);
+            if (!this.scopes.isEmpty()) {
+                this.prop("scope", String.join("-", this.scopes));
             }
         }
 
@@ -125,8 +124,8 @@ interface Objects extends Iterable<Directive> {
         }
 
         @Override
-        public void alias() {
-            this.aliases.push(
+        public void scope() {
+            this.scopes.push(
                 String.format(
                     "scope-%s",
                     UUID.randomUUID()
@@ -135,8 +134,8 @@ interface Objects extends Iterable<Directive> {
         }
 
         @Override
-        public void closeAlias() {
-            this.aliases.remove();
+        public void closeScope() {
+            this.scopes.remove();
         }
 
         @Override

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -77,7 +77,7 @@ public final class ParsingTrain extends TrEnvelope {
         "/org/eolang/parser/warnings/incorrect-version.xsl",
         "/org/eolang/parser/expand-aliases.xsl",
         "/org/eolang/parser/resolve-aliases.xsl",
-        "/org/eolang/parser/synthetic-references.xsl",
+        "/org/eolang/parser/scopes.xsl",
         "/org/eolang/parser/add-refs.xsl",
         "/org/eolang/parser/add-default-package.xsl",
         "/org/eolang/parser/errors/broken-refs.xsl",

--- a/eo-parser/src/main/java/org/eolang/parser/XeListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeListener.java
@@ -319,12 +319,12 @@ public final class XeListener implements ProgramListener, Iterable<Directive> {
 
     @Override
     public void enterScope(final ProgramParser.ScopeContext ctx) {
-        this.objects.alias();
+        this.objects.scope();
     }
 
     @Override
     public void exitScope(final ProgramParser.ScopeContext ctx) {
-        this.objects.closeAlias();
+        this.objects.closeScope();
     }
 
     @Override

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -34,7 +34,7 @@ SOFTWARE.
     </xs:sequence>
     <xs:attribute name="line" type="xs:decimal"/>
     <xs:attribute name="pos" type="xs:decimal"/>
-    <xs:attribute name="alias" type="xs:string"/>
+    <xs:attribute name="scope" type="xs:string"/>
     <xs:attribute name="name"/>
     <xs:attribute name="base"/>
     <xs:attribute name="data"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/scopes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/scopes.xsl
@@ -22,22 +22,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="synthetic-references" version="2.0">
-  <!--
-  Process alias attribute.
-  @todo #2110:90m Rename synthetic-attributes to synthetic-scopes.
-    We call all attributes in the transformation as "aliases".
-    (you can read more about the original issue and why it is named so right
-    <a href="https://github.com/objectionary/eo/issues/415">here</a>.)
-    which is quite confusing and conflicts with the concept of aliases as
-    foreign references. We should rename the transformation to "scopes" or
-    "synthetic-scopes" and rename the "aliases" attributes in that stylesheet
-    accordingly.
-  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="scopes" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="o[@alias and count(child::o) &gt; 1]">
+  <xsl:template match="o[@scope and count(child::o) &gt; 1]">
     <xsl:element name="o">
-      <xsl:variable name="curr" select="@alias"/>
+      <xsl:variable name="curr" select="@scope"/>
       <xsl:attribute name="abstract"/>
       <xsl:attribute name="name">
         <xsl:value-of select="concat('generated-',$curr)"/>
@@ -52,14 +41,14 @@ SOFTWARE.
         <xsl:copy-of select="@*"/>
         <xsl:attribute name="name">
           <xsl:text>org.eolang.</xsl:text>
-          <xsl:value-of select="@alias"/>
+          <xsl:value-of select="@scope"/>
         </xsl:attribute>
-        <xsl:apply-templates select="child::o[contains(@alias, $curr)]"/>
+        <xsl:apply-templates select="child::o[contains(@scope, $curr)]"/>
       </xsl:copy>
       <xsl:element name="o">
         <xsl:attribute name="base">
           <xsl:text>org.eolang.</xsl:text>
-          <xsl:value-of select="@alias"/>
+          <xsl:value-of select="@scope"/>
         </xsl:attribute>
         <xsl:attribute name="name">
           <xsl:text>@</xsl:text>
@@ -70,7 +59,7 @@ SOFTWARE.
         <xsl:attribute name="pos">
           <xsl:value-of select="@pos"/>
         </xsl:attribute>
-        <xsl:apply-templates select="child::o[not(@alias) or not(contains(@alias, $curr))]"/>
+        <xsl:apply-templates select="child::o[not(@scope) or not(contains(@scope, $curr))]"/>
       </xsl:element>
     </xsl:element>
   </xsl:template>

--- a/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
@@ -53,7 +53,6 @@ import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -75,13 +74,8 @@ final class XMIRTest {
      * which later can be used by the {@see https://ctan.org/pkg/naive-ebnf}.</p>
      *
      * @since 0.30.0
-     * @todo #2240:30min Test fails on github actions CI. On ubuntu 22.04
-     *  JARs of covert tool are downloaded from
-     *  <a href="http://public.yegor256.com/convert.zip"/>. Test seems to work
-     *  locally but it fails on github actions.
      */
     @Test
-    @Disabled
     void convertsAntlrToEbnf() throws Exception {
         String home = System.getenv("CONVERT_PATH");
         if (home == null) {

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/optimize/redundant-levels-with-arrays.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
   - /org/eolang/parser/optimize/abstracts-float-up.xsl
   - /org/eolang/parser/optimize/remove-levels.xsl
 tests:

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-double-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-double-scope.yaml
@@ -1,5 +1,5 @@
 xsls:
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]
@@ -13,5 +13,5 @@ eo: |
     [i j] > foobar
       44 > @
     eq. > @
-      foobar (foo (bar 1 2) 3) 4
+      foobar (foo 1 2) (bar 3 4)
       44

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-many-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-many-arguments.yaml
@@ -1,5 +1,5 @@
 xsls:
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='foo' and count(o)=3]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-nested.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-nested.yaml
@@ -1,5 +1,5 @@
 xsls:
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='foo' and count(o)=2]
   - //o[@base='bar' and count(o)=2]
@@ -13,5 +13,5 @@ eo: |
     [i j] > foobar
       44 > @
     eq. > @
-      foobar (foo 1 2) (bar 3 4)
+      foobar (foo (bar 1 2) 3) 4
       44

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-simple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-simple.yaml
@@ -1,5 +1,5 @@
 xsls:
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='foo' and count(o)=1]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-add-refs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-add-refs.yaml
@@ -2,7 +2,7 @@
 # The aim of this test is to check that all synthetic attributes are added
 # correctly and further optimization chain works as expected without creating
 # any warnings or errors.
-# Pay attention to synthetic-references.xsl and add-refs.xsl transformations.
+# Pay attention to scopes.xsl and add-refs.xsl transformations.
 xsls:
   - /org/eolang/parser/errors/not-empty-atoms.xsl
   - /org/eolang/parser/critical-errors/duplicate-names.xsl
@@ -25,7 +25,7 @@ xsls:
   - /org/eolang/parser/warnings/incorrect-version.xsl
   - /org/eolang/parser/expand-aliases.xsl
   - /org/eolang/parser/resolve-aliases.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
   - /org/eolang/parser/add-default-package.xsl
   - /org/eolang/parser/errors/broken-refs.xsl
   - /org/eolang/parser/errors/unknown-names.xsl

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-doubled-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-doubled-methods.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='.foo' and count(o[@abstract]/o[@base='.bar'])=2]
   - //o[@base='.bar' and count(o)=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-nested-methods.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-with-nested-methods.yaml
@@ -1,6 +1,6 @@
 xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with']/o[@base='foobar']
   - //o[@base='.with']/o[@abstract]/o[@base='.with']/o[@abstract]/o[@base='.with' and count(o)=3]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-without-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes-without-scope.yaml
@@ -1,5 +1,5 @@
 xsls:
-  - /org/eolang/parser/synthetic-references.xsl
+  - /org/eolang/parser/scopes.xsl
 tests:
   - //o[@base='foo' and count(o)=2]
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/scopes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/scopes.yaml
@@ -1,6 +1,6 @@
 xsls: []
 tests:
-  - //objects[count(.//o[@alias])=3]
+  - //objects[count(.//o[@scope])=3]
 eo: |
   [] > aliases
     a (b (c d))


### PR DESCRIPTION
Rename `synthetic-reference.xsl` transformation to `scopes.xsl` transformation and alias attribute to scope attribute.

Closes: #2119

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the concept of "aliases" with "scopes" in the codebase. 

### Detailed summary
- Replaced references to "aliases" with "scopes" in various files
- Renamed `alias()` method to `scope()` and `closeAlias()` method to `closeScope()` in `Objects` class
- Updated XSLT stylesheet names from `synthetic-references.xsl` to `scopes.xsl`
- Updated relevant test resources and configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->