### PR TITLE
fix(#2965): made tuple.at is great again

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -46,16 +46,11 @@
       ^.head.length.plus 1 > len!
 
   # Take one element from the tuple, at the given position.
-  # @todo #2931:30min Return previous optimizations for the object.
-  #  The optimization was removed because it does not work with new rho logic.
-  #  Please check previous version of the object and try to implement it again.
-  #  Also we need to enable the tuple tests: at-without-checks-with-first-element,
-  #  at-without-checks-with-last-element
   [i] > at
-    i > idx!
     ^.length > len
     if > index!
-      0.gt idx
+      0.gt
+        i > idx!
       len.plus idx
       idx
     if > @
@@ -63,12 +58,16 @@
         0.gt index
         len.lte index
       error "Given index is out of tuple bounds"
-      if
-        gt.
+      at-fast ^ len
+
+    # Fast recursive obtaining element from tuple.
+    [tup len] > at-fast
+      if > @
+        (len.plus -1).gt ^.index
+        ^.at-fast
+          tup.head
           len.plus -1
-          index
-        ^.head.at index
-        ^.tail
+        tup.tail
 
   # Create a new tuple with this element added to the end of it.
   [x] > with

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -171,24 +171,18 @@
     3
 
 # Test
-[] > at-without-checks-with-first-element
-  eq. > res
-    at-without-checks.
-      at.
-        * 100 101 102
-      0
+[] > at-fast-with-first-element
+  * 100 101 102 > arr
+  eq. > @
+    (arr.at 0).at-fast arr 3
     100
-  TRUE > @
 
 # Test
-[] > at-without-checks-with-last-element
-  eq. > res
-    at-without-checks.
-      at.
-        * 100 101 102
-      2
+[] > at-fast-with-last-element
+  * 100 101 102 > arr
+  eq. > @
+    (arr.at 2).at-fast arr 3
     102
-  TRUE > @
 
 # Test.
 [] > tuple-empty-fluent-with-indented-keyword


### PR DESCRIPTION
Closes: #2965 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing tuple element retrieval and adding new test cases.

### Detailed summary
- Optimized tuple element retrieval with `at-fast` method
- Added new test cases for `at-fast` method with first and last elements

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->