### PR TITLE
render two EBNFs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,7 +27,8 @@ jobs:
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v4.0.0-beta.3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./eo-parser/target/site/jacoco/jacoco.xml,./eo-runtime/target/site/jacoco/jacoco.xml,./eo-maven-plugin/target/site/jacoco/jacoco.xml
           fail_ci_if_error: true

--- a/.github/workflows/ebnf.yml
+++ b/.github/workflows/ebnf.yml
@@ -2,8 +2,6 @@
 name: ebnf
 on:
   push:
-    branches:
-      - master
     paths-ignore: ['paper/**', 'sandbox/**']
 concurrency:
   group: ebnf-${{ github.ref }}

--- a/.github/workflows/ebnf.yml
+++ b/.github/workflows/ebnf.yml
@@ -36,13 +36,13 @@ jobs:
       - run: sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
       - run: |
           mvn com.yegor256:antlr2ebnf-maven-plugin:0.0.7:generate \
-            -pl :eo-parser --debug --errors --batch-mode --quiet \
+            -pl :eo-parser --errors --batch-mode --quiet \
             "-Dantlr2ebnf.convertDir=$CONVERT_PATH" \
             "-Dantlr2ebnf.specials=eof,eol,eop,tab,untab" \
             "-Dantlr2ebnf.margin=40"
       - run: |
           set -x
-          for p in Program Phi; do
+          for p in Eo Phi; do
             cp "eo-parser/target/ebnf/org/eolang/parser/${p}.pdf" .
             pdfcrop --margins '10 10 10 10' "${p}.pdf" "${p}-cropped.pdf"
             pdf2svg "${p}-cropped.pdf" "${p}.svg"

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
@@ -37,10 +37,10 @@ attribute
     | SIGMA
     | VTX
     | LABEL
-    | alpha
+    | alphaAttr
     ;
 
-alpha
+alphaAttr
     : ALPHA INDEX
     ;
 

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -231,8 +231,8 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
             attr = "<";
         } else if (ctx.LABEL() != null) {
             attr = ctx.LABEL().getText();
-        } else if (ctx.alpha() != null) {
-            attr = ctx.alpha().INDEX().getText();
+        } else if (ctx.alphaAttr() != null) {
+            attr = ctx.alphaAttr().INDEX().getText();
         } else {
             attr = "";
         }
@@ -245,12 +245,12 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterAlpha(final PhiParser.AlphaContext ctx) {
+    public void enterAlphaAttr(final PhiParser.AlphaAttrContext ctx) {
         // Nothing here
     }
 
     @Override
-    public void exitAlpha(final PhiParser.AlphaContext ctx) {
+    public void exitAlphaAttr(final PhiParser.AlphaAttrContext ctx) {
         // Nothing here
     }
 


### PR DESCRIPTION
see #2696

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the code to use the new `alphaAttr` name instead of `alpha`. 

### Detailed summary
- Renamed `alpha` to `alphaAttr` in `Phi.g4` file.
- Updated references to `alpha` to `alphaAttr` in `XePhiListener.java`.
- Updated `codecov-action` version in `codecov.yml` file.
- Added `token` and `files` configurations in `codecov.yml` file.
- Updated workflow trigger in `ebnf.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->