### PR TITLE
#1953 Fixed `float.lte` and `float.gte` dataize their arguments twice

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -36,7 +36,7 @@
           ^.as-bytes > self-as-bytes!
           00-00-00-00-00-00-00-00 > zero-as-bytes!
         eq.
-          value.as-bytes > x-as-bytes!
+          x.as-bytes > x-as-bytes!
           zero-as-bytes
       eq.
         ^.neg.as-bytes

--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -29,17 +29,18 @@
 [] > float
   # Tests that $ = x
   [x] > eq
+    x > value!
     if. > @
       and.
         eq.
           ^.as-bytes > self-as-bytes!
           00-00-00-00-00-00-00-00 > zero-as-bytes!
         eq.
-          x.as-bytes > x-as-bytes!
+          value.as-bytes > x-as-bytes!
           zero-as-bytes
       eq.
         ^.neg.as-bytes
-        x.neg.as-bytes
+        value.neg.as-bytes
       eq.
         self-as-bytes
         x-as-bytes
@@ -48,25 +49,27 @@
   [x] > lt
     gt. > @
       plus.
-        x
         neg.
           ^
+        x
       0.0
 
   # Tests that $ ≤ x
   [x] > lte
+    x > value!
     or. > @
-      ^.eq x
-      ^.lt x
+      ^.eq value
+      ^.lt value
 
   # Tests that $ > x
   [x] > gt /bool
 
   # Tests that $ ≥ x
   [x] > gte
+    x > value!
     or. > @
