### PR TITLE
feat(#2336): fix flaky tests in BinarizeMojoTest

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Set Cargo config (Windows)
         if: matrix.os == 'windows-2022'
         run: |
-          echo "[http]" >> .cargo/config.toml
-          echo "multiplexing = false" >> .cargo/config.toml
+          echo "[http]" >> %USERPROFILE%\.cargo\config.toml
+          echo "multiplexing = false" >> %USERPROFILE%\.cargo\config.toml
         shell: cmd
       - run: |
           mkdir -p $CONVERT_PATH

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -33,6 +33,12 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      - name: Set Cargo config (Windows)
+        if: matrix.os == 'windows-2022'
+        run: |
+          echo "[http]" >> .cargo/config.toml
+          echo "multiplexing = false" >> .cargo/config.toml
+        shell: cmd
       - run: |
           mkdir -p $CONVERT_PATH
           wget --quiet http://public.yegor256.com/convert.zip -O /tmp/convert.zip

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-    paths-ignore: ['paper/**', 'sandbox/**']
+    paths-ignore: [ 'paper/**', 'sandbox/**' ]
   pull_request:
     branches:
       - master
-    paths-ignore: ['paper/**', 'sandbox/**']
+    paths-ignore: [ 'paper/**', 'sandbox/**' ]
 concurrency:
   group: mvn-${{ github.ref }}
   cancel-in-progress: true
@@ -17,8 +17,8 @@ jobs:
     name: mvn
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [11, 20]
+        os: [ ubuntu-20.04, windows-2022, macos-12 ]
+        java: [ 11, 20 ]
     runs-on: ${{ matrix.os }}
     env:
       CONVERT_PATH: /tmp/antlr4-to-bnf-converter
@@ -33,6 +33,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      # The next step is required to avoid some exceptions that occur
+      # when running on Windows OS. For example like this one:
+      # - https://github.com/objectionary/eo/issues/2336
+      # The step disables http multiplexing in Cargo which cause some problems
+      #on Windows OS.
+      # You can read more about multiplexing right here
+      # - https://stackoverflow.com/questions/36517829/what-does-multiplexing-mean-in-http-2
+      # Multiplexing in Rust:
+      # - https://doc.rust-lang.org/cargo/reference/config.html#httpmultiplexing
       - name: Set Cargo config (Windows)
         if: matrix.os == 'windows-2022'
         run: |

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -37,7 +37,7 @@ jobs:
       # when running on Windows OS. For example like this one:
       # - https://github.com/objectionary/eo/issues/2336
       # The step disables http multiplexing in Cargo which cause some problems
-      #on Windows OS.
+      # on Windows OS.
       # You can read more about multiplexing right here
       # - https://stackoverflow.com/questions/36517829/what-does-multiplexing-mean-in-http-2
       # Multiplexing in Rust:

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Set Cargo config (Windows)
         if: matrix.os == 'windows-2022'
         run: |
-          echo "[http]" >> %USERPROFILE%\.cargo\config.toml
-          echo "multiplexing = false" >> %USERPROFILE%\.cargo\config.toml
+          echo [http] >> %USERPROFILE%\.cargo\config.toml
+          echo multiplexing = false >> %USERPROFILE%\.cargo\config.toml
         shell: cmd
       - run: |
           mkdir -p $CONVERT_PATH

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -31,7 +31,6 @@ import org.eolang.maven.rust.Names;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java
@@ -41,13 +41,6 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link BinarizeMojo}.
  *
  * @since 0.1
- * @todo #1307:30min Resolve flaky tests: 1) {@code savesToCache} on windows CI,
- *  see an example
- *  <a href="https://github.com/objectionary/eo/actions/runs/5713175702/job/
- *  15478085290?pr=2332">here</a>
- *  2) {@code binarizesWithoutErrors}, see an example
- *  <a href="https://github.com/objectionary/eo/actions/runs/5713661855/job/
- *  15479445307?pr=2332">here</a>
  */
 final class BinarizeMojoTest {
 
@@ -64,7 +57,6 @@ final class BinarizeMojoTest {
     @Test
     @Tag("slow")
     @ExtendWith(CargoCondition.class)
-    @Disabled
     void binarizesWithoutErrors(@TempDir final Path temp) throws Exception {
         final FakeMaven maven;
         synchronized (BinarizeMojoTest.class) {
@@ -93,7 +85,6 @@ final class BinarizeMojoTest {
 
     @Test
     @Tag("slow")
-    @Disabled
     void savesToCache(@TempDir final Path temp) throws IOException {
         final FakeMaven maven;
         final Path cache = temp.resolve(".cache");

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -36,6 +36,7 @@ import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -46,10 +47,17 @@ import org.junitpioneer.jupiter.StdOut;
  * Test case for {@link EOstdout}.
  *
  * @since 0.1
+ * @todo #2336:90min Enable all the tests in EOstdoutTest.
+ *  The tests are disabled because they are flaky.
+ *  The original issue is here:
+ *  - https://github.com/objectionary/eo/issues/2371
+ *  When the issue is fixed, enable the tests and remove the @Disabled annotation.
+ *  Don't forget to remove the puzzle itself.
  */
 public final class EOstdoutTest {
 
     @Test
+    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void printsString() {
         final Phi format = new Data.ToPhi("Hello, world!\n");
         final Phi phi = new PhWith(
@@ -66,6 +74,7 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
+    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void doesNotPrintTwiceOnIntComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(
@@ -100,6 +109,7 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
+    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(


### PR DESCRIPTION
Fix all the flaky tests in BinarizeMojoTest

Closes: #2336

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on resolving flaky tests and disabling them temporarily. 

### Detailed summary
- `BinarizeMojoTest`:
  - Removed `@Disabled` annotation from `binarizesWithoutErrors` and `savesToCache` test methods.
- `.github/workflows/mvn.yml`:
  - Updated `paths-ignore` to include spaces around the values.
  - Added a step to disable http multiplexing in Cargo for Windows OS.
- `EOstdoutTest`:
  - Added `@Disabled` annotation to all test methods with a link to the related issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->