### PR TITLE
2454 universe put

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
@@ -104,7 +104,9 @@ public final class UniverseDefault implements Universe {
 
     @Override
     public void put(final int vertex, final byte[] bytes) {
-        //Empty yet.
+        this.get(vertex).attr("Δ").put(
+            new Data.Value<>(bytes)
+        );
     }
 
     @Override

--- a/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
@@ -57,17 +57,18 @@ impl<'local> EOEnv<'_> {
 
     pub fn put(&mut self, v: u32, bytes: &[u8]) -> Option<()> {
         let jbytes = JObject::from(self.java_env.byte_array_from_slice(bytes).unwrap());
-        match self.java_env
+        let JavaVal =  self.java_env
             .call_method(
                 &self.java_obj,
                 "put",
                 "(I[B)V",
                 &[JValue::Int(v as i32), JValue::from(&jbytes)]
-            )
-            .unwrap()
-            .v() {
-            Ok(()) => Some(()),
-            _ => None
+            );
+        return if JavaVal.is_err() {
+            self.java_env.exception_clear();
+            None
+        } else {
+            JavaVal.unwrap().v().ok()
         }
     }
 

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -180,23 +180,29 @@
     $.equal-to "Привет world"
 
 [] > rust-put-not-fails
-  QQ.rust > r
+  QQ.rust > put
     """
     use eo_env::EOEnv;
     use eo_env::eo_enum::EO;
-    use eo_env::eo_enum::EO::{EOInt};
+    use eo_env::eo_enum::EO::{EOInt, EOError};
     pub fn foo(env: &mut EOEnv) -> EO {
-      env.put(3, &[0x00, 0x1a, 0xEE, 0xf, 0xf3]).unwrap();
-      EOInt(0 as i64)
+      if(env.put(-1i32 as u32, &[0x00, 0x1a, 0xEE, 0xf, 0xf3])).is_none(){
+        return EOError("put failed".to_string());
+      } else {
+        EOInt(0 as i64)
+      }
     }
     """
     *
       []
   assert-that > @
-    r
-    $.not
-      $.less-than
-        0
+    try
+      []
+        put > @
+      [e]
+        e > @
+      nop
+    $.equal-to "Rust insert failed in Φ.org.eolang.rust-put-not-fails.put.α0:184:4 with message 'put failed'; caused by Phi object with vertex -1 was not indexed."
 
 [] > rust-bind-not-fails
   1 > a
@@ -316,3 +322,27 @@
     $.all-of
       $.string-starts-with "Rust insert failed "
       $.string-ends-with "'Custom error'"
+
+[] > rust-put-to-copy
+  QQ.rust > data
+    """
+    use eo_env::EOEnv;
+    use eo_env::eo_enum::EO;
+    use eo_env::eo_enum::EO::{EOVertex, EOError};
+
+    pub fn foo(env: &mut EOEnv) -> EO {
+      let eobytes = env.find("Q.org.eolang.bytes");
+      let copy = env.copy(eobytes as u32).unwrap();
+      if env.put(copy.clone(), &[0x00, 0x1a, 0xEE]).is_none() {
+        EOError("put failed".to_string())
+      } else {
+        EOVertex(copy)
+      }
+    }
+    """
+    *
+      []
+  assert-that > @
+    data
+    $.equal-to
+      00-1A-EE

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -24,6 +24,8 @@
 package org.eolang;
 
 import EOorg.EOeolang.EOseq;
+
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.hamcrest.MatcherAssert;
@@ -41,6 +43,8 @@ final class UniverseDefaultTest {
      * Name of attribute.
      */
     private static final String ATT = "value";
+
+    private static final byte[] DATA = new BytesOf(123456789L).take();
 
     @Test
     void findsSimpleAtt() {
@@ -135,6 +139,21 @@ final class UniverseDefaultTest {
             universe.dataize(copy),
             Matchers.equalTo(
                 universe.dataize(origin)
+            )
+        );
+    }
+
+    @Test
+    void outsToCopy() {
+        final Map<Integer, Phi> indexed = new HashMap<>();
+        final Universe universe = new UniverseDefault(Phi.Φ, indexed);
+        final int eoint = universe.find("Q.org.eolang.int");
+        final int copy = universe.copy(eoint);
+        universe.put(copy, UniverseDefaultTest.DATA);
+        MatcherAssert.assertThat(
+            new Dataized(indexed.get(copy)).take(),
+            Matchers.equalTo(
+                UniverseDefaultTest.DATA
             )
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -24,8 +24,6 @@
 package org.eolang;
 
 import EOorg.EOeolang.EOseq;
-
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.hamcrest.MatcherAssert;
@@ -44,6 +42,9 @@ final class UniverseDefaultTest {
      */
     private static final String ATT = "value";
 
+    /**
+     * Data byte array.
+     */
     private static final byte[] DATA = new BytesOf(123456789L).take();
 
     @Test


### PR DESCRIPTION
Closes #2454

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the `put` method in the `UniverseDefault` class and the `put` function in the `eo_env.rs` file. It also adds new test cases and makes changes to the `rust-tests.eo` file.

### Detailed summary:
- In `UniverseDefault.java`, the `put` method is modified to use the `attr` method to put the bytes into the `Δ` attribute of the specified vertex.
- In `eo_env.rs`, the `put` function is modified to handle errors when calling the `put` method in Java and return `None` if there is an error.
- In `UniverseDefaultTest.java`, a new test case is added to test the `put` method.
- In `rust-tests.eo`, the `rust-put-not-fails` and `rust-put-to-copy` functions are modified to handle errors when calling the `put` function in Rust and return an error message if there is an error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->