### PR TITLE
Configure Java version for Sonar to avoid incorrect issues

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -35,4 +35,4 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn --batch-mode install -Dinvoker.skip org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pjacoco -Dsonar.qualitygate.wait=true
+        run: mvn --batch-mode install -Dinvoker.skip org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pjacoco -Dsonar.java.source=1.8 -Dsonar.qualitygate.wait=true


### PR DESCRIPTION
Closes #2899 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the SonarQube configuration to specify Java source version 1.8 for better analysis accuracy.

### Detailed summary
- Updated SonarQube scan to use Java source version 1.8 for analysis accuracy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->