### PR TITLE
feat(#2506): copy sources mojo

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,3 +4,5 @@
 exclude_paths:
   - "eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java"
   - "eo-runtime/src/test/java/EOorg/EOeolang/EOintTest.java"
+  - "eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/Heaps.java"
+  - "eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/package-info.java"

--- a/eo-maven-plugin/src/it/hash_package_layer/README.md
+++ b/eo-maven-plugin/src/it/hash_package_layer/README.md
@@ -1,0 +1,3 @@
+<img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
+
+This test checks if one more package layer is added successfully to all source files.

--- a/eo-maven-plugin/src/it/hash_package_layer/invoker.properties
+++ b/eo-maven-plugin/src/it/hash_package_layer/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean test

--- a/eo-maven-plugin/src/it/hash_package_layer/invoker.properties
+++ b/eo-maven-plugin/src/it/hash_package_layer/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean test
+invoker.goals = clean eo:copy-sources

--- a/eo-maven-plugin/src/it/hash_package_layer/pom.xml
+++ b/eo-maven-plugin/src/it/hash_package_layer/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jcabi</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.66.0</version>
+  </parent>
+  <groupId>org.eolang</groupId>
+  <artifactId>examples</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <name>Fibonacci Numbers Calculator</name>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration combine.self="override"/>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>register</goal>
+              <goal>assemble</goal>
+              <goal>transpile</goal>
+              <goal>sodg</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <unrollExitError>true</unrollExitError>
+          <sodgIncludes>
+            <o>org.eolang.error</o>
+          </sodgIncludes>
+          <foreign>${project.build.directory}/eo/foreign.csv</foreign>
+          <foreignFormat>csv</foreignFormat>
+          <placed>${project.build.directory}/eo/placed.json</placed>
+          <placedFormat>json</placedFormat>
+          <trackOptimizationSteps>true</trackOptimizationSteps>
+          <generateSodgXmlFiles>true</generateSodgXmlFiles>
+          <generateGraphFiles>true</generateGraphFiles>
+          <generateXemblyFiles>true</generateXemblyFiles>
+          <generateDotFiles>true</generateDotFiles>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.Main</mainClass>
+          <arguments>
+            <argument>org.eolang.examples.app</argument>
+            <argument>6</argument>
+            <argument>8</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/eo-maven-plugin/src/it/hash_package_layer/pom.xml
+++ b/eo-maven-plugin/src/it/hash_package_layer/pom.xml
@@ -33,20 +33,21 @@ SOFTWARE.
   <artifactId>examples</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
-  <name>Fibonacci Numbers Calculator</name>
+  <name>Hash-package layer</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-resources-plugin</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eolang</groupId>
+      <artifactId>eo-maven-plugin</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration combine.self="override"/>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <failIfNoTests>false</failIfNoTests>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
@@ -54,48 +55,12 @@ SOFTWARE.
         <executions>
           <execution>
             <goals>
-              <goal>register</goal>
-              <goal>assemble</goal>
-              <goal>transpile</goal>
-              <goal>sodg</goal>
+              <goal>copy-sources</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <unrollExitError>true</unrollExitError>
-          <sodgIncludes>
-            <o>org.eolang.error</o>
-          </sodgIncludes>
-          <foreign>${project.build.directory}/eo/foreign.csv</foreign>
-          <foreignFormat>csv</foreignFormat>
-          <placed>${project.build.directory}/eo/placed.json</placed>
-          <placedFormat>json</placedFormat>
-          <trackOptimizationSteps>true</trackOptimizationSteps>
-          <generateSodgXmlFiles>true</generateSodgXmlFiles>
-          <generateGraphFiles>true</generateGraphFiles>
-          <generateXemblyFiles>true</generateXemblyFiles>
-          <generateDotFiles>true</generateDotFiles>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <phase>test</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>org.eolang.Main</mainClass>
-          <arguments>
-            <argument>org.eolang.examples.app</argument>
-            <argument>6</argument>
-            <argument>8</argument>
-          </arguments>
+          <deployHash>9c46a671f2bc68e777aab031d57da5012ba807a7</deployHash>
         </configuration>
       </plugin>
     </plugins>

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/Heaps.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/Heaps.java
@@ -1,0 +1,121 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ */
+package EOorg.EOeolang;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.eolang.Versionized;
+
+/**
+ * All heaps.
+ *
+ * @since 0.19
+ */
+@Versionized
+final class Heaps {
+
+    /**
+     * Heaps.
+     */
+    public static final ThreadLocal<Heaps> INSTANCE = ThreadLocal.withInitial(Heaps::new);
+
+    /**
+     * All.
+     */
+    private final ConcurrentHashMap<Phi, byte[]> all =
+        new ConcurrentHashMap<>(0);
+
+    /**
+     * Heads.
+     */
+    private final ConcurrentHashMap<Phi, Integer> heads =
+        new ConcurrentHashMap<>(0);
+
+    /**
+     * Ctor.
+     */
+    private Heaps() {
+        // intentionally empty, it's a singleton :(
+    }
+
+    /**
+     * Data.
+     * @param pointer Pointer
+     * @return Bytes comprising data
+     */
+    public byte[] data(final Phi pointer) {
+        final Phi heap = pointer.attr("ρ").get();
+        return this.all.computeIfAbsent(
+            heap,
+            key -> {
+                final long size = new Dataized(heap.attr("size").get()).take(Long.class);
+                if (size > (long) Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "The size of heap %d is too big",
+                            size
+                        )
+                    );
+                }
+                return new byte[(int) size];
+            }
+        );
+    }
+
+    /**
+     * Allocate a piece.
+     *
+     * The implementation is very primitive. It just allocates blocks
+     * of memory one after another. It doesn't listen to free()
+     * requests and never frees any blocks. They just go one by one.
+     *
+     * @param heap The heap
+     * @param size How many bytes?
+     * @return The pointer to it
+     */
+    public int malloc(final Phi heap, final int size) {
+        synchronized (this.heads) {
+            this.heads.putIfAbsent(heap, 0);
+            final int ptr = this.heads.get(heap);
+            this.heads.put(heap, ptr + size);
+            return ptr;
+        }
+    }
+
+    /**
+     * Free it.
+     * @param heap The heap
+     * @param ptr The pointer
+     * @checkstyle NonStaticMethodCheck (5 lines)
+     */
+    public void free(final Phi heap, final int ptr) {
+        // Nothing yet
+    }
+
+}

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/package-info.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,14 @@
  * SOFTWARE.
  */
 
