### PR TITLE
fix(#2864): added test pack for UnphiMojo

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -153,10 +153,8 @@ class UnphiMojoTest {
 
     @ParameterizedTest
     @CsvSource({"true", "false"})
-    void convertsValidXmirAndParsableEO(
-        final boolean reversed,
-        @TempDir final Path temp
-    ) throws Exception {
+    void convertsValidXmirAndParsableEO(final boolean reversed, @TempDir final Path temp)
+        throws Exception {
         final Map<String, Path> map = new FakeMaven(temp)
             .withProgram(
                 "# This is the default 64+ symbols comment in front of named abstract object.",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/as-phi.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/as-phi.yaml
@@ -1,0 +1,28 @@
+# @todo #2864:30min Enable phi test pack. Current test pack is disabled because it fails on
+#  UnphiMojoTest#convertsToXmirAndBack because our Phi grammar (Phi.g4) does not support XI without
+#  dispatch (see line 77). We need to resolve it and enable test pack.
+skip: true
+eo: |
+  # This is the default 64+ symbols comment in front of named abstract object.
+  [] > prints-itself
+    assert-that > @
+      length.
+        as-phi $
+      $.greater-than 0
+phi: |
+  {
+    prints-itself ↦ ⟦
+      φ ↦ Φ.org.eolang.assert-that(
+        α0 ↦ Φ.org.eolang.as-phi(
+          α0 ↦ ξ
+        ).length,
+        α1 ↦ ξ.greater-than(
+          α0 ↦ Φ.org.eolang.int(
+            α0 ↦ Φ.org.eolang.bytes(
+              Δ ⤍ 00-00-00-00-00-00-00-00
+            )
+          )
+        )
+      )
+    ⟧
+  }


### PR DESCRIPTION
Ref: #2864 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling the phi test pack in the UnphiMojoTest class. 

### Detailed summary
- The `convertsValidXmirAndParsableEO` method signature has been modified.
- A new comment has been added in the as-phi.yaml file explaining the reason for disabling the test pack.
- The skip property has been set to true in the as-phi.yaml file.
- The as-phi.yaml file now contains a new phi object definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->