### PR TITLE
feat(#2044): print meaningful cti messages

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/cti/cti-adds-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/cti/cti-adds-errors.xsl
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="cti-adds-errors" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="cti-adds-errors" version="2.0">
   <!--
   For every cti objects add error messages.
   -->
@@ -41,7 +41,7 @@ SOFTWARE.
           <xsl:attribute name="severity">
             <xsl:text>warning</xsl:text>
           </xsl:attribute>
-          <xsl:value-of select="element()[last()]"/>
+          <xsl:value-of select="eo:hex-to-utf8(element()[last()])"/>
         </xsl:element>
       </xsl:for-each>
     </xsl:copy>
@@ -51,4 +51,22 @@ SOFTWARE.
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
   </xsl:template>
+  <!--Converts hex sting into readable UTF-8 string-->
+  <xsl:function name="eo:hex-to-utf8">
+    <xsl:param name="str"/>
+    <xsl:variable name="hex">0123456789ABCDEF</xsl:variable>
+    <xsl:variable name="tail" select="translate($str, ' ', '')"/>
+    <xsl:if test="$tail">
+      <!-- extract first 2 digits -->
+      <xsl:variable name="first" select="substring($tail, 1, 1)"/>
+      <xsl:variable name="second" select="substring($tail, 2, 1)"/>
+      <!-- get their hex values -->
+      <xsl:variable name="val1" select="string-length(substring-before($hex, $first))"/>
+      <xsl:variable name="val2" select="string-length(substring-before($hex, $second))"/>
+      <!-- get the corresponding utf-8 character -->
+      <xsl:variable name="head" select="codepoints-to-string($val1 * 16 + $val2)"/>
+      <!-- recursive call with the rest of the hex string -->
+      <xsl:value-of select="concat($head, eo:hex-to-utf8(substring($tail, 3)))"/>
+    </xsl:if>
+  </xsl:function>
 </xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/cti/cti-adds-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/cti/cti-adds-errors.xsl
@@ -39,7 +39,7 @@ SOFTWARE.
             <xsl:value-of select="@line"/>
           </xsl:attribute>
           <xsl:attribute name="severity">
-            <xsl:text>warning</xsl:text>
+            <xsl:value-of select="eo:hex-to-utf8(element()[last() - 1])"/>
           </xsl:attribute>
           <xsl:value-of select="eo:hex-to-utf8(element()[last()])"/>
         </xsl:element>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-error.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-error.yaml
@@ -5,8 +5,7 @@ tests:
   - /program/errors/error[@check='cti']
   #  '65 72 72 6F 72' == 'error'
   - /program/errors/error[@severity='warning']
-  #  '54 68 69 73 20 6D 65 74 68 6F 64 20 69 73 20 64 65 70 72 65 63 61 74 65 64 21' == 'This method is deprecated!'
-  - /program/errors/error[text()='54 68 69 73 20 6D 65 74 68 6F 64 20 69 73 20 64 65 70 72 65 63 61 74 65 64 21']
+  - /program/errors/error[text()='This method is deprecated!']
 
 eo: |
   [] > foo

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-error.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-error.yaml
@@ -3,8 +3,7 @@ xsls:
 tests:
   - /program/errors[count(*)=1]
   - /program/errors/error[@check='cti']
-  #  '65 72 72 6F 72' == 'error'
-  - /program/errors/error[@severity='warning']
+  - /program/errors/error[@severity='error']
   - /program/errors/error[text()='This method is deprecated!']
 
 eo: |

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-warning.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/cti/cti-adds-warning.yaml
@@ -3,10 +3,8 @@ xsls:
 tests:
   - /program/errors[count(*)=1]
   - /program/errors/error[@check='cti']
-  #  - '77 61 72 6E 69 6E 67' == 'warning'
   - /program/errors/error[@severity='warning']
-  #  - '54 68 69 73 20 6D 65 74 68 6F 64 20 69 73 20 64 65 70 72 65 63 61 74 65 64 21' == 'This method is deprecated!'
-  - /program/errors/error[text()='54 68 69 73 20 6D 65 74 68 6F 64 20 69 73 20 64 65 70 72 65 63 61 74 65 64 21']
+  - /program/errors/error[text()='This method is deprecated!']
 
 eo: |
   [] > foo

--- a/eo-runtime/src/test/eo/org/eolang/cti-test.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cti-test.eo
@@ -35,15 +35,6 @@
       "This method is deprecated!"
     $.equal-to 4
 
-# @todo #1205:90min cti: Use normal string literals instead of hex literals.
-#  Currently we add errors for cti with hex representation of the error
-#  message which looks ugly. We should use normal string literals instead,
-#  but for now it seems impossible since during parsing we already
-#  have hex representation of the error message in cti.
-#  By that reason, the 'fails-since-deprecated' test passes
-#  successfully, but it should fail since it uses cti with "error" level.
-#  See cti-adds-error.yaml, cti-adds-warning.yaml pack tests
-#  and cti-adds-errors.xsl transformation for more details.
 [] > fails-since-deprecated
   assert-that > @
     cti

--- a/eo-runtime/src/test/eo/org/eolang/cti-test.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cti-test.eo
@@ -34,11 +34,3 @@
       "warning"
       "This method is deprecated!"
     $.equal-to 4
-
-[] > fails-since-deprecated
-  assert-that > @
-    cti
-      2.times 2
-      "error"
-      "This method is deprecated!"
-    $.equal-to 4


### PR DESCRIPTION
Print meaningful messages instead of hex values for cti.

Closes: #2044


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the error messages in the EO language parser. 

### Detailed summary
- Updated error messages in cti-adds-warning.yaml and cti-adds-error.yaml pack tests.
- Added a new function to convert hex strings to readable UTF-8 strings in cti-adds-errors.xsl.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->