-
-
-true
+/*
+ * @checkstyle PackageNameCheck (20 lines)
+ */
+/**
+ * EO runtime.
+ *
+ * @since 0.1
+ * @see <a href="https://www.eolang.org">project site www.eolang.org</a>
+ * @see <a href="https://github.com/objectionary/eo">GitHub project</a>
+ */
+package EOorg.EOeolang;

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/AtSimple.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/AtSimple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,61 @@
  * SOFTWARE.
  */
 
+package org.eolang;
 
+/**
+ * Default attribute.
+ *
+ * The class is NOT thread-safe.
+ *
+ * @since 0.1
+ */
+@Versionized
+public final class AtSimple implements Attr {
 
-true
+    /**
+     * Parent φ.
+     */
+    private Phi phi;
+
+    /**
+     * Ctor.
+     */
+    public AtSimple() {
+        this(Phi.Φ);
+    }
+
+    /**
+     * Ctor.
+     * @param src Source φ
+     */
+    public AtSimple(final Phi src) {
+        this.phi = src;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%sS", this.phi.toString());
+    }
+
+    @Override
+    public String φTerm() {
+        return this.phi.φTerm();
+    }
+
+    @Override
+    public Attr copy(final Phi self) {
+        return new AtSimple(this.phi);
+    }
+
+    @Override
+    public Phi get() {
+        return this.phi;
+    }
+
+    @Override
+    public void put(final Phi src) {
+        this.phi = src;
+    }
+
+}

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Attr.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Attr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,36 @@
  * SOFTWARE.
  */
 
