### PR TITLE
feat(#2171): Update jtcop plugin up to `0.1.18` version 

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ContainsFile.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ContainsFile.java
@@ -34,7 +34,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Asserting that path contains a file matching provided glob.
  * @since 0.28.12
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class ContainsFile extends TypeSafeMatcher<Path> {
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -68,7 +68,8 @@ import org.eolang.maven.util.Home;
 @SuppressWarnings({
     "PMD.TooManyMethods",
     "PMD.CouplingBetweenObjects",
-    "JTCOP.RuleAllTestsHaveProductionClass"
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName"
 })
 @NotThreadSafe
 public final class FakeMaven {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/log/Logs.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/log/Logs.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @since 0.30
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 public final class Logs {
 
     /**

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -275,6 +275,16 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>
+                  verify
+                </phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOandTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOandTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (4 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOboolEOandTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOnotTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOnotTest.java
@@ -40,11 +40,6 @@ import org.junit.jupiter.api.Test;
  * why we disable jtcop check.
  *
  * @since 0.1
- * @todo #2146:30min Remove RuleAllTestsHaveProductionClass suppressing.
- *  This rule was suppressed because the test class is generated and jtcop can't find it in the
- *  classpath. So, when that feature will be implemented in the jtcop, we have to remove all
- *  the similar suppression's from that test package.
- *  jtcop issue: https://github.com/volodya-lombrozo/jtcop/issues/178
  * @checkstyle TypeNameCheck (4 lines)
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (4 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOboolEOwhileTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.23
  * @checkstyle TypeNameCheck (4 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EObytesEOconcatTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOfailed.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOfailed.java
@@ -34,6 +34,6 @@ import org.eolang.PhDefault;
  *
  * @since 0.29
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class EOfailed extends PhDefault {
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOpointerEOblockTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOheapEOpointerEOblockTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.19
  * @checkstyle TypeNameCheck (4 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOheapEOpointerEOblockTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOplusTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOplusTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (4 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOintEOplusTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (2 lines)
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOtupleEOatTest {
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,14 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.14</version>
+            <version>0.1.18</version>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAssertionMessage
+                </exclusion>
+              </exclusions>
+            </configuration>
             <executions>
               <execution>
                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -344,11 +344,13 @@ SOFTWARE.
             <version>0.1.18</version>
             <configuration>
               <exclusions>
-                <!-- @todo #2171:30min Enable RuleAssertionMessage.
-                       This rule is disabled because lots of tests in the
-                       project are written without assertion messages. We have
-                       to add all messages for all assertions and then enable
-                       that rule. -->
+                <!--
+                  @todo #2171:30min Enable RuleAssertionMessage.
+                    This rule is disabled because lots of tests in the
+                    project are written without assertion messages. We have
+                    to add all messages for all assertions and then enable
+                    that rule and remove that puzzle.
+                -->
                 <exclusion>
                   JTCOP.RuleAssertionMessage
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@ SOFTWARE.
             <version>0.1.18</version>
             <configuration>
               <exclusions>
+                <!-- @todo #2171:30min Enable RuleAssertionMessage.
+                       This rule is disabled because lots of tests in the
+                       project are written without assertion messages. We have
+                       to add all messages for all assertions and then enable
+                       that rule. -->
                 <exclusion>
                   JTCOP.RuleAssertionMessage
                 </exclusion>


### PR DESCRIPTION
Update jtcop plugin up to `0.1.18` version.

Closes: #2171

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on making changes to the test classes and the jtcop-maven-plugin configuration.

### Detailed summary:
- Updated the test classes to suppress the "JTCOP.RuleCorrectTestName" rule in addition to "JTCOP.RuleAllTestsHaveProductionClass" rule.
- Added a new execution for the jtcop-maven-plugin in the pom.xml file to run the "check" goal during the "verify" phase.
- Updated the version of the jtcop-maven-plugin to 0.1.18 in the pom.xml file.
- Added a new configuration in the pom.xml file to exclude the "JTCOP.RuleAssertionMessage" rule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->