### PR TITLE
feat(#2259): Reveal the problem with getting several versions of the same object

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -52,7 +52,7 @@ final class DiscoverMojoTest {
      * Default assertion message.
      */
     private static final String SHOULD_CONTAIN =
-        "External tojos should not contain %s object after discovering, but they didn't";
+        "External tojos should contain %s object after discovering, but they didn't";
 
     /**
      * Default assertion message.
@@ -146,17 +146,22 @@ final class DiscoverMojoTest {
         final FakeMaven maven = new FakeMaven(tmp)
             .with("withVersions", true)
             .withProgram(
+                "+alias org.eolang.txt.sprintf\n",
                 "[] > main",
                 "  seq > @",
-                "    QQ.io.stdout|0.29.1",
-                "      \"Hello from 0.29.1\"",
-                "    QQ.io.stdout|0.29.2",
-                "      \"Hello from 0.29.2\"",
+                "    QQ.io.stdout",
+                "      sprintf|0.28.1",
+                "        \"Hello from %s\"",
+                "        \"0.28.1\"",
+                "    QQ.io.stdout",
+                "      sprintf|0.28.2",
+                "        \"Hello from %s\"",
+                "        \"0.28.1\"",
                 "    nop"
             )
             .execute(new FakeMaven.Discover());
-        final String first = "org.eolang.io.stdout|0.29.1";
-        final String second = "org.eolang.io.stdout|0.29.2";
+        final String first = "org.eolang.txt.sprintf|0.28.1";
+        final String second = "org.eolang.txt.sprintf|0.28.2";
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, first),
@@ -164,7 +169,7 @@ final class DiscoverMojoTest {
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_NOT, second),
+            String.format(DiscoverMojoTest.SHOULD_CONTAIN, second),
             tojos.contains(second),
             Matchers.is(true)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -36,6 +36,7 @@ import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.ForeignTojos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +46,12 @@ import org.junit.jupiter.params.provider.CsvSource;
  * Test case for {@link DiscoverMojo}.
  *
  * @since 0.28.11
+ * @todo #2259:30min Enable discoversWithSeveralObjectsWithDifferentVersions test.
+ *  The discoversWithSeveralObjectsWithDifferentVersions test is disabled because we have found
+ *  a bug in jcabi-xml library. You can read more about the bug
+ *  <a href="https://github.com/jcabi/jcabi-xml/issues/211">here</a>
+ *  When the bug will be fixed, we have to enable discoversWithSeveralObjectsWithDifferentVersions
+ *  test.
  */
 final class DiscoverMojoTest {
 
@@ -140,6 +147,7 @@ final class DiscoverMojoTest {
     }
 
     @Test
+    @Disabled
     void discoversWithSeveralObjectsWithDifferentVersions(
         @TempDir final Path tmp
     ) throws IOException {
@@ -156,7 +164,7 @@ final class DiscoverMojoTest {
                 "    QQ.io.stdout",
                 "      sprintf|0.28.2",
                 "        \"Hello from %s\"",
-                "        \"0.28.1\"",
+                "        \"0.28.2\"",
                 "    nop"
             )
             .execute(new FakeMaven.Discover());


### PR DESCRIPTION
Reveal the problem with getting several versions of the same object. What have been done:

1. Refactoring of `DiscoveryMojo` and `DiscoveryMojoTest` classes.
2. Add test that reveals the problem with getting of several versions of the same object
3. Add one more puzzle to solve that problem

Related to #2259 