### PR TITLE
fix(#2764): new tasks for the correct operation of the cache

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
@@ -41,11 +41,18 @@ import org.eolang.maven.footprint.FtDefault;
  * Returns already optimized XML if it's found in the cache.
  *
  * @since 0.28.11
- * @todo #2746:30min Use checksum, not time.
+ * @todo #2746:30min Fix caching mechanism in {@link OptCached}. Current
+ *  The last modified time of the files between stages may be different,
+ *  so it is not correct to do an equality comparison ({@code .equals(...)}).
+ *  The last modification time of the file at the current stage
+ *  must be less than or equal to the last modification time of file in cache at the next stage.
  *  The following tests show that fetching from the cache doesn't work correctly:
  *  - {@link OptCachedTest#returnsFromCacheCorrectProgram(Path path)},
  *  - {@link OptCachedTest#returnsFromCacheButTimesSaveAndExecuteDifferent(Path path)}.
- *  Need to fix the file validation from cache: using checksum, but not time.
+ * @todo #2746:30min Unify caching mechanism on stages: parse, optimize, pull and so on.
+ *  Current implementations of caching on parsing stage and optimize stages work differently.
+ *  In ParseMojo we have condition {@code if (tojo.hasHash()) }, in OptimizeMojo or ShakeMojo we
+ *  ompare creation time of files.
  *  Don't forget to enable the tests.
  */
 public final class OptCached implements Optimization {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/optimization/OptCached.java
@@ -52,7 +52,7 @@ import org.eolang.maven.footprint.FtDefault;
  * @todo #2746:30min Unify caching mechanism on stages: parse, optimize, pull and so on.
  *  Current implementations of caching on parsing stage and optimize stages work differently.
  *  In ParseMojo we have condition {@code if (tojo.hasHash()) }, in OptimizeMojo or ShakeMojo we
- *  ompare creation time of files.
+ *  compare creation time of files.
  *  Don't forget to enable the tests.
  */
 public final class OptCached implements Optimization {


### PR DESCRIPTION
Closes: #2764 
The solution was made in which we continue to use the modification time of files without using file internal components. Hash code isn't needed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the caching mechanism in `OptCached` and unifying the caching mechanism on different stages. 

### Detailed summary
- Changed the `@todo` comment to use checksum instead of time for file validation from cache.
- Added a new `@todo` comment to unify the caching mechanism on different stages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->