### PR TITLE
fix(#2552): removed special `hashCode`'s and refactored tests

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -158,9 +158,7 @@ SOFTWARE.
     <xsl:value-of select="eo:class-name(@name, eo:suffix(@line, @pos))"/>
     <xsl:text> extends PhDefault {</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
-    <xsl:apply-templates select="." mode="fields"/>
     <xsl:apply-templates select="." mode="ctors"/>
-    <xsl:apply-templates select="." mode="equals-and-hashCode"/>
     <xsl:if test="//meta[head='junit' or head='tests'] and not(@parent)">
       <xsl:apply-templates select="." mode="tests"/>
     </xsl:if>
@@ -174,14 +172,6 @@ SOFTWARE.
       <xsl:text>// </xsl:text>
       <xsl:value-of select="."/>
     </xsl:for-each>
-  </xsl:template>
-  <xsl:template match="class" mode="fields">
-    <xsl:value-of select="eo:tabs(1)"/>
-    <xsl:variable name="type" select="concat(//meta[head='package']/tail, '.', @name)"/>
-    <xsl:if test="$literal-objects[text()=$type]">
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>private final java.util.concurrent.atomic.AtomicBoolean initialized = new java.util.concurrent.atomic.AtomicBoolean(false);</xsl:text>
-    </xsl:if>
   </xsl:template>
   <xsl:template match="class" mode="ctors">
     <xsl:value-of select="eo:tabs(1)"/>
@@ -210,7 +200,7 @@ SOFTWARE.
     <xsl:variable name="type" select="concat(//meta[head='package']/tail, '.', @name)"/>
     <xsl:if test="$literal-objects[text()=$type]">
       <xsl:value-of select="eo:eol(2)"/>
-      <xsl:text>this.add("Δ", new AtFree(new AtSimple(), this.initialized));</xsl:text>
+      <xsl:text>this.add("Δ", new AtFree(new AtSimple()));</xsl:text>
     </xsl:if>
     <xsl:if test="$type='org.eolang.tuple'">
       <xsl:value-of select="eo:eol(2)"/>
@@ -225,44 +215,6 @@ SOFTWARE.
     <xsl:value-of select="eo:eol(1)"/>
     <xsl:text>}</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
-  </xsl:template>
-  <xsl:template match="class" mode="equals-and-hashCode">
-    <xsl:variable name="type" select="concat(//meta[head='package']/tail, '.', @name)"/>
-    <xsl:if test="$literal-objects[text()=$type] or $type='org.eolang.tuple'">
-      <xsl:value-of select="eo:tabs(1)"/>
-      <xsl:text>@Override</xsl:text>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>public int hashCode() {</xsl:text>
-      <xsl:choose>
-        <xsl:when test="$type='org.eolang.tuple'">
-          <xsl:value-of select="eo:eol(1)"/>
-          <xsl:text>return this.attr("Δ").get().hashCode();</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="eo:eol(2)"/>
-          <xsl:text>if (this.initialized.get()) {</xsl:text>
-          <xsl:value-of select="eo:eol(3)"/>
-          <xsl:text>return this.attr("Δ").get().hashCode();</xsl:text>
-          <xsl:value-of select="eo:eol(2)"/>
-          <xsl:text>} else {</xsl:text>
-          <xsl:value-of select="eo:eol(3)"/>
-          <xsl:text>return this.vertex;</xsl:text>
-          <xsl:value-of select="eo:eol(2)"/>
-          <xsl:text>}</xsl:text>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>}</xsl:text>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>@Override</xsl:text>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>public boolean equals(final Object obj) {</xsl:text>
-      <xsl:value-of select="eo:eol(2)"/>
-      <xsl:text>return this.attr("Δ").get().equals(obj);</xsl:text>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>}</xsl:text>
-      <xsl:value-of select="eo:eol(0)"/>
-    </xsl:if>
   </xsl:template>
   <xsl:template match="attr">
     <xsl:value-of select="eo:eol(2)"/>

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -128,18 +128,18 @@
 
 [] > positive-object-vertices
   eq. > @
-    and.
+    or.
       42.<.eq (42.<)
       "Hello".<.eq ("Hello".<)
-      42.plus.<.gt 0
       45-1F-E7.<.eq (45-1F-E7.<)
-    TRUE
+    FALSE
 
 [] > take-vertex-as-vertical-attribute
-  eq. > @
-    <.
-      42
-    42.<
+  not. > @
+    eq.
+      <.
+        42
+      42.<
 
 [] > negative-object-vertices
   [x] > a

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -46,7 +46,7 @@ final class DataTest {
     @Test
     void printsByteArray() {
         MatcherAssert.assertThat(
-            new Data.ToPhi(new byte[] {(byte) 0x01, (byte) 0xf2}).toString(),
+            new Data.ToPhi(new byte[]{(byte) 0x01, (byte) 0xf2}).toString(),
             Matchers.containsString("01-F2")
         );
     }
@@ -76,11 +76,13 @@ final class DataTest {
     }
 
     @Test
-    void comparesVertex() {
+    void comparesVertexOfLiterals() {
         MatcherAssert.assertThat(
             new Dataized(new Data.ToPhi(42L).attr("ν").get()).take(Long.class),
-            Matchers.equalTo(
-                new Dataized(new Data.ToPhi(42L).attr("ν").get()).take(Long.class)
+            Matchers.not(
+                Matchers.equalTo(
+                    new Dataized(new Data.ToPhi(42L).attr("ν").get()).take(Long.class)
+                )
             )
         );
     }
@@ -104,8 +106,8 @@ final class DataTest {
             Matchers.equalTo(new Data.ToPhi(2.18d))
         );
         MatcherAssert.assertThat(
-            new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}),
-            Matchers.equalTo(new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}))
+            new Data.ToPhi(new byte[]{(byte) 0x00, (byte) 0x1f}),
+            Matchers.equalTo(new Data.ToPhi(new byte[]{(byte) 0x00, (byte) 0x1f}))
         );
     }
 
