### PR TITLE
Decrease simian threshold down to 30

### DIFF
--- a/.github/workflows/simian.yml
+++ b/.github/workflows/simian.yml
@@ -24,4 +24,4 @@ jobs:
       - run: |
           wget --quiet http://public.yegor256.com/simian.jar -O /tmp/simian.jar
       - run: |
-          java -jar /tmp/simian.jar -threshold=35 -excludes=**/gen **/*.java
+          java -jar /tmp/simian.jar -threshold=30 -excludes=**/gen **/*.java

--- a/.github/workflows/simian.yml
+++ b/.github/workflows/simian.yml
@@ -24,4 +24,4 @@ jobs:
       - run: |
           wget --quiet http://public.yegor256.com/simian.jar -O /tmp/simian.jar
       - run: |
-          java -jar /tmp/simian.jar -threshold=30 -excludes=**/gen **/*.java
+          java -jar /tmp/simian.jar -threshold=30 -excludes=**/gen -excludes=**/it **/*.java


### PR DESCRIPTION
Simian threshold has been decreased down to 30. However, that caused the following output from simian:

```
Found 30 duplicate lines with fingerprint d75037e7a87019ed7c72f46613acf2c1 in the following files:
 Between lines 40 and 117 in /eo/eo-maven-plugin/src/it/hash_package_layer/src/main/java/EOorg/EOeolang/Heaps.java
 Between lines 40 and 117 in /eo/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
Found 60 duplicate lines in 2 blocks in 2 files
```

...which I believe is OK to ignore, since it's a duplicate between test and source code. Adding `-excludes=**/it` to exclude integration tests resolved it. @yegor256 WDYT?

Closes #2632