### PR TITLE
Create an object for testing application, that accepts arguments in the form of `tuple`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/io/tupled-stdout.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tupled-stdout.eo
@@ -1,0 +1,52 @@
+# The MIT License (MIT)
+#
+#  2016-2022 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.stdout
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++rt jvm org.eolang:eo-runtime:0.0.0
++version 0.0.0
+
+# An object for testing entire applications that accepts arguments in the form of a tuple.
+[args] > tupled-stdout
+  memory 0 > iter
+  args.length.minus 1 > max
+  if. > @
+    max.lt 0
+    error "tuple of arguments must contain at least one element"
+    if.
+      max.eq 0
+      stdout
+        args.at
+          0
+      while.
+        iter.as-int.lt max
+        [i]
+          seq > @
+            *
+              stdout
+                args.at
+                  i
+              iter.write
+                iter.as-int.plus 1
+              TRUE

--- a/eo-runtime/src/test/eo/org/eolang/io/tupled-stdout-test.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tupled-stdout-test.eo
@@ -1,0 +1,54 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2023 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.tupled-stdout
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.io
++version 0.0.0
+
+[] > tupled-stdout-single
+  tupled-stdout > @
+    *
+      "Hello, world! Single tupled.\n"
+
+[] > tupled-stdout-several
+  tupled-stdout > @
+    *
+      "Hello"
+      ", "
+      "world"
+      "! "
+      "Several "
+      "tupled.\n"
+
+[] > tupled-stdout-empty
+  eq. > @
+    try
+      []
+        tupled-stdout > @
+          *
+      [e]
+        e > @
+      nop
+    "tuple of arguments must contain at least one element"

--- a/eo-runtime/src/test/eo/org/eolang/io/tupled-stdout.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tupled-stdout.eo
@@ -24,7 +24,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+rt jvm org.eolang:eo-runtime:0.0.0
 +version 0.0.0
 
 # An object for testing entire applications that accepts arguments in the form of a tuple.

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -69,19 +69,17 @@ final class MainTest {
     }
 
     @Test
-    @Disabled
     void deliversCleanOutput() {
         MatcherAssert.assertThat(
-            MainTest.exec("org.eolang.io.stdout", "Hello!"),
+            MainTest.exec("org.eolang.io.tupled-stdout", "Hello!"),
             Matchers.equalTo(String.format("Hello!%n---%n%s%n", Arrays.toString(new byte[]{0x01})))
         );
     }
 
     @Test
-    @Disabled
     void executesJvmFullRun() {
         MatcherAssert.assertThat(
-            MainTest.exec("--verbose", "org.eolang.io.stdout", "Hello, dude!"),
+            MainTest.exec("--verbose", "org.eolang.io.tupled-stdout", "Hello, dude!"),
             Matchers.allOf(
                 Matchers.containsString("EOLANG"),
                 Matchers.containsString("Hello, "),

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -40,12 +40,6 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link Main}.
  *
  * @since 0.1
- * @todo #2718:30min Enable the tests. Tests {@link MainTest#deliversCleanOutput()} and
- *  {@link MainTest#executesJvmFullRun()} were disabled because they execute "org.eolang.io.stdout"
- *  object that accepts "string". But arguments after "org.eolang.io.stdout" are stored into "tuple"
- *  and are being passed as "tuple" object. And here we get the situation where
- *  "stdout" accepts "tuple" and fails. We need to enable the test by finding object that accepts
- *  "tuple" as the first argument, or make a custom one.
  */
 final class MainTest {
 


### PR DESCRIPTION
Closes #2723

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling two tests in the `MainTest` class that were previously disabled. The changes include replacing the `org.eolang.io.stdout` object with a new object `org.eolang.io.tupled-stdout` that accepts a tuple as the first argument. 

### Detailed summary
- Enabled the `deliversCleanOutput()` test by replacing `org.eolang.io.stdout` with `org.eolang.io.tupled-stdout`.
- Enabled the `executesJvmFullRun()` test by replacing `org.eolang.io.stdout` with `org.eolang.io.tupled-stdout`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->