### PR TITLE
chore: update jtcop version 1.2.0

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ContainsFiles.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ContainsFiles.java
@@ -35,7 +35,11 @@ import org.hamcrest.TypeSafeMatcher;
  * Asserting that path contains a files matching provided globs.
  * @since 0.31.0
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
+})
 final class ContainsFiles extends TypeSafeMatcher<Path> {
     /**
      * Patterns.

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOfailed.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOfailed.java
@@ -34,6 +34,10 @@ import org.eolang.PhDefault;
  *
  * @since 0.29
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
+})
 final class EOfailed extends PhDefault {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <configuration>
               <ignoreGeneratedTests>true</ignoreGeneratedTests>
               <exclusions>


### PR DESCRIPTION
Update `jtcop-maven-plugin` to `1.2.0` version.
Fix of this PR: https://github.com/objectionary/eo/pull/2885

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `jtcop-maven-plugin` version to `1.2.0` and adds a new suppression rule `JTCOP.RuleInheritanceInTests` to classes `EOfailed` and `ContainsFiles`.

### Detailed summary
- Updated `jtcop-maven-plugin` version to `1.2.0`
- Added `JTCOP.RuleInheritanceInTests` suppression rule to `EOfailed` class
- Added `JTCOP.RuleInheritanceInTests` suppression rule to `ContainsFiles` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->