### PR TITLE
feat(#2340): Remove shouldPass method from OptimizeMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -233,6 +233,4 @@ public final class OptimizeMojo extends SafeMojo {
         );
         return target;
     }
-
-
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -152,11 +152,12 @@ public final class OptimizeMojo extends SafeMojo {
             src
         );
         return () -> {
-            final XML optimized = this.optimization(tojo, common)
-                .apply(new XMLDocument(src));
-            if (this.shouldPass(optimized)) {
-                tojo.withOptimized(this.make(optimized, src).toAbsolutePath());
-            }
+            tojo.withOptimized(
+                this.make(
+                    this.optimization(tojo, common).apply(new XMLDocument(src)),
+                    src
+                ).toAbsolutePath()
+            );
             return 1;
         };
     }
@@ -233,13 +234,5 @@ public final class OptimizeMojo extends SafeMojo {
         return target;
     }
 
-    /**
-     * Should optimization steps pass without errors.
-     *
-     * @param xml Optimized xml
-     * @return Should fail
-     */
-    private boolean shouldPass(final XML xml) {
-        return xml.nodes("/program/errors/error").isEmpty() || this.failOnError;
-    }
+
 }


### PR DESCRIPTION
Remove `OptimizeMojo.shouldPass` method.

Closes: #2340

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The focus of this PR is to refactor the `OptimizeMojo` class in the `eo-maven-plugin` module.
- The notable changes in this PR include:
  - Refactoring the code to improve readability and maintainability.
  - Reorganizing the code to optimize the XML document in a more efficient way.
  - Removing the `shouldPass` method and its related logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->