+package org.eolang;
 
+/**
+ * Attribute.
+ *
+ * @since 0.1
+ */
+@Versionized
+public interface Attr extends Term {
 
-true
+    /**
+     * Make a copy of it.
+     *
+     * @param self The object that this attribute will belong to
+     * @return A copy
+     */
+    Attr copy(Phi self);
+
+    /**
+     * Take the object out.
+     *
+     * @return The object
+     */
+    Phi get();
+
+    /**
+     * Put a new object in.
+     *
+     * @param phi The object to put
+     */
+    void put(Phi phi);
+
+}

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Phi.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Phi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,54 @@
  * SOFTWARE.
  */
 
+package org.eolang;
 
+/**
+ * A simple object.
+ *
+ * We call it Phi because of the name of the φ-calculus. Actually, a better
+ * name would be "Object", but it's already occupied by Java. That's why
+ * we call it Phi.
+ *
+ * It is guaranteed that the hash codes of different Phi are different,
+ * and equal to the vertex.
+ *
+ * @since 0.1
+ */
+public interface Phi extends Term {
 
-true
+    /**
+     * Make a copy, leaving it at the same parent.
+     *
+     * @return A copy
+     */
+    Phi copy();
+
+    /**
+     * Get attribute by position.
+     *
+     * @param pos The position of the attribute
+     * @return The attr
+     */
+    Attr attr(int pos);
+
+    /**
+     * Get attribute.
+     *
+     * @param name The name of the attribute
+     * @return The attr
+     */
+    Attr attr(String name);
+
+    /**
+     * Get code locator of the phi.
+     * @return String containing code locator
+     */
+    String locator();
+
+    /**
+     * Get forma of the phi.
+     * @return Forma of it as {@link String}.
+     */
+    String forma();
+}

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Versionized.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Versionized.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,20 @@
  * SOFTWARE.
  */
 
+package org.eolang;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-true
+/**
+ * Annotation for an object which location should be extended with version package.
+ * More details <a href="https://github.com/objectionary/eo/issues/2506">here</a>
+ *
+ * @since 0.32.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Versionized {
+}

--- a/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/package-info.java
+++ b/eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2016-2023 Objectionary.com
@@ -22,6 +22,9 @@
  * SOFTWARE.
  */
 
-
-
-true
+/**
+ * EO runtime.
+ *
+ * @since 0.2
+ */
+package org.eolang;

--- a/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
+++ b/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
@@ -1,0 +1,25 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+true

--- a/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
+++ b/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
@@ -22,6 +22,19 @@
  * SOFTWARE.
  */
 
+final String sources = "target/generated-sources"
+final String hash = "9c46a67"
+final String[] files = [
+  'EOorg/EOeolang/Heaps.java',
+  'EOorg/EOeolang/package-info.java',
+  'org/eolang/package-info.java',
+  'org/eolang/AtSimple.java',
+  'org/eolang/Attr.java',
+  'org/eolang/Phi.java',
+  'org/eolang/Versionized.java',
+]
 
+files.each { assert new File(basedir, String.join(File.separator, sources, it)).exists() }
+files.each {assert new File(basedir, String.join(File.separator, sources, hash, it)).exists()}
 
 true

--- a/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
+++ b/eo-maven-plugin/src/it/hash_package_layer/verify.groovy
@@ -35,6 +35,6 @@ final String[] files = [
 ]
 
 files.each { assert new File(basedir, String.join(File.separator, sources, it)).exists() }
