### PR TITLE
fix(#2681): fixed NPE in ForeignTojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -184,8 +184,15 @@ public final class TranspileMojo extends SafeMojo {
      * @throws java.io.IOException If any issues with I/O
      */
     private int transpile(final ForeignTojo tojo) throws IOException {
-        final int saved;
-        final Path file = tojo.verified();
+        final Path file;
+        try {
+            file = tojo.verified();
+        }  catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                "You should check that verify goal of the plugin was run first",
+                exception
+            );
+        }
         final XML input = new XMLDocument(file);
         final String name = input.xpath("/program/@name").get(0);
         final Place place = new Place(name);
@@ -193,6 +200,7 @@ public final class TranspileMojo extends SafeMojo {
             this.targetDir.toPath().resolve(TranspileMojo.DIR),
             TranspileMojo.EXT
         );
+        final int saved;
         if (
             target.toFile().exists()
                 && target.toFile().lastModified() >= file.toFile().lastModified()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -50,6 +50,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.cactoos.experimental.Threads;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.number.SumOf;
+import org.eolang.maven.tojos.AttributeNotFoundException;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.util.HmBase;
 import org.eolang.maven.util.Rel;
@@ -187,7 +188,7 @@ public final class TranspileMojo extends SafeMojo {
         final Path file;
         try {
             file = tojo.verified();
-        }  catch (final IllegalStateException exception) {
+        }  catch (final AttributeNotFoundException exception) {
             throw new IllegalStateException(
                 "You should check that 'Verify' goal of the plugin was run first",
                 exception

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -189,7 +189,7 @@ public final class TranspileMojo extends SafeMojo {
             file = tojo.verified();
         }  catch (final IllegalStateException exception) {
             throw new IllegalStateException(
-                "You should check that verify goal of the plugin was run first",
+                "You should check that 'Verify' goal of the plugin was run first",
                 exception
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/AttributeNotFoundException.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/AttributeNotFoundException.java
@@ -25,15 +25,19 @@ package org.eolang.maven.tojos;
 
 /**
  * If the attributes were not found in the Tojo.
- * @since 1.0
+ * @since 0.35.0
  */
 public class AttributeNotFoundException extends RuntimeException {
 
     /**
      * Ctor.
-     * @param message The detail message.
+     * @param attribute The attribute of Tojo.
      */
-    AttributeNotFoundException(final String message) {
-        super(message);
+    AttributeNotFoundException(final ForeignTojos.Attribute attribute) {
+        super(
+            String.format(
+            "There is no '%s' attribute in the tojo", attribute
+            )
+        );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/AttributeNotFoundException.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/AttributeNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.tojos;
+
+/**
+ * If the attributes were not found in the Tojo.
+ * @since 1.0
+ */
+public class AttributeNotFoundException extends RuntimeException {
+
+    /**
+     * Ctor.
+     * @param message The detail message.
+     */
+    AttributeNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -413,11 +413,7 @@ public final class ForeignTojo {
     private String attribute(final ForeignTojos.Attribute attribute) {
         final String attr = this.delegate.get(attribute.key());
         if (attr == null) {
-            throw new AttributeNotFoundException(
-                String.format(
-                    "There is no '%s' attribute in the tojo", attribute
-                )
-            );
+            throw new AttributeNotFoundException(attribute);
         }
         return attr;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -58,7 +58,7 @@ public final class ForeignTojo {
      * @return The id of the tojo.
      */
     public String identifier() {
-        return this.delegate.get(ForeignTojos.Attribute.ID.key());
+        return this.attributeTojo(ForeignTojos.Attribute.ID);
     }
 
     /**
@@ -66,7 +66,7 @@ public final class ForeignTojo {
      * @return The xmir.
      */
     public Path xmir() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.XMIR.key()));
+        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.XMIR));
     }
 
     /**
@@ -74,7 +74,7 @@ public final class ForeignTojo {
      * @return The optimized xmir.
      */
     public Path optimized() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.OPTIMIZED.key()));
+        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.OPTIMIZED));
     }
 
     /**
@@ -82,7 +82,7 @@ public final class ForeignTojo {
      * @return The verified xmir.
      */
     public Path verified() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.VERIFIED.key()));
+        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.VERIFIED));
     }
 
     /**
@@ -90,7 +90,7 @@ public final class ForeignTojo {
      * @return The shaken xmir.
      */
     public Path shaken() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.SHAKEN.key()));
