### PR TITLE
feat(#2327): remove the old hash attribute

### DIFF
--- a/eo-maven-plugin/src/it/custom_goals/pom.xml
+++ b/eo-maven-plugin/src/it/custom_goals/pom.xml
@@ -36,7 +36,6 @@ SOFTWARE.
         <configuration>
           <foreign>${project.basedir}/target/eo/foreign.csv</foreign>
           <foreignFormat>csv</foreignFormat>
-          <hash>master</hash>
         </configuration>
         <executions>
           <execution>

--- a/eo-maven-plugin/src/it/duplicate_classes/pom.xml
+++ b/eo-maven-plugin/src/it/duplicate_classes/pom.xml
@@ -60,9 +60,6 @@ SOFTWARE.
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
         <version>@project.version@</version>
-        <configuration>
-          <hash>master</hash>
-        </configuration>
         <executions>
           <execution>
             <id>compile</id>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -90,19 +90,6 @@ public final class AssembleMojo extends SafeMojo {
     private boolean overWrite;
 
     /**
-     * The Git tag to pull objects from, in objectionary.
-     * @since 0.21.0
-     * @todo #2302:30min Rename the parameter "hash". This parameter is actually
-     *  a tag, not a hash. By this tag application actually finds hash and then
-     *  uses it. So need to rename this parameter to "tag" and rename it in all
-     *  places where it's used. Also it would be better to use name "hash" for
-     *  parameter "hsh" in {@link ProbeMojo} and {@link PullMojo}
-     */
-    @SuppressWarnings("PMD.ImmutableField")
-    @Parameter(property = "eo.hash", required = true, defaultValue = "master")
-    private String hash = "master";
-
-    /**
      * Skip artifact with the version 0.0.0.
      * @checkstyle MemberNameCheck (7 lines)
      * @since 0.9.0

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -86,7 +86,7 @@ public final class ProbeMojo extends SafeMojo {
      * @since 0.29.6
      */
     @SuppressWarnings("PMD.ImmutableField")
-    private CommitHash hsh;
+    private CommitHash hash;
 
     /**
      * Objectionaries.
@@ -99,8 +99,8 @@ public final class ProbeMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        if (this.hsh == null) {
-            this.hsh = new ChCached(
+        if (this.hash == null) {
+            this.hash = new ChCached(
                 new ChNarrow(
                     new ChRemote(this.tag)
                 )
@@ -129,7 +129,7 @@ public final class ProbeMojo extends SafeMojo {
                 new ChNarrow(
                     new OnSwap(
                         this.withVersions,
-                        new OnVersioned(tojo.identifier(), this.hsh)
+                        new OnVersioned(tojo.identifier(), this.hash)
                     ).hash()
                 )
             ).withProbed(count);
@@ -168,7 +168,7 @@ public final class ProbeMojo extends SafeMojo {
                         this.withVersions,
                         new OnVersioned(
                             new OnReplaced(ProbeMojo.noPrefix(obj), this.hashes),
-                            this.hsh
+                            this.hash
                         )
                     )
                 ),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -77,7 +77,7 @@ public final class PullMojo extends SafeMojo {
      * @since 0.29.6
      */
     @SuppressWarnings("PMD.ImmutableField")
-    private CommitHash hsh;
+    private CommitHash hash;
 
     /**
      * Objectionaries.
@@ -99,8 +99,8 @@ public final class PullMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        if (this.hsh == null) {
-            this.hsh = new ChCached(
+        if (this.hash == null) {
+            this.hash = new ChCached(
                 new ChNarrow(
                     new ChRemote(this.tag)
                 )
@@ -112,7 +112,7 @@ public final class PullMojo extends SafeMojo {
             final ObjectName name = new OnCached(
                 new OnSwap(
                     this.withVersions,
-                    new OnVersioned(tojo.identifier(), this.hsh)
+                    new OnVersioned(tojo.identifier(), this.hash)
                 )
             );
             names.add(name);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -95,7 +95,7 @@ final class ProbeMojoTest {
             ),
             new FakeMaven(temp)
                 .with(
-                    "hsh",
+                    "hash",
                     new ChCached(
                         new ChText(temp.resolve("tags.txt"), tag)
                     )
@@ -113,7 +113,7 @@ final class ProbeMojoTest {
         MatcherAssert.assertThat(
             "The hash of the program tojo should be equal to the given hash pattern",
             new FakeMaven(temp)
-                .with("hsh", new ChPattern("*.*.*:abcdefg", "1.0.0"))
+                .with("hash", new ChPattern("*.*.*:abcdefg", "1.0.0"))
                 .withProgram(ProbeMojoTest.program())
                 .execute(new FakeMaven.Probe())
                 .programTojo()
@@ -150,7 +150,7 @@ final class ProbeMojoTest {
     void findsProbesWithVersionsInOneObjectionary(@TempDir final Path temp) throws IOException {
         final CommitHash hash = new CommitHashesMap.Fake().get("0.28.5");
         final FakeMaven maven = new FakeMaven(temp)
-            .with("hsh", hash)
+            .with("hash", hash)
             .with("objectionaries", new Objectionaries.Fake(new OyRemote(hash)))
             .with("withVersions", true)
             .withVersionedHelloWorld()
@@ -191,7 +191,7 @@ final class ProbeMojoTest {
                 )
             )
             .with("withVersions", true)
-            .with("hsh", first)
+            .with("hash", first)
             .withVersionedProgram()
             .execute(new FakeMaven.Probe());
         final ObjectName text = new OnVersioned("org.eolang.txt.text", "5f82cc1");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -124,7 +124,7 @@ final class PullMojoTest {
             .withVersion("*.*.*");
         maven.with("skip", false)
             .with(
-                "hsh",
+                "hash",
                 new ChCached(new ChText(temp.resolve("tags.txt"), "master"))
             )
             .execute(PullMojo.class);
@@ -147,7 +147,7 @@ final class PullMojoTest {
             .withVersion("*.*.*");
         maven.with("skip", false)
             .with(
-                "hsh",
+                "hash",
                 new ChCached(new ChPattern("*.*.*:abcdefg", "1.0.0"))
             )
             .execute(PullMojo.class);
@@ -234,7 +234,7 @@ final class PullMojoTest {
                 )
             )
             .with("withVersions", true)
-            .with("hsh", fourth)
+            .with("hash", fourth)
             .withVersionedProgram()
             .execute(new FakeMaven.Pull());
         final ObjectName sprintf = new OnVersioned("org.eolang.txt.sprintf", "17f8929");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/it/SnippetTestCase.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/it/SnippetTestCase.java
@@ -181,7 +181,7 @@ final class SnippetTestCase {
             .withProgram(code)
             .with("sourcesDir", src.toFile())
             .with("objects", Arrays.asList("org.eolang.bool"))
-            .with("hsh", hash)
+            .with("hash", hash)
             .with("objectionaries", new Objectionaries.Fake(new OyFilesystem()));
         maven.execute(RegisterMojo.class);
         maven.execute(DemandMojo.class);

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -131,7 +131,6 @@ SOFTWARE.
         <configuration>
           <foreign>${project.basedir}/target/eo-foreign.csv</foreign>
           <foreignFormat>csv</foreignFormat>
-          <hash>master</hash>
           <failOnWarning>true</failOnWarning>
         </configuration>
         <executions>


### PR DESCRIPTION
Remove the old `hash` attribute from `AssembleMojo` and rename new `hsh` attribute to `hash`.

Closes: #2327


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed `hsh` parameter to `hash` in `PullMojo` and `ProbeMojo` classes.
- Updated references to the renamed parameter in affected classes.
- Removed unused `hash` parameter from `pom.xml` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->