### PR TITLE
docs(#1698): added docs for `cage`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/cage.eo
+++ b/eo-runtime/src/main/eo/org/eolang/cage.eo
@@ -59,5 +59,10 @@
 #         cge' # <--copy is made here
 #         1
 #     cge
+# @todo #1698:60min Make up with an idea how to prevent StackOverflow exception
+#  or warn a user if he writes cage into the same cage. Options: 1) xsl file
+#  that somehow checks if cage is about to write to the same cage 2) catch
+#  StackOverflow exception at the top level and say to the user that maybe he
+#  writes cage to the same cage
 [] > cage /?
 

--- a/eo-runtime/src/main/eo/org/eolang/cage.eo
+++ b/eo-runtime/src/main/eo/org/eolang/cage.eo
@@ -29,5 +29,35 @@
 # This object is doing exactly the same as "memory", but allows
 # you to store objects, not only data. In other words, it doesn't
 # do dataization when objects are being stored.
+# Attention: your program will fail with StackOverflow exception if you try to
+# write to "cage" an object that was obtained by any manipulations with the
+# same "cage".
+# For example, the code below fails
+# [] > example
+#   cage > cge
+#     plus.
+#       0
+#       0
+#   seq > @
+#     cge.write
+#       plus.
+#         cge
+#         1
+#     cge
+#
+# The reason of failing is described in detail here:
+# https://github.com/objectionary/eo/issues/1698#issuecomment-1675224923
+# To prevent failing you have to make a copy of "cage" before writing:
+# [] > example
+#   cage > cge
+#     plus.
+#       0
+#       0
+#   seq > @
+#     cge.write
+#       plus.
+#         cge' # <--copy is made here
+#         1
+#     cge
 [] > cage /?
 


### PR DESCRIPTION
Closes: #1698

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on preventing a StackOverflow exception when writing an object to the same "cage" in EO. 

### Detailed summary
- Added a note explaining the issue and how to prevent it
- Provided an example code that causes the failure
- Added a link to a detailed explanation of the issue
- Suggested two options to prevent the exception or warn the user
- Added a todo comment to address the issue in the future

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->