### PR TITLE
check licenses automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,23 @@ SOFTWARE.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.4.0</version>
+        <executions>
+          <execution>
+            <id>check-licenses</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check-file-header</goal>
+            </goals>
+            <configuration>
+              <licenseName>mit</licenseName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>groovy-maven-plugin</artifactId>
         <version>2.1.1</version>


### PR DESCRIPTION
With this plugin: https://www.mojohaus.org/license-maven-plugin/check-file-header-mojo.html

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `license-maven-plugin` to enforce MIT license headers in files during the `verify` phase.

### Detailed summary
- Added `license-maven-plugin` to enforce MIT license headers during `verify` phase in the build process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->