### PR TITLE
feat(#2236): Leave only 11 and 20 java versions for a regular build

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [11, 17, 18]
+        java: [11, 20]
     runs-on: ${{ matrix.os }}
     env:
       CONVERT_PATH: /tmp/convert


### PR DESCRIPTION
Leave only 11 and 20 java versions for a regular build.

Closes: #2236 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Java version in the GitHub Actions workflow. 

### Detailed summary:
- Updated the Java version to include Java 20 in the matrix configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->