### PR TITLE
feat(#2392): Add tests for ForeignTojos.find method

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import com.yegor256.tojos.Tojo;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import org.eolang.maven.Coordinates;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.util.Rel;
@@ -306,5 +307,24 @@ public final class ForeignTojo {
      */
     public String ver() {
         return this.delegate.get(ForeignTojos.Attribute.VER.key());
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        final boolean result;
+        if (this == other) {
+            result = true;
+        } else if (other == null || this.getClass() != other.getClass()) {
+            result = false;
+        } else {
+            final ForeignTojo tojo = (ForeignTojo) other;
+            result = Objects.equals(this.delegate, tojo.delegate);
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.delegate);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -128,9 +128,6 @@ public final class ForeignTojos implements Closeable {
      * Find tojo by tojo id.
      * @param id The id of the tojo.
      * @return The tojo.
-     * @todo #2331:90min Add unit test for ForeignTojos.find method.
-     *  The test should check that the method returns the tojo with the
-     *  specified id. When the test is ready, remove that puzzle.
      */
     public ForeignTojo find(final String id) {
         return new ForeignTojo(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -24,10 +24,14 @@
 package org.eolang.maven.tojos;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -76,6 +80,39 @@ final class ForeignTojosTest {
         MatcherAssert.assertThat(
             this.tojos.contains(considered),
             Matchers.is(false)
+        );
+    }
+
+    @Test
+    void findsLookingTojoCorrectly() {
+        final String looking = "looking";
+        MatcherAssert.assertThat(
+            "Found tojo should be the same as added",
+            this.tojos.add(looking),
+            Matchers.equalTo(this.tojos.find(looking))
+        );
+    }
+
+    @Test
+    void throwsExceptionIfTojoWasNotFound() {
+        final String id = "absent";
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> this.tojos.find(id),
+            String.format("Should throw an exception if tojo with id='%s' was not found", id)
+        );
+    }
+
+    @Test
+    void findsAnyTojoIfSeveralTojosWithTheSameIdWereAdded() {
+        final String same = "same";
+        final ForeignTojo first = this.tojos.add(same);
+        final ForeignTojo second = this.tojos.add(same);
+        final List<ForeignTojo> expected = Arrays.asList(first, second);
+        MatcherAssert.assertThat(
+            "We don't care which tojo will be returned, but it should be one of the added tojos",
+            expected,
+            Matchers.hasItem(this.tojos.find(same))
         );
     }
 


### PR DESCRIPTION
Add tests for `ForeignTojos#find()` method.

Closes: #2392


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding unit tests for the `ForeignTojos.find` method in the `eo-maven-plugin`. The changes include:
- Adding a unit test for the `find` method
- Implementing the `equals` and `hashCode` methods in `ForeignTojo` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->