### PR TITLE
2587 fix universe

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -355,15 +355,15 @@ SOFTWARE.
     </xsl:choose>
     <xsl:text>;</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
-    <xsl:apply-templates select="." mode="located">
-      <xsl:with-param name="name" select="$name"/>
-      <xsl:with-param name="indent" select="$indent"/>
-    </xsl:apply-templates>
     <xsl:apply-templates select="." mode="application">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
     </xsl:apply-templates>
     <xsl:apply-templates select=".[@copy]" mode="copy">
+      <xsl:with-param name="name" select="$name"/>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="located">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
     </xsl:apply-templates>

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -103,8 +103,8 @@ public final class ParsingTrain extends TrEnvelope {
         "/org/eolang/parser/errors/external-weak-typed-atoms.xsl",
         "/org/eolang/parser/errors/unused-aliases.xsl",
         "/org/eolang/parser/warnings/unit-test-without-phi.xsl",
-        "/org/eolang/parser/set-locators.xsl",
         "/org/eolang/parser/explicit-data.xsl",
+        "/org/eolang/parser/set-locators.xsl",
     };
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOrust.java
@@ -134,15 +134,6 @@ public class EOrust extends PhDefault {
     /**
      * Ctor.
      * @param sigma Sigma
-     * @todo #2437:60min Fix EOrust. After getting rid of delta attribute in data primitives
-     *  EOrust stopped working. Reason - it can't find proper locator of "code" attribute
-     *  because it's lost when it's wrapped with {@link org.eolang.PhCopy}. Need to figure out how
-     *  to fix it and enable all disabled rust tests: rust-returns-negative-int,
-     *  rust-returns-vertex, rust-invalid-put, rust-error, rust-returns-positive-int,
-     *  rust-find-returns-int, rust-plus, rust-bind-not-fails, rust-is-string, rust-copy-not-fails,
-     *  rust-is-byte-array, rust-bind-to-copy, rust-put-to-copy, rust-returns-positive-double,
-     *  rust-returns-negative-double, rust-dataize-not-fails,
-     *  UniverseDefaultTest#bindsCopyToAbstract, UniverseDefaultTest#putsToCopy,
      */
     public EOrust(final Phi sigma) {
         super(sigma);

--- a/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/rust-tests.eo
@@ -39,10 +39,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     r
     2
-  nop > @
 
 [] > rust-returns-negative-int
   QQ.rust > r
@@ -58,10 +57,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     r
     -10
-  nop > @
 
 [] > rust-returns-positive-double
   QQ.rust > r
@@ -76,10 +74,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     r
     1.23456789
-  nop > @
 
 [] > rust-returns-negative-double
   QQ.rust > r
@@ -94,10 +91,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     r
     -1.23456789
-  nop > @
 
 [] > rust-is-byte-array
   QQ.rust > my-bytes
@@ -118,10 +114,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     my-bytes
     00-1A-EE
-  nop > @
 
 [] > rust-find-returns-int
   123 > a
@@ -139,11 +134,10 @@
     """
     []
     *
-  not. > res
+  not. > @
     lt.
       r
       0
-  nop > @
 
 [] > rust-returns-vertex
   "content" > book
@@ -160,10 +154,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     read
     "content"
-  nop > @
 
 [] > rust-is-string
   QQ.rust > content
@@ -178,10 +171,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     content
     "Привет world"
-  nop > @
 
 [] > rust-invalid-put
   QQ.rust > put
@@ -196,7 +188,7 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     slice.
       try
         []
@@ -207,7 +199,6 @@
       0
       18
     "Rust insert failed"
-  nop > @
 
 [] > rust-bind-not-fails
   1 > a
@@ -233,12 +224,11 @@
     [e]
       e > @
     nop
-  eq. > result
+  eq. > @
     res.slice
       0
       to-check.length
     to-check
-  nop > @
 
 [] > rust-copy-not-fails
   123 > a
@@ -255,10 +245,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     copy
     123
-  nop > @
 
 [] > rust-dataize-not-fails
   1 > a
@@ -275,11 +264,10 @@
     """
     []
     *
-  not. > res
+  not. > @
     lt.
       dataized
       0
-  nop > @
 
 [] > rust-plus
   5 > a
@@ -307,10 +295,9 @@
     []
     *
       "byteorder:1.4.3"
-  eq. > res
+  eq. > @
     plus
     15
-  nop > @
 
 [] > rust-error
   "Rust insert failed " > message!
@@ -332,14 +319,13 @@
     [e]
       e > @
     nop
-  eq. > result
+  eq. > @
     slice.
       res
       0
       length.
         message
     message
-  nop > @
 
 [] > rust-put-to-copy
   QQ.rust > data
@@ -357,10 +343,9 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     data
     00-1A-EE
-  nop > @
 
 [] > rust-bind-to-copy
   [content] > book
@@ -381,7 +366,6 @@
     """
     []
     *
-  eq. > res
+  eq. > @
     applied.content
     "qwerty"
-  nop > @

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -150,8 +150,8 @@ final class UniverseDefaultTest {
     void putsToCopy() {
         final Map<Integer, Phi> indexed = new HashMap<>();
         final Universe universe = new UniverseDefault(Phi.Φ, indexed);
-        final int eoint = universe.find("Q.org.eolang.bytes");
-        final int copy = universe.copy(eoint);
+        final int eobytes = universe.find("Q.org.eolang.bytes");
+        final int copy = universe.copy(eobytes);
         universe.put(copy, UniverseDefaultTest.DATA);
         MatcherAssert.assertThat(
             new Dataized(indexed.get(copy)).take(),
@@ -166,8 +166,8 @@ final class UniverseDefaultTest {
         final Phi dummy = new DummyAbstract(Phi.Φ);
         final Map<Integer, Phi> indexed = new MapOf<>(dummy.hashCode(), dummy);
         final Universe universe = new UniverseDefault(dummy, indexed);
-        final int eoint = universe.find("Q.org.eolang.bytes");
-        final int copy = universe.copy(eoint);
+        final int eobytes = universe.find("Q.org.eolang.bytes");
+        final int copy = universe.copy(eobytes);
         universe.put(copy, UniverseDefaultTest.DATA);
         universe.bind(
             dummy.hashCode(), copy, UniverseDefaultTest.ATT

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -147,11 +147,10 @@ final class UniverseDefaultTest {
     }
 
     @Test
-    @Disabled
     void putsToCopy() {
         final Map<Integer, Phi> indexed = new HashMap<>();
         final Universe universe = new UniverseDefault(Phi.Φ, indexed);
-        final int eoint = universe.find("Q.org.eolang.int");
+        final int eoint = universe.find("Q.org.eolang.bytes");
         final int copy = universe.copy(eoint);
         universe.put(copy, UniverseDefaultTest.DATA);
         MatcherAssert.assertThat(
@@ -163,12 +162,11 @@ final class UniverseDefaultTest {
     }
 
     @Test
-    @Disabled
     void bindsCopyToAbstract() {
         final Phi dummy = new DummyAbstract(Phi.Φ);
         final Map<Integer, Phi> indexed = new MapOf<>(dummy.hashCode(), dummy);
         final Universe universe = new UniverseDefault(dummy, indexed);
-        final int eoint = universe.find("Q.org.eolang.int");
+        final int eoint = universe.find("Q.org.eolang.bytes");
         final int copy = universe.copy(eoint);
         universe.put(copy, UniverseDefaultTest.DATA);
         universe.bind(


### PR DESCRIPTION
Closes #2587

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing issues with the EOrust class and updating the UniverseDefaultTest class in the eo-runtime module.

### Detailed summary
- Fixed an issue in EOrust related to the "code" attribute locator.
- Updated the putsToCopy method in UniverseDefaultTest to use the "Q.org.eolang.bytes" type instead of "Q.org.eolang.int".
- Updated the bindsCopyToAbstract method in UniverseDefaultTest to use the "Q.org.eolang.bytes" type instead of "Q.org.eolang.int".
- Updated the rust-tests.eo file in the eo-runtime module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->