### PR TITLE
fix(#2769): spaces and EOLs in phi expression

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -95,6 +95,7 @@ public final class UnphiMojo extends SafeMojo {
                             phi.getFileName().toString().replace(".phi", ""),
                             new TextOf(phi)
                         ).parsed();
+                        System.out.println(parsed);
                         home.save(parsed.toString(), xmir);
                         Logger.info(
                             this,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -95,7 +95,6 @@ public final class UnphiMojo extends SafeMojo {
                             phi.getFileName().toString().replace(".phi", ""),
                             new TextOf(phi)
                         ).parsed();
-                        System.out.println(parsed);
                         home.save(parsed.toString(), xmir);
                         Logger.info(
                             this,

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/new-lines.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/new-lines.yaml
@@ -1,0 +1,8 @@
+tests:
+  - /program/objects/o[@name='main' and @abstract and o[@name='x']]
+phi: |
+  {
+    main ↦ ⟦
+      x ↦ ξ.y
+    ⟧
+  }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/normalized.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/normalized.yaml
@@ -1,0 +1,4 @@
+tests:
+  - /program/objects[count(o)=1]/o[@name='app']
+phi:
+  "{ ν ↦ ⟦ Δ ⤍ 01- ⟧, app ↦ ⟦ ν ↦ ⟦ Δ ⤍ 00- ⟧, args ↦ ∅, φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.string (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 48-65-6C-6C-6F-2C-20-77-6F-72-6C-64-21-0A))) ⟧ }"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/remove-vtx.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/remove-vtx.yaml
@@ -1,0 +1,4 @@
+tests:
+  - /program/objects[count(o)=1]/o[@name='x']
+phi:
+  "{ν ↦ ⟦Δ ⤍ 01-⟧, x ↦ ⟦z ↦ ξ.y⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/spaces.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/spaces.yaml
@@ -1,0 +1,3 @@
+tests:
+  - /program/objects/o[@name='main' and @abstract and o[@name='x']]
+phi: "{main   ↦ ⟦ x ↦ ξ.y  ⟧   } "

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
@@ -1,5 +1,9 @@
 grammar Phi;
 
+// Skip spaces, tabs, newLines
+WS  : [ \t\r\n]+ -> skip
+    ;
+
 program
     : LCB bindings RCB
     ;
@@ -17,7 +21,7 @@ formation
 
 bindings
     : binding?
-    | binding (COMMA SPACE binding)*
+    | binding (COMMA binding)*
     ;
 
 binding
@@ -28,7 +32,7 @@ binding
     ;
 
 alphaBinding
-    : attribute SPACE ARROW SPACE object
+    : attribute ARROW object
     ;
 
 attribute
@@ -45,15 +49,15 @@ alphaAttr
     ;
 
 emptyBinding
-    : attribute SPACE ARROW SPACE EMPTY
+    : attribute ARROW EMPTY
     ;
 
 deltaBidning
-    : DELTA SPACE DASHED_ARROW SPACE BYTES
+    : DELTA DASHED_ARROW BYTES
     ;
 
 lambdaBidning
-    : LAMBDA SPACE DASHED_ARROW SPACE FUNCTION
+    : LAMBDA DASHED_ARROW FUNCTION
     ;
 
 FUNCTION
@@ -107,9 +111,6 @@ DOT : '.'
     ;
 COMMA
     : ','
-    ;
-SPACE
-    : ' '
     ;
 ARROW
     : '↦'

--- a/eo-parser/src/main/java/org/eolang/parser/Objects.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Objects.java
@@ -90,6 +90,12 @@ interface Objects extends Iterable<Directive> {
     Objects leave();
 
     /**
+     * Remove current object.
+     * @return Self.
+     */
+    Objects remove();
+
+    /**
      * Xembly object tree.
      * @since 0.1
      */
@@ -144,6 +150,12 @@ interface Objects extends Iterable<Directive> {
         @Override
         public Objects leave() {
             this.dirs.up();
+            return this;
+        }
+
+        @Override
+        public Objects remove() {
+            this.dirs.remove();
             return this;
         }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -45,6 +45,7 @@ import org.xembly.Directives;
  * @checkstyle CyclomaticComplexityCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @checkstyle MethodCountCheck (1300 lines)
+ * @checkstyle NestedIfDepthCheck (1300 lines)
  * @since 0.34.0
  */
 @SuppressWarnings({
@@ -200,6 +201,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     }
 
     @Override
+    @SuppressWarnings("PMD.ConfusingTernary")
     public void exitBinding(final PhiParser.BindingContext ctx) {
         if (this.objs.size() > this.packages.size()) {
             if (ctx.alphaBinding() != null) {

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -201,9 +201,20 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
 
     @Override
     public void exitBinding(final PhiParser.BindingContext ctx) {
-        if ((ctx.alphaBinding() != null || ctx.emptyBinding() != null)
-            && this.objs.size() > this.packages.size()) {
-            this.objects().leave();
+        if (this.objs.size() > this.packages.size()) {
+            if (ctx.alphaBinding() != null) {
+                if (ctx.alphaBinding().attribute().VTX() != null) {
+                    this.objects().remove();
+                } else {
+                    this.objects().leave();
+                }
+            } else if (ctx.emptyBinding() != null) {
+                if (ctx.emptyBinding().attribute().VTX() != null) {
+                    this.objects().remove();
+                } else {
+                    this.objects().leave();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Ref: #2769 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding the `remove()` method to the `Objects` class and making changes to the `Phi.g4` grammar file.

### Detailed summary:
- Added `remove()` method to the `Objects` class.
- Modified the `Phi.g4` grammar file to skip spaces, tabs, and new lines.
- Updated the `exitBinding()` method in the `XePhiListener` class to remove objects based on certain conditions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->