### PR TITLE
fix(#3053): `PhPackage` copies objects

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOφ.java
@@ -62,7 +62,6 @@ final class EOmalloc$EOφ extends PhDefault implements Atom {
         final Phi pointer = this.take(Attr.SIGMA).take("memory-block-pointer").copy();
         pointer.put("id", new Data.ToPhi((long) identifier));
         pointer.put("size", size);
-        System.out.println(new Data.ToPhi((long) identifier));
         return pointer;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtSetRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSetRho.java
@@ -34,6 +34,16 @@ package org.eolang;
 final class AtSetRho extends AtEnvelope {
     /**
      * Ctor.
+     * @param obj Object
+     * @param rho Rho that will be set
+     * @param name Name of the attribute
+     */
+    AtSetRho(final Phi obj, final Phi rho, final String name) {
+        this(new AtSimple(obj), rho, name);
+    }
+
+    /**
+     * Ctor.
      * @param attr Origin attribute
      * @param rho Rho that will be set
      * @param name Name of the attribute

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -120,7 +120,9 @@ final class PhPackage implements Phi {
 
     @Override
     public void put(final String name, final Phi object) {
-        // Ignores it
+        throw new IllegalStateException(
+            String.format("Can't #put(%s, %s) to package object '%s'", name, object, this.pkg)
+        );
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -92,7 +92,16 @@ final class PhPackage implements Phi {
         if (!this.objects.get().containsKey(key)) {
             this.objects.get().put(key, this.loadPhi(key).orElseGet(() -> new PhPackage(obj)));
         }
-        return this.objects.get().get(key);
+        final Phi res;
+        final Phi phi = this.objects.get().get(key);
+        if (phi instanceof PhPackage) {
+            res = phi;
+        } else {
+            res = new AtSetRho(
+                this.objects.get().get(key).copy(), this, key
+            ).get();
+        }
+        return res;
     }
 
     @Override
@@ -111,9 +120,7 @@ final class PhPackage implements Phi {
 
     @Override
     public void put(final String name, final Phi object) {
-        throw new IllegalStateException(
-            String.format("Can't #put(%s, %s) to package object '%s'", name, object, this.pkg)
-        );
+        // Ignores it
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
@@ -47,8 +47,8 @@ public final class PhTracedLocator implements Phi {
      * Cages that are currently being dataized. If one cage is being datazed, and
      * it needs to be dataized inside current dataization, the locator of current object be here.
      */
-    private static final ThreadLocal<Map<Integer, Integer>>
-        DATAIZING_CAGES = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Map<Integer, Integer>> DATAIZING_CAGES = ThreadLocal
+        .withInitial(HashMap::new);
 
     /**
      * Encaged object itself.

--- a/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
@@ -29,11 +29,10 @@ import java.util.function.Supplier;
 
 /**
  * Class to trace if the "cage.new" got into recursion during the dataization.
- * NOT thread-safe.
+ * This class is thread safe in the meaning that different threads
+ * can safely use different instances of the class and recursion
+ * (If a thread dataizes the same recursively) will still be detected.
  * @since 0.36
- * @todo #2836:60min Make the class thread safe. It has private static
- *  field which can be accessed from differ thread and is not thread safe.
- *  Needs to synchronize this field.
  */
 @Versionized
 public final class PhTracedLocator implements Phi {
@@ -48,7 +47,8 @@ public final class PhTracedLocator implements Phi {
      * Cages that are currently being dataized. If one cage is being datazed, and
      * it needs to be dataized inside current dataization, the locator of current object be here.
      */
-    private static final Map<Integer, Integer> DATAIZING_CAGES = new HashMap<>();
+    private static final ThreadLocal<Map<Integer, Integer>>
+        DATAIZING_CAGES = ThreadLocal.withInitial(HashMap::new);
 
     /**
      * Encaged object itself.
@@ -185,7 +185,7 @@ public final class PhTracedLocator implements Phi {
          * @return New value in the map.
          */
         private Integer incrementCageCounter() {
-            return PhTracedLocator.DATAIZING_CAGES.compute(
+            return PhTracedLocator.DATAIZING_CAGES.get().compute(
                 PhTracedLocator.this.locator, (key, counter) -> {
                     final int ret = this.incremented(counter);
                     if (ret > PhTracedLocator.this.depth) {
@@ -226,11 +226,11 @@ public final class PhTracedLocator implements Phi {
         private void decrementCageCounter(final int incremented) {
             final int decremented = incremented - 1;
             if (decremented == 0) {
-                PhTracedLocator.DATAIZING_CAGES.remove(
+                PhTracedLocator.DATAIZING_CAGES.get().remove(
                     PhTracedLocator.this.locator
                 );
             } else {
-                PhTracedLocator.DATAIZING_CAGES.put(
+                PhTracedLocator.DATAIZING_CAGES.get().put(
                     PhTracedLocator.this.locator, decremented
                 );
             }

--- a/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/goto-tests.eo
@@ -28,9 +28,6 @@
 +version 0.0.0
 
 # Test.
-# @todo #3002:30min Enable the test "nested-goto". The test is disabled because top level object
-#  (like int, float, goto; which & is package eolang) are not copied when taken. When it's fixed,
-#  id inside "go" object should generate new number every time. And "nested-goto" should work.
 [] > goto-jumps-backwards
   (memory 0).alloc > i
   eq. > @
@@ -94,7 +91,7 @@
 
 # Test.
 [] > nested-goto
-  eq. > res
+  eq. > @
     go.to
       [g1]
         seq > @
@@ -104,4 +101,3 @@
                 g1.forward 42 > @
             7
     42
-  TRUE > @

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -56,12 +56,24 @@ final class PhPackageTest {
     private static final String DEFAULT_PACKAGE = "org.eolang";
 
     @Test
-    void takesPackage() {
+    void copiesObject() {
         MatcherAssert.assertThat(
             Phi.Φ.take("org").take("eolang").take("seq"),
-            Matchers.equalTo(
-                Phi.Φ.take("org").take("eolang").take("seq")
+            Matchers.not(
+                Matchers.equalTo(
+                    Phi.Φ.take("org").take("eolang").take("seq")
+                )
             )
+        );
+    }
+
+    @Test
+    void setsRhoToObject() {
+        final Phi eolang = Phi.Φ.take("org").take("eolang");
+        final Phi seq = eolang.take("seq");
+        MatcherAssert.assertThat(
+            seq.take(Attr.RHO),
+            Matchers.equalTo(eolang)
         );
     }
 


### PR DESCRIPTION
Closes: #3053
Closes: #3055
Closes: #2836

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance object copying and thread safety in the codebase.

### Detailed summary
- Added a constructor in `AtSetRho` to set attributes
- Improved object copying logic in `PhPackage`
- Enhanced thread safety in `PhTracedLocator`
- Added tests for object copying and thread safety

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->