### PR TITLE
fix(#2435): tests that uses memory

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/heap.eo
+++ b/eo-runtime/src/main/eo/org/eolang/heap.eo
@@ -35,7 +35,7 @@
     memory 0 > next
     plus. > new-next!
       s
-      ^.malloc.next
+      ^.malloc.next.as-int
     if. > @
       gt.
         new-next
@@ -47,7 +47,7 @@
           ^.malloc.next
           new-next
         0.plus
-          ^.malloc.next
+          ^.malloc.next.as-int
 
   # Freed a block in memory, which is referred by the
   # given pointer, which was earlier obtained with malloc().

--- a/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
@@ -100,6 +100,7 @@ public final class AtMemoized implements Attr {
                 this.length
             );
         }
+        System.out.println(bytes);
         this.object = new Data.ToPhi(bytes);
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
@@ -100,7 +100,6 @@ public final class AtMemoized implements Attr {
                 this.length
             );
         }
-        System.out.println(bytes);
         this.object = new Data.ToPhi(bytes);
     }
 

--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -62,20 +62,19 @@
 
 [] > iterates-over-simple-counter
   memory 0 > x
-  assert-that > res
+  assert-that > @
     and.
       eq.
         x.write 5
         5
       eq.
-        11
         while.
           x.as-int.lt 10
           [i]
-            ^.^.^ > x
-            x.write (x.as-int.plus 1) > @
+            x.write > @
+              x.as-int.plus 1
+        11
     $.equal-to TRUE
-  nop > @
 
 [] > prints-nice-formulas
   memory 0 > x
@@ -166,7 +165,7 @@
 
 [] > complex-bool-expression-in-while
   memory 0 > m
-  assert-that > res
+  assert-that > @
     seq
       m.write 5
       while.
@@ -175,11 +174,14 @@
           TRUE
         [i]
           seq > @
-            m.write (m.as-int.minus 1)
-            stdout (sprintf "%d\n" m.as-int)
+            m.write
+              m.as-int.minus 1
+            stdout
+              sprintf
+                "%d\n"
+                m.as-int
       TRUE
     $.equal-to TRUE
-  nop > @
 
 [] > last-while-dataization-object
   memory 0 > x

--- a/eo-runtime/src/test/eo/org/eolang/heap-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/heap-tests.eo
@@ -46,7 +46,7 @@
   heap 1024 > h!
   h.malloc 64 > p1!
   h.malloc 32 > p2!
-  assert-that > res
+  assert-that > @
     eq.
       seq
         QQ.io.stdout
@@ -57,24 +57,22 @@
         p1
       p2
     $.equal-to FALSE
-  nop > @
 
 [] > mallocs-do-not-overlap
   heap 1024 > h!
   h.malloc 64 > p1!
   h.malloc 32 > p2!
-  assert-that > res
+  assert-that > @
     or.
       p2.gte
         p1.plus 64
       p2.lte
         p1.minus 32
     $.equal-to TRUE
-  nop > @
 
 [] > malloc-return-error
   heap 2 > h!
-  assert-that > res
+  assert-that > @
     try
       []
         h.malloc > @
@@ -84,7 +82,6 @@
       nop
     $.equal-to
       "Allocation failed: bad alloc (not enough memory in the heap)"
-  nop > @
 
 [] > write-and-read-without-error
   heap 1024 > h

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -65,6 +65,7 @@
     anArray.at 0
     $.equal-to 100
 
+# @todo
 [] > tuple-as-a-bound-attribute-size-2
   * > anArray
     1

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -65,7 +65,9 @@
     anArray.at 0
     $.equal-to 100
 
-# @todo
+# @todo #2435:30min Enable test with array-each. assert-that.array-each object
+#  uses memory. So after changing memory behaviour array-each started to work
+#  incorrectly. Need to fix the object and then enable the test
 [] > tuple-as-a-bound-attribute-size-2
   * > anArray
     1

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOboolEOwhileTest.java
@@ -110,7 +110,6 @@ final class EOboolEOwhileTest {
     }
 
     @Test
