### PR TITLE
feat(#2624): xi in front + fibonaci test

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -53,10 +53,14 @@ SOFTWARE.
     <select>ν</select>
   </xsl:variable>
   <xsl:variable name="arrow">
-    <select> ↦ </select>
+    <xsl:text> </xsl:text>
+    <select>↦</select>
+    <xsl:text> </xsl:text>
   </xsl:variable>
   <xsl:variable name="dashed-arrow">
-    <select> ⤍ </select>
+    <xsl:text> </xsl:text>
+    <select>⤍</select>
+    <xsl:text> </xsl:text>
   </xsl:variable>
   <xsl:variable name="lb">
     <select>⟦</select>
@@ -192,29 +196,26 @@ SOFTWARE.
     <xsl:value-of select="$empty"/>
   </xsl:template>
   <!-- Find path template -->
-  <xsl:template match="o" mode="path">
+  <xsl:template match="*" mode="path">
     <xsl:param name="find"/>
-    <xsl:variable name="parent" select="parent::o"/>
+    <xsl:variable name="parent" select="parent::*"/>
+    <xsl:variable name="rho-dot">
+      <xsl:value-of select="eo:specials('^', true())"/>
+      <xsl:text>.</xsl:text>
+    </xsl:variable>
     <xsl:choose>
-      <xsl:when test="$parent[not(@abstract)]">
+      <xsl:when test="$parent[@abstract]">
+        <xsl:if test="not($parent/o[@name=$find])">
+          <xsl:value-of select="$rho-dot"/>
+          <xsl:apply-templates select="$parent" mode="path">
+            <xsl:with-param name="find" select="$find"/>
+          </xsl:apply-templates>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="not($parent[name()='objects'])">
         <xsl:apply-templates select="$parent" mode="path">
           <xsl:with-param name="find" select="$find"/>
         </xsl:apply-templates>
-      </xsl:when>
-      <xsl:when test="$parent[@abstract]">
-        <xsl:choose>
-          <xsl:when test="@base=$find">
-            <xsl:value-of select="eo:specials('^', true())"/>
-            <xsl:text>.</xsl:text>
-          </xsl:when>
-          <xsl:when test="not(o[@base=$find])">
-            <xsl:value-of select="eo:specials('^', true())"/>
-            <xsl:text>.</xsl:text>
-            <xsl:apply-templates select="$parent" mode="path">
-              <xsl:with-param name="find" select="$find"/>
-            </xsl:apply-templates>
-          </xsl:when>
-        </xsl:choose>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -25,6 +25,7 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="to-phi" version="2.0">
   <xsl:output encoding="UTF-8" method="text"/>
   <!-- Variables -->
+  <xsl:variable name="aliases" select="program/metas/meta/part[last()]"/>
   <xsl:variable name="xi">
     <select>ξ</select>
   </xsl:variable>
@@ -123,6 +124,11 @@ SOFTWARE.
         <xsl:value-of select="$program"/>
       </xsl:when>
       <xsl:when test="starts-with($n, 'org.eolang')">
+        <xsl:value-of select="$program"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="$n"/>
+      </xsl:when>
+      <xsl:when test="$aliases[text()=$n]">
         <xsl:value-of select="$program"/>
         <xsl:text>.</xsl:text>
         <xsl:value-of select="$n"/>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/custom-alias.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/custom-alias.yaml
@@ -1,0 +1,7 @@
+eo: |
+  +package foo.bar
+  +alias com.yegor256.x
+  
+  [y] > main
+    x y > z
+phi: ""{foo ↦ ⟦bar ↦ ⟦main ↦ ⟦y ↦ ∅, z ↦ Φ.com.yegor256.x(α0 ↦ ξ.y)⟧⟧⟧}""

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/custom-alias.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/custom-alias.yaml
@@ -4,4 +4,4 @@ eo: |
   
   [y] > main
     x y > z
-phi: ""{foo ↦ ⟦bar ↦ ⟦main ↦ ⟦y ↦ ∅, z ↦ Φ.com.yegor256.x(α0 ↦ ξ.y)⟧⟧⟧}""
+phi: "{foo ↦ ⟦bar ↦ ⟦main ↦ ⟦y ↦ ∅, z ↦ Φ.com.yegor256.x(α0 ↦ ξ.y)⟧⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/fibonaci.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/fibonaci.yaml
@@ -1,0 +1,15 @@
+eo: |
+  +package eo.example
+
+  [n] > fibonacci
+    if. > @
+      lt.
+        n
+        2
+      n
+      plus.
+        fibonacci
+          n.minus 1
+        fibonacci
+          n.minus 2
+phi: "{eo ↦ ⟦example ↦ ⟦fibonacci ↦ ⟦n ↦ ∅, φ ↦ ξ.n.lt(α0 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-02))).if(α0 ↦ ξ.n, α1 ↦ ξ.ρ.fibonacci(α0 ↦ ξ.n.minus(α0 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-01)))).plus(α0 ↦ ξ.ρ.fibonacci(α0 ↦ ξ.n.minus(α0 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-02))))))⟧⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/nested.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/nested.yaml
@@ -1,0 +1,10 @@
+eo: |
+  [a] > main
+    [] > x
+      [] > y
+        a > d
+        [] > z
+          main 5 > five
+          a > b
+          d > e
+phi: "{main ↦ ⟦a ↦ ∅, x ↦ ⟦y ↦ ⟦d ↦ ξ.ρ.ρ.a, z ↦ ⟦five ↦ ξ.ρ.ρ.ρ.ρ.main(α0 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05))), b ↦ ξ.ρ.ρ.ρ.a, e ↦ ξ.ρ.d⟧⟧⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
@@ -5,4 +5,5 @@ eo: |
     $.a > a
     < > vtx
     ^.< > self
-phi: "{main ↦ ⟦x ↦ ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ρ.a, vtx ↦ ν, self ↦ ρ.ν⟧}"
+    @.@ > phi
+phi: "{main ↦ ⟦x ↦ ξ.ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ξ.ρ.a, vtx ↦ ξ.ν, self ↦ ξ.ρ.ν, phi ↦ ξ.φ.φ⟧}"


### PR DESCRIPTION
Closes: #2624

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the code in the eo-maven-plugin module. It includes changes to YAML files and an XSL file.

### Detailed summary:
- Added a new package `foo.bar` and an alias `com.yegor256.x` in `custom-alias.yaml`
- Changed the `phi` value in `custom-alias.yaml`
- Removed `vtx` and `self` from the `phi` value in `specials.yaml` and replaced with `phi`
- Added new objects and updated the `phi` value in `nested.yaml`
- Added a new package `eo.example` and a new object `fibonacci` in `fibonacci.yaml`
- Updated the `phi` value in `fibonacci.yaml`
- Updated the XSL file `to-phi.xsl` with new variables and functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->