### PR TITLE
EBNF rendering fixed

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
@@ -128,8 +128,8 @@ final class XMIRTest {
                 Matchers.containsString("<byte> := /[0-9A-F]/ /[0-9A-F]/ \\\\"),
                 Matchers.containsString("<string> := 'DQ' {"),
                 Matchers.containsString("<text> := 'DQ' 'DQ' 'DQ' ["),
-                Matchers.containsString("\\textvisiblespace{}"),
-                Matchers.containsString("\\textquotesingle{}")
+                Matchers.containsString("\"\\textvisiblespace{}\""),
+                Matchers.containsString("\"\\textquotesingle{}\"")
             )
         );
         Files.write(

--- a/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
@@ -127,7 +127,9 @@ final class XMIRTest {
             Matchers.allOf(
                 Matchers.containsString("<byte> := /[0-9A-F]/ /[0-9A-F]/ \\\\"),
                 Matchers.containsString("<string> := 'DQ' {"),
-                Matchers.containsString("<text> := 'DQ' 'DQ' 'DQ' [")
+                Matchers.containsString("<text> := 'DQ' 'DQ' 'DQ' ["),
+                Matchers.containsString("\\textvisiblespace{}"),
+                Matchers.containsString("\\textquotesingle{}")
             )
         );
         Files.write(

--- a/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
+++ b/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
@@ -37,7 +37,7 @@ SOFTWARE.
     <xsl:variable name="r8" select="replace($r7, '#', '\\#')"/>
     <xsl:variable name="r9" select="replace($r8, '_', '\\_')"/>
     <xsl:variable name="r10" select="replace($r9, '&quot;', '\\textquotedbl{}')"/>
-    <xsl:variable name="r11" select="replace($r10, &quot;&apos;&quot;, '\\textquotesingle{}')"/>
+    <xsl:variable name="r11" select="replace($r10, &quot;'&quot;, '\\textquotesingle{}')"/>
     <xsl:value-of select="$r11"/>
   </xsl:function>
   <xsl:function name="eo:term" as="xs:string">

--- a/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
+++ b/eo-parser/src/test/resources/org/eolang/parser/ebnf/to-ebnf.xsl
@@ -37,7 +37,7 @@ SOFTWARE.
     <xsl:variable name="r8" select="replace($r7, '#', '\\#')"/>
     <xsl:variable name="r9" select="replace($r8, '_', '\\_')"/>
     <xsl:variable name="r10" select="replace($r9, '&quot;', '\\textquotedbl{}')"/>
-    <xsl:variable name="r11" select="replace($r10, '&amp;', '\\textquotesingle{}')"/>
+    <xsl:variable name="r11" select="replace($r10, &quot;&apos;&quot;, '\\textquotesingle{}')"/>
     <xsl:value-of select="$r11"/>
   </xsl:function>
   <xsl:function name="eo:term" as="xs:string">


### PR DESCRIPTION
There was a typo, we were replacing `&` instead of a single quote.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the XMIRTest and to-ebnf.xsl files. 

### Detailed summary
- Added new assertions to XMIRTest
- Updated variable replacement in to-ebnf.xsl

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->