### PR TITLE
#2558: Dataized::take returns byte array

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -109,7 +109,7 @@ public final class Dataized {
                 }
             }
             final Object data = Data.class.cast(src).take();
-            if (! (data instanceof byte[])) {
+            if (!(data instanceof byte[])) {
                 throw new ExFailure(
                     "data of must be %s, but was %s",
                     this.phi.toString(),

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -111,7 +111,7 @@ public final class Dataized {
             final Object data = Data.class.cast(src).take();
             if (!(data instanceof byte[])) {
                 throw new ExFailure(
-                    "data of must be %s, but was %s",
+                    "data of %s must be %s, but was %s",
                     this.phi.toString(),
                     byte[].class,
                     data.getClass()

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -108,7 +108,7 @@ public final class Dataized {
                     );
                 }
             }
-            final Object data = ((Data<?>) src).take();
+            final Object data = Data.class.cast(src).take();
             if (! (data instanceof byte[])) {
                 throw new ExFailure(
                     "data of must be %s, but was %s",


### PR DESCRIPTION
Closes #2558

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The signature of the `take()` method in the `Dataized` class has been changed to return a `byte[]` instead of an `Object`.
- Added a check to ensure that the returned data is always a `byte[]` and throw an exception if it's not.
- Fixed a type casting issue in the `take()` method when calling it with a specific type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->