### PR TITLE
Test pack for vertical method in scope

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/typos/vertical-method-in-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/typos/vertical-method-in-scope.yaml
@@ -1,0 +1,10 @@
+# @todo #2526:30min Enable the test when it's possible. Such syntax is invalid - scope braces should
+#  not be placed on different lines. It happens because of the next sequence of rules:
+#  scopeExtended -> happlicationExtended -> happlicationHeadExtended -> vmethod. The sequence
+#  allows using of vertical method in the head of scoped horizontal application. It should not be
+#  legal. Don't forget to remove the puzzle.
+skip: true
+line: 1
+eo: |
+  x (a
+  .b e).c > d


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added a comment to disable a test case in the `vertical-method-in-scope.yaml` file.
- Explained that the syntax used in the test case is invalid and should not be allowed.
- Provided information about the sequence of rules that led to the invalid syntax.
- Noted that the test case should be enabled once the issue is resolved.
- Added a puzzle to be removed later.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->