### PR TITLE
#1143 `xcop` checks xsl via strategy in CI

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,7 +12,12 @@ concurrency:
   cancel-in-progress: true
 jobs:
   xcop:
+    strategy:
+      matrix:
+        glob: ["**/*.xml", "**/*.xsl"]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: g4s8/xcop-action@1.1
+        with:
+          files: glob


### PR DESCRIPTION
Ref: #1143 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new job `xcop` to the `.github/workflows/xcop.yml` file. The job runs on Ubuntu 20.04 and performs code analysis using the `g4s8/xcop-action` action. Notable changes include adding a strategy matrix to specify the files to analyze and passing the file patterns to the `xcop-action` action. 

### Detailed summary
- Added a new job `xcop` to `.github/workflows/xcop.yml`
- Set the job to run on Ubuntu 20.04
- Added a strategy matrix to specify the files to analyze
- Passed the file patterns `**/*.xml` and `**/*.xsl` to the `xcop-action` action

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->