### PR TITLE
fix(#2541): removed `master` commit hash pair

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SafeMojo.java
@@ -237,6 +237,15 @@ abstract class SafeMojo extends AbstractMojo {
     );
 
     /**
+     * The Git hash to pull objects from, in objectionary.
+     * If not set, will be computed from {@code tag} field.
+     *
+     * @since 0.29.6
+     */
+    @SuppressWarnings({"PMD.ImmutableField", "PMD.UnusedPrivateField"})
+    private CommitHash hash;
+
+    /**
      * Cached tojos.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
@@ -99,10 +99,6 @@ public final class CommitHashesMap extends MapEnvelope<String, CommitHash> {
      * Fake commit hashes hash-table.
      *
      * @since 0.29.6
-     * @todo #2528:30min Remove "master" pair from the table. Hash of "master" tag is not static
-     *  and is being updated dynamically. That's why we should not use it in fake CommitHashesMap
-     *  with {@link org.eolang.maven.objectionary.OyRemote}. That's why it would be better to remove
-     *  it from the table and assure that all tests are green. Don't forget to remove the puzzle.
      */
     public static final class Fake extends MapEnvelope<String, CommitHash> {
         /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesMap.java
@@ -130,8 +130,7 @@ public final class CommitHashesMap extends MapEnvelope<String, CommitHash> {
                         "9c9352890b5d30e1b89c9147e7c95a90c9b8709f 0.28.5",
                         "17f89293e5ae6115e9a0234b754b22918c11c602 0.28.6",
                         "5f82cc1edffad67bf4ba816610191403eb18af5d 0.28.7",
-                        "be83d9adda4b7c9e670e625fe951c80f3ead4177 0.28.9",
-                        "c28d5e7f11076c83b0ae45ae19207cdb6a992224 master"
+                        "be83d9adda4b7c9e670e625fe951c80f3ead4177 0.28.9"
                     )
                 )
             );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import org.cactoos.map.MapEntry;
+import org.eolang.maven.hash.ChCached;
+import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.CommitHash;
 import org.eolang.maven.hash.CommitHashesMap;
 import org.eolang.maven.log.CaptureLogs;
@@ -118,9 +120,10 @@ final class AssembleMojoTest {
     }
 
     @Test
+    @ExtendWith(OnlineCondition.class)
     void assemblesTogetherWithVersions(@TempDir final Path temp) throws Exception {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
-        final CommitHash master = hashes.get("master");
+        final CommitHash master = new ChCached(new ChRemote("master"));
         final CommitHash five = hashes.get("0.28.5");
         final CommitHash six = hashes.get("0.28.6");
         final Map<String, Path> result = new FakeMaven(temp)
@@ -142,6 +145,7 @@ final class AssembleMojoTest {
                     new MapEntry<>(six, new OyRemote(six))
                 )
             )
+            .with("hash", master)
             .execute(AssembleMojo.class)
             .result();
         final String stdout = "**/io/stdout";


### PR DESCRIPTION
Closes: #2541

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new field to the SafeMojo class and making changes to the CommitHashesMap class. 

### Detailed summary
- Added a new field "hash" to the SafeMojo class.
- Updated the CommitHashesMap class to remove the "master" hash from the table and update tests accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->