### PR TITLE
#1602 Change delimiter between name and version

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -112,7 +112,7 @@ public final class DiscoverMojo extends SafeMojo {
     }
 
     /**
-     * Get unique list of object names from given XML.
+     * Get a unique list of object names from given XML.
      * @param xml XML.
      * @return Object names.
      */
@@ -122,15 +122,17 @@ public final class DiscoverMojo extends SafeMojo {
                 obj -> !obj.isEmpty(),
                 xml.xpath(
                     String.join(
-                        " ",
+                        "",
                         "//o[",
                         "not(starts-with(@base,'.'))",
-                        "and @base != 'Q'",
-                        "and @base != '^'",
-                        "and @base != '$'",
-                        "and @base != '&'",
-                        "and not(@ref)",
-                        "]/string-join((@base, @ver),'|')"
+                        " and @base != 'Q'",
+                        " and @base != '^'",
+                        " and @base != '$'",
+                        " and @base != '&'",
+                        " and not(@ref)",
+                        "]/string-join((@base, @ver),'",
+                        VersionsMojo.DELIMITER,
+                        "')"
                     )
                 )
             )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VersionsMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VersionsMojo.java
@@ -68,12 +68,17 @@ import org.eolang.maven.util.Home;
  */
 public final class VersionsMojo extends SafeMojo {
     /**
+     * Delimiter between name and hash in EO object name.
+     */
+    public static final String DELIMITER = "#";
+
+    /**
      * Tag pattern.
      */
     private static final Pattern SEMVER = Pattern.compile("[0-9]+\\.[0-9]+\\.[0-9]+");
 
     /**
-     * Commit hashes map.
+     * Commit-hashes map.
      */
     private final Map<String, CommitHash> hashes = new CommitHashesMap();
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/ObjectName.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/ObjectName.java
@@ -26,7 +26,7 @@ package org.eolang.maven.name;
 import org.eolang.maven.hash.CommitHash;
 
 /**
- * Object name with version.
+ * Object name with a version.
  *
  * @since 0.29.6
  */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.name;
 
+import org.eolang.maven.VersionsMojo;
 import org.eolang.maven.hash.CommitHash;
 
 /**
@@ -64,15 +65,19 @@ public final class OnDefault implements ObjectName {
 
     @Override
     public String toString() {
-        return String.join("|", this.split()[0], this.split()[1]);
+        return String.join(
+            VersionsMojo.DELIMITER,
+            this.split()[0],
+            this.split()[1]
+        );
     }
 
     /**
-     * Split given object.
+     * Split a given object.
      * @return Split object to name and hash.
      */
     private String[] split() {
-        String[] splt = this.object.split("\\|");
+        String[] splt = this.object.split(VersionsMojo.DELIMITER);
         if (splt.length == 1) {
             splt = new String[]{splt[0], this.hsh.value()};
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
@@ -45,6 +45,17 @@ public final class OnDefault implements ObjectName {
 
     /**
      * Ctor.
+     * Please use the constructor for tests only because it can't guarantee
+     * that {@code hash} is actually hash but not a random string.
+     * @param object Object full name with a version or not.
+     * @param hash Default hash is a version in full name is absent.
+     */
+    public OnDefault(final String object, final String hash) {
+        this(object, new CommitHash.ChConstant(hash));
+    }
+
+    /**
+     * Ctor.
      * @param object Object full name with a version or not.
      * @param def Default hash if a version in full name is absent.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
@@ -45,8 +45,8 @@ public final class OnDefault implements ObjectName {
 
     /**
      * Ctor.
-     * @param object Object full name with version or not.
-     * @param def Default hash if version in full name is absent.
+     * @param object Object full name with a version or not.
+     * @param def Default hash if a version in full name is absent.
      */
     public OnDefault(final String object, final CommitHash def) {
         this.object = object;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
@@ -33,6 +33,12 @@ import org.eolang.maven.hash.CommitHash;
  * If a second object is not provided - behaves like {@link OnUnversioned}
  *
  * @since 0.29.6
+ * @todo #2328:30min Inline code in {@code toString()} method. For some reason
+ *  Codacy static analyzer fails on {@code toString()} method and says that
+ *  "it's unnecessary to call toString() on String object". It does not
+ *  understand that {@code this.swapped.value()} is not a String for some
+ *  reason. Codacy checks only new added files, so need to inline that code when
+ *  this file is already in the codebase.
  */
 public final class OnSwap implements ObjectName {
     /**
@@ -87,6 +93,7 @@ public final class OnSwap implements ObjectName {
 
     @Override
     public String toString() {
-        return this.swapped.value().toString();
+        final ObjectName name = this.swapped.value();
+        return name.toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
@@ -30,15 +30,9 @@ import org.eolang.maven.hash.CommitHash;
 /**
  * Swapped object name.
  * Depends on encapsulated condition behaves like one of the encapsulated object names.
- * If second object is not provided - behaves like {@link OnUnversioned}
+ * If a second object is not provided - behaves like {@link OnUnversioned}
  *
  * @since 0.29.6
- * @todo #2328:30min Inline code in {@code toString()} method. For some reason
- *  Codacy static analyzer fails on {@code toString()} method and says that
- *  "it's unnecessary to call toString() on String object". It does not
- *  understand that {@code this.swapped.value()} is not a String for some
- *  reason. Codacy checks only new added files, so need to inline that code when
- *  this file is already in the codebase.
  */
 public final class OnSwap implements ObjectName {
     /**
@@ -93,7 +87,6 @@ public final class OnSwap implements ObjectName {
 
     @Override
     public String toString() {
-        final ObjectName name = this.swapped.value();
-        return name.toString();
+        return this.swapped.value().toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -210,6 +210,15 @@ public final class ForeignTojos implements Closeable {
     }
 
     /**
+     * Check if the tojos contains a foreign tojo with given object name.
+     * @param name The name of the tojo.
+     * @return True if tojo exists.
+     */
+    public boolean contains(final ObjectName name) {
+        return this.contains(name.toString());
+    }
+
+    /**
      * Get the size of the tojos.
      * @return The size of the tojos.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -210,7 +210,7 @@ public final class ForeignTojos implements Closeable {
     }
 
     /**
-     * Check if the tojos contains a foreign tojo with given object name.
+     * Check if the tojos contains a foreign tojo with object name.
      * @param name The name of the tojo.
      * @return True if tojo exists.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -35,7 +35,6 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.eolang.maven.name.ObjectName;
-import org.eolang.maven.name.OnCached;
 import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.ForeignTojos;
@@ -55,12 +54,7 @@ final class DiscoverMojoTest {
     /**
      * Text.
      */
-    private static final ObjectName TEXT = new OnCached(
-        new OnDefault(
-            "org.eolang.txt.text",
-            new CommitHash.ChConstant("5f82cc1")
-        )
-    );
+    private static final ObjectName TEXT = new OnDefault("org.eolang.txt.text", "5f82cc1");
 
     /**
      * Default assertion message.
@@ -124,9 +118,7 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final ObjectName stdout = new OnCached(
-            new OnDefault("org.eolang.stdout", new CommitHash.ChConstant("9c93528"))
-        );
+        final ObjectName stdout = new OnDefault("org.eolang.stdout", "9c93528");
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
@@ -169,12 +161,8 @@ final class DiscoverMojoTest {
                 "    nop"
             )
             .execute(new FakeMaven.Discover());
-        final ObjectName first = new OnCached(
-            new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.1"))
-        );
-        final ObjectName second = new OnCached(
-            new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.2"))
-        );
+        final ObjectName first = new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.1"));
+        final ObjectName second = new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.2"));
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, first),
@@ -196,9 +184,7 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final ObjectName seq = new OnCached(
-            new OnDefault("org.eolang.seq", new CommitHash.ChConstant("6c6269d"))
-        );
+        final ObjectName seq = new OnDefault("org.eolang.seq", "6c6269d");
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
             maven.externalTojos().contains(seq.toString()),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
 import org.cactoos.io.ResourceOf;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
+import org.eolang.maven.name.ObjectName;
+import org.eolang.maven.name.OnCached;
+import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.ForeignTojos;
 import org.hamcrest.MatcherAssert;
@@ -52,10 +55,11 @@ final class DiscoverMojoTest {
     /**
      * Text.
      */
-    private static final String TEXT = String.join(
-        VersionsMojo.DELIMITER,
-        "org.eolang.txt.text",
-        "5f82cc1"
+    private static final ObjectName TEXT = new OnCached(
+        new OnDefault(
+            "org.eolang.txt.text",
+            new CommitHash.ChConstant("5f82cc1")
+        )
     );
 
     /**
@@ -120,17 +124,19 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String stdout = String.join(VersionsMojo.DELIMITER, "org.eolang.stdout", "9c93528");
+        final ObjectName stdout = new OnCached(
+            new OnDefault("org.eolang.stdout", new CommitHash.ChConstant("9c93528"))
+        );
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, DiscoverMojoTest.TEXT),
-            tojos.contains(DiscoverMojoTest.TEXT),
+            tojos.contains(DiscoverMojoTest.TEXT.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, stdout),
-            tojos.contains(stdout),
+            tojos.contains(stdout.toString()),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
@@ -163,25 +169,21 @@ final class DiscoverMojoTest {
                 "    nop"
             )
             .execute(new FakeMaven.Discover());
-        final String first = String.join(
-            VersionsMojo.DELIMITER,
-            "org.eolang.txt.sprintf",
-            hashes.get("0.28.1").value()
+        final ObjectName first = new OnCached(
+            new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.1"))
         );
-        final String second = String.join(
-            VersionsMojo.DELIMITER,
-            "org.eolang.txt.sprintf",
-            hashes.get("0.28.2").value()
+        final ObjectName second = new OnCached(
+            new OnDefault("org.eolang.txt.sprintf", hashes.get("0.28.2"))
         );
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, first),
-            tojos.contains(first),
+            tojos.contains(first.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, second),
-            tojos.contains(second),
+            tojos.contains(second.toString()),
             Matchers.is(true)
         );
     }
@@ -194,15 +196,17 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String seq = String.join(VersionsMojo.DELIMITER, "org.eolang.seq", "6c6269d");
+        final ObjectName seq = new OnCached(
+            new OnDefault("org.eolang.seq", new CommitHash.ChConstant("6c6269d"))
+        );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
-            maven.externalTojos().contains(seq),
+            maven.externalTojos().contains(seq.toString()),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, DiscoverMojoTest.TEXT),
-            maven.externalTojos().contains(DiscoverMojoTest.TEXT),
+            maven.externalTojos().contains(DiscoverMojoTest.TEXT.toString()),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -123,12 +123,12 @@ final class DiscoverMojoTest {
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, DiscoverMojoTest.TEXT),
-            tojos.contains(DiscoverMojoTest.TEXT.toString()),
+            tojos.contains(DiscoverMojoTest.TEXT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, stdout),
-            tojos.contains(stdout.toString()),
+            tojos.contains(stdout),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
@@ -166,12 +166,12 @@ final class DiscoverMojoTest {
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, first),
-            tojos.contains(first.toString()),
+            tojos.contains(first),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, second),
-            tojos.contains(second.toString()),
+            tojos.contains(second),
             Matchers.is(true)
         );
     }
@@ -187,12 +187,12 @@ final class DiscoverMojoTest {
         final ObjectName seq = new OnDefault("org.eolang.seq", "6c6269d");
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
-            maven.externalTojos().contains(seq.toString()),
+            maven.externalTojos().contains(seq),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, DiscoverMojoTest.TEXT),
-            maven.externalTojos().contains(DiscoverMojoTest.TEXT.toString()),
+            maven.externalTojos().contains(DiscoverMojoTest.TEXT),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -52,7 +52,11 @@ final class DiscoverMojoTest {
     /**
      * Text.
      */
-    private static final String TEXT = "org.eolang.txt.text|5f82cc1";
+    private static final String TEXT = String.join(
+        VersionsMojo.DELIMITER,
+        "org.eolang.txt.text",
+        "5f82cc1"
+    );
 
     /**
      * Default assertion message.
@@ -116,7 +120,7 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String stdout = "org.eolang.stdout|9c93528";
+        final String stdout = String.join(VersionsMojo.DELIMITER, "org.eolang.stdout", "9c93528");
         final String nop = "org.eolang.nop";
         final ForeignTojos tojos = maven.externalTojos();
         MatcherAssert.assertThat(
@@ -159,12 +163,14 @@ final class DiscoverMojoTest {
                 "    nop"
             )
             .execute(new FakeMaven.Discover());
-        final String first = String.format(
-            "org.eolang.txt.sprintf|%s",
+        final String first = String.join(
+            VersionsMojo.DELIMITER,
+            "org.eolang.txt.sprintf",
             hashes.get("0.28.1").value()
         );
-        final String second = String.format(
-            "org.eolang.txt.sprintf|%s",
+        final String second = String.join(
+            VersionsMojo.DELIMITER,
+            "org.eolang.txt.sprintf",
             hashes.get("0.28.2").value()
         );
         final ForeignTojos tojos = maven.externalTojos();
@@ -188,7 +194,7 @@ final class DiscoverMojoTest {
             .with("hashes", new CommitHashesMap.Fake())
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
-        final String seq = "org.eolang.seq|6c6269d";
+        final String seq = String.join(VersionsMojo.DELIMITER, "org.eolang.seq", "6c6269d");
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
             maven.externalTojos().contains(seq),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -67,7 +67,11 @@ final class ProbeMojoTest {
     /**
      * Stdout.
      */
-    private static final String STDOUT = "org.eolang.io.stdout|9c93528";
+    private static final String STDOUT = String.join(
+        VersionsMojo.DELIMITER,
+        "org.eolang.io.stdout",
+        "9c93528"
+    );
 
     @Test
     @ExtendWith(OnlineCondition.class)
@@ -187,7 +191,7 @@ final class ProbeMojoTest {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
-        final String number = "org.eolang.txt.text|5f82cc1";
+        final String number = String.join(VersionsMojo.DELIMITER, "org.eolang.txt.text", "5f82cc1");
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -39,6 +39,9 @@ import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.ChText;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
+import org.eolang.maven.name.ObjectName;
+import org.eolang.maven.name.OnCached;
+import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.ObjsDefault;
 import org.eolang.maven.objectionary.OyRemote;
@@ -67,10 +70,8 @@ final class ProbeMojoTest {
     /**
      * Stdout.
      */
-    private static final String STDOUT = String.join(
-        VersionsMojo.DELIMITER,
-        "org.eolang.io.stdout",
-        "9c93528"
+    private static final ObjectName STDOUT = new OnCached(
+        new OnDefault("org.eolang.io.stdout", new CommitHash.ChConstant("9c93528"))
     );
 
     @Test
@@ -163,7 +164,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -191,7 +192,9 @@ final class ProbeMojoTest {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
-        final String number = String.join(VersionsMojo.DELIMITER, "org.eolang.txt.text", "5f82cc1");
+        final ObjectName number = new OnCached(
+            new OnDefault("org.eolang.txt.text", new CommitHash.ChConstant("5f82cc1"))
+        );
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
@@ -209,7 +212,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -217,7 +220,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 number
             ),
-            maven.externalTojos().contains(number),
+            maven.externalTojos().contains(number.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -40,7 +40,6 @@ import org.eolang.maven.hash.ChText;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.eolang.maven.name.ObjectName;
-import org.eolang.maven.name.OnCached;
 import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.ObjsDefault;
@@ -70,9 +69,7 @@ final class ProbeMojoTest {
     /**
      * Stdout.
      */
-    private static final ObjectName STDOUT = new OnCached(
-        new OnDefault("org.eolang.io.stdout", new CommitHash.ChConstant("9c93528"))
-    );
+    private static final ObjectName STDOUT = new OnDefault("org.eolang.io.stdout", "9c93528");
 
     @Test
     @ExtendWith(OnlineCondition.class)
@@ -192,9 +189,7 @@ final class ProbeMojoTest {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
         final CommitHash first = hashes.get("0.28.5");
         final CommitHash second = hashes.get("0.28.6");
-        final ObjectName number = new OnCached(
-            new OnDefault("org.eolang.txt.text", new CommitHash.ChConstant("5f82cc1"))
-        );
+        final ObjectName text = new OnDefault("org.eolang.txt.text", "5f82cc1");
         final FakeMaven maven = new FakeMaven(temp)
             .with(
                 "objectionaries",
@@ -218,9 +213,9 @@ final class ProbeMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "Tojos should have contained versioned object %s after probing, but they didn't",
-                number
+                text
             ),
-            maven.externalTojos().contains(number.toString()),
+            maven.externalTojos().contains(text.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -161,7 +161,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(ProbeMojoTest.STDOUT.toString()),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -207,7 +207,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(ProbeMojoTest.STDOUT.toString()),
+            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
@@ -215,7 +215,7 @@ final class ProbeMojoTest {
                 "Tojos should have contained versioned object %s after probing, but they didn't",
                 text
             ),
-            maven.externalTojos().contains(text.toString()),
+            maven.externalTojos().contains(text),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -69,7 +69,11 @@ final class PullMojoTest {
     /**
      * Versioned source.
      */
-    private static final String VERSIONED = "%s/org/eolang/io/stdout|9c93528.eo";
+    private static final String VERSIONED = String.join(
+        VersionsMojo.DELIMITER,
+        "%s/org/eolang/io/stdout",
+        "9c93528.eo"
+    );
 
     @Test
     void pullsSuccessfully(@TempDir final Path temp) throws IOException {
@@ -173,12 +177,11 @@ final class PullMojoTest {
         );
     }
 
-    @Disabled
     @Test
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         maven.foreignTojos()
-            .add("org.eolang.io.stdout|9c93528")
+            .add(String.join(VersionsMojo.DELIMITER, PullMojoTest.STDOUT, "9c93528"))
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
         MatcherAssert.assertThat(
@@ -238,8 +241,16 @@ final class PullMojoTest {
             .with("hsh", third)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
-        final String sprintf = "%s/org/eolang/io/sprintf|17f892.eo";
-        final String string = "%s/org/eolang/string|5f82cc";
+        final String sprintf = String.join(
+            VersionsMojo.DELIMITER,
+            "%s/org/eolang/io/sprintf",
+            "17f892.eo"
+        );
+        final String string = String.join(
+            VersionsMojo.DELIMITER,
+            "%s/org/eolang/string",
+            "5f82cc.eo"
+        );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
@@ -280,7 +291,7 @@ final class PullMojoTest {
     }
 
     /**
-     * Format given source path.
+     * Format given a source path.
      * @param source Source path.
      * @return Formatted source path.
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -37,6 +37,9 @@ import org.eolang.maven.hash.ChPattern;
 import org.eolang.maven.hash.ChText;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
+import org.eolang.maven.name.ObjectName;
+import org.eolang.maven.name.OnCached;
+import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.ObjsDefault;
 import org.eolang.maven.objectionary.OyRemote;
@@ -69,10 +72,8 @@ final class PullMojoTest {
     /**
      * Versioned source.
      */
-    private static final String VERSIONED = String.join(
-        VersionsMojo.DELIMITER,
-        "%s/org/eolang/io/stdout",
-        "9c93528.eo"
+    private static final ObjectName VERSIONED = new OnCached(
+        new OnDefault("%s/org/eolang/io/stdout", new CommitHash.ChConstant("9c93528.eo"))
     );
 
     @Test
@@ -181,15 +182,15 @@ final class PullMojoTest {
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         maven.foreignTojos()
-            .add(String.join(VersionsMojo.DELIMITER, PullMojoTest.STDOUT, "9c93528"))
+            .add(new OnDefault(PullMojoTest.STDOUT, new CommitHash.ChConstant("9c93528")))
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED)
+                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
             Matchers.is(true)
         );
     }
@@ -213,9 +214,9 @@ final class PullMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED)
+                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
             Matchers.is(true)
         );
     }
@@ -241,44 +242,40 @@ final class PullMojoTest {
             .with("hsh", third)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
-        final String sprintf = String.join(
-            VersionsMojo.DELIMITER,
-            "%s/org/eolang/io/sprintf",
-            "17f892.eo"
+        final ObjectName sprintf = new OnCached(
+            new OnDefault("%s/org/eolang/io/sprintf", new CommitHash.ChConstant("17f892.eo"))
         );
-        final String string = String.join(
-            VersionsMojo.DELIMITER,
-            "%s/org/eolang/string",
-            "5f82cc.eo"
+        final ObjectName string = new OnCached(
+            new OnDefault("%s/org/eolang/string", new CommitHash.ChConstant("5f82cc.eo"))
         );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED)
+                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(sprintf)
+                PullMojoTest.path(sprintf.toString())
             ),
-            PullMojoTest.exists(temp, sprintf),
+            PullMojoTest.exists(temp, sprintf.toString()),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(string)
+                PullMojoTest.path(string.toString())
             ),
-            PullMojoTest.exists(temp, string),
+            PullMojoTest.exists(temp, string.toString()),
             Matchers.is(true)
         );
     }
 
     /**
-     * Check if given source files exists in target directory.
+     * Check if the given source file exists in the target directory.
      *
      * @param temp Test temporary directory.
      * @param source Source file.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -38,7 +38,6 @@ import org.eolang.maven.hash.ChText;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.eolang.maven.name.ObjectName;
-import org.eolang.maven.name.OnCached;
 import org.eolang.maven.name.OnDefault;
 import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.ObjsDefault;
@@ -72,8 +71,9 @@ final class PullMojoTest {
     /**
      * Versioned source.
      */
-    private static final ObjectName VERSIONED = new OnCached(
-        new OnDefault("%s/org/eolang/io/stdout", new CommitHash.ChConstant("9c93528.eo"))
+    private static final ObjectName VERSIONED = new OnDefault(
+        "%s/org/eolang/io/stdout",
+        "9c93528.eo"
     );
 
     @Test
@@ -182,7 +182,7 @@ final class PullMojoTest {
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         maven.foreignTojos()
-            .add(new OnDefault(PullMojoTest.STDOUT, new CommitHash.ChConstant("9c93528")))
+            .add(new OnDefault(PullMojoTest.STDOUT, "9c93528"))
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
         MatcherAssert.assertThat(
@@ -242,12 +242,8 @@ final class PullMojoTest {
             .with("hsh", third)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
-        final ObjectName sprintf = new OnCached(
-            new OnDefault("%s/org/eolang/io/sprintf", new CommitHash.ChConstant("17f892.eo"))
-        );
-        final ObjectName string = new OnCached(
-            new OnDefault("%s/org/eolang/string", new CommitHash.ChConstant("5f82cc.eo"))
-        );
+        final ObjectName sprintf = new OnDefault("%s/org/eolang/io/sprintf", "17f892.eo");
+        final ObjectName string = new OnDefault("%s/org/eolang/string", "5f82cc.eo");
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnDefaultTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.name;
 
+import org.eolang.maven.VersionsMojo;
 import org.eolang.maven.hash.CommitHash;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -48,7 +49,7 @@ final class OnDefaultTest {
      * Test object.
      */
     private static final String OBJECT = String.join(
-        "|",
+        VersionsMojo.DELIMITER,
         OnDefaultTest.STDOUT,
         OnDefaultTest.HASH
     );
@@ -105,7 +106,7 @@ final class OnDefaultTest {
     @Test
     void buildsFullNameWithGivenDefaultHash() {
         final String built = String.join(
-            "|",
+            VersionsMojo.DELIMITER,
             OnDefaultTest.STDOUT,
             OnDefaultTest.FAKE.value()
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnSwapTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnSwapTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.name;
 
+import org.eolang.maven.VersionsMojo;
 import org.eolang.maven.hash.CommitHash;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -37,12 +38,12 @@ class OnSwapTest {
     /**
      * First.
      */
-    private static final String FIRST = "stdout|1234567";
+    private static final String FIRST = String.join(VersionsMojo.DELIMITER, "stdout", "1234567");
 
     /**
      * Second.
      */
-    private static final String SECOND = "sprintf|7654321";
+    private static final String SECOND = String.join(VersionsMojo.DELIMITER, "sprintf", "7654321");
 
     /**
      * Fake hash.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnUnversionedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnUnversionedTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.name;
 
+import org.eolang.maven.VersionsMojo;
 import org.eolang.maven.hash.CommitHash;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -37,7 +38,7 @@ final class OnUnversionedTest {
     @Test
     void returnsFullNameWithVersions() {
         final String stdout = "stdout";
-        final String object = String.join("|", stdout, "1234567");
+        final String object = String.join(VersionsMojo.DELIMITER, stdout, "1234567");
         MatcherAssert.assertThat(
             String.format(
                 "Unversioned object %s as string should have been equal to %s, but it didn't",

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -24,7 +24,7 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="add-probes" version="2.0">
   <!--
-  For every object which starts with '.' add probe meta
+  For every object that starts with '.' add probe meta
   with fully qualified name of the object.
   Example:
    For object:
@@ -73,7 +73,7 @@ SOFTWARE.
                 <xsl:text>probe</xsl:text>
               </xsl:element>
               <xsl:element name="tail">
-                <xsl:value-of select="string-join(($p, @ver),'|')"/>
+                <xsl:value-of select="string-join(($p, @ver),'#')"/>
               </xsl:element>
               <xsl:element name="part">
                 <xsl:value-of select="$p"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-versioned-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-versioned-probes.yaml
@@ -8,7 +8,7 @@ tests:
   - //metas[count(.//meta[head/text()='probe'])=3]
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang' and part/text()='Q.org.eolang']
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage' and part/text()='Q.org.eolang.cage']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage|0.28.10' and part/text()='Q.org.eolang.cage']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage#0.28.10' and part/text()='Q.org.eolang.cage']
 eo: |
   +home https://github.com/objectionary/eo
   +package org.eolang.custom


### PR DESCRIPTION
Ref: #1602 

What's done: 
- changed delimiter between name and version in EO object from `|` to `#`. Reason: `|` is [illegal](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) for windows
- refactored tests

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving object name handling in the EO Maven plugin. 

### Detailed summary
- Updated comments and method names for clarity.
- Added a new method to check if a foreign tojo contains a specific object name.
- Updated delimiter constant for EO object names.
- Renamed a variable for consistency.
- Updated XSL stylesheet to use the new delimiter in probe meta.
- Updated tests to use the new object name format.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->