### PR TITLE
feat(#2394): replace # with |

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
@@ -68,7 +68,7 @@ public final class Place {
         if (versioned.length > 1) {
             out.append(versioned[0].replace(".", File.separator));
             out.append('_');
-            out.append(versioned[1].replace(".", "_"));
+            out.append(versioned[1]);
         } else {
             out.append(this.name.replace(".", File.separator));
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Place.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import java.io.File;
 import java.nio.file.Path;
 import org.eolang.maven.name.ObjectName;
+import org.eolang.maven.name.OnReplaced;
 
 /**
  * Make the place for the object.
@@ -63,7 +64,14 @@ public final class Place {
      */
     public Path make(final Path dir, final String ext) {
         final StringBuilder out = new StringBuilder();
-        out.append(this.name.replace(".", File.separator));
+        final String[] versioned = this.name.split(String.format("\\%s", OnReplaced.DELIMITER));
+        if (versioned.length > 1) {
+            out.append(versioned[0].replace(".", File.separator));
+            out.append('_');
+            out.append(versioned[1].replace(".", "_"));
+        } else {
+            out.append(this.name.replace(".", File.separator));
+        }
         if (!ext.isEmpty()) {
             out.append('.').append(ext);
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -126,7 +126,7 @@ public final class PullMojo extends SafeMojo {
     /**
      * Pull one object.
      *
-     * @param object Name of the object with/without version, e.g. "org.eolang.io.stdout#5f82cc1"
+     * @param object Name of the object with/without version, e.g. "org.eolang.io.stdout|5f82cc1"
      * @return The path of .eo file
      * @throws IOException If fails
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
@@ -55,6 +55,13 @@ public final class OnReplaced implements ObjectName {
 
     /**
      * Delimiter between name and hash in EO object name.
+     * @todo #2394:30min Hide static constant DELIMITER.
+     *  We should hide static constant DELIMITER because it creates code duplication
+     *  in many places. For example in {@link OnReplaced#split()} and {@link OnVersioned#split()}.
+     *  Apparently we have to create a class which will parse raw string into two parts value and
+     *  optional version. Maybe this new class won't implement ObjectName interface.
+     *  Why static fields are bad you can read here:
+     *  - https://www.yegor256.com/2015/07/06/public-static-literals.html
      */
     public static final String DELIMITER = "|";
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
@@ -33,9 +33,9 @@ import org.eolang.maven.hash.CommitHashesMap;
 /**
  * Object name replaced.
  * This is object name that parses raw sting like:
- * - "org.eolang.text#0.1.0" into "org.eolang.text"
+ * - "org.eolang.text|0.1.0" into "org.eolang.text"
  *   and "4b19944"
- * - "org.eolang.string#a1b2c3d" into "org.eolang.string"
+ * - "org.eolang.string|a1b2c3d" into "org.eolang.string"
  *   and "be83d9a"
  * Pay attention to that versions transformed into narrow hashes.
  * If a version is not provided - behaves like {@link OnUnversioned}.
@@ -56,7 +56,7 @@ public final class OnReplaced implements ObjectName {
     /**
      * Delimiter between name and hash in EO object name.
      */
-    public static final String DELIMITER = "#";
+    public static final String DELIMITER = "|";
 
     /**
      * Default hashes.
@@ -66,9 +66,9 @@ public final class OnReplaced implements ObjectName {
     /**
      * Raw string.
      * Examples:
-     * - "org.eolang.text#0.1.0"
-     * - "org.eolang.string#1.23.1"
-     * - "org.eolang.math#3.3.3"
+     * - "org.eolang.text|0.1.0"
+     * - "org.eolang.string|1.23.1"
+     * - "org.eolang.math|3.3.3"
      */
     private final Unchecked<String> raw;
 
@@ -161,7 +161,7 @@ public final class OnReplaced implements ObjectName {
      * @return Array of two elements: name and hash.
      */
     private String[] split() {
-        return this.raw.value().split(OnReplaced.DELIMITER);
+        return this.raw.value().split(String.format("\\%s", OnReplaced.DELIMITER));
     }
 }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
@@ -57,7 +57,8 @@ public final class OnReplaced implements ObjectName {
      * Delimiter between name and hash in EO object name.
      * @todo #2394:30min Hide static constant DELIMITER.
      *  We should hide static constant DELIMITER because it creates code duplication
-     *  in many places. For example in {@link OnReplaced#split()} and {@link OnVersioned#split()}.
+     *  in many places. For example in {@link OnReplaced#split()} and {@link OnVersioned#split()}
+     *  and {@link org.eolang.maven.Place#make(java.nio.file.Path, String)}.
      *  Apparently we have to create a class which will parse raw string into two parts value and
      *  optional version. Maybe this new class won't implement ObjectName interface.
      *  Why static fields are bad you can read here:

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -107,7 +107,7 @@ public final class OnVersioned implements ObjectName {
      * @return Split object to name and hash.
      */
     private String[] split() {
-        String[] splt = this.object.value().split(OnReplaced.DELIMITER);
+        String[] splt = this.object.value().split(String.format("\\%s", OnReplaced.DELIMITER));
         if (splt.length == 1) {
             splt = new String[]{splt[0], this.hsh.value()};
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -54,6 +55,24 @@ final class PlaceTest {
                 .toString()
                 .replace("\\", "/"),
             Matchers.equalTo("/tmp/hey.xml")
+        );
+    }
+
+    @Test
+    void makesPathForVersionedObject() {
+        final String object = "org.eolang.io.stdout|25.0.1";
+        final Path actual = new Place(object)
+            .make(Paths.get("/tmp/test"), TranspileMojo.EXT);
+        final Path expected = Paths.get("/tmp/test/org/eolang/io/stdout_25_0_1.xmir");
+        MatcherAssert.assertThat(
+            String.format(
+                "Expected path for object '%s' is '%s' but got '%s'",
+                object,
+                expected,
+                actual
+            ),
+            actual,
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PlaceTest.java
@@ -60,10 +60,10 @@ final class PlaceTest {
 
     @Test
     void makesPathForVersionedObject() {
-        final String object = "org.eolang.io.stdout|25.0.1";
+        final String object = "org.eolang.io.stdout|15c85d7";
         final Path actual = new Place(object)
             .make(Paths.get("/tmp/test"), TranspileMojo.EXT);
-        final Path expected = Paths.get("/tmp/test/org/eolang/io/stdout_25_0_1.xmir");
+        final Path expected = Paths.get("/tmp/test/org/eolang/io/stdout_15c85d7.xmir");
         MatcherAssert.assertThat(
             String.format(
                 "Expected path for object '%s' is '%s' but got '%s'",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -204,8 +204,7 @@ final class PullMojoTest {
                 )
             )
             .withVersionedHelloWorld()
-            .execute(new FakeMaven.Pull())
-            .result();
+            .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -63,16 +63,11 @@ final class PullMojoTest {
     private static final String STDOUT = "org.eolang.io.stdout";
 
     /**
-     * Stdout source.
-     */
-    private static final String SOURCE = "%s/org/eolang/io/stdout.eo";
-
-    /**
      * Versioned source.
      */
     private static final ObjectName VERSIONED = new OnVersioned(
-        "%s/org/eolang/io/stdout",
-        "9c93528.eo"
+        "org.eolang.io.stdout",
+        "9c93528"
     );
 
     @Test
@@ -84,7 +79,7 @@ final class PullMojoTest {
         maven.with("skip", false)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            PullMojoTest.exists(temp, PullMojoTest.SOURCE),
+            PullMojoTest.exists(temp, PullMojoTest.STDOUT),
             Matchers.is(true)
         );
     }
@@ -112,7 +107,7 @@ final class PullMojoTest {
             )
             .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
-            PullMojoTest.exists(temp, PullMojoTest.SOURCE),
+            PullMojoTest.exists(temp, PullMojoTest.STDOUT),
             Matchers.is(true)
         );
     }
@@ -172,7 +167,7 @@ final class PullMojoTest {
         maven.with("skip", true)
             .execute(PullMojo.class);
         MatcherAssert.assertThat(
-            PullMojoTest.exists(temp, PullMojoTest.SOURCE),
+            PullMojoTest.exists(temp, PullMojoTest.STDOUT),
             Matchers.is(false)
         );
     }
@@ -209,7 +204,8 @@ final class PullMojoTest {
                 )
             )
             .withVersionedHelloWorld()
-            .execute(new FakeMaven.Pull());
+            .execute(new FakeMaven.Pull())
+            .result();
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
@@ -242,8 +238,8 @@ final class PullMojoTest {
             .with("hsh", fourth)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
-        final ObjectName sprintf = new OnVersioned("%s/org/eolang/txt/sprintf", "17f8929.eo");
-        final ObjectName string = new OnVersioned("%s/org/eolang/string", "5f82cc1.eo");
+        final ObjectName sprintf = new OnVersioned("org.eolang.txt.sprintf", "17f8929");
+        final ObjectName string = new OnVersioned("org.eolang.string", "5f82cc1");
         MatcherAssert.assertThat(
             String.format(
                 "File by path %s should have existed after pulling, but it didn't",
@@ -288,9 +284,16 @@ final class PullMojoTest {
      * @return If given source file exists.
      */
     private static boolean exists(final Path temp, final String source) {
-        return new Home(temp.resolve("target")).exists(
-            Paths.get(PullMojoTest.path(source))
-        );
+        return new Home(temp.resolve("target")).exists(PullMojoTest.path(source));
+    }
+
+    /**
+     * Format given a source path.
+     * @param name Source path as object name.
+     * @return Formatted source path.
+     */
+    private static Path path(final ObjectName name) {
+        return PullMojoTest.path(name.toString());
     }
 
     /**
@@ -298,16 +301,8 @@ final class PullMojoTest {
      * @param source Source path as object name.
      * @return Formatted source path.
      */
-    private static String path(final ObjectName source) {
-        return PullMojoTest.path(source.toString());
+    private static Path path(final String source) {
+        return new Place(source).make(Paths.get(PullMojo.DIR), "eo");
     }
 
-    /**
-     * Format given a source path.
-     * @param source Source path.
-     * @return Formatted source path.
-     */
-    private static String path(final String source) {
-        return String.format(source, PullMojo.DIR);
-    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
@@ -43,23 +43,23 @@ final class OnReplacedTest {
 
     @ParameterizedTest
     @CsvSource({
-        "org.eolang.string, org.eolang.string#0.23.17",
-        "org.eolang.dummy, org.eolang.dummy#0.23.19",
-        "org.eolang.text, org.eolang.text#0.25.0",
-        "org.eolang.aug, org.eolang.aug#0.25.5",
-        "org.eolang.sept, org.eolang.sept#0.26.0",
-        "org.eolang.oct, org.eolang.oct#0.27.0",
-        "org.eolang.nov, org.eolang.nov#0.27.2",
-        "org.eolang.dec, org.eolang.dec#0.28.0",
-        "org.eolang.mon, org.eolang.mon#0.28.1",
-        "org.eolang.tu, org.eolang.tu#0.28.10",
-        "org.eolang.wen, org.eolang.wen#0.28.14",
-        "org.eolang.th, org.eolang.th#0.28.2",
-        "org.eolang.fri, org.eolang.fri#0.28.4",
-        "org.eolang.sat, org.eolang.sat#0.28.5",
-        "org.eolang.sun, org.eolang.sun#0.28.6",
-        "org.eolang.penguin, org.eolang.penguin#0.28.7",
-        "org.eolang.eagle, org.eolang.eagle#0.28.9"
+        "org.eolang.string, org.eolang.string|0.23.17",
+        "org.eolang.dummy, org.eolang.dummy|0.23.19",
+        "org.eolang.text, org.eolang.text|0.25.0",
+        "org.eolang.aug, org.eolang.aug|0.25.5",
+        "org.eolang.sept, org.eolang.sept|0.26.0",
+        "org.eolang.oct, org.eolang.oct|0.27.0",
+        "org.eolang.nov, org.eolang.nov|0.27.2",
+        "org.eolang.dec, org.eolang.dec|0.28.0",
+        "org.eolang.mon, org.eolang.mon|0.28.1",
+        "org.eolang.tu, org.eolang.tu|0.28.10",
+        "org.eolang.wen, org.eolang.wen|0.28.14",
+        "org.eolang.th, org.eolang.th|0.28.2",
+        "org.eolang.fri, org.eolang.fri|0.28.4",
+        "org.eolang.sat, org.eolang.sat|0.28.5",
+        "org.eolang.sun, org.eolang.sun|0.28.6",
+        "org.eolang.penguin, org.eolang.penguin|0.28.7",
+        "org.eolang.eagle, org.eolang.eagle|0.28.9"
     })
     void retrievesName(final String expected, final String origin) {
         final ObjectName name = new OnReplaced(origin);
@@ -72,23 +72,23 @@ final class OnReplacedTest {
 
     @ParameterizedTest
     @CsvSource({
-        "15c85d7, org.eolang.string#0.23.17",
-        "4b19944, org.eolang.dummy#0.23.19",
-        "0aa6875, org.eolang.text#0.25.0",
-        "ff32e9f, org.eolang.aug#0.25.5",
-        "e0b7836, org.eolang.sept#0.26.0",
-        "cc554ab, org.eolang.oct#0.27.0",
-        "00b60c7, org.eolang.nov#0.27.2",
-        "6a70071, org.eolang.dec#0.28.0",
-        "0c15066, org.eolang.mon#0.28.1",
-        "9b88393, org.eolang.tu#0.28.10",
-        "a7a4556, org.eolang.wen#0.28.14",
-        "54d83d4, org.eolang.th#0.28.2",
-        "6c6269d, org.eolang.fri#0.28.4",
-        "9c93528, org.eolang.sat#0.28.5",
-        "17f8929, org.eolang.sun#0.28.6",
-        "5f82cc1, org.eolang.penguin#0.28.7",
-        "be83d9a, org.eolang.eagle#0.28.9"
+        "15c85d7, org.eolang.string|0.23.17",
+        "4b19944, org.eolang.dummy|0.23.19",
+        "0aa6875, org.eolang.text|0.25.0",
+        "ff32e9f, org.eolang.aug|0.25.5",
+        "e0b7836, org.eolang.sept|0.26.0",
+        "cc554ab, org.eolang.oct|0.27.0",
+        "00b60c7, org.eolang.nov|0.27.2",
+        "6a70071, org.eolang.dec|0.28.0",
+        "0c15066, org.eolang.mon|0.28.1",
+        "9b88393, org.eolang.tu|0.28.10",
+        "a7a4556, org.eolang.wen|0.28.14",
+        "54d83d4, org.eolang.th|0.28.2",
+        "6c6269d, org.eolang.fri|0.28.4",
+        "9c93528, org.eolang.sat|0.28.5",
+        "17f8929, org.eolang.sun|0.28.6",
+        "5f82cc1, org.eolang.penguin|0.28.7",
+        "be83d9a, org.eolang.eagle|0.28.9"
     })
     void retrievesHash(final String expected, final String origin) {
         final ObjectName name = new OnReplaced(origin, new CommitHashesMap.Fake());

--- a/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-probes.xsl
@@ -73,7 +73,7 @@ SOFTWARE.
                 <xsl:text>probe</xsl:text>
               </xsl:element>
               <xsl:element name="tail">
-                <xsl:value-of select="string-join(($p, @ver),'#')"/>
+                <xsl:value-of select="string-join(($p, @ver),'|')"/>
               </xsl:element>
               <xsl:element name="part">
                 <xsl:value-of select="$p"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/add-versioned-probes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/add-versioned-probes.yaml
@@ -8,7 +8,7 @@ tests:
   - //metas[count(.//meta[head/text()='probe'])=3]
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang' and part/text()='Q.org.eolang']
   - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage' and part/text()='Q.org.eolang.cage']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage#0.28.10' and part/text()='Q.org.eolang.cage']
+  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.cage|0.28.10' and part/text()='Q.org.eolang.cage']
 eo: |
   +home https://github.com/objectionary/eo
   +package org.eolang.custom


### PR DESCRIPTION
Replace internal delimiter for versions from # to |

Closes: #2394

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the delimiter used in object names from "#" to "|". 

### Detailed summary
- Updated the delimiter in object names from "#" to "|".
- Updated relevant code and tests to use the new delimiter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->