### PR TITLE
feat(#2506): versionize annotation

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * An attribute that knows how to memoize an object.
@@ -39,6 +40,7 @@ import org.eolang.Phi;
  * @since 0.24
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 public final class AtMemoized implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/AtMemoized.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * An attribute that knows how to memoize an object.
@@ -40,7 +40,7 @@ import org.eolang.Versionize;
  * @since 0.24
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 public final class AtMemoized implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOas_phi.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOas_phi.java
@@ -32,6 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "as-phi")
 public class EOas_phi extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOas_phi.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOas_phi.java
@@ -32,7 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "as-phi")
 public class EOas_phi extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOand.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOand.java
@@ -35,7 +35,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -44,7 +44,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bool.and")
 public class EObool$EOand extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOand.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOand.java
@@ -35,6 +35,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -43,6 +44,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bool.and")
 public class EObool$EOand extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOif.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOif.java
@@ -32,6 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bool.if")
 public class EObool$EOif extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOif.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOif.java
@@ -32,7 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bool.if")
 public class EObool$EOif extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOor.java
@@ -35,7 +35,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -44,7 +44,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bool.or")
 public class EObool$EOor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOor.java
@@ -35,6 +35,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -43,6 +44,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bool.or")
 public class EObool$EOor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOwhile.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOwhile.java
@@ -34,7 +34,7 @@ import org.eolang.Dataized;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -43,7 +43,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bool.while")
 public class EObool$EOwhile extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOwhile.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOwhile.java
@@ -34,6 +34,7 @@ import org.eolang.Dataized;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bool.while")
 public class EObool$EOwhile extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOand.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOand.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.and")
 public class EObytes$EOand extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOand.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOand.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.and")
 public class EObytes$EOand extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
@@ -27,13 +27,12 @@
  */
 package EOorg.EOeolang;
 
-import java.nio.ByteBuffer;
 import org.eolang.AtComposite;
 import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.18
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.as-float")
 public class EObytes$EOas_float extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.18
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.as-float")
 public class EObytes$EOas_float extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.18
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.as-int")
 public class EObytes$EOas_int extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.18
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.as-int")
 public class EObytes$EOas_int extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_string.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_string.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.16
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.as-string")
 public class EObytes$EOas_string extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_string.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_string.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.16
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.as-string")
 public class EObytes$EOas_string extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOconcat.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOconcat.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.concat")
 public class EObytes$EOconcat extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOconcat.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOconcat.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.concat")
 public class EObytes$EOconcat extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOeq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOeq.java
@@ -36,6 +36,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -44,6 +45,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.eq")
 public class EObytes$EOeq extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOeq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOeq.java
@@ -36,7 +36,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -45,7 +45,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.eq")
 public class EObytes$EOeq extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOnot.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOnot.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.not")
 public class EObytes$EOnot extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOnot.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOnot.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.not")
 public class EObytes$EOnot extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (15 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.or")
 public class EObytes$EOor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (15 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.or")
 public class EObytes$EOor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOright.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOright.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (15 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.right")
 public class EObytes$EOright extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOright.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOright.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (15 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.right")
 public class EObytes$EOright extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOsize.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOsize.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.size")
 public class EObytes$EOsize extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOsize.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOsize.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.size")
 public class EObytes$EOsize extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
@@ -34,6 +34,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.slice")
 public class EObytes$EOslice extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
@@ -34,7 +34,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -43,7 +43,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.slice")
 public class EObytes$EOslice extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOxor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOxor.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "bytes.xor")
 public class EObytes$EOxor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOxor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOxor.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.Bytes;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "bytes.xor")
 public class EObytes$EOxor extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
@@ -33,6 +33,7 @@ import org.eolang.AtFree;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.Volatile;
 import org.eolang.XmirObject;
 
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.17
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @Volatile
 @XmirObject(oname = "cage")
 public class EOcage extends PhDefault {

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
@@ -33,7 +33,7 @@ import org.eolang.AtFree;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.Volatile;
 import org.eolang.XmirObject;
 
@@ -43,7 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.17
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @Volatile
 @XmirObject(oname = "cage")
 public class EOcage extends PhDefault {

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
@@ -33,7 +33,7 @@ import org.eolang.ExAbstract;
 import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -47,7 +47,7 @@ import org.eolang.XmirObject;
  * @since 0.22
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "error")
 public final class EOerror extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
@@ -33,6 +33,7 @@ import org.eolang.ExAbstract;
 import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -46,6 +47,7 @@ import org.eolang.XmirObject;
  * @since 0.22
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "error")
 public final class EOerror extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "float.as-bytes")
 public class EOfloat$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
@@ -27,13 +27,12 @@
  */
 package EOorg.EOeolang;
 
-import java.nio.ByteBuffer;
 import org.eolang.AtComposite;
 import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "float.as-bytes")
 public class EOfloat$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "float.div")
 public class EOfloat$EOdiv extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "float.div")
 public class EOfloat$EOdiv extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOgt.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOgt.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "float.gt")
 public class EOfloat$EOgt extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOgt.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOgt.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "float.gt")
 public class EOfloat$EOgt extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "float.plus")
 public class EOfloat$EOplus extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "float.plus")
 public class EOfloat$EOplus extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "float.times")
 public class EOfloat$EOtimes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "float.times")
 public class EOfloat$EOtimes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOgoto.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOgoto.java
