### PR TITLE
Added check if there are atoms, but no +rt meta.

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/errors/rt-and-atoms.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/rt-and-atoms.xsl
@@ -22,20 +22,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<!--
-  @todo #2921:30m Add check if there are atoms, but no +rt meta. It should be illegal.
-    Don't forget to remove the puzzle.
--->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="rt-without-atom" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="rt-and-atoms" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:if test="/program/metas/meta[head='rt']">
-        <xsl:if test="not(//o[@atom])">
+      <xsl:if test="//o[@atom]">
+        <xsl:if test="not(/program/metas/meta[head='rt'])">
           <xsl:element name="error">
             <xsl:attribute name="check">
-              <xsl:text>rt-without-atoms</xsl:text>
+              <xsl:text>rt-and-atoms</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="line">
+              <xsl:value-of select="@line"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>error</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Using atoms without +rt meta</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:if>
+      <xsl:if test="not(//o[@atom])">
+        <xsl:if test="/program/metas/meta[head='rt']">
+          <xsl:element name="error">
+            <xsl:attribute name="check">
+              <xsl:text>rt-and-atoms</xsl:text>
             </xsl:attribute>
             <xsl:attribute name="line">
               <xsl:value-of select="@line"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/rt-and-atoms.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/rt-and-atoms.xsl
@@ -39,7 +39,7 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>error</xsl:text>
             </xsl:attribute>
-            <xsl:text>Using atoms without +rt meta</xsl:text>
+            <xsl:text>Using atoms without +rt meta is prohibited</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:if>
@@ -55,7 +55,7 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>error</xsl:text>
             </xsl:attribute>
-            <xsl:text>Using +rt meta without atoms</xsl:text>
+            <xsl:text>Using +rt meta without atoms is prohibited</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:if>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-atoms-without-rt.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-atoms-without-rt.yaml
@@ -6,9 +6,9 @@ eo: |
   +architect yegor256@gmail.com
   +home https://github.com/objectionary/eo
   +package org.eolang
-  +rt jvm org.eolang:eo-runtime:0.0.0
   +version 0.0.0
 
-  # Boolean.
-  [attr] > obj
-    attr > @
+  # Bytes.
+  [] > bytes
+    # Equals to another object.
+    [x] > eq /bool


### PR DESCRIPTION
Closes #2948

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update error handling in the EO parser to enforce the presence of atoms with the +rt meta.

### Detailed summary
- Updated XSL file from `rt-without-atom` to `rt-and-atoms`
- Added error handling for using atoms without +rt meta
- Improved error message clarity

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->