### PR TITLE
feat(#2682): unphi mojo test packs + bug fixes

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -25,7 +25,6 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -25,6 +25,7 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -87,7 +88,7 @@ public final class UnphiMojo extends SafeMojo {
                         );
                         home.save(
                             new PhiSyntax(
-                                phi.getFileName().toString(),
+                                phi.getFileName().toString().replace(".phi", ""),
                                 new TextOf(phi)
                             ).parsed().toString(),
                             relative

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -109,8 +109,7 @@ SOFTWARE.
         <xsl:value-of select="$home"/>
       </xsl:when>
       <xsl:when test="$n='$'">
-        <xsl:value-of select="eo:add-xi(not($is-name))"/>
-        <xsl:value-of select="$rho"/>
+        <xsl:value-of select="$xi"/>
       </xsl:when>
       <xsl:when test="$n='&lt;'">
         <xsl:value-of select="eo:add-xi(not($is-name))"/>
@@ -311,6 +310,9 @@ SOFTWARE.
     <xsl:value-of select="eo:comma($position)"/>
     <xsl:choose>
       <xsl:when test="@as">
+        <xsl:if test="matches(@as,'^[0-9][1-9]*$')">
+          <xsl:value-of select="$alpha"/>
+        </xsl:if>
         <xsl:value-of select="eo:specials(@as, true())"/>
       </xsl:when>
       <xsl:otherwise>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -25,7 +25,6 @@ package org.eolang.maven;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -37,7 +36,6 @@ import org.eolang.jucs.ClasspathSource;
 import org.eolang.maven.util.HmBase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,9 +44,6 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Test cases for {@link UnphiMojo}.
  * @since 0.34.0
- * @todo #2642:30min Create test packs for {@link UnphiMojo}. UnphiMojo seems to work correctly.
- *  We need to create yaml packs and enable {@link UnphiMojoTest#checksUnphiPacks(String, Path)}
- *  and make sure all of them are passed. Don't forget to remove the puzzle.
  */
 class UnphiMojoTest {
     @Test
@@ -111,21 +106,11 @@ class UnphiMojoTest {
         final FakeMaven maven = new FakeMaven(temp).execute(UnphiMojo.class);
         maven.foreignTojos().add("name")
             .withXmir(temp.resolve(String.format("target/%s/main.xmir", ParseMojo.DIR)));
-        System.out.println(
-            new TextOf(
-                temp.resolve("target/1-parse/main.xmir")
-            ).asString()
-        );
         final Path result = maven
             .execute(OptimizeMojo.class)
             .execute(PhiMojo.class)
             .result()
             .get(main);
-        System.out.println(
-            new TextOf(
-                temp.resolve("target/2-optimize/main.xmir")
-            ).asString()
-        );
         MatcherAssert.assertThat(
             result.toFile().lastModified(),
             Matchers.greaterThan(saved)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -112,10 +112,12 @@ class UnphiMojoTest {
             .result()
             .get(main);
         MatcherAssert.assertThat(
+            String.format("%s should have been rewritten after optimization, but it wasn't", main),
             result.toFile().lastModified(),
             Matchers.greaterThan(saved)
         );
         MatcherAssert.assertThat(
+            "Origin phi should equal to phi got from \"unphied\" xmir, but it isn't",
             phi,
             Matchers.equalTo(
                 new TextOf(result).asString()

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/specials.yaml
@@ -6,4 +6,4 @@ eo: |
     < > vtx
     ^.< > self
     @.@ > phi
-phi: "{main ↦ ⟦x ↦ ξ.ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ξ.ρ.a, vtx ↦ ξ.ν, self ↦ ξ.ρ.ν, phi ↦ ξ.φ.φ⟧}"
+phi: "{main ↦ ⟦x ↦ ξ.ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ξ.a, vtx ↦ ξ.ν, self ↦ ξ.ρ.ν, phi ↦ ξ.φ.φ⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/atoms.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/atoms.yaml
@@ -1,0 +1,6 @@
+tests:
+  - /program/objects/o[@name='main' and @atom and @abstract]
+  - /program/objects/o[@name='outer' and @abstract]
+  - /program/objects/o[@name='outer' and @abstract]/o[@name='inner' and @atom and @abstract]
+phi:
+  "{main ↦ ⟦λ ⤍ Lambda⟧, outer ↦ ⟦inner ↦ ⟦λ ⤍ Lambda⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/bindings.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/bindings.yaml
@@ -1,0 +1,26 @@
+tests:
+  - /program/objects/o[@base='Q']
+  - /program/objects/o[@method and @base='.org']
+  - /program/objects/o[@method and @base='.eolang']
+  - /program/objects/o[@method and @base='.x']
+
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='Q']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.org' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.eolang' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.y' and @method and @as='attr']
+
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@name='z' and not(@base)]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='Q']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.org' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.eolang' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.w' and @method and @name='@']
+
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='Q']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.org' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.eolang' and @method]
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.bytes' and @method and @as='0']
+  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.bytes' and @method and @as='0']/text()
+phi:
+  "{xyz ↦ Φ.org.eolang.x(attr ↦ Φ.org.eolang.y, abs ↦ ⟦z ↦ ∅, φ ↦ Φ.org.eolang.w⟧, five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05)))}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
@@ -3,5 +3,5 @@ tests:
   - /program/objects/o[@base='.org' and @method]
   - /program/objects/o[@base='.eolang' and @method]
   - /program/objects/o[@base='.bytes' and @method and @name='empty']
-  - /program/objects/o[@base='.bytes' and @method and @name='empty' and not(text())]
+  - /program/objects/o[@base='.bytes' and @method and @name='empty' and o[@base='org.eolang.bytes' and not(text())]]
 phi: "{empty ↦ Φ.org.eolang.bytes(Δ ⤍ --)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
@@ -1,0 +1,7 @@
+tests:
+  - /program/objects/o[@base='Q']
+  - /program/objects/o[@base='.org' and @method]
+  - /program/objects/o[@base='.eolang' and @method]
+  - /program/objects/o[@base='.bytes' and @method and @name='empty']
+  - /program/objects/o[@base='.bytes' and @method and @name='empty' and not(text())]
+phi: "{empty ↦ Φ.org.eolang.bytes(Δ ⤍ --)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/one-byte.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/one-byte.yaml
@@ -1,0 +1,6 @@
+tests:
+  - /program/objects/o[@base='Q']
+  - /program/objects/o[@base='.org' and @method]
+  - /program/objects/o[@base='.eolang' and @method]
+  - /program/objects/o[@base='.bytes' and @method and text()='A2' and @name='bts']
+phi: "{bts ↦ Φ.org.eolang.bytes(Δ ⤍ A2-)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/one-byte.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/one-byte.yaml
@@ -2,5 +2,5 @@ tests:
   - /program/objects/o[@base='Q']
   - /program/objects/o[@base='.org' and @method]
   - /program/objects/o[@base='.eolang' and @method]
-  - /program/objects/o[@base='.bytes' and @method and text()='A2' and @name='bts']
+  - /program/objects/o[@base='.bytes' and @method and @name='bts' and o[@base='org.eolang.bytes' and text()='A2']]
 phi: "{bts ↦ Φ.org.eolang.bytes(Δ ⤍ A2-)}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/package.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/package.yaml
@@ -1,0 +1,8 @@
+tests:
+  - /program/metas/meta[head[text()='package'] and tail[text()='foo.bar.baz'] and part[text()='foo.bar.baz']]
+  - /program/objects/o[@abstract and @name='main']
+  - /program/objects/o[@abstract and @name='main']/o[@base='Q']
+  - /program/objects/o[@abstract and @name='main']/o[@base='.org' and @method]
+  - /program/objects/o[@abstract and @name='main']/o[@base='.eolang' and @method]
+  - /program/objects/o[@abstract and @name='main']/o[@base='.stdout' and @method and @name='@']
+phi: "{foo ↦ ⟦bar ↦ ⟦baz ↦ ⟦main ↦ ⟦φ ↦ Φ.org.eolang.stdout⟧, λ ⤍ Package⟧, λ ⤍ Package⟧, λ ⤍ Package⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/specials.yaml
@@ -1,0 +1,26 @@
+tests:
+  - /program/objects/o[@name='main']
+  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.^' and @method]/following-sibling::o[@base='.x' and @method and @name='x']
+
+  - /program/objects/o[@name='main']/o[@base='Q']
+  - /program/objects/o[@name='main']/o[@base='.org' and @method]
+  - /program/objects/o[@name='main']/o[@base='.eolang' and @method]
+  - /program/objects/o[@name='main']/o[@base='.y' and @method]
+  - /program/objects/o[@name='main']/o[@base='.&' and @method and @name='h']
+
+  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.a' and @method and @name='a']
+
+  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.<' and @method and @name='vtx']
+
+  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.^' and @method]/following-sibling::o[@base='.<' and @method and @name='self']
+
+  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.@' and @method]/following-sibling::o[@base='.@' and @method and @name='phi']
+eo: |
+  [] > main
+    ^.x > x
+    y.& > h
+    $.a > a
+    < > vtx
+    ^.< > self
+    @.@ > phi
+phi: "{main ↦ ⟦x ↦ ξ.ρ.x, h ↦ Φ.org.eolang.y.σ, a ↦ ξ.ρ.a, vtx ↦ ξ.ν, self ↦ ξ.ρ.ν, phi ↦ ξ.φ.φ⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
@@ -6,5 +6,5 @@ tests:
   - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='Q']
   - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.org' and @method]
   - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.eolang' and @method]
-  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.bytes' and @method and @as='0' and text()='00 00 00 00 00 00 00 05']
+  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.bytes' and @method and @as='0' and o[@base='org.eolang.bytes' and text()='00 00 00 00 00 00 00 05']]
 phi: "{five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05))}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
@@ -1,0 +1,10 @@
+tests:
+  - /program/objects/o[@base='Q']
+  - /program/objects/o[@base='.org' and @method]
+  - /program/objects/o[@base='.eolang' and @method]
+  - /program/objects/o[@base='.int' and @method and @name='five']
+  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='Q']
+  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.org' and @method]
+  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.eolang' and @method]
+  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.bytes' and @method and @as='0' and text()='00 00 00 00 00 00 00 05']
+phi: "{five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05))}"

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -173,7 +173,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
         if (!XePhiListener.hasLambdaPackage(ctx.bindings())) {
             this.objects()
                 .prop("abstract")
-                .prop("name", this.attributes.pop());
+                .prop(this.properties.peek(), this.attributes.pop());
         }
     }
 
@@ -266,13 +266,14 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
 
     @Override
     public void enterDeltaBidning(final PhiParser.DeltaBidningContext ctx) {
+        this.objects()
+            .start()
+            .prop("data", "bytes")
+            .prop("base", "org.eolang.bytes");
         if (!ctx.BYTES().getText().equals("--")) {
-            this.objects().data(
-                ctx.BYTES().getText()
-                    .replaceAll("-", " ")
-                    .trim()
-            );
+            this.objects().data(ctx.BYTES().getText().replaceAll("-", " ").trim());
         }
+        this.objects().leave();
     }
 
     @Override

--- a/eo-parser/src/main/resources/org/eolang/parser/explicit-data.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/explicit-data.xsl
@@ -65,9 +65,9 @@ SOFTWARE.
       </a>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:template match="//o[@data and not(@data='tuple') and not(@base='org.eolang.bytes' or @base='bytes')]">
+  <xsl:template match="//o[@data and not(@base='org.eolang.bytes' or @base='bytes')]">
     <xsl:choose>
-      <xsl:when test="parent::*[$literal-objects/text()=@base or $reversed/text()=@base]">
+      <xsl:when test="parent::*[$literal-objects/text()=@base or ($reversed/text()=@base and o[@base='.eolang' and o[@base='.org' and o[@base='Q']]])]">
         <o base="org.eolang.bytes">
           <xsl:attribute name="data">
             <xsl:value-of select="./@data"/>
@@ -94,6 +94,19 @@ SOFTWARE.
         <xsl:copy-of select="."/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+  <xsl:template match="//o[((@base='.bytes' and o[@base='.eolang' and o[@base='.org' and o[@base='Q']]]) or @base='org.eolang.bytes') and o[last() and @data]]">
+    <o base="org.eolang.bytes">
+      <xsl:for-each select="@*[name()!='data' and name()!='base']">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:attribute name="data">
+        <xsl:text>bytes</xsl:text>
+      </xsl:attribute>
+      <xsl:value-of select="o[@data]/text()"/>
+    </o>
   </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/explicit-data.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/explicit-data.yaml
@@ -9,8 +9,9 @@ tests:
   - //o[@base='org.eolang.float' and @name='bts' and o[@base='org.eolang.bytes' and @data]]
   - //o[@base='org.eolang.float' and @name='second' and o[@base='org.eolang.bytes' and @data]]
   - //o[@base='.bool' and @name='third' and count(o)=2 and o[last() and @base='org.eolang.bytes' and @data]]
-  - //o[@base='.bytes' and @name='fourth' and count(o)=2 and o[last() and @base='org.eolang.bytes' and @data]]
+  - //o[@base='org.eolang.bytes' and @name='fourth' and count(o)=0 and @data]
   - //o[@base='.string' and @name='str' and count(o)=2 and o[last() and @base='org.eolang.bytes' and @data]]
+  - //o[@base='org.eolang.bytes' and @name='bt' and count(o)=0 and @data]
   - //o[@base='org.eolang.tuple' and o[@base='org.eolang.tuple' and o[@base='org.eolang.int' and o[@base='org.eolang.bytes' and @data]]]]
 eo: |
   42 > first
@@ -20,6 +21,7 @@ eo: |
   QQ.bytes > fourth
     11-21
   Q.org.eolang.string "Hey" > str
+  Q.org.eolang.bytes A2- > bt
   tuple
     * 1
     2


### PR DESCRIPTION
Closes: #2682
Closes: #2642 

What's done:
- Added test packs for UnphiMojo
- Added test that converts phi to xmir and back
- Fixed bugs with explicit data transformation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the UnphiMojo class in the eo-maven-plugin. 

### Detailed summary
- The `UnphiMojo` class in the `eo-maven-plugin` has been modified.
- The `home.save()` method has been updated to use a modified `PhiSyntax` object.
- The `phi.getFileName().toString()` now replaces the ".phi" extension with an empty string.
- The `UnphiMojoTest` class has been modified to remove the `@

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->