### PR TITLE
Enable `printsMessageWithEoIfExceptionIsThrown` test from `StEoLoggedTest`

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StEoLoggedTest.java
@@ -34,7 +34,6 @@ import java.util.function.Consumer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -77,12 +76,8 @@ class StEoLoggedTest {
 
     /**
      * Check EO log message on exception thrown.
-     * @todo #2750:30min After removing conversion from bytes to value from 'xmir-to-eo.xsl' this
-     *  test fails. All logic related to bytes conversion was moved to {@link StUnhex} class. Need
-     *  to fix or remove this test.
      */
     @Test
-    @Disabled
     void printsMessageWithEoIfExceptionIsThrown() {
         final FakeLog log = new FakeLog();
         Assertions.assertThrows(


### PR DESCRIPTION
Closes #2779 
It seems like refactoring of [Xmir.java](https://github.com/objectionary/eo/blob/master/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java) class fixed this test ([this commit](https://github.com/objectionary/eo/commit/af4b50d98d929ec2aa4e319f0f409e6dfcb7cd99)).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing a test that is no longer valid due to changes in the code. 

### Detailed summary
- Removed the `@Disabled` annotation from the `printsMessageWithEoIfExceptionIsThrown` test in `StEoLoggedTest.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->