### PR TITLE
fix(#2577): split `OptimizeMojo`, intoroduced `ShakeMojo`

### DIFF
--- a/eo-maven-plugin/src/it/custom_goals/README.md
+++ b/eo-maven-plugin/src/it/custom_goals/README.md
@@ -13,6 +13,7 @@ can check in the [pom.xml](pom.xml) in `eo-maven-plugin` description:
   <goal>register</goal>
   <goal>parse</goal>
   <goal>optimize</goal>
+  <goal>shake</goal>
   <goal>discover-foreign</goal>
   <goal>probe</goal>
   <goal>pull</goal>

--- a/eo-maven-plugin/src/it/custom_goals/pom.xml
+++ b/eo-maven-plugin/src/it/custom_goals/pom.xml
@@ -43,6 +43,7 @@ SOFTWARE.
               <goal>register</goal>
               <goal>parse</goal>
               <goal>optimize</goal>
+              <goal>shake</goal>
               <goal>discover-foreign</goal>
               <goal>probe</goal>
               <goal>pull</goal>

--- a/eo-maven-plugin/src/it/custom_goals/verify.groovy
+++ b/eo-maven-plugin/src/it/custom_goals/verify.groovy
@@ -26,7 +26,8 @@
   'target/eo/foreign.csv',
   'target/eo/1-parse',
   'target/eo/2-optimize',
-  'target/eo/3-pull',
+  'target/eo/3-shake',
+  'target/eo/4-pull',
 ].each { assert new File(basedir, it).exists() }
 
 /**
@@ -35,9 +36,9 @@
  * and only on the next step it starts to resolve the dependencies.
  */
 [
-  'target/eo/4-resolve',
-  'target/eo/5-pre',
-  'target/eo/6-transpile',
+  'target/eo/5-resolve',
+  'target/eo/6-pre',
+  'target/eo/7-transpile',
 ].each { assert !new File(basedir, it).exists() }
 
 true

