### PR TITLE
fix(#2825): copy to phi

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -350,7 +350,7 @@ SOFTWARE.
     </xsl:if>
     <xsl:value-of select="$lb"/>
     <!-- Atom or not empty formation -->
-    <xsl:if test="@atom or count(o)>0">
+    <xsl:if test="@atom or count(o)&gt;0">
       <xsl:value-of select="eo:eol($tabs+1)"/>
       <!-- Atom -->
       <xsl:if test="@atom">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -281,6 +281,11 @@ SOFTWARE.
             <xsl:value-of select="eo:specials(@base, false())"/>
           </xsl:otherwise>
         </xsl:choose>
+        <!-- Copy -->
+        <xsl:if test="@copy">
+          <xsl:text>()</xsl:text>
+        </xsl:if>
+        <!-- Nested objects -->
         <xsl:if test="count(o)&gt;0">
           <xsl:text>(</xsl:text>
           <xsl:value-of select="eo:eol($tabs+1)"/>
@@ -300,6 +305,11 @@ SOFTWARE.
           <xsl:with-param name="tabs" select="$tabs"/>
         </xsl:apply-templates>
         <xsl:value-of select="eo:specials(@base, true())"/>
+        <!-- Copy -->
+        <xsl:if test="@copy">
+          <xsl:text>()</xsl:text>
+        </xsl:if>
+        <!-- Nested objects -->
         <xsl:if test="count(o)&gt;1">
           <xsl:text>(</xsl:text>
           <xsl:value-of select="eo:eol($tabs+1)"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -349,22 +349,26 @@ SOFTWARE.
       <xsl:value-of select="$arrow"/>
     </xsl:if>
     <xsl:value-of select="$lb"/>
-    <xsl:value-of select="eo:eol($tabs+1)"/>
-    <xsl:if test="@atom">
-      <xsl:value-of select="$lambda"/>
-      <xsl:value-of select="$dashed-arrow"/>
-      <xsl:text>Lambda</xsl:text>
-      <xsl:if test="count(o)&gt;0">
-        <xsl:value-of select="eo:comma(2, $tabs+1)"/>
+    <!-- Atom or not empty formation -->
+    <xsl:if test="@atom or count(o)>0">
+      <xsl:value-of select="eo:eol($tabs+1)"/>
+      <!-- Atom -->
+      <xsl:if test="@atom">
+        <xsl:value-of select="$lambda"/>
+        <xsl:value-of select="$dashed-arrow"/>
+        <xsl:text>Lambda</xsl:text>
+        <xsl:if test="count(o)&gt;0">
+          <xsl:value-of select="eo:comma(2, $tabs+1)"/>
+        </xsl:if>
       </xsl:if>
+      <xsl:for-each select="o">
+        <xsl:value-of select="eo:comma(position(), $tabs+1)"/>
+        <xsl:apply-templates select=".">
+          <xsl:with-param name="tabs" select="$tabs+1"/>
+        </xsl:apply-templates>
+      </xsl:for-each>
+      <xsl:value-of select="eo:eol($tabs)"/>
     </xsl:if>
-    <xsl:for-each select="o">
-      <xsl:value-of select="eo:comma(position(), $tabs+1)"/>
-      <xsl:apply-templates select=".">
-        <xsl:with-param name="tabs" select="$tabs+1"/>
-      </xsl:apply-templates>
-    </xsl:for-each>
-    <xsl:value-of select="eo:eol($tabs)"/>
     <xsl:value-of select="$rb"/>
   </xsl:template>
   <!-- Application -->

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/copy.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/copy.yaml
@@ -1,7 +1,3 @@
-# @todo #2610:30min Enable the test when PhiMojo supports "copy" syntax. The test is disabled
-#  because PhiMojo does not support converting "copy" EO syntax to phi. Need to extend
-#  "xmir-to-phi.xsl" and enable the test. Don't forget to remove the puzzle
-skip: true
 eo: |
   [] > obj
     cage' > x
@@ -10,6 +6,8 @@ phi: |
   {
     obj ↦ ⟦
       x ↦ Φ.org.eolang.cage(),
-      y ↦ Φ.org.eolang.cage()(α0 ↦ Φ.org.eolang.a)
+      y ↦ Φ.org.eolang.cage()(
+        α0 ↦ Φ.org.eolang.a
+      )
     ⟧
   }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/empty.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/empty.yaml
@@ -1,0 +1,12 @@
+eo: |
+  [z] > main
+    [] > x
+    seq' > y
+phi: |
+  {
+    main ↦ ⟦
+      z ↦ ∅,
+      x ↦ ⟦⟧,
+      y ↦ Φ.org.eolang.seq()
+    ⟧
+  }

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -192,6 +192,9 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
         if (XePhiListener.hasLambdaPackage(ctx)) {
             this.objs.poll();
         }
+        if (this.properties.peek().equals("as") && ctx.binding().size() == 0) {
+            this.objects().prop("copy");
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes: #2825 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the "copy" syntax in the XePhiListener class and the to-phi.xsl file. 

### Detailed summary
- Added support for the "copy" syntax in XePhiListener class.
- Updated to-phi.xsl file to handle the "copy" syntax.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->