### PR TITLE
fix(#2744):issues is ready

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -114,10 +114,6 @@ final class OptimizeMojoTest {
      *
      * @param temp Temporary test directory.
      * @throws Exception if unexpected error happened.
-     * @todo #2422:60min This test is unstable for now.
-     *  We should resolve issues with unstable failures and only
-     *  then enable the test.
-     *  Also, see this <a href="https://github.com/objectionary/eo/issues/2727">issue</a>.
      */
     @Test
     void getsAlreadyOptimizedResultsFromCache(@TempDir final Path temp) throws Exception {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/optimization/OptCachedTest.java
@@ -52,10 +52,6 @@ final class OptCachedTest {
      * @param cache Temp cache dir.
      * @param dir Temp program dir
      * @throws IOException if I/O fails
-     * @todo #2422:60min returnsFromCacheIfXmlAlreadyInCache: this test is unstable.
-     *  We should resolve issues with unstable failures and only
-     *  then enable the test.
-     *  Also, see this <a href="https://github.com/objectionary/eo/issues/2727">issue</a>.
      * @todo #2790:30min There is repeating logic in tests.
      *  Code logic repeats in {@link OptCacedTest},
      *  {@link OptimizeMojoTest.getAlreadyOptimizedResultsFromCache}


### PR DESCRIPTION
Closed: #2744
Closed: #2727
Closed: #2743

Closed tasks were added from code.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on resolving issues with unstable test failures in the `OptimizeMojoTest` and `OptCachedTest` classes. The changes include disabling unstable tests and addressing repeating logic in the tests.

### Detailed summary
- Disables the `getsAlreadyOptimizedResultsFromCache` test in `OptimizeMojoTest` due to instability.
- Disables the `returnsFromCacheIfXmlAlreadyInCache` test in `OptCachedTest` due to instability.
- Addresses repeating logic in the tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->