@@ -29,12 +29,11 @@ package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -43,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.17
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "goto")
 public class EOgoto extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOgoto.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOgoto.java
@@ -34,6 +34,7 @@ import org.eolang.Dataized;
 import org.eolang.ExAbstract;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.17
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "goto")
 public class EOgoto extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOheap$EOpointer$EOblock.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOheap$EOpointer$EOblock.java
@@ -35,7 +35,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -44,7 +44,7 @@ import org.eolang.XmirObject;
  * @since 0.19
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "heap.pointer.block")
 public class EOheap$EOpointer$EOblock extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOheap$EOpointer$EOblock.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOheap$EOpointer$EOblock.java
@@ -35,6 +35,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -43,6 +44,7 @@ import org.eolang.XmirObject;
  * @since 0.19
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "heap.pointer.block")
 public class EOheap$EOpointer$EOblock extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOas_bytes.java
@@ -27,13 +27,12 @@
  */
 package EOorg.EOeolang;
 
-import java.math.BigInteger;
 import org.eolang.AtComposite;
 import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "int.as-bytes")
 public class EOint$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOas_bytes.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "int.as-bytes")
 public class EOint$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
@@ -37,6 +37,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -45,6 +46,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "int.div")
 public class EOint$EOdiv extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java
@@ -28,16 +28,11 @@
 package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
-import org.eolang.AtFree;
 import org.eolang.AtVararg;
-import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.ExprReduce;
-import org.eolang.Param;
 import org.eolang.PhDefault;
-import org.eolang.PhWith;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -46,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "int.div")
 public class EOint$EOdiv extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOgt.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOgt.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "int.gt")
 public class EOint$EOgt extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOgt.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOgt.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "int.gt")
 public class EOint$EOgt extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
@@ -36,6 +36,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -44,6 +45,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "int.plus")
 public class EOint$EOplus extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java
@@ -29,14 +29,10 @@ package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
 import org.eolang.AtVararg;
-import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.ExprReduce;
-import org.eolang.Param;
 import org.eolang.PhDefault;
-import org.eolang.PhWith;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -45,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "int.plus")
 public class EOint$EOplus extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
@@ -32,6 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "int.times")
 public class EOint$EOtimes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java
@@ -32,7 +32,7 @@ import org.eolang.AtVararg;
 import org.eolang.ExprReduce;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "int.times")
 public class EOint$EOtimes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOnext_line.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOnext_line.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Standard Input. Consumes only one line.
@@ -41,7 +41,7 @@ import org.eolang.Versionize;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 public class EOstdin$EOnext_line extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOnext_line.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOnext_line.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Standard Input. Consumes only one line.
@@ -40,6 +41,7 @@ import org.eolang.Phi;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 public class EOstdin$EOnext_line extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOφ.java
@@ -31,7 +31,7 @@ import org.eolang.AtComposite;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Standard Input. Consumes all data.
@@ -39,7 +39,7 @@ import org.eolang.Versionize;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 public class EOstdin$EOφ extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOφ.java
@@ -31,6 +31,7 @@ import org.eolang.AtComposite;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Standard Input. Consumes all data.
@@ -38,6 +39,7 @@ import org.eolang.Phi;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 public class EOstdin$EOφ extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
@@ -34,7 +34,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -43,7 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "stdout")
 public class EOstdout extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdout.java
@@ -34,6 +34,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "stdout")
 public class EOstdout extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
@@ -31,14 +31,14 @@
 package EOorg.EOeolang.EOio;
 
 import java.util.Scanner;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * All system inputs.
  *
  * @since 0.28.0
  */
