### PR TITLE
fix(#2729): phi-unphi-eo test

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
@@ -1,0 +1,14 @@
+# @todo #2729:60min Enable the test when it's possible. Current syntax is not supported now. In our
+#  EBNF such is understood as vertical application with 3 arguments. But all arguments in
+#  application must be either all bound or not. But it should not be like that with reversed
+#  application. Need to extend the grammar and make sure the test works. Don't forget to remove the
+#  puzzle.
+skip: true
+xsls: []
+tests:
+  - /program/errors[count(*)=0]
+eo: |
+  if. > condition
+    TRUE
+    "TRUE":0
+    "FALSE":1

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
@@ -1,8 +1,9 @@
 # @todo #2729:60min Enable the test when it's possible. Current syntax is not supported now. In our
 #  EBNF such is understood as vertical application with 3 arguments. But all arguments in
 #  application must be either all bound or not. But it should not be like that with reversed
-#  application. Need to extend the grammar and make sure the test works. Don't forget to remove the
-#  puzzle.
+#  application. Need to extend the grammar and make sure the test works.
+#  Test UnphiMojoTest#convertsValidXmirAndParsableEO also does not work because of this.
+#  Don't forget to remove the puzzle.
 skip: true
 xsls: []
 tests:


### PR DESCRIPTION
Ref: #2729

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on enabling a test that is currently not supported due to syntax limitations in the EBNF. It also includes other changes related to the test.

### Detailed summary:
- Added a comment to explain the reason for skipping the test
- Added new test cases for program errors
- Added new EO code for if condition
- Modified the `UnphiMojoTest` class to include a new test method
- Added imports and dependencies to the `UnphiMojoTest` class
- Modified the `PrintMojo` class to include new imports and dependencies
- Modified the `PrintMojo` class to use multi-threading for processing XMIR sources
- Added a new condition to check if no XMIR sources are found during printing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->