### PR TITLE
fix(#3040): less max_tokens, 2000 for now

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -25,5 +25,5 @@ jobs:
           PROMPT: Please check if there are any confusions or irregularities in the following code diff
           top_p: 1
           temperature: 1
-          max_tokens: 10000
+          max_tokens: 2000
           MAX_PATCH_LENGTH: 10000


### PR DESCRIPTION
I've found this error in GHA run logs: https://github.com/objectionary/eo/actions/runs/8595002306/job/23548974948

This pull request fixes amount of `max_tokens`, making it less than `8192` (ChatGPT-4 maximum context length).

ref: #3040

<!-- start pr-codex -->

---

## PR-Codex overview
This PR reduces the `max_tokens` value from 10000 to 2000 in the `.github/workflows/cr.yml` file.

### Detailed summary
- Updated `max_tokens` value from 10000 to 2000 in `.github/workflows/cr.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->