### PR TITLE
feat(#2259): simplify xpath in DiscoveryMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -31,7 +31,6 @@ import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -98,10 +97,10 @@ public final class DiscoverMojo extends SafeMojo {
     private Collection<String> discover(final Path file)
         throws FileNotFoundException {
         final XML saxon = new SaxonDocument(file);
-        final Collection<String> names = DiscoverMojo.names(saxon, this.xpath(false));
+        final Collection<String> names = DiscoverMojo.names(saxon, this.xpath());
         if (this.withVersions) {
             names.addAll(
-                DiscoverMojo.names(saxon, this.xpath(true))
+                DiscoverMojo.names(saxon, this.xpath())
             );
         }
         if (!new XMLDocument(file).nodes("//o[@vararg]").isEmpty()) {
@@ -123,7 +122,6 @@ public final class DiscoverMojo extends SafeMojo {
 
     /**
      * Xpath for selecting objects from given xml.
-     * @param versioned Select with versions or not.
      * @return Xpath as list of strings
      * @todo #1602:30min Simplify xpath. Current implementation for building
      *  xpath with and without versions is quite ugly. For some reason
@@ -133,7 +131,7 @@ public final class DiscoverMojo extends SafeMojo {
      *  then if flag `withVersions` is `true` - take `concat(@base,'|',@ver)`
      *  from objects attribute `ver` is present.
      */
-    private String xpath(final boolean versioned) {
+    private String xpath() {
         final Collection<String> xpath = new ListOf<>(
             "//o[",
             "not(starts-with(@base,'.'))",
@@ -141,22 +139,9 @@ public final class DiscoverMojo extends SafeMojo {
             "and @base != '^'",
             "and @base != '$'",
             "and @base != '&'",
-            "and not(@ref)"
+            "and not(@ref)",
+            "]/string-join((@base, @ver),'|')"
         );
-        final List<String> tail;
-        if (versioned) {
-            tail = new ListOf<>(
-                "and @ver",
-                "]/string-join((@base, @ver),'|')"
-            );
-        } else {
-            tail = new ListOf<>();
-            if (this.withVersions) {
-                tail.add("and not(@ver)");
-            }
-            tail.add("]/@base");
-        }
-        xpath.addAll(tail);
         return String.join(
             " ",
             xpath

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -26,7 +26,6 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.SaxonDocument;
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -91,12 +90,11 @@ public final class DiscoverMojo extends SafeMojo {
      *
      * @param file The .xmir file
      * @return List of foreign objects found
-     * @throws FileNotFoundException If not found
      */
-    private Collection<String> discover(final Path file)
-        throws FileNotFoundException {
-        final Collection<String> names = this.names(new SaxonDocument(file));
-        if (!new XMLDocument(file).nodes("//o[@vararg]").isEmpty()) {
+    private Collection<String> discover(final Path file) {
+        final XML saxon = new SaxonDocument(file);
+        final Collection<String> names = DiscoverMojo.names(saxon);
+        if (!saxon.xpath("//o[@vararg]").isEmpty()) {
             names.add("org.eolang.tuple");
         }
         if (names.isEmpty()) {
@@ -118,7 +116,7 @@ public final class DiscoverMojo extends SafeMojo {
      * @param xml XML.
      * @return Object names.
      */
-    private Set<String> names(final XML xml) {
+    private static Set<String> names(final XML xml) {
         return new SetOf<>(
             new Filtered<>(
                 obj -> !obj.isEmpty(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -147,7 +147,7 @@ public final class DiscoverMojo extends SafeMojo {
         if (versioned) {
             tail = new ListOf<>(
                 "and @ver",
-                "]/concat(@base,'|',@ver)"
+                "]/string-join((@base, @ver),'|')"
             );
         } else {
             tail = new ListOf<>();


### PR DESCRIPTION
Simplify xpath in `DiscoveryMojo`.

Closes: #2259 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Removed unused imports
- Simplified XPath expression for object discovery
- Refactored code to use `SaxonDocument` instead of `XMLDocument` for better performance

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->