### PR TITLE
fix(#2529): remove IOException from Schema#check declaration

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Schema.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Schema.java
@@ -26,7 +26,6 @@ package org.eolang.parser;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XSDDocument;
-import java.io.IOException;
 import java.util.Collection;
 import javax.xml.transform.dom.DOMSource;
 import org.cactoos.io.ResourceOf;
@@ -56,9 +55,8 @@ public final class Schema {
 
     /**
      * Check and crash if mistakes.
-     * @throws IOException If fails
      */
-    public void check() throws IOException {
+    public void check() {
         final Collection<SAXParseException> violations = new XSDDocument(
             new UncheckedText(
                 new TextOf(new ResourceOf("XMIR.xsd"))


### PR DESCRIPTION
Remove `IOException` from `Schema#check` method declaration.

Closes: #2529


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on removing the `throws IOException` declaration from the `check()` method in the `Schema` class.

### Detailed summary:
- Removed the `throws IOException` declaration from the `check()` method in the `Schema` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->