### PR TITLE
fix(#2909): unphi with metas via parameters

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -37,7 +36,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.experimental.Threads;
 import org.cactoos.iterable.IterableEnvelope;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
@@ -48,10 +46,8 @@ import org.eolang.maven.util.HmBase;
 import org.eolang.maven.util.Home;
 import org.eolang.maven.util.Walk;
 import org.eolang.parser.PhiSyntax;
-import org.eolang.parser.XeEoListener;
 import org.xembly.Directive;
 import org.xembly.Directives;
-import org.xembly.Xembler;
 
 /**
  * Read PHI files and parse them to the XMIR.
@@ -89,6 +85,7 @@ public final class UnphiMojo extends SafeMojo {
      * Extra metas to add to unphied XMIR.
      * @checkstyle MemberNameCheck (10 lines)
      */
+    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.unphiMetas")
     private Set<String> unphiMetas = new SetOf<>();
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -151,7 +151,7 @@ public final class UnphiMojo extends SafeMojo {
         /**
          * Package meta.
          */
-        private static final String PACKAGE = "+package";
+        private static final String PACKAGE = "package";
 
         /**
          * Ctor.
@@ -166,11 +166,12 @@ public final class UnphiMojo extends SafeMojo {
                             final String head = pair[0].substring(1);
                             if (head.equals(UnphiMojo.Metas.PACKAGE)) {
                                 throw new IllegalStateException(
-                                    "+package meta can't be attached to unphied XMIR"
+                                    "+package meta is prohibited for attaching to unphied XMIR"
                                 );
                             }
                             final Directives dirs = new Directives()
                                 .xpath("/program/metas")
+                                .add("meta")
                                 .add("head").set(head).up()
                                 .add("tail");
                             if (pair.length > 1) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -96,7 +96,10 @@ class UnphiMojoTest {
             "Unphied XMIR must contain metas, added via \"unphiMetas\" parameter",
             new XMLDocument(
                 new FakeMaven(temp)
-                    .with("unphiMetas", new SetOf<>("+tests", "+home https://github.com/objectionary/eo"))
+                    .with(
+                        "unphiMetas",
+                        new SetOf<>("+tests", "+home https://github.com/objectionary/eo")
+                    )
                     .execute(UnphiMojo.class)
                     .result()
                     .get(String.format("target/%s/std.xmir", ParseMojo.DIR))
@@ -107,7 +110,7 @@ class UnphiMojoTest {
             )
         );
     }
-    
+
     @Test
     void failsIfPackageMetaIsAdded(@TempDir final Path temp) throws IOException {
         new HmBase(temp).save(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnphiMojoTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.maven.util.HmBase;
@@ -82,6 +83,43 @@ class UnphiMojoTest {
             () -> new FakeMaven(temp)
                 .execute(UnphiMojo.class),
             "UnphiMojo execution should fail because of parsing errors"
+        );
+    }
+
+    @Test
+    void addsMetas(@TempDir final Path temp) throws IOException {
+        new HmBase(temp).save(
+            "{⟦std ↦ Φ.org.eolang.io.stdout⟧}",
+            Paths.get("target/phi/std.phi")
+        );
+        MatcherAssert.assertThat(
+            "Unphied XMIR must contain metas, added via \"unphiMetas\" parameter",
+            new XMLDocument(
+                new FakeMaven(temp)
+                    .with("unphiMetas", new SetOf<>("+tests", "+home https://github.com/objectionary/eo"))
+                    .execute(UnphiMojo.class)
+                    .result()
+                    .get(String.format("target/%s/std.xmir", ParseMojo.DIR))
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/program/metas/meta[head/text()='tests' and not(tail/text())]",
+                "/program/metas/meta[head/text()='home' and tail/text()='https://github.com/objectionary/eo']"
+            )
+        );
+    }
+    
+    @Test
+    void failsIfPackageMetaIsAdded(@TempDir final Path temp) throws IOException {
+        new HmBase(temp).save(
+            "{⟦std ↦ Φ.org.eolang.io.stdout⟧}",
+            Paths.get("target/phi/std.phi")
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .with("unphiMetas", new SetOf<>("+package org.eolang"))
+                .execute(UnphiMojo.class),
+            "UnphiMojo execution should fail if \"+package\" meta is added"
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/PhiSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/PhiSyntax.java
@@ -32,6 +32,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.cactoos.Text;
 import org.cactoos.io.InputStreamOf;
+import org.xembly.Directive;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -51,21 +52,32 @@ public final class PhiSyntax implements Syntax {
     private final Text input;
 
     /**
+     * Extra directives to append to parsed phi.
+     */
+    private final Iterable<Directive> extra;
+
+    /**
      * Ctor for the tests.
      * @param input Input
      */
     PhiSyntax(final String input) {
-        this("test", () -> input);
+        this("test", () -> input, new Directives());
     }
 
     /**
      * Ctor.
      * @param nme Name of the program
      * @param inpt Input
+     * @param extra Extra directives to append
      */
-    public PhiSyntax(final String nme, final Text inpt) {
+    public PhiSyntax(
+        final String nme,
+        final Text inpt,
+        final Iterable<Directive> extra
+    ) {
         this.name = nme;
         this.input = inpt;
+        this.extra = extra;
     }
 
     @Override
@@ -86,7 +98,7 @@ public final class PhiSyntax implements Syntax {
         new ParseTreeWalker().walk(xel, parser.program());
         final XML dom = new XMLDocument(
             new Xembler(
-                new Directives(xel).append(spy)
+                new Directives(xel).append(spy).append(extra)
             ).domQuietly()
         );
         new Schema(dom).check();

--- a/eo-parser/src/main/java/org/eolang/parser/PhiSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/PhiSyntax.java
@@ -98,7 +98,7 @@ public final class PhiSyntax implements Syntax {
         new ParseTreeWalker().walk(xel, parser.program());
         final XML dom = new XMLDocument(
             new Xembler(
-                new Directives(xel).append(spy).append(extra)
+                new Directives(xel).append(spy).append(this.extra)
             ).domQuietly()
         );
         new Schema(dom).check();

--- a/eo-parser/src/test/java/org/eolang/parser/PhiSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/PhiSyntaxTest.java
@@ -27,6 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
 
 /**
  * Test cases for {@link PhiSyntax}.
@@ -43,6 +44,21 @@ class PhiSyntaxTest {
             ).parsed(),
             XhtmlMatchers.hasXPath(
                 "//errors[count(error)>0]"
+            )
+        );
+    }
+
+    @Test
+    void addsExtra() throws IOException {
+        MatcherAssert.assertThat(
+            "Result XML must contain extra object",
+            new PhiSyntax(
+                "test",
+                () -> "{⟦obj ↦ ⟦⟧⟧}",
+                new Directives().xpath("/program/objects").add("o").attr("base", "x")
+            ).parsed(),
+            XhtmlMatchers.hasXPath(
+                "//objects/o[@base='x']"
             )
         );
     }


### PR DESCRIPTION
Closes: #2909 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `UnphiMojo` functionality by allowing the addition of extra metas to unphied XMIR.

### Detailed summary
- Added support for appending extra directives to parsed phi in `PhiSyntax`.
- Implemented the ability to add extra metas to unphied XMIR in `UnphiMojo`.
- Prohibited adding "+package" meta to the unphied XMIR.
- Introduced a new class `Metas` to accumulate metas for the unphied XMIR.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->