### PR TITLE
Remove on pull-request check from Sonar workflow.

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
     paths-ignore: [ 'paper/**', 'sandbox/**' ]

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
-    branches:
-      - master
-    paths-ignore: [ 'paper/**', 'sandbox/**' ]
 concurrency:
   group: sonar-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Related to #2251.
All workarounds to share `secrets` with workflows on pull-request leads to security issues (check [1](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), [2](https://stackoverflow.com/questions/76952023/how-to-make-github-actions-safely-access-secrets-for-prs-created-from-forks)). So the best decision is to remove this action.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `master` branch restriction and paths to ignore in the Sonar workflow, sets concurrency group to `sonar-${{ github.ref }}`, and enables canceling in-progress jobs.

### Detailed summary
- Removed `master` branch restriction
- Removed paths to ignore in Sonar workflow
- Set concurrency group to `sonar-${{ github.ref }}`
- Enabled canceling in-progress jobs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->