### PR TITLE
2238 names

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -58,6 +58,9 @@ import org.eolang.parser.ParsingTrain;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
+ * @todo #2238:30min Specify directory for names via pom.xml.Now names map is
+ *  serialized in targetDir.toPath().getParent() which is a bad decision since
+ *  it must be created just as target/names.
  */
 @Mojo(
     name = "binarize_parse",
@@ -102,13 +105,6 @@ public final class BinarizeParseMojo extends SafeMojo {
     @SuppressWarnings("PMD.UnusedPrivateField")
     private File generatedDir;
 
-    /**
-     * Exec.
-     * @throws IOException If any issues with IO.
-     * @todo #2238: 30min Specify directory for names via pom.xml.Now names map is
-     *  serialized in targetDir.toPath().getParent() which is a bad decision since
-     *  it must be created just as target/names.
-     */
     @Override
     public void exec() throws IOException {
         final Names names = new Names(targetDir.toPath().getParent());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -104,7 +104,7 @@ public final class BinarizeParseMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        final Names names = new Names(targetDir.toPath(), "Java2Rust_");
+        final Names names = new Names(targetDir.toPath().getParent());
         new File(this.targetDir.toPath().resolve("Lib/").toString()).mkdirs();
         for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
             final Path file = tojo.optimized();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -105,11 +105,9 @@ public final class BinarizeParseMojo extends SafeMojo {
     /**
      * Exec.
      * @throws IOException If any issues with IO.
-     * @todo: 30min Specify directory for names via
-     *  pom.xml.Now names map is serialized in
-     *  targetDir.toPath().getParent() which is a bad
-     *  decision since it must be created just as
-     *  target/names.
+     * @todo #2238: 30min Specify directory for names via pom.xml.Now names map is
+     *  serialized in targetDir.toPath().getParent() which is a bad decision since
+     *  it must be created just as target/names.
      */
     @Override
     public void exec() throws IOException {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -104,7 +104,7 @@ public final class BinarizeParseMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        final Names names = new Names(targetDir.toPath());
+        final Names names = new Names(targetDir.toPath(), "Java2Rust_");
         new File(this.targetDir.toPath().resolve("Lib/").toString()).mkdirs();
         for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
             final Path file = tojo.optimized();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -102,6 +102,15 @@ public final class BinarizeParseMojo extends SafeMojo {
     @SuppressWarnings("PMD.UnusedPrivateField")
     private File generatedDir;
 
+    /**
+     * Exec.
+     * @throws IOException If any issues with IO.
+     * @todo: 30min Specify directory for names via
+     *  pom.xml.Now names map is serialized in
+     *  targetDir.toPath().getParent() which is a bad
+     *  decision since it must be created just as
+     *  target/names.
+     */
     @Override
     public void exec() throws IOException {
         final Names names = new Names(targetDir.toPath().getParent());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.cactoos.scalar.IoChecked;
@@ -51,6 +50,11 @@ import org.eolang.maven.util.Home;
 public final class Names {
 
     /**
+     * Prefix for the names.
+     */
+    public static final String PREFIX = "native_";
+
+    /**
      * Target directory.
      * @checkstyle MemberNameCheck (7 lines)
      */
@@ -62,17 +66,11 @@ public final class Names {
     private final IoChecked<ConcurrentHashMap<String, String>> all;
 
     /**
-     * Prefix for the name.
-     */
-    private final String prefix;
-
-    /**
      * Ctor.
      * @param target Directory where to serialize names.
      */
-    public Names(final Path target, final String prefix) {
+    public Names(final Path target) {
         this.dest = target.resolve("names");
-        this.prefix = prefix;
         this.all = Names.checked(this.dest);
     }
 
@@ -98,7 +96,7 @@ public final class Names {
             loc,
             key -> String.format(
                 "%s%d",
-                this.prefix,
+                Names.PREFIX,
                 cached.size()
             )
         );
@@ -116,7 +114,7 @@ public final class Names {
         final Names names = (Names) object;
         try {
             return this.dest.equals(names.dest)
-                && this.prefix.equals(names.prefix)
+                && Names.PREFIX.equals(Names.PREFIX)
                 && this.all.value().equals(names.all.value());
         } catch (final IOException exc) {
             throw new IllegalArgumentException(
@@ -129,7 +127,6 @@ public final class Names {
     @Override
     public int hashCode() {
         return 31 * this.dest.hashCode()
-            + 829 * this.prefix.hashCode()
             + 9719 * this.all.hashCode();
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
@@ -70,9 +70,9 @@ public final class Names {
      * Ctor.
      * @param target Directory where to serialize names.
      */
-    public Names(final Path target) {
+    public Names(final Path target, final String prefix) {
         this.dest = target.resolve("names");
-        this.prefix = target.toString().toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]", "x");
+        this.prefix = prefix;
         this.all = Names.checked(this.dest);
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
@@ -52,7 +52,7 @@ public final class Names {
     /**
      * Prefix for the names.
      */
-    public static final String PREFIX = "native_";
+    public static final String PREFIX = "native";
 
     /**
      * Target directory.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
@@ -114,7 +114,6 @@ public final class Names {
         final Names names = (Names) object;
         try {
             return this.dest.equals(names.dest)
-                && Names.PREFIX.equals(Names.PREFIX)
                 && this.all.value().equals(names.all.value());
         } catch (final IOException exc) {
             throw new IllegalArgumentException(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
@@ -25,10 +25,10 @@ package org.eolang.maven;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 import java.util.Map;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
+import org.eolang.maven.rust.Names;
 import org.eolang.xax.XaxStory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -58,9 +58,7 @@ final class BinarizeParseMojoTest {
             .result();
         final String function = String.format(
             "%s0",
-            temp.resolve("target").toString()
-                .toLowerCase(Locale.ENGLISH)
-                .replaceAll("[^a-z0-9]", "x")
+            Names.PREFIX
         );
         final String rust = String.format(
             "target/binarize/codes/%s.rs",
@@ -104,16 +102,13 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
-        final String prefix = temp.resolve("target").toString()
-            .toLowerCase(Locale.ENGLISH)
-            .replaceAll("[^a-z0-9]", "x");
         final String one = String.format(
             "target/binarize/codes/%s0.rs",
-            prefix
+            Names.PREFIX
         );
         final String two = String.format(
             "target/binarize/codes/%s1.rs",
-            prefix
+            Names.PREFIX
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(one)
@@ -158,19 +153,16 @@ final class BinarizeParseMojoTest {
         final Map<String, Path> res = maven
             .execute(new FakeMaven.BinarizeParse())
             .result();
-        final String prefix = temp.resolve("target").toString()
-            .toLowerCase(Locale.ENGLISH)
-            .replaceAll("[^a-z0-9]", "x");
         final String dir = String.format(
             "target/Lib/%s1/",
-            prefix
+            Names.PREFIX
         );
         final String cargo = dir.concat("Cargo.toml");
         final String lib = dir.concat("src/lib.rs");
         final String module = String.format(
             "%ssrc/%s1.rs",
             dir,
-            prefix
+            Names.PREFIX
         );
         MatcherAssert.assertThat(
             res, Matchers.hasKey(cargo)

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -32,19 +32,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Base64;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.SystemUtils;
 import org.cactoos.bytes.Base64Bytes;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.IoCheckedBytes;
-import org.cactoos.scalar.IoChecked;
-import org.cactoos.text.Base64Decoded;
-import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
@@ -73,7 +68,7 @@ public class EOrust extends PhDefault {
 
     static {
         try {
-            NAMES = load("target/eo-test/names");
+            NAMES = load("target/names");
         } catch (final IOException exc) {
             throw new ExFailure(
                 "Cannot read the file target/eo-test/names",


### PR DESCRIPTION
Closes: #2238
Now funactions are named like `native0`, `native1`, ..

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on specifying the directory for names via pom.xml in the `BinarizeParseMojo` class. The notable changes are:

- The `Names` class now has a `PREFIX` constant for name prefixes.
- The `Names` class no longer uses the `prefix` field.
- The `BinarizeParseMojo` class now uses the parent directory of `targetDir` for creating the `Names` object.
- The `EOrust` class now loads the "target/names" file instead of "target/eo-test/names".
- The test classes now import the `Names` class from the `org.eolang.maven.rust` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->