### PR TITLE
fix: rename VTX -> VERTEX

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
@@ -39,7 +39,7 @@ attribute
     : PHI
     | RHO
     | SIGMA
-    | VTX
+    | VERTEX
     | LABEL
     | alphaAttr
     ;
@@ -131,7 +131,8 @@ RHO : 'ρ'
 SIGMA
     : 'σ'
     ;
-VTX : 'ν'
+VERTEX
+    : 'ν'
     ;
 DELTA
     : 'Δ'

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -209,13 +209,13 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     public void exitBinding(final PhiParser.BindingContext ctx) {
         if (this.objs.size() > this.packages.size()) {
             if (ctx.alphaBinding() != null) {
-                if (ctx.alphaBinding().attribute().VTX() != null) {
+                if (ctx.alphaBinding().attribute().VERTEX() != null) {
                     this.objects().remove();
                 } else {
                     this.objects().leave();
                 }
             } else if (ctx.emptyBinding() != null) {
-                if (ctx.emptyBinding().attribute().VTX() != null) {
+                if (ctx.emptyBinding().attribute().VERTEX() != null) {
                     this.objects().remove();
                 } else {
                     this.objects().leave();
@@ -244,7 +244,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
             attr = "^";
         } else if (ctx.SIGMA() != null) {
             attr = "&";
-        } else if (ctx.VTX() != null) {
+        } else if (ctx.VERTEX() != null) {
             attr = "<";
         } else if (ctx.LABEL() != null) {
             attr = ctx.LABEL().getText();


### PR DESCRIPTION
Make the name more understandable

<!-- start pr-codex -->

---

## PR-Codex overview
This PR renames `VTX` to `VERTEX` in the Phi grammar and Java code for consistency and clarity.

### Detailed summary
- Renamed `VTX` to `VERTEX` in the Phi grammar file.
- Updated references of `VTX` to `VERTEX` in Java code for attribute binding.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->