+        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.SHAKEN));
     }
 
     /**
@@ -98,7 +98,7 @@ public final class ForeignTojo {
      * @return The eo object.
      */
     public Path source() {
-        return Paths.get(this.delegate.get(ForeignTojos.Attribute.EO.key()));
+        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.EO));
     }
 
     /**
@@ -106,7 +106,7 @@ public final class ForeignTojo {
      * @return The version.
      */
     public String version() {
-        return this.delegate.get(ForeignTojos.Attribute.VERSION.key());
+        return this.attributeTojo(ForeignTojos.Attribute.VERSION);
     }
 
     /**
@@ -116,7 +116,7 @@ public final class ForeignTojo {
     public String description() {
         return String.format(
             "%s:%s",
-            this.delegate.get(ForeignTojos.Attribute.ID.key()),
+            this.attributeTojo(ForeignTojos.Attribute.ID),
             this.version()
         );
     }
@@ -126,7 +126,7 @@ public final class ForeignTojo {
      * @return The hash.
      */
     public String hash() {
-        return this.delegate.get(ForeignTojos.Attribute.HASH.key());
+        return this.attributeTojo(ForeignTojos.Attribute.HASH);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class ForeignTojo {
      * @return The probed.
      */
     public String probed() {
-        return this.delegate.get(ForeignTojos.Attribute.PROBED.key());
+        return this.attributeTojo(ForeignTojos.Attribute.PROBED);
     }
 
     /**
@@ -365,7 +365,7 @@ public final class ForeignTojo {
      * @return The scope.
      */
     public String scope() {
-        return this.delegate.get(ForeignTojos.Attribute.SCOPE.key());
+        return this.attributeTojo(ForeignTojos.Attribute.SCOPE);
     }
 
     /**
@@ -383,7 +383,7 @@ public final class ForeignTojo {
      * @return The version.
      */
     public String ver() {
-        return this.delegate.get(ForeignTojos.Attribute.VER.key());
+        return this.attributeTojo(ForeignTojos.Attribute.VER);
     }
 
     @Override
@@ -404,4 +404,22 @@ public final class ForeignTojo {
     public int hashCode() {
         return Objects.hash(this.delegate);
     }
+
+    /**
+     * Return the attribute from the tojo.
+     * @param attribute The attribute from ForeignTojos.Attribute.
+     * @return The attribute.
+     */
+    private String attributeTojo(final ForeignTojos.Attribute attribute) {
+        final String path = this.delegate.get(attribute.key());
+        if (path == null) {
+            throw new IllegalStateException(
+                String.format(
+                    "There is no '%s' attribute in the tojo", attribute
+                )
+            );
+        }
+        return path;
+    }
 }
+

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -411,15 +411,15 @@ public final class ForeignTojo {
      * @return The attribute.
      */
     private String attribute(final ForeignTojos.Attribute attribute) {
-        final String path = this.delegate.get(attribute.key());
-        if (path == null) {
+        final String attr = this.delegate.get(attribute.key());
+        if (attr == null) {
             throw new IllegalStateException(
                 String.format(
                     "There is no '%s' attribute in the tojo", attribute
                 )
             );
         }
-        return path;
+        return attr;
     }
 }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -413,7 +413,7 @@ public final class ForeignTojo {
     private String attribute(final ForeignTojos.Attribute attribute) {
         final String attr = this.delegate.get(attribute.key());
         if (attr == null) {
-            throw new IllegalStateException(
+            throw new AttributeNotFoundException(
                 String.format(
                     "There is no '%s' attribute in the tojo", attribute
                 )
@@ -422,4 +422,3 @@ public final class ForeignTojo {
         return attr;
     }
 }
-

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -58,7 +58,7 @@ public final class ForeignTojo {
      * @return The id of the tojo.
      */
     public String identifier() {
-        return this.attributeTojo(ForeignTojos.Attribute.ID);
+        return this.attribute(ForeignTojos.Attribute.ID);
     }
 
     /**
@@ -66,7 +66,7 @@ public final class ForeignTojo {
      * @return The xmir.
      */
     public Path xmir() {
-        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.XMIR));
+        return Paths.get(this.attribute(ForeignTojos.Attribute.XMIR));
     }
 
     /**
@@ -74,7 +74,7 @@ public final class ForeignTojo {
      * @return The optimized xmir.
      */
     public Path optimized() {
-        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.OPTIMIZED));
+        return Paths.get(this.attribute(ForeignTojos.Attribute.OPTIMIZED));
     }
 
     /**
@@ -82,7 +82,7 @@ public final class ForeignTojo {
      * @return The verified xmir.
      */
     public Path verified() {
-        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.VERIFIED));
+        return Paths.get(this.attribute(ForeignTojos.Attribute.VERIFIED));
     }
 
     /**
@@ -90,7 +90,7 @@ public final class ForeignTojo {
      * @return The shaken xmir.
      */
     public Path shaken() {
-        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.SHAKEN));
+        return Paths.get(this.attribute(ForeignTojos.Attribute.SHAKEN));
     }
 
     /**
@@ -98,7 +98,7 @@ public final class ForeignTojo {
      * @return The eo object.
      */
     public Path source() {
-        return Paths.get(this.attributeTojo(ForeignTojos.Attribute.EO));
+        return Paths.get(this.attribute(ForeignTojos.Attribute.EO));
     }
 
     /**
@@ -106,7 +106,7 @@ public final class ForeignTojo {
      * @return The version.
      */
     public String version() {
-        return this.attributeTojo(ForeignTojos.Attribute.VERSION);
+        return this.attribute(ForeignTojos.Attribute.VERSION);
     }
 
     /**
@@ -116,7 +116,7 @@ public final class ForeignTojo {
     public String description() {
         return String.format(
             "%s:%s",
-            this.attributeTojo(ForeignTojos.Attribute.ID),
+            this.attribute(ForeignTojos.Attribute.ID),
             this.version()
         );
     }
@@ -126,7 +126,7 @@ public final class ForeignTojo {
      * @return The hash.
      */
     public String hash() {
-        return this.attributeTojo(ForeignTojos.Attribute.HASH);
+        return this.attribute(ForeignTojos.Attribute.HASH);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class ForeignTojo {
      * @return The probed.
      */
     public String probed() {
-        return this.attributeTojo(ForeignTojos.Attribute.PROBED);
+        return this.attribute(ForeignTojos.Attribute.PROBED);
     }
 
     /**
@@ -365,7 +365,7 @@ public final class ForeignTojo {
      * @return The scope.
      */
     public String scope() {
-        return this.attributeTojo(ForeignTojos.Attribute.SCOPE);
+        return this.attribute(ForeignTojos.Attribute.SCOPE);
     }
 
     /**
@@ -383,7 +383,7 @@ public final class ForeignTojo {
      * @return The version.
      */
     public String ver() {
-        return this.attributeTojo(ForeignTojos.Attribute.VER);
+        return this.attribute(ForeignTojos.Attribute.VER);
     }
 
     @Override
@@ -410,7 +410,7 @@ public final class ForeignTojo {
      * @param attribute The attribute from ForeignTojos.Attribute.
      * @return The attribute.
      */
-    private String attributeTojo(final ForeignTojos.Attribute attribute) {
+    private String attribute(final ForeignTojos.Attribute attribute) {
         final String path = this.delegate.get(attribute.key());
         if (path == null) {
             throw new IllegalStateException(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -224,22 +223,23 @@ final class TranspileMojoTest {
 
     @Test
     @CaptureLogs
-    void transpilesThrowExceptionIfWasNotVerified(
+    void throwsExpectionIfWasNotVerified(
         @TempDir final Path temp, final Logs out) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp);
-        maven.withHelloWorld();
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> maven
+            () -> new FakeMaven(temp)
+                .withHelloWorld()
                 .execute(ParseMojo.class)
                 .execute(OptimizeMojo.class)
                 .execute(ShakeMojo.class)
                 .execute(TranspileMojo.class)
         );
-        final Collection<String> logs = out.captured();
-        final String message = "You should check that verify goal of the plugin was run first";
         Assertions.assertTrue(
-            logs.stream().anyMatch(log -> log.contains(message)),
+            out.captured().stream().anyMatch(
+                log -> log.contains(
+                    "You should check that 'Verify' goal of the plugin was run first"
+                )
+            ),
             "Should throw an exception if VerifyMojo wasn't run before TranspileMojo"
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -224,7 +224,7 @@ final class TranspileMojoTest {
     @Test
     @CaptureLogs
     void throwsExpectionIfWasNotVerified(
-        @TempDir final Path temp, final Logs out) throws IOException {
+        @TempDir final Path temp, final Logs out) {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -127,7 +127,7 @@ final class ForeignTojosTest {
         final Func<ForeignTojo, Object> method) {
         final ForeignTojo tojo = this.tojos.add("string");
         Assertions.assertThrows(
-            IllegalStateException.class,
+            AttributeNotFoundException.class,
             () -> method.apply(tojo),
             String.format("Should throw an exception if key='%s' was not found in Tojo", key)
         );
@@ -136,8 +136,8 @@ final class ForeignTojosTest {
     @Test
     void getsExceptionMessageIfKeyWasNotFoundInTojo() {
         final ForeignTojo tojo = this.tojos.add("string");
-        final IllegalStateException thrown = Assertions.assertThrows(
-            IllegalStateException.class,
+        final AttributeNotFoundException thrown = Assertions.assertThrows(
+            AttributeNotFoundException.class,
             tojo::verified
         );
         Assertions.assertEquals(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -26,6 +26,8 @@ package org.eolang.maven.tojos;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
+import org.cactoos.Func;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -33,7 +35,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests from {@link ForeignTojos}.
@@ -116,8 +120,41 @@ final class ForeignTojosTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("tojoFunctions")
+    void throwsExceptionIfKeyWasNotFoundInTojo(
+        final String key,
+        final Func<ForeignTojo, Object> method) {
+        final ForeignTojo tojo = this.tojos.add("string");
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> method.apply(tojo),
+            String.format("Should throw an exception if key='%s' was not found in Tojo", key)
+        );
+        Assertions.assertEquals(tojo.identifier(), "string");
+        Assertions.assertEquals(tojo.scope(), "compile");
+        tojo.withVer("version");
+        Assertions.assertEquals(tojo.ver(), "version");
+    }
+
     @AfterEach
     void tearDown() throws IOException {
         this.tojos.close();
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> tojoFunctions() {
+        return Stream.of(
+            Arguments.of("XMIR", (Func<ForeignTojo, Object>) ForeignTojo::xmir),
+            Arguments.of("OPTIMIZED", (Func<ForeignTojo, Object>) ForeignTojo::optimized),
+            Arguments.of("VERIFIED", (Func<ForeignTojo, Object>) ForeignTojo::verified),
+            Arguments.of("SHAKEN", (Func<ForeignTojo, Object>) ForeignTojo::shaken),
+            Arguments.of("EO", (Func<ForeignTojo, Object>) ForeignTojo::source),
+            Arguments.of("VERSION", (Func<ForeignTojo, Object>) ForeignTojo::version),
+            Arguments.of("ID", (Func<ForeignTojo, Object>) ForeignTojo::description),
+            Arguments.of("HASH", (Func<ForeignTojo, Object>) ForeignTojo::hash),
+            Arguments.of("PROBED", (Func<ForeignTojo, Object>) ForeignTojo::probed),
+            Arguments.of("VER", (Func<ForeignTojo, Object>) ForeignTojo::ver)
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -131,6 +131,19 @@ final class ForeignTojosTest {
             () -> method.apply(tojo),
             String.format("Should throw an exception if key='%s' was not found in Tojo", key)
         );
+        final IllegalStateException thrown = Assertions.assertThrows(
+            IllegalStateException.class,
+            tojo::verified
+        );
+        Assertions.assertEquals(
+            "There is no 'VERIFIED' attribute in the tojo",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    void findsKeyInTojo() {
+        final ForeignTojo tojo = this.tojos.add("string");
         Assertions.assertEquals(tojo.identifier(), "string");
         Assertions.assertEquals(tojo.scope(), "compile");
         tojo.withVer("version");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -137,17 +137,30 @@ final class ForeignTojosTest {
         );
         Assertions.assertEquals(
             "There is no 'VERIFIED' attribute in the tojo",
-            thrown.getMessage()
+            thrown.getMessage(),
+            "Should throw an exception if key 'VERIFIED' was not found in Tojo"
         );
     }
 
     @Test
     void findsKeyInTojo() {
         final ForeignTojo tojo = this.tojos.add("string");
-        Assertions.assertEquals(tojo.identifier(), "string");
-        Assertions.assertEquals(tojo.scope(), "compile");
+        Assertions.assertEquals(
+            tojo.identifier(),
+            "string",
+            "Shouldn't throw an exception if key 'ID' was found in Tojo"
+        );
+        Assertions.assertEquals(
+            tojo.scope(),
+            "compile",
+            "Shouldn't throw an exception if key 'ID' was found in Tojo"
+        );
         tojo.withVer("version");
-        Assertions.assertEquals(tojo.ver(), "version");
+        Assertions.assertEquals(
+            tojo.ver(),
+            "version",
+            "Shouldn't throw an exception if key 'VER' was found in Tojo"
+        );
     }
 
     @AfterEach

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/tojos/ForeignTojosTest.java
@@ -121,7 +121,7 @@ final class ForeignTojosTest {
     }
 
     @ParameterizedTest
-    @MethodSource("tojoFunctions")
+    @MethodSource("tojoFunctionsWithoutDefaultValues")
     void throwsExceptionIfKeyWasNotFoundInTojo(
         final String key,
         final Func<ForeignTojo, Object> method) {
@@ -131,6 +131,11 @@ final class ForeignTojosTest {
             () -> method.apply(tojo),
             String.format("Should throw an exception if key='%s' was not found in Tojo", key)
         );
+    }
+
+    @Test
+    void getsExceptionMessageIfKeyWasNotFoundInTojo() {
+        final ForeignTojo tojo = this.tojos.add("string");
         final IllegalStateException thrown = Assertions.assertThrows(
             IllegalStateException.class,
             tojo::verified
@@ -142,24 +147,17 @@ final class ForeignTojosTest {
         );
     }
 
-    @Test
-    void findsKeyInTojo() {
+    @ParameterizedTest
+    @MethodSource("tojoFunctionsWithDefaultValues")
+    void doesNotThrowsAnException(
+        final String key,
+        final Func<ForeignTojo, ?> method
+    ) throws Exception {
         final ForeignTojo tojo = this.tojos.add("string");
         Assertions.assertEquals(
-            tojo.identifier(),
-            "string",
-            "Shouldn't throw an exception if key 'ID' was found in Tojo"
-        );
-        Assertions.assertEquals(
-            tojo.scope(),
-            "compile",
-            "Shouldn't throw an exception if key 'ID' was found in Tojo"
-        );
-        tojo.withVer("version");
-        Assertions.assertEquals(
-            tojo.ver(),
-            "version",
-            "Shouldn't throw an exception if key 'VER' was found in Tojo"
+            method.apply(tojo),
+            key,
+            String.format("Shouldn't throw an exception if key='%s' was found in Tojo", key)
         );
     }
 
@@ -169,7 +167,7 @@ final class ForeignTojosTest {
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
-    private static Stream<Arguments> tojoFunctions() {
+    private static Stream<Arguments> tojoFunctionsWithoutDefaultValues() {
         return Stream.of(
             Arguments.of("XMIR", (Func<ForeignTojo, Object>) ForeignTojo::xmir),
             Arguments.of("OPTIMIZED", (Func<ForeignTojo, Object>) ForeignTojo::optimized),
@@ -181,6 +179,14 @@ final class ForeignTojosTest {
             Arguments.of("HASH", (Func<ForeignTojo, Object>) ForeignTojo::hash),
             Arguments.of("PROBED", (Func<ForeignTojo, Object>) ForeignTojo::probed),
             Arguments.of("VER", (Func<ForeignTojo, Object>) ForeignTojo::ver)
+        );
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> tojoFunctionsWithDefaultValues() {
+        return Stream.of(
+            Arguments.of("string", (Func<ForeignTojo, Object>) ForeignTojo::identifier),
+            Arguments.of("compile", (Func<ForeignTojo, Object>) ForeignTojo::scope)
         );
     }
 }


### PR DESCRIPTION
Ref: #2681

NPE have been fixed in ForeignTojo. The method attributeTojo() has been added to search for NullPointers.  The method throws exception IllegalStateException.

Test "throwsExceptionIfKeyWasNotFoundInTojo" was added to check the added method.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `TranspileMojo` class now throws an exception if the `verified` attribute is not found in the `tojo` object.
- The `TranspileMojoTest` class now includes a test case that checks if the exception is thrown when the `VerifyMojo` was not run before the `TranspileMojo`.
- Added the `AttributeNotFoundException` class to handle the exception when an attribute is not found in the `tojo` object.
- Updated the `ForeignTojo` class to use the `AttributeNotFoundException` when an attribute is not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->