-      ^.eq x
-      ^.gt x
+      ^.eq value
+      ^.gt value
 
   # Multiplication of $ and x
   [x...] > times /float

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
@@ -55,6 +55,16 @@ public class EOstdout extends PhDefault {
      * @param sigma Sigma
      */
     public EOstdout(final Phi sigma) {
+        this(sigma, EOstdout.OUT);
+    }
+
+    /**
+     * Ctor.
+     * It's supposed to used only for the test purposes.
+     * @param sigma Sigma
+     * @param out Output stream.
+     */
+    public EOstdout(final Phi sigma, final PrintStream out) {
         super(sigma);
         this.add("text", new AtFree());
         this.add(
@@ -62,7 +72,7 @@ public class EOstdout extends PhDefault {
             new AtComposite(
                 this,
                 rho -> {
-                    EOstdout.OUT.print(
+                    out.print(
                         new Param(rho, "text").strong(String.class)
                     );
                     return new Data.ToPhi(true);

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
@@ -27,7 +27,6 @@
  */
 package EOorg.EOeolang.EOio;
 
-import java.io.PrintStream;
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
 import org.eolang.Data;
@@ -44,27 +43,11 @@ import org.eolang.XmirObject;
  */
 @XmirObject(oname = "stdout")
 public class EOstdout extends PhDefault {
-
-    /**
-     * Default out.
-     */
-    private static final PrintStream OUT = System.out;
-
     /**
      * Ctor.
      * @param sigma Sigma
      */
     public EOstdout(final Phi sigma) {
-        this(sigma, EOstdout.OUT);
-    }
-
-    /**
-     * Ctor.
-     * It's supposed to used only for the test purposes.
-     * @param sigma Sigma
-     * @param out Output stream.
-     */
-    public EOstdout(final Phi sigma, final PrintStream out) {
         super(sigma);
         this.add("text", new AtFree());
         this.add(
@@ -72,7 +55,7 @@ public class EOstdout extends PhDefault {
             new AtComposite(
                 this,
                 rho -> {
-                    out.print(
+                    System.out.print(
                         new Param(rho, "text").strong(String.class)
                     );
                     return new Data.ToPhi(true);

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -27,10 +27,6 @@
 +package org.eolang
 +version 0.0.0
 
-# @todo #1299:60min Implement test that will
-#  check output of stdout. That should proven
-#  that there is no double printage, when
-#  methods lt., gt., lte., gte. are called.
 [] > seq-single-dataization-float-less-than-test
   memory 0.0 > counter
   assert-that > @

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -64,23 +64,14 @@ public final class EOstdoutTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1,2,lt",
-        "1,2,gt",
-        "1,2,lte",
-        "1,2,gte"
-    })
-    public void doesNotPrintTwiceOnIntComparisonMethods(
-        final int first,
-        final int second,
-        final String method
-    ) {
+    @CsvSource({"lt", "gt", "lte", "gte"})
+    public void doesNotPrintTwiceOnIntComparisonMethods(final String method) {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";
         new Dataized(
             new PhWith(
                 new PhMethod(
-                    new Data.ToPhi((long) first),
+                    new Data.ToPhi(1L),
                     method
                 ),
                 0,
@@ -95,10 +86,10 @@ public final class EOstdoutTest {
                         )
                     ),
                     0,
-                    new Data.ToPhi((long) second)
+                    new Data.ToPhi(2L)
                 )
             )
-        ).take(Boolean.class);
+        ).take();
         MatcherAssert.assertThat(
             stream.toString(),
             Matchers.equalTo(str)
@@ -106,23 +97,14 @@ public final class EOstdoutTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0,2.0,lt",
-        "1.0,2.0,gt",
-        "1.0,2.0,lte",
-        "1.0,2.0,gte"
-    })
-    public void doesNotPrintTwiceOnFloatComparisonMethods(
-        final double first,
-        final double second,
-        final String method
-    ) {
+    @CsvSource({"lt", "gt", "lte", "gte"})
+    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method) {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";
         new Dataized(
             new PhWith(
                 new PhMethod(
-                    new Data.ToPhi(first),
+                    new Data.ToPhi(1.0),
                     method
                 ),
                 0,
@@ -137,10 +119,10 @@ public final class EOstdoutTest {
                         )
                     ),
                     0,
-                    new Data.ToPhi(second)
+                    new Data.ToPhi(2.0)
                 )
             )
-        ).take(Boolean.class);
+        ).take();
         MatcherAssert.assertThat(
             stream.toString(),
             Matchers.equalTo(str)

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -27,9 +27,9 @@
  */
 package EOorg.EOeolang.EOio;
 
+import EOorg.EOeolang.EOseq;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import EOorg.EOeolang.EOseq;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhCopy;
@@ -68,7 +68,7 @@ public final class EOstdoutTest {
         "1,2,lt",
         "1,2,gt",
         "1,2,lte",
-        "1,2,gte",
+        "1,2,gte"
     })
     public void doesNotPrintTwiceOnIntComparisonMethods(
         final int first,
@@ -110,7 +110,7 @@ public final class EOstdoutTest {
         "1.0,2.0,lt",
         "1.0,2.0,gt",
         "1.0,2.0,lte",
-        "1.0,2.0,gte",
+        "1.0,2.0,gte"
     })
     public void doesNotPrintTwiceOnFloatComparisonMethods(
         final double first,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -120,7 +120,7 @@ public final class EOstdoutTest {
                         )
                     ),
                     0,
-                    new Data.ToPhi(2.0)
+                    new Data.ToPhi(3.0)
                 )
             )
         ).take();

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -27,14 +27,20 @@
  */
 package EOorg.EOeolang.EOio;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import EOorg.EOeolang.EOseq;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhCopy;
+import org.eolang.PhMethod;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Test case for {@link EOstdout}.
@@ -57,4 +63,87 @@ public final class EOstdoutTest {
         );
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "1,2,lt",
+        "1,2,gt",
+        "1,2,lte",
+        "1,2,gte",
+    })
+    public void doesNotPrintTwiceOnIntComparisonMethods(
+        final int first,
+        final int second,
+        final String method
+    ) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final String str = "Hello world";
+        new Dataized(
+            new PhWith(
+                new PhMethod(
+                    new Data.ToPhi((long) first),
+                    method
+                ),
+                0,
+                new PhWith(
+                    new PhWith(
+                        new EOseq(Phi.Φ),
+                        0,
+                        new PhWith(
+                            new EOstdout(Phi.Φ, new PrintStream(stream)),
+                            "text",
+                            new Data.ToPhi(str)
+                        )
+                    ),
+                    0,
+                    new Data.ToPhi((long) second)
+                )
+            )
+        ).take(Boolean.class);
+        MatcherAssert.assertThat(
+            stream.toString(),
+            Matchers.equalTo(str)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0,2.0,lt",
+        "1.0,2.0,gt",
+        "1.0,2.0,lte",
+        "1.0,2.0,gte",
+    })
+    public void doesNotPrintTwiceOnFloatComparisonMethods(
+        final double first,
+        final double second,
+        final String method
+    ) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final String str = "Hello world";
+        new Dataized(
+            new PhWith(
+                new PhMethod(
+                    new Data.ToPhi(first),
+                    method
+                ),
+                0,
+                new PhWith(
+                    new PhWith(
+                        new EOseq(Phi.Φ),
+                        0,
+                        new PhWith(
+                            new EOstdout(Phi.Φ, new PrintStream(stream)),
+                            "text",
+                            new Data.ToPhi(str)
+                        )
+                    ),
+                    0,
+                    new Data.ToPhi(second)
+                )
+            )
+        ).take(Boolean.class);
+        MatcherAssert.assertThat(
+            stream.toString(),
+            Matchers.equalTo(str)
+        );
+    }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -28,8 +28,6 @@
 package EOorg.EOeolang.EOio;
 
 import EOorg.EOeolang.EOseq;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhCopy;
@@ -41,6 +39,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
 
 /**
  * Test case for {@link EOstdout}.
@@ -63,10 +63,10 @@ public final class EOstdoutTest {
         );
     }
 
+    @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnIntComparisonMethods(final String method) {
-        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    public void doesNotPrintTwiceOnIntComparisonMethods(final String method, StdOut out) {
         final String str = "Hello world";
         new Dataized(
             new PhWith(
@@ -80,7 +80,7 @@ public final class EOstdoutTest {
                         new EOseq(Phi.Φ),
                         0,
                         new PhWith(
-                            new EOstdout(Phi.Φ, new PrintStream(stream)),
+                            new EOstdout(Phi.Φ),
                             "text",
                             new Data.ToPhi(str)
                         )
@@ -91,15 +91,16 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            stream.toString(),
+            out.capturedLines()[0],
             Matchers.equalTo(str)
         );
+        out.capturedLines();
     }
 
+    @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method) {
-        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, StdOut out) {
         final String str = "Hello world";
         new Dataized(
             new PhWith(
@@ -113,7 +114,7 @@ public final class EOstdoutTest {
                         new EOseq(Phi.Φ),
                         0,
                         new PhWith(
-                            new EOstdout(Phi.Φ, new PrintStream(stream)),
+                            new EOstdout(Phi.Φ),
                             "text",
                             new Data.ToPhi(str)
                         )
@@ -124,7 +125,7 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            stream.toString(),
+            out.capturedLines()[0],
             Matchers.equalTo(str)
         );
     }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -66,7 +66,7 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnIntComparisonMethods(final String method, StdOut out) {
+    public void doesNotPrintTwiceOnIntComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(
             new PhWith(
@@ -100,7 +100,7 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, StdOut out) {
+    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(
             new PhWith(


### PR DESCRIPTION
Closes: #1953

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing tests for the `lt`, `gt`, `lte`, and `gte` methods in the `float.eo` file to ensure that there is no double printing. 

### Detailed summary
- Added tests for `lt`, `gt`, `lte`, and `gte` methods in `float.eo`
- Modified `stdout.java` to remove unused code
- Added tests for `EOstdout` class in `EOstdoutTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->