-files.each {assert new File(basedir, String.join(File.separator, sources, hash, it)).exists()}
+files.each { assert new File(basedir, String.join(File.separator, sources, hash, it)).exists() }
 
 true

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+
+/**
+ * Copied resources via maven-resources-plugin.
+ * @since 0.33.0
+ */
+public class CopiedResources implements BiConsumer<Path, Path> {
+    /**
+     * Maven executor environment;
+     */
+    private final MojoExecutor.ExecutionEnvironment environment;
+
+    /**
+     * Ctor.
+     * @param project Maven project.
+     * @param session Maven session.
+     * @param manager Maven build manager.
+     */
+    public CopiedResources(
+        final MavenProject project,
+        final MavenSession session,
+        final BuildPluginManager manager
+    ) {
+        this.environment = MojoExecutor.executionEnvironment(
+            project,
+            session,
+            manager
+        );
+    }
+
+    @Override
+    public void accept(final Path sources, final Path destination) {
+        try {
+            MojoExecutor.executeMojo(
+                MojoExecutor.plugin(
+                    MojoExecutor.groupId("org.apache.maven.plugins"),
+                    MojoExecutor.artifactId("maven-resources-plugin")
+                ),
+                MojoExecutor.goal("copy-resources"),
+                MojoExecutor.configuration(
+                    MojoExecutor.element("outputDirectory", destination.toString()),
+                    MojoExecutor.element(
+                        "resources",
+                        MojoExecutor.element("resource", sources.toString()),
+                        MojoExecutor.element("filtering", "true")
+                    )
+                ),
+                this.environment
+            );
+        } catch (final MojoExecutionException ex) {
+            throw new IllegalStateException(ex);
+        }
+        Logger.info(
+            this, "Resources from %s were copied to %s",
+            sources.toString(), destination.toString()
+        );
+    }
+
+    @Override
+    public BiConsumer<Path, Path> andThen(
+        final BiConsumer<? super Path, ? super Path> after) {
+        throw new UnsupportedOperationException("not implemented #andThen()");
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
@@ -73,8 +73,11 @@ public class CopiedResources implements BiConsumer<Path, Path> {
                     MojoExecutor.element("outputDirectory", destination.toString()),
                     MojoExecutor.element(
                         "resources",
-                        MojoExecutor.element("resource", sources.toString()),
-                        MojoExecutor.element("filtering", "true")
+                        MojoExecutor.element(
+                            "resource",
+                            MojoExecutor.element("directory", sources.toString()),
+                            MojoExecutor.element("filtering", "true")
+                        )
                     )
                 ),
                 this.environment

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
@@ -36,9 +36,9 @@ import org.twdata.maven.mojoexecutor.MojoExecutor;
  * Copied resources via maven-resources-plugin.
  * @since 0.33.0
  */
-public class CopiedResources implements BiConsumer<Path, Path> {
+public final class CopiedResources implements BiConsumer<Path, Path> {
     /**
-     * Maven executor environment;
+     * Maven executor environment.
      */
     private final MojoExecutor.ExecutionEnvironment environment;
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java
@@ -62,6 +62,8 @@ public final class CopiedResources implements BiConsumer<Path, Path> {
 
     @Override
     public void accept(final Path sources, final Path destination) {
+        final String src = sources.toString();
+        final String dst = destination.toString();
         try {
             MojoExecutor.executeMojo(
                 MojoExecutor.plugin(
@@ -70,12 +72,12 @@ public final class CopiedResources implements BiConsumer<Path, Path> {
                 ),
                 MojoExecutor.goal("copy-resources"),
                 MojoExecutor.configuration(
-                    MojoExecutor.element("outputDirectory", destination.toString()),
+                    MojoExecutor.element("outputDirectory", dst),
                     MojoExecutor.element(
                         "resources",
                         MojoExecutor.element(
                             "resource",
-                            MojoExecutor.element("directory", sources.toString()),
+                            MojoExecutor.element("directory", src),
                             MojoExecutor.element("filtering", "true")
                         )
                     )
@@ -83,12 +85,11 @@ public final class CopiedResources implements BiConsumer<Path, Path> {
                 this.environment
             );
         } catch (final MojoExecutionException ex) {
-            throw new IllegalStateException(ex);
+            throw new IllegalStateException(
+                String.format("Couldn't copy resources from %s to %s", src, dst), ex
+            );
         }
-        Logger.info(
-            this, "Resources from %s were copied to %s",
-            sources.toString(), destination.toString()
-        );
+        Logger.info(this, "Resources from %s were copied to %s", src, dst);
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
@@ -38,13 +38,15 @@ import org.eolang.maven.hash.CommitHash;
  * This mojo is about to be used only on deployment step.
  * See more details
  * <a href="https://github.com/objectionary/eo/issues/2506#issuecomment-1759609269">here</a>
+ *
+ * @since 0.33.0
  */
 @Mojo(
     name = "copy-sources",
     defaultPhase = LifecyclePhase.DEPLOY,
     threadSafe = true
 )
-public class CopySourcesMojo extends SafeMojo {
+public final class CopySourcesMojo extends SafeMojo {
     /**
      * Directory with java sources.
      * @checkstyle MemberNameCheck (10 lines)
@@ -74,6 +76,7 @@ public class CopySourcesMojo extends SafeMojo {
      *  that is provided with command `mvn versions:set "-DnewVersion=${tag}"` which is executed
      *  before actual `mvn deploy`. Now for the test purposes we can specify deployHash from
      *  pom.xml but it should be remade or removed in the future.
+     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
         property = "deployHash",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Copy source files from source directory with extra package on top.
+ * This mojo is about to be used only on deployment step.
+ * See more details
+ * <a href="https://github.com/objectionary/eo/issues/2506#issuecomment-1759609269">here</a>
+ */
+@Mojo(
+    name = "copySources",
+    defaultPhase = LifecyclePhase.DEPLOY,
+    threadSafe = true
+)
+public class CopySourcesMojo extends SafeMojo {
+    /**
+     * Directory with java sources.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(
+        property = "eo.javaSources",
+        required = true,
+        defaultValue = "${project.basedir}/src/main/java"
+    )
+    private File javaSources;
+
+
+    /**
+     * Directory with generated sources.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(
+        property = "eo.generatedDir",
+        required = true,
+        defaultValue = "${project.build.directory}/generated-sources"
+    )
+    private File generatedDir;
+
+    @Parameter(
+        property = "deployHash",
+        required = true
+    )
+    private String deployHash;
+
+    @Override
+    void exec() throws IOException {
+        final BiConsumer<Path, Path> copied = new CopiedResources(
+            this.project,
+            this.session,
+            this.manager
+        );
+        copied.accept(
+            this.javaSources.toPath(),
+            this.generatedDir.toPath().resolve(this.deployHash)
+        );
+        copied.accept(
+            this.javaSources.toPath(),
+            this.generatedDir.toPath()
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
@@ -30,6 +30,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
 import java.io.IOException;
+import org.eolang.maven.hash.ChNarrow;
+import org.eolang.maven.hash.CommitHash;
 
 /**
  * Copy source files from source directory with extra package on top.
@@ -38,7 +40,7 @@ import java.io.IOException;
  * <a href="https://github.com/objectionary/eo/issues/2506#issuecomment-1759609269">here</a>
  */
 @Mojo(
-    name = "copySources",
+    name = "copy-sources",
     defaultPhase = LifecyclePhase.DEPLOY,
     threadSafe = true
 )
@@ -81,7 +83,9 @@ public class CopySourcesMojo extends SafeMojo {
         );
         copied.accept(
             this.javaSources.toPath(),
-            this.generatedDir.toPath().resolve(this.deployHash)
+            this.generatedDir.toPath().resolve(
+                new ChNarrow(new CommitHash.ChConstant(this.deployHash)).value()
+            )
         );
         copied.accept(
             this.javaSources.toPath(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java
@@ -23,13 +23,13 @@
  */
 package org.eolang.maven;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import java.io.File;
-import java.io.IOException;
 import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.CommitHash;
 
@@ -56,7 +56,6 @@ public class CopySourcesMojo extends SafeMojo {
     )
     private File javaSources;
 
-
     /**
      * Directory with generated sources.
      * @checkstyle MemberNameCheck (10 lines)
@@ -68,6 +67,14 @@ public class CopySourcesMojo extends SafeMojo {
     )
     private File generatedDir;
 
+    /**
+     * Hash to deploy.
+     * @todo #2506:30min Replace hash with tag or remove it at all. This mojo should be executed
+     *  on "deploy" phase and copy sources with dynamic hash. The hash should be taken from tag
+     *  that is provided with command `mvn versions:set "-DnewVersion=${tag}"` which is executed
+     *  before actual `mvn deploy`. Now for the test purposes we can specify deployHash from
+     *  pom.xml but it should be remade or removed in the future.
+     */
     @Parameter(
         property = "deployHash",
         required = true

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
@@ -127,7 +127,7 @@ public final class CommitHashesMap extends MapEnvelope<String, CommitHash> {
                         "17f89293e5ae6115e9a0234b754b22918c11c602 0.28.6",
                         "5f82cc1edffad67bf4ba816610191403eb18af5d 0.28.7",
                         "be83d9adda4b7c9e670e625fe951c80f3ead4177 0.28.9",
-                        "9c46a671f2bc68e777aab031d57da5012ba807a7 master"
+                        "c28d5e7f11076c83b0ae45ae19207cdb6a992224 master"
                     )
                 )
             );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
@@ -23,10 +23,12 @@
  */
 package org.eolang.maven.name;
 
+import org.eolang.maven.OnlineCondition;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -42,6 +44,7 @@ final class OnReplacedTest {
     private static final String STRING = "org.eolang.string";
 
     @ParameterizedTest
+    @ExtendWith(OnlineCondition.class)
     @CsvSource({
         "org.eolang.string, org.eolang.string|0.23.17",
         "org.eolang.dummy, org.eolang.dummy|0.23.19",
@@ -71,6 +74,7 @@ final class OnReplacedTest {
     }
 
     @ParameterizedTest
+    @ExtendWith(OnlineCondition.class)
     @CsvSource({
         "15c85d7, org.eolang.string|0.23.17",
         "4b19944, org.eolang.dummy|0.23.19",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/name/OnReplacedTest.java
@@ -23,12 +23,10 @@
  */
 package org.eolang.maven.name;
 
-import org.eolang.maven.OnlineCondition;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -44,7 +42,6 @@ final class OnReplacedTest {
     private static final String STRING = "org.eolang.string";
 
     @ParameterizedTest
-    @ExtendWith(OnlineCondition.class)
     @CsvSource({
         "org.eolang.string, org.eolang.string|0.23.17",
         "org.eolang.dummy, org.eolang.dummy|0.23.19",
@@ -74,7 +71,6 @@ final class OnReplacedTest {
     }
 
     @ParameterizedTest
-    @ExtendWith(OnlineCondition.class)
     @CsvSource({
         "15c85d7, org.eolang.string|0.23.17",
         "4b19944, org.eolang.dummy|0.23.19",


### PR DESCRIPTION
Ref: #2506 

What's done:
- Introduced `CopySourcesMojo` that copies sources to `target/generated-sources` folder and adds extra folder on top
- Added integration test for testing whole pipeline described in the ticket

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new package layer to all source files. 

### Detailed summary
- Added a new package layer to all source files.
- Updated invoker goals in the properties file.
- Added a logo image and test description in the README file.
- Updated CommitHashesMap.java with a new commit hash.
- Updated the exclude_paths in the codacy.yml file.
- Added package-info.java files to the source files.
- Added annotations to certain Java files.
- Added verify.groovy file for verification.
- Added new Java files for attribute and phi classes.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/it/hash_package_layer/src/main/java/org/eolang/Phi.java`, `eo-maven-plugin/src/it/hash_package_layer/pom.xml`, `eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/Heaps.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/CopiedResources.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/CopySourcesMojo.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->