### PR TITLE
feat(#2713): check time in OptCached

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
@@ -28,6 +28,11 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import org.eolang.maven.AssembleMojo;
 import org.eolang.maven.Place;
 import org.eolang.maven.footprint.FtDefault;
@@ -67,11 +72,9 @@ public final class OptCached implements Optimization {
     @Override
     public XML apply(final XML xml) {
         try {
-            final Path path = new Place(xml.xpath("/program/@name").get(0))
-                .make(this.folder, AssembleMojo.IR_EXTENSION);
             final XML optimized;
-            if (Files.exists(path)) {
-                optimized = new XMLDocument(path);
+            if (this.contains(xml)) {
+                optimized = new XMLDocument(this.cached(xml));
             } else {
                 optimized = this.delegate.apply(xml);
                 new FtDefault(this.folder).save(
@@ -84,5 +87,40 @@ public final class OptCached implements Optimization {
         } catch (final IOException ex) {
             throw new IllegalStateException(String.format("Can't optimize '%s'", xml), ex);
         }
+    }
+
+    /**
+     * Returns the path to the cached program.
+     * Pay attention that the path is not checked for existence.
+     * @param xml Eo program.
+     * @return Path to the cached program.
+     */
+    private Path cached(final XML xml) {
+        return new Place(xml.xpath("/program/@name").get(0))
+            .make(this.folder, AssembleMojo.IR_EXTENSION);
+    }
+
+    /**
+     * Checks if the cache contains the program.
+     * @param xml Eo program.
+     * @return True if the cache contains the program.
+     * @throws IOException If fails.
+     */
+    private boolean contains(final XML xml) throws IOException {
+        final Path path = this.cached(xml);
+        final Optional<String> time = xml.xpath("/program/@time").stream().findFirst();
+        final boolean res;
+        if (Files.exists(path) && time.isPresent()) {
+            res = Files.readAttributes(path, BasicFileAttributes.class)
+                .creationTime()
+                .toInstant()
+                .truncatedTo(ChronoUnit.SECONDS)
+                .equals(
+                    ZonedDateTime.parse(time.get()).toInstant().truncatedTo(ChronoUnit.SECONDS)
+                );
+        } else {
+            res = false;
+        }
+        return res;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
@@ -45,10 +45,11 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class OptCachedTest {
     @Test
-    void optimizesIfXmlAlreadyInCache(final @TempDir Path tmp) throws IOException {
+    void returnsFromCacheIfXmlAlreadyInCache(final @TempDir Path tmp) throws IOException {
         final XML program = OptCachedTest.program();
         OptCachedTest.save(tmp, program);
         MatcherAssert.assertThat(
+            "We expected that the program will be returned from the cache",
             new OptCached(path -> program, tmp).apply(program),
             Matchers.equalTo(program)
         );
@@ -58,18 +59,15 @@ class OptCachedTest {
     void optimizesIfXmlIsAbsentInCache(final @TempDir Path tmp) {
         final XML program = OptCachedTest.program();
         final Path cache = tmp.resolve("cache");
-        final XML res = new OptCached(path -> program, cache)
-            .apply(program);
         MatcherAssert.assertThat(
-            res,
-            Matchers.equalTo(program)
+            "We expect that the program will be created and returned as is (same instance)",
+            new OptCached(path -> program, cache).apply(program),
+            Matchers.sameInstance(program)
         );
         MatcherAssert.assertThat(
+            "We expect that the cache saved the program after the first run",
             cache.resolve("main.xmir").toFile(),
             FileMatchers.anExistingFile()
-        );
-        MatcherAssert.assertThat(
-            res, Matchers.equalTo(program)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
@@ -31,17 +31,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import org.cactoos.bytes.BytesOf;
-import org.cactoos.bytes.UncheckedBytes;
-import org.cactoos.io.ResourceOf;
 import org.eolang.maven.util.HmBase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.xembly.Directive;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -56,9 +51,12 @@ class OptCachedTest {
         OptCachedTest.save(tmp, program);
         MatcherAssert.assertThat(
             "We expected that the program will be returned from the cache",
-            new OptCached(path -> {
-                throw new IllegalStateException("This code shouldn't be executed");
-            }, tmp).apply(program),
+            new OptCached(
+                path -> {
+                    throw new IllegalStateException("This code shouldn't be executed");
+                },
+                tmp
+            ).apply(program),
             Matchers.equalTo(program)
         );
     }


### PR DESCRIPTION
Check the time when XMIR was created and compare it with the time of a program crated in cache. 

Closes: #2713.
____
History:
- feat(#2713): add explanaiton messages for tests
- feat(#2713): add simple implementation of time checking
- feat(#2713): add one more test that checks outdated cache
- feat(#2713): add more tests
- feat(#2713): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the caching mechanism in the `OptCached` class. It introduces methods to check if the cache contains a program and to retrieve the path to the cached program. Additionally, it adds logic to compare the creation time of the cached program with the time specified in the XML program. 

### Detailed summary
- Introduces `cached` method to return the path to the cached program
- Introduces `contains` method to check if the cache contains the program
- Compares creation time of the cached program with the time specified in the XML program

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->