### PR TITLE
#2714: loggingOfErrors

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -119,6 +119,23 @@ public final class VerifyMojo extends SafeMojo {
         return opt;
     }
 
-
+    /**
+     * Such {@link Optimization} that just logs errors (with any severity) of xmir.
+     * @return Optimization.
+     */
+    private Optimization loggingOfErrors() {
+        return xml -> {
+            for (final XML message: xml.nodes("/program/errors/error")) {
+                Logger.warn(
+                    this,
+                    "%[file]s, line %s: %s",
+                    xml.xpath("/program/@source").get(0),
+                    message.xpath("@line").get(0),
+                    message.xpath("text()").get(0)
+                );
+            }
+            return xml;
+        };
+    }
 
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -106,7 +106,7 @@ public final class VerifyMojo extends SafeMojo {
      */
     private Optimization optimization() {
         Optimization opt = new OptTrain(
-            this.loggingOfErrors(),
+            this::logErrors,
             new TrClasspath<>(
                 new TrDefault<>(),
                 "/org/eolang/parser/fail-on-errors.xsl",
@@ -120,22 +120,21 @@ public final class VerifyMojo extends SafeMojo {
     }
 
     /**
-     * Such {@link Optimization} that just logs errors (with any severity) of xmir.
-     * @return Optimization.
+     * Log errors of xml.
+     * @param xml XMIR.
+     * @return XML.
      */
-    private Optimization loggingOfErrors() {
-        return xml -> {
-            for (final XML message: xml.nodes("/program/errors/error")) {
-                Logger.warn(
-                    this,
-                    "%[file]s, line %s: %s",
-                    xml.xpath("/program/@source").get(0),
-                    message.xpath("@line").get(0),
-                    message.xpath("text()").get(0)
-                );
-            }
-            return xml;
-        };
+    private XML logErrors(final XML xml) {
+        for (final XML message: xml.nodes("/program/errors/error")) {
+            Logger.warn(
+                this,
+                "%[file]s, line %s: %s",
+                xml.xpath("/program/@source").get(0),
+                message.xpath("@line").get(0),
+                message.xpath("text()").get(0)
+            );
+        }
+        return xml;
     }
 
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -125,14 +125,27 @@ public final class VerifyMojo extends SafeMojo {
      * @return XML.
      */
     private XML logErrors(final XML xml) {
-        for (final XML message: xml.nodes("/program/errors/error")) {
-            Logger.warn(
-                this,
+        for (final XML error: xml.nodes("/program/errors/error")) {
+            final String message = Logger.format(
                 "%[file]s, line %s: %s",
                 xml.xpath("/program/@source").get(0),
-                message.xpath("@line").get(0),
-                message.xpath("text()").get(0)
+                error.xpath("@line").get(0),
+                error.xpath("text()").get(0)
             );
+            final String severity = error.xpath("@severity").get(0);
+            switch (severity) {
+                case "warning":
+                    Logger.warn(this, message);
+                    break;
+                case "error":
+                case "critical":
+                    Logger.error(this, message);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                        String.format("Incorrect severity: %s", severity)
+                    );
+            }
         }
         return xml;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -119,23 +119,6 @@ public final class VerifyMojo extends SafeMojo {
         return opt;
     }
 
-    /**
-     * Such {@link Optimization} that just logs errors (with any severity) of xmir.
-     * @return Optimization.
-     */
-    private Optimization loggingOfErrors() {
-        return xml -> {
-            for (final XML message: xml.nodes("/program/errors/error")) {
-                Logger.warn(
-                    this,
-                    "%[file]s, line %s: %s",
-                    xml.xpath("/program/@source").get(0),
-                    message.xpath("@line").get(0),
-                    message.xpath("text()").get(0)
-                );
-            }
-            return xml;
-        };
-    }
+
 
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -114,9 +114,7 @@ public final class VerifyMojo extends SafeMojo {
             ).back()
         );
         if (this.failOnWarning) {
-            opt = new OptTrain(
-                opt, "/org/eolang/parser/fail-on-warnings.xsl"
-            );
+            opt = new OptTrain(opt, "/org/eolang/parser/fail-on-warnings.xsl");
         }
         return opt;
     }


### PR DESCRIPTION
Closes #2714 
Prints warnings in format:
```
[WARNING] eo-runtime/src/test/eo/org/eolang/switch-tests.eo, line 101: Sparse decoration is prohibited
[WARNING] eo-runtime/src/test/eo/org/eolang/int-tests.eo, line 26: Package org.eolang is reserved for internal object only
[WARNING] eo-runtime/src/test/eo/org/eolang/memory-tests.eo, line 26: Package org.eolang is reserved for internal object only
[WARNING] eo-runtime/src/test/eo/org/eolang/try-tests.eo, line 52: Sparse decoration is prohibited
[WARNING] eo-runtime/src/test/eo/org/eolang/heap-tests.eo, line 26: Package org.eolang is reserved for internal object only
[WARNING] eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo, line 25: Package org.eolang is reserved for internal object only
[WARNING] eo-runtime/src/test/eo/org/eolang/cti-test.eo, line 32: This method is deprecated!
```

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a method to log errors of XML in the `VerifyMojo` class.

### Detailed summary:
- Added import statement for `com.jcabi.xml.XML`.
- Added a new method `logErrors` to log errors of XML.
- The `logErrors` method takes an XML parameter and returns XML.
- The `logErrors` method iterates over the XML nodes to log errors.
- The severity of each error is checked and corresponding logging action is taken.
- The `logErrors` method returns the modified XML.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->