### PR TITLE
#2329 Versioned program for `FakeMaven`

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -49,6 +49,10 @@ import org.junit.jupiter.params.provider.CsvSource;
  * @since 0.28.11
  */
 final class DiscoverMojoTest {
+    /**
+     * Text.
+     */
+    private static final String TEXT = "org.eolang.txt.text|5f82cc1";
 
     /**
      * Default assertion message.
@@ -112,13 +116,12 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String text = "org.eolang.txt.text|5f82cc1";
         final String stdout = "org.eolang.stdout|9c93528";
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_CONTAIN, text),
-            tojos.contains(text),
+            String.format(DiscoverMojoTest.SHOULD_CONTAIN, DiscoverMojoTest.TEXT),
+            tojos.contains(DiscoverMojoTest.TEXT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -186,15 +189,14 @@ final class DiscoverMojoTest {
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
         final String seq = "org.eolang.seq|6c6269d";
-        final String text = "org.eolang.txt.text|5f82cc1";
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
             maven.externalTojos().contains(seq),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_NOT, text),
-            maven.externalTojos().contains(text),
+            String.format(DiscoverMojoTest.SHOULD_NOT, DiscoverMojoTest.TEXT),
+            maven.externalTojos().contains(DiscoverMojoTest.TEXT),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -110,24 +110,16 @@ final class DiscoverMojoTest {
         final FakeMaven maven = new FakeMaven(tmp)
             .with("withVersions", true)
             .with("hashes", new CommitHashesMap.Fake())
-            .withProgram(
-                "+alias org.eolang.txt.sprintf\n",
-                "[] > main",
-                "  seq > @",
-                "    QQ.io.stdout|0.28.9",
-                "      sprintf|0.28.5",
-                "        \"Hello world\"",
-                "          TRUE",
-                "    nop"
-            )
+            .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String sprintf = "org.eolang.txt.sprintf|9c93528";
-        final String stdout = "org.eolang.io.stdout|be83d9a";
+        final String text = "org.eolang.txt.text|5f82cc1";
+        final String stdout = "org.eolang.stdout|9c93528";
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
+        tojos.all().forEach(tojo -> System.out.println(tojo.identifier()));
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_CONTAIN, sprintf),
-            tojos.contains(sprintf),
+            String.format(DiscoverMojoTest.SHOULD_CONTAIN, text),
+            tojos.contains(text),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -151,7 +143,10 @@ final class DiscoverMojoTest {
             .with("withVersions", true)
             .with("hashes", hashes)
             .withProgram(
-                "+alias org.eolang.txt.sprintf\n",
+                "+alias org.eolang.txt.sprintf",
+                "+home https://objectionary.home",
+                "+package f",
+                "+version 0.0.0\n",
                 "[] > main",
                 "  seq > @",
                 "    QQ.io.stdout",
@@ -192,26 +187,18 @@ final class DiscoverMojoTest {
             .with("withVersions", false)
             .with("failOnError", false)
             .with("hashes", new CommitHashesMap.Fake())
-            .withProgram(
-                "+alias org.eolang.txt.sprintf\n",
-                "[] > main",
-                "  seq > @",
-                "    QQ.io.stdout|0.28.9",
-                "      sprintf|0.28.5",
-                "        \"Hello world\"",
-                "          TRUE"
-            )
+            .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String sprintf = "org.eolang.txt.sprintf|9c93528";
-        final String stdout = "org.eolang.io.stdout|be83d9a";
+        final String seq = "org.eolang.seq|6c6269d";
+        final String text = "org.eolang.txt.text|5f82cc1";
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_NOT, sprintf),
-            maven.externalTojos().contains(sprintf),
+            String.format(DiscoverMojoTest.SHOULD_NOT, seq),
+            maven.externalTojos().contains(seq),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
-            String.format(DiscoverMojoTest.SHOULD_NOT, stdout),
-            maven.externalTojos().contains(stdout),
+            String.format(DiscoverMojoTest.SHOULD_NOT, text),
+            maven.externalTojos().contains(text),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -142,10 +142,7 @@ final class DiscoverMojoTest {
             .with("withVersions", true)
             .with("hashes", hashes)
             .withProgram(
-                "+alias org.eolang.txt.sprintf",
-                "+home https://objectionary.home",
-                "+package f",
-                "+version 0.0.0\n",
+                "+alias org.eolang.txt.sprintf\n",
                 "[] > main",
                 "  seq > @",
                 "    QQ.io.stdout",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -116,7 +116,6 @@ final class DiscoverMojoTest {
         final String stdout = "org.eolang.stdout|9c93528";
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
-        tojos.all().forEach(tojo -> System.out.println(tojo.identifier()));
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, text),
             tojos.contains(text),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -319,7 +319,37 @@ public final class FakeMaven {
      * @throws IOException If method can't save eo program to the workspace.
      */
     FakeMaven withHelloWorld() throws IOException {
-        return this.withProgram("+package f\n", "[args] > main", "  (stdout \"Hello!\").print");
+        return this.withProgram(
+            "+home https://objectionary.home",
+            "+package f",
+            "+version 0.0.0\n",
+            "[args] > main",
+            "  (stdout \"Hello!\").print"
+        );
+    }
+
+    /**
+     * Add correct versioned program to workspace.
+     * @return The same maven instance.
+     * @throws IOException If method can't save eo program to the workspace.
+     */
+    FakeMaven withVersionedProgram() throws IOException {
+        return this.withProgram(
+            "+alias org.eolang.math.number",
+            "+alias org.eolang.txt.text",
+            "+home https://objectionary.home",
+            "+package f",
+            "+version 0.0.0\n",
+            "[args] > main",
+            "  seq|0.28.4 > @",
+            "    QQ.io.stdout|0.28.5",
+            "      QQ.txt.sprintf|0.28.6",
+            "        \"Number %d, text %s\"",
+            "        number 2",
+            "        text|0.28.7",
+            "          \"text\"",
+            "    nop"
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -319,13 +319,7 @@ public final class FakeMaven {
      * @throws IOException If method can't save eo program to the workspace.
      */
     FakeMaven withHelloWorld() throws IOException {
-        return this.withProgram(
-            "+home https://objectionary.home",
-            "+package f",
-            "+version 0.0.0\n",
-            "[args] > main",
-            "  (stdout \"Hello!\").print"
-        );
+        return this.withProgram("+package f\n", "[args] > main", "  (stdout \"Hello!\").print");
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -376,16 +376,11 @@ final class OptimizeMojoTest {
     void containsValidVersionAfterReplacingAndOptimization(@TempDir final Path tmp)
         throws Exception {
         new FakeMaven(tmp)
-            .withProgram(
-                "+package f\n",
-                "[] > main",
-                "  seq|0.28.10 > @",
-                "    nop"
-            )
+            .withVersionedProgram()
             .with("withVersions", true)
             .with("hashes", new CommitHashesMap.Fake())
             .execute(new FakeMaven.Optimize());
-        final String ver = "9b88393";
+        final String ver = "6c6269d";
         final int size = 1;
         MatcherAssert.assertThat(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -190,10 +190,10 @@ final class ProbeMojoTest {
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
-        final CommitHash first = new CommitHashesMap.Fake().get("0.28.10");
-        final CommitHash second = new CommitHashesMap.Fake().get("0.28.0");
-        final String stdout = "org.eolang.io.stdout|9b88393";
-        final String sprintf = "org.eolang.txt.sprintf|6a70071";
+        final CommitHash first = new CommitHashesMap.Fake().get("0.28.5");
+        final CommitHash second = new CommitHashesMap.Fake().get("0.28.7");
+        final String stdout = "org.eolang.io.stdout|9c93528";
+        final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
@@ -203,14 +203,8 @@ final class ProbeMojoTest {
                 )
             )
             .with("withVersions", true)
-            .with("hsh", first)
-            .withProgram(
-                "+package org.eolang.custom\n",
-                "[] > main",
-                "  QQ.io.stdout|0.28.10 > @",
-                "    QQ.txt.sprintf|0.28.0",
-                "      \"Hello world!\""
-            )
+            .with("hsh", second)
+            .withVersionedProgram()
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
             String.format(
@@ -223,9 +217,9 @@ final class ProbeMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "Tojos should have contained versioned object %s after probing, but they didn't",
-                sprintf
+                number
             ),
-            maven.externalTojos().contains(sprintf),
+            maven.externalTojos().contains(number),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -255,13 +249,7 @@ final class ProbeMojoTest {
             )
             .with("withVersions", true)
             .with("hsh", master)
-            .withProgram(
-                "+package org.eolang.custom\n",
-                "[] > main",
-                "  QQ.io.stdout|0.28.10 > @",
-                "    QQ.txt.sprintf",
-                "      \"Hello world!\""
-            )
+            .withVersionedProgram()
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -64,11 +64,6 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(OnlineCondition.class)
 final class ProbeMojoTest {
-    /**
-     * Fake hashes.
-     */
-    private static final Map<String, CommitHash> HASHES = new CommitHashesMap.Fake();
-
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbes(@TempDir final Path temp) throws Exception {
@@ -147,7 +142,7 @@ final class ProbeMojoTest {
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInOneObjectionary(@TempDir final Path temp) throws IOException {
-        final CommitHash hash = ProbeMojoTest.HASHES.get("0.28.10");
+        final CommitHash hash = new CommitHashesMap.Fake().get("0.28.10");
         final String object = "org.eolang.io.stdout|9b88393";
         final FakeMaven maven = new FakeMaven(temp)
             .with("hsh", hash)
@@ -190,9 +185,10 @@ final class ProbeMojoTest {
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
-        final CommitHash first = ProbeMojoTest.HASHES.get("0.28.5");
-        final CommitHash second = ProbeMojoTest.HASHES.get("0.28.6");
-        final CommitHash third = ProbeMojoTest.HASHES.get("0.28.7");
+        final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
+        final CommitHash first = hashes.get("0.28.5");
+        final CommitHash second = hashes.get("0.28.6");
+        final CommitHash third = hashes.get("0.28.7");
         final String stdout = "org.eolang.io.stdout|9c93528";
         final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -64,6 +64,11 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(OnlineCondition.class)
 final class ProbeMojoTest {
+    /**
+     * Stdout.
+     */
+    private static final String STDOUT = "org.eolang.io.stdout|9c93528";
+
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbes(@TempDir final Path temp) throws Exception {
@@ -142,8 +147,7 @@ final class ProbeMojoTest {
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInOneObjectionary(@TempDir final Path temp) throws IOException {
-        final CommitHash hash = new CommitHashesMap.Fake().get("0.28.10");
-        final String object = "org.eolang.io.stdout|9b88393";
+        final CommitHash hash = new CommitHashesMap.Fake().get("0.28.5");
         final FakeMaven maven = new FakeMaven(temp)
             .with("hsh", hash)
             .with("objectionaries", new Objectionaries.Fake(new OyRemote(hash)))
@@ -151,16 +155,16 @@ final class ProbeMojoTest {
             .withProgram(
                 "+package org.eolang.custom\n",
                 "[] > main",
-                "  QQ.io.stdout|0.28.10 > @",
+                "  QQ.io.stdout|0.28.5 > @",
                 "    \"Hello world\""
             )
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
             String.format(
                 "Tojos should have contained versioned object %s after probing, but they didn't",
-                object
+                ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(object),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -189,7 +193,6 @@ final class ProbeMojoTest {
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
         final CommitHash third = hashes.get("0.28.7");
-        final String stdout = "org.eolang.io.stdout|9c93528";
         final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)
             .with(
@@ -207,9 +210,9 @@ final class ProbeMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "Tojos should have contained versioned object %s after probing, but they didn't",
-                stdout
+                ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(stdout),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -185,7 +185,8 @@ final class ProbeMojoTest {
     void findsProbesWithVersionsInDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
         final CommitHash first = new CommitHashesMap.Fake().get("0.28.5");
-        final CommitHash second = new CommitHashesMap.Fake().get("0.28.7");
+        final CommitHash second = new CommitHashesMap.Fake().get("0.28.6");
+        final CommitHash third = new CommitHashesMap.Fake().get("0.28.7");
         final String stdout = "org.eolang.io.stdout|9c93528";
         final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)
@@ -193,11 +194,12 @@ final class ProbeMojoTest {
                 "objectionaries",
                 new ObjsDefault(
                     new MapEntry<>(first, new OyRemote(first)),
-                    new MapEntry<>(second, new OyRemote(second))
+                    new MapEntry<>(second, new OyRemote(second)),
+                    new MapEntry<>(third, new OyRemote(third))
                 )
             )
             .with("withVersions", true)
-            .with("hsh", second)
+            .with("hsh", third)
             .withVersionedProgram()
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
@@ -224,50 +226,13 @@ final class ProbeMojoTest {
             ),
             Matchers.equalTo("2")
         );
-    }
-
-    @Test
-    @ExtendWith(OnlineCondition.class)
-    void findsProbesWithDefaultHash(@TempDir final Path temp) throws IOException {
-        final CommitHash first = new CommitHashesMap.Fake().get("0.28.10");
-        final CommitHash master = new CommitHashesMap().get("master");
-        final String stdout = "org.eolang.io.stdout|9b88393";
-        final String sprintf = "org.eolang.txt.sprintf|9c46a67";
-        final FakeMaven maven = new FakeMaven(temp)
-            .with(
-                "objectionaries",
-                new ObjsDefault(
-                    new MapEntry<>(first, new OyRemote(first)),
-                    new MapEntry<>(master, new OyRemote(master))
-                )
-            )
-            .with("withVersions", true)
-            .with("hsh", master)
-            .withVersionedProgram()
-            .execute(new FakeMaven.Probe());
-        MatcherAssert.assertThat(
-            String.format(
-                "Tojos should have contained versioned object %s after probing, but they didn't",
-                stdout
-            ),
-            maven.externalTojos().contains(stdout),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            String.format(
-                "Tojos should have contained versioned object %s after probing, but they didn't",
-                sprintf
-            ),
-            maven.externalTojos().contains(sprintf),
-            Matchers.is(true)
-        );
         MatcherAssert.assertThat(
             "First entry of tojos after probing should have contained given hash, but it didn't",
             ProbeMojoTest.firstEntry(
                 maven.externalPath(),
                 "hash"
             ),
-            Matchers.equalTo(master.value())
+            Matchers.equalTo(third.value())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -52,12 +52,6 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link ProbeMojo}.
  *
  * @since 0.28.11
- * @todo #2302:30min Add special method to {@link FakeMaven} for versioned
- *  program. On many compilation steps we test programs with versions and such
- *  programs looks similar or identical. We can create a separate method for it.
- *  Something like withVersionedProgram()
- *  See tests in {@link OptimizeMojoTest}, {@link VersionsMojoTest},
- *  {@link DiscoverMojoTest}, {@link ProbeMojoTest}.
  * @todo #2302:30min Refactor tests in the class. Looks like there is a lot of
  *  code duplication among all tests in the class. Need to reduce it somehow.
  * @todo #2302:30min Refactor firstEntity method. The "first entity of the

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
+import java.util.Map;
+
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.text.TextOf;
@@ -63,6 +65,11 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(OnlineCondition.class)
 final class ProbeMojoTest {
+    /**
+     * Fake hashes.
+     */
+    private static final Map<String, CommitHash> HASHES = new CommitHashesMap.Fake();
+
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbes(@TempDir final Path temp) throws Exception {
@@ -141,7 +148,7 @@ final class ProbeMojoTest {
     @Test
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInOneObjectionary(@TempDir final Path temp) throws IOException {
-        final CommitHash hash = new CommitHashesMap.Fake().get("0.28.10");
+        final CommitHash hash = ProbeMojoTest.HASHES.get("0.28.10");
         final String object = "org.eolang.io.stdout|9b88393";
         final FakeMaven maven = new FakeMaven(temp)
             .with("hsh", hash)
@@ -184,9 +191,9 @@ final class ProbeMojoTest {
     @ExtendWith(OnlineCondition.class)
     void findsProbesWithVersionsInDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
-        final CommitHash first = new CommitHashesMap.Fake().get("0.28.5");
-        final CommitHash second = new CommitHashesMap.Fake().get("0.28.6");
-        final CommitHash third = new CommitHashesMap.Fake().get("0.28.7");
+        final CommitHash first = ProbeMojoTest.HASHES.get("0.28.5");
+        final CommitHash second = ProbeMojoTest.HASHES.get("0.28.6");
+        final CommitHash third = ProbeMojoTest.HASHES.get("0.28.7");
         final String stdout = "org.eolang.io.stdout|9c93528";
         final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.Map;
-
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.text.TextOf;


### PR DESCRIPTION
What's done:
- Added versioned program to `FakeMaven`
- Refactored tests that test versioning

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding versioned programs to the EO Maven Plugin. 

### Detailed summary
- Added `withVersionedProgram` method to `FakeMaven` for versioned programs
- Updated test cases in `OptimizeMojoTest`, `VersionsMojoTest`, `DiscoverMojoTest`, and `ProbeMojoTest` to use versioned programs
- Updated program versions in test cases

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->