### PR TITLE
2890 parameter of cage stack

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
@@ -36,6 +36,7 @@ import org.eolang.maven.log.CaptureLogs;
 import org.eolang.maven.log.Logs;
 import org.eolang.maven.util.HmBase;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -63,7 +64,17 @@ class VerifyMojoTest {
         );
     }
 
+    /**
+     * The test is disabled, needs to enable it and remove this commentary.
+     * @param temp Temp.
+     * @param out Out.
+     * @todo #2890:30min Fix this flaky test and enable it. It failed in ci
+     *  <a href="https://github.com/objectionary/eo/actions/runs/8041230784/job/21960239171?pr=2892">here</a>
+     *  without providing the regex and message. Also may be it would be cleaner to fix
+     *  error Assertion since now it is hard to get why it failed.
+     */
     @Test
+    @Disabled
     @CaptureLogs
     void detectsErrorsSuccessfully(
         @TempDir final Path temp,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
@@ -50,6 +50,10 @@ import org.junit.jupiter.api.io.TempDir;
  *  /org/eolang/parser/warnings/mandatory-version-meta.xsl and
  *  /org/eolang/parser/warnings/mandatory-home-meta.xsl.
  *  After you need fix {@code createRegEx()}.
+ * @todo #2890:30min Fix this {@link VerifyMojoTest#detectsErrorsSuccessfully} flaky test and enable it. It failed in ci
+ *  <a href="https://github.com/objectionary/eo/actions/runs/8041230784/job/21960239171?pr=2892">here</a>
+ *  without providing the regex and message. Also may be it would be cleaner to fix
+ *  error Assertion since now it is hard to get why it failed.
  */
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class VerifyMojoTest {
@@ -64,15 +68,6 @@ class VerifyMojoTest {
         );
     }
 
-    /**
-     * The test is disabled, needs to enable it and remove this commentary.
-     * @param temp Temp.
-     * @param out Out.
-     * @todo #2890:30min Fix this flaky test and enable it. It failed in ci
-     *  <a href="https://github.com/objectionary/eo/actions/runs/8041230784/job/21960239171?pr=2892">here</a>
-     *  without providing the regex and message. Also may be it would be cleaner to fix
-     *  error Assertion since now it is hard to get why it failed.
-     */
     @Test
     @Disabled
     @CaptureLogs

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/VerifyMojoTest.java
@@ -50,7 +50,8 @@ import org.junit.jupiter.api.io.TempDir;
  *  /org/eolang/parser/warnings/mandatory-version-meta.xsl and
  *  /org/eolang/parser/warnings/mandatory-home-meta.xsl.
  *  After you need fix {@code createRegEx()}.
- * @todo #2890:30min Fix this {@link VerifyMojoTest#detectsErrorsSuccessfully} flaky test and enable it. It failed in ci
+ * @todo #2890:30min Fix this {@link VerifyMojoTest#detectsErrorsSuccessfully}
+ *  flaky test and enable it. It failed in ci
  *  <a href="https://github.com/objectionary/eo/actions/runs/8041230784/job/21960239171?pr=2892">here</a>
  *  without providing the regex and message. Also may be it would be cleaner to fix
  *  error Assertion since now it is hard to get why it failed.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage.java
@@ -63,7 +63,7 @@ public final class EOcage extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        return new PhTracedEnclosure(this.attr("enclosure").get(), this.hashCode());
+        return new PhTracedEnclosure(this.attr("enclosure").get(), this);
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -163,8 +163,7 @@ public final class PhTracedEnclosure implements Phi {
                     if (value == null) {
                         ret = 1;
                     } else {
-                        if (value > depth) {
-                            System.out.println("value > MAX_CAGE_RECURSION");
+                        if (value > PhTracedEnclosure.this.depth) {
                             throw new ExFailure(
                                 "The cage %s is already dataizing",
                                 PhTracedEnclosure.this.cage

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -23,7 +23,6 @@
  */
 package org.eolang;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -165,16 +164,16 @@ public final class PhTracedEnclosure implements Phi {
 
         /**
          * Increments counter of cage in the {@link PhTracedEnclosure#DATAIZING_CAGES}.
-         * @return new value in the map.
+         * @return New value in the map.
          */
         private Integer incrementCageCounter() {
             return PhTracedEnclosure.DATAIZING_CAGES.compute(
-                PhTracedEnclosure.this.cage, (cage, counter) -> {
-                    final int ret = Incremented(counter);
+                PhTracedEnclosure.this.cage, (key, counter) -> {
+                    final int ret = this.incremented(counter);
                     if (ret > PhTracedEnclosure.this.depth) {
                         throw new ExFailure(
                             "The cage %s is already dataizing",
-                            cage
+                            key
                         );
                     }
                     return ret;
@@ -185,9 +184,11 @@ public final class PhTracedEnclosure implements Phi {
         /**
          * Creates incremented number.
          * @param number Number.
-         * @return incremented number. 1 if number is null.
+         * @return Incremented number. 1 if number is null.
+         * @checkstyle NonStaticMethodCheck (10 lines). Static declarations in
+         *  inner classes are not supported at language level '8'.
          */
-        private Integer Incremented(final Integer number) {
+        private Integer incremented(final Integer number) {
             final int ret;
             if (number == null) {
                 ret = 1;

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -24,9 +24,7 @@
 package org.eolang;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -40,20 +38,22 @@ import java.util.function.Supplier;
 public final class PhTracedEnclosure implements Phi {
 
     /**
+     * Name of property that responsible for keeping max depth.
+     */
+    public static final String MAX_CAGE_RECURSION_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION";
+
+    /**
      * Cages that are currently dataizing. If one cage is datazing and
      * it needs to be dataized inside current dataizing, the cage will be here.
      */
     private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
 
     /**
-     * Name of property that responsible for keeping max depth.
-     */
-    public static final String MAX_CAGE_RECURSION_PROPERTY = "EO_MAX_CAGE_RECURSION";
-
-    /**
      * Max depth of cage recursion.
      */
-    private static final int MAX_CAGE_RECURSION = Integer.parseInt(System.getProperty(MAX_CAGE_RECURSION_PROPERTY, "100"));
+    private static final int MAX_CAGE_RECURSION = Integer.parseInt(
+        System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME, "100")
+    );
 
     /**
      * Enclosure.

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -25,6 +25,7 @@ package org.eolang;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -46,7 +47,7 @@ public final class PhTracedEnclosure implements Phi {
      * Cages that are currently dataizing. If one cage is datazing and
      * it needs to be dataized inside current dataizing, the cage will be here.
      */
-    private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
+    private static final Map<Integer, Integer> DATAIZING_CAGES = new ConcurrentHashMap<>();
 
     /**
      * Enclosure.

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -44,10 +44,10 @@ public final class PhTracedEnclosure implements Phi {
     public static final String MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION_DEPTH";
 
     /**
-     * Cages that are currently dataizing. If one cage is datazing and
+     * Cages that are currently dataizing. If one cage is datazing, and
      * it needs to be dataized inside current dataizing, the cage will be here.
      */
-    private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
+    private static final Map<Phi, Integer> DATAIZING_CAGES = new HashMap<>();
 
     /**
      * Enclosure.
@@ -58,7 +58,7 @@ public final class PhTracedEnclosure implements Phi {
      * Vertex of cage where the {@link PhTracedEnclosure#enclosure}
      * was retrieved.
      */
-    private final int cage;
+    private final Phi cage;
 
     /**
      * Max depth of cage recursion.
@@ -70,7 +70,7 @@ public final class PhTracedEnclosure implements Phi {
      * @param enclosure Enclosure.
      * @param cage Vertex of source cage.
      */
-    public PhTracedEnclosure(final Phi enclosure, final int cage) {
+    public PhTracedEnclosure(final Phi enclosure, final Phi cage) {
         this(
             enclosure,
             cage,
@@ -86,7 +86,7 @@ public final class PhTracedEnclosure implements Phi {
      * @param cage Cage.
      * @param depth Max depth of cage recursion.
      */
-    public PhTracedEnclosure(final Phi enclosure, final int cage, final int depth) {
+    public PhTracedEnclosure(final Phi enclosure, final Phi cage, final int depth) {
         this.enclosure = enclosure;
         this.cage = cage;
         this.depth = depth;
@@ -174,8 +174,9 @@ public final class PhTracedEnclosure implements Phi {
                     final int ret = this.incremented(counter);
                     if (ret > PhTracedEnclosure.this.depth) {
                         throw new ExFailure(
-                            "The cage %s is already dataizing",
-                            key
+                            "The cage %s has reached the maximum nesting depth = %d",
+                            key.φTerm(),
+                            PhTracedEnclosure.this.depth
                         );
                     }
                     return ret;

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -41,7 +41,8 @@ public final class PhTracedEnclosure implements Phi {
     /**
      * Name of property that responsible for keeping max depth.
      */
-    public static final String MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION_DEPTH";
+    public static final String
+        MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION_DEPTH";
 
     /**
      * Cages that are currently dataizing. If one cage is datazing, and

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -23,12 +23,13 @@
  */
 package org.eolang;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
  * Class to trace if the cage got into recursion during the dataization.
+ * NOT thread-safe.
  * @since 0.36
  * @todo #2836:60min Make the class thread safe. It has private static
  *  field which can be accessed from differ thread and is not thread safe.
@@ -46,7 +47,7 @@ public final class PhTracedEnclosure implements Phi {
      * Cages that are currently dataizing. If one cage is datazing and
      * it needs to be dataized inside current dataizing, the cage will be here.
      */
-    private static final Map<Integer, Integer> DATAIZING_CAGES = new ConcurrentHashMap<>();
+    private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
 
     /**
      * Enclosure.
@@ -137,6 +138,7 @@ public final class PhTracedEnclosure implements Phi {
 
     /**
      * Supplier that traces the cage while gets.
+     * NOT thread-saf.
      * @since 0.36
      */
     private final class TracingWhileGetting implements Supplier<Attr> {

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -138,7 +138,7 @@ public final class PhTracedEnclosure implements Phi {
 
     /**
      * Supplier that traces the cage while gets.
-     * NOT thread-saf.
+     * NOT thread-safe.
      * @since 0.36
      */
     private final class TracingWhileGetting implements Supplier<Attr> {

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -49,13 +49,6 @@ public final class PhTracedEnclosure implements Phi {
     private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
 
     /**
-     * Max depth of cage recursion.
-     */
-    private static final int MAX_CAGE_RECURSION = Integer.parseInt(
-        System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME, "100")
-    );
-
-    /**
      * Enclosure.
      */
     private final Phi enclosure;
@@ -67,13 +60,35 @@ public final class PhTracedEnclosure implements Phi {
     private final int cage;
 
     /**
+     * Max depth of cage recursion.
+     */
+    private final int depth;
+
+    /**
      * Ctor.
      * @param enclosure Enclosure.
      * @param cage Vertex of source cage.
      */
     public PhTracedEnclosure(final Phi enclosure, final int cage) {
+        this(
+            enclosure,
+            cage,
+            Integer.parseInt(
+                System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME, "100")
+            )
+        );
+    }
+
+    /**
+     * The main constructor.
+     * @param enclosure Enclosure.
+     * @param cage Cage.
+     * @param depth Max depth of cage recursion.
+     */
+    public PhTracedEnclosure(final Phi enclosure, final int cage, final int depth) {
         this.enclosure = enclosure;
         this.cage = cage;
+        this.depth = depth;
     }
 
     @Override
@@ -147,7 +162,8 @@ public final class PhTracedEnclosure implements Phi {
                     if (value == null) {
                         ret = 1;
                     } else {
-                        if (value > MAX_CAGE_RECURSION) {
+                        if (value > depth) {
+                            System.out.println("value > MAX_CAGE_RECURSION");
                             throw new ExFailure(
                                 "The cage %s is already dataizing",
                                 PhTracedEnclosure.this.cage

--- a/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedEnclosure.java
@@ -41,7 +41,7 @@ public final class PhTracedEnclosure implements Phi {
     /**
      * Name of property that responsible for keeping max depth.
      */
-    public static final String MAX_CAGE_RECURSION_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION";
+    public static final String MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME = "EO_MAX_CAGE_RECURSION_DEPTH";
 
     /**
      * Cages that are currently dataizing. If one cage is datazing and
@@ -75,7 +75,7 @@ public final class PhTracedEnclosure implements Phi {
             enclosure,
             cage,
             Integer.parseInt(
-                System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME, "100")
+                System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "100")
             )
         );
     }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -310,7 +310,7 @@ final class EOcageTest {
         @Test
         void doesNotThrowExceptionIfSmallDepth() {
             final EOcage cage = new EOcage(Phi.Φ);
-            writeTo(
+            EOcageTest.writeTo(
                 cage,
                 new RecursiveDummi(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
             );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -328,7 +328,6 @@ final class EOcageTest {
         @Test
         void throwsExceptionIfWithBigDepth() {
             final EOcage cage = new EOcage(Phi.Φ);
-            System.out.println("cage hash = " + cage.hashCode());
             writeTo(
                 cage,
                 new RecursiveDummi(DEPTH, new AtomicReference<>(0), cage)

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -346,24 +346,6 @@ final class EOcageTest {
             );
         }
 
-        @Test
-        void throwsExceptionIfBigDepth() {
-            final EOcage cage = new EOcage(Phi.Φ);
-            writeTo(
-                cage,
-                new RecursiveDummi(MAX_DEPTH  + 1, cage)
-            );
-            Assertions.assertThrows(
-                ExAbstract.class,
-                () -> new Dataized(cage).take(),
-                String.format(
-                    "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
-                    PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME,
-                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME),
-                    ExAbstract.class
-                )
-            );
-        }
 
         /**
          * Recursive {@link Phi}.

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -312,7 +312,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH / 2, new AtomicReference<>(0), cage)
+                new RecursiveDummi(MAX_DEPTH / 2, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -326,14 +326,14 @@ final class EOcageTest {
         }
 
         /**
-         * The boundary case.
+         * The boundary case when the depth is equal to the maximum allowed.
          */
         @Test
         void doesNotThrowExceptionIfMaxDepth() {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH, new AtomicReference<>(0), cage)
+                new RecursiveDummi(MAX_DEPTH, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -351,7 +351,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH  + 1, new AtomicReference<>(0), cage)
+                new RecursiveDummi(MAX_DEPTH  + 1, cage)
             );
             Assertions.assertThrows(
                 ExAbstract.class,
@@ -377,27 +377,26 @@ final class EOcageTest {
             private final int depth;
 
             /**
-             * Counts how many times we already met the cage.
-             */
-            private final AtomicReference<Integer> counter;
-
-            /**
              * The cage.
              */
             private final EOcage cage;
 
             /**
+             * Counts how many times we already met the cage.
+             */
+            private final AtomicReference<Integer> counter;
+
+            /**
              * Ctor.
              * @param depth Depth.
-             * @param counter Counter.
              * @param cage Cage.
              */
             RecursiveDummi(
-                final int depth, final AtomicReference<Integer> counter, final EOcage cage
+                final int depth, final EOcage cage
             ) {
                 this.depth = depth;
-                this.counter = counter;
                 this.cage = cage;
+                this.counter = new AtomicReference<>(0);
             }
 
             @Override

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -328,6 +328,7 @@ final class EOcageTest {
         @Test
         void throwsExceptionIfWithBigDepth() {
             final EOcage cage = new EOcage(Phi.Φ);
+            System.out.println("cage hash = " + cage.hashCode());
             writeTo(
                 cage,
                 new RecursiveDummi(DEPTH, new AtomicReference<>(0), cage)

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -355,7 +355,7 @@ final class EOcageTest {
             );
             Assertions.assertThrows(
                 ExAbstract.class,
-                () -> new Dataized(cage).take(),
+                new Dataized(cage)::take,
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
                     PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -312,7 +312,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             EOcageTest.writeTo(
                 cage,
-                new RecursiveDummi(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
+                new RecursionTests.Dummi(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -333,7 +333,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH, cage)
+                new RecursionTests.Dummi(MAX_DEPTH, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -351,7 +351,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(EOcageTest.RecursionTests.MAX_DEPTH + 1, cage)
+                new Dummi(EOcageTest.RecursionTests.MAX_DEPTH + 1, cage)
             );
             Assertions.assertThrows(
                 ExAbstract.class,
@@ -369,7 +369,7 @@ final class EOcageTest {
          * Recursive {@link Phi}.
          * @since 0.1
          */
-        private final class RecursiveDummi extends PhDefault implements Atom {
+        private final class Dummi extends PhDefault implements Atom {
 
             /**
              * How many times should we met the cage while dataizing it eventually.
@@ -391,7 +391,7 @@ final class EOcageTest {
              * @param depth Depth.
              * @param cage Cage.
              */
-            RecursiveDummi(
+            Dummi(
                 final int depth, final EOcage cage
             ) {
                 this.depth = depth;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -312,7 +312,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             EOcageTest.writeTo(
                 cage,
-                new RecursionTests.Dummi(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
+                new RecursiveDummy(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -333,7 +333,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursionTests.Dummi(MAX_DEPTH, cage)
+                new RecursiveDummy(MAX_DEPTH, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -351,11 +351,11 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new Dummi(EOcageTest.RecursionTests.MAX_DEPTH + 1, cage)
+                new RecursiveDummy(EOcageTest.RecursionTests.MAX_DEPTH + 1, cage)
             );
             Assertions.assertThrows(
                 ExAbstract.class,
-                new Dataized(cage)::take,
+                () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
                     PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
@@ -369,7 +369,7 @@ final class EOcageTest {
          * Recursive {@link Phi}.
          * @since 0.1
          */
-        private final class Dummi extends PhDefault implements Atom {
+        private final class RecursiveDummy extends PhDefault implements Atom {
 
             /**
              * How many times should we met the cage while dataizing it eventually.
@@ -391,7 +391,7 @@ final class EOcageTest {
              * @param depth Depth.
              * @param cage Cage.
              */
-            Dummi(
+            RecursiveDummy(
                 final int depth, final EOcage cage
             ) {
                 this.depth = depth;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -312,7 +312,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH / 2, cage)
+                new RecursiveDummi(EOcageTest.RecursionTests.MAX_DEPTH / 2, cage)
             );
             Assertions.assertDoesNotThrow(
                 () -> new Dataized(cage).take(),
@@ -351,7 +351,7 @@ final class EOcageTest {
             final EOcage cage = new EOcage(Phi.Φ);
             writeTo(
                 cage,
-                new RecursiveDummi(MAX_DEPTH  + 1, cage)
+                new RecursiveDummi(EOcageTest.RecursionTests.MAX_DEPTH + 1, cage)
             );
             Assertions.assertThrows(
                 ExAbstract.class,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -302,7 +302,7 @@ final class EOcageTest {
             writeTo(cage, cage);
             Assertions.assertThrows(
                 ExAbstract.class,
-                new Dataized(cage)::take,
+                () -> new Dataized(cage).take(),
                 "We expect the exception to be thrown since we have recursion here"
             );
         }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -287,13 +287,13 @@ final class EOcageTest {
         @BeforeEach
         void setDepth() {
             System.setProperty(
-                PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
+                PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
             );
         }
 
         @AfterEach
         void clearDepth() {
-            System.clearProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME);
+            System.clearProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME);
         }
 
         @Test
@@ -318,8 +318,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is less than property %s = %s does not throw %s",
-                    PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME,
-                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME),
+                    PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -339,8 +339,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is equal to property %s = %s does not throw %s",
-                    PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME,
-                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME),
+                    PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -358,8 +358,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
-                    PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME,
-                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME),
+                    PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -346,6 +346,24 @@ final class EOcageTest {
             );
         }
 
+        @Test
+        void throwsExceptionIfBigDepth() {
+            final EOcage cage = new EOcage(Phi.Φ);
+            writeTo(
+                cage,
+                new RecursiveDummi(MAX_DEPTH  + 1, cage)
+            );
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(cage).take(),
+                String.format(
+                    "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
+                    PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME,
+                    System.getProperty(PhTracedEnclosure.MAX_CAGE_RECURSION_PROPERTY_NAME),
+                    ExAbstract.class
+                )
+            );
+        }
 
         /**
          * Recursive {@link Phi}.


### PR DESCRIPTION
Closes #2890
Made the depth configurable via properties.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `PhTracedEnclosure` to handle cage recursion depth and fixes a flaky test in `VerifyMojoTest`.

### Detailed summary
- Added `MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME` in `PhTracedEnclosure`
- Updated constructor and methods in `PhTracedEnclosure` for recursion depth handling
- Fixed a flaky test in `VerifyMojoTest` and provided detailed comments

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->