### PR TITLE
#2302 Objectionaries as interface in ProbeMojo + tests

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -33,7 +33,9 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.Objectionary;
+import org.eolang.maven.objectionary.OysSimple;
 
 /**
  * Pull all necessary EO XML files from Objectionary and parse them all.
@@ -69,6 +71,14 @@ public final class AssembleMojo extends SafeMojo {
      */
     @SuppressWarnings("PMD.ImmutableField")
     private Objectionary objectionary;
+
+    /**
+     * Objectionaries.
+     * @checkstyle MemberNameCheck (6 lines)
+     * @checkstyle ConstantUsageCheck (5 lines)
+     */
+    @SuppressWarnings("PMD.ImmutableField")
+    private final Objectionaries objectionaries = new OysSimple();
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -73,7 +73,7 @@ public final class AssembleMojo extends SafeMojo {
     private Objectionary objectionary;
 
     /**
-     * Objectionaries.
+     * The objectionaries.
      * @checkstyle MemberNameCheck (6 lines)
      * @checkstyle ConstantUsageCheck (5 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChSafe.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.hash;
+
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Safe commit hash.
+ * If original hash is null - replace with default one.
+ * @since 0.29.6
+ */
+public final class ChSafe implements CommitHash {
+    /**
+     * Result hash.
+     */
+    private final Unchecked<String> hash;
+
+    /**
+     * Ctor.
+     * @param origin Condition.
+     * @param def Default hash.
+     */
+    public ChSafe(
+        final CommitHash origin,
+        final CommitHash def
+    ) {
+        this.hash = new Unchecked<>(
+            new Sticky<>(
+                () -> {
+                    final CommitHash hsh;
+                    if (origin == null) {
+                        hsh = def;
+                    } else {
+                        hsh = origin;
+                    }
+                    return hsh.value();
+                }
+            )
+        );
+    }
+
+    @Override
+    public String value() {
+        return this.hash.value();
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.objectionary;
+
+import org.eolang.maven.hash.CommitHash;
+
+/**
+ * Objectionaries.
+ * @since 0.29.6
+ */
+public interface Objectionaries {
+    /**
+     * Objectionaries with given objectionary by given hash.
+     * @param hash Hash as String.
+     * @param objectionary Objectionary.
+     * @return Objectionaries with new objectionary.
+     */
+    Objectionaries with(String hash, Objectionary objectionary);
+
+    /**
+     * Objectionaries with given objectionary by given hash.
+     * @param hash Hash as {@link CommitHash}.
+     * @param objectionary Objectionary.
+     * @return Objectionaries with new objectionary.
+     */
+    default Objectionaries with(CommitHash hash, Objectionary objectionary) {
+        return this.with(hash.value(), objectionary);
+    }
+
+    /**
+     * Whether objectionaries has objectionary by given hash.
+     * @param hash Hash.
+     * @return If objectionary has objectionary by given hash.
+     */
+    boolean has(String hash);
+
+    /**
+     * Whether objectionaries has objectionary by given hash.
+     * @param hash Hash.
+     * @return If objectionary has objectionary by given hash.
+     */
+    default boolean has(CommitHash hash) {
+        return this.has(hash.value());
+    }
+
+    /**
+     * Get objectionary by given hash.
+     * @param hash Hash.
+     * @return Objectionary by hash.
+     */
+    Objectionary get(String hash);
+
+    /**
+     * Get objectionary by given hash.
+     * @param hash Hash as {@link CommitHash}.
+     * @return Objectionary by hash.
+     */
+    default Objectionary get(CommitHash hash) {
+        return this.get(hash.value());
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OyFallbackSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OyFallbackSwap.java
@@ -25,6 +25,7 @@ package org.eolang.maven.objectionary;
 
 import java.io.IOException;
 import org.cactoos.Input;
+import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 import org.eolang.maven.PullMojo;
@@ -57,18 +58,32 @@ public final class OyFallbackSwap implements Objectionary {
      * Ctor.
      * @param first Initial primary
      * @param second Initial secondary
-     * @param swap Whether to swap
+     * @param swap Whether to swap as boolean
      */
     public OyFallbackSwap(
         final Objectionary first,
         final Objectionary second,
         final boolean swap
     ) {
+        this(first, second, () -> swap);
+    }
+
+    /**
+     * Ctor.
+     * @param first Initial primary
+     * @param second Initial secondary
+     * @param swap Whether to swap as scalar
+     */
+    public OyFallbackSwap(
+        final Objectionary first,
+        final Objectionary second,
+        final Scalar<Boolean> swap
+    ) {
         this.swapped = new Unchecked<>(
             new Sticky<>(
                 () -> {
                     final Objectionary result;
-                    if (swap) {
+                    if (swap.value()) {
                         result = new OyFallback(
                             second,
                             first

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OysSimple.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OysSimple.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.objectionary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple objectionaries.
+ * @since 0.26.6
+ */
+public final class OysSimple implements Objectionaries {
+    /**
+     * Hash-Objectionary map.
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private final Map<String, Objectionary> objectionaries;
+
+    /**
+     * Ctor.
+     */
+    public OysSimple() {
+        this(new HashMap<>());
+    }
+
+    /**
+     * Ctor.
+     * @param map Hash-map.
+     */
+    OysSimple(final Map<String, Objectionary> map) {
+        this.objectionaries = map;
+    }
+
+    @Override
+    public OysSimple with(final String hash, final Objectionary objectionary) {
+        this.objectionaries.putIfAbsent(hash, objectionary);
+        return this;
+    }
+
+    @Override
+    public boolean has(final String hash) {
+        return this.objectionaries.containsKey(hash);
+    }
+
+    @Override
+    public Objectionary get(final String hash) {
+        return this.objectionaries.get(hash);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -371,6 +371,14 @@ public final class FakeMaven {
     }
 
     /**
+     * Path to or eo-external.* file after all changes.
+     * @return Path to eo-foreign.* file.
+     */
+    Path externalPath() {
+        return this.workspace.absolute(Paths.get("eo-external.csv"));
+    }
+
+    /**
      * Tojo for placed.json file.
      *
      * @return TjSmart of the current placed.json file.
@@ -507,14 +515,6 @@ public final class FakeMaven {
             res = mojoFields(mojo.getSuperclass(), fields);
         }
         return res;
-    }
-
-    /**
-     * Path to or eo-external.* file after all changes.
-     * @return Path to eo-foreign.* file.
-     */
-    private Path externalPath() {
-        return this.workspace.absolute(Paths.get("eo-external.csv"));
     }
 
     /**
@@ -708,6 +708,7 @@ public final class FakeMaven {
         public Iterator<Class<? extends AbstractMojo>> iterator() {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
+                VersionsMojo.class,
                 OptimizeMojo.class,
                 DiscoverMojo.class,
                 ProbeMojo.class

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -105,7 +105,7 @@ final class OptimizeMojoTest {
                 String.format("target/%s/foo/x/main.%s", OptimizeMojo.DIR, TranspileMojo.EXT)
             );
         final long start = System.currentTimeMillis();
-        final long old = start - TimeUnit.SECONDS.toMillis(10L);
+        final long old = start - TimeUnit.SECONDS.toMillis(20L);
         if (!tgt.toFile().setLastModified(old)) {
             Assertions.fail(String.format("The last modified attribute can't be set for %s", tgt));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -29,9 +29,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import org.cactoos.io.ResourceOf;
+import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChCompound;
+import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyRemote;
+import org.eolang.maven.objectionary.OysSimple;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -71,10 +74,12 @@ final class PullMojoTest {
     }
 
     @Test
+    @ExtendWith(OnlineCondition.class)
     void pullsFromProbes(@TempDir final Path temp) throws IOException {
-        final Objectionary objectionary = new OyRemote(
+        final CommitHash hash = new ChCached(
             new ChCompound(null, null, "master")
         );
+        final Objectionary objectionary = new OyRemote(hash);
         new FakeMaven(temp)
             .withProgram(
                 "+package org.eolang.custom",
@@ -87,6 +92,8 @@ final class PullMojoTest {
                 "        228"
             )
             .with("objectionary", objectionary)
+            .with("objectionaries", new OysSimple().with(hash, objectionary))
+            .with("defaultHash", hash)
             .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
             new Home(temp.resolve("target")).exists(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChSafeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChSafeTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.hash;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ChSafe}.
+ * @since 0.29.6
+ */
+class ChSafeTest {
+    @Test
+    void takesOrigin() {
+        final String hash = "abcdef";
+        MatcherAssert.assertThat(
+            String.format(
+                "Safe commit hash should have returned value %s of the first hash, but didn't",
+                hash
+            ),
+            new ChSafe(
+                new CommitHash.ChConstant(hash),
+                new CommitHash.ChConstant("fedcab")
+            ).value(),
+            Matchers.equalTo(hash)
+        );
+    }
+
+    @Test
+    void takesDefault() {
+        final String hash = "abcdef";
+        MatcherAssert.assertThat(
+            String.format(
+                "Safe commit hash should have returned value %s of the default hash, but didn't",
+                hash
+            ),
+            new ChSafe(
+                null,
+                new CommitHash.ChConstant(hash)
+            ).value(),
+            Matchers.equalTo(hash)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/it/SnippetTestCase.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/it/SnippetTestCase.java
@@ -51,7 +51,12 @@ import org.eolang.maven.FakeMaven;
 import org.eolang.maven.OnlineCondition;
 import org.eolang.maven.RegisterMojo;
 import org.eolang.maven.TranspileMojo;
+import org.eolang.maven.hash.ChCached;
+import org.eolang.maven.hash.ChRemote;
+import org.eolang.maven.hash.CommitHash;
+import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.OyFilesystem;
+import org.eolang.maven.objectionary.OysSimple;
 import org.eolang.maven.util.Walk;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -148,11 +153,15 @@ final class SnippetTestCase {
         final Output stdout
     ) throws Exception {
         final Path src = tmp.resolve("src");
+        final Objectionary objectionary = new OyFilesystem();
+        final CommitHash hash = new ChCached(new ChRemote("master"));
         final FakeMaven maven = new FakeMaven(tmp)
             .withProgram(code)
             .with("sourcesDir", src.toFile())
             .with("objects", Arrays.asList("org.eolang.bool"))
-            .with("objectionary", new OyFilesystem());
+            .with("defaultHash", hash)
+            .with("objectionaries", new OysSimple().with(hash, objectionary))
+            .with("objectionary", objectionary);
         maven.execute(RegisterMojo.class);
         maven.execute(DemandMojo.class);
         maven.execute(AssembleMojo.class);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OysSimpleTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OysSimpleTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.objectionary;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link OysSimple}.
+ * @since 0.29.6
+ */
+class OysSimpleTest {
+    @Test
+    void putsIfAbsent() {
+        final String hash = "abcdef";
+        MatcherAssert.assertThat(
+            String.format(
+                "Objectionaries with objectionary by hash %s should have contained objectionary by that hash, but didn't",
+                hash
+            ),
+            new OysSimple()
+                .with(hash, new Objectionary.Fake())
+                .has(hash),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotRewrite() {
+        final String hash = "abcdef";
+        MatcherAssert.assertThat(
+            "Objectionaries should have not rewrite objectionary if it presents, but it did",
+            new OysSimple()
+                .with(hash, new Objectionary.Fake())
+                .with(hash, new OyEmpty())
+                .get(hash),
+            Matchers.instanceOf(Objectionary.Fake.class)
+        );
+    }
+}


### PR DESCRIPTION
Ref: #1602 

What's done:
- Introduced new interface `Objectionaries` that is used in ProbeMojo and PullMojo
- Added tests for simple implementation of `Objectionaries`
- Introduced new `ChSafe` that returns value of default hash if origin is null (+ added tests)
- Refactored ProbeMojo and PullMojo tests
- Added disabled tests for future implementation probing with versions
- Added todo to implement probing with versioning

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the value of `old` variable in `OptimizeMojoTest.java` from 10 seconds to 20 seconds.
- Added new imports and variables in `AssembleMojo.java`.
- Added new method `externalPath()` in `FakeMaven.java`.
- Added new class `ProbeMojo` in `FakeMaven.java`.
- Added new imports and variables in `OyFallbackSwap.java`.
- Added new imports and variables in `SnippetTestCase.java`.
- Added new imports and variables in `PullMojoTest.java`.
- Added new class `ChSafe` in `ChSafe.java`.
- Added new imports and variables in `PullMojo.java`.
- Added new class `ChSafeTest` in `ChSafeTest.java`.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChSafeTest.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/objectionary/OysSimpleTest.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OysSimple.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java`, `eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->