### PR TITLE
#2255: increased threshold

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
@@ -60,7 +60,9 @@ public final class OptTrain implements Optimization {
             "/org/eolang/parser/errors/broken-refs.xsl",
             "/org/eolang/parser/optimize/constant-folding.xsl",
             "/org/eolang/parser/set-locators.xsl"
-        ).back()
+        ).back(),
+        TrFast.class,
+        500L
     );
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -119,7 +119,9 @@ public final class ParsingTrain extends TrEnvelope {
                             Level.FINEST
                         ),
                         StEoLogged::new
-                    )
+                    ),
+                    TrFast.class,
+                    500L
                 ),
                 shift -> new StSequence(
                     shift.uid(),


### PR DESCRIPTION
Closes: #2255
`100ms` was the default value for Ctor, now more verbose ctor is called.
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `TrFast.class` and `500L` as arguments to `StEoLogged` constructor in `ParsingTrain.java`
- Added `TrFast.class` and `500L` as arguments to `StSequence` constructor in `OptTrain.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->