### PR TITLE
feat(#2206): Remove AccessDenied catch from TranspileMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -35,7 +35,6 @@ import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -252,11 +252,6 @@ public final class TranspileMojo extends SafeMojo {
      * generated sources. In other words, if generated-sources (or generated-test-sources) folder
      * has java classes, we expect that they will be only compiled from that folder.
      * @param java The list of java files.
-     * @todo #2169:30min Find the original cause of the problem with access denied.
-     *  The problem is that sometimes we can't remove the file due to access denied.
-     *  We need to find the original cause of the problem and fix it.
-     *  Then, just remove AccessDeniedException from the catch block.
-     *  For now, we just ignore the problem and log the warning.
      */
     private void cleanUpClasses(final Collection<? extends Path> java) {
         final Set<Path> unexpected = java.stream()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -267,10 +267,6 @@ public final class TranspileMojo extends SafeMojo {
         for (final Path binary : unexpected) {
             try {
                 Files.deleteIfExists(binary);
-            } catch (final AccessDeniedException cause) {
-                Logger.warn(
-                    this, "Can't delete file %s due to access denied", binary
-                );
             } catch (final IOException cause) {
                 throw new IllegalStateException(
                     String.format("Can't delete file %s", binary),


### PR DESCRIPTION
Try to remove AccessDenied exception catch from TranspileMojo. I close the puzzle because it seems that we don't have the problem anymore and all PR checks don't reveal the problem with AccessDenied exception.

Closes: #2206

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with file deletion in the TranspileMojo class. The AccessDeniedException catch block is removed and a warning is logged instead.

### Detailed summary
- Removed the catch block for AccessDeniedException in the cleanUpClasses method of TranspileMojo class.
- Logging a warning instead of handling the exception.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->
