### PR TITLE
#2546: Improved error describing

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
@@ -33,6 +33,10 @@ import org.junit.jupiter.api.io.TempDir;
  * Test cases for {@link VerifyMojo}.
  *
  * @since 0.31.0
+ * @todo #2546:90min Add test that checks the message of exception in case of
+ *  warning, error and critical in xmir. According to
+ *  eo-parser/src/main/resources/org/eolang/parser/fail-on-critical.xsl it includes
+ *  filename and line inside.
  */
 class VerifyMojoTest {
 

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-critical.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-critical.xsl
@@ -29,9 +29,10 @@ Raise an error if errors are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='critical']">
     <xsl:message terminate="yes">
-      <xsl:text>Critical error identified: &#xa;</xsl:text>
+      <xsl:text>Critical error identified:
+</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='critical']">
-        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#10;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-critical.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-critical.xsl
@@ -29,9 +29,9 @@ Raise an error if errors are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='critical']">
     <xsl:message terminate="yes">
-      <xsl:text>Critical error identified: </xsl:text>
+      <xsl:text>Critical error identified: &#xa;</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='critical']">
-        <xsl:value-of select="concat(text(), '; ')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-errors.xsl
@@ -29,9 +29,10 @@ Raise an error if errors are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='error']">
     <xsl:message terminate="yes">
-      <xsl:text>Errors identified: &#xa;</xsl:text>
+      <xsl:text>Errors identified:
+</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='error']">
-        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#10;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-errors.xsl
@@ -29,9 +29,9 @@ Raise an error if errors are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='error']">
     <xsl:message terminate="yes">
-      <xsl:text>Errors identified: </xsl:text>
+      <xsl:text>Errors identified: &#xa;</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='error']">
-        <xsl:value-of select="concat(text(), '; ')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-warnings.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-warnings.xsl
@@ -29,9 +29,9 @@ Raise an error if warnings are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='warning']">
     <xsl:message terminate="yes">
-      <xsl:text>Warnings identified: </xsl:text>
+      <xsl:text>Warnings identified: &#xa;</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='warning']">
-        <xsl:value-of select="concat(text(), '; ')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/fail-on-warnings.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/fail-on-warnings.xsl
@@ -29,9 +29,10 @@ Raise an error if warnings are found within program
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors/error[@severity='warning']">
     <xsl:message terminate="yes">
-      <xsl:text>Warnings identified: &#xa;</xsl:text>
+      <xsl:text>Warnings identified:
+</xsl:text>
       <xsl:for-each select="/program/errors/error[@severity='warning']">
-        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#xa;')"/>
+        <xsl:value-of select="concat('  ', /program/@source, ', ', @line, ': ',  text() , ';&#10;')"/>
       </xsl:for-each>
     </xsl:message>
     <xsl:copy>


### PR DESCRIPTION
Closes #2546 
Improved description of errors. Now it looks like
```
18:21:21 [INFO] org.eolang.maven.ParseMojo: Parsed 1 .eo sources to XMIRs
18:21:23 [ERROR] com.jcabi.xml.XSLDocument: net.sf.saxon.style.XSLMessage@23e78dd0: Warnings identified: 
  /tmp/junit9253374041433086166/foo/x/main.eo, 3: Sparse decoration is prohibited;
  /tmp/junit9253374041433086166/foo/x/main.eo, 4: Sparse decoration is prohibited;
  /tmp/junit9253374041433086166/foo/x/main.eo, : Missing home;
  /tmp/junit9253374041433086166/foo/x/main.eo, : Missing version meta;
18:21:23 [ERROR] com.jcabi.xml.ConsoleErrorListener: #fatalError(): Processing terminated by xsl:message at line 31 in fail-on-warnings.xsl; SystemID: file:///org/eolang/parser/fail-on-warnings.xsl; Line#: 31; Column#: 34
``` 
I did not add  tests since it is just error message.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a test that checks the message of exceptions in case of warnings, errors, and critical issues in xmir. The test includes the filename and line information. 

### Detailed summary
- Added a test in `VerifyMojoTest` class that checks the message of exceptions in xmir.
- Modified `fail-on-errors.xsl`, `fail-on-warnings.xsl`, and `fail-on-critical.xsl` files to include filename and line information in the error messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->