-@Versionize
+@Versionized
 public final class Input {
     /**
      * Default input.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
@@ -30,6 +30,7 @@
  */
 package EOorg.EOeolang.EOio;
 
+import org.eolang.Versionize;
 import java.util.Scanner;
 
 /**
@@ -37,6 +38,7 @@ import java.util.Scanner;
  *
  * @since 0.28.0
  */
+@Versionize
 public final class Input {
     /**
      * Default input.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOio/Input.java
@@ -30,8 +30,8 @@
  */
 package EOorg.EOeolang.EOio;
 
-import org.eolang.Versionize;
 import java.util.Scanner;
+import org.eolang.Versionize;
 
 /**
  * All system inputs.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
@@ -32,7 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Attr;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "memory")
 public class EOmemory extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
@@ -32,6 +32,7 @@ import org.eolang.AtFree;
 import org.eolang.Attr;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "memory")
 public class EOmemory extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOwrite.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOwrite.java
@@ -33,12 +33,14 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Write bytes to memory from position, according to the ram.slice object.
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 public class EOram$EOram_slice$EOwrite extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOwrite.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOwrite.java
@@ -33,14 +33,14 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Write bytes to memory from position, according to the ram.slice object.
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 public class EOram$EOram_slice$EOwrite extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOφ.java
@@ -32,12 +32,14 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Read from memory.
  * @since 0.25
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 public class EOram$EOram_slice$EOφ extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOφ.java
@@ -32,14 +32,14 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Read from memory.
  * @since 0.25
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 public class EOram$EOram_slice$EOφ extends PhDefault {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOslice.java
@@ -34,6 +34,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.25
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "ram.slice")
 public class EOram$EOslice extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOslice.java
@@ -34,7 +34,7 @@ import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.25
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "ram.slice")
 public class EOram$EOslice extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOwrite.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOwrite.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "ram.write")
 public class EOram$EOwrite extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOwrite.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOwrite.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.1
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "ram.write")
 public class EOram$EOwrite extends PhDefault {
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -58,7 +58,7 @@ import org.eolang.Phi;
 import org.eolang.Universe;
 import org.eolang.UniverseDefault;
 import org.eolang.UniverseSafe;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -69,7 +69,7 @@ import org.eolang.XmirObject;
  * @checkstyle LineLengthCheck (100 lines)
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "rust")
 public class EOrust extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -58,6 +58,7 @@ import org.eolang.Phi;
 import org.eolang.Universe;
 import org.eolang.UniverseDefault;
 import org.eolang.UniverseSafe;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -68,6 +69,7 @@ import org.eolang.XmirObject;
  * @checkstyle LineLengthCheck (100 lines)
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "rust")
 public class EOrust extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "seq")
 public class EOseq extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "seq")
 public class EOseq extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOas_bytes.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "string.as-bytes")
 public class EOstring$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOas_bytes.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "string.as-bytes")
 public class EOstring$EOas_bytes extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOlength.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOlength.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "string.length")
 public class EOstring$EOlength extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOlength.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOlength.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "string.length")
 public class EOstring$EOlength extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOslice.java
@@ -34,6 +34,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -42,6 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "string.slice")
 public class EOstring$EOslice extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOslice.java
@@ -34,7 +34,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -43,7 +43,7 @@ import org.eolang.XmirObject;
  * @since 0.23
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "string.slice")
 public class EOstring$EOslice extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 0.19
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "try")
 public class EOtry extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
@@ -29,11 +29,10 @@ package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
 import org.eolang.AtFree;
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 0.19
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "try")
 public class EOtry extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOat.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOat.java
@@ -33,7 +33,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "tuple.at")
 public class EOtuple$EOat extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOat.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOat.java
@@ -33,6 +33,7 @@ import org.eolang.ExFailure;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "tuple.at")
 public class EOtuple$EOat extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOlength.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOlength.java
@@ -32,7 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -41,7 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "tuple.length")
 public class EOtuple$EOlength extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOlength.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOlength.java
@@ -32,6 +32,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "tuple.length")
 public class EOtuple$EOlength extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOwith.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOwith.java
@@ -33,6 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 import org.eolang.XmirObject;
 
 /**
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
+@Versionize
 @XmirObject(oname = "tuple.with")
 public class EOtuple$EOwith extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOwith.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOwith.java
@@ -33,7 +33,7 @@ import org.eolang.Data;
 import org.eolang.Param;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
@@ -42,7 +42,7 @@ import org.eolang.XmirObject;
  * @since 1.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@Versionize
+@Versionized
 @XmirObject(oname = "tuple.with")
 public class EOtuple$EOwith extends PhDefault {
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/ExReduceBytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/ExReduceBytes.java
@@ -34,14 +34,14 @@ import org.eolang.Dataized;
 import org.eolang.Expr;
 import org.eolang.Param;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Reduce on BYTES.
  *
  * @since 1.0
  */
-@Versionize
+@Versionized
 final class ExReduceBytes implements Expr {
     /**
      * Reduce operation.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/ExReduceBytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/ExReduceBytes.java
@@ -34,12 +34,14 @@ import org.eolang.Dataized;
 import org.eolang.Expr;
 import org.eolang.Param;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Reduce on BYTES.
  *
  * @since 1.0
  */
+@Versionize
 final class ExReduceBytes implements Expr {
     /**
      * Reduce operation.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
@@ -30,14 +30,14 @@ package EOorg.EOeolang;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eolang.Dataized;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * All heaps.
  *
  * @since 0.19
  */
-@Versionize
+@Versionized
 final class Heaps {
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
@@ -30,12 +30,14 @@ package EOorg.EOeolang;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eolang.Dataized;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * All heaps.
  *
  * @since 0.19
  */
+@Versionize
 final class Heaps {
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Ram.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Ram.java
@@ -36,12 +36,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eolang.Dataized;
 import org.eolang.Phi;
+import org.eolang.Versionize;
 
 /**
  * Random access.
  *
  * @since 0.19
  */
+@Versionize
 public enum Ram {
     /**
      * Ram instance.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Ram.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Ram.java
@@ -36,14 +36,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eolang.Dataized;
 import org.eolang.Phi;
-import org.eolang.Versionize;
+import org.eolang.Versionized;
 
 /**
  * Random access.
  *
  * @since 0.19
  */
-@Versionize
+@Versionized
 public enum Ram {
     /**
      * Ram instance.

--- a/eo-runtime/src/main/java/org/eolang/AtAbsent.java
+++ b/eo-runtime/src/main/java/org/eolang/AtAbsent.java
@@ -33,7 +33,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 final class AtAbsent implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtAbsent.java
+++ b/eo-runtime/src/main/java/org/eolang/AtAbsent.java
@@ -33,6 +33,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 final class AtAbsent implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtCage.java
+++ b/eo-runtime/src/main/java/org/eolang/AtCage.java
@@ -34,7 +34,7 @@ import EOorg.EOeolang.EOcage;
  *
  * @since 0.29.6
  */
-@Versionize
+@Versionized
 public final class AtCage implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtCage.java
+++ b/eo-runtime/src/main/java/org/eolang/AtCage.java
@@ -34,6 +34,7 @@ import EOorg.EOeolang.EOcage;
  *
  * @since 0.29.6
  */
+@Versionize
 public final class AtCage implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtComposite.java
+++ b/eo-runtime/src/main/java/org/eolang/AtComposite.java
@@ -30,7 +30,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class AtComposite implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtComposite.java
+++ b/eo-runtime/src/main/java/org/eolang/AtComposite.java
@@ -30,6 +30,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public final class AtComposite implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtConst.java
+++ b/eo-runtime/src/main/java/org/eolang/AtConst.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @todo #1614:30min This class don't have enough tests. We need to add more, at least for
  *  the next methods: toString(), φTerm(), copy(), put().
  */
-@Versionize
+@Versionized
 final class AtConst implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtConst.java
+++ b/eo-runtime/src/main/java/org/eolang/AtConst.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @todo #1614:30min This class don't have enough tests. We need to add more, at least for
  *  the next methods: toString(), φTerm(), copy(), put().
  */
+@Versionize
 final class AtConst implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtFixed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFixed.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 final class AtFixed implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtFixed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFixed.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 final class AtFixed implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtFree.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFree.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @since 0.1
  */
+@Versionize
 public final class AtFree implements Attr {
     /**
      * Origin.

--- a/eo-runtime/src/main/java/org/eolang/AtFree.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFree.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class AtFree implements Attr {
     /**
      * Origin.

--- a/eo-runtime/src/main/java/org/eolang/AtLocated.java
+++ b/eo-runtime/src/main/java/org/eolang/AtLocated.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 final class AtLocated implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtLocated.java
+++ b/eo-runtime/src/main/java/org/eolang/AtLocated.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 final class AtLocated implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/AtLogged.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  *
  * @since 0.24
  */
-@Versionize
+@Versionized
 final class AtLogged implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/AtLogged.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
  *
  * @since 0.24
  */
+@Versionize
 final class AtLogged implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtNamed.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 final class AtNamed implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtNamed.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 final class AtNamed implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @since 0.1
  */
+@Versionize
 public final class AtOnce implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class AtOnce implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtPhiSensitive.java
+++ b/eo-runtime/src/main/java/org/eolang/AtPhiSensitive.java
@@ -31,6 +31,7 @@ package org.eolang;
  *
  * @since 0.22
  */
+@Versionize
 final class AtPhiSensitive implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtPhiSensitive.java
+++ b/eo-runtime/src/main/java/org/eolang/AtPhiSensitive.java
@@ -31,7 +31,7 @@ package org.eolang;
  *
  * @since 0.22
  */
-@Versionize
+@Versionized
 final class AtPhiSensitive implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSafe.java
@@ -32,6 +32,7 @@ import EOorg.EOeolang.EOerror;
  *
  * @since 0.26
  */
+@Versionize
 public final class AtSafe implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSafe.java
@@ -32,7 +32,7 @@ import EOorg.EOeolang.EOerror;
  *
  * @since 0.26
  */
-@Versionize
+@Versionized
 public final class AtSafe implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtSimple.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSimple.java
@@ -31,6 +31,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public final class AtSimple implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtSimple.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSimple.java
@@ -31,7 +31,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class AtSimple implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtVararg.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVararg.java
@@ -33,7 +33,7 @@ import java.util.List;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class AtVararg implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtVararg.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVararg.java
@@ -33,6 +33,7 @@ import java.util.List;
  *
  * @since 0.1
  */
+@Versionize
 public final class AtVararg implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public interface Attr extends Term {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public interface Attr extends Term {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Bytes.java
+++ b/eo-runtime/src/main/java/org/eolang/Bytes.java
@@ -34,6 +34,7 @@ import EOorg.EOeolang.EObytes;
  *
  * @since 1.0
  */
+@Versionize
 public interface Bytes extends Data<byte[]> {
     /**
      * NOT operation.

--- a/eo-runtime/src/main/java/org/eolang/Bytes.java
+++ b/eo-runtime/src/main/java/org/eolang/Bytes.java
@@ -34,7 +34,7 @@ import EOorg.EOeolang.EObytes;
  *
  * @since 1.0
  */
-@Versionize
+@Versionized
 public interface Bytes extends Data<byte[]> {
     /**
      * NOT operation.

--- a/eo-runtime/src/main/java/org/eolang/BytesOf.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesOf.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
  *
  * @since 1.0
  */
+@Versionize
 public final class BytesOf implements Bytes {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/BytesOf.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesOf.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
  *
  * @since 1.0
  */
-@Versionize
+@Versionized
 public final class BytesOf implements Bytes {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/CachedPhi.java
+++ b/eo-runtime/src/main/java/org/eolang/CachedPhi.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
  *
  * @since 0.17
  */
+@Versionize
 final class CachedPhi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/CachedPhi.java
+++ b/eo-runtime/src/main/java/org/eolang/CachedPhi.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  *
  * @since 0.17
  */
-@Versionize
+@Versionized
 final class CachedPhi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
  * @param <T> Data type.
  * @since 0.1
  */
+@Versionize
 public interface Data<T> {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
  * @param <T> Data type.
  * @since 0.1
  */
-@Versionize
+@Versionized
 public interface Data<T> {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -43,6 +43,7 @@ import java.util.logging.Logger;
  * @see <a href="https://arxiv.org/abs/2111.13384">Canonical explanation of the Dataization concept</a>
  * @since 0.1
  */
+@Versionize
 public final class Dataized {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  * @see <a href="https://arxiv.org/abs/2111.13384">Canonical explanation of the Dataization concept</a>
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class Dataized {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExAbstract.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAbstract.java
@@ -32,7 +32,7 @@ package org.eolang;
 
  * @since 0.21
  */
-@Versionize
+@Versionized
 public abstract class ExAbstract extends RuntimeException {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExAbstract.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAbstract.java
@@ -32,6 +32,7 @@ package org.eolang;
 
  * @since 0.21
  */
+@Versionize
 public abstract class ExAbstract extends RuntimeException {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExFailure.java
+++ b/eo-runtime/src/main/java/org/eolang/ExFailure.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public class ExFailure extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExFailure.java
+++ b/eo-runtime/src/main/java/org/eolang/ExFailure.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 public class ExFailure extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExFlow.java
+++ b/eo-runtime/src/main/java/org/eolang/ExFlow.java
@@ -32,6 +32,7 @@ import EOorg.EOeolang.EOgoto;
  *
  * @since 0.21
  */
+@Versionize
 public final class ExFlow extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExFlow.java
+++ b/eo-runtime/src/main/java/org/eolang/ExFlow.java
@@ -32,7 +32,7 @@ import EOorg.EOeolang.EOgoto;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public final class ExFlow extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
+++ b/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.28.3
  */
+@Versionize
 public class ExInterrupted extends ExAbstract {
     /**
      * Serialization identifier.

--- a/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
+++ b/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.28.3
  */
-@Versionize
+@Versionized
 public class ExInterrupted extends ExAbstract {
     /**
      * Serialization identifier.

--- a/eo-runtime/src/main/java/org/eolang/ExNative.java
+++ b/eo-runtime/src/main/java/org/eolang/ExNative.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.32
  */
+@Versionize
 public final class ExNative extends ExFailure {
 
     private static final long serialVersionUID = 5726845593921315515L;

--- a/eo-runtime/src/main/java/org/eolang/ExNative.java
+++ b/eo-runtime/src/main/java/org/eolang/ExNative.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.32
  */
-@Versionize
+@Versionized
 public final class ExNative extends ExFailure {
 
     private static final long serialVersionUID = 5726845593921315515L;

--- a/eo-runtime/src/main/java/org/eolang/ExReadOnly.java
+++ b/eo-runtime/src/main/java/org/eolang/ExReadOnly.java
@@ -30,7 +30,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public final class ExReadOnly extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExReadOnly.java
+++ b/eo-runtime/src/main/java/org/eolang/ExReadOnly.java
@@ -30,6 +30,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 public final class ExReadOnly extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExUnset.java
+++ b/eo-runtime/src/main/java/org/eolang/ExUnset.java
@@ -30,6 +30,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 public final class ExUnset extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExUnset.java
+++ b/eo-runtime/src/main/java/org/eolang/ExUnset.java
@@ -30,7 +30,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public final class ExUnset extends ExAbstract {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Expr.java
+++ b/eo-runtime/src/main/java/org/eolang/Expr.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public interface Expr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Expr.java
+++ b/eo-runtime/src/main/java/org/eolang/Expr.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public interface Expr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExprReduce.java
+++ b/eo-runtime/src/main/java/org/eolang/ExprReduce.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
  * @param <T> Type of arguments that are going to be reduced
  * @since 1.0
  */
+@Versionize
 public final class ExprReduce<T> implements Expr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/ExprReduce.java
+++ b/eo-runtime/src/main/java/org/eolang/ExprReduce.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
  * @param <T> Type of arguments that are going to be reduced
  * @since 1.0
  */
-@Versionize
+@Versionized
 public final class ExprReduce<T> implements Expr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Indented.java
+++ b/eo-runtime/src/main/java/org/eolang/Indented.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 final class Indented {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Indented.java
+++ b/eo-runtime/src/main/java/org/eolang/Indented.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
  *
  * @since 0.1
  */
+@Versionize
 final class Indented {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/JavaPath.java
+++ b/eo-runtime/src/main/java/org/eolang/JavaPath.java
@@ -34,7 +34,7 @@ package org.eolang;
  *
  * @since 0.29
  */
-@Versionize
+@Versionized
 final class JavaPath {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/JavaPath.java
+++ b/eo-runtime/src/main/java/org/eolang/JavaPath.java
@@ -34,6 +34,7 @@ package org.eolang;
  *
  * @since 0.29
  */
+@Versionize
 final class JavaPath {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class Main {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -49,6 +49,7 @@ import java.util.logging.Logger;
  *
  * @since 0.1
  */
+@Versionize
 public final class Main {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Param.java
+++ b/eo-runtime/src/main/java/org/eolang/Param.java
@@ -37,6 +37,7 @@ package org.eolang;
  *
  * @since 0.20
  */
+@Versionize
 public final class Param {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Param.java
+++ b/eo-runtime/src/main/java/org/eolang/Param.java
@@ -37,7 +37,7 @@ package org.eolang;
  *
  * @since 0.20
  */
-@Versionize
+@Versionized
 public final class Param {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhConst.java
+++ b/eo-runtime/src/main/java/org/eolang/PhConst.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.16
  */
+@Versionize
 public final class PhConst implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhConst.java
+++ b/eo-runtime/src/main/java/org/eolang/PhConst.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.16
  */
-@Versionize
+@Versionized
 public final class PhConst implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhCopy.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCopy.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public final class PhCopy extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhCopy.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCopy.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class PhCopy extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (500 lines)
  */
-@Versionize
+@Versionized
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.ConstructorShouldDoInitialization"})
 public abstract class PhDefault implements Phi, Cloneable {
 

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (500 lines)
  */
+@Versionize
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.ConstructorShouldDoInitialization"})
 public abstract class PhDefault implements Phi, Cloneable {
 

--- a/eo-runtime/src/main/java/org/eolang/PhFake.java
+++ b/eo-runtime/src/main/java/org/eolang/PhFake.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
  *
  * @since 0.29
  */
+@Versionize
 public final class PhFake extends PhDefault {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhFake.java
+++ b/eo-runtime/src/main/java/org/eolang/PhFake.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  *
  * @since 0.29
  */
-@Versionize
+@Versionized
 public final class PhFake extends PhDefault {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhImmovable.java
+++ b/eo-runtime/src/main/java/org/eolang/PhImmovable.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.23
  */
+@Versionize
 final class PhImmovable implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhImmovable.java
+++ b/eo-runtime/src/main/java/org/eolang/PhImmovable.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.23
  */
-@Versionize
+@Versionized
 final class PhImmovable implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhLocated.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLocated.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public final class PhLocated implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhLocated.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLocated.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 public final class PhLocated implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -32,7 +32,7 @@ package org.eolang;
  *
  * @since 0.24
  */
-@Versionize
+@Versionized
 public final class PhLogged implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -32,6 +32,7 @@ package org.eolang;
  *
  * @since 0.24
  */
+@Versionize
 public final class PhLogged implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhMethod.java
+++ b/eo-runtime/src/main/java/org/eolang/PhMethod.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class PhMethod extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhMethod.java
+++ b/eo-runtime/src/main/java/org/eolang/PhMethod.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public final class PhMethod extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNamed.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.17
  */
+@Versionize
 final class PhNamed implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNamed.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.17
  */
-@Versionize
+@Versionized
 final class PhNamed implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 class PhOnce implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
  *
  * @since 0.1
  */
+@Versionize
 class PhOnce implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.22
  */
-@Versionize
+@Versionized
 final class PhPackage implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.22
  */
+@Versionize
 final class PhPackage implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -32,7 +32,7 @@ import EOorg.EOeolang.EOerror;
  *
  * @since 0.26
  */
-@Versionize
+@Versionized
 public final class PhSafe implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -32,6 +32,7 @@ import EOorg.EOeolang.EOerror;
  *
  * @since 0.26
  */
+@Versionize
 public final class PhSafe implements Phi {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhUnvar.java
+++ b/eo-runtime/src/main/java/org/eolang/PhUnvar.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
-@Versionize
+@Versionized
 public final class PhUnvar extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhUnvar.java
+++ b/eo-runtime/src/main/java/org/eolang/PhUnvar.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.21
  */
+@Versionize
 public final class PhUnvar extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhWith.java
+++ b/eo-runtime/src/main/java/org/eolang/PhWith.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
-@Versionize
+@Versionized
 public final class PhWith extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhWith.java
+++ b/eo-runtime/src/main/java/org/eolang/PhWith.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.1
  */
+@Versionize
 public final class PhWith extends PhOnce {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Term.java
+++ b/eo-runtime/src/main/java/org/eolang/Term.java
@@ -29,7 +29,7 @@ package org.eolang;
  *
  * @since 0.17
  */
-@Versionize
+@Versionized
 public interface Term {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Term.java
+++ b/eo-runtime/src/main/java/org/eolang/Term.java
@@ -29,6 +29,7 @@ package org.eolang;
  *
  * @since 0.17
  */
+@Versionize
 public interface Term {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -27,7 +27,7 @@ package org.eolang;
  * Class to manipulate eo objects within "Universe" paradigm.
  * @since 0.30
  */
-@Versionize
+@Versionized
 public interface Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Universe.java
+++ b/eo-runtime/src/main/java/org/eolang/Universe.java
@@ -27,6 +27,7 @@ package org.eolang;
  * Class to manipulate eo objects within "Universe" paradigm.
  * @since 0.30
  */
+@Versionize
 public interface Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  * Default implementation that can be used on the java side.
  * @since 0.32
  */
+@Versionize
 public final class UniverseDefault implements Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseDefault.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  * Default implementation that can be used on the java side.
  * @since 0.32
  */
-@Versionize
+@Versionized
 public final class UniverseDefault implements Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/UniverseSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseSafe.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 0.32
  * @checkstyle IllegalCatchCheck (200 lines)
  */
+@Versionize
 public final class UniverseSafe implements Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/UniverseSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/UniverseSafe.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 0.32
  * @checkstyle IllegalCatchCheck (200 lines)
  */
-@Versionize
+@Versionized
 public final class UniverseSafe implements Universe {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Versionize.java
+++ b/eo-runtime/src/main/java/org/eolang/Versionize.java
@@ -25,6 +25,8 @@
 package org.eolang;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -34,6 +36,6 @@ import java.lang.annotation.Target;
  * @since 0.32.0
  */
 @Target(ElementType.TYPE)
-@Versionize
+@Retention(RetentionPolicy.CLASS)
 public @interface Versionize {
 }

--- a/eo-runtime/src/main/java/org/eolang/Versionize.java
+++ b/eo-runtime/src/main/java/org/eolang/Versionize.java
@@ -25,39 +25,15 @@
 package org.eolang;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for an object made from XMIR.
+ * Annotation for an object which location should be extended with version package.
+ * More details <a href="https://github.com/objectionary/eo/issues/2506">here</a>
  *
- * @since 0.17
+ * @since 0.32.0
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
 @Versionize
-public @interface XmirObject {
-
-    /**
-     * The original name of the object in EO, before optimization.
-     *
-     * @return The name as it was in EO
-     */
-    String oname();
-
-    /**
-     * The name of the object in EO.
-     *
-     * @return The name as it is in EO
-     */
-    String name() default "";
-
-    /**
-     * The name of the source file where this Java code was generated from.
-     *
-     * @return The absolute path
-     */
-    String source() default "";
-
+public @interface Versionize {
 }

--- a/eo-runtime/src/main/java/org/eolang/Versionized.java
+++ b/eo-runtime/src/main/java/org/eolang/Versionized.java
@@ -37,5 +37,5 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
-public @interface Versionize {
+public @interface Versionized {
 }

--- a/eo-runtime/src/main/java/org/eolang/Volatile.java
+++ b/eo-runtime/src/main/java/org/eolang/Volatile.java
@@ -36,5 +36,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Versionize
 public @interface Volatile {
 }

--- a/eo-runtime/src/main/java/org/eolang/Volatile.java
+++ b/eo-runtime/src/main/java/org/eolang/Volatile.java
@@ -36,6 +36,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Versionize
+@Versionized
 public @interface Volatile {
 }

--- a/eo-runtime/src/main/java/org/eolang/XmirObject.java
+++ b/eo-runtime/src/main/java/org/eolang/XmirObject.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Versionize
+@Versionized
 public @interface XmirObject {
 
     /**


### PR DESCRIPTION
Ref: #2506 

Created `@Versionize` annotation and attached it to almost all classes in `eo-runtime`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `@Versionized` annotation to various classes and interfaces in the codebase. 

### Detailed summary
- Added `@Versionized` annotation to `Expr`, `Term`, `Main`, `Data`, `Indented`, `JavaPath`, `Param`, `CachedPhi`, `PhOnce`, `Universe`, `Dataized`, `Attr`, `AtFixed`, `AtNamed`, `PhNamed`, `AtAbsent`, `AtLogged`, `PhCopy`, `PhPackage`, `PhWith`, `AtLocated`, `AtOnce`, `PhSafe`, `AtSafe`, `PhConst`, `PhUnvar`, `AtCage`, `BytesOf`, `PhFake`, `PhImmovable`, `PhMethod`, `AtSimple`, `AtVararg`, `ExFailure`, `ExFlow`, `PhLogged`, `ExUnset`, `PhLocated`, `AtFree`, `AtComposite`, `AtPhiSensitive`, `ExprReduce`, `ExReadOnly`, `Bytes`, `ExAbstract`, `UniverseDefault`, `Volatile`, `XmirObject`, `AtConst`, `ExInterrupted`, `UniverseSafe`, `ExNative`, `Heaps`, `Input`, `Ram`, `PhDefault`, `ExReduceBytes`, `EOram$EOram_slice$EOφ`, `EOseq`, `EOas_phi`, `EOmemory`, `AtMemoized`, `EOerror`, `EOint$EOgt`, `EObool$EOif`, `EObool$EOor`, `EOstdout`, `EObytes$EOeq`


> The following files were skipped due to too many changes: `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOeq.java`, `/eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EO\317\206.java"`, `eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOand.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOgt.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOat.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOand.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOnot.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOxor.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOtimes.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOdiv.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOslice.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObool$EOwhile.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOsize.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOwrite.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOwith.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOplus.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOtimes.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOright.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOio/EOstdin$EOnext_line.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOtuple$EOlength.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOconcat.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOslice.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOlength.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOstring$EOas_bytes.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_string.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOram$EOram_slice$EOwrite.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOheap$EOpointer$EOblock.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOgoto.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOas_bytes.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOplus.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOdiv.java`, `eo-runtime/src/main/java/org/eolang/Versionized.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->