### PR TITLE
fix(#1469): remove empty lines in runtime

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -92,12 +92,10 @@
             (terms.at index).neg
           index.plus 1
           terms
-
     rec-terms > neg-terms
       *
       0
       x
-
     ^.plus > @
       ...neg-terms
 

--- a/eo-runtime/src/main/eo/org/eolang/int.eo
+++ b/eo-runtime/src/main/eo/org/eolang/int.eo
@@ -84,12 +84,10 @@
             (terms.at index).neg
           index.plus 1
           terms
-
     rec-terms > neg-terms
       *
       0
       x
-
     ^.plus > @
       ...neg-terms
 

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -191,7 +191,6 @@
             acc
             index.plus 1
             terms
-
     if. > @
       eq.
         x.length > terms-count!

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -51,7 +51,6 @@
         check-case-at
           index.plus 1
           cases
-
   if. > @
     cases.length.eq 0
     error "switch cases are empty"


### PR DESCRIPTION
Ref: #1469 

Removed unnecessary empty lines in eo-runtime. Reason for that is simple: integration tests in `eo-maven-plugin` take last available version of `eo-runtime` stored in objectionary. 
So changes in `eo-runtime` should be made and released firstly, before changes in grammar