### PR TITLE
#2299 Tests for pulling with versions

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChCompound.java
@@ -30,6 +30,9 @@ import java.nio.file.Path;
  * parameters.
  *
  * @since 0.28.14
+ * @todo #2299:30min Do we really need the class? It seems it's used only for
+ *  the test purposes but with last updates it is no longer of value. Also it
+ *  assumes that any of its arguments may be null which is a doubtful design
  */
 public final class ChCompound implements CommitHash {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -751,6 +751,7 @@ public final class FakeMaven {
         public Iterator<Class<? extends AbstractMojo>> iterator() {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
+                VersionsMojo.class,
                 OptimizeMojo.class,
                 DiscoverMojo.class,
                 ProbeMojo.class,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -323,6 +323,20 @@ public final class FakeMaven {
     }
 
     /**
+     * Add correct versioned 'Hello world' program to workspace.
+     * @return The same maven instance.
+     * @throws IOException If method can't save eo program to the workspace.
+     */
+    FakeMaven withVersionedHelloWorld() throws IOException {
+        return this.withProgram(
+            "+package f\n",
+            "[] > main",
+            "  QQ.io.stdout|0.28.5 > @",
+            "    \"Hello world\""
+        );
+    }
+
+    /**
      * Add correct versioned program to workspace.
      * @return The same maven instance.
      * @throws IOException If method can't save eo program to the workspace.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -152,12 +152,7 @@ final class ProbeMojoTest {
             .with("hsh", hash)
             .with("objectionaries", new Objectionaries.Fake(new OyRemote(hash)))
             .with("withVersions", true)
-            .withProgram(
-                "+package org.eolang.custom\n",
-                "[] > main",
-                "  QQ.io.stdout|0.28.5 > @",
-                "    \"Hello world\""
-            )
+            .withVersionedHelloWorld()
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
             String.format(
@@ -192,19 +187,17 @@ final class ProbeMojoTest {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
-        final CommitHash third = hashes.get("0.28.7");
         final String number = "org.eolang.txt.text|5f82cc1";
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
                 new ObjsDefault(
                     new MapEntry<>(first, new OyRemote(first)),
-                    new MapEntry<>(second, new OyRemote(second)),
-                    new MapEntry<>(third, new OyRemote(third))
+                    new MapEntry<>(second, new OyRemote(second))
                 )
             )
             .with("withVersions", true)
-            .with("hsh", third)
+            .with("hsh", first)
             .withVersionedProgram()
             .execute(new FakeMaven.Probe());
         MatcherAssert.assertThat(
@@ -237,7 +230,7 @@ final class ProbeMojoTest {
                 maven.externalPath(),
                 "hash"
             ),
-            Matchers.equalTo(third.value())
+            Matchers.equalTo(first.value())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -182,6 +182,10 @@ final class PullMojoTest {
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
         MatcherAssert.assertThat(
+            String.format(
+                "File by path %s should have existed after pulling, but it didn't",
+                PullMojoTest.path(PullMojoTest.VERSIONED)
+            ),
             PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
@@ -191,13 +195,23 @@ final class PullMojoTest {
     @Test
     void pullsProbedVersionedObjectFromOneObjectionary(@TempDir final Path temp)
         throws IOException {
-        final CommitHash hash = new ChCached(new CommitHashesMap.Fake().get("0.28.5"));
         new FakeMaven(temp)
             .with("withVersions", true)
-            .with("objectionaries", new Objectionaries.Fake(new OyRemote(hash)))
+            .with(
+                "objectionaries",
+                new Objectionaries.Fake(
+                    new OyRemote(
+                        new ChCached(new CommitHashesMap.Fake().get("0.28.5"))
+                    )
+                )
+            )
             .withVersionedHelloWorld()
             .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
+            String.format(
+                "File by path %s should have existed after pulling, but it didn't",
+                PullMojoTest.path(PullMojoTest.VERSIONED)
+            ),
             PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
@@ -224,16 +238,30 @@ final class PullMojoTest {
             .with("hsh", third)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
+        final String sprintf = "%s/org/eolang/io/sprintf|17f892.eo";
+        final String string = "%s/org/eolang/string|5f82cc";
         MatcherAssert.assertThat(
+            String.format(
+                "File by path %s should have existed after pulling, but it didn't",
+                PullMojoTest.path(PullMojoTest.VERSIONED)
+            ),
             PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            PullMojoTest.exists(temp, "%s/org/eolang/io/sprintf|17f892.eo"),
+            String.format(
+                "File by path %s should have existed after pulling, but it didn't",
+                PullMojoTest.path(sprintf)
+            ),
+            PullMojoTest.exists(temp, sprintf),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            PullMojoTest.exists(temp, "%s/org/eolang/string|5f82cc.eo"),
+            String.format(
+                "File by path %s should have existed after pulling, but it didn't",
+                PullMojoTest.path(string)
+            ),
+            PullMojoTest.exists(temp, string),
             Matchers.is(true)
         );
     }
@@ -247,7 +275,16 @@ final class PullMojoTest {
      */
     private static boolean exists(final Path temp, final String source) {
         return new Home(temp.resolve("target")).exists(
-            Paths.get(String.format(source, PullMojo.DIR))
+            Paths.get(PullMojoTest.path(source))
         );
+    }
+
+    /**
+     * Format given source path.
+     * @param source Source path.
+     * @return Formatted source path.
+     */
+    private static String path(final String source) {
+        return String.format(source, PullMojo.DIR);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -62,14 +62,7 @@ final class PullMojoTest {
         maven.with("skip", false)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            new Home(temp.resolve("target")).exists(
-                Paths.get(
-                    String.format(
-                        "%s/org/eolang/io/stdout.eo",
-                        PullMojo.DIR
-                    )
-                )
-            ),
+            PullMojoTest.exists(temp, "%s/org/eolang/io/stdout.eo"),
             Matchers.is(true)
         );
     }
@@ -97,14 +90,7 @@ final class PullMojoTest {
             )
             .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
-            new Home(temp.resolve("target")).exists(
-                Paths.get(
-                    String.format(
-                        "%s/org/eolang/io/stdout.eo",
-                        PullMojo.DIR
-                    )
-                )
-            ),
+            PullMojoTest.exists(temp, "%s/org/eolang/io/stdout.eo"),
             Matchers.is(true)
         );
     }
@@ -166,14 +152,7 @@ final class PullMojoTest {
         maven.with("skip", true)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            new Home(temp.resolve("target")).exists(
-                Paths.get(
-                    String.format(
-                        "%s/org/eolang/io/stdout.eo",
-                        PullMojo.DIR
-                    )
-                )
-            ),
+            PullMojoTest.exists(temp, "%s/org/eolang/io/stdout.eo"),
             Matchers.is(false)
         );
     }
