### PR TITLE
Portal is not in tuple anymore

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/rust.eo
+++ b/eo-runtime/src/main/eo/org/eolang/rust.eo
@@ -26,4 +26,4 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 
-[code params] > rust /?
+[code portal params] > rust /?

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -138,6 +138,7 @@ public class EOrust extends PhDefault {
     public EOrust(final Phi sigma) {
         super(sigma);
         this.add("code", new AtFree());
+        this.add("portal", new AtFree());
         this.add("params", new AtFree());
         this.add(
             Attr.LAMBDA,
@@ -161,10 +162,7 @@ public class EOrust extends PhDefault {
                             byte[].class
                         );
                     }
-                    final Phi portal = new PhWith(
-                        rho.attr("params").get().attr("at").get().copy(),
-                        0, new Data.ToPhi(0L)
-                    );
+                    final Phi portal = rho.attr("portal").get();
                     return this.translate(
                         (byte[]) method.invoke(
                             null,

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -37,8 +37,8 @@
       Some(EOInt(2))
     }
     """
+    []
     *
-      []
   eq. > @
     r
     2
@@ -55,8 +55,8 @@
       Some(EOInt(-10))
     }
     """
+    []
     *
-      []
   eq. > @
     r
     -10
@@ -72,8 +72,8 @@
       Some(EOFloat(1.23456789))
     }
     """
+    []
     *
-      []
   eq. > @
     r
     1.23456789
@@ -89,12 +89,16 @@
       Some(EOFloat(-1.23456789))
     }
     """
+    []
     *
-      []
   eq. > @
     r
     -1.23456789
 
+# @todo #2565:90min Refactor the test below. Now it is bad
+#  because it is unclear how 00-1A-EE was received. Instead,
+#  there should be some logical calculations that return an
+#  array of bytes.
 [] > rust-is-byte-array
   QQ.rust > my-bytes
     """
@@ -112,11 +116,12 @@
       )
     }
     """
+    []
     *
-      []
-  eq. > @
-    my-bytes
-    00-1A-EE
+  nop > @
+    eq.
+      my-bytes
+      00-1A-EE
 
 # @todo #2555:30min Enable rust tests when it's possible to get an abstract object from tuple.
 #  Many rust tests were disabled because "portal" inside EOrust stopped working because of new
@@ -137,13 +142,12 @@
       )
     }
     """
+    []
     *
-      []
-  not. > res
+  not. > @
     lt.
       r
       0
-  nop > @
 
 [] > rust-returns-vertex
   "content" > book
@@ -158,12 +162,11 @@
       Some(EOVertex(v))
     }
     """
+    []
     *
-      []
-  eq. > res
+  eq. > @
     read
     "content"
-  nop > @
 
 [] > rust-is-string
   QQ.rust > content
@@ -176,8 +179,8 @@
       Some(EOString("Привет world".to_string()))
     }
     """
+    []
     *
-      []
   eq. > @
     content
     "Привет world"
@@ -193,8 +196,8 @@
       Some(EOError("put failed".to_string()))
     }
     """
+    []
     *
-      []
   eq. > @
     slice.
       try
@@ -223,8 +226,8 @@
       Some(EOInt(0 as i64))
     }
     """
+    []
     *
-      []
   try > res!
     []
       insert > @
@@ -250,12 +253,11 @@
       Some(EOVertex(copy))
     }
     """
+    []
     *
-      []
-  eq. > res
+  eq. > @
     copy
     123
-  nop > @
 
 [] > rust-dataize-not-fails
   1 > a
@@ -270,14 +272,12 @@
       Some(EOInt(v as i64))
     }
     """
+    []
     *
-      []
-      3
-  not. > res
+  not. > @
     lt.
       dataized
       0
-  nop > @
 
 [] > rust-plus
   5 > a
@@ -302,15 +302,15 @@
       Some(EOInt(a + b))
     }
     """
+    []
     *
-      []
       "byteorder:1.4.3"
-  eq. > res
+  eq. > @
     plus
     15
-  nop > @
 
 [] > rust-error
+  "Rust insert failed " > message!
   QQ.rust > err!
     """
     use eo_env::EOEnv;
@@ -321,22 +321,21 @@
       Some(EOError("Custom error".to_string()))
     }
     """
+    []
     *
-      []
   try > res
     []
       err > @
     [e]
       e > @
     nop
-  nop > @
-    and.
-      eq.
-        res
-        "Rust insert failed "
-      eq.
-        res
-        "'Custom error'"
+  eq. > @
+    slice.
+      res
+      0
+      length.
+        message
+    message
 
 [] > rust-put-to-copy
   QQ.rust > data
@@ -352,8 +351,8 @@
       Some(EOVertex(copy))
     }
     """
+    []
     *
-      []
   eq. > @
     data
     00-1A-EE
@@ -375,9 +374,8 @@
       Some(EOVertex(copy))
     }
     """
+    []
     *
-      []
-  eq. > res
+  eq. > @
     applied.content
     "qwerty"
-  nop > @

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -95,10 +95,6 @@
     r
     -1.23456789
 
-# @todo #2565:90min Refactor the test below. Now it is bad
-#  because it is unclear how 00-1A-EE was received. Instead,
-#  there should be some logical calculations that return an
-#  array of bytes.
 [] > rust-is-byte-array
   QQ.rust > my-bytes
     """
@@ -118,16 +114,10 @@
     """
     []
     *
-  nop > @
-    eq.
-      my-bytes
-      00-1A-EE
+  eq. > @
+    my-bytes
+    00-1A-EE
 
-# @todo #2555:30min Enable rust tests when it's possible to get an abstract object from tuple.
-#  Many rust tests were disabled because "portal" inside EOrust stopped working because of new
-#  implementation of "tuple". Now it's not possible to put an abstract object into tuple and take
-#  it back. Need to enable the next tests when it's possible: rust-find-returns-int,
-#  rust-returns-vertex, rust-copy-not-fails, rust-dataize-not-fails, rust-plus, rust-bind-to-copy
 [] > rust-find-returns-int
   123 > a
   QQ.rust > r


### PR DESCRIPTION
Closes #2565 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new `portal` attribute to the `EOrust` class in the `EOorg/EOeolang/EOrust.java` file. 

### Detailed summary
- Added `portal` attribute to `EOrust` class in `EOorg/EOeolang/EOrust.java`
- Modified `EOrust` constructor to retrieve the `portal` attribute from `rho`
- Updated tests in `rust-tests.eo` to account for the new `portal` attribute

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->