### PR TITLE
fix(#2952): fixed translation XMIR to EO with child abstract

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/same-name-inner.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/same-name-inner.yaml
@@ -1,0 +1,35 @@
+eo: |
+  # Test.
+  [] > compiles-correctly-with-long-duplicate-names
+    # Long object 1.
+    [] > long-object-name
+      # Long object 2.
+      [] > long-object-name
+        # Long object 3.
+        [] > long-object-name
+          # Long object 4.
+          [] > long-object-name
+            # Long object 5.
+            [] > long-object-name
+    TRUE > @
+phi: |
+  {
+    ⟦
+      compiles-correctly-with-long-duplicate-names ↦ ⟦
+        long-object-name ↦ ⟦
+          long-object-name ↦ ⟦
+            long-object-name ↦ ⟦
+              long-object-name ↦ ⟦
+                long-object-name ↦ ⟦⟧
+              ⟧
+            ⟧
+          ⟧
+        ⟧,
+        φ ↦ Φ.org.eolang.bool(
+          α0 ↦ Φ.org.eolang.bytes(
+            Δ ⤍ 01-
+          )
+        )
+      ⟧
+    ⟧
+  }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/long-names-inner.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/long-names-inner.yaml
@@ -1,0 +1,23 @@
+tests:
+  - //o[@abstract and @name='long-object-name' and o[@abstract and @name='long-object-name' and o[@abstract and @name='long-object-name' and o[@abstract and @name='long-object-name' and o[@abstract and @name='long-object-name']]]]]
+phi: |
+  {
+    ⟦
+      compiles-correctly-with-long-duplicate-names ↦ ⟦
+        long-object-name ↦ ⟦
+          long-object-name ↦ ⟦
+            long-object-name ↦ ⟦
+              long-object-name ↦ ⟦
+                long-object-name ↦ ⟦⟧
+              ⟧
+            ⟧
+          ⟧
+        ⟧,
+        φ ↦ Φ.org.eolang.bool(
+          α0 ↦ Φ.org.eolang.bytes(
+            Δ ⤍ 01-
+          )
+        )
+      ⟧
+    ⟧
+  }

--- a/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
@@ -29,7 +29,7 @@ SOFTWARE.
   </xsl:function>
   <xsl:function name="eo:attr" as="xs:boolean">
     <xsl:param name="o" as="element()"/>
-    <xsl:sequence select="$o/parent::o[not(@base)] and not($o/@base) and not($o/@atom) and not($o/o)"/>
+    <xsl:sequence select="$o/parent::o[not(@base)] and not($o/@base) and not($o/@atom) and not($o/o) and $o[not(eo:abstract(.))]"/>
   </xsl:function>
   <xsl:function name="eo:alias-name" as="xs:string">
     <xsl:param name="object" as="element()"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/samples/same-name-inners.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/samples/same-name-inners.yaml
@@ -1,0 +1,44 @@
+origin: |
+  # This is the default 64+ symbols comment in front of named abstract object.
+  [] > compiles-correctly-with-long-duplicate-names
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > long-object-name
+      # This is the default 64+ symbols comment in front of named abstract object.
+      [] > long-object-name
+        # This is the default 64+ symbols comment in front of named abstract object.
+        [] > long-object-name
+          # This is the default 64+ symbols comment in front of named abstract object.
+          [] > long-object-name
+            # This is the default 64+ symbols comment in front of named abstract object.
+            [] > long-object-name
+    TRUE > @
+
+straight: |
+  # This is the default 64+ symbols comment in front of named abstract object.
+  [] > compiles-correctly-with-long-duplicate-names
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > long-object-name
+      # This is the default 64+ symbols comment in front of named abstract object.
+      [] > long-object-name
+        # This is the default 64+ symbols comment in front of named abstract object.
+        [] > long-object-name
+          # This is the default 64+ symbols comment in front of named abstract object.
+          [] > long-object-name
+            # This is the default 64+ symbols comment in front of named abstract object.
+            [] > long-object-name
+    TRUE > @
+
+reversed: |
+  # This is the default 64+ symbols comment in front of named abstract object.
+  [] > compiles-correctly-with-long-duplicate-names
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > long-object-name
+      # This is the default 64+ symbols comment in front of named abstract object.
+      [] > long-object-name
+        # This is the default 64+ symbols comment in front of named abstract object.
+        [] > long-object-name
+          # This is the default 64+ symbols comment in front of named abstract object.
+          [] > long-object-name
+            # This is the default 64+ symbols comment in front of named abstract object.
+            [] > long-object-name
+    TRUE > @


### PR DESCRIPTION
Ref: #2952 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes related to handling abstract objects with long duplicate names in EO code parsing and testing.

### Detailed summary
- Added a check for abstract objects with long duplicate names in `eo:attr` function
- Updated test YAML files to include long duplicate names for abstract objects

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->