### PR TITLE
3048 seq refactoring

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -81,7 +81,7 @@ public final class EOseq extends PhDefault implements Atom {
         Phi external = args;
         for (int ind = length - 1; ind >= 0; --ind) {
             res[ind] = new PhMethod(external, "tail");
-            external = external.copy().take("head");
+            external = external.take("head");
         }
         return res;
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -71,6 +71,11 @@ public final class EOseq extends PhDefault implements Atom {
         return ret;
     }
 
+    /**
+     * Converts eo tuple to java array.
+     * @param args Eo tuple.
+     * @return Java array.
+     */
     private static Phi[] eoTupleAsJavaArray(final Phi args) {
         final int length = Math.toIntExact(
             new Dataized(

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -58,7 +58,7 @@ public final class EOseq extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final Phi steps = this.take("steps");
-        final Phi[] items = EOseq.eoTupleAsJavaArray(steps);
+        final Phi[] items = EOseq.eoTupleAsArray(steps);
         for (int ind = 0; ind < items.length - 1; ++ind) {
             new Dataized(items[ind]).take();
         }
@@ -76,7 +76,7 @@ public final class EOseq extends PhDefault implements Atom {
      * @param args Eo tuple.
      * @return Java array.
      */
-    private static Phi[] eoTupleAsJavaArray(final Phi args) {
+    private static Phi[] eoTupleAsArray(final Phi args) {
         final int length = Math.toIntExact(
             new Dataized(
                 args.take("length")

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -58,7 +58,7 @@ public final class EOseq extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final Phi steps = this.take("steps");
-        final Phi[] items = eoTupleAsJavaArray(steps);
+        final Phi[] items = EOseq.eoTupleAsJavaArray(steps);
         for (int ind = 0; ind < items.length - 1; ++ind) {
             new Dataized(items[ind]).take();
         }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -60,8 +60,8 @@ public final class EOseq extends PhDefault implements Atom {
     public Phi lambda() {
         final Phi steps = this.take("steps");
         final Phi[] items = toArray(steps);
-        for (int i = 0; i < items.length - 1; i++) {
-            new Dataized(items[i]).take();
+        for (int ind = 0; ind < items.length - 1; ++ind) {
+            new Dataized(items[ind]).take();
         }
         final Phi ret;
         if (items.length > 0) {
@@ -82,8 +82,8 @@ public final class EOseq extends PhDefault implements Atom {
         );
         final Phi[] res = new Phi[length];
         Phi external = args;
-        for (int i = length - 1; i >= 0; i--) {
-            res[i] = new PhMethod(external, "tail");
+        for (int ind = length - 1; ind >= 0; --ind) {
+            res[ind] = new PhMethod(external, "tail");
             external = external.copy().take("head");
         }
         return res;

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -32,6 +32,7 @@ import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
+import org.eolang.PhMethod;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.eolang.Versionized;
@@ -58,25 +59,33 @@ public final class EOseq extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final Phi steps = this.take("steps");
-        final Long length = new Dataized(
-            steps.take("length")
-        ).take(Long.class);
-        for (long idx = 0; idx < length - 1; ++idx) {
-            new Dataized(
-                new PhWith(
-                    steps.take("at").copy(),
-                    0, new Data.ToPhi(idx)
-                )
-            ).take();
+        final Phi[] items = toArray(steps);
+        for (int i = 0; i < items.length - 1; i++) {
+            new Dataized(items[i]).take();
         }
         final Phi ret;
-        if (length > 0) {
+        if (items.length > 0) {
             final Phi last = steps.take("at").copy();
-            last.put(0, new Data.ToPhi(length - 1));
+            last.put(0, new Data.ToPhi((long) items.length - 1L));
             ret = last;
         } else {
             ret = new Data.ToPhi(false);
         }
         return ret;
+    }
+
+    private static Phi[] toArray(final Phi args) {
+        final int length = Math.toIntExact(
+            new Dataized(
+                args.take("length")
+            ).take(Long.class)
+        );
+        final Phi[] res = new Phi[length];
+        Phi external = args;
+        for (int i = length - 1; i >= 0; i--) {
+            res[i] = new PhMethod(external, "tail");
+            external = external.copy().take("head");
+        }
+        return res;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOseq.java
@@ -33,7 +33,6 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
-import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.eolang.Versionized;
 import org.eolang.XmirObject;
@@ -59,22 +58,20 @@ public final class EOseq extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final Phi steps = this.take("steps");
-        final Phi[] items = toArray(steps);
+        final Phi[] items = eoTupleAsJavaArray(steps);
         for (int ind = 0; ind < items.length - 1; ++ind) {
             new Dataized(items[ind]).take();
         }
         final Phi ret;
         if (items.length > 0) {
-            final Phi last = steps.take("at").copy();
-            last.put(0, new Data.ToPhi((long) items.length - 1L));
-            ret = last;
+            ret = new PhMethod(steps, "tail");
         } else {
             ret = new Data.ToPhi(false);
         }
         return ret;
     }
 
-    private static Phi[] toArray(final Phi args) {
+    private static Phi[] eoTupleAsJavaArray(final Phi args) {
         final int length = Math.toIntExact(
             new Dataized(
                 args.take("length")

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -129,3 +129,32 @@
             counter.as-int.plus 1
           counter.as-int
     1
+
+# This test should have acceptable time to pass.
+[] > very-long-seq
+  eq. > @
+    TRUE
+    seq
+      *
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -158,3 +158,23 @@
         TRUE
         TRUE
         TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE
+        TRUE


### PR DESCRIPTION
Closes #3048 
New test passes for `0.180 s`

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the conversion of EO tuple to a Java array in `EOseq.java`.

### Detailed summary
- Added a method `eoTupleAsArray` to convert EO tuple to Java array efficiently.
- Refactored the `lambda` method in `EOseq.java` to use the new `eoTupleAsArray` method for better performance.
- Replaced usage of `PhWith` with `PhMethod` for consistency and improved readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->