### PR TITLE
new syntax for oneOrMore

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
+++ b/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
@@ -95,16 +95,9 @@ SOFTWARE.
     <xsl:text> } </xsl:text>
   </xsl:template>
   <xsl:template match="g:oneOrMore">
-    <xsl:if test="count(g:*) &gt; 1">
-      <xsl:text> ( </xsl:text>
-    </xsl:if>
-    <xsl:apply-templates select="g:*"/>
-    <xsl:if test="count(g:*) &gt; 1">
-      <xsl:text> ) </xsl:text>
-    </xsl:if>
     <xsl:text> { </xsl:text>
     <xsl:apply-templates select="g:*"/>
-    <xsl:text> } </xsl:text>
+    <xsl:text> }+ </xsl:text>
   </xsl:template>
   <xsl:template match="g:sequence">
     <xsl:if test="count(g:*) &gt; 1">


### PR DESCRIPTION
see #2360

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- In the file `to-ebnf.xsl`, the template `oneOrMore` has been modified.
- The opening and closing parentheses around the elements have been removed.
- The closing curly brace `}` has been replaced with `}+`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->