### PR TITLE
feat(#2287): Increase outdated time for already optimized xmir

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -241,7 +241,6 @@ public final class OptimizeMojo extends SafeMojo {
      * @return Should fail
      */
     private boolean shouldPass(final XML xml) {
-        final List<XML> errors = xml.nodes("/program/errors/error");
-        return errors.isEmpty() || this.failOnError;
+        return xml.nodes("/program/errors/error").isEmpty() || this.failOnError;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -29,7 +29,6 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.List;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -113,7 +113,7 @@ public final class ForeignTojo {
     }
 
     /**
-     * Checks if tojo was already optimized.
+     * Checks if tojo was not already optimized.
      *
      * @return True if optimization is required, false otherwise.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -104,13 +104,13 @@ final class OptimizeMojoTest {
             .get(
                 String.format("target/%s/foo/x/main.%s", OptimizeMojo.DIR, TranspileMojo.EXT)
             );
-        final long start = System.currentTimeMillis();
-        final long old = start - TimeUnit.SECONDS.toMillis(10L);
+        final long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(10L);
         if (!tgt.toFile().setLastModified(old)) {
             Assertions.fail(String.format("The last modified attribute can't be set for %s", tgt));
         }
         maven.execute(OptimizeMojo.class);
         MatcherAssert.assertThat(
+            "We expect that already optimized xmir will be replaced by a new optimized xmir, because the first xmir is outdated and should be updated",
             tgt.toFile().lastModified(),
             Matchers.greaterThan(old)
         );


### PR DESCRIPTION
Increase outdated time for already optimized xmir in `OptimizeMojoTest.optimizeIfExpired`.

Closes: #2287

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- In `ForeignTojo.java`, the comment was updated to clarify that the check is for optimization not being already done.
- In `OptimizeMojo.java`, the `shouldPass` method was simplified by removing unnecessary variable assignment.
- In `OptimizeMojoTest.java`, the calculation of the `old` variable was updated to use `System.currentTimeMillis()` instead of calculating it based on the current time.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->