### PR TITLE
feat(#2220): ForeignTojos in memory 

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.Func;
-import org.eolang.maven.tojos.ForeignTojos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
@@ -73,9 +72,7 @@ final class ResolveMojoTest {
             "    a",
             "    b"
         );
-        new ForeignTojos(() -> Catalogs.INSTANCE.make(maven.foreignPath(), "json"))
-            .add("sum")
-            .withDiscovered(0);
+        maven.foreignTojos().add("sum").withDiscovered(0);
         maven.execute(new FakeMaven.Resolve());
         final Path path = temp.resolve("target/4-resolve/org.eolang/eo-runtime/-/");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -24,13 +24,10 @@
 package org.eolang.maven.tojos;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import org.eolang.maven.FakeMaven;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -48,15 +45,10 @@ final class ForeignTojosTest {
 
     /**
      * Set up environment before each test.
-     *
-     * @param tmp Temporary dir.
-     * @todo #2213:60min Create an instance of ForeignTojos in memory.
-     *  It would be better to be able to create an instance of ForeignTojos in
-     *  memory for test purposes.
      */
     @BeforeEach
-    void setUp(@TempDir final Path tmp) {
-        this.tojos = new ForeignTojos(() -> new FakeMaven(tmp).foreign());
+    void setUp() {
+        this.tojos = new ForeignTojos();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Add constructor for `ForeignTojos` which will place all created tojos into memory.
Also I've removed unused method `ForeignTojos.withSource`

Closes: #2220 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on refactoring the `ForeignTojos` class and its related tests in the `eo-maven-plugin` module.

### Detailed summary:
- Remove unnecessary import statements in `ResolveMojoTest` and `ForeignTojosTest`.
- Simplify the setup method in `ForeignTojosTest`.
- Add new imports in `ForeignTojos.java`.
- Refactor the constructors and methods in the `ForeignTojos` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->