### PR TITLE
feat(#2610): special braces, arrows and empty set

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -45,7 +45,7 @@ import org.eolang.maven.util.Walk;
 
 /**
  * Read XMIR files and translate them to the phi-calculus expression.
- * @since 0.33.0
+ * @since 0.34.0
  */
 @Mojo(
     name = "xmir-to-phi",

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -52,6 +52,18 @@ SOFTWARE.
   <xsl:variable name="arrow">
     <select> ↦ </select>
   </xsl:variable>
+  <xsl:variable name="dashed-arrow">
+    <select> ⤍ </select>
+  </xsl:variable>
+  <xsl:variable name="lb">
+    <select>⟦</select>
+  </xsl:variable>
+  <xsl:variable name="rb">
+    <select>⟧</select>
+  </xsl:variable>
+  <xsl:variable name="empty">
+    <select>∅</select>
+  </xsl:variable>
   <!-- Functions -->
   <xsl:function name="eo:specials">
     <xsl:param name="n"/>
@@ -128,9 +140,23 @@ SOFTWARE.
   </xsl:function>
   <!-- Program -->
   <xsl:template match="program">
-    <xsl:text>[</xsl:text>
+    <xsl:text>{</xsl:text>
+    <xsl:variable name="has-package" select="metas/meta/head[text()='package']"/>
+    <xsl:variable name="parts" select="tokenize(metas/meta[head[text()='package']]/tail[1], '\.')"/>
+    <xsl:if test="$has-package">
+      <xsl:for-each select="$parts">
+        <xsl:value-of select="."/>
+        <xsl:value-of select="$arrow"/>
+        <xsl:value-of select="$lb"/>
+      </xsl:for-each>
+    </xsl:if>
     <xsl:apply-templates select="objects"/>
-    <xsl:text>]</xsl:text>
+    <xsl:if test="$has-package">
+      <xsl:for-each select="$parts">
+        <xsl:value-of select="$rb"/>
+      </xsl:for-each>
+    </xsl:if>
+    <xsl:text>}</xsl:text>
   </xsl:template>
   <!-- Objects  -->
   <xsl:template match="objects">
@@ -143,7 +169,7 @@ SOFTWARE.
   <xsl:template match="o[parent::o[not(@base)] and not(@base) and not(@atom) and not(o)]">
     <xsl:value-of select="./@name"/>
     <xsl:value-of select="$arrow"/>
-    <xsl:text>?</xsl:text>
+    <xsl:value-of select="$empty"/>
   </xsl:template>
   <!-- Just object -->
   <xsl:template match="o[@base]">
@@ -184,7 +210,7 @@ SOFTWARE.
     <xsl:if test="@data">
       <xsl:text>(</xsl:text>
       <xsl:value-of select="$delta"/>
-      <xsl:value-of select="$arrow"/>
+      <xsl:value-of select="$dashed-arrow"/>
       <xsl:value-of select="eo:bytes(.)"/>
       <xsl:text>)</xsl:text>
     </xsl:if>
@@ -195,11 +221,11 @@ SOFTWARE.
       <xsl:value-of select="eo:specials(@name)"/>
       <xsl:value-of select="$arrow"/>
     </xsl:if>
-    <xsl:text>[</xsl:text>
+    <xsl:value-of select="$lb"/>
     <xsl:if test="@atom">
       <xsl:value-of select="$lambda"/>
-      <xsl:value-of select="$arrow"/>
-      <xsl:text>lambda</xsl:text>
+      <xsl:value-of select="$dashed-arrow"/>
+      <xsl:text>Lambda</xsl:text>
       <xsl:if test="count(o)&gt;0">
         <xsl:text>, </xsl:text>
       </xsl:if>
@@ -208,7 +234,7 @@ SOFTWARE.
       <xsl:value-of select="eo:comma(position())"/>
       <xsl:apply-templates select="."/>
     </xsl:for-each>
-    <xsl:text>]</xsl:text>
+    <xsl:value-of select="$rb"/>
   </xsl:template>
   <!-- Application -->
   <xsl:template match="o" mode="application">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -143,19 +143,22 @@ SOFTWARE.
     <xsl:text>{</xsl:text>
     <xsl:variable name="has-package" select="metas/meta/head[text()='package']"/>
     <xsl:variable name="parts" select="tokenize(metas/meta[head[text()='package']]/tail[1], '\.')"/>
-    <xsl:if test="$has-package">
-      <xsl:for-each select="$parts">
-        <xsl:value-of select="."/>
-        <xsl:value-of select="$arrow"/>
-        <xsl:value-of select="$lb"/>
-      </xsl:for-each>
-    </xsl:if>
-    <xsl:apply-templates select="objects"/>
-    <xsl:if test="$has-package">
-      <xsl:for-each select="$parts">
-        <xsl:value-of select="$rb"/>
-      </xsl:for-each>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="$has-package">
+        <xsl:for-each select="$parts">
+          <xsl:value-of select="."/>
+          <xsl:value-of select="$arrow"/>
+          <xsl:value-of select="$lb"/>
+        </xsl:for-each>
+        <xsl:apply-templates select="objects"/>
+        <xsl:for-each select="$parts">
+          <xsl:value-of select="$rb"/>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="objects"/>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>}</xsl:text>
   </xsl:template>
   <!-- Objects  -->

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
@@ -36,7 +36,6 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * Test cases for {@link PhiMojo}.
- *
  * @since 0.33.0
  */
 class PhiMojoTest {
@@ -66,6 +65,10 @@ class PhiMojoTest {
     void checksPhiPacks(final String pack, @TempDir final Path temp) throws Exception {
         final Map<String, Object> map = new Yaml().load(pack);
         MatcherAssert.assertThat(
+            String.format(
+                "Result phi expression should be equal to %s, but it doesn't",
+                map.get("phi").toString()
+            ),
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(map.get("eo").toString())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
@@ -36,7 +36,7 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * Test cases for {@link PhiMojo}.
- * @since 0.33.0
+ * @since 0.34.0
  */
 class PhiMojoTest {
     @Test

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/application.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/application.yaml
@@ -5,4 +5,4 @@ eo: |
       w > @
     5
 phi:
-  "[xyz ↦ Φ.org.eolang.x(attr ↦ Φ.org.eolang.y, α1 ↦ [z ↦ ?, φ ↦ Φ.org.eolang.w], α2 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ↦ 00-00-00-00-00-00-00-05)))]"
+  "{xyz ↦ Φ.org.eolang.x(attr ↦ Φ.org.eolang.y, α1 ↦ ⟦z ↦ ∅, φ ↦ Φ.org.eolang.w⟧, α2 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05)))}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/atoms.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/atoms.yaml
@@ -3,4 +3,4 @@ eo: |
   [] > outer
     [] > inner /bytes
 phi:
-  "[main ↦ [λ ↦ lambda], outer ↦ [inner ↦ [λ ↦ lambda]]]"
+  "{main ↦ ⟦λ ⤍ Lambda⟧, outer ↦ ⟦inner ↦ ⟦λ ⤍ Lambda⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/empty-bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/empty-bytes.yaml
@@ -1,2 +1,2 @@
 eo: -- > empty
-phi: "[empty ↦ Φ.org.eolang.bytes(Δ ↦ --)]"
+phi: "{empty ↦ Φ.org.eolang.bytes(Δ ⤍ --)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/full-path.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/full-path.yaml
@@ -2,4 +2,4 @@ eo: |
   QQ.io.stdout > std
   Q.org.eolang.x > y
 phi:
-  "[std ↦ Φ.org.eolang.io.stdout, y ↦ Φ.org.eolang.x]"
+  "{std ↦ Φ.org.eolang.io.stdout, y ↦ Φ.org.eolang.x}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/method.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/method.yaml
@@ -1,2 +1,2 @@
 eo: x.y.z > xyz
-phi: [xyz ↦ Φ.org.eolang.x.y.z]
+phi: "{xyz ↦ Φ.org.eolang.x.y.z}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/one-byte.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/one-byte.yaml
@@ -1,2 +1,2 @@
 eo: A2- > bts
-phi: "[bts ↦ Φ.org.eolang.bytes(Δ ↦ A2-)]"
+phi: "{bts ↦ Φ.org.eolang.bytes(Δ ⤍ A2-)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/package.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/package.yaml
@@ -1,0 +1,6 @@
+eo: |
+  +package foo.bar.baz
+  
+  [] > main
+    stdout > @
+phi: "{foo ↦ ⟦bar ↦ ⟦baz ↦ ⟦main ↦ ⟦φ ↦ Φ.org.eolang.stdout⟧⟧⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
@@ -5,4 +5,4 @@ eo: |
     $.a > a
     < > vtx
     ^.< > self
-phi: "[main ↦ [x ↦ ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ρ.a, vtx ↦ ν, self ↦ ρ.ν]]"
+phi: "{main ↦ ⟦x ↦ ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ρ.a, vtx ↦ ν, self ↦ ρ.ν⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/with-data.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/with-data.yaml
@@ -1,2 +1,2 @@
 eo: 5 > five
-phi: "[five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ↦ 00-00-00-00-00-00-00-05))]"
+phi: "{five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05))}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/with-free-attributes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/with-free-attributes.yaml
@@ -2,4 +2,4 @@ eo: |
   [a b] > c
     d > @
 phi:
-  "[c ↦ [a ↦ ?, b ↦ ?, φ ↦ Φ.org.eolang.d]]"
+  "{c ↦ ⟦a ↦ ∅, b ↦ ∅, φ ↦ Φ.org.eolang.d⟧}"


### PR DESCRIPTION
Closes: #2610

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code diff for the eo-maven-plugin. 

### Detailed summary
- Updated phi values in method.yaml files to be enclosed in double quotes.
- Updated the @since version in PhiMojo.java.
- Updated phi values in one-byte.yaml, empty-bytes.yaml, with-free-attributes.yaml, with-data.yaml, full-path.yaml, atoms.yaml, specials.yaml, and application.yaml files to use curly braces instead of square brackets.
- Updated the @since version in PhiMojoTest.java.
- Added new package.yaml file.
- Updated the to-phi.xsl file to include new variables and templates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->