### PR TITLE
feat(#2278): Use a convenient constructor for SaxonDocument

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -38,8 +38,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
-import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Rel;
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -96,16 +96,10 @@ public final class DiscoverMojo extends SafeMojo {
      * @param file The .xmir file
      * @return List of foreign objects found
      * @throws FileNotFoundException If not found
-     * @todo #2266:30min Use more convenient constructor for SaxonDocument.
-     *  The current constructor for SaxonDocument is not convenient and requires a lot of
-     *  code. It would be better to create SaxonDocument right from the file.
-     *  When the related issue will be implemented in jcabi-xml (you can check the progress
-     *  <a href="https://github.com/jcabi/jcabi-xml/issues/215">here</a>)
-     *  We have to change the constructor for SaxonDocument in this class and remove that puzzle.
      */
     private Collection<String> discover(final Path file)
         throws FileNotFoundException {
-        final XML saxon = new SaxonDocument(new UncheckedText(new TextOf(file)).asString());
+        final XML saxon = new SaxonDocument(file);
         final Collection<String> names = DiscoverMojo.names(saxon, this.xpath(false));
         if (this.withVersions) {
             names.addAll(


### PR DESCRIPTION
Use a convenient constructor for `SaxonDocument`.

Closes: #2278

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Removed unused imports `org.cactoos.text.TextOf` and `org.cactoos.text.UncheckedText`.
- Updated the constructor for `SaxonDocument` to use a more convenient method that takes a `Path` object directly.
- Updated the related documentation for the constructor change.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->