### PR TITLE
fix(#2668): fix test with child parameters

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -262,7 +262,6 @@ final class AssembleMojoTest {
     }
 
     @Test
-    @Disabled
     void configuresChildParameters(@TempDir final Path temp) throws IOException {
         final Map<String, Path> res = new FakeMaven(temp)
             .withHelloWorld()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -70,13 +70,6 @@ import org.eolang.maven.util.Home;
  * their behaviour and results.
  * NOT thread-safe.
  * @since 0.28.12
- * @todo #2406:30min Fix {@link FakeMaven#allowedParams(Class)}
- *  This function configures parameters of executed Mojo in {@link FakeMaven#execute(Class)}
- *  and parameters those Mojos which are inside this executed Mojo.
- *  If executed Mojo doesn't have parameters that are inside other Mojos,
- *  other Mojos parameters will not be configured.
- *  We need to make sure that custom parameters can be configured too.
- *  We need to enable the test {@link AssembleMojoTest#configuresChildParameters(Path)}.
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",


### PR DESCRIPTION
Ref: #2668

What's done:

Test AssembleMojoTest.configuresChildParameters(Path) was fixed and unlocked, but duplication of parameters for Mojos was not fixed.
In order to be able to fix duplication of parameters in Mojos a task was created.
