### PR TITLE
#3017: simple assert

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl
@@ -597,19 +597,11 @@ SOFTWARE.
   <xsl:template match="class" mode="assert">
     <xsl:param name="indent"/>
     <xsl:value-of select="eo:tabs($indent)"/>
-    <xsl:text>Object obj = new Dataized(new </xsl:text>
+    <xsl:text>Boolean obj = new Dataized(new </xsl:text>
     <xsl:value-of select="eo:class-name(@name, eo:suffix(@line, @pos))"/>
     <xsl:text>()).take(Boolean.class);</xsl:text>
     <xsl:value-of select="eo:eol(2 + $indent)"/>
-    <xsl:text>if (obj instanceof String) {</xsl:text>
-    <xsl:value-of select="eo:eol(2 + $indent)"/>
-    <xsl:text>  Assertions.fail(obj.toString());</xsl:text>
-    <xsl:value-of select="eo:eol(2 + $indent)"/>
-    <xsl:text>} else {</xsl:text>
-    <xsl:value-of select="eo:eol(2 + $indent)"/>
-    <xsl:text>  Assertions.assertTrue((Boolean) obj);</xsl:text>
-    <xsl:value-of select="eo:eol(2 + $indent)"/>
-    <xsl:text>}</xsl:text>
+    <xsl:text>Assertions.assertTrue(obj);</xsl:text>
   </xsl:template>
   <!-- Package -->
   <xsl:template match="meta[head='package']" mode="head">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/test-object-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/packs/pre/test-object-to-java.yaml
@@ -1,0 +1,22 @@
+xsls:
+  - /org/eolang/parser/add-default-package.xsl
+  - /org/eolang/maven/pre/classes.xsl
+  - /org/eolang/maven/pre/attrs.xsl
+  - /org/eolang/maven/pre/data.xsl
+  - /org/eolang/maven/pre/to-java.xsl
+tests:
+  - /program/errors[count(*)=0]
+  - //java[contains(text(), '  @Test')]
+  - //java[contains(text(), '  public void works() throws java.lang.Exception {')]
+  - //java[contains(text(), '    Boolean obj = new Dataized(new EOcompares_two_bools()).take(Boolean.class);')]
+  - //java[contains(text(), '    Assertions.assertTrue(obj);')]
+  - //java[contains(text(), '  }')]
+eo: |
+  +tests
+  +version 0.0.0
+
+  # Test.
+  [] > compares-two-bools
+  eq. > @
+    TRUE
+    TRUE


### PR DESCRIPTION
Closes #3017
Now it looks 
```java
  @Test
  public void works() throws java.lang.Exception {
    Boolean obj = new Dataized(new EOtuple_fluent_withTest()).take(Boolean.class);
    Assertions.assertTrue(obj);
  }
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds test cases and updates Java generation logic in the EO Maven plugin.

### Detailed summary
- Added new test cases for Java generation
- Updated Java generation logic to use `Boolean` instead of `Object` for type safety
- Simplified assertion logic in test cases

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->