### PR TITLE
2314 handle vertex returning

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -36,6 +36,8 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.SystemUtils;
@@ -67,6 +69,8 @@ import org.eolang.XmirObject;
  */
 @XmirObject(oname = "rust")
 public class EOrust extends PhDefault {
+
+    private final Map<Integer, Phi> phis = new HashMap<>();
 
     /**
      * Map with location of the `code` attribute as the key
@@ -150,10 +154,10 @@ public class EOrust extends PhDefault {
                         .attr("params").get()
                         .attr("Δ").get()
                     ).take(Phi[].class)[0];
-                    return EOrust.translate(
+                    return this.translate(
                         (byte[]) method.invoke(
                             null, new Universe(
-                                portal
+                                portal, this.phis
                             )
                         )
                     );
@@ -213,17 +217,28 @@ public class EOrust extends PhDefault {
      *  It must convert message array from 1 to last byte to the String
      *  and return eo object with converted String Data.
      */
-    private static Phi translate(final byte[] message) {
+    private Phi translate(final byte[] message) {
         final byte determinant = message[0];
         final byte[] content = Arrays.copyOfRange(message, 1, message.length);
         final Phi ret;
         switch (determinant) {
             case 0:
-                throw new ExFailure(
-                    "Returning vertex is not implemented yet"
-                );
+                ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
+                buffer.put(content);
+                buffer.flip();
+                final int vertex = buffer.getInt();
+                ret = this.phis.get(vertex);
+                if (ret == null) {
+                    throw new ExFailure(
+                        String.format(
+                            "Returned phi with vertex %d was not indexed",
+                            vertex
+                        )
+                    );
+                }
+                break;
             case 1:
-                ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES);
+                buffer = ByteBuffer.allocate(Double.BYTES);
                 buffer.put(content);
                 buffer.flip();
                 ret = new Data.ToPhi(buffer.getDouble());

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -213,9 +213,6 @@ public class EOrust extends PhDefault {
      * Translates byte message from rust side to Phi object.
      * @param message Message that native method returns.
      * @return Phi object.
-     * @todo #2283:45min Implement handling of vertex returning.
-     *  It must convert message array from 1 to last byte to the int
-     *  and return eo object with corresponding vertex then.
      * @todo #2283:45min Implement handling of String returning.
      *  It must convert message array from 1 to last byte to the String
      *  and return eo object with converted String Data.
@@ -234,9 +231,10 @@ public class EOrust extends PhDefault {
                 if (ret == null) {
                     throw new ExFailure(
                         String.format(
-                            "Returned phi with vertex %d was not indexed",
-                            vertex
-                        )
+                            "Returned phi with vertex %d (%s in bytes) was not indexed",
+                            vertex,
+                            Arrays.toString(content)
+                            )
                     );
                 }
                 break;

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -70,13 +70,16 @@ import org.eolang.XmirObject;
 @XmirObject(oname = "rust")
 public class EOrust extends PhDefault {
 
-    private final Map<Integer, Phi> phis = new HashMap<>();
-
     /**
      * Map with location of the `code` attribute as the key
      * and native method as the value.
      */
     private static final ConcurrentHashMap<String, String> NAMES;
+
+    /**
+     * All phis indexed while executing of native method.
+     */
+    private final Map<Integer, Phi> phis = new HashMap<>();
 
     static {
         try {

--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -69,7 +69,9 @@ public class Universe {
         final String[] atts = Universe.replace(name)
             .split("\\.");
         for (final String att: atts) {
-            accum = accum.attr(att).get();
+            if (!"".equals(att)) {
+                accum = accum.attr(att).get();
+            }
         }
         this.indexed.putIfAbsent(accum.hashCode(), accum);
         return accum.hashCode();
@@ -79,13 +81,12 @@ public class Universe {
      * Puts data to eo object by vertex.
      * @param vertex Vertex off object.
      * @param bytes Data to put.
-     * @todo #2237:45min Implement the "put" method. Now it does
-     *  nothing and created to check rust2java interaction. This
-     *  method relates to building a new eo object in rust insert.
      * @checkstyle NonStaticMethodCheck (4 lines)
      */
     public void put(final int vertex, final byte[] bytes) {
-        //Empty yet.
+        this.get(vertex).attr("Δ").put(
+            new Data.ToPhi(bytes)
+        );
     }
 
     /**
@@ -122,18 +123,22 @@ public class Universe {
      */
     public byte[] dataize(final int vertex) {
         return new Param(
-            Optional.ofNullable(
-                this.indexed.get(vertex)
-            ).orElseThrow(
-                () -> new ExFailure(
-                    String.format(
-                        "Phi object with vertex %d was not indexed.",
-                        vertex
-                    )
-                )
-            ),
+            this.get(vertex),
             "Δ"
         ).asBytes().take();
+    }
+
+    private Phi get(final int vertex) {
+        return Optional.ofNullable(
+            this.indexed.get(vertex)
+        ).orElseThrow(
+            () -> new ExFailure(
+                String.format(
+                    "Phi object with vertex %d was not indexed.",
+                    vertex
+                )
+            )
+        );
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -46,6 +46,7 @@ public class Universe {
     /**
      * Ctor.
      * @param connector Connector.
+     * @param indexed Map to index eo objects.
      */
     public Universe(final Phi connector, final Map<Integer, Phi> indexed) {
         this.connector = connector;
@@ -94,9 +95,7 @@ public class Universe {
      * @checkstyle NonStaticMethodCheck (4 lines)
      */
     public void put(final int vertex, final byte[] bytes) {
-        this.get(vertex).attr("Δ").put(
-            new Data.ToPhi(bytes)
-        );
+        //Empty yet.
     }
 
     /**
@@ -138,6 +137,12 @@ public class Universe {
         ).asBytes().take();
     }
 
+    /**
+     * Find phi by vertex.
+     * @param vertex Vertex.
+     * @return Phi.
+     * @throws ExFailure if vertex does not exist in the map.
+     */
     private Phi get(final int vertex) {
         return Optional.ofNullable(
             this.indexed.get(vertex)

--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -47,9 +47,19 @@ public class Universe {
      * Ctor.
      * @param connector Connector.
      */
-    public Universe(final Phi connector) {
+    public Universe(final Phi connector, final Map<Integer, Phi> indexed) {
         this.connector = connector;
-        this.indexed = new HashMap<>();
+        this.indexed = indexed;
+    }
+
+    /**
+     * Ctor.
+     * @param connector Connector.
+     */
+    public Universe(final Phi connector) {
+        this(
+            connector, new HashMap<>()
+        );
     }
 
     /**

--- a/eo-runtime/src/main/rust/eo_env/src/eo_enum.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_enum.rs
@@ -36,7 +36,7 @@ impl EO {
             EO::EOVertex(v) => {
                 let mut res: Vec<u8> = vec![0; 1 + 4];
                 res[0] = 0;
-                res[1..].copy_from_slice(&v.to_le_bytes());
+                res[1..].copy_from_slice(&v.to_be_bytes());
                 res
             }
             EO::EOFloat(x) => {

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -120,6 +120,26 @@
       $.less-than
         0
 
+[] > rust-returns-vertex
+  "content" > book
+  QQ.rust > read
+    """
+    use eo_env::EOEnv;
+    use eo_env::eo_enum::EO;
+    use eo_env::eo_enum::EO::{EOVertex};
+
+    pub fn foo(env: &mut EOEnv) -> EO {
+      let v = env.find("^.book") as u32;
+      EOVertex(v)
+    }
+    """
+    *
+      []
+  assert-that > @
+    read
+    $.equal-to
+      "content"
+
 [] > rust-put-not-fails
   QQ.rust > r
     """

--- a/eo-runtime/src/test/java/org/eolang/UniverseTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseTest.java
@@ -58,7 +58,7 @@ final class UniverseTest {
         MatcherAssert.assertThat(
             universe.find(
                 String.format(
-                    "%s.%s",
+                    "%s.%s..",
                     UniverseTest.ATT,
                     UniverseTest.ATT
                     )
@@ -103,6 +103,31 @@ final class UniverseTest {
         );
     }
 
+    @Test
+    void putsToIndexed() {
+        final Universe universe = new Universe(new DummyWithAt(Phi.Φ));
+        final int attribute = universe.find("");
+        final byte[] data = new byte[]{0x1, 0x2, 0x3};
+        universe.put(
+            attribute,
+            data
+        );
+        MatcherAssert.assertThat(
+            universe.dataize(attribute),
+            Matchers.equalTo(data)
+        );
+    }
+
+    @Test
+    void throwsIfWrongPut() {
+        Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new Universe(
+                new DummyWithStructure(Phi.Φ)
+            ).put(-1, new byte[]{0x1})
+        );
+    }
+
     /**
      * Dummy phi with plain attribute.
      * @since 0.31
@@ -116,6 +141,7 @@ final class UniverseTest {
          */
         DummyWithAt(final Phi sigma, final String att) {
             super(sigma);
+            this.add("Δ", new AtFree());
             this.add(att, new AtComposite(sigma, self -> new Data.ToPhi(1L)));
         }
 

--- a/eo-runtime/src/test/java/org/eolang/UniverseTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseTest.java
@@ -58,7 +58,7 @@ final class UniverseTest {
         MatcherAssert.assertThat(
             universe.find(
                 String.format(
-                    "%s.%s..",
+                    "%s.%s",
                     UniverseTest.ATT,
                     UniverseTest.ATT
                     )
@@ -103,31 +103,6 @@ final class UniverseTest {
         );
     }
 
-    @Test
-    void putsToIndexed() {
-        final Universe universe = new Universe(new DummyWithAt(Phi.Φ));
-        final int attribute = universe.find("");
-        final byte[] data = new byte[]{0x1, 0x2, 0x3};
-        universe.put(
-            attribute,
-            data
-        );
-        MatcherAssert.assertThat(
-            universe.dataize(attribute),
-            Matchers.equalTo(data)
-        );
-    }
-
-    @Test
-    void throwsIfWrongPut() {
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new Universe(
-                new DummyWithStructure(Phi.Φ)
-            ).put(-1, new byte[]{0x1})
-        );
-    }
-
     /**
      * Dummy phi with plain attribute.
      * @since 0.31
@@ -141,7 +116,6 @@ final class UniverseTest {
          */
         DummyWithAt(final Phi sigma, final String att) {
             super(sigma);
-            this.add("Δ", new AtFree());
             this.add(att, new AtComposite(sigma, self -> new Data.ToPhi(1L)));
         }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on implementing new functionality and making improvements to existing code in the eo-runtime and EOorg/EOrust modules.

### Detailed summary:
- In `eo_enum.rs`, the code has been modified to use big-endian byte order instead of little-endian byte order.
- In `rust-tests.eo`, a new function `foo` has been added which retrieves a value from the environment and returns an `EOVertex` object.
- In `Universe.java`, a new constructor has been added that accepts a `Map<Integer, Phi>` parameter and initializes the `indexed` field with it. The existing constructor has been modified to call this new constructor with an empty `HashMap` as the parameter.
- The `find` method in `Universe.java` has been modified to skip empty attributes when splitting the name string.
- The `put` method in `Universe.java` has been modified to do nothing and is marked as a TODO.
- The `dataize` method in `Universe.java` has been modified to use the `get` method to retrieve the `Phi` object instead of directly accessing the `indexed` map.
- The `get` method has been added to `Universe.java` to retrieve a `Phi` object from the `indexed` map.
- The `EOrust` class in `EOrust.java` has been modified to use the new constructor of `Universe` that accepts a `Map<Integer, Phi>` parameter.
- The `translate` method in `EOrust.java` has been modified to handle the case when the determinant is 0 and retrieve the corresponding `Phi` object using the `phis` map.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->