### PR TITLE
`Objectionary.java` duplicated javadoc

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionary.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionary.java
@@ -24,7 +24,6 @@
 package org.eolang.maven.objectionary;
 
 import java.io.IOException;
-
 import org.cactoos.Func;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionary.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionary.java
@@ -24,6 +24,7 @@
 package org.eolang.maven.objectionary;
 
 import java.io.IOException;
+
 import org.cactoos.Func;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
@@ -46,12 +47,6 @@ public interface Objectionary {
 
     /**
      * Checks whether an Objectionary contains a provided object.
-     * @param name Object name.
-     * @return Object code.
-     * @throws IOException If fails to fetch.
-     */
-    /**
-     * Checks whether an Objectionary contains a provided object.
      *
      * @param name Object name.
      * @return Boolean: "true" if found, "false" if not.
@@ -62,8 +57,8 @@ public interface Objectionary {
     /**
      * Objectionary with lambda-function Ctor-s for testing.
      *
-     * @since 0.28.11
      * @checkstyle IllegalCatchCheck (150 lines)
+     * @since 0.28.11
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     final class Fake implements Objectionary {


### PR DESCRIPTION
closes #2309
@Graur take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on cleaning up the Objectionary interface in the eo-maven-plugin. 

### Detailed summary
- Removed unnecessary method parameter in the `get` method.
- Removed the `throws IOException` declaration in the `get` method.
- Removed the commented-out Javadoc for the `get` method.
- Removed the `@checkstyle` annotation in the `Fake` class.
- Reordered the `@since` annotation in the `Fake` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->