### PR TITLE
fix(#2405): `noname-attributes.xsl` fix

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/errors/noname-attributes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/noname-attributes.xsl
@@ -34,8 +34,7 @@ SOFTWARE.
     </xsl:copy>
   </xsl:template>
   <xsl:template match="o" mode="abstract">
-    <xsl:variable name="attr" select="o[not(@name) and not(starts-with(@base, '.'))]"/>
-    <xsl:if test="$attr">
+    <xsl:for-each select="o[not(@name)]">
       <xsl:element name="error">
         <xsl:attribute name="check">
           <xsl:text>noname-attributes</xsl:text>
@@ -54,11 +53,11 @@ SOFTWARE.
         </xsl:if>
         <xsl:text>has attribute without a name</xsl:text>
         <xsl:text>, line=</xsl:text>
-        <xsl:value-of select="$attr/@line"/>
+        <xsl:value-of select="@line"/>
         <xsl:text>, pos=</xsl:text>
-        <xsl:value-of select="$attr/@pos"/>
+        <xsl:value-of select="@pos"/>
       </xsl:element>
-    </xsl:if>
+    </xsl:for-each>
   </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-noname-attrs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-noname-attrs.yaml
@@ -1,4 +1,5 @@
 xsls:
+  - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/errors/noname-attributes.xsl
 tests:
   - /program/errors[count(error[@severity='error'])=2]

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-noname-attrs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-noname-attrs.yaml
@@ -2,11 +2,11 @@ xsls:
   - /org/eolang/parser/wrap-method-calls.xsl
   - /org/eolang/parser/errors/noname-attributes.xsl
 tests:
-  - /program/errors[count(error[@severity='error'])=2]
-  - /program/errors/error[@line='1']
-  - /program/errors/error[@line='8']
-  - //o[@base='first' and @line='2']
-  - //o[@base='second' and @line='3']
+  - /program/errors[count(error[@severity='error'])=4]
+  - /program/errors/error[@line='2' and contains(text(),'pos=2')]
+  - /program/errors/error[@line='3' and contains(text(),'pos=2')]
+  - /program/errors/error[@line='9' and contains(text(),'pos=19')]
+  - /program/errors/error[@line='14' and contains(text(),'pos=2')]
 eo: |
   []
     first

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/priority/additional-brackets.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/priority/additional-brackets.yaml
@@ -7,4 +7,4 @@ eo: |
   +version 0.0.0
 
   [] > x
-    1.times 2 (1.plus other.value)
+    1.times 2 (1.plus other.value) > @


### PR DESCRIPTION
Closes: #2405 