@@ -186,15 +165,25 @@ final class PullMojoTest {
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
         MatcherAssert.assertThat(
-            new Home(temp.resolve("target")).exists(
-                Paths.get(
-                    String.format(
-                        "%s/org/eolang/io/stdout|9c93528.eo",
-                        PullMojo.DIR
-                    )
-                )
-            ),
+            PullMojoTest.exists(temp, "%s/org/eolang/io/stdout|9c93528.eo"),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void pullsProbedVersionedObjectFromOneObjectionary() {
+
+    }
+
+    /**
+     * Check if given source files exists in target directory.
+     * @param temp Test temporary directory.
+     * @param source Source file.
+     * @return If given source file exists.
+     */
+    private static boolean exists(final Path temp, final String source) {
+        return new Home(temp.resolve("target")).exists(
+            Paths.get(String.format(source, PullMojo.DIR))
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -173,6 +173,7 @@ final class PullMojoTest {
         );
     }
 
+    @Disabled
     @Test
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -171,8 +171,15 @@ final class PullMojoTest {
     }
 
     @Test
-    void pullsProbedVersionedObjectFromOneObjectionary() {
-
+    void pullsProbedVersionedObjectFromOneObjectionary(@TempDir final Path temp)
+        throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("withVersions", true)
+            .withProgram(
+                "+package f\n",
+                "[] > main",
+                "  QQ.io.stdout|"
+            );
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -123,13 +123,11 @@ final class PullMojoTest {
         maven.foreignTojos()
             .add(PullMojoTest.STDOUT)
             .withVersion("*.*.*");
-        maven.with(
+        maven.with("skip", false)
+            .with(
                 "hsh",
-                new ChCached(
-                    new ChText(temp.resolve("tags.txt"), "master")
-                )
+                new ChCached(new ChText(temp.resolve("tags.txt"), "master"))
             )
-            .with("skip", false)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
             new LinkedList<>(new MnCsv(maven.foreignPath()).read()).getFirst().get("hash"),
@@ -148,11 +146,11 @@ final class PullMojoTest {
         maven.foreignTojos()
             .add(PullMojoTest.STDOUT)
             .withVersion("*.*.*");
-        maven.with(
+        maven.with("skip", false)
+            .with(
                 "hsh",
                 new ChCached(new ChPattern("*.*.*:abcdefg", "1.0.0"))
             )
-            .with("skip", false)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
             new LinkedList<>(new MnCsv(maven.foreignPath()).read()).getFirst().get("hash"),
@@ -212,7 +210,7 @@ final class PullMojoTest {
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
         final CommitHash third = hashes.get("0.28.7");
-        final FakeMaven maven = new FakeMaven(temp)
+        new FakeMaven(temp)
             .with(
                 "objectionaries",
                 new ObjsDefault(
@@ -242,7 +240,7 @@ final class PullMojoTest {
     /**
      * Check if given source files exists in target directory.
      *
-     * @param temp   Test temporary directory.
+     * @param temp Test temporary directory.
      * @param source Source file.
      * @return If given source file exists.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(OnlineCondition.class)
 final class PullMojoTest {
+    private static final String STDOUT = "org.eolang.io.stdout|9c93528";
+
 
     @Test
     void pullsSuccessfully(@TempDir final Path temp) throws IOException {
@@ -173,6 +175,26 @@ final class PullMojoTest {
                 )
             ),
             Matchers.is(false)
+        );
+    }
+
+    @Test
+    void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        maven.foreignTojos()
+            .add("org.eolang.io.stdout|9c93528")
+            .withVersion("*.*.*");
+        maven.execute(PullMojo.class);
+        MatcherAssert.assertThat(
+            new Home(temp.resolve("target")).exists(
+                Paths.get(
+                    String.format(
+                        "%s/org/eolang/io/stdout|9c93528.eo",
+                        PullMojo.DIR
+                    )
+                )
+            ),
+            Matchers.is(true)
         );
     }
 }


### PR DESCRIPTION
Ref: #2299

What's done:
- Minor refactoring of tests for `ProbeMojo` and `PullMojo`
- Added disabled tests for `PullMojo` for testing versioning

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `ChCompound` class and adding a new method `withVersionedHelloWorld()` to the `FakeMaven` class. 

### Detailed summary
- Removed the `ChCompound` class as it is no longer needed and has a doubtful design.
- Added the `withVersionedHelloWorld()` method to the `FakeMaven` class to add a correct versioned 'Hello world' program to the workspace.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->