### PR TITLE
#1143 Xcop checks xsl with xcop-action@1.2

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -17,5 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: g4s8/xcop-action@v1.2
         with:
-          files: |
-            **/*.xml
+          files: "**/*.xml"

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -19,4 +19,3 @@ jobs:
         with:
           files: |
             **/*.xml
-            **/*.xsl

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: g4s8/xcop-action@1.2
+      - uses: g4s8/xcop-action@v1.2
         with:
           files: |
             **/*.xml

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -17,4 +17,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: g4s8/xcop-action@v1.2
         with:
-          files: "**/*.xml"
+          files: |
+            **/*.xsl
+            **/*.xml

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,12 +12,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   xcop:
-    strategy:
-      matrix:
-        glob: ["**/*.xml", "**/*.xsl"]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: g4s8/xcop-action@1.1
+      - uses: g4s8/xcop-action@1.2
         with:
-          files: glob
+          files: |
+            **/*.xml
+            **/*.xsl


### PR DESCRIPTION
Closes: #1143

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `g4s8/xcop-action` GitHub Action and modifying the file patterns for the `xcop` job. 

### Detailed summary
- Updated the `g4s8/xcop-action` GitHub Action from version `1.1` to `v1.2`.
- Modified the file patterns for the `xcop` job to include `**/*.xsl` and `**/*.xml` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->