### PR TITLE
feat(#2596): fix the problem with commons-text 1.11.0 library version

### DIFF
--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -139,7 +139,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.10.0</version>
+      <!-- version from parent POM -->
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -103,7 +103,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.10.0</version>
+      <!-- version from parent POM -->
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,16 @@ SOFTWARE.
         <version>2.0.2</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.13.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.11.0</version>
+      </dependency>
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.15.0</version>


### PR DESCRIPTION
Short Description:

`commons-text:1.11.0` requires new features  from `commons-lang3:3.13.0` library

Detailed: 

When the Java `ClassLoader` initializes the `StringEscapeUtils` class from `commons-text:1.11.0`, it runs static initialization blocks in `StringEscapeUtils`. Here is one such block (line 267):

```java
ESCAPE_XML10 = new AggregateTranslator(
        new LookupTranslator(EntityArrays.BASIC_ESCAPE),
        new LookupTranslator(EntityArrays.APOS_ESCAPE),
        new LookupTranslator(Collections.unmodifiableMap(escapeXml10Map)),
        NumericEntityEscaper.between(0x7f, 0x84),
        NumericEntityEscaper.between(0x86, 0x9f),
        new UnicodeUnpairedSurrogateRemover()
);
````
The usage of `NumericEntityEscaper.between(0x7f, 0x84)` in version `1.11.0` internally relies on the `org.apache.commons.lang3.Range.of(below, above)` function.
It's worth noting that this function was introduced only in `commons-lang3:3.13.0` which caused the problem.

Closes: #2596.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `commons-text` dependency to `1.11.0` and adds a new dependency `commons-lang3` with version `3.13.0`.

### Detailed summary
- Updated `commons-text` dependency version to `1.11.0`
- Added new dependency `commons-lang3` with version `3.13.0`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->