### PR TITLE
Return previous values of the limits

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -430,23 +430,16 @@ SOFTWARE.
               <rules>
                 <rule>
                   <element>BUNDLE</element>
-                  <!--
-                  @todo #2437:30min Return previous values of the limits. Limits were changed
-                   after changing "explicit-data.xsl" and disabling some tests. Need to return
-                   limits back after tests are enabled. Previous values:
-                   INSTRUCTION.COVEREDRATIO - 0.70, LINE.COVEREDRATIO - 0.73,
-                   CLASS.MISSEDCOUNT - 6
-                  -->
                   <limits>
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.69</minimum>
+                      <minimum>0.70</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.71</minimum>
+                      <minimum>0.73</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
@@ -466,7 +459,7 @@ SOFTWARE.
                     <limit>
                       <counter>CLASS</counter>
                       <value>MISSEDCOUNT</value>
-                      <maximum>10</maximum>
+                      <maximum>6</maximum>
                     </limit>
                   </limits>
                 </rule>


### PR DESCRIPTION
Closes #2584

Previous values for the limits seems to be OK now. Successfully tested with `mvn install -Pjacoco`

Also, _observed while testing_, actual values for the affected limits are as following:

- `LINE.COVEREDRATIO = 0.81`
- `CLASS.MISSEDCOUNT = 5`
- `INSTRUCTION.COVEREDRATIO = 0.81`

@yegor256 
