### PR TITLE
fix(#2938): improved logging in PhiMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -108,6 +108,12 @@ public final class PhiMojo extends SafeMojo {
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
                     xmir -> () -> {
+                        final Path processed = this.phiInputDir.toPath().relativize(xmir);
+                        Logger.info(
+                            this,
+                            "Processing XMIR: %[file]s (%[size]s)",
+                            processed, xmir.toFile().length()
+                        );
                         final XML xml = new XMLDocument(
                             new TextOf(xmir).asString()
                         );
@@ -121,8 +127,11 @@ public final class PhiMojo extends SafeMojo {
                         home.save(PhiMojo.translated(train, xml), relative);
                         Logger.info(
                             this,
-                            "Translated to phi: %s -> %s",
-                            xmir, this.phiOutputDir.toPath().resolve(relative)
+                            "Translated to phi: %[file]s (%[size]s) -> %[file]s (%[size]s)",
+                            processed,
+                            xmir.toFile().length(),
+                            relative,
+                            this.phiOutputDir.toPath().resolve(relative).toFile().length()
                         );
                         return 1;
                     },


### PR DESCRIPTION
It's unclear which file fails in #2938, so logging is improved

Ref: #2938

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances logging in the `PhiMojo` class of the `eo-maven-plugin`, providing detailed information about processing and translation of files.

### Detailed summary
- Added logging for processing XMIR files with size
- Improved logging for translation to phi with file sizes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->