### PR TITLE
feat(#2281): Add OnVersioned to replace VersionMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -37,7 +37,6 @@ import org.cactoos.iterable.Filtered;
 import org.cactoos.set.SetOf;
 import org.eolang.maven.name.ObjectName;
 import org.eolang.maven.name.OnVersioned;
-import org.eolang.maven.name.OnUnversioned;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Rel;
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -35,6 +35,9 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.set.SetOf;
+import org.eolang.maven.name.ObjectName;
+import org.eolang.maven.name.OnVersioned;
+import org.eolang.maven.name.OnUnversioned;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.Rel;
 
@@ -54,15 +57,19 @@ public final class DiscoverMojo extends SafeMojo {
     @Override
     public void exec() throws FileNotFoundException {
         final Collection<ForeignTojo> tojos = this.scopedTojos().notDiscovered();
-        final Collection<String> discovered = new HashSet<>(1);
+        final Collection<ObjectName> discovered = new HashSet<>(1);
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
             tojo.withDiscovered(
                 (int) this.discover(src)
                     .stream()
                     .filter(name -> !name.isEmpty())
-                    .peek(name -> this.scopedTojos().add(name).withDiscoveredAt(src))
-                    .peek(discovered::add)
+                    .map(OnVersioned::new)
+                    .peek(
+                        name -> this.scopedTojos()
+                            .add(name.toString())
+                            .withDiscoveredAt(src)
+                    ).peek(discovered::add)
                     .count()
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -66,7 +66,7 @@ public final class DiscoverMojo extends SafeMojo {
                     .map(OnVersioned::new)
                     .peek(
                         name -> this.scopedTojos()
-                            .add(name.toString())
+                            .add(name)
                             .withDiscoveredAt(src)
                     ).peek(discovered::add)
                     .count()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VersionsMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VersionsMojo.java
@@ -55,13 +55,6 @@ import org.eolang.maven.util.Home;
  *
  * @see <a href="https://home.objectionary.com/tags.txt">Tags</a>
  * @since 0.29.6
- * @todo #1602:30min Don't rewrite parsed xmir. VersionsMojo is executed right
- *  after ParseMojo and rewrites {@code .xmir} files in "1-parse" directory.
- *  Maybe this is not quite right, because files after parsing should be
- *  untouched. We either should 1) create a new folder where files after
- *  executing VersionsMojo are stored 2) or find another way to catch wrong
- *  versions without touching files in "1-parse" directory 3) or just accept
- *  rewriting files in "1-parse" and don't do anything if is not really critical
  */
 public final class VersionsMojo extends SafeMojo {
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -39,6 +39,7 @@ import org.eolang.maven.hash.CommitHash;
  *  version. In other words this class should replace the behavior of
  *  {@link org.eolang.maven.VersionsMojo} class. When this class is implemented,
  *  remove the {@link org.eolang.maven.VersionsMojo class}.
+ *  Don't forget to add tests for this class.
  */
 public final class OnVersioned implements ObjectName {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.maven.name;
 
 import org.eolang.maven.hash.CommitHash;
@@ -17,7 +40,7 @@ import org.eolang.maven.hash.CommitHash;
  *  {@link org.eolang.maven.VersionsMojo} class. When this class is implemented,
  *  remove the {@link org.eolang.maven.VersionsMojo class}.
  */
-public class OnVersioned implements ObjectName {
+public final class OnVersioned implements ObjectName {
 
     /**
      * Raw string.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -1,0 +1,57 @@
+package org.eolang.maven.name;
+
+import org.eolang.maven.hash.CommitHash;
+
+/**
+ * Object name versioned.
+ * This is object name that parses raw sting like:
+ * - "org.eolang.text#0.1.0" into "org.eolang.text" and "a1b2c3d"
+ * - "org.eolang.string#a1b2c3d" into "org.eolang.string" and "b2c3d4e"
+ * Pay attention that versions transformed into hashes.
+ * If a version is not provided - behaves like {@link OnUnversioned}.
+ *
+ * @since 0.30
+ * @todo #2281:30min Implement OnVersioned class.
+ *  This class should parse raw string into object name and hash from object name with semver
+ *  version. In other words this class should replace the behavior of
+ *  {@link org.eolang.maven.VersionsMojo} class. When this class is implemented,
+ *  remove the {@link org.eolang.maven.VersionsMojo class}.
+ */
+public class OnVersioned implements ObjectName {
+
+    /**
+     * Raw string.
+     * Examples:
+     * - "org.eolang.text#0.1.0"
+     * - "org.eolang.string#1.23.1"
+     * - "org.eolang.math#3.3.3"
+     */
+    private final String raw;
+
+    /**
+     * Constructor.
+     * @param origin Raw string.
+     */
+    public OnVersioned(final String origin) {
+        this.raw = origin;
+    }
+
+    @Override
+    public String value() {
+        throw new UnsupportedOperationException(
+            "This 'value()' method is not supported for OnVersioned yet"
+        );
+    }
+
+    @Override
+    public CommitHash hash() {
+        throw new UnsupportedOperationException(
+            "The 'hash()' method is not supported for OnVersioned yet"
+        );
+    }
+
+    @Override
+    public String toString() {
+        return this.raw;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -28,8 +28,10 @@ import org.eolang.maven.hash.CommitHash;
 /**
  * Object name versioned.
  * This is object name that parses raw sting like:
- * - "org.eolang.text#0.1.0" into "org.eolang.text" and "4b19944d86058e3c81e558340a3a13bc335a2b48"
- * - "org.eolang.string#a1b2c3d" into "org.eolang.string" and "be83d9adda4b7c9e670e625fe951c80f3ead4177"
+ * - "org.eolang.text#0.1.0" into "org.eolang.text"
+ *   and "4b19944d86058e3c81e558340a3a13bc335a2b48"
+ * - "org.eolang.string#a1b2c3d" into "org.eolang.string"
+ *   and "be83d9adda4b7c9e670e625fe951c80f3ead4177"
  * Pay attention that versions transformed into hashes.
  * If a version is not provided - behaves like {@link OnUnversioned}.
  *

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -28,8 +28,8 @@ import org.eolang.maven.hash.CommitHash;
 /**
  * Object name versioned.
  * This is object name that parses raw sting like:
- * - "org.eolang.text#0.1.0" into "org.eolang.text" and "a1b2c3d"
- * - "org.eolang.string#a1b2c3d" into "org.eolang.string" and "b2c3d4e"
+ * - "org.eolang.text#0.1.0" into "org.eolang.text" and "4b19944d86058e3c81e558340a3a13bc335a2b48"
+ * - "org.eolang.string#a1b2c3d" into "org.eolang.string" and "be83d9adda4b7c9e670e625fe951c80f3ead4177"
  * Pay attention that versions transformed into hashes.
  * If a version is not provided - behaves like {@link OnUnversioned}.
  *

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
@@ -61,7 +61,7 @@ final class OnVersionedTest {
     void retrievesName(final String expected, final String origin) {
         final OnVersioned name = new OnVersioned(origin);
         MatcherAssert.assertThat(
-            String.format("Can't retrieve object name from versioned object %s", origin),
+            String.format("Can't retrieve object name from %s, versioned object %s", name, origin),
             name.value(),
             Matchers.equalTo(expected)
         );
@@ -91,7 +91,7 @@ final class OnVersionedTest {
     void retrievesHash(final String expected, final String origin) {
         final OnVersioned name = new OnVersioned(origin);
         MatcherAssert.assertThat(
-            String.format("Can't retrieve object hash from versioned object %s", origin),
+            String.format("Can't retrieve object hash from %s versioned object %s", name, origin),
             name.hash().value(),
             Matchers.equalTo(expected)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.name;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link OnVersioned}.
+ *
+ * @since 0.30
+ */
+final class OnVersionedTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "org.eolang.string, org.eolang.string#0.23.17",
+        "org.eolang.dummy, org.eolang.dummy#0.23.19",
+        "org.eolang.text, org.eolang.text#0.25.0",
+        "org.eolang.aug, org.eolang.aug#0.25.5",
+        "org.eolang.sept, org.eolang.sept#0.26.0",
+        "org.eolang.oct, org.eolang.oct#0.27.0",
+        "org.eolang.nov, org.eolang.nov#0.27.2",
+        "org.eolang.dec, org.eolang.dec#0.28.0",
+        "org.eolang.mon, org.eolang.mon#0.28.1",
+        "org.eolang.tu, org.eolang.tu#0.28.10",
+        "org.eolang.wen, org.eolang.wen#0.28.14",
+        "org.eolang.th, org.eolang.th#0.28.2",
+        "org.eolang.fri, org.eolang.fri#0.28.4",
+        "org.eolang.sat, org.eolang.sat#0.28.5",
+        "org.eolang.sun, org.eolang.sun#0.28.6",
+        "org.eolang.penguin, org.eolang.penguin#0.28.7",
+        "org.eolang.eagle, org.eolang.eagle#0.28.9"
+    })
+    @Disabled("Enable when OnVersioned.value() is implemented")
+    void retrievesName(final String expected, final String origin) {
+        final OnVersioned name = new OnVersioned(origin);
+        MatcherAssert.assertThat(
+            String.format("Can't retrieve object name from versioned object %s", origin),
+            name.value(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    @CsvSource({
+        "15c85d7f8cffe15b0deba96e90bdac98a76293bb, org.eolang.string#0.23.17",
+        "4b19944d86058e3c81e558340a3a13bc335a2b48, org.eolang.dummy#0.23.19",
+        "0aa6875c40d099c3f670e93d4134b629566c5643, org.eolang.text#0.25.0",
+        "ff32e9ff70c2b3be75982757f4b0607dc37b258a, org.eolang.aug#0.25.5",
+        "e0b783692ef749bb184244acb2401f551388a328, org.eolang.sept#0.26.0",
+        "cc554ab82909eebbfdacd8a840f9cf42a99b64cf, org.eolang.oct#0.27.0",
+        "00b60c7b2112cbad4e37ba96b162469a0e75f6df, org.eolang.nov#0.27.2",
+        "6a70071580e95aeac104b2e48293d3dfe0669973, org.eolang.dec#0.28.0",
+        "0c15066a2026cec69d613b709a301f1573f138ec, org.eolang.mon#0.28.1",
+        "9b883935257bd59d1ba36240f7e213d4890df7ca, org.eolang.tu#0.28.10",
+        "a7a4556bf1aa697324d805570f42d70affdddb75, org.eolang.wen#0.28.14",
+        "54d83d4b1d28075ee623d58fd742eaa529febd3d, org.eolang.th#0.28.2",
+        "6c6269d1f9a1c81ffe641538f119fe4e12706cb3, org.eolang.fri#0.28.4",
+        "9c9352890b5d30e1b89c9147e7c95a90c9b8709f, org.eolang.sat#0.28.5",
+        "17f89293e5ae6115e9a0234b754b22918c11c602, org.eolang.sun#0.28.6",
+        "5f82cc1edffad67bf4ba816610191403eb18af5d, org.eolang.penguin#0.28.7",
+        "be83d9adda4b7c9e670e625fe951c80f3ead4177, org.eolang.eagle#0.28.9"
+    })
+    @Disabled("Enable when OnVersioned.hash() is implemented")
+    void retrievesHash(final String expected, final String origin) {
+        final OnVersioned name = new OnVersioned(origin);
+        MatcherAssert.assertThat(
+            String.format("Can't retrieve object hash from versioned object %s", origin),
+            name.hash().value(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    @Disabled("Enable when OnVersioned.toString() is implemented properly")
+    void convertsToStringWithNonEmptyVersion() {
+        final String string = "org.eolang.string#0.23.17";
+        final OnVersioned name = new OnVersioned(string);
+        MatcherAssert.assertThat(
+            String.format("Can't convert versioned object %s to string", name),
+            name.toString(),
+            Matchers.equalTo("org.eolang.string#15c85d7f8cffe15b0deba96e90bdac98a76293bb")
+        );
+    }
+
+    @Test
+    void convertsToStringWithEmptyVersion() {
+        final String string = "org.eolang.string";
+        final OnVersioned name = new OnVersioned(string);
+        MatcherAssert.assertThat(
+            String.format("Can't convert versioned object %s to string", name),
+            name.toString(),
+            Matchers.equalTo(string)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnVersionedTest.java
@@ -100,8 +100,7 @@ final class OnVersionedTest {
     @Test
     @Disabled("Enable when OnVersioned.toString() is implemented properly")
     void convertsToStringWithNonEmptyVersion() {
-        final String string = "org.eolang.string#0.23.17";
-        final OnVersioned name = new OnVersioned(string);
+        final OnVersioned name = new OnVersioned("org.eolang.string#0.23.17");
         MatcherAssert.assertThat(
             String.format("Can't convert versioned object %s to string", name),
             name.toString(),


### PR DESCRIPTION
Add OnVersioned which will replace VersionMojo.
____
I don't think we need to perform such a heavy task with rewriting files in VersionMojo because we can solve the problem with object hashes in place where it is needed (DiscoveryMojo).
It could simplify the entire solution and speed up the build.

Closes: #2281

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `VersionsMojo` class and introducing the `OnVersioned` class. 

### Detailed summary
- Remove the `VersionsMojo` class and replace it with the `OnVersioned` class.
- Introduce the `OnVersioned` class to parse raw strings into object names and hashes.
- Add tests for the `OnVersioned` class.
- Remove the catch block for `AccessDeniedException` in the `cleanUpClasses` method of `TranspileMojo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->