@@ -156,12 +158,12 @@ final class DataTest {
     @Test
     void comparesTwoByteArrays() {
         MatcherAssert.assertThat(
-            new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}),
-            Matchers.equalTo(new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}))
+            new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}),
+            Matchers.equalTo(new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}))
         );
         MatcherAssert.assertThat(
-            new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}),
-            Matchers.not(Matchers.equalTo(new Data.Value<>(new byte[] {(byte) 0xf0})))
+            new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}),
+            Matchers.not(Matchers.equalTo(new Data.Value<>(new byte[]{(byte) 0xf0})))
         );
     }
 
@@ -169,7 +171,7 @@ final class DataTest {
     void comparesTwoPhiArrays() {
         MatcherAssert.assertThat(
             new Data.Value<>(
-                new Phi[] {
+                new Phi[]{
                     new Data.ToPhi("foo"),
                     new Data.ToPhi(1L),
                 }
@@ -177,7 +179,7 @@ final class DataTest {
             Matchers.not(
                 Matchers.equalTo(
                     new Data.Value<>(
-                        new Phi[] {
+                        new Phi[]{
                             new Data.ToPhi("foo"),
                             new Data.ToPhi(1L),
                         }

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -46,7 +46,7 @@ final class DataTest {
     @Test
     void printsByteArray() {
         MatcherAssert.assertThat(
-            new Data.ToPhi(new byte[]{(byte) 0x01, (byte) 0xf2}).toString(),
+            new Data.ToPhi(new byte[] {(byte) 0x01, (byte) 0xf2}).toString(),
             Matchers.containsString("01-F2")
         );
     }
@@ -76,7 +76,7 @@ final class DataTest {
     }
 
     @Test
-    void comparesVertexOfLiterals() {
+    void comparesVertex() {
         MatcherAssert.assertThat(
             new Dataized(new Data.ToPhi(42L).attr("ν").get()).take(Long.class),
             Matchers.not(
@@ -106,8 +106,8 @@ final class DataTest {
             Matchers.equalTo(new Data.ToPhi(2.18d))
         );
         MatcherAssert.assertThat(
-            new Data.ToPhi(new byte[]{(byte) 0x00, (byte) 0x1f}),
-            Matchers.equalTo(new Data.ToPhi(new byte[]{(byte) 0x00, (byte) 0x1f}))
+            new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}),
+            Matchers.equalTo(new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}))
         );
     }
 
@@ -158,12 +158,12 @@ final class DataTest {
     @Test
     void comparesTwoByteArrays() {
         MatcherAssert.assertThat(
-            new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}),
-            Matchers.equalTo(new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}))
+            new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}),
+            Matchers.equalTo(new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}))
         );
         MatcherAssert.assertThat(
-            new Data.Value<>(new byte[]{(byte) 0x00, (byte) 0x1f}),
-            Matchers.not(Matchers.equalTo(new Data.Value<>(new byte[]{(byte) 0xf0})))
+            new Data.Value<>(new byte[] {(byte) 0x00, (byte) 0x1f}),
+            Matchers.not(Matchers.equalTo(new Data.Value<>(new byte[] {(byte) 0xf0})))
         );
     }
 
@@ -171,7 +171,7 @@ final class DataTest {
     void comparesTwoPhiArrays() {
         MatcherAssert.assertThat(
             new Data.Value<>(
-                new Phi[]{
+                new Phi[] {
                     new Data.ToPhi("foo"),
                     new Data.ToPhi(1L),
                 }
@@ -179,7 +179,7 @@ final class DataTest {
             Matchers.not(
                 Matchers.equalTo(
                     new Data.Value<>(
-                        new Phi[]{
+                        new Phi[] {
                             new Data.ToPhi("foo"),
                             new Data.ToPhi(1L),
                         }


### PR DESCRIPTION
Closes: #2552

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to the code in order to improve functionality and fix issues.

### Detailed summary:
- Changed the logical operator from "and" to "or" in the `positive-object-vertices` test.
- Replaced the `eq.` and `<.` operators with `not.`, `eq.`, and `<.` in the `take-vertex-as-vertical-attribute` test.
- Modified the assertion in the `DataTest` class to use the `not` method and added parentheses to improve clarity.
- Removed unnecessary code in the `to-java.xsl` file related to fields, equals-and-hashCode methods, and constructors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->