### PR TITLE
fix(#2969): enable cage tests

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -51,8 +51,7 @@ class PhOnce implements Phi {
      * @param blank The string value
      * @param expr The expression
      */
-    PhOnce(final Data<Phi> data, final Supplier<String> blank,
-        final Supplier<String> expr) {
+    PhOnce(final Data<Phi> data, final Supplier<String> blank, final Supplier<String> expr) {
         this.object = new Data.Once<>(data, blank);
         this.exp = expr;
     }

--- a/eo-runtime/src/test/eo/org/eolang/cage-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cage-tests.eo
@@ -27,10 +27,6 @@
 +version 0.0.0
 
 # Test.
-# @todo #2931:30min Enable cage tests. The tests were disabled because they stopped working
-#  when \rho attribute became immutable. Need to find out what's going on and enable them.
-#  Tests: infinite-loop-check, dataizes-encaged-object-lazily-third,
-#  dataizes-encaged-object-lazily-first
 [] > writes-into-cage
   # Object with free attribute.
   [z] > a
@@ -76,10 +72,18 @@
     42
 
 # Test.
-[] > dataizes-encaged-object-lazily-first
+# The test seems not obvious, but it illustrates `cage` side effects well.
+# Here when `sum.write (x.plus 1)` is dataized `sum` needs to check if given
+# object has the valid form - `int.plus`. But `x.plus` does not have form at
+# the beginning because attribute `plus` in not taken from `x` yet.
+# So to get forma this `plus` is taken from `x`. As the result we get object
+# `42.plus` which means `42.plus.^` is `42` and it won't be changed.
+# That's why `x.write 7` rewrites value of `x` but does not affect `42.plus` and
+# does not affect `sum`.
+[] > dataizes-encaged-object-not-lazily-first
   cage 0 > x
   cage 0.plus > sum
-  eq. > res
+  eq. > @
     seq
       *
         x.write 42
@@ -87,8 +91,7 @@
           x.plus 1
         x.write 7
         sum
-    8
-  TRUE > @
+    43
 
 # Test.
 [] > dataizes-encaged-object-lazily-second
@@ -105,11 +108,13 @@
     8
 
 # Test.
+# The test seems not obvious, but you may see detailed explanation in
+# `dataizes-encaged-object-not-lazily-first` test.
 [] > dataizes-encaged-object-lazily-third
   cage 0 > x
   cage 0 > y
   cage 0.plus > sum
-  eq. > res
+  eq. > @
     seq
       *
         x.write 42
@@ -119,8 +124,7 @@
         y.write 13
         x.write 4
         sum
-    17
-  nop > @
+    55
 
 # Test.
 [] > stores-abstract-object-into-cage
@@ -179,20 +183,21 @@
   [value] > pyint
     # Add.
     [y] > add
-      pyint (value.plus y.value) > @
+      pyint (^.value.plus y.value) > @
   cage pyint > x
   cage > tmp
     x.add
-  eq. > res
+  eq. > @
     seq
       *
         x.write
           pyint 0
         tmp.write
           x.add (pyint 1)
+        QQ.io.stdout
+          tmp.value
         tmp.value
     1
-  nop > @
 
 # Test.
 [] > catches-writing-objects-of-different-types

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -53,9 +53,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 /**
  * Test case for {@link EOcage}.
  * @since 0.19
- * @todo #2931:30min Resolve test {@link EOcageTest#evaluatesLazily}. This test stopped working
- *  after introducing new rho logic. Need to decide either we can remove the test or we can resolve
- *  it somehow.
  */
 final class EOcageTest {
 
@@ -153,30 +150,6 @@ final class EOcageTest {
         MatcherAssert.assertThat(
             new Dataized(new PhMethod(cage, "x")).take(Long.class),
             Matchers.equalTo(2L)
-        );
-    }
-
-    @Test
-    @Disabled
-    void evaluatesLazily() {
-        final Phi cage = new EOcage(Phi.Φ);
-        final Phi first = cage.copy();
-        EOcageTest.writeTo(first, new Data.ToPhi(3L));
-        final Phi second = cage.copy();
-        EOcageTest.writeTo(second, new Data.ToPhi(5L));
-        final Phi sum = cage.copy();
-        EOcageTest.writeTo(
-            sum,
-            new PhWith(
-                new PhCopy(new PhMethod(first, "plus")),
-                0, second
-            )
-        );
-        EOcageTest.writeTo(first, new Data.ToPhi(1L));
-        EOcageTest.writeTo(second, new Data.ToPhi(9L));
-        MatcherAssert.assertThat(
-            new Dataized(sum).take(Long.class),
-            Matchers.equalTo(10L)
         );
     }
 


### PR DESCRIPTION
Closes: #2969 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `PhOnce` constructor and resolve issues with tests related to the `EOcage` class.

### Detailed summary
- Refactored the `PhOnce` constructor parameters
- Resolved issues with the `evaluatesLazily` test in `EOcageTest`
- Enabled and explained `cage` tests in `cage-tests.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->