### PR TITLE
#2585: Fixed test

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeParseMojoTest.java
@@ -31,7 +31,6 @@ import org.eolang.maven.rust.Names;
 import org.eolang.xax.XaxStory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -42,9 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
  * Test case for {@link BinarizeParseMojo}.
  *
  * @since 0.1
- * @todo #2437:30min Enable the tests: Some tests in the class were disabled after changing
- *  "explicit-data.xsl". Need to fix them and enable. Don't forget to remove the puzzle.
- *  Disabled tests: {@link BinarizeParseMojoTest#createsDependenciesSection(String)}.
  */
 @Execution(ExecutionMode.CONCURRENT)
 final class BinarizeParseMojoTest {
@@ -139,7 +135,6 @@ final class BinarizeParseMojoTest {
         );
     }
 
-    @Disabled
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/binarize/add_rust/", glob = "**.yaml")
     void createsDependenciesSection(final String yaml) {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/binarize/add_rust/add-dependencies.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/binarize/add_rust/add-dependencies.yaml
@@ -41,7 +41,7 @@ document:
                   </o>
                   <o base="org.eolang.string"
                   line="297"
-                  loc="Φ.org.eolang.rust-plus.plus.α2.α1"
+                  loc="Φ.org.eolang.rust-plus.plus.α3.α1"
                   pos="6">
                      <o base="org.eolang.bytes"
                      data="bytes"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/binarize/add_rust/add-dependencies.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/binarize/add_rust/add-dependencies.yaml
@@ -31,14 +31,22 @@ document:
                   data="tuple"
                   loc="Φ.org.eolang.creates-object.r.α1"
                   pos="4">
-                 <o base="org.eolang.string"
+                  <o base="org.eolang.string"
+                  line="297"
+                  loc="Φ.org.eolang.rust-plus.plus.α2.α1"
+                  pos="6">
+                     <o base="org.eolang.bytes"
                      data="bytes"
-                     loc="Φ.org.eolang.creates-object.r.α1.α0"
-                     pos="6">72 65 6F 3A 20 30 2E 30 2E 32</o>
-                 <o base="org.eolang.string"
+                     loc="Φ.org.eolang.rust-plus.plus.α2.α1.α0">72 65 6F 3A 20 30 2E 30 2E 32</o>
+                  </o>
+                  <o base="org.eolang.string"
+                  line="297"
+                  loc="Φ.org.eolang.rust-plus.plus.α2.α1"
+                  pos="6">
+                     <o base="org.eolang.bytes"
                      data="bytes"
-                     loc="Φ.org.eolang.creates-object.r.α1.α1"
-                     pos="6">72 61 6E 64 3A 20 30 2E 35 2E 35</o>
+                     loc="Φ.org.eolang.rust-plus.plus.α2.α1.α0">72 61 6E 64 3A 20 30 2E 35 2E 35</o>
+                  </o>
               </o>
            </o>
         </o>


### PR DESCRIPTION
Closes #2585 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on enabling and fixing tests in the `BinarizeParseMojoTest` class.

### Detailed summary:
- Enabled the tests that were previously disabled.
- Removed the `@Disabled` annotation from the `createsDependenciesSection` test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->