### PR TITLE
Old puzzle in `Cargo.java`, class-level fields in `Native.java`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Cargo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Cargo.java
@@ -35,11 +35,8 @@ import org.cactoos.map.MapOf;
 /**
  * Class to manipulate Cargo.toml file.
  * @since 1.0
- * @todo #2239:60 min. Make this class extending Savable class.
- *  This class have save method and needs to have explanatory
- *  comment too via Commented class.
  */
-public class Cargo extends Savable {
+public final class Cargo extends Savable {
     /**
      * Package attributes.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Native.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/rust/Native.java
@@ -60,11 +60,11 @@ public final class Native extends Savable {
             "import org.eolang.Universe;",
             String.format(
                 "public class %s {",
-                name
+                this.name
             ),
             String.format(
                 "    public static native byte[] %s",
-                name
+                this.name
             ),
             "        (final Universe universe);",
             "}"


### PR DESCRIPTION
@maxonfjvipon take a look, please
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on making changes to the `Native` and `Cargo` classes in the `eo-maven-plugin` module. 

### Detailed summary
- Changed the variable `name` to `this.name` in the `Native` class.
- Added a new parameter `final Universe universe` to the `public static native byte[]` method in the `Native` class.
- Changed the class `Cargo` to be `final` instead of extending `Savable`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->