### PR TITLE
feat(#1602): discover depends on place

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -65,7 +65,6 @@ public final class DiscoverMojo extends SafeMojo {
             discovered.addAll(names);
             for (final String name : names) {
                 this.scopedTojos().add(name).withDiscoveredAt(src);
-                discovered.add(name);
             }
             tojo.withDiscovered(discovered.size());
         }
@@ -152,7 +151,7 @@ public final class DiscoverMojo extends SafeMojo {
      * Handle versioning of given object name.
      * If {@code this.withVersions} is set to FALSE - don't append a version to
      * the object name.
-     * Otherwise, try to append a version from tojo if there's no one already
+     * Otherwise, try to append a version from tojo if there's no one yet
      *
      * @param name Object name with tag on not.
      * @param tojo Current tojo.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -150,6 +150,10 @@ public final class DiscoverMojo extends SafeMojo {
 
     /**
      * Handle versioning of given object name.
+     * If {@code this.withVersions} is set to FALSE - don't append a version to
+     * the object name.
+     * Otherwise, there are two options:
+     * 1. If current tojo is versioned -
      *
      * @param name Object name with tag on not.
      * @param tojo Current tojo.
@@ -163,8 +167,7 @@ public final class DiscoverMojo extends SafeMojo {
                 tojo.contains(OnReplaced.DELIMITER),
                 new OnVersioned(
                     replaced,
-                    new OnDefault(tojo)::hash,
-                    true
+                    new OnDefault(tojo)::hash
                 ),
                 replaced
             )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -156,7 +156,7 @@ public final class DiscoverMojo extends SafeMojo {
     }
 
     /**
-     * Get a version for an object to concatenate with.
+     * Get a version to concatenate with.
      * @param xml XML
      * @return Version to concatenate with
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -151,8 +151,12 @@ public final class DiscoverMojo extends SafeMojo {
         );
     }
 
-    // OnReplaced - меняет tag на хэш, если он там есть
-    // OnVersioned - если нет хэша - добавляет
+    /**
+     * Handle versioning of given object name.
+     * @param name Object name with tag on not.
+     * @param tojo Current tojo.
+     * @return Versioned object name.
+     */
     private ObjectName versioned(final String name, final ForeignTojo tojo) {
         final String identifier = tojo.identifier();
         final ObjectName replaced = new OnReplaced(name, this.hashes);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -156,7 +156,7 @@ public final class DiscoverMojo extends SafeMojo {
     }
 
     /**
-     * Get a version for an object to concatenate with
+     * Get a version for an object to concatenate with.
      * @param xml XML
      * @return Version to concatenate with
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -152,8 +152,7 @@ public final class DiscoverMojo extends SafeMojo {
      * Handle versioning of given object name.
      * If {@code this.withVersions} is set to FALSE - don't append a version to
      * the object name.
-     * Otherwise, there are two options:
-     * 1. If current tojo is versioned -
+     * Otherwise, try to append a version from tojo if there's no one already
      *
      * @param name Object name with tag on not.
      * @param tojo Current tojo.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -160,12 +161,13 @@ public final class DiscoverMojo extends SafeMojo {
      * @return Version to concatenate with
      */
     private String version(final XML xml) {
-        final String head = xml.xpath("//meta[head/text()='version']/tail/text()").get(0);
-        final String version;
-        if (!this.withVersions || head.isEmpty() || head.equals(ParseMojo.ZERO)) {
-            version = "@ver";
-        } else {
-            version = String.format("if(@ver)then(@ver)else('%s')", head);
+        final List<String> head = xml.xpath("//meta[head/text()='version']/tail/text()");
+        String version = "@ver";
+        if (!head.isEmpty()) {
+            final String ver = head.get(0);
+            if (this.withVersions && !ver.isEmpty() && !ver.equals(ParseMojo.ZERO)) {
+                version = String.format("if(@ver)then(@ver)else('%s')", ver);
+            }
         }
         return version;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -61,7 +61,7 @@ public final class DiscoverMojo extends SafeMojo {
         final Collection<String> discovered = new HashSet<>();
         for (final ForeignTojo tojo : tojos) {
             final Path src = tojo.optimized();
-            final Collection<String> names = this.discover(src, tojo);
+            final Collection<String> names = this.discover(src, tojo.identifier());
             discovered.addAll(names);
             for (final String name : names) {
                 this.scopedTojos().add(name).withDiscoveredAt(src);
@@ -95,7 +95,7 @@ public final class DiscoverMojo extends SafeMojo {
      * @param tojo Current tojo.
      * @return List of foreign objects found
      */
-    private Collection<String> discover(final Path file, final ForeignTojo tojo) {
+    private Collection<String> discover(final Path file, final String tojo) {
         final XML xml = new SaxonDocument(file);
         final Collection<String> names = this.names(xml, tojo);
         if (!xml.xpath("//o[@vararg]").isEmpty()) {
@@ -122,7 +122,7 @@ public final class DiscoverMojo extends SafeMojo {
      * @param tojo Current tojo.
      * @return Object names.
      */
-    private Collection<String> names(final XML xml, final ForeignTojo tojo) {
+    private Collection<String> names(final XML xml, final String tojo) {
         return new SetOf<>(
             new Mapped<>(
                 (String name) -> this.versioned(name, tojo).toString(),
@@ -155,16 +155,15 @@ public final class DiscoverMojo extends SafeMojo {
      * @param tojo Current tojo.
      * @return Versioned object name.
      */
-    private ObjectName versioned(final String name, final ForeignTojo tojo) {
-        final String identifier = tojo.identifier();
+    private ObjectName versioned(final String name, final String tojo) {
         final ObjectName replaced = new OnReplaced(name, this.hashes);
         return new OnSwap(
             this.withVersions,
             new OnSwap(
-                identifier.contains(OnReplaced.DELIMITER),
+                tojo.contains(OnReplaced.DELIMITER),
                 new OnVersioned(
                     replaced,
-                    new OnDefault(identifier)::hash,
+                    new OnDefault(tojo)::hash,
                     true
                 ),
                 replaced

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -92,6 +92,7 @@ public final class DiscoverMojo extends SafeMojo {
      * Pull all deps found in the provided XML file.
      *
      * @param file The .xmir file
+     * @param tojo Current tojo.
      * @return List of foreign objects found
      */
     private Collection<String> discover(final Path file, final ForeignTojo tojo) {
@@ -118,6 +119,7 @@ public final class DiscoverMojo extends SafeMojo {
      * Get a unique list of object names from given XML.
      *
      * @param xml XML.
+     * @param tojo Current tojo.
      * @return Object names.
      */
     private Collection<String> names(final XML xml, final ForeignTojo tojo) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.name;
+
+import org.eolang.maven.hash.CommitHash;
+
+/**
+ * Default object name that just split given raw string to name and hash.
+ */
+public final class OnDefault implements ObjectName {
+
+    /**
+     * Raw string.
+     */
+    private final String raw;
+
+    /**
+     * Ctor.
+     * @param object Object name with hash.
+     */
+    public OnDefault(final String object) {
+        this.raw = object;
+    }
+
+    @Override
+    public String value() {
+        return this.split()[0];
+    }
+
+    @Override
+    public CommitHash hash() {
+        return new CommitHash.ChConstant(this.split()[1]);
+    }
+
+    /**
+     * Split raw to name and hash.
+     * @return Split raw
+     */
+    private String[] split() {
+        return this.raw.split(String.format("\\%s", OnReplaced.DELIMITER));
+    }
+
+    @Override
+    public String toString() {
+        return this.raw;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnDefault.java
@@ -27,6 +27,8 @@ import org.eolang.maven.hash.CommitHash;
 
 /**
  * Default object name that just split given raw string to name and hash.
+ *
+ * @since 0.31.0
  */
 public final class OnDefault implements ObjectName {
 
@@ -53,16 +55,16 @@ public final class OnDefault implements ObjectName {
         return new CommitHash.ChConstant(this.split()[1]);
     }
 
+    @Override
+    public String toString() {
+        return this.raw;
+    }
+
     /**
      * Split raw to name and hash.
      * @return Split raw
      */
     private String[] split() {
         return this.raw.split(String.format("\\%s", OnReplaced.DELIMITER));
-    }
-
-    @Override
-    public String toString() {
-        return this.raw;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
@@ -57,8 +57,9 @@ public final class OnReplaced implements ObjectName {
      * Delimiter between name and hash in EO object name.
      * @todo #2394:30min Hide static constant DELIMITER.
      *  We should hide static constant DELIMITER because it creates code duplication
-     *  in many places. For example in {@link OnReplaced#split()} and {@link OnVersioned#split()}
-     *  and {@link org.eolang.maven.Place#make(java.nio.file.Path, String)}.
+     *  in many places. For example in {@link OnReplaced#split()}, {@link OnVersioned#split()},
+     *  {@link OnDefault#split()} and
+     *  {@link org.eolang.maven.Place#make(java.nio.file.Path, String)}.
      *  Apparently we have to create a class which will parse raw string into two parts value and
      *  optional version. Maybe this new class won't implement ObjectName interface.
      *  Why static fields are bad you can read here:

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.name;
 
+import org.cactoos.Scalar;
 import org.cactoos.scalar.Unchecked;
 import org.eolang.maven.hash.CommitHash;
 
@@ -42,7 +43,7 @@ public final class OnVersioned implements ObjectName {
     /**
      * Default hash.
      */
-    private final CommitHash hsh;
+    private final Unchecked<CommitHash> hsh;
 
     /**
      * Put default hash forcibly.
@@ -55,17 +56,21 @@ public final class OnVersioned implements ObjectName {
      * @param hash Default hash if a version in full name is absent.
      */
     public OnVersioned(final ObjectName origin, final CommitHash hash) {
-        this(origin, hash, false);
+        this(origin, () -> hash, false);
     }
 
     /**
      * Ctor.
      * @param origin Origin object name
-     * @param hash Default hash if a version in full name is absent.
-     * @param force Put a default version forcibly.
+     * @param hash Default hash if a version in full name is absent
+     * @param force Put a default version forcibly
      */
-    public OnVersioned(final ObjectName origin, final CommitHash hash, final boolean force) {
-        this(new Unchecked<>(origin::toString), hash, force);
+    public OnVersioned(
+        final ObjectName origin,
+        final Scalar<CommitHash> hash,
+        final boolean force
+    ) {
+        this(new Unchecked<>(origin::toString), new Unchecked<>(hash), force);
     }
 
     /**
@@ -85,7 +90,7 @@ public final class OnVersioned implements ObjectName {
      * @param def Default hash if a version in full name is absent.
      */
     public OnVersioned(final String object, final CommitHash def) {
-        this(new Unchecked<>(() -> object), def, false);
+        this(new Unchecked<>(() -> object), new Unchecked<>(() -> def), false);
     }
 
     /**
@@ -94,7 +99,7 @@ public final class OnVersioned implements ObjectName {
      * @param def Default hash if a version in full name is absent.
      * @param force Put a default version forcibly.
      */
-    private OnVersioned(final Unchecked<String> object, final CommitHash def, final boolean force) {
+    private OnVersioned(final Unchecked<String> object, final Unchecked<CommitHash> def, final boolean force) {
         this.object = object;
         this.hsh = def;
         this.force = force;
@@ -126,7 +131,7 @@ public final class OnVersioned implements ObjectName {
     private String[] split() {
         String[] splt = this.object.value().split(String.format("\\%s", OnReplaced.DELIMITER));
         if (splt.length == 1 || this.force) {
-            splt = new String[]{splt[0], this.hsh.value()};
+            splt = new String[]{splt[0], this.hsh.value().value()};
         }
         return splt;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -62,6 +62,7 @@ public final class OnVersioned implements ObjectName {
      * Ctor.
      * @param origin Origin object name
      * @param hash Default hash if a version in full name is absent.
+     * @param force Put a default version forcibly.
      */
     public OnVersioned(final ObjectName origin, final CommitHash hash, final boolean force) {
         this(new Unchecked<>(origin::toString), hash, force);
@@ -75,18 +76,7 @@ public final class OnVersioned implements ObjectName {
      * @param hash Default hash if a version in full name is absent.
      */
     public OnVersioned(final String object, final String hash) {
-        this(object, hash, false);
-    }
-
-    /**
-     * Ctor.
-     * Please use the constructor for tests only because it can't guarantee
-     * that {@code hash} is actually hash but not a random string.
-     * @param object Object full name with a version or not.
-     * @param hash Default hash if a version in full name is absent.
-     */
-    public OnVersioned(final String object, final String hash, final boolean force) {
-        this(object, new CommitHash.ChConstant(hash), force);
+        this(object, new CommitHash.ChConstant(hash));
     }
 
     /**
@@ -100,17 +90,9 @@ public final class OnVersioned implements ObjectName {
 
     /**
      * Ctor.
-     * @param object Object full name with a version or not.
-     * @param def Default hash if a version in full name is absent.
-     */
-    public OnVersioned(final String object, final CommitHash def, final boolean force) {
-        this(new Unchecked<>(() -> object), def, force);
-    }
-
-    /**
-     * Ctor.
      * @param object Object full name with a version or not as scalar.
      * @param def Default hash if a version in full name is absent.
+     * @param force Put a default version forcibly.
      */
     private OnVersioned(final Unchecked<String> object, final CommitHash def, final boolean force) {
         this.object = object;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -45,12 +45,26 @@ public final class OnVersioned implements ObjectName {
     private final CommitHash hsh;
 
     /**
+     * Put default hash forcibly.
+     */
+    private final boolean force;
+
+    /**
      * Ctor.
      * @param origin Origin object name
      * @param hash Default hash if a version in full name is absent.
      */
     public OnVersioned(final ObjectName origin, final CommitHash hash) {
-        this(new Unchecked<>(origin::toString), hash);
+        this(origin, hash, false);
+    }
+
+    /**
+     * Ctor.
+     * @param origin Origin object name
+     * @param hash Default hash if a version in full name is absent.
+     */
+    public OnVersioned(final ObjectName origin, final CommitHash hash, final boolean force) {
+        this(new Unchecked<>(origin::toString), hash, force);
     }
 
     /**
@@ -61,7 +75,18 @@ public final class OnVersioned implements ObjectName {
      * @param hash Default hash if a version in full name is absent.
      */
     public OnVersioned(final String object, final String hash) {
-        this(object, new CommitHash.ChConstant(hash));
+        this(object, hash, false);
+    }
+
+    /**
+     * Ctor.
+     * Please use the constructor for tests only because it can't guarantee
+     * that {@code hash} is actually hash but not a random string.
+     * @param object Object full name with a version or not.
+     * @param hash Default hash if a version in full name is absent.
+     */
+    public OnVersioned(final String object, final String hash, final boolean force) {
+        this(object, new CommitHash.ChConstant(hash), force);
     }
 
     /**
@@ -70,7 +95,16 @@ public final class OnVersioned implements ObjectName {
      * @param def Default hash if a version in full name is absent.
      */
     public OnVersioned(final String object, final CommitHash def) {
-        this(new Unchecked<>(() -> object), def);
+        this(new Unchecked<>(() -> object), def, false);
+    }
+
+    /**
+     * Ctor.
+     * @param object Object full name with a version or not.
+     * @param def Default hash if a version in full name is absent.
+     */
+    public OnVersioned(final String object, final CommitHash def, final boolean force) {
+        this(new Unchecked<>(() -> object), def, force);
     }
 
     /**
@@ -78,9 +112,10 @@ public final class OnVersioned implements ObjectName {
      * @param object Object full name with a version or not as scalar.
      * @param def Default hash if a version in full name is absent.
      */
-    private OnVersioned(final Unchecked<String> object, final CommitHash def) {
+    private OnVersioned(final Unchecked<String> object, final CommitHash def, final boolean force) {
         this.object = object;
         this.hsh = def;
+        this.force = force;
     }
 
     @Override
@@ -108,7 +143,7 @@ public final class OnVersioned implements ObjectName {
      */
     private String[] split() {
         String[] splt = this.object.value().split(String.format("\\%s", OnReplaced.DELIMITER));
-        if (splt.length == 1) {
+        if (splt.length == 1 || this.force) {
             splt = new String[]{splt[0], this.hsh.value()};
         }
         return splt;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -99,7 +99,11 @@ public final class OnVersioned implements ObjectName {
      * @param def Default hash if a version in full name is absent.
      * @param force Put a default version forcibly.
      */
-    private OnVersioned(final Unchecked<String> object, final Unchecked<CommitHash> def, final boolean force) {
+    private OnVersioned(
+        final Unchecked<String> object,
+        final Unchecked<CommitHash> def,
+        final boolean force
+    ) {
         this.object = object;
         this.hsh = def;
         this.force = force;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnVersioned.java
@@ -46,31 +46,21 @@ public final class OnVersioned implements ObjectName {
     private final Unchecked<CommitHash> hsh;
 
     /**
-     * Put default hash forcibly.
+     * Ctor.
+     * @param origin Origin object name
+     * @param hash Default hash if a version in full name is absent.
      */
-    private final boolean force;
+    public OnVersioned(final ObjectName origin, final CommitHash hash) {
+        this(origin, () -> hash);
+    }
 
     /**
      * Ctor.
      * @param origin Origin object name
      * @param hash Default hash if a version in full name is absent.
      */
-    public OnVersioned(final ObjectName origin, final CommitHash hash) {
-        this(origin, () -> hash, false);
-    }
-
-    /**
-     * Ctor.
-     * @param origin Origin object name
-     * @param hash Default hash if a version in full name is absent
-     * @param force Put a default version forcibly
-     */
-    public OnVersioned(
-        final ObjectName origin,
-        final Scalar<CommitHash> hash,
-        final boolean force
-    ) {
-        this(new Unchecked<>(origin::toString), new Unchecked<>(hash), force);
+    public OnVersioned(final ObjectName origin, final Scalar<CommitHash> hash) {
+        this(new Unchecked<>(origin::toString), new Unchecked<>(hash));
     }
 
     /**
@@ -90,23 +80,17 @@ public final class OnVersioned implements ObjectName {
      * @param def Default hash if a version in full name is absent.
      */
     public OnVersioned(final String object, final CommitHash def) {
-        this(new Unchecked<>(() -> object), new Unchecked<>(() -> def), false);
+        this(new Unchecked<>(() -> object), new Unchecked<>(() -> def));
     }
 
     /**
      * Ctor.
      * @param object Object full name with a version or not as scalar.
      * @param def Default hash if a version in full name is absent.
-     * @param force Put a default version forcibly.
      */
-    private OnVersioned(
-        final Unchecked<String> object,
-        final Unchecked<CommitHash> def,
-        final boolean force
-    ) {
+    private OnVersioned(final Unchecked<String> object, final Unchecked<CommitHash> def) {
         this.object = object;
         this.hsh = def;
-        this.force = force;
     }
 
     @Override
@@ -134,7 +118,7 @@ public final class OnVersioned implements ObjectName {
      */
     private String[] split() {
         String[] splt = this.object.value().split(String.format("\\%s", OnReplaced.DELIMITER));
-        if (splt.length == 1 || this.force) {
+        if (splt.length == 1) {
             splt = new String[]{splt[0], this.hsh.value().value()};
         }
         return splt;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -175,24 +175,45 @@ final class DiscoverMojoTest {
     }
 
     @Test
-    void discoversDifferentUnversionedObjectsFromDifferentVersionedObjects(
-        @TempDir final Path tmp
-    ) throws IOException {
+    void discoversDifferentUnversionedObjectsFromDifferentVersionedObjects(@TempDir final Path tmp)
+        throws IOException {
+        final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
+        final String format = "+version %s\n";
+        final String tail = "[] > main\n  \"Hello\" > x";
+        final String one = "0.28.1";
+        final String two = "0.28.2";
+        final String string = "org.eolang.string";
         final ForeignTojos tojos = new FakeMaven(tmp)
             .with("withVersions", true)
-            .withProgram(
-                "+version 0.0.1\n",
-                "[] > main",
-                "  \"Hello\" > x"
-            )
-            .withProgram(
-                "+version 0.0.2\n",
-                "[] > main",
-                "  \"Hello\" > x"
-            )
+            .withProgram(String.format(format, one), tail)
+            .withProgram(String.format(format, two), tail)
+            .withProgram(tail)
             .execute(new FakeMaven.Discover())
             .externalTojos();
-
+        MatcherAssert.assertThat(
+            String.format(
+                "Tojos should contained %s object with version %s from meta, but they didn't",
+                string, one
+            ),
+            tojos.contains(new OnVersioned(string, hashes.get(one))),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Tojos should contained %s object with version %s from meta, but they didn't",
+                string, two
+            ),
+            tojos.contains(new OnVersioned(string, hashes.get(two))),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Tojos should contained unversioned %s object, but they didn't"
+                string
+            ),
+            tojos.contains(string),
+            Matchers.is(true)
+        );
     }
 
     @Test

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -181,10 +181,12 @@ final class DiscoverMojoTest {
     void discoversDifferentUnversionedObjectsFromDifferentVersionedObjects(@TempDir final Path tmp)
         throws IOException {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
-        final String program = String.join("\n", "[] > sprintf", "  \"Hello world\" > @");
+        final String first = String.join("\n", "[] > sprintf", "  text > @");
+        final String second = String.join("\n", "[] > sprintf", "  text|0.28.5 > @");
         final String one = hashes.get("0.28.1").value();
         final String two = hashes.get("0.28.2").value();
-        final String string = "org.eolang.string";
+        final String three = hashes.get("0.28.5").value();
+        final String string = "org.eolang.text";
         final String sprintf = "foo/x/sprintf";
         final String object = "foo.x.sprintf";
         final String ext = "%s.eo";
@@ -193,17 +195,17 @@ final class DiscoverMojoTest {
             .with("withVersions", true)
             .withProgram(
                 Paths.get(String.format(format, sprintf, one)),
-                program,
+                first,
                 new OnVersioned(object, one)
             )
             .withProgram(
                 Paths.get(String.format(format, sprintf, two)),
-                program,
+                second,
                 new OnVersioned(object, two)
             )
             .withProgram(
                 Paths.get(String.format(ext, sprintf)),
-                program,
+                first,
                 new OnDefault(object)
             )
             .execute(new FakeMaven.Discover())
@@ -212,11 +214,11 @@ final class DiscoverMojoTest {
             String.format(
                 "Tojos should contained 3 similar objects %s: 2 with different hashes %s and one without; but they didn't",
                 string,
-                Arrays.toString(new String[]{one, two})
+                Arrays.toString(new String[]{one, three})
             ),
             tojos.contains(
                 new OnVersioned(string, one),
-                new OnVersioned(string, two),
+                new OnVersioned(string, three),
                 new OnDefault(string)
             ),
             Matchers.is(true)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -208,7 +208,7 @@ final class DiscoverMojoTest {
         );
         MatcherAssert.assertThat(
             String.format(
-                "Tojos should contained unversioned %s object, but they didn't"
+                "Tojos should contained unversioned %s object, but they didn't",
                 string
             ),
             tojos.contains(string),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -26,7 +26,6 @@ package org.eolang.maven;
 import com.yegor256.tojos.MnCsv;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -187,27 +186,12 @@ final class DiscoverMojoTest {
         final String two = hashes.get("0.28.2").value();
         final String three = hashes.get("0.28.5").value();
         final String string = "org.eolang.text";
-        final String sprintf = "foo/x/sprintf";
         final String object = "foo.x.sprintf";
-        final String ext = "%s.eo";
-        final String format = String.join("_", "%s", ext);
         final ForeignTojos tojos = new FakeMaven(tmp)
             .with("withVersions", true)
-            .withProgram(
-                Paths.get(String.format(format, sprintf, one)),
-                first,
-                new OnVersioned(object, one)
-            )
-            .withProgram(
-                Paths.get(String.format(format, sprintf, two)),
-                second,
-                new OnVersioned(object, two)
-            )
-            .withProgram(
-                Paths.get(String.format(ext, sprintf)),
-                first,
-                new OnDefault(object)
-            )
+            .withProgram(first, new OnVersioned(object, one))
+            .withProgram(second, new OnVersioned(object, two))
+            .withProgram(first, new OnDefault(object))
             .execute(new FakeMaven.Discover())
             .externalTojos();
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -172,7 +172,7 @@ final class DiscoverMojoTest {
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-           String.format(DiscoverMojoTest.SHOULD_CONTAIN, second),
+            String.format(DiscoverMojoTest.SHOULD_CONTAIN, second),
             tojos.contains(second),
             Matchers.is(true)
         );
@@ -213,7 +213,7 @@ final class DiscoverMojoTest {
             String.format(
                 "Tojos should contained 3 similar objects %s: 2 with different hashes %s and one without; but they didn't",
                 string,
-                Arrays.toString(new String[]{one,two})
+                Arrays.toString(new String[]{one, two})
             ),
             tojos.contains(
                 new OnVersioned(string, one),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -38,7 +38,6 @@ import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.eolang.maven.name.ObjectName;
 import org.eolang.maven.name.OnDefault;
-import org.eolang.maven.name.OnReplaced;
 import org.eolang.maven.name.OnVersioned;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.ForeignTojos;
@@ -189,7 +188,7 @@ final class DiscoverMojoTest {
         final String sprintf = "foo/x/sprintf";
         final String object = "foo.x.sprintf";
         final String ext = "%s.eo";
-        final String format = String.join(OnReplaced.DELIMITER, "%s", ext);
+        final String format = String.join("_", "%s", ext);
         final ForeignTojos tojos = new FakeMaven(tmp)
             .with("withVersions", true)
             .withProgram(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -175,6 +175,27 @@ final class DiscoverMojoTest {
     }
 
     @Test
+    void discoversDifferentUnversionedObjectsFromDifferentVersionedObjects(
+        @TempDir final Path tmp
+    ) throws IOException {
+        final ForeignTojos tojos = new FakeMaven(tmp)
+            .with("withVersions", true)
+            .withProgram(
+                "+version 0.0.1\n",
+                "[] > main",
+                "  \"Hello\" > x"
+            )
+            .withProgram(
+                "+version 0.0.2\n",
+                "[] > main",
+                "  \"Hello\" > x"
+            )
+            .execute(new FakeMaven.Discover())
+            .externalTojos();
+
+    }
+
+    @Test
     void doesNotDiscoverWithVersions(@TempDir final Path tmp) throws IOException {
         final FakeMaven maven = new FakeMaven(tmp)
             .with("withVersions", false)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -378,23 +378,6 @@ public final class FakeMaven {
      */
     FakeMaven withProgram(final String... program) throws IOException {
         return this.withProgram(
-            Paths.get(
-                String.format("foo/x/main%s.eo", FakeMaven.suffix(this.current.get()))
-            ),
-            program
-        );
-    }
-
-    /**
-     * Adds eo program to a workspace.
-     * @param path Path to save EO program.
-     * @param program Program as a raw string.
-     * @return The same maven instance.
-     * @throws IOException If method can't save eo program to the workspace.
-     */
-    FakeMaven withProgram(final Path path, final String... program) throws IOException {
-        return this.withProgram(
-            path,
             String.join("\n", program),
             new OnDefault(FakeMaven.tojoId(this.current.get()))
         );
@@ -413,14 +396,16 @@ public final class FakeMaven {
 
     /**
      * Adds eo program to a workspace.
-     * @param path Path to save EO program.
      * @param content EO program content.
      * @param object Object name to save in tojos.
      * @return The same maven instance.
      * @throws IOException If method can't save eo program to the workspace.
      */
-    FakeMaven withProgram(final Path path, final String content, final ObjectName object)
+    FakeMaven withProgram(final String content, final ObjectName object)
         throws IOException {
+        final Path path = Paths.get(
+            String.format("foo/x/main%s.eo", FakeMaven.suffix(this.current.get()))
+        );
         this.workspace.save(content, path);
         final String scope = this.scope();
         final String version = "0.25.0";

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -453,7 +453,7 @@ public final class FakeMaven {
      * @return Tojo entry.
      */
     ForeignTojo programTojo() {
-        return this.foreignTojos().find(this.tojoId(this.current.get() - 1));
+        return this.foreignTojos().find(FakeMaven.tojoId(this.current.get() - 1));
     }
 
     /**
@@ -461,7 +461,7 @@ public final class FakeMaven {
      * @return Tojo entry.
      */
     ForeignTojo programExternalTojo() {
-        return this.externalTojos().find(this.tojoId(this.current.get() - 1));
+        return this.externalTojos().find(FakeMaven.tojoId(this.current.get() - 1));
     }
 
     /**
@@ -513,7 +513,7 @@ public final class FakeMaven {
             String.format("foo/x/main%s.eo", FakeMaven.suffix(this.current.get()))
         );
         this.workspace.save(content, path);
-        final String object = this.tojoId(this.current.get());
+        final String object = FakeMaven.tojoId(this.current.get());
         final String scope = this.scope();
         final String version = "0.25.0";
         final Path source = this.workspace.absolute(path);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -384,6 +384,7 @@ public final class FakeMaven {
             program
         );
     }
+
     /**
      * Adds eo program to a workspace.
      * @param path Path to save EO program.
@@ -391,7 +392,7 @@ public final class FakeMaven {
      * @return The same maven instance.
      * @throws IOException If method can't save eo program to the workspace.
      */
-    FakeMaven withProgram(final Path path, final String ...program) throws IOException {
+    FakeMaven withProgram(final Path path, final String... program) throws IOException {
         return this.withProgram(
             path,
             String.join("\n", program),
@@ -412,7 +413,9 @@ public final class FakeMaven {
 
     /**
      * Adds eo program to a workspace.
+     * @param path Path to save EO program.
      * @param content EO program content.
+     * @param object Object name to save in tojos.
      * @return The same maven instance.
      * @throws IOException If method can't save eo program to the workspace.
      */


### PR DESCRIPTION
Ref: #1602

More details [here](https://github.com/objectionary/eo/issues/1602#issuecomment-1686546967)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on hiding a static constant `DELIMITER` to avoid code duplication in multiple places. 

### Detailed summary
- Updated the `OnReplaced` class to include `OnDefault` in the list of places where `DELIMITER` is used.
- Added a new class `OnDefault` to handle default object names.
- Updated the `DiscoverMojo` class to use the `OnDefault` class for object discovery.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->