### PR TITLE
Removed test with application to tuples element

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -461,16 +461,3 @@
               2
         build 2 > @
     9
-
-# @todo #2555:30min Enable the test when it's possible normalize object before application.
-#  Now this test does not work because we (arr.at 0).@ "returns" "if" from tuple.at which is
-#  wrong. Possibly we would need to extend EO syntax and phi calculus in order to be able to
-#  support such behavior.
-[] > application-to-abstract-inside-tuple
-  [x] > add
-    x.plus 1 > @
-  * add > arr
-  eq. > res
-    (arr.at 0).@ 5
-    6
-  nop > @


### PR DESCRIPTION
Closes #2564

It was decided, that it is impossible to "normalize" object from tuple before application because of PR #2555. So it was decided to remove test with application to tuples element.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR focuses on enabling a test in the `runtime-tests.eo` file.
- The test is currently disabled due to a bug.
- The bug is related to incorrect behavior in the `application-to-abstract-inside-tuple` object.
- The test requires extending the EO syntax and phi calculus to support the desired behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->