### PR TITLE
antlr2ebnf plugin 0.0.7

### DIFF
--- a/.github/workflows/ebnf.yml
+++ b/.github/workflows/ebnf.yml
@@ -37,10 +37,11 @@ jobs:
           unzip -o -d "$CONVERT_PATH" /tmp/convert.zip
       - run: sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
       - run: |
-          mvn com.yegor256:antlr2ebnf-maven-plugin:0.0.6:generate \
+          mvn com.yegor256:antlr2ebnf-maven-plugin:0.0.7:generate \
             -pl :eo-parser --debug --errors --batch-mode --quiet \
             "-Dantlr2ebnf.convertDir=$CONVERT_PATH" \
-            "-Dantlr2ebnf.specials=eol,eop,tab,untab"
+            "-Dantlr2ebnf.specials=eol,eop,tab,untab" \
+            "-Dantlr2ebnf.margin=40"
       - run: |
           set -x
           cp eo-parser/target/ebnf/org/eolang/parser/Program.pdf .


### PR DESCRIPTION
Version up, it has `margin` parameter now (see #2526)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `mvn` command in the workflow file and adding a new parameter for `antlr2ebnf-maven-plugin`. 

### Detailed summary
- Updated `mvn` command to use version 0.0.7 of `antlr2ebnf-maven-plugin`
- Added `-Dantlr2ebnf.margin=40` parameter to the `mvn` command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->