### PR TITLE
feat(#2339): inline code in OnSwap#toString() method

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
@@ -93,7 +93,6 @@ public final class OnSwap implements ObjectName {
 
     @Override
     public String toString() {
-        final ObjectName name = this.swapped.value();
-        return name.toString();
+        return this.swapped.value().toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
@@ -87,6 +87,6 @@ public final class OnSwap implements ObjectName {
 
     @Override
     public String toString() {
-        return this.swapped.value().toString();
+        return String.valueOf(this.swapped.value());
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnSwap.java
@@ -33,12 +33,6 @@ import org.eolang.maven.hash.CommitHash;
  * If a second object is not provided - behaves like {@link OnUnversioned}
  *
  * @since 0.29.6
- * @todo #2328:30min Inline code in {@code toString()} method. For some reason
- *  Codacy static analyzer fails on {@code toString()} method and says that
- *  "it's unnecessary to call toString() on String object". It does not
- *  understand that {@code this.swapped.value()} is not a String for some
- *  reason. Codacy checks only new added files, so need to inline that code when
- *  this file is already in the codebase.
  */
 public final class OnSwap implements ObjectName {
     /**


### PR DESCRIPTION
Inline code in `OnSwap#toString()` method.

Closes: #2339

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on inlining code in the `toString()` method of the `OnSwap` class to resolve a Codacy static analyzer issue.

### Detailed summary
- Inline code in the `toString()` method of the `OnSwap` class.
- Change the return statement to use `String.valueOf()` instead of directly calling `toString()` on the `name` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->