### PR TITLE
fix(#2718): enable snippet test

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/SnippetTestCase.java
+++ b/eo-runtime/src/test/java/org/eolang/SnippetTestCase.java
@@ -57,11 +57,11 @@ import org.yaml.snakeyaml.Yaml;
  *
  * @since 0.1
  *
- * @todo #2660:30min One snippet is disabled now, in
- *  the "src/test/resources/snippets/*.yaml" because it doesn't work.
- *  I don't understand what's wrong with it (parenting.yaml). Let's
- *  try to find out and enable it (by removing the "skip" attribute from
- *  the YAML file).
+ * @todo #2718:30min One snippet is disabled now, in
+ *  the "src/test/resources/snippets/*.yaml" because there's no
+ *  "sprintf" object in objectionary (fibo.yaml).
+ *  When "sprintf" is in objectionary again - we need to enable
+ *  it (by removing the "skip" attribute from the YAML file).
  */
 @ExtendWith(WeAreOnline.class)
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")

--- a/eo-runtime/src/test/resources/org/eolang/snippets/parenting.yaml
+++ b/eo-runtime/src/test/resources/org/eolang/snippets/parenting.yaml
@@ -1,5 +1,4 @@
 file: org/eolang/snippets/parenting.eo
-skip: true
 out:
   - ".*123.*"
 args: [ "org.eolang.snippets.parenting", "123" ]


### PR DESCRIPTION
Closes: #2718

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling a disabled snippet in the "parenting.yaml" file. 

### Detailed summary
- The "skip" attribute is removed from the "parenting.yaml" file to enable the snippet.
- A new "todo" task (#2718) is added to address the absence of the "sprintf" object in the "fibo.yaml" file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->