### PR TITLE
Dataize returns u8 array

### DIFF
--- a/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
@@ -98,7 +98,7 @@ impl<'local> EOEnv<'_> {
         }
     }
 
-    pub fn dataize(&mut self, v: u32) -> Option<Vec<i8>> {
+    pub fn dataize(&mut self, v: u32) -> Option<Vec<u8>> {
         let java_array = JByteArray::from(
             self.java_env
             .call_method(
@@ -114,6 +114,7 @@ impl<'local> EOEnv<'_> {
         if self.java_env.get_byte_array_region(&java_array, 0, &mut bytes[0..]).is_err() {
             return None;
         }
-        return Some(bytes);
+        let unsigned = unsafe { &*(&bytes[0..] as *const _  as *const [u8]) };
+        return Some(unsigned.to_vec());
     }
 }

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -237,15 +237,12 @@
 
     pub fn foo(env: &mut EOEnv) -> EO {
       let a = env.find("^.a") as u32;
-      let b = env.find("^.b") as u32;
       let bytes_a = env.dataize(a).unwrap();
-      let mut arr_a = unsafe { &*(&bytes_a[0..] as *const _  as *const [u8]) };
+      let a = bytes_a.as_slice().read_i64::<BigEndian>().unwrap();
 
+      let b = env.find("^.b") as u32;
       let bytes_b = env.dataize(b).unwrap();
-      let mut arr_b = unsafe { &*(&bytes_b[0..] as *const _  as *const [u8]) };
-
-      let a = arr_a.read_i64::<BigEndian>().unwrap();
-      let b = arr_b.read_i64::<BigEndian>().unwrap();
+      let b = bytes_b.as_slice().read_i64::<BigEndian>().unwrap();
       println!("sum 5 + 10 = {}", a + b);
 
       EOInt(a + b)


### PR DESCRIPTION
Closes: #2445 
`eo_env.dataize` should return `Vec<u8>` in order to avoid unsafe operations in the insert.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the `dataize` function in `eo_env.rs` to return a `Vec<u8>` instead of `Vec<i8>`. It also updates the usage of `dataize` in `rust-tests.eo` to handle the new return type. 

### Detailed summary
- Changed `dataize` function in `eo_env.rs` to return `Vec<u8>` instead of `Vec<i8>`
- Updated usage of `dataize` in `rust-tests.eo` to handle new return type

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->