### PR TITLE
fix(#3050): Lambdas in phi to unique names 

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -174,6 +174,9 @@ public final class PhiMojo extends SafeMojo {
      */
     private static String translated(final Train<Shift> train, final XML xmir)
         throws ImpossibleToPhiTranslationException {
+        System.out.println(
+            new Xsline(train).pass(xmir)
+        );
         final XML translated = new Xsline(
             train.with(new StClasspath("/org/eolang/maven/phi/to-phi.xsl"))
         ).pass(xmir);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -174,9 +174,6 @@ public final class PhiMojo extends SafeMojo {
      */
     private static String translated(final Train<Shift> train, final XML xmir)
         throws ImpossibleToPhiTranslationException {
-        System.out.println(
-            new Xsline(train).pass(xmir)
-        );
         final XML translated = new Xsline(
             train.with(new StClasspath("/org/eolang/maven/phi/to-phi.xsl"))
         ).pass(xmir);

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -277,7 +277,7 @@ SOFTWARE.
       <!-- Not method -->
       <xsl:when test="not(starts-with(@base, '.'))">
         <xsl:choose>
-          <xsl:when test="@ref">
+          <xsl:when test="@ref and not(@data)">
             <xsl:value-of select="eo:add-xi(true())"/>
             <xsl:apply-templates select="." mode="path">
               <xsl:with-param name="find" select="@base"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -190,6 +190,11 @@ SOFTWARE.
           </xsl:for-each>
           <xsl:apply-templates select="objects">
             <xsl:with-param name="tabs" select="$tabs + $length + 1"/>
+            <xsl:with-param name="package">
+              <xsl:value-of select="$program"/>
+              <xsl:text>.</xsl:text>
+              <xsl:value-of select="$package"/>
+            </xsl:with-param>
           </xsl:apply-templates>
           <xsl:for-each select="$parts">
             <xsl:value-of select="eo:comma(2, $tabs + $length + 2 - position())"/>
@@ -203,6 +208,7 @@ SOFTWARE.
         <xsl:otherwise>
           <xsl:apply-templates select="objects">
             <xsl:with-param name="tabs" select="$tabs"/>
+            <xsl:with-param name="package" select="$program"/>
           </xsl:apply-templates>
         </xsl:otherwise>
       </xsl:choose>
@@ -215,10 +221,12 @@ SOFTWARE.
   <!-- Objects  -->
   <xsl:template match="objects">
     <xsl:param name="tabs"/>
+    <xsl:param name="package"/>
     <xsl:for-each select="o">
       <xsl:value-of select="eo:comma(position(), $tabs)"/>
       <xsl:apply-templates select=".">
         <xsl:with-param name="tabs" select="$tabs"/>
+        <xsl:with-param name="package" select="$package"/>
       </xsl:apply-templates>
     </xsl:for-each>
   </xsl:template>
@@ -255,6 +263,7 @@ SOFTWARE.
   <!-- Just object -->
   <xsl:template match="o[@base]">
     <xsl:param name="tabs"/>
+    <xsl:param name="package"/>
     <xsl:if test="@name">
       <xsl:value-of select="eo:specials(@name, true())"/>
       <xsl:value-of select="$arrow"/>
@@ -296,6 +305,7 @@ SOFTWARE.
       <xsl:otherwise>
         <xsl:apply-templates select="o[position()=1]">
           <xsl:with-param name="tabs" select="$tabs"/>
+          <xsl:with-param name="package" select="$package"/>
         </xsl:apply-templates>
         <xsl:value-of select="eo:specials(@base, true())"/>
         <!-- Copy -->
@@ -337,8 +347,10 @@ SOFTWARE.
   <!-- Formation -->
   <xsl:template match="o[not(@base) and (@abstract or @atom)]">
     <xsl:param name="tabs"/>
+    <xsl:param name="package"/>
+    <xsl:variable name="name" select="eo:specials(@name, true())"/>
     <xsl:if test="@name">
-      <xsl:value-of select="eo:specials(@name, true())"/>
+      <xsl:value-of select="$name"/>
       <xsl:value-of select="$arrow"/>
     </xsl:if>
     <xsl:value-of select="$lb"/>
@@ -349,7 +361,9 @@ SOFTWARE.
       <xsl:if test="@atom">
         <xsl:value-of select="$lambda"/>
         <xsl:value-of select="$dashed-arrow"/>
-        <xsl:text>Lambda</xsl:text>
+        <xsl:value-of select="$package"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="$name"/>
         <xsl:if test="count(o)&gt;0">
           <xsl:value-of select="eo:comma(2, $tabs+1)"/>
         </xsl:if>
@@ -358,6 +372,11 @@ SOFTWARE.
         <xsl:value-of select="eo:comma(position(), $tabs+1)"/>
         <xsl:apply-templates select=".">
           <xsl:with-param name="tabs" select="$tabs+1"/>
+          <xsl:with-param name="package">
+            <xsl:value-of select="$package"/>
+            <xsl:text>.</xsl:text>
+            <xsl:value-of select="$name"/>
+          </xsl:with-param>
         </xsl:apply-templates>
       </xsl:for-each>
       <xsl:value-of select="eo:eol($tabs)"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -79,6 +79,11 @@ SOFTWARE.
       <xsl:text>.</xsl:text>
     </xsl:if>
   </xsl:function>
+  <!-- Get clean escaped object name  -->
+  <xsl:function name="eo:lambda-name">
+    <xsl:param name="name"/>
+    <xsl:value-of select="concat('L', replace(replace(replace(substring($name, 3), '\.', '_'), '-', '_'), '@', 'φ'))"/>
+  </xsl:function>
   <!-- SPECIAL CHARACTERS -->
   <xsl:function name="eo:specials">
     <xsl:param name="n"/>
@@ -359,11 +364,14 @@ SOFTWARE.
       <xsl:value-of select="eo:eol($tabs+1)"/>
       <!-- Atom -->
       <xsl:if test="@atom">
+        <xsl:variable name="lambda-name">
+          <xsl:value-of select="$package"/>
+          <xsl:text>.</xsl:text>
+          <xsl:value-of select="$name"/>
+        </xsl:variable>
         <xsl:value-of select="$lambda"/>
         <xsl:value-of select="$dashed-arrow"/>
-        <xsl:value-of select="$package"/>
-        <xsl:text>.</xsl:text>
-        <xsl:value-of select="$name"/>
+        <xsl:value-of select="eo:lambda-name($lambda-name)"/>
         <xsl:if test="count(o)&gt;0">
           <xsl:value-of select="eo:comma(2, $tabs+1)"/>
         </xsl:if>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/atoms.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/atoms.yaml
@@ -9,11 +9,11 @@ phi: |
   {
     ⟦
       main ↦ ⟦
-        λ ⤍ Lambda
+        λ ⤍ Lmain
       ⟧,
       outer ↦ ⟦
         inner ↦ ⟦
-          λ ⤍ Lambda
+          λ ⤍ Louter_inner
         ⟧
       ⟧
     ⟧

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
@@ -114,7 +114,7 @@ phi: |
             ⟧,
             as-bool ↦ ⟦
               φ ↦ ξ.ρ.eq(
-                α0 ↦ ξ.σ.σ.Φ.org.eolang.bytes(
+                α0 ↦ Φ.org.eolang.bytes(
                   Δ ⤍ 01-
                 )
               )

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
@@ -1,0 +1,135 @@
+eo: |
+  +architect yegor256@gmail.com
+  +home https://github.com/objectionary/eo
+  +package org.eolang
+  +rt jvm org.eolang:eo-runtime:0.0.0
+  +version 0.0.0 
+  
+  # This is the default 64+ symbols comment in front of named abstract object.
+  [] > bytes
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [x] > eq /bool
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > size /int
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [start len] > slice /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > as-string /string
+
+    # Turn this chain of eight bytes into an integer.
+    # If there are less or more than eight bytes, there will
+    # be an error returned.
+    [] > as-int /int
+
+    # Turn this chain of eight bytes into a float.
+    # If there are less or more than eight bytes, there will
+    # be an error returned.
+    [] > as-float /float
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [b] > and /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [b] > or /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [b] > xor /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > not /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [x] > left
+      ^.right x.neg > @
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [x] > right /bytes
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > as-bool
+      ^.eq 01- > @
+
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > as-bytes
+      ^ > @
+
+    # Concatenation of two byte sequences:
+    # the current and the provided one,
+    # as a new sequence.
+    [b] > concat /bytes
+phi: |
+  {
+    ⟦
+      org ↦ ⟦
+        eolang ↦ ⟦
+          bytes ↦ ⟦
+            eq ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_eq,
+              x ↦ ∅
+            ⟧,
+            size ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_size
+            ⟧,
+            slice ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_slice,
+              start ↦ ∅,
+              len ↦ ∅
+            ⟧,
+            as-string ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_as_string
+            ⟧,
+            as-int ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_as_int
+            ⟧,
+            as-float ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_as_float
+            ⟧,
+            and ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_and,
+              b ↦ ∅
+            ⟧,
+            or ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_or,
+              b ↦ ∅
+            ⟧,
+            xor ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_xor,
+              b ↦ ∅
+            ⟧,
+            not ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_not
+            ⟧,
+            left ↦ ⟦
+              x ↦ ∅,
+              φ ↦ ξ.ρ.right(
+                α0 ↦ ξ.x.neg
+              )
+            ⟧,
+            right ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_right,
+              x ↦ ∅
+            ⟧,
+            as-bool ↦ ⟦
+              φ ↦ ξ.ρ.eq(
+                α0 ↦ ξ.σ.σ.Φ.org.eolang.bytes(
+                  Δ ⤍ 01-
+                )
+              )
+            ⟧,
+            as-bytes ↦ ⟦
+              φ ↦ ξ.ρ
+            ⟧,
+            concat ↦ ⟦
+              λ ⤍ Lorg_eolang_bytes_concat,
+              b ↦ ∅
+            ⟧
+          ⟧,
+          λ ⤍ Package
+        ⟧,
+        λ ⤍ Package
+      ⟧
+    ⟧
+  }


### PR DESCRIPTION
Closes: #3050

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates YAML and XSL files in `eo-maven-plugin`. It renames lambda functions and adds new object definitions.

### Detailed summary
- Renamed `Lambda` to `Lmain` in YAML files
- Updated object definitions in YAML files
- Added new functions and parameters in XSL file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->