### PR TITLE
#2716: tuple optimization

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -60,8 +60,8 @@
       ^.at-without-checks index
 
   # Takes element from the tuple without checking i.
-  # i must be less than len and greater or equal 0.
-  # This is faster than ^.at.
+  # i must be less than length and greater or equal 0.
+  # This is faster than at.
   [i] > at-without-checks
     i > idx!
     if. > @

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -59,15 +59,15 @@
       error "Given index is out of tuple bounds"
       ^.at-without-checks index
 
-  # Takes element from the tuple without checking i.
-  # i must be less than length and greater or equal 0.
-  # This is faster than at.
-  [i] > at-without-checks
-    i > idx!
-    if. > @
-      idx.lt head.length
-      ^.head.at-without-checks idx
-      ^.tail
+    # Takes element from the tuple without checking i.
+    # i must be less than length and greater or equal 0.
+    # This is faster than at.
+    [i] > at-without-checks
+      i > idx!
+      if. > @
+        idx.lt head.length
+        ^.^.head.at.at-without-checks idx
+        ^.^.tail
 
   # Create a new tuple with this element added to the end of it.
   [x] > with

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -65,8 +65,8 @@
   [i] > at-without-checks
     i > idx!
     if. > @
-      i.lt head.length
-      ^.head.at-without-checks i
+      idx.lt head.length
+      ^.head.at-without-checks idx
       ^.tail
 
   # Create a new tuple with this element added to the end of it.

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -57,7 +57,7 @@
         index.lt 0
         index.gte len
       error "Given index is out of tuple bounds"
-      ^.at.at-without-checks index
+      at-without-checks index
 
     # Takes element from the tuple without checking i.
     # i must be less than length and greater or equal 0.

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -57,10 +57,17 @@
         index.lt 0
         index.gte len
       error "Given index is out of tuple bounds"
-      if.
-        index.lt (len.plus -1)
-        ^.head.at index
-        ^.tail
+      ^.at-without-checks index
+
+  # Takes element from the tuple without checking i.
+  # i must be less than len and greater or equal 0.
+  # This is faster than ^.at.
+  [i] > at-without-checks
+    i > idx!
+    if. > @
+      i.lt head.length
+      ^.head.at-without-checks i
+      ^.tail
 
   # Create a new tuple with this element added to the end of it.
   [x] > with

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -59,8 +59,8 @@
       error "Given index is out of tuple bounds"
       at-without-checks index
 
-    # Takes element from the tuple without checking i.
-    # i must be less than length and greater or equal 0.
+    # Takes element from the tuple without index validation.
+    # Here i must be an object that can be comparable with int using lt attribute.
     [i] > at-without-checks
       i > idx!
       if. > @

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -60,7 +60,7 @@
       at-without-checks index
 
     # Takes element from the tuple without index validation.
-    # Here i must be an object that can be comparable with int using lt attribute.
+    # Here "i" must be an object that can be comparable with "int" using "lt" attribute.
     [i] > at-without-checks
       i > idx!
       if. > @

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -61,7 +61,6 @@
 
     # Takes element from the tuple without checking i.
     # i must be less than length and greater or equal 0.
-    # This is faster than at.
     [i] > at-without-checks
       i > idx!
       if. > @

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -60,7 +60,7 @@
       at-without-checks index
 
     # Takes element from the tuple without index validation.
-    # Here "i" must be an object that can be comparable with "int" using "lt" attribute.
+    # Here `i` must be an object that can be comparable with `int` using `lt` attribute.
     [i] > at-without-checks
       i > idx!
       if. > @

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -57,7 +57,7 @@
         index.lt 0
         index.gte len
       error "Given index is out of tuple bounds"
-      ^.at-without-checks index
+      ^.at.at-without-checks index
 
     # Takes element from the tuple without checking i.
     # i must be less than length and greater or equal 0.

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -172,6 +172,22 @@
     a.at 0
     3
 
+# Test
+[] > at-without-checks-with-first-element
+  eq. > @
+    at.
+      * 100 101 102
+      0
+    100
+
+# Test
+[] > at-without-checks-with-last-element
+  eq. > @
+    at.
+      * 100 101 102
+      2
+    102
+
 # Test.
 [] > tuple-empty-fluent-with-indented-keyword
   tuple

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -175,16 +175,18 @@
 # Test
 [] > at-without-checks-with-first-element
   eq. > @
-    at.
-      * 100 101 102
+    at-without-checks.
+      at.
+        * 100 101 102
       0
     100
 
 # Test
 [] > at-without-checks-with-last-element
   eq. > @
-    at.
-      * 100 101 102
+    at-without-checks.
+      at.
+        * 100 101 102
       2
     102
 


### PR DESCRIPTION
Relates to #2716
This pr makes `tuple.at` faster. Testing time decreased by 2 times on my laptop.
Such test became more than 10 times faster:
```
#Test
[] > just-long-test
  seq > @
    *
      TRUE
      TRUE
      TRUE
      TRUE
      TRUE
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new tests and a method `at-without-checks` to the `tuple` object in the `eo-runtime`. 

### Detailed summary
- Added tests for `at-without-checks` method with first and last element
- Added `at-without-checks` method to `tuple` object for retrieving elements without index validation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->