### PR TITLE
fix(#2321): added typo check for suffix with dots

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/typos/suffix-with-dots.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/typos/suffix-with-dots.yaml
@@ -1,0 +1,3 @@
+line: 1
+eo: |
+  [] > foo.x.main


### PR DESCRIPTION
Closes: #2321 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new test resource file `suffix-with-dots.yaml` in the `eo-parser` module.
- The file contains an EO code snippet `[] > foo.x.main` as the value for the `eo` key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->