-    @Disabled
     void loopsOverAbstractObjects() {
         final Phi parent = new Parent(Phi.Φ);
         final Phi toggle = new PhCopy(new PhMethod(parent, "toggle"));
@@ -123,7 +122,7 @@ final class EOboolEOwhileTest {
         MatcherAssert.assertThat(
             new Dataized(
                 new PhWith(
-                    new PhCopy(new PhMethod(toggle, "while")),
+                    toggle.attr("as-bool").get().attr("while").get().copy(),
                     0, new Kid(Phi.Φ, toggle)
                 )
             ).take(),
@@ -132,10 +131,8 @@ final class EOboolEOwhileTest {
     }
 
     @Test
-    @Disabled
     void dataizesComplexBooleanToggle() {
-        final Phi parent = new Parent(Phi.Φ);
-        final Phi toggle = new PhMethod(parent, "toggle");
+        final Phi toggle = new PhMethod(new Parent(Phi.Φ), "toggle");
         new Dataized(
             new PhWith(
                 new PhMethod(toggle, "write"),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmemoryTest.java
@@ -42,14 +42,6 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link EOmemory}.
  *
  * @since 0.1
- * @todo #2211:30min Enable tests that uses memory object.
- *  After memory started behave like bytes some tests had been stopped worked.
- *  Need to refactor and enable disabled tests that uses memory object:
- *  malloc-return-error, complex-bool-expression-in-while,
- *  EOboolEOwhileTest.dataizesComplexBooleanToggle,
- *  EOboolEOwhileTest.loopsOverAbstractObjects,
- *  malloc-returns-different-pointers, mallocs-do-not-overlap,
- *  tuple-as-a-bound-attribute-size-2, iterates-over-simple-counter
  */
 public final class EOmemoryTest {
 


### PR DESCRIPTION
Closes: #2435

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing memory-related issues in the code. 

### Detailed summary
- Added `.as-int` to `^.malloc.next` in `heap.eo`
- Added a TODO comment in `tuple-tests.eo`
- Added a TODO comment in `EOmemoryTest.java`
- Changed `assert-that > res` to `assert-that > @` in `heap-tests.eo`
- Removed `nop > @` in `mallocs-do-not-overlap` test in `heap-tests.eo`
- Changed `assert-that > res` to `assert-that > @` in `malloc-return-error` test in `heap-tests.eo`
- Removed `nop > @` in `write-and-read-without-error` test in `heap-tests.eo`
- Removed `assert-that > res` in `iterates-over-simple-counter` test in `bool-tests.eo`
- Changed `^.^.^ > x` to `x.write` in `iterates-over-simple-counter` test in `bool-tests.eo`
- Removed `nop > @` in `iterates-over-simple-counter` test in `bool-tests.eo`
- Removed `assert-that > res` in `complex-bool-expression-in-while` test in `bool-tests.eo`
- Changed `m.write (m.as-int.minus 1)` to `m.write` and `m.as-int.minus 1` in `complex-bool-expression-in-while` test in `bool-tests.eo`
- Removed `nop > @` in `complex-bool-expression-in-while` test in `bool-tests.eo`
- Removed `@Disabled` annotation in `loopsOverAbstractObjects` test in `EOboolEOwhileTest.java`
- Changed `new PhCopy(new PhMethod(toggle, "while"))` to `toggle.attr("as-bool").get().attr("while").get().copy()` in `loopsOverAbstractObjects` test in `EOboolEOwhileTest.java`
- Removed `@Disabled` annotation in `dataizesComplexBooleanToggle` test in `EOboolEOwhileTest.java`
- Changed `final Phi parent = new Parent(Phi.Φ);` to `final Phi toggle = new PhMethod(new Parent(Phi.Φ), "toggle");` in `dataizesComplexBooleanToggle` test in `EOboolEOwhileTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->