### PR TITLE
fix(#3013): enable stdout tests

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -68,12 +68,10 @@
 
   # Tests that $ < x.
   [x] > lt
-    gt. > @
-      plus.
-        neg.
-          ^
-        x
-      0.0
+    0.0.gt > @
+      ^.minus
+        int
+          x > value!
 
   # Tests that $ ≤ x.
   [x] > lte

--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -70,7 +70,7 @@
   [x] > lt
     0.0.gt > @
       ^.minus
-        int
+        float
           x > value!
 
   # Tests that $ ≤ x.

--- a/eo-runtime/src/main/eo/org/eolang/int.eo
+++ b/eo-runtime/src/main/eo/org/eolang/int.eo
@@ -38,17 +38,16 @@
 
   # Tests that $ < x.
   [x] > lt
-    gt. > @
-      plus.
-        x
-        neg.
-          ^
-      0
+    0.gt > @
+      ^.minus
+        int
+          x > value!
 
   # Tests that $ ≤ x.
   [x] > lte
     not. > @
-      ^.gt x
+      ^.gt
+        x > value!
 
   # Tests that $ > x.
   [x] > gt /bool
@@ -56,7 +55,8 @@
   # Tests that $ ≥ x.
   [x] > gte
     not. > @
-      ^.lt x
+      ^.lt
+        x > value!
 
   # Change the sign of the number.
   [] > neg

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -23,6 +23,7 @@
  */
 package org.eolang;
 
+import EOorg.EOeolang.EOseq;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -231,6 +232,10 @@ public abstract class PhDefault implements Phi, Cloneable {
 
     @Override
     public Phi take(final String name, final Phi rho) {
+        if (this.form.equals(EOseq.class.getName())) {
+            System.out.println(this);
+            System.out.println(name);
+        }
         PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
         final Phi object;
         if (this.attrs.containsKey(name)) {

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -232,10 +232,6 @@ public abstract class PhDefault implements Phi, Cloneable {
 
     @Override
     public Phi take(final String name, final Phi rho) {
-        if (this.form.equals(EOseq.class.getName())) {
-            System.out.println(this);
-            System.out.println(name);
-        }
         PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
         final Phi object;
         if (this.attrs.containsKey(name)) {

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -23,7 +23,6 @@
  */
 package org.eolang;
 
-import EOorg.EOeolang.EOseq;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/eo-runtime/src/test/eo/org/eolang/float-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/float-tests.eo
@@ -27,43 +27,41 @@
 +version 0.0.0
 
 # Test.
-[] > less-true
-  eq. > @
-    -10.5.lt 50.3
-    TRUE
+[] > float-less-true
+  -10.5.lt 50.3 > @
 
 # Test.
-[] > less-equal
+[] > float-less-equal
   eq. > @
     -10.7.lt -10.7
     FALSE
 
 # Test.
-[] > less-false
+[] > float-less-false
   eq. > @
     10.13.lt -5.3
     FALSE
 
 # Test.
-[] > greater-true
+[] > float-greater-true
   gt. > @
     -200.1
     -1000.0
 
 # Test.
-[] > greater-false
+[] > float-greater-false
   eq. > @
     0.5.gt 100.1
     FALSE
 
 # Test.
-[] > greater-equal
+[] > float-greater-equal
   eq. > @
     0.7.gt 0.7
     FALSE
 
 # Test.
-[] > leq-true
+[] > float-leq-true
   eq. > @
     lte.
       -200.5
@@ -71,7 +69,7 @@
     TRUE
 
 # Test.
-[] > leq-equal
+[] > float-leq-equal
   eq. > @
     lte.
       50.1
@@ -79,7 +77,7 @@
     TRUE
 
 # Test.
-[] > leq-false
+[] > float-leq-false
   eq. > @
     lte.
       0.9
@@ -87,7 +85,7 @@
     FALSE
 
 # Test.
-[] > gte-true
+[] > float-gte-true
   eq. > @
     gte.
       -1000.1
@@ -95,7 +93,7 @@
     TRUE
 
 # Test.
-[] > gte-equal
+[] > float-gte-equal
   eq. > @
     gte.
       113.333
@@ -103,7 +101,7 @@
     TRUE
 
 # Test.
-[] > gte-false
+[] > float-gte-false
   eq. > @
     gte.
       0.7
@@ -135,7 +133,7 @@
     FALSE
 
 # Test.
-[] > zero-eq-to-zero
+[] > float-zero-eq-to-zero
   eq. > @
     eq.
       0.0

--- a/eo-runtime/src/test/eo/org/eolang/int-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/int-tests.eo
@@ -30,15 +30,13 @@
 # @todo #2931:30min Enable the test calculates-fibonacci-number-with-recursion. The test was
 #  disabled because for some reason it executes endlessly. Need to find what's wrong and enable the
 #  test.
-[] > less-true
-  eq. > @
-    lt.
-      10
-      50
-    TRUE
+[] > int-less-true
+  lt. > @
+    10
+    50
 
 # Test.
-[] > less-equal
+[] > int-less-equal
   eq. > @
     not.
       lt.
@@ -47,7 +45,7 @@
     TRUE
 
 # Test.
-[] > less-false
+[] > int-less-false
   eq. > @
     not.
       lt.
@@ -56,7 +54,7 @@
     TRUE
 
 # Test.
-[] > greater-true
+[] > int-greater-true
   eq. > @
     gt.
       -200
@@ -64,7 +62,7 @@
     TRUE
 
 # Test.
-[] > greater-false
+[] > int-greater-false
   eq. > @
     not.
       gt.
@@ -73,7 +71,7 @@
     TRUE
 
 # Test.
-[] > greater-equal
+[] > int-greater-equal
   eq. > @
     not.
       gt.
@@ -82,7 +80,7 @@
     TRUE
 
 # Test.
-[] > leq-true
+[] > int-leq-true
   eq. > @
     lte.
       -200
@@ -90,7 +88,7 @@
     TRUE
 
 # Test.
-[] > leq-equal
+[] > int-leq-equal
   eq. > @
     lte.
       50
@@ -98,7 +96,7 @@
     TRUE
 
 # Test.
-[] > leq-false
+[] > int-leq-false
   eq. > @
     not.
       lte.
@@ -107,7 +105,7 @@
     TRUE
 
 # Test.
-[] > gte-true
+[] > int-gte-true
   eq. > @
     gte.
       -1000
@@ -115,7 +113,7 @@
     TRUE
 
 # Test.
-[] > gte-equal
+[] > int-gte-equal
   eq. > @
     gte.
       113
@@ -123,7 +121,7 @@
     TRUE
 
 # Test.
-[] > gte-false
+[] > int-gte-false
   eq. > @
     not.
       gte.
@@ -148,7 +146,7 @@
     TRUE
 
 # Test.
-[] > zero-eq-to-zero
+[] > int-zero-eq-to-zero
   eq. > @
     eq.
       0
@@ -164,7 +162,7 @@
     TRUE
 
 # Test.
-[] > eq-true
+[] > int-eq-true
   eq. > @
     eq.
       123
@@ -172,7 +170,7 @@
     TRUE
 
 # Test.
-[] > eq-false
+[] > int-eq-false
   eq. > @
     not.
       eq.

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -51,10 +51,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Test case for {@link EOstdout}.
  * @since 0.1
- * @todo #2931:30min Enable the tests {@link EOstdoutTest#doesNotPrintTwiceOnIntComparisonMethods}
- *  and {@link EOstdoutTest#doesNotPrintTwiceOnFloatComparisonMethods}.
- *  The tests were disabled after new rho logic was introduced working properly. Need to enable
- *  the tests when it's possible.
  */
 public final class EOstdoutTest {
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -91,7 +91,6 @@ public final class EOstdoutTest {
 
     @ParameterizedTest
     @CsvSource({"lt", "gt", "lte", "gte", "eq"})
-    @Disabled
     public void doesNotPrintTwiceOnIntComparisonMethods(final String method) {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";
@@ -117,7 +116,6 @@ public final class EOstdoutTest {
 
     @ParameterizedTest()
     @CsvSource({"lt", "gt", "lte", "gte"})
-    @Disabled
     public void doesNotPrintTwiceOnFloatComparisonMethods(final String method) {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final String str = "Hello world";


### PR DESCRIPTION
Closes: #3013

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates comparison methods in `float` and `int` classes, improves test coverage, and enables previously disabled tests.

### Detailed summary
- Updated comparison methods in `float` and `int` classes
- Improved test coverage for `EOstdout`
- Enabled previously disabled tests in `EOstdoutTest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->