### PR TITLE
#2471: Removed unsafe unwrap() and handle it via "?"

### DIFF
--- a/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
+++ b/eo-runtime/src/main/rust/eo_env/src/eo_env.rs
@@ -32,11 +32,6 @@ pub struct EOEnv<'local> {
     java_obj: JObject<'local>
 }
 
-/*
- * @todo #2442:45min Add correct processing of the return value of functions.
- *  call_method returns Result<JValueOwned<'local>> which we should not just unwrap.
- *  We need to check it instead and return None if exception in java side happened.
-*/
 impl<'local> EOEnv<'_> {
     pub fn new(java_env: JNIEnv<'local>, _java_class: JClass<'local>, java_obj: JObject<'local>) -> EOEnv<'local> {
         EOEnv {

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -128,7 +128,7 @@
 
     pub fn foo(env: &mut EOEnv) -> Option<EO> {
       Some(
-        EOInt(env.find("$.^.a").unwrap() as i64)
+        EOInt(env.find("$.^.a")? as i64)
       )
     }
     """
@@ -282,7 +282,7 @@
 
     pub fn foo(env: &mut EOEnv) -> Option<EO> {
       let a = env.find("$.^.a")?;
-      let bytes_a = env.dataize(a).unwrap();
+      let bytes_a = env.dataize(a)?;
       let a = bytes_a.as_slice().read_i64::<BigEndian>().ok()?;
 
       let b = env.find("$.^.b")?;


### PR DESCRIPTION
Closes #2471 
 In fact, this issue was already solved in pull request #2510 , so I improved the tests before this change

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `foo` function and adding a detailed summary of the changes. 

### Detailed summary
- Improved error handling by using the `?` operator instead of `unwrap()` in the `foo` function.
- Updated the `dataize` function call to use `?` operator instead of `unwrap()`.
- Removed a block comment related to future improvements in the `EOEnv` implementation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->