### PR TITLE
feat(#2226): remove external tojos

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -94,17 +94,6 @@ abstract class SafeMojo extends AbstractMojo {
     protected File foreign;
 
     /**
-     * File with external "tojos".
-     * @checkstyle VisibilityModifierCheck (10 lines)
-     */
-    @Parameter(
-        property = "eo.external",
-        required = true,
-        defaultValue = "${project.build.directory}/eo-external.csv"
-    )
-    protected File external;
-
-    /**
      * Format of "foreign" file ("json" or "csv").
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
@@ -202,8 +191,7 @@ abstract class SafeMojo extends AbstractMojo {
 
     /**
      * Used for object versioning implementation.
-     * If set to TRUE, external tojos are used instead of foreign ones and all
-     * inherited Mojos behave a bit differently.
+     * If set to TRUE all inherited Mojos behave a bit differently.
      * @todo #1602:30min Remove the flag when objection versioned is
      *  implemented. The variable is used for implementation of object
      *  versioning. It allows to use external tojos instead of foreign in Mojos.
@@ -214,21 +202,6 @@ abstract class SafeMojo extends AbstractMojo {
      */
     @Parameter(property = "eo.withVersions", defaultValue = "false")
     protected boolean withVersions;
-
-    /**
-     * External tojos.
-     * @todo #1602:30min Use external tojos to implement object versioning.
-     *  Implementation of object versioning will bring a lot significant
-     *  changes. That's why it's better to use independent separated tojos for
-     *  that purpose. At the end when object versioning works - just replace
-     *  them and remove unnecessary one.
-     * @checkstyle MemberNameCheck (7 lines)
-     * @checkstyle VisibilityModifierCheck (5 lines)
-     */
-    protected final ForeignTojos externalTojos = new ForeignTojos(
-        () -> Catalogs.INSTANCE.make(this.external.toPath(), this.foreignFormat),
-        () -> this.scope
-    );
 
     /**
      * Commit hashes.
@@ -323,9 +296,6 @@ abstract class SafeMojo extends AbstractMojo {
                 if (this.foreign != null) {
                     SafeMojo.closeTojos(this.tojos);
                 }
-                if (this.external != null) {
-                    SafeMojo.closeTojos(this.externalTojos);
-                }
                 if (this.placed != null) {
                     SafeMojo.closeTojos(this.placedTojos);
                 }
@@ -342,13 +312,7 @@ abstract class SafeMojo extends AbstractMojo {
      * @checkstyle AnonInnerLengthCheck (100 lines)
      */
     protected final ForeignTojos scopedTojos() {
-        final ForeignTojos tjs;
-        if (this.external != null && this.withVersions) {
-            tjs = this.externalTojos;
-        } else {
-            tjs = this.tojos;
-        }
-        return tjs;
+        return this.tojos;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -191,11 +191,10 @@ abstract class SafeMojo extends AbstractMojo {
 
     /**
      * Used for object versioning implementation.
-     * If set to TRUE all inherited Mojos behave a bit differently.
+     * If set to TRUE - objects are parsed, stored in tojos and processed as versioned.
      * @todo #1602:30min Remove the flag when objection versioned is
      *  implemented. The variable is used for implementation of object
-     *  versioning. It allows to use external tojos instead of foreign in Mojos.
-     *  for the test purposes. When object versioning is implemented there
+     *  versioning. When object versioning is implemented there
      *  will be no need for that variable
      * @checkstyle VisibilityModifierCheck (10 lines)
      * @checkstyle MemberNameCheck (10 lines)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -62,13 +62,13 @@ final class DiscoverMojoTest {
      * Default assertion message.
      */
     private static final String SHOULD_CONTAIN =
-        "External tojos should contain %s object after discovering, but they didn't";
+        "Tojos should contain %s object after discovering, but they didn't";
 
     /**
      * Default assertion message.
      */
     private static final String SHOULD_NOT =
-        "External tojos should not contain %s object after discovering, but they did";
+        "Tojos should not contain %s object after discovering, but they did";
 
     @ParameterizedTest
     @CsvSource({
@@ -121,7 +121,7 @@ final class DiscoverMojoTest {
             .execute(new FakeMaven.Discover());
         final ObjectName stdout = new OnVersioned("org.eolang.stdout", "9c93528");
         final String nop = "org.eolang.nop";
-        final ForeignTojos tojos = maven.externalTojos();
+        final ForeignTojos tojos = maven.foreignTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, DiscoverMojoTest.TEXT),
             tojos.contains(DiscoverMojoTest.TEXT),
@@ -163,7 +163,7 @@ final class DiscoverMojoTest {
             .execute(new FakeMaven.Discover());
         final ObjectName first = new OnVersioned("org.eolang.txt.sprintf", hashes.get("0.28.1"));
         final ObjectName second = new OnVersioned("org.eolang.txt.sprintf", hashes.get("0.28.2"));
-        final ForeignTojos tojos = maven.externalTojos();
+        final ForeignTojos tojos = maven.foreignTojos();
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_CONTAIN, first),
             tojos.contains(first),
@@ -193,7 +193,7 @@ final class DiscoverMojoTest {
             .withProgram(second, new OnVersioned(object, two))
             .withProgram(first, new OnDefault(object))
             .execute(new FakeMaven.Discover())
-            .externalTojos();
+            .foreignTojos();
         MatcherAssert.assertThat(
             String.format(
                 "Tojos should contained 3 similar objects %s: 2 with different hashes %s and one without; but they didn't",
@@ -219,12 +219,12 @@ final class DiscoverMojoTest {
         final ObjectName seq = new OnVersioned("org.eolang.seq", "6c6269d");
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, seq),
-            maven.externalTojos().contains(seq),
+            maven.foreignTojos().contains(seq),
             Matchers.is(false)
         );
         MatcherAssert.assertThat(
             String.format(DiscoverMojoTest.SHOULD_NOT, DiscoverMojoTest.TEXT),
-            maven.externalTojos().contains(DiscoverMojoTest.TEXT),
+            maven.foreignTojos().contains(DiscoverMojoTest.TEXT),
             Matchers.is(false)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -197,7 +197,6 @@ public final class FakeMaven {
         if (this.defaults) {
             this.params.putIfAbsent("targetDir", this.targetPath().toFile());
             this.params.putIfAbsent("foreign", this.foreignPath().toFile());
-            this.params.putIfAbsent("external", this.externalPath().toFile());
             this.params.putIfAbsent("foreignFormat", "csv");
             this.params.putIfAbsent("project", new MavenProjectStub());
             final Path transpiled = Paths.get("transpiled");
@@ -282,28 +281,6 @@ public final class FakeMaven {
         return new ForeignTojos(
             () -> Catalogs.INSTANCE.make(this.foreignPath()),
             this::scope
-        );
-    }
-
-    /**
-     * External tojos for eo-external.* file.
-     * @return External tojos.
-     */
-    ForeignTojos externalTojos() {
-        return new ForeignTojos(
-            () -> Catalogs.INSTANCE.make(this.externalPath()),
-            this::scope
-        );
-    }
-
-    /**
-     * Tojo for eo-external.* file.
-     *
-     * @return TjSmart of the current eo-external.file.
-     */
-    TjSmart external() {
-        return new TjSmart(
-            Catalogs.INSTANCE.make(this.externalPath())
         );
     }
 
@@ -415,23 +392,17 @@ public final class FakeMaven {
             .withScope(scope)
             .withVersion(version)
             .withSource(source);
-        this.externalTojos()
-            .add(object)
-            .withScope(scope)
-            .withVersion(version)
-            .withSource(source);
         this.current.incrementAndGet();
         return this;
     }
 
     /**
-     * Specify hash for all foreign and external tojos.
+     * Specify hash for all foreign tojos.
      * @param hash Commit hash
      * @return The same maven instance.
      */
     FakeMaven allTojosWithHash(final CommitHash hash) {
         this.foreignTojos().all().forEach(tojo -> tojo.withHash(hash));
-        this.externalTojos().all().forEach(tojo -> tojo.withHash(hash));
         return this;
     }
 
@@ -449,14 +420,6 @@ public final class FakeMaven {
      */
     Path foreignPath() {
         return this.workspace.absolute(Paths.get("eo-foreign.csv"));
-    }
-
-    /**
-     * Path to or eo-external.* file after all changes.
-     * @return Path to eo-foreign.* file.
-     */
-    Path externalPath() {
-        return this.workspace.absolute(Paths.get("eo-external.csv"));
     }
 
     /**
@@ -494,14 +457,6 @@ public final class FakeMaven {
      */
     ForeignTojo programTojo() {
         return this.foreignTojos().find(FakeMaven.tojoId(this.current.get() - 1));
-    }
-
-    /**
-     * Same as {@link FakeMaven#programTojo()} but for external tojos.
-     * @return Tojo entry.
-     */
-    ForeignTojo programExternalTojo() {
-        return this.externalTojos().find(FakeMaven.tojoId(this.current.get() - 1));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MarkMojoTest.java
@@ -85,7 +85,7 @@ final class MarkMojoTest {
         final ForeignTojos tojos = new FakeMaven(temp)
             .with("withVersions", true)
             .execute(MarkMojo.class)
-            .externalTojos();
+            .foreignTojos();
         final ObjectName object = new OnVersioned("foo.bar", "6a70071");
         MatcherAssert.assertThat(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -160,17 +160,17 @@ final class ProbeMojoTest {
                 "Tojos should contain versioned object %s after probing, but they didn't",
                 ProbeMojoTest.STDOUT
             ),
-            maven.externalTojos().contains(ProbeMojoTest.STDOUT),
+            maven.foreignTojos().contains(ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             "Program tojo entry in tojos after probing should contain one probed object",
-            maven.programExternalTojo().probed(),
+            maven.programTojo().probed(),
             Matchers.equalTo("1")
         );
         MatcherAssert.assertThat(
             "Program tojo entry in tojos after probing should contain given hash",
-            maven.programExternalTojo().hash(),
+            maven.programTojo().hash(),
             Matchers.equalTo(hash.value())
         );
     }
@@ -200,17 +200,17 @@ final class ProbeMojoTest {
                 "Tojos should contain versioned objects '%s' after probing, but they didn't",
                 Arrays.asList(text, ProbeMojoTest.STDOUT)
             ),
-            maven.externalTojos().contains(text, ProbeMojoTest.STDOUT),
+            maven.foreignTojos().contains(text, ProbeMojoTest.STDOUT),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             "Program tojo after probing should contain exactly two probed objects",
-            maven.programExternalTojo().probed(),
+            maven.programTojo().probed(),
             Matchers.equalTo("2")
         );
         MatcherAssert.assertThat(
             "Program tojo after probing should have given hash",
-            maven.programExternalTojo().hash(),
+            maven.programTojo().hash(),
             Matchers.equalTo(first.value())
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -175,7 +175,7 @@ final class PullMojoTest {
     @Test
     void pullsVersionedObjectSuccessfully(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
-        maven.externalTojos()
+        maven.foreignTojos()
             .add(new OnVersioned(PullMojoTest.STDOUT, "9c93528"))
             .withVersion("*.*.*");
         maven.with("withVersions", true)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
@@ -26,7 +26,6 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.NoSuchElementException;
 import org.cactoos.io.ResourceOf;
 import org.eolang.maven.util.Home;
 import org.hamcrest.MatcherAssert;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoTest.java
@@ -103,61 +103,6 @@ final class RegisterMojoTest {
     }
 
     @Test
-    void registersInExternal(@TempDir final Path temp) throws IOException {
-        new Home(temp).save(
-            new ResourceOf("org/eolang/maven/file-name/abc-def.eo"),
-            Paths.get("src/eo/org/eolang/maven/foo.eo")
-        );
-        final String name = "org.eolang.maven.foo";
-        final FakeMaven maven = new FakeMaven(temp)
-            .with(RegisterMojoTest.PARAM, temp.resolve(RegisterMojoTest.SOURCES).toFile())
-            .with("withVersions", true)
-            .execute(new FakeMaven.Register());
-        MatcherAssert.assertThat(
-            String.format(
-                "Source object %s placed in %s should have been registered in external tojos but it didn't",
-                name,
-                RegisterMojoTest.SOURCES
-            ),
-            maven.external()
-                .getById(name)
-                .exists("id"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "External and foreign tojos should not have the same status after registering because external should replace foreign but they didn't",
-            maven.foreignTojos().status(),
-            Matchers.not(
-                Matchers.equalTo(
-                    maven.externalTojos().status()
-                )
-            )
-        );
-    }
-
-    @Test
-    void doesNotRegisterInExternal(@TempDir final Path temp) throws IOException {
-        new Home(temp).save(
-            new ResourceOf("org/eolang/maven/file-name/abc-def.eo"),
-            Paths.get("src/eo/org/eolang/maven/foo.eo")
-        );
-        final String name = "org.eolang.maven.foo";
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new FakeMaven(temp)
-                .with(RegisterMojoTest.PARAM, temp.resolve(RegisterMojoTest.SOURCES).toFile())
-                .with("withVersions", false)
-                .execute(new FakeMaven.Register())
-                .external()
-                .getById(name),
-            String.format(
-                "External tojos should not have contained %s because \"withVersions\" is FALSE, but they did",
-                name
-            )
-        );
-    }
-
-    @Test
     void throwsExceptionInCaseSourceDirIsNotSet(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,


### PR DESCRIPTION
Closes: #2226

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the usage of "externalTojos" with "foreignTojos" in the codebase. 

### Detailed summary
- Replaced all occurrences of "externalTojos" with "foreignTojos".
- Removed the "externalTojos" field and related methods and references.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->