### PR TITLE
Remove failOnError from AssembleMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -165,20 +165,6 @@ public final class AssembleMojo extends SafeMojo {
     private boolean ignoreVersionConflicts;
 
     /**
-     * Whether we should fail on error.
-     * @checkstyle MemberNameCheck (11 lines)
-     * @since 0.23.0
-     * @todo #2443:90min Remove the following failOnError flag. Now we
-     *  have already got rid from it in {@link OptimizeMojo} and {@link VerifyMojo}.
-     *  We need to make failOnError the behaviour default.
-     */
-    @SuppressWarnings("PMD.ImmutableField")
-    @Parameter(
-        property = "eo.failOnError",
-        defaultValue = "true")
-    private boolean failOnError = true;
-
-    /**
      * Whether we should fail on warn.
      * @checkstyle MemberNameCheck (10 lines)
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -122,7 +122,7 @@ public final class OptimizeMojo extends SafeMojo {
      * @return Optimization for all tojos.
      */
     private Optimization optimization() {
-        Optimization opt;
+        final Optimization opt;
         if (this.trackOptimizationSteps) {
             opt = new OptSpy(
                 new ParsingTrain(),
@@ -131,7 +131,6 @@ public final class OptimizeMojo extends SafeMojo {
         } else {
             opt = new OptTrain(new ParsingTrain());
         }
-        opt = new OptTrain(opt, "/org/eolang/parser/fail-on-critical.xsl");
         return opt;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -165,12 +165,12 @@ public final class ParseMojo extends SafeMojo {
         );
         final XML xmir = new XMLDocument(footprint.load(name, "xmir"));
         final List<XML> errors = xmir.nodes("/program/errors/error");
+        final Path target = new Place(name).make(
+            this.targetDir.toPath().resolve(ParseMojo.DIR),
+            TranspileMojo.EXT
+        );
+        tojo.withXmir(target.toAbsolutePath());
         if (errors.isEmpty()) {
-            final Path target = new Place(name).make(
-                this.targetDir.toPath().resolve(ParseMojo.DIR),
-                TranspileMojo.EXT
-            );
-            tojo.withXmir(target.toAbsolutePath());
             Logger.debug(
                 this, "Parsed %s to %s",
                 new Rel(source), new Rel(target)
@@ -183,12 +183,6 @@ public final class ParseMojo extends SafeMojo {
                     source, error.xpath("@line").get(0), error.xpath("text()").get(0)
                 );
             }
-            throw new IllegalArgumentException(
-                String.format(
-                    "Failed to parse %s (%d parsing errors)",
-                    source, errors.size()
-                )
-            );
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ParseMojo.java
@@ -80,17 +80,6 @@ public final class ParseMojo extends SafeMojo {
     public static final String PARSED = "parsed";
 
     /**
-     * Whether we should fail on parsing error.
-     * @checkstyle MemberNameCheck (7 lines)
-     * @since 0.23.0
-     */
-    @SuppressWarnings("PMD.ImmutableField")
-    @Parameter(
-        property = "eo.failOnError",
-        defaultValue = "true")
-    private boolean failOnError = true;
-
-    /**
      * The current version of eo-maven-plugin.
      * Maven 3 only.
      * You can read more about that property
@@ -190,18 +179,16 @@ public final class ParseMojo extends SafeMojo {
             for (final XML error : errors) {
                 Logger.error(
                     this,
-                    "Failed to parse '%s:%s': %s (just logging, because of failOnError=false)",
+                    "Failed to parse '%s:%s': %s",
                     source, error.xpath("@line").get(0), error.xpath("text()").get(0)
                 );
             }
-            if (this.failOnError) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        "Failed to parse %s (%d parsing errors)",
-                        source, errors.size()
-                    )
-                );
-            }
+            throw new IllegalArgumentException(
+                String.format(
+                    "Failed to parse %s (%d parsing errors)",
+                    source, errors.size()
+                )
+            );
         }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -104,11 +104,10 @@ public final class VerifyMojo extends SafeMojo {
      */
     private Optimization optimization() {
         Optimization opt = new OptTrain(
-            new TrClasspath<>(
-                new TrDefault<>(),
-                "/org/eolang/parser/fail-on-errors.xsl",
-                "/org/eolang/parser/fail-on-critical.xsl"
-            ).back()
+            new TrClasspath<>(new TrDefault<>())
+                .with("/org/eolang/parser/fail-on-errors.xsl")
+                .with("/org/eolang/parser/fail-on-critical.xsl")
+                .back()
         );
         if (this.failOnWarning) {
             opt = new OptTrain(opt, "/org/eolang/parser/fail-on-warnings.xsl");

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -24,6 +24,7 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
+import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -103,8 +104,11 @@ public final class VerifyMojo extends SafeMojo {
      */
     private Optimization optimization() {
         Optimization opt = new OptTrain(
-            new OptTrain(new TrDefault<>()),
-            "/org/eolang/parser/fail-on-errors.xsl"
+            new TrClasspath<>(
+                new TrDefault<>(),
+                "/org/eolang/parser/fail-on-errors.xsl",
+                "/org/eolang/parser/fail-on-critical.xsl"
+            ).back()
         );
         if (this.failOnWarning) {
             opt = new OptTrain(opt, "/org/eolang/parser/fail-on-warnings.xsl");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -215,20 +215,12 @@ final class AssembleMojoTest {
     }
 
     @Test
-    void assemblesNotFailWithFailOnErrorFlag(@TempDir final Path temp) throws IOException {
-        final Map<String, Path> result = new FakeMaven(temp)
-            .withProgram(AssembleMojoTest.INVALID_PROGRAM)
-            .with("failOnError", false)
-            .execute(AssembleMojo.class).result();
-        MatcherAssert.assertThat(
-            "Even if the eo program invalid we still have to parse it, but we didn't",
-            result.get(String.format("target/%s", ParseMojo.DIR)),
-            new ContainsFiles(String.format("**/main.%s", TranspileMojo.EXT))
-        );
-        MatcherAssert.assertThat(
-            "Since the eo program invalid we shouldn't have optimized it, but we did",
-            result.get(String.format("target/%s", OptimizeMojo.DIR)),
-            Matchers.not(new ContainsFiles(String.format("**/main.%s", TranspileMojo.EXT)))
+    void assembleFailsOnError(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(AssembleMojoTest.INVALID_PROGRAM)
+                .execute(new FakeMaven.Verify())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -220,7 +220,8 @@ final class AssembleMojoTest {
             IllegalStateException.class,
             () -> new FakeMaven(temp)
                 .withProgram(AssembleMojoTest.INVALID_PROGRAM)
-                .execute(new FakeMaven.Verify())
+                .execute(new FakeMaven.Verify()),
+                "Invalid program with wrong syntax should have failed, but it didn't"
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -225,18 +225,6 @@ final class AssembleMojoTest {
         );
     }
 
-    @Test
-    void doesNotAssembleIfFailOnErrorFlagIsTrue(@TempDir final Path temp) {
-        final Class<IllegalStateException> expected = IllegalStateException.class;
-        Assertions.assertThrows(
-            expected,
-            () -> new FakeMaven(temp)
-                .withProgram(AssembleMojoTest.INVALID_PROGRAM)
-                .execute(AssembleMojo.class),
-            String.format("AssembleMojo should have failed with %s, but didn't", expected)
-        );
-    }
-
     @CaptureLogs
     @Test
     void assemblesSuccessfullyInOfflineMode(final Logs out, @TempDir final Path temp) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -215,7 +215,7 @@ final class AssembleMojoTest {
     }
 
     @Test
-    void assembleFailsOnError(@TempDir final Path temp) {
+    void failsOnError(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -215,7 +215,7 @@ final class AssembleMojoTest {
     }
 
     @Test
-    void failsOnError(@TempDir final Path temp) {
+    void failsOnInvalidProgram(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoTest.java
@@ -74,7 +74,7 @@ final class AssembleMojoTest {
     /**
      * Invalid eo program for testing.
      */
-    private static final String[] INVALID_PROGRAM = {
+    static final String[] INVALID_PROGRAM = {
         "+alias stdout org.eolang.io.stdout",
         "+home https://github.com/objectionary/eo",
         "+package test",
@@ -215,13 +215,20 @@ final class AssembleMojoTest {
     }
 
     @Test
-    void failsOnInvalidProgram(@TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new FakeMaven(temp)
-                .withProgram(AssembleMojoTest.INVALID_PROGRAM)
-                .execute(new FakeMaven.Verify()),
-                "Invalid program with wrong syntax should have failed, but it didn't"
+    void assemblesNotFailWithFailOnError(@TempDir final Path temp) throws IOException {
+        final Map<String, Path> result = new FakeMaven(temp)
+            .withProgram(AssembleMojoTest.INVALID_PROGRAM)
+            .execute(new FakeMaven.Optimize())
+            .result();
+        MatcherAssert.assertThat(
+            "Even if the eo program invalid we still have to parse it, but we didn't",
+            result.get(String.format("target/%s", ParseMojo.DIR)),
+            new ContainsFiles(String.format("**/main.%s", TranspileMojo.EXT))
+        );
+        MatcherAssert.assertThat(
+            "Even if the eo program invalid we still have to optimize it, but we didn't",
+            result.get(String.format("target/%s", OptimizeMojo.DIR)),
+            new ContainsFiles(String.format("**/main.%s", TranspileMojo.EXT))
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiscoverMojoTest.java
@@ -213,7 +213,6 @@ final class DiscoverMojoTest {
     void doesNotDiscoverWithVersions(@TempDir final Path tmp) throws IOException {
         final FakeMaven maven = new FakeMaven(tmp)
             .with("withVersions", false)
-            .with("failOnError", false)
             .withVersionedProgram()
             .execute(new FakeMaven.Discover());
         final ObjectName seq = new OnVersioned("org.eolang.seq", "6c6269d");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -219,10 +219,9 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void failsOnCritical(@TempDir final Path temp) throws IOException {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new FakeMaven(temp)
+    void doesNotCrashesOnError(@TempDir final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            new FakeMaven(temp)
                 .withProgram(
                     "+package f\n",
                     "[args] > main",
@@ -230,7 +229,11 @@ final class OptimizeMojoTest {
                     "    TRUE > x",
                     "    FALSE > x"
                 ).with("trackOptimizationSteps", true)
-                .execute(new FakeMaven.Verify())
+                .execute(new FakeMaven.Optimize())
+                .result(),
+            Matchers.hasKey(
+                String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -230,7 +230,7 @@ final class OptimizeMojoTest {
                     "    TRUE > x",
                     "    FALSE > x"
                 ).with("trackOptimizationSteps", true)
-                .execute(new FakeMaven.Optimize())
+                .execute(new FakeMaven.Verify())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -116,13 +116,15 @@ final class ParseMojoTest {
     }
 
     @Test
-    void crashesOnInvalidSyntax(@TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new FakeMaven(temp)
-                .withProgram("something > is wrong here")
-                .execute(new FakeMaven.Verify()),
-                "Program with invalid syntax should have failed, but it didn't"
+    void doesNotCrashesOnError(@TempDir final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            new FakeMaven(temp)
+                .withProgram("something < is wrong here")
+                .execute(new FakeMaven.Parse())
+                .result(),
+            Matchers.hasKey(
+                String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -122,24 +122,9 @@ final class ParseMojoTest {
                 IllegalStateException.class,
                 () -> new FakeMaven(temp)
                     .withProgram("something > is wrong here")
-                    .with("failOnError", true)
                     .execute(ParseMojo.class)
             ).getCause().getCause().getMessage(),
             Matchers.containsString("Failed to parse")
-        );
-    }
-
-    @Test
-    void doesNotCrashesWithFailOnError(@TempDir final Path temp) throws Exception {
-        MatcherAssert.assertThat(
-            new FakeMaven(temp)
-                .withProgram("something < is wrong here")
-                .with("failOnError", false)
-                .execute(new FakeMaven.Parse())
-                .result(),
-            Matchers.hasKey(
-                String.format("target/%s/foo/x/main.%s", ParseMojo.DIR, TranspileMojo.EXT)
-            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -117,14 +117,12 @@ final class ParseMojoTest {
 
     @Test
     void crashesOnInvalidSyntax(@TempDir final Path temp) {
-        MatcherAssert.assertThat(
-            Assertions.assertThrows(
-                IllegalStateException.class,
-                () -> new FakeMaven(temp)
-                    .withProgram("something > is wrong here")
-                    .execute(ParseMojo.class)
-            ).getCause().getCause().getMessage(),
-            Matchers.containsString("Failed to parse")
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram("something > is wrong here")
+                .execute(new FakeMaven.Verify()),
+                "Program with invalid syntax should have failed, but it didn't"
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
@@ -46,7 +46,6 @@ final class SafeMojoTest {
             IllegalStateException.class,
             () -> new FakeMaven(temp)
                 .withProgram("something > is definitely wrong here")
-                .with("failOnError", true)
                 .execute(ParseMojo.class)
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
@@ -42,11 +42,10 @@ final class SafeMojoTest {
     @Test
     @CaptureLogs
     void logsStackTrace(final Logs out, @TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalStateException.class,
+        Assertions.assertDoesNotThrow(
             () -> new FakeMaven(temp)
                 .withProgram("something > is definitely wrong here")
-                .execute(new FakeMaven.Verify())
+                .execute(new FakeMaven.Parse())
         );
         MatcherAssert.assertThat(
             String.join("\n", out.captured()),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SafeMojoTest.java
@@ -46,7 +46,7 @@ final class SafeMojoTest {
             IllegalStateException.class,
             () -> new FakeMaven(temp)
                 .withProgram("something > is definitely wrong here")
-                .execute(ParseMojo.class)
+                .execute(new FakeMaven.Verify())
         );
         MatcherAssert.assertThat(
             String.join("\n", out.captured()),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
@@ -125,6 +125,44 @@ class VerifyMojoTest {
     }
 
     @Test
+    void failsOptimizationOnCritical(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(
+                    "+package f\n",
+                    "[args] > main",
+                    "  seq > @",
+                    "    TRUE > x",
+                    "    FALSE > x"
+                ).with("trackOptimizationSteps", true)
+                .execute(new FakeMaven.Verify())
+        );
+    }
+
+    @Test
+    void failsParsingOnError(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram("something > is wrong here")
+                .execute(new FakeMaven.Verify()),
+            "Program with invalid syntax should have failed, but it didn't"
+        );
+    }
+
+    @Test
+    void failsOnInvalidProgram(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(AssembleMojoTest.INVALID_PROGRAM)
+                .execute(new FakeMaven.Verify()),
+                "Invalid program with wrong syntax should have failed to assemble, but it didn't"
+        );
+    }
+
+    @Test
     void failsOnWarning(@TempDir final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp)
             .withProgram(


### PR DESCRIPTION
Closes #2678

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `failOnError` flag in the `OptimizeMojo`, `VerifyMojo`, and `AssembleMojo` classes. 

### Detailed summary
- Removed the `failOnError` flag in the `OptimizeMojo` class.
- Removed the `failOnError` flag in the `VerifyMojo` class.
- Removed the `failOnError` flag in the `AssembleMojo` class.
- Replaced `Assertions.assertThrows` with `Assertions.assertDoesNotThrow` in the `SafeMojoTest` class.
- Updated the `OptimizeMojoTest` class to use `MatcherAssert.assertThat` instead of `Assertions.assertThrows`.
- Updated the `ParseMojoTest` class to use `MatcherAssert.assertThat` instead of `Assertions.assertThrows`.
- Updated the `VerifyMojoTest` class to use `Assertions.assertThrows` for testing failures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->