### PR TITLE
#2516: Refactored the test

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -196,12 +196,10 @@
       nop
     "Rust insert failed in Φ.org.eolang.rust-put-not-fails.put.α0:176:4 with message 'put failed'; caused by Phi object with vertex -1 was not indexed."
 
-# @todo #2498:30min Enable the tests. After removing assert-that from eo-runtime
-#  $.string-starts-with it not allowed anymore. Need to refactor the next tests and enable them:
-#  - rust-bind-not-fails, - rust-error
 [] > rust-bind-not-fails
   1 > a
   2 > b
+  "Rust insert failed" > to-check!
   QQ.rust > insert
     """
     use eo_env::EOEnv;
@@ -219,16 +217,17 @@
     """
     *
       []
-  try > res
+  try > res!
     []
       insert > @
     [e]
       e > @
     nop
-  nop > @
-    eq.
-      res
-      "Rust insert failed"
+  eq. > @
+    res.slice
+      0
+      to-check.length
+    to-check
 
 [] > rust-copy-not-fails
   123 > a


### PR DESCRIPTION
Closes #2516 

<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Enable tests in the `eo-runtime` by removing the usage of `assert-that` and refactoring the affected tests.

### Detailed summary:
- Removed the usage of `assert-that` from the `eo-runtime` tests.
- Refactored the `rust-bind-not-fails` and `rust-error` tests to enable them.
- Updated the `rust-tests.eo` file to handle Rust insert failures in the `Φ.org.eolang.rust-put-not-fails.put.α0` function.
- Updated the `rust-tests.eo` file to handle Rust copy failures in the `rust-copy-not-fails` test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->