### PR TITLE
#2257: BinarizeDir can be configured via pom.xml

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeMojo.java
@@ -80,6 +80,17 @@ public final class BinarizeMojo extends SafeMojo {
     private File generatedDir;
 
     /**
+     * File where to save {@link org.eolang.maven.rust.Names} map.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(
+        required = true,
+        defaultValue = "${project.build.directory}/names"
+    )
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private File namesDir;
+
+    /**
      * The directory with portal project. It is a necessary dependency
      * that provides rust-eo interaction.
      * @checkstyle MemberNameCheck (8 lines)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -33,7 +33,6 @@ import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -34,6 +34,7 @@ import com.yegor256.xsline.Xsline;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -222,8 +223,8 @@ public final class BinarizeParseMojo extends SafeMojo {
         final String result;
         try {
             final byte[] bytes = Hex.decodeHex(String.valueOf(hex).toCharArray());
-            result = new String(bytes, "UTF-8");
-        } catch (final DecoderException | UnsupportedEncodingException exception) {
+            result = new String(bytes, StandardCharsets.UTF_8);
+        } catch (final DecoderException exception) {
             throw new IllegalArgumentException(
                 String.format("Invalid String %s, cannot unhex", txt),
                 exception

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -63,9 +63,6 @@ import org.eolang.parser.ParsingTrain;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
- * @todo #2238:30min Specify directory for names via pom.xml.Now names map is
- *  serialized in targetDir.toPath().getParent() which is a bad decision since
- *  it must be created just as target/names.
  */
 @Mojo(
     name = "binarize_parse",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/BinarizeParseMojo.java
@@ -112,6 +112,16 @@ public final class BinarizeParseMojo extends SafeMojo {
     private File generatedDir;
 
     /**
+     * File where to save {@link org.eolang.maven.rust.Names} map.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(
+        required = true,
+        defaultValue = "${project.build.directory}/names"
+    )
+    private File namesDir;
+
+    /**
      * The directory with portal project.
      * @checkstyle MemberNameCheck (8 lines)
      */
@@ -125,7 +135,7 @@ public final class BinarizeParseMojo extends SafeMojo {
 
     @Override
     public void exec() throws IOException {
-        final Names names = new Names(targetDir.toPath().getParent());
+        final Names names = new Names(this.namesDir.toPath());
         new File(this.targetDir.toPath().resolve("Lib/").toString()).mkdirs();
         for (final ForeignTojo tojo : this.scopedTojos().withOptimized()) {
             final Path file = tojo.shaken();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Names.java
@@ -70,7 +70,7 @@ public final class Names {
      * @param target Directory where to serialize names.
      */
     public Names(final Path target) {
-        this.dest = target.resolve("names");
+        this.dest = target;
         this.all = Names.checked(this.dest);
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -239,6 +239,7 @@ public final class FakeMaven {
                 "eoPortalDir",
                 new File("../eo-runtime/src/main/rust/eo")
             );
+            this.params.putIfAbsent("namesDir", this.generatedPath().resolve("names").toFile());
             this.params.putIfAbsent("hashes", new CommitHashesMap.Fake());
         }
         final Moja<T> moja = new Moja<>(mojo);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/rust/NamesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/rust/NamesTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class NamesTest {
     @Test
     void solvesSameHashes(@TempDir final Path temp) throws IOException {
-        final Names dispatcher = new Names(temp);
+        final Names dispatcher = new Names(temp.resolve("names"));
         final String one = "AaAaAa";
         final String two = "AaAaBB";
         MatcherAssert.assertThat(
@@ -59,10 +59,11 @@ final class NamesTest {
 
     @Test
     void recoversNames(@TempDir final Path temp) throws IOException {
+        final String names = "names";
         final List<String> locations = IntStream.range(0, 1000)
             .mapToObj(String::valueOf)
             .collect(Collectors.toList());
-        final Names before = new Names(temp);
+        final Names before = new Names(temp.resolve(names));
         final Map<String, String> functions = locations.stream().collect(
             Collectors.toMap(loc -> loc, before::name)
         );
@@ -71,7 +72,7 @@ final class NamesTest {
             Matchers.equalTo(functions.size())
         );
         before.save();
-        final Names after = new Names(temp);
+        final Names after = new Names(temp.resolve(names));
         MatcherAssert.assertThat(
             before,
             Matchers.equalTo(after)


### PR DESCRIPTION
Closes #2257

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `Names` file in the `eo-maven-plugin`. 

### Detailed summary
- The `Names` constructor now takes a `target` parameter and assigns it to the `dest` field.
- The `namesDir` parameter is added to the `BinarizeMojo` and `BinarizeParseMojo` classes.
- The `namesDir` parameter is used to create a `Names` object in the `BinarizeParseMojo` class.
- The `NamesTest` class now uses the `names` directory for creating `Names` objects.
- The `BinarizeParseMojo` class uses the `namesDir` parameter to create a `Names` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->