### PR TITLE
fix(#2787): eo to strait xmir

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -147,7 +147,10 @@ class UnphiMojoTest {
 
     @ParameterizedTest
     @CsvSource({"true", "false"})
-    void convertsValidXmirAndParsableEO(final boolean reversed, @TempDir final Path temp) throws Exception {
+    void convertsValidXmirAndParsableEO(
+        final boolean reversed,
+        @TempDir final Path temp
+    ) throws Exception {
         final Map<String, Path> map = new FakeMaven(temp)
             .withProgram(
                 "[args] > app",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -144,8 +145,9 @@ class UnphiMojoTest {
         );
     }
 
-    @Test
-    void convertsValidXmirAndParsableEO(@TempDir final Path temp) throws IOException {
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    void convertsValidXmirAndParsableEO(final boolean reversed, @TempDir final Path temp) throws Exception {
         final Map<String, Path> map = new FakeMaven(temp)
             .withProgram(
                 "[args] > app",
@@ -154,6 +156,7 @@ class UnphiMojoTest {
             )
             .with("printSourcesDir", temp.resolve("target/1-parse").toFile())
             .with("printOutputDir", temp.resolve("target/generated-sources").toFile())
+            .with("printReversed", reversed)
             .execute(ParseMojo.class)
             .execute(OptimizeMojo.class)
             .execute(PhiMojo.class)

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -181,16 +181,19 @@ vapplication
 // Vertical application head
 vapplicationHead
     : applicable
-    | hmethodExtended
-    | hmethodExtendedVersioned
-    | vmethod
-    | vmethodVersioned
+    | hmethodOptional
+    | vmethodOptional
     | versioned
     ;
 
 // Vertical application head with optional name
 vapplicationHeadNamed
     : vapplicationHead oname?
+    ;
+
+// Vertical application head with binding
+vapplicationHeadAs
+    : vapplicationHead as
     ;
 
 // Vertical application arguments
@@ -243,11 +246,6 @@ vapplicationArgHapplicationBinded
 
 vapplicationArgHapplicationUnbinded
     : happlicationExtended oname?
-    ;
-
-// Vertical application head with binding
-vapplicationHeadAs
-    : (applicable | hmethodOptional | versioned) as
     ;
 
 // Vertical anonym object as argument of vertical application

--- a/eo-parser/src/main/java/org/eolang/parser/xmir/XmirReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/xmir/XmirReversed.java
@@ -33,7 +33,7 @@ public final class XmirReversed extends XmirEnvelope {
     /**
      * XSL transformation that converts XMIR to EO with reversed methods.
      */
-    private static final String REVERSED = "/org/eolang/parser/xmir-to-eo.xsl";
+    private static final String REVERSED = "/org/eolang/parser/xmir-to-eo-reversed.xsl";
 
     /**
      * Ctor.

--- a/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-reversed.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-reversed.xsl
@@ -22,10 +22,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="xmir-to-eo" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="xmir-to-eo-reversed" version="2.0">
   <!--
-  This one maps XMIR to EO original syntax in strait notation.
-  It's used in Xmir.java class.
+  This one maps XMIR to EO original syntax in reversed notation.
+  It's used in XmirReversed.java class.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:variable name="eol" select="'&#10;'"/>
@@ -71,43 +71,27 @@ SOFTWARE.
   <!-- OBJECT, NOT FREE ATTRIBUTE -->
   <xsl:template match="o[not(eo:attr(.))]">
     <xsl:param name="indent" select="''"/>
-    <xsl:choose>
-      <!-- METHOD -->
-      <xsl:when test="starts-with(@base,'.')">
-        <xsl:apply-templates select="o[position()=1]">
-          <xsl:with-param name="indent" select="$indent"/>
-        </xsl:apply-templates>
-        <xsl:value-of select="$indent"/>
-        <xsl:apply-templates select="." mode="head">
-          <xsl:with-param name="indent" select="$indent"/>
-        </xsl:apply-templates>
-        <xsl:apply-templates select="." mode="tail"/>
-        <xsl:value-of select="$eol"/>
-        <xsl:apply-templates select="o[position()&gt;1 and not(eo:attr(.))]">
-          <xsl:with-param name="indent" select="concat('  ', $indent)"/>
-        </xsl:apply-templates>
-      </xsl:when>
-      <!-- NOT METHOD -->
-      <xsl:otherwise>
-        <!--IF NOT THE FIRST TOP OBJECT -->
-        <xsl:if test="position()&gt;1 and parent::objects">
-          <xsl:value-of select="$eol"/>
-        </xsl:if>
-        <xsl:value-of select="$indent"/>
-        <xsl:apply-templates select="." mode="head">
-          <xsl:with-param name="indent" select="$indent"/>
-        </xsl:apply-templates>
-        <xsl:apply-templates select="." mode="tail"/>
-        <xsl:value-of select="$eol"/>
-        <xsl:apply-templates select="o[not(eo:attr(.))]">
-          <xsl:with-param name="indent" select="concat('  ', $indent)"/>
-        </xsl:apply-templates>
-      </xsl:otherwise>
-    </xsl:choose>
+    <!--IF NOT THE FIRST TOP OBJECT -->
+    <xsl:if test="position()&gt;1 and parent::objects">
+      <xsl:value-of select="$eol"/>
+    </xsl:if>
+    <xsl:value-of select="$indent"/>
+    <xsl:apply-templates select="." mode="head">
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="tail"/>
+    <xsl:value-of select="$eol"/>
+    <xsl:apply-templates select="o[not(eo:attr(.))]">
+      <xsl:with-param name="indent" select="concat('  ', $indent)"/>
+    </xsl:apply-templates>
   </xsl:template>
   <!-- BASED -->
   <xsl:template match="o[not(@data) and @base]" mode="head">
     <xsl:choose>
+      <xsl:when test="starts-with(@base,'.')">
+        <xsl:value-of select="substring(@base,2)"/>
+        <xsl:text>.</xsl:text>
+      </xsl:when>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
         <xsl:text>*</xsl:text>

--- a/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
@@ -34,7 +34,6 @@ import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.yaml.snakeyaml.Yaml;
 
@@ -45,18 +44,7 @@ import org.yaml.snakeyaml.Yaml;
  * @checkstyle AbbreviationAsWordInNameCheck (500 lines)
  */
 final class XmirTest {
-    /**
-     * Convert EO to xmir and back and compare.
-     * @param pack EO pack.
-     * @throws Exception If fails.
-     * @todo #2758:30min Implement printing from XMIR to EO in strait notation
-     *  (where method starts on the next line). It should be done via XSL which
-     *  should be used in {@link Xmir.Default} object. The next disabled test
-     *  shows that such implementation does not work now:
-     *  {@link XmirTest#printsStrait(String)}
-     */
     @ParameterizedTest
-    @Disabled
     @ClasspathSource(value = "org/eolang/parser/samples/", glob = "**.yaml")
     void printsStrait(final String pack) throws IOException {
         final Map<String, Object> map = new Yaml().load(pack);

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/vertical-methods-in-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/vertical-methods-in-application.yaml
@@ -20,8 +20,8 @@ eo: |
     .org
     .eolang
     .string:0
-      Q.
+      Q
       .org
       .eolang
       .bytes
-        00-AX-23
+        00-42-23

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/vertical-methods-in-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/vertical-methods-in-application.yaml
@@ -11,3 +11,17 @@ eo: |
     c
     .d
     .e:1
+  Q
+  .org
+  .eolang
+  .io
+  .stdout > third
+    Q
+    .org
+    .eolang
+    .string:0
+      Q.
+      .org
+      .eolang
+      .bytes
+        00-AX-23

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/dataless.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/dataless.yaml
@@ -16,7 +16,7 @@ strait: |
   [args] > main
     QQ
     .io
-    stdout > @
+    .stdout > @
       args
       .at
         args

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/idiomatic.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/idiomatic.yaml
@@ -48,7 +48,9 @@ strait: |
         """
         4.55 > x!
         *
-          "Hello, \u0434\u0440\u0443\u0433"
+          """
+          Hello, \u0434\u0440\u0443\u0433
+          """
           2.18
           TRUE
     .plus
@@ -57,7 +59,7 @@ strait: |
         .plus
           """
           hello, \u5927\u5BB6!
-          """"
+          """
     .if > @
 
 reversed: |

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/inheritance.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/inheritance.yaml
@@ -13,6 +13,7 @@ origin: |
       self.f > @
         self
         v
+
   [] > derived
     base > @
     [self v] > f
@@ -27,7 +28,8 @@ strait: |
   +architect yegor256@gmail.com
   
   [] > base
-    memory 0 > x
+    memory > x
+      0
     [self v] > f
       x
       .write > @
@@ -37,13 +39,14 @@ strait: |
       .f > @
         self
         v
+
   [] > derived
     base > @
     [self v] > f
       self
       .g > @
         self
-        v 
+        v
 
 reversed: |
   +package sandbox

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/just-float.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/just-float.yaml
@@ -5,6 +5,7 @@ origin: |
 
 strait: |
   3.14 > pi
+
   [] > foo
     2.18 > e
 

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/times.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/times.yaml
@@ -12,13 +12,13 @@ strait: |
     .stdout > @
       QQ
       .txt
-      .sprintf 
+      .sprintf
         """
         result is %d\n
         """
-          -1
-          .times
-            228
+        -1
+        .times
+          228
 
 reversed: |
   [] > app


### PR DESCRIPTION
Closes: #2787 
Ref: #2758 

What's done:
- Added new xsl to print XMIR to EO in strait human readable notation
- Fixed test packs
- Fixed EO grammar to allow parsing vertical methods in arguments of vertical application

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated the `just-float.yaml` file.
- Updated the `dataless.yaml` file.
- Updated the `times.yaml` file.
- Updated the `idiomatic.yaml` file.
- Updated the `vertical-methods-in-application.yaml` file.
- Updated the `XmirReversed.java` file.
- Updated the `inheritance.yaml` file.
- Updated the `XmirTest.java` file.
- Updated the `UnphiMojoTest.java` file.
- Updated the `xmir-to-eo.xsl` file.
- Added the `xmir-to-eo-reversed.xsl` file.

> The following files were skipped due to too many changes: `eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-reversed.xsl`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->