### PR TITLE
2716 too long unit tests

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -286,7 +286,6 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludedGroups>slow</excludedGroups>
           <argLine>@{argLine} -Xss${stack-size}</argLine>
           <systemPropertyVariables>
             <runtime.path>${project.basedir}/../eo-runtime</runtime.path>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -490,13 +490,6 @@ SOFTWARE.
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludedGroups>nothing-to-exclude</excludedGroups>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
           </plugin>

--- a/eo-runtime/src/test/java/org/eolang/SnippetTestCase.java
+++ b/eo-runtime/src/test/java/org/eolang/SnippetTestCase.java
@@ -40,6 +40,7 @@ import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -80,6 +81,7 @@ final class SnippetTestCase {
      * @throws IOException If fails
      */
     @ParameterizedTest
+    @Tag("slow")
     @ExtendWith(WeAreOnline.class)
     @SuppressWarnings("unchecked")
     @ClasspathSource(value = "org/eolang/snippets/", glob = "**.yaml")

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,14 @@ SOFTWARE.
             </configuration>
           </plugin>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!--In order to include slow tests too-->
+              <excludedGroups>nothing-to-exclude</excludedGroups>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
             <version>1.2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,7 @@ SOFTWARE.
             <systemPropertyVariables>
               <basedir>${project.basedir}</basedir>
             </systemPropertyVariables>
+            <excludedGroups>slow</excludedGroups>
             <properties>
               <configurationParameters>
                 junit.jupiter.execution.parallel.enabled = true


### PR DESCRIPTION
Closes #2716 
Now `SnippetCase` is the bottleneck in fast passing of tests in `eo-runtime`:
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.362 s -- in EOorg.EOeolang.EOcalculates_only_once_BROKENTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.775 s -- in EOorg.EOeolang.EOswitch_strings_caseTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.096 s -- in EOorg.EOeolang.EOswitch_with_all_false_casesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.113 s -- in EOorg.EOeolang.EOswitch_with_several_true_casesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.07 s -- in EOorg.EOeolang.EOswitch_complex_caseTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 120.2 s -- in org.eolang.SnippetTestCase
```
We already tag such tests "slow" in `eo-maven-plugin`, see https://github.com/objectionary/eo/blob/master/eo-maven-plugin/src/test/java/org/eolang/maven/BinarizeMojoTest.java#L60. So I think we can do the same here. Then `SnippetTestCase` tests will be passed with `qulice` profile only. 
BTW these tests cases are performed sequentially and cannot parallelized.

