### PR TITLE
2294 bind

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -49,9 +49,6 @@ public interface Universe {
      * @param parent Vertex of the parent eo object.
      * @param child Vertex of the child eo object.
      * @param att Name of attribute.
-     * @todo #2237:45min Implement the "bind" method. It has tp
-     *  put data to eo object by vertex. It does nothing now
-     *  but it is called from rust via jni call_method function.
      * @checkstyle NonStaticMethodCheck (4 lines)
      */
     void bind(int parent, int child, String att);

--- a/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
@@ -111,7 +111,9 @@ public final class UniverseDefault implements Universe {
 
     @Override
     public void bind(final int parent, final int child, final String att) {
-        //Empty yet.
+        this.get(parent)
+            .attr(att)
+            .put(this.get(child));
     }
 
     @Override

--- a/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
@@ -73,7 +73,7 @@ impl<'local> EOEnv<'_> {
     }
 
     pub fn bind(&mut self, v1: u32, v2: u32, name: &str) -> Option<()> {
-        match self.java_env
+        let java_val =  self.java_env
             .call_method(
                 &self.java_obj,
                 "bind",
@@ -83,10 +83,13 @@ impl<'local> EOEnv<'_> {
                     JValue::Int(v2 as i32),
                     JValue::from(&JObject::from(self.java_env.new_string(name).unwrap()))
                 ]
-            ).unwrap().v() {
-            Ok(()) => Some(()),
-            _ => None,
-        }
+            );
+        return if java_val.is_err() {
+            self.java_env.exception_clear().ok()?;
+            None
+        } else {
+            java_val.unwrap().v().ok()
+        };
     }
 
     pub fn copy(&mut self, v: u32) -> Option<u32> {

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -327,7 +327,6 @@
       nop
     $.all-of
       $.string-starts-with "Rust insert failed "
-      $.string-ends-with "'Custom error'"
 
 [] > rust-put-to-copy
   QQ.rust > data

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -211,21 +211,27 @@
     """
     use eo_env::EOEnv;
     use eo_env::eo_enum::EO;
-    use eo_env::eo_enum::EO::{EOInt};
+    use eo_env::eo_enum::EO::{EOError, EOInt};
     pub fn foo(env: &mut EOEnv) -> EO {
-        let v1 = env.find("$.^.a") as u32;
-        let v2 = env.find("$.^.b") as u32;
-        env.bind(v1 , v2, "EO-att");
-        return EOInt(v1 as i64);
+      let v1 = env.find("$.^.a") as u32;
+      let v2 = env.find("$.^.b") as u32;
+      if(env.bind(v1 , v2, "EO-att")).is_none(){
+        return EOError("bind failed".to_string());
+      } else {
+        return EOInt(0 as i64);
+      }
     }
     """
     *
       []
   assert-that > @
-    insert
-    $.not
-      $.less-than
-        0
+    try
+      []
+        insert > @
+      [e]
+        e > @
+      nop
+    $.string-starts-with "Rust insert failed"
 
 [] > rust-copy-not-fails
   123 > a
@@ -346,3 +352,30 @@
     data
     $.equal-to
       00-1A-EE
+
+[] > rust-bind-to-copy
+  [content] > book
+  "qwerty" > line
+  QQ.rust > applied
+    """
+    use eo_env::EOEnv;
+    use eo_env::eo_enum::EO;
+    use eo_env::eo_enum::EO::{EOVertex, EOError};
+
+    pub fn foo(env: &mut EOEnv) -> EO {
+      let eobook = env.find("$.^.book");
+      let copy = env.copy(eobook as u32).unwrap();
+      let eoline = env.find("$.^.line") as u32;
+      if env.bind(copy.clone(), eoline, "content").is_none() {
+        EOError("bind failed".to_string())
+      } else {
+        EOVertex(copy)
+      }
+    }
+    """
+    *
+      []
+  assert-that > @
+    applied.content
+    $.equal-to
+      "qwerty"

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -145,7 +145,7 @@ final class UniverseDefaultTest {
     }
 
     @Test
-    void outsToCopy() {
+    void putsToCopy() {
         final Map<Integer, Phi> indexed = new HashMap<>();
         final Universe universe = new UniverseDefault(Phi.Φ, indexed);
         final int eoint = universe.find("Q.org.eolang.int");

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -26,6 +26,7 @@ package org.eolang;
 import EOorg.EOeolang.EOseq;
 import java.util.HashMap;
 import java.util.Map;
+import org.cactoos.map.MapOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -159,6 +160,25 @@ final class UniverseDefaultTest {
         );
     }
 
+    @Test
+    void bindsCopyToAbstract() {
+        final Phi dummy = new DummyAbstract(Phi.Φ);
+        final Map<Integer, Phi> indexed = new MapOf<>(dummy.hashCode(), dummy);
+        final Universe universe = new UniverseDefault(dummy, indexed);
+        final int eoint = universe.find("Q.org.eolang.int");
+        final int copy = universe.copy(eoint);
+        universe.put(copy, UniverseDefaultTest.DATA);
+        universe.bind(
+            dummy.hashCode(), copy, UniverseDefaultTest.ATT
+        );
+        MatcherAssert.assertThat(
+            new Dataized(dummy.attr(UniverseDefaultTest.ATT).get()).take(),
+            Matchers.equalTo(
+                UniverseDefaultTest.DATA
+            )
+        );
+    }
+
     /**
      * Dummy phi with plain attribute.
      * @since 0.31
@@ -198,6 +218,22 @@ final class UniverseDefaultTest {
         DummyWithStructure(final Phi sigma) {
             super(sigma);
             this.add(UniverseDefaultTest.ATT, new AtComposite(this, DummyWithAt::new));
+        }
+    }
+
+    /**
+     * Dummy phi with free attribute.
+     * @since 0.31
+     */
+    private static class DummyAbstract extends PhDefault {
+
+        /**
+         * Ctor.
+         * @param sigma Sigma
+         */
+        DummyAbstract(final Phi sigma) {
+            super(sigma);
+            this.add(UniverseDefaultTest.ATT, new AtFree());
         }
     }
 }


### PR DESCRIPTION
Closes #2294

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR
Implementing the `bind` method in the `UniverseDefault` class and updating related code in the `Universe` class and Rust code.

### Detailed summary
- Implemented the `bind` method in the `UniverseDefault` class.
- Updated the `Universe` class to include documentation for the `bind` method.
- Updated the Rust code in `eo_env.rs` to handle the `bind` method.
- Updated the Rust tests in `rust-tests.eo` to use the `bind` method.
- Updated the Java tests in `UniverseDefaultTest.java` to test the `bind` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->