### PR TITLE
fix(#1468): added check for reversed as separated argument

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/typos/reversed-as-separate-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/typos/reversed-as-separate-argument.yaml
@@ -1,0 +1,4 @@
+line: 2
+eo: |
+  [] > foo
+    a. b. c > x


### PR DESCRIPTION
Closes: #1468 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new test resource file `reversed-as-separate-argument.yaml` in the `eo-parser` module.
- Added content to the `eo` field in the test resource file.
- The `eo` field contains a code snippet with a list, `foo`, and a nested object structure, `a.b.c`, with a value assigned to `x`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->