### PR TITLE
#2299 Pulling with versions

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
@@ -23,10 +23,9 @@
  */
 package org.eolang.maven;
 
-import org.eolang.maven.name.ObjectName;
-
 import java.io.File;
 import java.nio.file.Path;
+import org.eolang.maven.name.ObjectName;
 
 /**
  * Make the place for the object.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.maven;
 
+import org.eolang.maven.name.ObjectName;
+
 import java.io.File;
 import java.nio.file.Path;
 
@@ -37,6 +39,14 @@ public final class Place {
      * The name of the object, e.g. "org.eolang.io.stdout"
      */
     private final String name;
+
+    /**
+     * Ctor.
+     * @param obj The name of the object
+     */
+    public Place(final ObjectName obj) {
+        this(obj.toString());
+    }
 
     /**
      * Ctor.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -113,7 +113,8 @@ public final class PullMojo extends SafeMojo {
                     new OnDefault(tojo.identifier(), this.hsh)
                 )
             );
-            tojo.withSource(this.pull(name).toAbsolutePath()).withHash(name.hash());
+            tojo.withSource(this.pull(name).toAbsolutePath())
+                .withHash(new ChNarrow(name.hash()));
         }
         Logger.info(
             this,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -107,16 +107,13 @@ public final class PullMojo extends SafeMojo {
         }
         final Collection<ForeignTojo> tojos = this.scopedTojos().withoutSources();
         for (final ForeignTojo tojo : tojos) {
-            tojo.withSource(
-                this.pull(
-                    new OnCached(
-                        new OnSwap(
-                            this.withVersions,
-                            new OnDefault(tojo.identifier(), this.hsh)
-                        )
-                    )
-                ).toAbsolutePath()
-            ).withHash(new ChNarrow(this.hsh));
+            final ObjectName name = new OnCached(
+                new OnSwap(
+                    this.withVersions,
+                    new OnDefault(tojo.identifier(), this.hsh)
+                )
+            );
+            tojo.withSource(this.pull(name).toAbsolutePath()).withHash(name.hash());
         }
         Logger.info(
             this,
@@ -134,22 +131,22 @@ public final class PullMojo extends SafeMojo {
      */
     private Path pull(final ObjectName object) throws IOException {
         final Path dir = this.targetDir.toPath().resolve(PullMojo.DIR);
-        final Path src = new Place(name).make(
+        final Path src = new Place(object).make(
             dir, "eo"
         );
         if (src.toFile().exists() && !this.overWrite) {
             Logger.debug(
                 this, "The object '%s' already pulled to %s (and 'overWrite' is false)",
-                name, new Rel(src)
+                object, new Rel(src)
             );
         } else {
             new Home(dir).save(
-                this.objectionaries.object(this.hsh, name),
+                this.objectionaries.object(object),
                 dir.relativize(src)
             );
             Logger.debug(
                 this, "The sources of the object '%s' pulled to %s",
-                name, new Rel(src)
+                object, new Rel(src)
             );
         }
         return src;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -25,7 +25,6 @@ package org.eolang.maven.objectionary;
 
 import java.io.IOException;
 import org.cactoos.Input;
-import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.name.ObjectName;
 
 /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/Objectionaries.java
@@ -35,19 +35,18 @@ import org.eolang.maven.name.ObjectName;
 public interface Objectionaries {
 
     /**
-     * Get object by hash and name.
-     * @param hash Commit hash
+     * Get an object by hash and name.
      * @param name Object name
      * @return Object
      * @throws IOException If some I/O problem happens.
      */
-    Input object(CommitHash hash, String name) throws IOException;
+    Input object(ObjectName name) throws IOException;
 
     /**
-     * Check if object exists.
+     * Check if an object exists.
      *
      * @param name Object name
-     * @return True if object exists, false otherwise
+     * @return True if an object exists, false otherwise
      * @throws IOException If some I/O problem happens.
      */
     boolean contains(ObjectName name) throws IOException;
@@ -80,8 +79,8 @@ public interface Objectionaries {
         }
 
         @Override
-        public Input object(final CommitHash hash, final String name) throws IOException {
-            return this.objectionary.get(name);
+        public Input object(final ObjectName name) throws IOException {
+            return this.objectionary.get(name.value());
         }
 
         @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjsDefault.java
@@ -113,8 +113,8 @@ public final class ObjsDefault implements Objectionaries {
     }
 
     @Override
-    public Input object(final CommitHash hash, final String name) throws IOException {
-        return this.objectionary(hash).get(name);
+    public Input object(final ObjectName name) throws IOException {
+        return this.objectionary(name.hash()).get(name.value());
     }
 
     @Override

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapEntry;
+import org.cactoos.text.Joined;
 import org.eolang.maven.hash.ChCached;
 import org.eolang.maven.hash.ChCompound;
 import org.eolang.maven.hash.ChPattern;
@@ -223,27 +224,29 @@ final class PullMojoTest {
     void pullsProbedVersionedObjectsFromDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
-        final CommitHash first = hashes.get("0.28.5");
-        final CommitHash second = hashes.get("0.28.6");
-        final CommitHash third = hashes.get("0.28.7");
+        final CommitHash first = hashes.get("0.28.4");
+        final CommitHash second = hashes.get("0.28.5");
+        final CommitHash third = hashes.get("0.28.6");
+        final CommitHash fourth = hashes.get("0.28.7");
         new FakeMaven(temp)
             .with(
                 "objectionaries",
                 new ObjsDefault(
                     new MapEntry<>(first, new OyRemote(first)),
                     new MapEntry<>(second, new OyRemote(second)),
-                    new MapEntry<>(third, new OyRemote(third))
+                    new MapEntry<>(third, new OyRemote(third)),
+                    new MapEntry<>(fourth, new OyRemote(fourth))
                 )
             )
             .with("withVersions", true)
-            .with("hsh", third)
+            .with("hsh", fourth)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
         final ObjectName sprintf = new OnCached(
-            new OnDefault("%s/org/eolang/io/sprintf", new CommitHash.ChConstant("17f892.eo"))
+            new OnDefault("%s/org/eolang/txt/sprintf", new CommitHash.ChConstant("17f8929.eo"))
         );
         final ObjectName string = new OnCached(
-            new OnDefault("%s/org/eolang/string", new CommitHash.ChConstant("5f82cc.eo"))
+            new OnDefault("%s/org/eolang/string", new CommitHash.ChConstant("5f82cc1.eo"))
         );
         MatcherAssert.assertThat(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 @ExtendWith(OnlineCondition.class)
 final class PullMojoTest {
     /**
@@ -183,13 +183,14 @@ final class PullMojoTest {
         maven.externalTojos()
             .add(new OnDefault(PullMojoTest.STDOUT, "9c93528"))
             .withVersion("*.*.*");
-        maven.execute(PullMojo.class);
+        maven.with("withVersions", true)
+            .execute(PullMojo.class);
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
+                PullMojoTest.path(PullMojoTest.VERSIONED)
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
     }
@@ -212,9 +213,9 @@ final class PullMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
+                PullMojoTest.path(PullMojoTest.VERSIONED)
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
     }
@@ -246,25 +247,25 @@ final class PullMojoTest {
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(PullMojoTest.VERSIONED.toString())
+                PullMojoTest.path(PullMojoTest.VERSIONED)
             ),
-            PullMojoTest.exists(temp, PullMojoTest.VERSIONED.toString()),
+            PullMojoTest.exists(temp, PullMojoTest.VERSIONED),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(sprintf.toString())
+                PullMojoTest.path(sprintf)
             ),
-            PullMojoTest.exists(temp, sprintf.toString()),
+            PullMojoTest.exists(temp, sprintf),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
-                PullMojoTest.path(string.toString())
+                PullMojoTest.path(string)
             ),
-            PullMojoTest.exists(temp, string.toString()),
+            PullMojoTest.exists(temp, string),
             Matchers.is(true)
         );
     }
@@ -283,11 +284,30 @@ final class PullMojoTest {
     }
 
     /**
+     * Check if the given source file exists in the target directory.
+     * @param temp Test temporary directory.
+     * @param source Source file as object name.
+     * @return If given source file exists.
+     */
+    private static boolean exists(final Path temp, final ObjectName source) {
+        return PullMojoTest.exists(temp, source.toString());
+    }
+
+    /**
      * Format given a source path.
      * @param source Source path.
      * @return Formatted source path.
      */
     private static String path(final String source) {
         return String.format(source, PullMojo.DIR);
+    }
+
+    /**
+     * Format given a source path.
+     * @param source Source path as object name.
+     * @return Formatted source path.
+     */
+    private static String path(final ObjectName source) {
+        return PullMojoTest.path(source.toString());
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -46,7 +46,6 @@ import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -180,8 +179,8 @@ final class PullMojoTest {
 
     @Test
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp);
-        maven.foreignTojos()
+        final FakeMaven maven = new FakeMaven(temp).with("withVersions", true);
+        maven.externalTojos()
             .add(new OnDefault(PullMojoTest.STDOUT, new CommitHash.ChConstant("9c93528")))
             .withVersion("*.*.*");
         maven.execute(PullMojo.class);
@@ -195,7 +194,6 @@ final class PullMojoTest {
         );
     }
 
-    @Disabled
     @Test
     void pullsProbedVersionedObjectFromOneObjectionary(@TempDir final Path temp)
         throws IOException {
@@ -221,7 +219,6 @@ final class PullMojoTest {
         );
     }
 
-    @Disabled
     @Test
     void pullsProbedVersionedObjectsFromDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -272,6 +272,16 @@ final class PullMojoTest {
 
     /**
      * Check if the given source file exists in the target directory.
+     * @param temp Test temporary directory.
+     * @param source Source file as object name.
+     * @return If given source file exists.
+     */
+    private static boolean exists(final Path temp, final ObjectName source) {
+        return PullMojoTest.exists(temp, source.toString());
+    }
+
+    /**
+     * Check if the given source file exists in the target directory.
      *
      * @param temp Test temporary directory.
      * @param source Source file.
@@ -284,13 +294,12 @@ final class PullMojoTest {
     }
 
     /**
-     * Check if the given source file exists in the target directory.
-     * @param temp Test temporary directory.
-     * @param source Source file as object name.
-     * @return If given source file exists.
+     * Format given a source path.
+     * @param source Source path as object name.
+     * @return Formatted source path.
      */
-    private static boolean exists(final Path temp, final ObjectName source) {
-        return PullMojoTest.exists(temp, source.toString());
+    private static String path(final ObjectName source) {
+        return PullMojoTest.path(source.toString());
     }
 
     /**
@@ -300,14 +309,5 @@ final class PullMojoTest {
      */
     private static String path(final String source) {
         return String.format(source, PullMojo.DIR);
-    }
-
-    /**
-     * Format given a source path.
-     * @param source Source path as object name.
-     * @return Formatted source path.
-     */
-    private static String path(final ObjectName source) {
-        return PullMojoTest.path(source.toString());
     }
 }


### PR DESCRIPTION
Ref: #1602 

What's done:
- Added ability to pull versioned objects
- Enabled and refactored tests

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving object naming in the code. 

### Detailed summary
- Updated the `object` method in `ObjsDefault` and `Fake` classes to accept an `ObjectName` instead of `CommitHash` and `String`.
- Updated the `Place` constructor to accept an `ObjectName` instead of `String`.
- Updated the `object` method in `Objectionaries` interface to accept an `ObjectName` instead of `CommitHash` and `String`.
- Updated the `pull` method in `PullMojo` to accept an `ObjectName` instead of `String`.
- Updated the `pullsVersionedObjectSuccessfully` test in `PullMojoTest` to use `ObjectName` instead of `String`.
- Updated the `pullsProbedVersionedObjectFromOneObjectionary` test in `PullMojoTest` to use `ObjectName` instead of `String`.
- Updated the `pullsProbedVersionedObjectsFromDifferentObjectionaries` test in `PullMojoTest` to use `ObjectName` instead of `String`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->