### PR TITLE
fix(#2846): renamed COMMENT

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -13,7 +13,7 @@ eop : EOL EOL
 
 // Licence
 license
-    : (COMMENT EOL)* COMMENT eop
+    : (COMMENTARY EOL)* COMMENTARY eop
     ;
 
 // Metas
@@ -28,7 +28,7 @@ objects
     ;
 
 comment
-    : COMMENT EOL
+    : COMMENTARY EOL
     ;
 
 commentOptional
@@ -545,7 +545,7 @@ data: BYTES
     | HEX
     ;
 
-COMMENT
+COMMENTARY
     : HASH
     | (HASH ~[\r\n]* ~[\r\n\t ])
     ;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -160,7 +160,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
                 "\n",
                 new Mapped<>(
                     cmt -> cmt.getText().substring(1).trim(),
-                    ctx.COMMENT()
+                    ctx.COMMENTARY()
                 )
             )
         ).up();
@@ -232,9 +232,9 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     public void enterCommentMandatory(final EoParser.CommentMandatoryContext ctx) {
         final String comment = String.join(
             "",
-            ctx.comment().COMMENT().getText().substring(1).trim(),
+            ctx.comment().COMMENTARY().getText().substring(1).trim(),
             ctx.commentOptional().comment().stream().map(
-                context -> context.COMMENT().getText().substring(1).trim()
+                context -> context.COMMENTARY().getText().substring(1).trim()
             ).collect(Collectors.joining(""))
         );
         final String length = String.format(


### PR DESCRIPTION
Closes: #2846 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Eo.g4 grammar file and XeEoListener.java to replace occurrences of `COMMENT` with `COMMENTARY`. 

### Detailed summary
- In Eo.g4 grammar file, `COMMENT` is replaced with `COMMENTARY`.
- In XeEoListener.java, `COMMENT` is replaced with `COMMENTARY` in multiple places.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->