### PR TITLE
feat(#2438): memory with limit

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml
@@ -87,7 +87,7 @@ eo: |
 
   test
     me
-      now:i (f (f (f (f 1)))).f
+      now (f (f (f (f 1)))).f
 
   [] > ooo
     # This is one

--- a/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
@@ -90,7 +90,9 @@ public final class AtMemoized implements Attr {
     @Override
     public void put(final Phi phi) {
         final byte[] bytes = new Param(phi, "Δ").asBytes().take();
-        if (this.length != null && this.length < bytes.length) {
+        if (this.length == null) {
+            this.length = bytes.length;
+        } else if (this.length < bytes.length) {
             throw new ExFailure(
                 "Can't write to memory %d bytes because %d were already allocated",
                 bytes.length,
@@ -98,7 +100,6 @@ public final class AtMemoized implements Attr {
             );
         }
         this.object = new Data.ToPhi(bytes);
-        this.length = bytes.length;
     }
 
     @Override

--- a/eo-runtime/src/test/eo/org/eolang/memory-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/memory-tests.eo
@@ -45,7 +45,7 @@
     $.equal-to 10
 
 [] > double-writes
-  memory 0 > m
+  memory "1234567890123" > m
   assert-that > @
     seq
       m.write "Hello, world!"

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
@@ -27,6 +27,7 @@
  */
 package EOorg.EOeolang;
 
+import org.cactoos.scalar.True;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhCopy;
@@ -35,6 +36,7 @@ import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -250,5 +252,31 @@ public final class EOmemoryTest {
         );
     }
 
+    @Test
+    public void doesNotWriteMoreThanAllocated() {
+        final Phi mem = new EOmemory(Phi.Φ);
+        mem.attr(0).put(new Data.ToPhi(true));
+        Assertions.assertThrows(
+            EOerror.ExError.class,
+            () -> new Dataized(
+                new PhWith(
+                    mem.attr(EOmemoryTest.WRITE).get(),
+                    0, new Data.ToPhi(8L)
+                )
+            ).take()
+        );
+    }
 
+    @Test
+    public void writesLessAndRewritesTheSame() {
+        final Phi mem = new EOmemory(Phi.Φ);
+        mem.attr(0).put(new Data.ToPhi(2L));
+        final Phi write = mem.attr(EOmemoryTest.WRITE).get().copy();
+        new Dataized(new PhWith(write, 0, new Data.ToPhi(true))).take();
+        Assertions.assertDoesNotThrow(
+            () -> new Dataized(
+                new PhWith(write, 0, new Data.ToPhi(1L))
+            ).take()
+        );
+    }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
@@ -271,11 +271,11 @@ public final class EOmemoryTest {
     public void writesLessAndRewritesTheSame() {
         final Phi mem = new EOmemory(Phi.Φ);
         mem.attr(0).put(new Data.ToPhi(2L));
-        final Phi write = mem.attr(EOmemoryTest.WRITE).get().copy();
-        new Dataized(new PhWith(write, 0, new Data.ToPhi(true))).take();
+        final Phi write = mem.attr(EOmemoryTest.WRITE).get();
+        new Dataized(new PhWith(write.copy(), 0, new Data.ToPhi(true))).take();
         Assertions.assertDoesNotThrow(
             () -> new Dataized(
-                new PhWith(write, 0, new Data.ToPhi(1L))
+                new PhWith(write.copy(), 0, new Data.ToPhi(1L))
             ).take()
         );
     }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
@@ -250,4 +250,5 @@ public final class EOmemoryTest {
         );
     }
 
+
 }


### PR DESCRIPTION
Closes: #2438 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing memory allocation and writing in the EO runtime.

### Detailed summary:
- Fixed a bug in the `AtMemoized` class where the length of allocated bytes was not being tracked correctly.
- Added a check to ensure that memory is not written more than the allocated length.
- Added test cases to cover the fixed and new functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->