### PR TITLE
#2490: Return raw data.

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -268,6 +268,9 @@ public class EOrust extends PhDefault {
                 buffer.flip();
                 ret = new Data.ToPhi(buffer.getLong());
                 break;
+            case 4:
+                ret = new Data.ToPhi(content);
+                break;
             case 5:
                 if (this.error.get() == null) {
                     throw new ExNative(

--- a/eo-runtime/src/main/rust/eo_env/src/eo_enum.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_enum.rs
@@ -53,8 +53,12 @@ impl EO {
                 res
             }
             EO::EOString(_) => { vec![0xff] }
-            EO::EORaw(_) => { vec![0xff] }
-
+            EO::EORaw(content) => {
+                let mut res: Vec<u8> = vec![0; 1 + content.len()];
+                res[0] = 4;
+                res[1..].copy_from_slice(&content.to_vec());
+                res
+            }
             EO::EOError(_) => {
                 let mut res: Vec<u8> = vec![0; 1];
                 res[0] = 5;

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -100,6 +100,28 @@
     $.equal-to
       -1.23456789
 
+[] > rust-is-byte-array
+  QQ.rust > my-bytes
+    """
+    use eo_env::EOEnv;
+    use eo_env::eo_enum::EO;
+    use eo_env::eo_enum::EO::{EORaw};
+
+    pub fn foo(_env: &mut EOEnv) -> EO {
+      EORaw(
+        Box::from(
+          [0x00, 0x1a, 0xEE]
+        )
+      )
+    }
+    """
+    *
+      []
+  assert-that > @
+    my-bytes
+    $.equal-to
+      00-1A-EE
+
 [] > rust-find-returns-int
   123 > a
   QQ.rust > r


### PR DESCRIPTION
Closes #2490

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new case in `EOrust.java` to handle a specific condition and making changes in `eo_enum.rs` to update the behavior of `EO::EORaw`. It also includes updates in `rust-tests.eo` to add a new function `foo` and related test cases.

### Detailed summary:
- In `EOrust.java`:
  - Added a new case `4` in a switch statement.
  - Created a new instance of `Data.ToPhi` with `content` as a parameter.

- In `eo_enum.rs`:
  - Modified the behavior of `EO::EORaw` case.
  - Created a new `Vec<u8>` called `res` with a length of `1 + content.len()`.
  - Assigned `4` to the first element of `res`.
  - Copied `content.to_vec()` to the remaining elements of `res`.

- In `rust-tests.eo`:
  - Added a new function `foo` with related code.
  - Added test cases for `foo` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->