### PR TITLE
#2371 Resolve flaky stdout tests

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
@@ -27,6 +27,7 @@
  */
 package EOorg.EOeolang.EOio;
 
+import java.io.PrintStream;
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
 import org.eolang.Data;
@@ -44,10 +45,24 @@ import org.eolang.XmirObject;
 @XmirObject(oname = "stdout")
 public class EOstdout extends PhDefault {
     /**
-     * Ctor.
+     * Default out print stream.
+     */
+    private static final PrintStream OUT = System.out;
+
+    /**
+     * Default ctor.
      * @param sigma Sigma
      */
     public EOstdout(final Phi sigma) {
+        this(sigma, EOstdout.OUT);
+    }
+
+    /**
+     * Ctor for the tests.
+     * @param sigma Sigma
+     * @param out Stream to print
+     */
+    EOstdout(final Phi sigma, final PrintStream out) {
         super(sigma);
         this.add("text", new AtFree());
         this.add(
@@ -55,7 +70,7 @@ public class EOstdout extends PhDefault {
             new AtComposite(
                 this,
                 rho -> {
-                    System.out.print(
+                    out.print(
                         new Param(rho, "text").strong(String.class)
                     );
                     return new Data.ToPhi(true);

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -36,8 +36,8 @@ import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junitpioneer.jupiter.StdIo;
@@ -47,17 +47,11 @@ import org.junitpioneer.jupiter.StdOut;
  * Test case for {@link EOstdout}.
  *
  * @since 0.1
- * @todo #2336:90min Enable all the tests in EOstdoutTest.
- *  The tests are disabled because they are flaky.
- *  The original issue is here:
- *  - https://github.com/objectionary/eo/issues/2371
- *  When the issue is fixed, enable the tests and remove the @Disabled annotation.
- *  Don't forget to remove the puzzle itself.
  */
+@Isolated
 public final class EOstdoutTest {
 
     @Test
-    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void printsString() {
         final Phi format = new Data.ToPhi("Hello, world!\n");
         final Phi phi = new PhWith(
@@ -74,7 +68,6 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void doesNotPrintTwiceOnIntComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(
@@ -109,7 +102,6 @@ public final class EOstdoutTest {
     @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    @Disabled("https://github.com/objectionary/eo/issues/2371")
     public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, final StdOut out) {
         final String str = "Hello world";
         new Dataized(

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -28,6 +28,8 @@
 package EOorg.EOeolang.EOio;
 
 import EOorg.EOeolang.EOseq;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhCopy;
@@ -37,18 +39,14 @@ import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junitpioneer.jupiter.StdIo;
-import org.junitpioneer.jupiter.StdOut;
 
 /**
  * Test case for {@link EOstdout}.
  *
  * @since 0.1
  */
-@Isolated
 public final class EOstdoutTest {
 
     @Test
@@ -65,10 +63,10 @@ public final class EOstdoutTest {
         );
     }
 
-    @StdIo
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnIntComparisonMethods(final String method, final StdOut out) {
+    public void doesNotPrintTwiceOnIntComparisonMethods(final String method) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";
         new Dataized(
             new PhWith(
@@ -82,7 +80,7 @@ public final class EOstdoutTest {
                         new EOseq(Phi.Φ),
                         0,
                         new PhWith(
-                            new EOstdout(Phi.Φ),
+                            new EOstdout(Phi.Φ, new PrintStream(stream)),
                             "text",
                             new Data.ToPhi(str)
                         )
@@ -93,16 +91,15 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            out.capturedLines()[0],
+            stream.toString(),
             Matchers.equalTo(str)
         );
-        out.capturedLines();
     }
 
-    @StdIo
-    @ParameterizedTest
+    @ParameterizedTest()
     @CsvSource({"lt", "gt", "lte", "gte"})
-    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method, final StdOut out) {
+    public void doesNotPrintTwiceOnFloatComparisonMethods(final String method) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";
         new Dataized(
             new PhWith(
@@ -116,7 +113,7 @@ public final class EOstdoutTest {
                         new EOseq(Phi.Φ),
                         0,
                         new PhWith(
-                            new EOstdout(Phi.Φ),
+                            new EOstdout(Phi.Φ, new PrintStream(stream)),
                             "text",
                             new Data.ToPhi(str)
                         )
@@ -127,7 +124,7 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            out.capturedLines()[0],
+            stream.toString(),
             Matchers.equalTo(str)
         );
     }


### PR DESCRIPTION
Closes: #2371

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `EOstdout` class by introducing a default print stream and adding a constructor for tests. 

### Detailed summary
- Added `import` statements for `PrintStream` and `ByteArrayOutputStream` in `EOstdoutTest.java`
- Added a `private static final` field `OUT` of type `PrintStream` in `EOstdout.java`
- Added a new constructor `EOstdout(final Phi sigma, final PrintStream out)` in `EOstdout.java`
- Updated the existing constructor `EOstdout(final Phi sigma)` in `EOstdout.java` to use the new constructor with `EOstdout.OUT` as the default print stream
- Updated the test method `printsString()` in `EOstdoutTest.java` to use the new constructor with `System.out` as the default print stream
- Updated the test method `doesNotPrintTwiceOnIntComparisonMethods()` in `EOstdoutTest.java` to use the new constructor with a `PrintStream` object created from a `ByteArrayOutputStream`
- Updated the test method `doesNotPrintTwiceOnFloatComparisonMethods()` in `EOstdoutTest.java` to use the new constructor with a `PrintStream` object created from a `ByteArrayOutputStream`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->