### PR TITLE
feat(#3027): new `EOtry` implementation

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
@@ -79,11 +79,14 @@ public final class EOtry extends PhDefault implements Atom {
         private final Phi ctch;
 
         /**
-         * Finally object
+         * Finally object.
          */
         private final Phi last;
 
-        private final Consumer<Consumer<Phi>> put;
+        /**
+         * Put function.
+         */
+        private final Consumer<Consumer<Phi>> func;
 
         /**
          * Ctor.
@@ -95,7 +98,7 @@ public final class EOtry extends PhDefault implements Atom {
             this.body = body;
             this.ctch = ctch;
             this.last = last;
-            this.put = new TryExecute(body, ctch);
+            this.func = new TryExecute(body, ctch);
         }
 
         @Override
@@ -126,12 +129,12 @@ public final class EOtry extends PhDefault implements Atom {
 
         @Override
         public void put(final int pos, final Phi object) {
-            this.put.accept(phi -> phi.put(pos, object));
+            this.func.accept(phi -> phi.put(pos, object));
         }
 
         @Override
         public void put(final String name, final Phi object) {
-            this.put.accept(phi -> phi.put(name, object));
+            this.func.accept(phi -> phi.put(name, object));
         }
 
         @Override
@@ -182,7 +185,7 @@ public final class EOtry extends PhDefault implements Atom {
         }
 
         @Override
-        public void accept(Consumer<Phi> func) {
+        public void accept(final Consumer<Phi> func) {
             try {
                 func.accept(this.body);
             } catch (final EOerror.ExError ex) {
@@ -194,8 +197,9 @@ public final class EOtry extends PhDefault implements Atom {
     }
 
     /**
-     * Tries to return value from given function and catches {@link EOorg.EOeolang.EOerror.ExError}
+     * Tries to return value from given function and catches {@link EOorg.EOeolang.EOerror.ExError}.
      * @param <T> Type of return value.
+     * @since 0.36.0
      */
     private static class TryReturn<T> implements Function<Function<Phi, T>, T> {
         /**
@@ -209,7 +213,7 @@ public final class EOtry extends PhDefault implements Atom {
         private final Phi ctch;
 
         /**
-         * Finally object
+         * Finally object.
          */
         private final Phi last;
 
@@ -226,7 +230,7 @@ public final class EOtry extends PhDefault implements Atom {
         }
 
         @Override
-        public T apply(Function<Phi, T> func) {
+        public T apply(final Function<Phi, T> func) {
             T result;
             try {
                 result = func.apply(this.body);

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
@@ -27,8 +27,11 @@
  */
 package EOorg.EOeolang;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -44,7 +47,6 @@ import org.eolang.XmirObject;
 @Versionized
 @XmirObject(oname = "try")
 public final class EOtry extends PhDefault implements Atom {
-
     /**
      * Ctor.
      * @param sigma Sigma
@@ -58,16 +60,184 @@ public final class EOtry extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        Phi ret = this.take("main");
-        try {
-            new Dataized(ret).take();
-        } catch (final EOerror.ExError ex) {
-            final Phi ctch = this.take("catch").copy();
-            ctch.put(0, ex.enclosure());
-            ret = ctch;
-        } finally {
-            new Dataized(this.take("finally")).take();
+        return new PhTry(this.take("main"), this.take("catch"), this.take("finally"));
+    }
+
+    /**
+     * Object that knows how to deal with {@link EOorg.EOeolang.EOerror.ExError}.
+     * @since 0.36.0
+     */
+    private static class PhTry implements Phi {
+        /**
+         * Body object.
+         */
+        private final Phi body;
+
+        /**
+         * Catch object.
+         */
+        private final Phi ctch;
+
+        /**
+         * Finally object
+         */
+        private final Phi last;
+
+        private final Consumer<Consumer<Phi>> put;
+
+        /**
+         * Ctor.
+         * @param body Body object
+         * @param ctch Catch object
+         * @param last Finally object
+         */
+        PhTry(final Phi body, final Phi ctch, final Phi last) {
+            this.body = body;
+            this.ctch = ctch;
+            this.last = last;
+            this.put = new TryExecute(body, ctch);
         }
-        return ret;
+
+        @Override
+        public byte[] delta() {
+            return new TryReturn<byte[]>(
+                this.body, this.ctch, this.last
+            ).apply(Data::delta);
+        }
+
+        @Override
+        public Phi copy() {
+            return new PhTry(this.body.copy(), this.ctch.copy(), this.last.copy());
+        }
+
+        @Override
+        public Phi take(final String name) {
+            return new TryReturn<Phi>(
+                this.body, this.ctch, this.last
+            ).apply(phi -> phi.take(name));
+        }
+
+        @Override
+        public Phi take(final String name, final Phi rho) {
+            return new TryReturn<Phi>(
+                this.body, this.ctch, this.last
+            ).apply(phi -> phi.take(name, rho));
+        }
+
+        @Override
+        public void put(final int pos, final Phi object) {
+            this.put.accept(phi -> phi.put(pos, object));
+        }
+
+        @Override
+        public void put(final String name, final Phi object) {
+            this.put.accept(phi -> phi.put(name, object));
+        }
+
+        @Override
+        public String locator() {
+            return new TryReturn<String>(
+                this.body, this.ctch, this.last
+            ).apply(Phi::locator);
+        }
+
+        @Override
+        public String forma() {
+            return new TryReturn<String>(
+                this.body, this.ctch, this.last
+            ).apply(Phi::forma);
+        }
+
+        @Override
+        public String φTerm() {
+            return new TryReturn<String>(
+                this.body, this.ctch, this.last
+            ).apply(Phi::φTerm);
+        }
+    }
+
+    /**
+     * Tries to execute given function and catches {@link EOorg.EOeolang.EOerror.ExError}.
+     * @since 0.36.0
+     */
+    private static class TryExecute implements Consumer<Consumer<Phi>> {
+        /**
+         * Body object.
+         */
+        private final Phi body;
+
+        /**
+         * Catch object.
+         */
+        private final Phi ctch;
+
+        /**
+         * Ctor.
+         * @param main Body object
+         * @param ctch Catch object
+         */
+        TryExecute(final Phi main, final Phi ctch) {
+            this.body = main;
+            this.ctch = ctch;
+        }
+
+        @Override
+        public void accept(Consumer<Phi> func) {
+            try {
+                func.accept(this.body);
+            } catch (final EOerror.ExError ex) {
+                final Phi caught = this.ctch.copy();
+                caught.put(0, ex.enclosure());
+                func.accept(caught);
+            }
+        }
+    }
+
+    /**
+     * Tries to return value from given function and catches {@link EOorg.EOeolang.EOerror.ExError}
+     * @param <T> Type of return value.
+     */
+    private static class TryReturn<T> implements Function<Function<Phi, T>, T> {
+        /**
+         * Body object.
+         */
+        private final Phi body;
+
+        /**
+         * Catch object.
+         */
+        private final Phi ctch;
+
+        /**
+         * Finally object
+         */
+        private final Phi last;
+
+        /**
+         * Ctor.
+         * @param main Body object
+         * @param ctch Catch object
+         * @param last Finally object
+         */
+        TryReturn(final Phi main, final Phi ctch, final Phi last) {
+            this.body = main;
+            this.ctch = ctch;
+            this.last = last;
+        }
+
+        @Override
+        public T apply(Function<Phi, T> func) {
+            T result;
+            try {
+                result = func.apply(this.body);
+            } catch (final EOerror.ExError ex) {
+                final Phi caught = this.ctch.copy();
+                caught.put(0, ex.enclosure());
+                result = func.apply(caught);
+            } finally {
+                new Dataized(this.last).take();
+            }
+            return result;
+        }
     }
 }

--- a/eo-runtime/src/test/eo/org/eolang/try-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/try-tests.eo
@@ -27,9 +27,6 @@
 +version 0.0.0
 
 # Test.
-# @todo #2931:30min Enable the tests try-memory-update, try-memory-update-catch. The test were
-#  disabled because 1) "try" object dataizes body twice 2) implementation of "memory" is wrong.
-#  Need to fix it and enable the test.
 [] > simple-division-by-zero
   try > @
     []
@@ -84,8 +81,8 @@
 
 # Test.
 [] > try-memory-update
-  memory 0 > m
-  eq. > res
+  memory.alloc 0 > m
+  eq. > @
     seq
       *
         m.write 1
@@ -97,12 +94,11 @@
           nop
         m.as-int
     2
-  TRUE > @
 
 # Test.
 [] > try-memory-update-catch
-  memory 0 > m
-  eq. > res
+  memory.alloc 0 > m
+  eq. > @
     seq
       *
         m.write 1
@@ -116,4 +112,3 @@
           nop
         m
     1
-  TRUE > @

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -147,7 +147,7 @@ public final class EOtryTest {
         /**
          * Counter.
          */
-        public int count = 0;
+        private int count;
 
         /**
          * Ctor.
@@ -159,7 +159,7 @@ public final class EOtryTest {
                 new AtComposite(
                     this,
                     rho -> {
-                        this.count++;
+                        ++this.count;
                         return new Data.ToPhi(1L);
                     }
                 )

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang;
 
 import org.eolang.AtComposite;
 import org.eolang.AtVoid;
+import org.eolang.Attr;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
@@ -124,17 +125,59 @@ public final class EOtryTest {
         );
     }
 
+    @Test
+    public void doesNotDataizeBodyTwice() {
+        final Phi trier = new EOtry(Phi.Φ);
+        final MainWithCounter main = new MainWithCounter();
+        trier.put(0, main);
+        trier.put(1, new Catcher(Phi.Φ));
+        trier.put(2, new EOnop(Phi.Φ));
+        new Dataized(trier).take();
+        MatcherAssert.assertThat(
+            main.count,
+            Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * Body object with counter.
+     * @since 0.36.0
+     */
+    private static class MainWithCounter extends PhDefault {
+        /**
+         * Counter.
+         */
+        public int count = 0;
+
+        /**
+         * Ctor.
+         */
+        MainWithCounter() {
+            super(Phi.Φ);
+            this.add(
+                Attr.PHI,
+                new AtComposite(
+                    this,
+                    rho -> {
+                        this.count++;
+                        return new Data.ToPhi(1L);
+                    }
+                )
+            );
+        }
+    }
+
     /**
      * Main.
      * @since 1.0
      */
-    public static class Main extends PhDefault {
+    private static class Main extends PhDefault {
 
         /**
          * Ctor.
          * @param sigma Sigma
          */
-        public Main(final Phi sigma) {
+        Main(final Phi sigma) {
             super(sigma);
             this.add(
                 "φ",
@@ -152,12 +195,12 @@ public final class EOtryTest {
      * Broken.
      * @since 1.0
      */
-    public static class Broken extends PhDefault {
+    private static class Broken extends PhDefault {
         /**
          * Ctor.
          * @param sigma Sigma.
          */
-        public Broken(final Phi sigma) {
+        Broken(final Phi sigma) {
             super(sigma);
             this.add(
                 "φ",
@@ -175,12 +218,12 @@ public final class EOtryTest {
      * Catcher.
      * @since 1.0
      */
-    public static class Catcher extends PhDefault {
+    private static class Catcher extends PhDefault {
         /**
          * Ctor.
          * @param sigma Sigma
          */
-        public Catcher(final Phi sigma) {
+        Catcher(final Phi sigma) {
             super(sigma);
             this.add("ex", new AtVoid("ex"));
             this.add(


### PR DESCRIPTION
What's done:
- Introduced new `EOtry` implementation that does not dataize body twice but returns object that knows how to deal with exceptions
- try-tests with `memory` are enabled

Closes: #3027 
Closes: #3011

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `try-memory-update` and `try-memory-update-catch` tests in `try-tests.eo` and refactors the `EOtry` class in Java.

### Detailed summary
- Updated memory allocation in `try-memory-update` and `try-memory-update-catch` tests
- Refactored `EOtry` class to use `PhTry` for error handling
- Added new test for `EOtry` class to ensure body is not dataized twice

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->