### PR TITLE
feat(#2299): Refactoring the raw implementation of Objectionaries

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -70,7 +70,7 @@ public final class AssembleMojo extends SafeMojo {
      * @checkstyle MemberNameCheck (6 lines)
      * @checkstyle ConstantUsageCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(this.cache,  () -> this.session.getRequest().isUpdateSnapshots());
+    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache,  () -> this.session.getRequest().isUpdateSnapshots());
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -70,7 +70,10 @@ public final class AssembleMojo extends SafeMojo {
      * @checkstyle MemberNameCheck (6 lines)
      * @checkstyle ConstantUsageCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache,  () -> this.session.getRequest().isUpdateSnapshots());
+    private final Objectionaries objectionaries = new ObjsDefault(
+        () -> this.cache,
+        () -> this.session.getRequest().isUpdateSnapshots()
+    );
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -70,7 +70,7 @@ public final class AssembleMojo extends SafeMojo {
      * @checkstyle MemberNameCheck (6 lines)
      * @checkstyle ConstantUsageCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault();
+    private final Objectionaries objectionaries = new ObjsDefault(this.cache,  () -> this.session.getRequest().isUpdateSnapshots());
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -92,7 +92,7 @@ public final class ProbeMojo extends SafeMojo {
      * Objectionaries.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(this.cache, this::forceUpdate);
+    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache, this::forceUpdate);
 
     @Override
     public void exec() throws IOException {
@@ -109,7 +109,7 @@ public final class ProbeMojo extends SafeMojo {
             }
             int count = 0;
             for (final String name : names) {
-                if (!this.objectionaryByHash(this.hsh).contains(name)) {
+                if (!this.objectionaries.contains(this.hsh, name)) {
                     continue;
                 }
                 ++count;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -92,7 +92,7 @@ public final class ProbeMojo extends SafeMojo {
      * Objectionaries.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault();
+    private final Objectionaries objectionaries = new ObjsDefault(this.cache, this::forceUpdate);
 
     @Override
     public void exec() throws IOException {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -140,30 +140,6 @@ public final class ProbeMojo extends SafeMojo {
     }
 
     /**
-     * Get objectionary by given hash from the map.
-     * @param hash Hash.
-     * @return Objectionary by given hash.
-     */
-    private Objectionary objectionaryByHash(final CommitHash hash) {
-        final CommitHash cached = new ChCached(hash);
-        return this.objectionaries
-            .with(
-                cached,
-                new OyFallbackSwap(
-                    new OyHome(
-                        new ChNarrow(hash),
-                        this.cache
-                    ),
-                    new OyIndexed(
-                        new OyRemote(hash)
-                    ),
-                    this::forceUpdate
-                )
-            )
-            .get(cached);
-    }
-
-    /**
      * Find all probes found in the provided XML file.
      *
      * @param file The .xmir file

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -36,17 +36,11 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterator.Mapped;
 import org.cactoos.list.ListOf;
-import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.objectionary.Objectionaries;
-import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.ObjsDefault;
-import org.eolang.maven.objectionary.OyFallbackSwap;
-import org.eolang.maven.objectionary.OyHome;
-import org.eolang.maven.objectionary.OyIndexed;
-import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Rel;
 
@@ -92,7 +86,10 @@ public final class ProbeMojo extends SafeMojo {
      * Objectionaries.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache, this::forceUpdate);
+    private final Objectionaries objectionaries = new ObjsDefault(
+        () -> this.cache,
+        () -> this.session.getRequest().isUpdateSnapshots()
+    );
 
     @Override
     public void exec() throws IOException {
@@ -189,12 +186,4 @@ public final class ProbeMojo extends SafeMojo {
         return result;
     }
 
-    /**
-     * Is force update option enabled.
-     *
-     * @return True if option enabled and false otherwise
-     */
-    private boolean forceUpdate() {
-        return this.session.getRequest().isUpdateSnapshots();
-    }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -90,7 +90,9 @@ public final class PullMojo extends SafeMojo {
      *  objectionary by name.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(this.cache, () -> this.session.getRequest().isUpdateSnapshots());
+    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache,
+        () -> this.session.getRequest().isUpdateSnapshots()
+    );
 
     /**
      * Pull again even if the .eo file is already present?
@@ -165,7 +167,7 @@ public final class PullMojo extends SafeMojo {
             );
         } else {
             new Home(dir).save(
-                this.objectionaryByHash(this.hsh).get(name),
+                this.objectionaries.object(this.hsh, name),
                 dir.relativize(src)
             );
             Logger.debug(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -113,39 +113,6 @@ public final class PullMojo extends SafeMojo {
             tojo.withSource(this.pull(tojo.identifier()).toAbsolutePath())
                 .withHash(new ChNarrow(this.hsh));
         }
-        Logger.info(
-            this, "%d program(s) pulled from %s",
-            tojos.size(), this.objectionaryByHash(this.hsh)
-        );
-    }
-
-    /**
-     * Get objectionary from the map by given hash.
-     * @param hash Hash.
-     * @return Objectionary by given hash.
-     */
-    private Objectionary objectionaryByHash(final CommitHash hash) {
-        final CommitHash cached = new ChCached(hash);
-        final CommitHash narrow = new ChNarrow(cached);
-        return this.objectionaries
-            .with(
-                cached,
-                new OyFallbackSwap(
-                    new OyHome(
-                        narrow,
-                        this.cache
-                    ),
-                    new OyCaching(
-                        narrow,
-                        this.cache,
-                        new OyIndexed(
-                            new OyRemote(cached)
-                        )
-                    ),
-                    () -> this.session.getRequest().isUpdateSnapshots()
-                )
-            )
-            .get(cached);
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -30,18 +30,11 @@ import java.util.Collection;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.objectionary.Objectionaries;
-import org.eolang.maven.objectionary.Objectionary;
 import org.eolang.maven.objectionary.ObjsDefault;
-import org.eolang.maven.objectionary.OyCaching;
-import org.eolang.maven.objectionary.OyFallbackSwap;
-import org.eolang.maven.objectionary.OyHome;
-import org.eolang.maven.objectionary.OyIndexed;
-import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Rel;
@@ -82,15 +75,10 @@ public final class PullMojo extends SafeMojo {
 
     /**
      * Objectionaries.
-     * @todo #1602:30min Use objectionaries to pull objects with different
-     *  versions. Objects with different versions are stored in different
-     *  storages (objectionaries). Every objectionary has its own hash.
-     *  To pull versioned object from objectionary firstly we need to get
-     *  right objectionary by object's version and then get object from that
-     *  objectionary by name.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(()->this.cache,
+    private final Objectionaries objectionaries = new ObjsDefault(
+        () -> this.cache,
         () -> this.session.getRequest().isUpdateSnapshots()
     );
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -101,6 +101,11 @@ public final class PullMojo extends SafeMojo {
             tojo.withSource(this.pull(tojo.identifier()).toAbsolutePath())
                 .withHash(new ChNarrow(this.hsh));
         }
+        Logger.info(
+            this,
+            "%d program(s) were pulled",
+            tojos.size()
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -90,7 +90,7 @@ public final class PullMojo extends SafeMojo {
      *  objectionary by name.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault();
+    private final Objectionaries objectionaries = new ObjsDefault(this.cache, () -> this.session.getRequest().isUpdateSnapshots());
 
     /**
      * Pull again even if the .eo file is already present?

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -28,7 +28,7 @@ import org.cactoos.Input;
 import org.eolang.maven.hash.CommitHash;
 
 /**
- * Hash-Objectionary hash map.
+ * Many objectionaries for different hashes.
  * @since 0.29.6
  */
 public interface Objectionaries {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -40,13 +40,6 @@ public interface Objectionaries {
      */
     Objectionaries with(CommitHash hash, Objectionary objectionary);
 
-    /**
-     * Get objectionary by given hash.
-     * @param hash Hash as {@link CommitHash}.
-     * @return Objectionary by given hash.
-     */
-    Objectionary get(CommitHash hash);
-
     Input object(CommitHash hash, String name);
 
     boolean contains(CommitHash hash, String name);
@@ -81,11 +74,6 @@ public interface Objectionaries {
         @Override
         public Objectionaries with(final CommitHash hash, final Objectionary objectionary) {
             return this;
-        }
-
-        @Override
-        public Objectionary get(final CommitHash hash) {
-            return this.objry;
         }
 
         @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -32,16 +32,23 @@ import org.eolang.maven.hash.CommitHash;
  * @since 0.29.6
  */
 public interface Objectionaries {
-    /**
-     * Set new objectionary by given hash only if it's absent.
-     * @param hash Hash as {@link CommitHash}.
-     * @param objectionary Objectionary to store.
-     * @return Objectionaries with new objectionary by given hash.
-     */
-    Objectionaries with(CommitHash hash, Objectionary objectionary);
 
+    /**
+     * Get object by hash and name.
+     * @param hash Commit hash
+     * @param name Object name
+     * @return Object
+     * @throws IOException If some I/O problem happens.
+     */
     Input object(CommitHash hash, String name) throws IOException;
 
+    /**
+     * Check if object exists.
+     * @param hash Commit hash
+     * @param name Object name
+     * @return True if object exists, false otherwise
+     * @throws IOException If some I/O problem happens.
+     */
     boolean contains(CommitHash hash, String name) throws IOException;
 
     /**
@@ -69,11 +76,6 @@ public interface Objectionaries {
          */
         public Fake(final Objectionary objectionary) {
             this.objry = objectionary;
-        }
-
-        @Override
-        public Objectionaries with(final CommitHash hash, final Objectionary objectionary) {
-            return this;
         }
 
         @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -61,7 +61,7 @@ public interface Objectionaries {
         /**
          * Default objectionary.
          */
-        private final Objectionary objry;
+        private final Objectionary objectionary;
 
         /**
          * Ctor.
@@ -72,20 +72,20 @@ public interface Objectionaries {
 
         /**
          * Ctor.
-         * @param objectionary Default objectionary
+         * @param objry Default objectionary
          */
-        public Fake(final Objectionary objectionary) {
-            this.objry = objectionary;
+        public Fake(final Objectionary objry) {
+            this.objectionary = objry;
         }
 
         @Override
         public Input object(final CommitHash hash, final String name) throws IOException {
-            return this.objry.get(name);
+            return this.objectionary.get(name);
         }
 
         @Override
         public boolean contains(final CommitHash hash, final String name) throws IOException {
-            return this.objry.contains(name);
+            return this.objectionary.contains(name);
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.maven.objectionary;
 
+import java.io.IOException;
+import org.cactoos.Input;
 import org.eolang.maven.hash.CommitHash;
 
 /**
@@ -44,6 +46,8 @@ public interface Objectionaries {
      * @return Objectionary by given hash.
      */
     Objectionary get(CommitHash hash);
+
+    Input object(CommitHash hash, String name);
 
     boolean contains(CommitHash hash, String name);
 
@@ -85,8 +89,21 @@ public interface Objectionaries {
         }
 
         @Override
+        public Input object(final CommitHash hash, final String name) {
+            try {
+                return this.objry.get(name);
+            } catch (final IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        @Override
         public boolean contains(final CommitHash hash, final String name) {
-            return false;
+            try {
+                return this.objry.contains(name);
+            } catch (final IOException ex) {
+                throw new RuntimeException(ex);
+            }
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -40,9 +40,9 @@ public interface Objectionaries {
      */
     Objectionaries with(CommitHash hash, Objectionary objectionary);
 
-    Input object(CommitHash hash, String name);
+    Input object(CommitHash hash, String name) throws IOException;
 
-    boolean contains(CommitHash hash, String name);
+    boolean contains(CommitHash hash, String name) throws IOException;
 
     /**
      * Fake objectionaries.
@@ -77,21 +77,13 @@ public interface Objectionaries {
         }
 
         @Override
-        public Input object(final CommitHash hash, final String name) {
-            try {
-                return this.objry.get(name);
-            } catch (final IOException ex) {
-                throw new RuntimeException(ex);
-            }
+        public Input object(final CommitHash hash, final String name) throws IOException {
+            return this.objry.get(name);
         }
 
         @Override
-        public boolean contains(final CommitHash hash, final String name) {
-            try {
-                return this.objry.contains(name);
-            } catch (final IOException ex) {
-                throw new RuntimeException(ex);
-            }
+        public boolean contains(final CommitHash hash, final String name) throws IOException {
+            return this.objry.contains(name);
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -45,6 +45,8 @@ public interface Objectionaries {
      */
     Objectionary get(CommitHash hash);
 
+    boolean contains(CommitHash hash, String name);
+
     /**
      * Fake objectionaries.
      * Contains only one default objectionary that will be returned by any hash.
@@ -80,6 +82,11 @@ public interface Objectionaries {
         @Override
         public Objectionary get(final CommitHash hash) {
             return this.objry;
+        }
+
+        @Override
+        public boolean contains(final CommitHash hash, final String name) {
+            return false;
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -91,26 +91,16 @@ public final class ObjsDefault implements Objectionaries {
     }
 
     @Override
-    public Input object(final CommitHash hash, final String name) {
-        try {
-            return this.byHash(hash).get(name);
-        } catch (final IOException ex) {
-            //todo
-            throw new IllegalStateException(ex);
-        }
+    public Input object(final CommitHash hash, final String name) throws IOException {
+        return this.objectionary(hash).get(name);
     }
 
     @Override
-    public boolean contains(final CommitHash hash, final String name) {
-        try {
-            return this.byHash(hash).contains(name);
-        } catch (final IOException ex) {
-            //todo
-            throw new IllegalStateException(ex);
-        }
+    public boolean contains(final CommitHash hash, final String name) throws IOException {
+        return this.objectionary(hash).contains(name);
     }
 
-    private Objectionary byHash(final CommitHash hash) {
+    private Objectionary objectionary(final CommitHash hash) {
         final CommitHash cached = new ChCached(hash);
         final CommitHash narrow = new ChNarrow(cached);
         this.with(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -25,12 +25,13 @@ package org.eolang.maven.objectionary;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
 import org.cactoos.scalar.Unchecked;
 import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChNarrow;
@@ -64,10 +65,15 @@ public final class ObjsDefault implements Objectionaries {
      */
     @SafeVarargs
     public ObjsDefault(final Map.Entry<CommitHash, Objectionary>... entries) {
-        this(
-            Arrays.stream(entries)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-        );
+        this(new Mapped<>(e -> new MapEntry<>(e.getKey().value(), e.getValue()), entries));
+    }
+
+    /**
+     * Constructor for tests with predefined Objectionaries.
+     * @param entries Predefined Objectionaries.
+     */
+    private ObjsDefault(final Iterable<Map.Entry<String, Objectionary>> entries) {
+        this(new MapOf<>(entries));
     }
 
     /**
@@ -78,6 +84,7 @@ public final class ObjsDefault implements Objectionaries {
     public ObjsDefault(final Scalar<Path> cache, final Scalar<Boolean> cached) {
         this(cache, cached, new HashMap<>(0));
     }
+
 
     /**
      * Constructor for tests.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -52,7 +52,7 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Use cache.
      */
-    private final Scalar<Boolean> usehash;
+    private final Scalar<Boolean> remote;
 
     /**
      * Hash-map.
@@ -62,10 +62,10 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Constructor.
      * @param cache Cache path.
-     * @param usehash Use cache.
+     * @param remote Use cache.
      */
-    public ObjsDefault(final Scalar<Path> cache, final Scalar<Boolean> usehash) {
-        this(cache, usehash, new HashMap<>(0));
+    public ObjsDefault(final Scalar<Path> cache, final Scalar<Boolean> remote) {
+        this(cache, remote, new HashMap<>(0));
     }
 
     /**
@@ -98,16 +98,16 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Primary constructor.
      * @param cache Cache path.
-     * @param usehash Use cache.
+     * @param remote Use cache.
      * @param map Objectionaries hash-map.
      */
     private ObjsDefault(
         final Scalar<Path> cache,
-        final Scalar<Boolean> usehash,
+        final Scalar<Boolean> remote,
         final Map<? super String, Objectionary> map
     ) {
         this.cache = new Unchecked<>(cache);
-        this.usehash = usehash;
+        this.remote = remote;
         this.map = map;
     }
 
@@ -144,7 +144,7 @@ public final class ObjsDefault implements Objectionaries {
                             new OyRemote(sticky)
                         )
                     ),
-                    this.usehash
+                    this.remote
                 )
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -89,9 +89,9 @@ public final class ObjsDefault implements Objectionaries {
 
     /**
      * Primary constructor.
-     * @param map Objectionaries hash-map.
      * @param cache Cache path.
      * @param cached Use cache.
+     * @param map Objectionaries hash-map.
      */
     private ObjsDefault(
         final Scalar<Path> cache,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -91,11 +91,6 @@ public final class ObjsDefault implements Objectionaries {
     }
 
     @Override
-    public Objectionary get(final CommitHash hash) {
-        return this.map.get(hash.value());
-    }
-
-    @Override
     public Input object(final CommitHash hash, final String name) {
         try {
             return this.byHash(hash).get(name);
@@ -118,7 +113,7 @@ public final class ObjsDefault implements Objectionaries {
     private Objectionary byHash(final CommitHash hash) {
         final CommitHash cached = new ChCached(hash);
         final CommitHash narrow = new ChNarrow(cached);
-        return this.with(
+        this.with(
             cached,
             new OyFallbackSwap(
                 new OyHome(
@@ -134,6 +129,7 @@ public final class ObjsDefault implements Objectionaries {
                 ),
                 this.usecache
             )
-        ).get(cached);
+        );
+        return this.map.get(cached.value());
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -60,23 +60,6 @@ public final class ObjsDefault implements Objectionaries {
     private final Map<? super String, Objectionary> map;
 
     /**
-     * Constructor for tests with predefined Objectionaries.
-     * @param entries Predefined Objectionaries.
-     */
-    @SafeVarargs
-    public ObjsDefault(final Map.Entry<CommitHash, Objectionary>... entries) {
-        this(new Mapped<>(e -> new MapEntry<>(e.getKey().value(), e.getValue()), entries));
-    }
-
-    /**
-     * Constructor for tests with predefined Objectionaries.
-     * @param entries Predefined Objectionaries.
-     */
-    private ObjsDefault(final Iterable<Map.Entry<String, Objectionary>> entries) {
-        this(new MapOf<>(entries));
-    }
-
-    /**
      * Constructor.
      * @param cache Cache path.
      * @param usehash Use cache.
@@ -85,6 +68,23 @@ public final class ObjsDefault implements Objectionaries {
         this(cache, usehash, new HashMap<>(0));
     }
 
+    /**
+     * Constructor for tests with predefined Objectionaries.
+     * @param entries Predefined Objectionaries.
+     */
+    @SafeVarargs
+    public ObjsDefault(final Map.Entry<CommitHash, Objectionary>... entries) {
+        this(new Mapped<>(e -> new MapEntry<>(e.getKey().value(), e.getValue()), entries));
+    }
+
+
+    /**
+     * Constructor for tests with predefined Objectionaries.
+     * @param entries Predefined Objectionaries.
+     */
+    private ObjsDefault(final Iterable<Map.Entry<String, Objectionary>> entries) {
+        this(new MapOf<>(entries));
+    }
 
     /**
      * Constructor for tests.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -81,7 +81,9 @@ public final class ObjsDefault implements Objectionaries {
      * Constructor for tests with predefined Objectionaries.
      * @param entries Predefined Objectionaries.
      */
-    private ObjsDefault(final Iterable<Map.Entry<String, Objectionary>> entries) {
+    private ObjsDefault(
+        final Iterable<Map.Entry<? extends String, ? extends Objectionary>> entries
+    ) {
         this(new MapOf<>(entries));
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -52,7 +52,7 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Use cache.
      */
-    private final Scalar<Boolean> cached;
+    private final Scalar<Boolean> usehash;
 
     /**
      * Hash-map.
@@ -79,10 +79,10 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Constructor.
      * @param cache Cache path.
-     * @param cached Use cache.
+     * @param usehash Use cache.
      */
-    public ObjsDefault(final Scalar<Path> cache, final Scalar<Boolean> cached) {
-        this(cache, cached, new HashMap<>(0));
+    public ObjsDefault(final Scalar<Path> cache, final Scalar<Boolean> usehash) {
+        this(cache, usehash, new HashMap<>(0));
     }
 
 
@@ -97,16 +97,16 @@ public final class ObjsDefault implements Objectionaries {
     /**
      * Primary constructor.
      * @param cache Cache path.
-     * @param cached Use cache.
+     * @param usehash Use cache.
      * @param map Objectionaries hash-map.
      */
     private ObjsDefault(
         final Scalar<Path> cache,
-        final Scalar<Boolean> cached,
+        final Scalar<Boolean> usehash,
         final Map<? super String, Objectionary> map
     ) {
         this.cache = new Unchecked<>(cache);
-        this.cached = cached;
+        this.usehash = usehash;
         this.map = map;
     }
 
@@ -143,7 +143,7 @@ public final class ObjsDefault implements Objectionaries {
                             new OyRemote(sticky)
                         )
                     ),
-                    this.cached
+                    this.usehash
                 )
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -77,7 +77,6 @@ public final class ObjsDefault implements Objectionaries {
         this(new Mapped<>(e -> new MapEntry<>(e.getKey().value(), e.getValue()), entries));
     }
 
-
     /**
      * Constructor for tests with predefined Objectionaries.
      * @param entries Predefined Objectionaries.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.map.MapEntry;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.maven.hash.ChCached;
@@ -198,9 +199,10 @@ final class ProbeMojoTest {
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
-                new ObjsDefault()
-                    .with(first, new OyRemote(first))
-                    .with(second, new OyRemote(second))
+                new ObjsDefault(
+                    new MapEntry<>(first, new OyRemote(first)),
+                    new MapEntry<>(second, new OyRemote(second))
+                )
             )
             .with("withVersions", true)
             .withProgram(
@@ -248,9 +250,10 @@ final class ProbeMojoTest {
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
-                new ObjsDefault()
-                    .with(first, new OyRemote(first))
-                    .with(master, new OyRemote(master))
+                new ObjsDefault(
+                    new MapEntry<>(first, new OyRemote(first)),
+                    new MapEntry<>(master, new OyRemote(master))
+                )
             )
             .with("withVersions", true)
             .with("hsh", master)


### PR DESCRIPTION
Refactor Objectionaries interface: replace `with` and `get` methods with `object` and `contains` methods.
Make `ObjsDefault` class immutable.

History:
- feat(#2299): Add contains method to Objectionaries
- feat(#2299): Ugly working implementation
- feat(#2299): Remove unused methods
- feat(#2299): Remove get method from Objectionaries
- feat(#2299): Make Objectionaries to throw IOException for object() and contains() methods
- feat(#2299): Don't use with method
- feat(#2299): Add javadocs for new methods
- feat(#2299): Remove the puzzle for #2299 issue

Closes: #2299

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `Objectionaries` class in the `eo-maven-plugin` module. The notable changes include:
- Adding new constructors to `ObjsDefault` class
- Modifying the `objectionaries` field in multiple classes to use the new constructors
- Updating the `with` method in `Objectionaries` interface to return `Input` instead of `Objectionaries`
- Adding a new method `object` in `Objectionaries` interface to get an object by hash and name
- Adding a new method `contains` in `Objectionaries` interface to check if an object exists by hash and name

> The following files were skipped due to too many changes: `eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->