### PR TITLE
Add XSL check for the case of using +rt meta without atoms

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/errors/rt-without-atom.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/rt-without-atom.xsl
@@ -22,27 +22,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="signed-binding-indexes" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="rt-without-atom" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="//o[@as and matches(@as, '^(-|\+)\d+$')]">
-        <xsl:element name="error">
-          <xsl:attribute name="check">
-            <xsl:text>signed-binding-indexes</xsl:text>
-          </xsl:attribute>
-          <xsl:attribute name="line">
-            <xsl:value-of select="@line"/>
-          </xsl:attribute>
-          <xsl:attribute name="severity">
-            <xsl:text>error</xsl:text>
-          </xsl:attribute>
-          <xsl:text>Binding index of application must not be a signed number "</xsl:text>
-          <xsl:value-of select="tail/text()"/>
-          <xsl:text>"</xsl:text>
-        </xsl:element>
-      </xsl:for-each>
+      <xsl:if test="/program/metas/meta[head='rt']">
+        <xsl:if test="not(//o[@atom])">
+          <xsl:element name="error">
+            <xsl:attribute name="check">
+              <xsl:text>rt-without-atoms</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="line">
+              <xsl:value-of select="@line"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>error</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Using +rt meta without atoms</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:if>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="node()|@*">

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/rt-without-atom.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/rt-without-atom.xsl
@@ -22,6 +22,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
+<!--
+  @todo #2921:30m Add check if there are atoms, but no +rt meta. It should be illegal.
+    Don't forget to remove the puzzle.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="rt-without-atom" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors">

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-rt-without-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-rt-without-atoms.yaml
@@ -1,0 +1,14 @@
+xsls:
+  - /org/eolang/parser/errors/rt-without-atom.xsl
+tests:
+  - /program/errors[count(error[@severity='error'])=1]
+eo: |
+  +architect yegor256@gmail.com
+  +home https://github.com/objectionary/eo
+  +package org.eolang
+  +rt jvm org.eolang:eo-runtime:0.0.0
+  +version 0.0.0
+
+  # Boolean.
+  [attr] > obj
+    attr > @


### PR DESCRIPTION
Closes #2921

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates error handling in the EO parser. It introduces a new XSL file for checking signed binding indexes and refactors the existing XSL file for checking RT without atoms.

### Detailed summary
- Added `signed-binding-indexes.xsl` for error checking
- Updated `rt-without-atom.xsl` for improved error handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->