--- a/eo-maven-plugin/src/it/fibonacci/verify.groovy
+++ b/eo-maven-plugin/src/it/fibonacci/verify.groovy
@@ -46,8 +46,8 @@ private static boolean online() {
   'target/eo/1-parse/org/eolang/examples/app.xmir',
   'target/eo/2-optimization-steps/org/eolang/examples/app/00-not-empty-atoms.xml',
   'target/eo/2-optimize/org/eolang/examples/app.xmir',
-  'target/eo/5-pre/org/eolang/examples/app/01-classes.xml',
-  'target/eo/6-transpile/org/eolang/examples/app.xmir',
+  'target/eo/6-pre/org/eolang/examples/app/01-classes.xml',
+  'target/eo/7-transpile/org/eolang/examples/app.xmir',
   'target/eo/sodg/org/eolang/error.sodg',
   'target/eo/sodg/org/eolang/error.sodg.xe',
   'target/eo/sodg/org/eolang/error.sodg.graph.xml',
@@ -57,7 +57,7 @@ private static boolean online() {
 [
   'target/classes/EOorg/EOeolang/EOexamples/EOapp.class',
   'target/eo/placed.json',
-  'target/eo/3-pull/org/eolang/tuple.eo',
+  'target/eo/4-pull/org/eolang/tuple.eo',
 ].each { assert new File(basedir, it).exists() || !online() }
 
 String log = new File(basedir, 'build.log').text

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -203,6 +204,7 @@ public final class AssembleMojo extends SafeMojo {
         final Moja<?>[] mojas = {
             new Moja<>(ParseMojo.class),
             new Moja<>(OptimizeMojo.class),
+            new Moja<>(ShakeMojo.class),
             new Moja<>(DiscoverMojo.class),
             new Moja<>(ProbeMojo.class),
             new Moja<>(PullMojo.class),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -128,7 +128,7 @@ public final class BinarizeParseMojo extends SafeMojo {
         final Names names = new Names(targetDir.toPath().getParent());
         new File(this.targetDir.toPath().resolve("Lib/").toString()).mkdirs();
         for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
-            final Path file = tojo.optimized();
+            final Path file = tojo.shaken();
             final XML input = new XMLDocument(file);
             final List<XML> nodes = this.addRust(input).nodes("/program/rusts/rust");
             for (final XML node: nodes) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DiscoverMojo.java
@@ -60,7 +60,7 @@ public final class DiscoverMojo extends SafeMojo {
         final Collection<ForeignTojo> tojos = this.scopedTojos().notDiscovered();
         final Collection<String> discovered = new HashSet<>();
         for (final ForeignTojo tojo : tojos) {
-            final Path src = tojo.optimized();
+            final Path src = tojo.shaken();
             final Collection<String> names = this.discover(src, tojo.identifier());
             discovered.addAll(names);
             for (final String name : names) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LatexMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LatexMojo.java
@@ -82,7 +82,7 @@ public final class LatexMojo extends SafeMojo {
     @Override
     void exec() throws IOException {
         for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
-            final Path file = tojo.optimized();
+            final Path file = tojo.shaken();
             final Place place = new Place(
                 LatexMojo.last(new XMLDocument(file).xpath("/program/@name").get(0))
             );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -109,7 +109,7 @@ public final class ProbeMojo extends SafeMojo {
         final Collection<ObjectName> probed = new HashSet<>(1);
         final Collection<ForeignTojo> tojos = this.scopedTojos().unprobed();
         for (final ForeignTojo tojo : tojos) {
-            final Path src = tojo.optimized();
+            final Path src = tojo.shaken();
             final Collection<ObjectName> objects = this.probes(src);
             if (!objects.isEmpty()) {
                 Logger.info(this, "Probing object(s): %s", objects);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -58,7 +58,7 @@ public final class PullMojo extends SafeMojo {
     /**
      * The directory where to process to.
      */
-    public static final String DIR = "3-pull";
+    public static final String DIR = "4-pull";
 
     /**
      * The Git tag to pull objects from, in objectionary.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolveMojo.java
@@ -65,7 +65,7 @@ public final class ResolveMojo extends SafeMojo {
     /**
      * The directory where to resolve to.
      */
-    public static final String DIR = "4-resolve";
+    public static final String DIR = "5-resolve";
 
     /**
      * Skip artifact with the version 0.0.0.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
@@ -45,6 +45,11 @@ import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.HmBase;
 import org.eolang.maven.util.Rel;
 
+/**
+ * Shake (prepare) XML files after optimizations for translation to java.
+ *
+ * @since 0.33.0
+ */
 @Mojo(
     name = "shake",
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
@@ -49,6 +49,13 @@ import org.eolang.maven.util.Rel;
  * Shake (prepare) XML files after optimizations for translation to java.
  *
  * @since 0.33.0
+ * @todo #2577:30min Resolve code duplication between {@link OptimizeMojo} and {@link ShakeMojo}.
+ *  ShakeMojo was created in order to split two optimization stages: optimizations themselves and
+ *  preparations for translation to java. Now these two mojo look almost the same and there's a lot
+ *  of code duplication. So it's needed to resolve that. Don't forget to remove the puzzle
+ * @todo #2577:30min Add tests for ShakeMojo. ShakeMojo was created in order to split two
+ *  optimization stages: optimizations themselves and preparations for translation to java
+ *  Need to create tests for {@link ShakeMojo} in order to be sure that it does only it's job.
  */
 @Mojo(
     name = "shake",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/SodgMojo.java
@@ -366,7 +366,7 @@ public final class SodgMojo extends SafeMojo {
                 continue;
             }
             final Path sodg = new Place(name).make(home, "sodg");
-            final Path xmir = tojo.optimized();
+            final Path xmir = tojo.shaken();
             if (sodg.toFile().lastModified() >= xmir.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already converted %s to %s (it's newer than the source)",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -73,7 +73,7 @@ public final class TranspileMojo extends SafeMojo {
     /**
      * The directory where to transpile to.
      */
-    public static final String DIR = "6-transpile";
+    public static final String DIR = "7-transpile";
 
     /**
      * Extension for compiled sources in XMIR format (XML).
@@ -110,7 +110,7 @@ public final class TranspileMojo extends SafeMojo {
     /**
      * The directory where to put pre-transpile files.
      */
-    private static final String PRE = "5-pre";
+    private static final String PRE = "6-pre";
 
     /**
      * Target directory.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -188,7 +188,7 @@ public final class TranspileMojo extends SafeMojo {
      */
     private int transpile(final ForeignTojo tojo) throws IOException {
         final int saved;
-        final Path file = tojo.optimized();
+        final Path file = tojo.shaken();
         final XML input = new XMLDocument(file);
         final String name = input.xpath("/program/@name").get(0);
         final Place place = new Place(name);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptSpy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptSpy.java
@@ -25,6 +25,8 @@ package org.eolang.maven.optimization;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Train;
 import java.nio.file.Path;
 import org.eolang.maven.Place;
 import org.eolang.maven.SpyTrain;
@@ -35,6 +37,10 @@ import org.eolang.maven.util.Rel;
  * @since 0.28.12
  */
 public final class OptSpy implements Optimization {
+    /**
+     * Optimizations train.
+     */
+    private final Train<Shift> train;
 
     /**
      * Where to track optimization steps.
@@ -42,10 +48,19 @@ public final class OptSpy implements Optimization {
     private final Path target;
 
     /**
-     * The main constructor.
+     * Ctor.
      * @param target Where to track optimization steps.
      */
     public OptSpy(final Path target) {
+        this(OptTrain.DEFAULT_TRAIN, target);
+    }
+
+    /**
+     * The main constructor.
+     * @param target Where to track optimization steps.
+     */
+    public OptSpy(final Train<Shift> trn, final Path target) {
+        this.train = trn;
         this.target = target;
     }
 
@@ -57,6 +72,6 @@ public final class OptSpy implements Optimization {
             this, "Optimization steps will be tracked to %s",
             new Rel(dir)
         );
-        return new OptTrain(new SpyTrain(OptTrain.DEFAULT_TRAIN, dir)).apply(xml);
+        return new OptTrain(new SpyTrain(this.train, dir)).apply(xml);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptSpy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptSpy.java
@@ -57,6 +57,7 @@ public final class OptSpy implements Optimization {
 
     /**
      * The main constructor.
+     * @param trn Optimizations train
      * @param target Where to track optimization steps.
      */
     public OptSpy(final Train<Shift> trn, final Path target) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
@@ -49,7 +49,7 @@ public final class OptTrain implements Optimization {
      */
     static final Train<Shift> DEFAULT_TRAIN = new TrFast(
         new TrClasspath<>(
-            new ParsingTrain(),
+            new TrDefault<>(),
             "/org/eolang/parser/optimize/globals-to-abstracts.xsl",
             "/org/eolang/parser/optimize/remove-refs.xsl",
             "/org/eolang/parser/optimize/abstracts-float-up.xsl",
@@ -87,7 +87,7 @@ public final class OptTrain implements Optimization {
      *
      * @param shifts XLS shifts.
      */
-    OptTrain(final Train<Shift> shifts) {
+    public OptTrain(final Train<Shift> shifts) {
         this(xml -> xml, shifts);
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptTrain.java
@@ -31,7 +31,6 @@ import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.TrFast;
 import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
-import org.eolang.parser.ParsingTrain;
 
 /**
  * Optimisation train of XLS`s.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -78,6 +78,14 @@ public final class ForeignTojo {
     }
 
     /**
+     * The tojo shaken xmir.
+     * @return The shaken xmir.
+     */
+    public Path shaken() {
+        return Paths.get(this.delegate.get(ForeignTojos.Attribute.SHAKEN.key()));
+    }
+
+    /**
      * The tojo eo object.
      * @return The eo object.
      */
@@ -134,6 +142,26 @@ public final class ForeignTojo {
             if (tgt.toFile().lastModified() >= src.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already optimized %s to %s",
+                    new Rel(src), new Rel(tgt)
+                );
+                res = false;
+            }
+        }
+        return res;
+    }
+
+    /**
+     * Checks if tojo was not already shaken.
+     * @return True if shake is required, false otherwise.
+     */
+    public boolean notShaken() {
+        final Path src = this.optimized();
+        boolean res = true;
+        if (this.delegate.exists(ForeignTojos.Attribute.SHAKEN.key())) {
+            final Path tgt = this.shaken();
+            if (tgt.toFile().lastModified() >= src.toFile().lastModified()) {
+                Logger.debug(
+                    this, "Already shaken %s to %s",
                     new Rel(src), new Rel(tgt)
                 );
                 res = false;
@@ -220,6 +248,16 @@ public final class ForeignTojo {
      */
     public ForeignTojo withOptimized(final Path xmir) {
         this.delegate.set(ForeignTojos.Attribute.OPTIMIZED.key(), xmir.toString());
+        return this;
+    }
+
+    /**
+     * Set the shaken xmir.
+     * @param xmir The shaken xmir.
+     * @return The tojo itself.
+     */
+    public ForeignTojo withShaken(final Path xmir) {
+        this.delegate.set(ForeignTojos.Attribute.SHAKEN.key(), xmir.toString());
         return this;
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojos.java
@@ -314,6 +314,11 @@ public final class ForeignTojos implements Closeable {
         OPTIMIZED("optimized"),
 
         /**
+         * Path to the shaken xmir file.
+         */
+        SHAKEN("shaken"),
+
+        /**
          * Absolute location of SODG file.
          */
         SODG("sodg"),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -582,7 +582,7 @@ public final class FakeMaven {
         }
     }
 
-    /**
+    /**1
      * Check errors and warnings.
      *
      * @since 0.31.0
@@ -593,6 +593,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 VerifyMojo.class
             ).iterator();
         }
@@ -610,6 +611,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 LatexMojo.class
             ).iterator();
         }
@@ -627,6 +629,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 TranspileMojo.class
             ).iterator();
         }
@@ -644,6 +647,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 BinarizeMojo.class
             ).iterator();
         }
@@ -661,6 +665,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 BinarizeParseMojo.class
             ).iterator();
         }
@@ -678,6 +683,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 ResolveMojo.class
             ).iterator();
         }
@@ -695,6 +701,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 TranslateToPhiMojo.class
             ).iterator();
         }
@@ -712,6 +719,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 ResolveMojo.class,
                 PlaceMojo.class
             ).iterator();
@@ -730,6 +738,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 SodgMojo.class
             ).iterator();
         }
@@ -760,6 +769,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 DiscoverMojo.class,
                 ProbeMojo.class
             ).iterator();
@@ -778,6 +788,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 DiscoverMojo.class,
                 ProbeMojo.class,
                 PullMojo.class
@@ -797,6 +808,7 @@ public final class FakeMaven {
             return Arrays.<Class<? extends AbstractMojo>>asList(
                 ParseMojo.class,
                 OptimizeMojo.class,
+                ShakeMojo.class,
                 DiscoverMojo.class
             ).iterator();
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -572,7 +572,6 @@ public final class FakeMaven {
      * @since 0.28.12
      */
     static final class Optimize implements Iterable<Class<? extends AbstractMojo>> {
-
         @Override
         public Iterator<Class<? extends AbstractMojo>> iterator() {
             return Arrays.<Class<? extends AbstractMojo>>asList(
@@ -582,7 +581,7 @@ public final class FakeMaven {
         }
     }
 
-    /**1
+    /**
      * Check errors and warnings.
      *
      * @since 0.31.0

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoTest.java
@@ -56,7 +56,7 @@ final class ResolveMojoTest {
                     "[] > foo /int"
                 )
             ).execute(new FakeMaven.Resolve());
-        final Path path = temp.resolve("target/4-resolve/org.eolang/eo-runtime/-/0.7.0");
+        final Path path = temp.resolve("target/5-resolve/org.eolang/eo-runtime/-/0.7.0");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
         MatcherAssert.assertThat(
             path.resolve("eo-runtime-0.7.0.jar").toFile(),
@@ -74,7 +74,7 @@ final class ResolveMojoTest {
         );
         maven.foreignTojos().add("sum").withDiscovered(0);
         maven.execute(new FakeMaven.Resolve());
-        final Path path = temp.resolve("target/4-resolve/org.eolang/eo-runtime/-/");
+        final Path path = temp.resolve("target/5-resolve/org.eolang/eo-runtime/-/");
         MatcherAssert.assertThat(path.toFile(), FileMatchers.anExistingDirectory());
         MatcherAssert.assertThat(
             path,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -106,7 +106,7 @@ final class TranspileMojoTest {
             .execute(new FakeMaven.Transpile())
             .result();
         final Path java = res.get(this.compiled);
-        final Path xmir = res.get("target/6-transpile/foo/x/main.xmir");
+        final Path xmir = res.get("target/7-transpile/foo/x/main.xmir");
         MatcherAssert.assertThat(java.toFile(), FileMatchers.anExistingFile());
         MatcherAssert.assertThat(xmir.toFile(), FileMatchers.anExistingFile());
         MatcherAssert.assertThat(java.toFile().setLastModified(0L), Matchers.is(true));

--- a/eo-runtime/src/test/groovy/check-folders-numbering.groovy
+++ b/eo-runtime/src/test/groovy/check-folders-numbering.groovy
@@ -35,10 +35,11 @@ List<File> directories = target.toFile().listFiles(new FileFilter() {
 List<String> allowed = [
   '1-parse',
   '2-optimize',
-  '3-pull',
-  '4-resolve',
-  '5-pre',
-  '6-transpile',
+  '3-shake',
+  '4-pull',
+  '5-resolve',
+  '6-pre',
+  '7-transpile',
 ]
 List<File> allowedDirs = allowed.stream()
   .map { target.resolve(it).toFile() }


### PR DESCRIPTION
Closes: #2577 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new goal `shake` to the Maven plugin.
- Updated the `DIR` constant in `ResolveMojo`, `PullMojo`, and `TranspileMojo` classes.
- Updated the target directories in the `verify.groovy` scripts.
- Updated the `xmir` file path in multiple classes.
- Added a new constant `SHAKEN` in `ForeignTojos` class.
- Updated the `OptTrain` class to use `TrDefault` instead of `ParsingTrain`.
- Updated the `OptimizeMojo` class to use `OptTrain` with `ParsingTrain` and `TrDefault`.
- Added the `OptSpy` class for tracking optimization steps.
- Added the `shaken()` method in `ForeignTojo` class to get the shaken xmir path.
- Added the `notShaken()` method in `ForeignTojo` class to check if shake is required.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java`, `eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->