### PR TITLE
Enable OptimizeMojoTest.checksPacks test

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -45,7 +45,6 @@ import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OptimizeMojoTest.java
@@ -53,15 +53,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 /**
  * Test case for {@link OptimizeMojo}.
  * @since 0.1
- * @todo #2931:30min Enable the test {@link OptimizeMojoTest#checksPacks(String)}. The test was
- *  disabled because java generation (to-java.xsl) was changed. Need to change .yaml packs and
- *  enable the test.
  */
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class OptimizeMojoTest {
 
     @ParameterizedTest
-    @Disabled
     @ClasspathSource(value = "org/eolang/maven/packs/", glob = "**.yaml")
     void checksPacks(final String pack) throws IOException {
         final CheckPack check = new CheckPack(pack);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/tuple-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/tuple-to-java.yaml
@@ -10,17 +10,15 @@ xsls:
   - /org/eolang/maven/pre/to-java.xsl
 tests:
   - /program/errors[count(*)=0]
-  - //java[contains(text(), 'Phi ret = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '  Phi ret_1 = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '    Phi ret_1_1 = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '      Phi ret_1_1_1_base = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
+  - //java[contains(text(), 'Phi ret = Phi.Φ.take("org").take("eolang").take("tuple");')]
+  - //java[contains(text(), '  Phi ret_1 = Phi.Φ.take("org").take("eolang").take("tuple");')]
+  - //java[contains(text(), '    Phi ret_1_1 = Phi.Φ.take("org").take("eolang").take("tuple");')]
+  - //java[contains(text(), '      Phi ret_1_1_1_base = Phi.Φ.take("org").take("eolang").take("tuple");')]
   - //java[contains(text(), '      Phi ret_1_1_1 = new PhMethod(ret_1_1_1_base, "empty");')]
-  - //java[contains(text(), '  Phi ret_2 = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '    Phi ret_2_1 = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '      Phi ret_2_1_1_base = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
+  - //java[contains(text(), '  Phi ret_2 = Phi.Φ.take("org").take("eolang").take("tuple");')]
+  - //java[contains(text(), '    Phi ret_2_1 = Phi.Φ.take("org").take("eolang").take("tuple");')]
+  - //java[contains(text(), '      Phi ret_2_1_1_base = Phi.Φ.take("org").take("eolang").take("tuple");')]
   - //java[contains(text(), '      Phi ret_2_1_1 = new PhMethod(ret_2_1_1_base, "empty");')]
-  - //java[contains(text(), '  Phi ret_2_base = Phi.Φ.attr("org").get().attr("eolang").get().attr("tuple").get();')]
-  - //java[contains(text(), '  Phi ret_2 = new PhMethod(ret_2_base, "empty");')]
 eo: |
   # This is the default 64+ symbols comment in front of named abstract object.
   [] > foo


### PR DESCRIPTION
Closes #2999

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enable a previously disabled test in `OptimizeMojoTest`. 

### Detailed summary
- Re-enabled the `checksPacks` test in `OptimizeMojoTest`
- Updated test assertions in `tuple-to-java.yaml` to reflect code changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->