### PR TITLE
fix(#2737): reversed bound application

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -329,27 +329,25 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     @Override
     @SuppressWarnings("PMD.ConfusingTernary")
     public void enterApplicable(final EoParser.ApplicableContext ctx) {
-        if (ctx.reversed() == null) {
-            this.startObject(ctx);
-            final String base;
-            if (ctx.STAR() != null) {
-                base = "tuple";
-                this.objects.prop("star");
-            } else if (ctx.NAME() != null) {
-                base = ctx.NAME().getText();
-            } else if (ctx.AT() != null) {
-                base = "@";
-            } else {
-                base = "";
-            }
-            if (!base.isEmpty()) {
-                this.objects.prop("base", base);
-            }
-            if (ctx.COPY() != null) {
-                this.objects.prop("copy");
-            }
-            this.objects.leave();
+        this.startObject(ctx);
+        final String base;
+        if (ctx.STAR() != null) {
+            base = "tuple";
+            this.objects.prop("star");
+        } else if (ctx.NAME() != null) {
+            base = ctx.NAME().getText();
+        } else if (ctx.AT() != null) {
+            base = "@";
+        } else {
+            base = "";
         }
+        if (!base.isEmpty()) {
+            this.objects.prop("base", base);
+        }
+        if (ctx.COPY() != null) {
+            this.objects.prop("copy");
+        }
+        this.objects.leave();
     }
 
     @Override
@@ -364,6 +362,26 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void exitHapplicationTail(final EoParser.HapplicationTailContext ctx) {
+        this.objects.leave();
+    }
+
+    @Override
+    public void enterHapplicationTailReversed(final EoParser.HapplicationTailReversedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitHapplicationTailReversed(final EoParser.HapplicationTailReversedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterHapplicationTailReversedFirst(final EoParser.HapplicationTailReversedFirstContext ctx) {
+        this.objects.enter();
+    }
+
+    @Override
+    public void exitHapplicationTailReversedFirst(final EoParser.HapplicationTailReversedFirstContext ctx) {
         this.objects.leave();
     }
 
@@ -388,6 +406,26 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     public void exitHapplicationTailExtended(
         final EoParser.HapplicationTailExtendedContext ctx
     ) {
+        this.objects.leave();
+    }
+
+    @Override
+    public void enterHapplicationTailReversedExtended(final EoParser.HapplicationTailReversedExtendedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitHapplicationTailReversedExtended(final EoParser.HapplicationTailReversedExtendedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterHapplicationTailReversedExtendedFirst(final EoParser.HapplicationTailReversedExtendedFirstContext ctx) {
+        this.objects.enter();
+    }
+
+    @Override
+    public void exitHapplicationTailReversedExtendedFirst(final EoParser.HapplicationTailReversedExtendedFirstContext ctx) {
         this.objects.leave();
     }
 
@@ -437,12 +475,22 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterVapplicationArgs(final EoParser.VapplicationArgsContext ctx) {
-        this.objects.enter();
+        // Nothing here
     }
 
     @Override
     public void exitVapplicationArgs(final EoParser.VapplicationArgsContext ctx) {
-        this.objects.leave();
+        // Nothing here
+    }
+
+    @Override
+    public void enterVapplicationArgsReversed(final EoParser.VapplicationArgsReversedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVapplicationArgsReversed(final EoParser.VapplicationArgsReversedContext ctx) {
+        // Nothing here
     }
 
     @Override
@@ -457,22 +505,22 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterVapplicationArgBinded(final EoParser.VapplicationArgBindedContext ctx) {
-        // Nothing here
+        this.objects.enter();
     }
 
     @Override
     public void exitVapplicationArgBinded(final EoParser.VapplicationArgBindedContext ctx) {
-        // Nothing here
+        this.objects.leave();
     }
 
     @Override
     public void enterVapplicationArgUnbinded(final EoParser.VapplicationArgUnbindedContext ctx) {
-        // Nothing here
+        this.objects.enter();
     }
 
     @Override
     public void exitVapplicationArgUnbinded(final EoParser.VapplicationArgUnbindedContext ctx) {
-        // Nothing here
+        this.objects.leave();
     }
 
     @Override
@@ -662,6 +710,16 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
+    public void enterHmethodOptional(final EoParser.HmethodOptionalContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitHmethodOptional(final EoParser.HmethodOptionalContext ctx) {
+        // Nothing here
+    }
+
+    @Override
     public void enterHmethodExtended(final EoParser.HmethodExtendedContext ctx) {
         // Nothing here
     }
@@ -742,6 +800,56 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void exitVmethodHead(final EoParser.VmethodHeadContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterVmethodTailOptional(final EoParser.VmethodTailOptionalContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVmethodTailOptional(final EoParser.VmethodTailOptionalContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterVmethodHeadApplicationTail(final EoParser.VmethodHeadApplicationTailContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVmethodHeadApplicationTail(final EoParser.VmethodHeadApplicationTailContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterVmethodHeadHmethodExtended(final EoParser.VmethodHeadHmethodExtendedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVmethodHeadHmethodExtended(final EoParser.VmethodHeadHmethodExtendedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterVmethodHeadVapplication(final EoParser.VmethodHeadVapplicationContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVmethodHeadVapplication(final EoParser.VmethodHeadVapplicationContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterVmethodHeadHapplication(final EoParser.VmethodHeadHapplicationContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitVmethodHeadHapplication(final EoParser.VmethodHeadHapplicationContext ctx) {
         // Nothing here
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/binded-reversed-application.yaml
@@ -1,15 +1,13 @@
-# @todo #2729:60min Enable the test when it's possible. Current syntax is not supported now. In our
-#  EBNF such is understood as vertical application with 3 arguments. But all arguments in
-#  application must be either all bound or not. But it should not be like that with reversed
-#  application. Need to extend the grammar and make sure the test works.
-#  Test UnphiMojoTest#convertsValidXmirAndParsableEO also does not work because of this.
-#  Don't forget to remove the puzzle.
-skip: true
 xsls: []
 tests:
   - /program/errors[count(*)=0]
+  - //o[@base='.if' and o[@base='string' and @as='0']]
+  - //o[@base='.if' and o[@base='string' and @as='1']]
+  - //o[@base='.if' and o[@base='int' and @as='a']]
+  - //o[@base='.if' and o[@base='int' and @as='b']]
 eo: |
-  if. > condition
+  if. > first
     TRUE
     "TRUE":0
     "FALSE":1
+  if. FALSE 1:a 2:b > second


### PR DESCRIPTION
Closes: #2737

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Extended the grammar to handle reversed application in EBNF.
- Added support for reversed vertical application in the grammar.
- Updated the listener to handle reversed application and vertical application with reversed arguments.

> The following files were skipped due to too many changes: `eo-parser/src/main/java/org/eolang/parser/XeEoListener.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->