### PR TITLE
feat(#2592): introduced print mojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.cactoos.text.TextOf;
+import org.eolang.maven.util.HmBase;
+import org.eolang.maven.util.Home;
+import org.eolang.maven.util.Walk;
+import org.eolang.parser.XMIR;
+
+/**
+ * Print XMIR to EO.
+ */
+@Mojo(
+    name = "print",
+    defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+    threadSafe = true
+)
+public final class PrintMojo extends SafeMojo {
+    /**
+     * Directory with XMIR sources to print.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(
+        property = "eo.printSourcesDir",
+        required = true
+    )
+    private File printSourcesDir;
+
+    /**
+     * Directory where printed EO files are placed.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(
+        property = "eo.printOutputDir",
+        required = true
+    )
+    private File printOutputDir;
+
+    @Override
+    void exec() throws IOException {
+        final Collection<Path> sources = new Walk(this.printSourcesDir.toPath());
+        final Home home = new HmBase(printOutputDir);
+        for (final Path source : sources) {
+            final Path relative = Paths.get(
+                printSourcesDir.toPath().relativize(source).toString()
+                    .replace(".xmir", ".eo")
+            );
+            home.save(new XMIR(new TextOf(source)).toEO(), relative);
+            Logger.info(
+                this,
+                "Printed: %s => %s", source, printOutputDir.toPath().resolve(relative)
+            );
+        }
+        Logger.info(this, "Printed %d sources", sources.size());
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
@@ -54,7 +54,8 @@ public final class PrintMojo extends SafeMojo {
      */
     @Parameter(
         property = "eo.printSourcesDir",
-        required = true
+        required = true,
+        defaultValue = "${project.basedir}/src/main/xmir"
     )
     private File printSourcesDir;
 
@@ -64,7 +65,8 @@ public final class PrintMojo extends SafeMojo {
      */
     @Parameter(
         property = "eo.printOutputDir",
-        required = true
+        required = true,
+        defaultValue = "${project.build.directory}/generated-sources/eo"
     )
     private File printOutputDir;
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PrintMojo.java
@@ -40,6 +40,7 @@ import org.eolang.parser.XMIR;
 
 /**
  * Print XMIR to EO.
+ * @since 0.33.0
  */
 @Mojo(
     name = "print",
@@ -70,16 +71,16 @@ public final class PrintMojo extends SafeMojo {
     @Override
     void exec() throws IOException {
         final Collection<Path> sources = new Walk(this.printSourcesDir.toPath());
-        final Home home = new HmBase(printOutputDir);
+        final Home home = new HmBase(this.printOutputDir);
         for (final Path source : sources) {
             final Path relative = Paths.get(
-                printSourcesDir.toPath().relativize(source).toString()
+                this.printSourcesDir.toPath().relativize(source).toString()
                     .replace(".xmir", ".eo")
             );
             home.save(new XMIR(new TextOf(source)).toEO(), relative);
             Logger.info(
                 this,
-                "Printed: %s => %s", source, printOutputDir.toPath().resolve(relative)
+                "Printed: %s => %s", source, this.printOutputDir.toPath().resolve(relative)
             );
         }
         Logger.info(this, "Printed %d sources", sources.size());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -62,6 +62,7 @@ import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.ForeignTojos;
 import org.eolang.maven.tojos.PlacedTojos;
 import org.eolang.maven.util.HmBase;
+import org.eolang.maven.util.Home;
 
 /**
  * Fake maven workspace that executes Mojos in order to test
@@ -81,7 +82,7 @@ public final class FakeMaven {
     /**
      * Test workspace where we place all programs, files, compilation results, etc.
      */
-    private final HmBase workspace;
+    private final Home workspace;
 
     /**
      * Mojos params.
@@ -133,7 +134,7 @@ public final class FakeMaven {
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     private FakeMaven(
-        final HmBase workspace,
+        final Home workspace,
         final Map<String, Object> params,
         final AtomicInteger current,
         final boolean defaults
@@ -809,6 +810,20 @@ public final class FakeMaven {
                 OptimizeMojo.class,
                 ShakeMojo.class,
                 DiscoverMojo.class
+            ).iterator();
+        }
+    }
+
+    /**
+     * Printing pipeline.
+     *
+     * @since 0.33.0
+     */
+    static final class Print implements Iterable<Class<? extends AbstractMojo>> {
+        @Override
+        public Iterator<Class<? extends AbstractMojo>> iterator() {
+            return Arrays.<Class<? extends AbstractMojo>>asList(
+                PrintMojo.class
             ).iterator();
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import org.cactoos.text.TextOf;
+import org.eolang.maven.util.HmBase;
+import org.eolang.maven.util.Home;
+import org.eolang.maven.util.Walk;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@link PrintMojo};
+ */
+final class PrintMojoTest {
+    @Test
+    void printsSuccessfully(@TempDir final Path temp) throws Exception {
+        final Home home = new HmBase(temp);
+        final Path resources = new File("src/test/resources/org/eolang/maven/print")
+            .toPath();
+        final Collection<Path> walk = new Walk(resources);
+        for (final Path source : walk) {
+            home.save(new TextOf(source), source);
+        }
+        final Path output = temp.resolve("output");
+        final Path sources = temp.resolve(resources);
+        new FakeMaven(temp)
+            .with("printSourcesDir", sources.toFile())
+            .with("printOutputDir", output.toFile())
+            .execute(new FakeMaven.Print())
+            .result();
+        for (final Path source : walk) {
+            final String src =  resources.relativize(source).toString()
+                .replace(".xmir", ".eo");
+            MatcherAssert.assertThat(
+                String.format(
+                    "File with name %s should have existed in output directory, but it didn't",
+                    src
+                ),
+                Files.exists(output.resolve(Paths.get(src))),
+                Matchers.is(true)
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoTest.java
@@ -38,7 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test cases for {@link PrintMojo};
+ * Test cases for {@link PrintMojo}.
+ * @since 0.33.0
  */
 final class PrintMojoTest {
     @Test

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/print/inner/a.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/print/inner/a.xmir
@@ -1,0 +1,23 @@
+<program ms="18" name="a" time="2023-10-19T09:27:28.852003Z">
+  <errors/>
+  <sheets/>
+  <license/>
+  <metas/>
+  <objects>
+    <o abstract="" line="6" name="a" pos="0">
+      <o line="6" name="d" pos="1"/>
+      <o base="cage" line="7" name="this-d" pos="2">
+        <o base="d" line="7" pos="7"/>
+      </o>
+      <o abstract="" line="8" name="new" pos="2">
+        <o base="^" line="9" name="@" pos="4"/>
+      </o>
+      <o abstract="" line="10" name="foo" pos="2">
+        <o base=".plus" line="11" name="@" pos="10">
+          <o base="this-d" line="11" pos="4"/>
+          <o base="int" data="bytes" line="11" pos="16">00 00 00 00 00 00 00 02</o>
+        </o>
+      </o>
+    </o>
+  </objects>
+</program>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/print/inner/b.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/print/inner/b.xmir
@@ -1,0 +1,29 @@
+<program ms="18" name="a" time="2023-10-19T09:27:28.852003Z">
+  <errors/>
+  <sheets/>
+  <license/>
+  <metas/>
+  <objects>
+    <o abstract="" line="13" name="b" pos="0">
+      <o line="13" name="a" pos="1"/>
+      <o line="13" name="z" pos="3"/>
+      <o base="cage" line="14" name="this-a" pos="2">
+        <o base="a" line="14" pos="7"/>
+      </o>
+      <o base="cage" line="15" name="this-z" pos="2">
+        <o base="z" line="15" pos="7"/>
+      </o>
+      <o abstract="" line="16" name="new" pos="2">
+        <o base="^" line="17" name="@" pos="4"/>
+      </o>
+      <o abstract="" line="18" name="bar" pos="2">
+        <o base=".plus" line="19" name="@" pos="14">
+          <o base=".foo" line="19" pos="10">
+            <o base="this-a" line="19" pos="4"/>
+          </o>
+          <o base="int" data="bytes" line="19" pos="20">00 00 00 00 00 00 00 02</o>
+        </o>
+      </o>
+    </o>
+  </objects>
+</program>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/print/main.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/print/main.xmir
@@ -1,0 +1,29 @@
+<program ms="18" name="main" time="2023-10-19T09:27:28.852003Z">
+  <listing>[] &gt; main
+    [args...] &gt; main
+    b.new (a.new 42) 21
+  </listing>
+  <errors/>
+  <sheets/>
+  <license/>
+  <metas/>
+  <objects>
+    <o abstract="" line="1" name="main" pos="0">
+      <o abstract="" line="2" name="main" pos="2">
+        <o line="2" name="args" pos="3" vararg=""/>
+        <o base=".bar" line="3" name="@" pos="25">
+          <o base=".new" line="3" pos="21">
+            <o base="b" line="3" pos="5">
+              <o base=".new" line="3" pos="13">
+                <o base="a" line="3" pos="8">
+                  <o base="int" data="bytes" line="3" pos="10">00 00 00 00 00 00 00 2A</o>
+                </o>
+              </o>
+              <o base="int" data="bytes" line="3" pos="18">00 00 00 00 00 00 00 0C</o>
+            </o>
+          </o>
+        </o>
+      </o>
+    </o>
+  </objects>
+</program>

--- a/eo-parser/src/main/java/org/eolang/parser/XMIR.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XMIR.java
@@ -30,6 +30,9 @@ import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Xsline;
+import org.cactoos.Scalar;
+import org.cactoos.Text;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Prints XMIR to EO.
@@ -59,7 +62,7 @@ public final class XMIR {
     /**
      * The XML content.
      */
-    private final XML xml;
+    private final Unchecked<String> content;
 
     /**
      * Ctor.
@@ -73,8 +76,24 @@ public final class XMIR {
      * Ctor.
      * @param src The source
      */
+    public XMIR(final Text src) {
+        this(new Unchecked<>(src::asString));
+    }
+
+    /**
+     * Ctor.
+     * @param src The source
+     */
     public XMIR(final XML src) {
-        this.xml = src;
+        this(new Unchecked<>(src::toString));
+    }
+
+    /**
+     * Ctor.
+     * @param src The source
+     */
+    private XMIR(final Unchecked<String> src) {
+        this.content = src;
     }
 
     /**
@@ -84,7 +103,9 @@ public final class XMIR {
      */
     public String toEO() {
         return XMIR.SHEET.applyTo(
-            new Xsline(new TrDefault<>(new StUnhex())).pass(this.xml)
+            new Xsline(new TrDefault<>(new StUnhex())).pass(
+                new XMLDocument(this.content.value())
+            )
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XMIR.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XMIR.java
@@ -30,7 +30,6 @@ import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Xsline;
-import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.scalar.Unchecked;
 

--- a/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
@@ -61,11 +61,11 @@ final class XMIRTest {
     void printsToEO(final String src) throws Exception {
         Logger.debug(this, "Original EOLANG:%n%s", src);
         final XML first = XMIRTest.clean(XMIRTest.parse(src));
-        Logger.debug(this, "First:%n%s", first);
+        Logger.info(this, "First:%n%s", first);
         final String eolang = new XMIR(first).toEO();
-        Logger.debug(this, "EOLANG:%n%s", eolang);
+        Logger.info(this, "EOLANG:%n%s", eolang);
         final XML second = XMIRTest.clean(XMIRTest.parse(eolang));
-        Logger.debug(this, "Second:%n%s", second);
+        Logger.info(this, "Second:%n%s", second);
         final String ignore = "data=\"\\S+\"";
         MatcherAssert.assertThat(
             first

--- a/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XMIRTest.java
@@ -61,11 +61,11 @@ final class XMIRTest {
     void printsToEO(final String src) throws Exception {
         Logger.debug(this, "Original EOLANG:%n%s", src);
         final XML first = XMIRTest.clean(XMIRTest.parse(src));
-        Logger.info(this, "First:%n%s", first);
+        Logger.debug(this, "First:%n%s", first);
         final String eolang = new XMIR(first).toEO();
-        Logger.info(this, "EOLANG:%n%s", eolang);
+        Logger.debug(this, "EOLANG:%n%s", eolang);
         final XML second = XMIRTest.clean(XMIRTest.parse(eolang));
-        Logger.info(this, "Second:%n%s", second);
+        Logger.debug(this, "Second:%n%s", second);
         final String ignore = "data=\"\\S+\"";
         MatcherAssert.assertThat(
             first


### PR DESCRIPTION
Closes: #2592

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new Maven plugin called "PrintMojo" that converts XMIR files to EO files. 

### Detailed summary
- Added a new Maven plugin called "PrintMojo" that converts XMIR files to EO files.
- The plugin takes XMIR source files as input and generates corresponding EO files.
- The XMIR to EO conversion is done using the XMIR class from the eo-parser module.
- The plugin has two parameters: "printSourcesDir" for specifying the directory containing XMIR source files, and "printOutputDir" for specifying the directory where the generated EO files will be placed.
- The plugin uses the HmBase and Home classes from the eo-maven-plugin module for file handling.
- The plugin logs the conversion process and the number of sources converted.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->