### PR TITLE
fix(#3060): object is not copied on dispatch if it has `\rho` 

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/go.eo
+++ b/eo-runtime/src/main/eo/org/eolang/go.eo
@@ -72,7 +72,7 @@
       # Backward jump.
       error > backward
         []
-          &.^.@ > value
+          &.^.^.to &.^.body > value
           &.^.^.id > id
 
       # Forward jump.

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -45,8 +45,9 @@
 
   # Pointer to allocated block in memory.
   # Here `id` is identifier of pointer, `size` is length of the block.
-  [id size] > memory-block-pointer
+  [id] > memory-block-pointer
     $ > pointer
+    ^.size > size
 
     # Read `bytes` from the block in memory by the pointer.
     [] > read /bytes

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOnew.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOnew.java
@@ -131,7 +131,7 @@ public final class EOcage$EOnew extends PhDefault implements Atom {
         }
 
         @Override
-        public void put(final Phi phi) {
+        public boolean put(final Phi phi) {
             if (this.forma == null) {
                 this.forma = phi.forma();
             } else if (!this.forma.equals(phi.forma())) {
@@ -147,6 +147,7 @@ public final class EOcage$EOnew extends PhDefault implements Atom {
                 }
             }
             EOcage$EOnew.CAGES.put(this.locator, phi);
+            return true;
         }
 
         @Override

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOφ.java
@@ -59,9 +59,8 @@ final class EOmalloc$EOφ extends PhDefault implements Atom {
         final int identifier = Heaps.INSTANCE.get().malloc(
             this, new Dataized(size).take(Long.class).intValue()
         );
-        final Phi pointer = this.take(Attr.SIGMA).take("memory-block-pointer").copy();
+        final Phi pointer = this.take(Attr.RHO).take("memory-block-pointer").copy();
         pointer.put("id", new Data.ToPhi((long) identifier));
-        pointer.put("size", size);
         return pointer;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtry.java
@@ -126,13 +126,17 @@ public final class EOtry extends PhDefault implements Atom {
         }
 
         @Override
-        public void put(final int pos, final Phi object) {
-            this.func.accept(phi -> phi.put(pos, object));
+        public boolean put(final int pos, final Phi object) {
+            return new TryReturn<Boolean>(
+                this.body, this.ctch, this.last
+            ).apply(phi -> phi.put(pos, object));
         }
 
         @Override
-        public void put(final String name, final Phi object) {
-            this.func.accept(phi -> phi.put(name, object));
+        public boolean put(final String name, final Phi object) {
+            return new TryReturn<Boolean>(
+                this.body, this.ctch, this.last
+            ).apply(phi -> phi.put(name, object));
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/AtComposite.java
+++ b/eo-runtime/src/main/java/org/eolang/AtComposite.java
@@ -77,7 +77,7 @@ public final class AtComposite implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         throw new ExReadOnly(
             "You can't overwrite lambda expression"
         );

--- a/eo-runtime/src/main/java/org/eolang/AtEnvelope.java
+++ b/eo-runtime/src/main/java/org/eolang/AtEnvelope.java
@@ -54,8 +54,8 @@ public abstract class AtEnvelope implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
-        this.origin.put(phi);
+    public boolean put(final Phi phi) {
+        return this.origin.put(phi);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/AtFixed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFixed.java
@@ -74,7 +74,7 @@ final class AtFixed implements Attr {
     }
 
     @Override
-    public void put(final Phi src) {
-        // ignore it
+    public boolean put(final Phi src) {
+        return false;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtFormed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtFormed.java
@@ -70,7 +70,7 @@ public final class AtFormed implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         throw new ExReadOnly(
             "Formed attribute is read only"
         );

--- a/eo-runtime/src/main/java/org/eolang/AtGetOnly.java
+++ b/eo-runtime/src/main/java/org/eolang/AtGetOnly.java
@@ -58,7 +58,7 @@ final class AtGetOnly implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         throw new IllegalStateException(
             "Should never happen"
         );

--- a/eo-runtime/src/main/java/org/eolang/AtLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/AtLogged.java
@@ -98,9 +98,10 @@ final class AtLogged implements Attr {
     }
 
     @Override
-    public void put(final Phi src) {
+    public boolean put(final Phi src) {
         this.log.info(String.format("  %s.put()...\n", this.owner));
-        this.origin.put(src);
+        final boolean ret = this.origin.put(src);
         this.log.info(String.format("  %s.put()!\n", this.owner));
+        return ret;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtNamed.java
@@ -98,9 +98,9 @@ final class AtNamed implements Attr {
     }
 
     @Override
-    public void put(final Phi src) {
+    public boolean put(final Phi src) {
         try {
-            this.origin.put(src);
+            return this.origin.put(src);
         } catch (final ExReadOnly ex) {
             throw new ExReadOnly(this.label(), ex);
         } catch (final ExFailure ex) {

--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -94,7 +94,7 @@ public final class AtOnce implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         throw new ExReadOnly(
             String.format(
                 "You can't overwrite '%s'",

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -81,10 +81,15 @@ final class AtRho implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
+        final boolean ret;
         if (this.rho.get() == null) {
             this.rho.set(phi);
+            ret = true;
+        } else {
+            ret = false;
         }
+        return ret;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/AtSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSafe.java
@@ -85,9 +85,9 @@ final class AtSafe implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         try {
-            this.origin.put(phi);
+            return this.origin.put(phi);
         } catch (final ExFailure ex) {
             throw new EOerror.ExError(
                 new Data.ToPhi(EOerror.message(ex))

--- a/eo-runtime/src/main/java/org/eolang/AtSetRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSetRho.java
@@ -25,8 +25,8 @@
 package org.eolang;
 
 /**
- * The attribute tries to set \rho to the given attribute.
- * If the name of the attribute is {@link Attr#RHO} or {@link Attr#SIGMA} - just attribute is
+ * The attribute tries to copy object and set \rho to it.
+ * If the name of the attribute is {@link Attr#RHO} or {@link Attr#SIGMA} - just object is
  * returned.
  *
  * @since 0.36.0

--- a/eo-runtime/src/main/java/org/eolang/AtSetRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtSetRho.java
@@ -25,10 +25,10 @@
 package org.eolang;
 
 /**
- * Attribute that tries to set \rho to retrieved object.
- * Attribute does not set \rho if retrieved object is \rho or \sigma.
- * Since every \rho attribute of {@link Phi} is {@link AtRho} it won't be
- * reset because {@link AtRho} ignores all puts except first.
+ * The attribute tries to set \rho to the given attribute.
+ * If the name of the attribute is {@link Attr#RHO} or {@link Attr#SIGMA} - just attribute is
+ * returned.
+ *
  * @since 0.36.0
  */
 final class AtSetRho extends AtEnvelope {
@@ -52,9 +52,12 @@ final class AtSetRho extends AtEnvelope {
         super(
             new AtGetOnly(
                 () -> {
-                    final Phi ret = attr.get();
+                    Phi ret = attr.get();
                     if (!name.equals(Attr.RHO) && !name.equals(Attr.SIGMA)) {
-                        ret.put(Attr.RHO, rho);
+                        final Phi copy = ret.copy();
+                        if (copy.put(Attr.RHO, rho)) {
+                            ret = copy;
+                        }
                     }
                     return ret;
                 }

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -112,7 +112,7 @@ public final class AtVoid implements Attr {
     }
 
     @Override
-    public void put(final Phi phi) {
+    public boolean put(final Phi phi) {
         if (this.object.get() == null) {
             this.object.set(phi);
         } else {
@@ -120,6 +120,7 @@ public final class AtVoid implements Attr {
                 "This void attribute is already set, can't reset"
             );
         }
+        return true;
     }
 
 }

--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -75,7 +75,7 @@ public interface Attr extends Term {
      * Put a new object in.
      *
      * @param phi The object to put
+     * @return Was attribute set
      */
-    void put(Phi phi);
-
+    boolean put(Phi phi);
 }

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -100,13 +100,13 @@ public interface Data {
         }
 
         @Override
-        public void put(final int pos, final Phi obj) {
-            this.object.put(pos, obj);
+        public boolean put(final int pos, final Phi obj) {
+            return this.object.put(pos, obj);
         }
 
         @Override
-        public void put(final String name, final Phi obj) {
-            this.object.put(name, obj);
+        public boolean put(final String name, final Phi obj) {
+            return this.object.put(name, obj);
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/PhConst.java
+++ b/eo-runtime/src/main/java/org/eolang/PhConst.java
@@ -97,13 +97,13 @@ public final class PhConst implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
-        this.primitive().put(pos, object);
+    public boolean put(final int pos, final Phi object) {
+        return this.primitive().put(pos, object);
     }
 
     @Override
-    public void put(final String name, final Phi object) {
-        this.primitive().put(name, object);
+    public boolean put(final String name, final Phi object) {
+        return this.primitive().put(name, object);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -195,12 +195,12 @@ public abstract class PhDefault implements Phi, Cloneable {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
-        this.put(this.attr(pos), object);
+    public boolean put(final int pos, final Phi object) {
+        return this.put(this.attr(pos), object);
     }
 
     @Override
-    public void put(final String name, final Phi object) {
+    public boolean put(final String name, final Phi object) {
         if (!this.attrs.containsKey(name)) {
             throw new ExUnset(
                 String.format(
@@ -209,7 +209,7 @@ public abstract class PhDefault implements Phi, Cloneable {
                 )
             );
         }
-        new AtSafe(this.named(this.attrs.get(name), name)).put(object);
+        return new AtSafe(this.named(this.attrs.get(name), name)).put(object);
     }
 
     @Override
@@ -220,7 +220,7 @@ public abstract class PhDefault implements Phi, Cloneable {
             object = new AtSafe(
                 this.named(
                     new AtSetRho(
-                        new AtCopied(this.attrs.get(name), name),
+                        this.attrs.get(name),
                         this,
                         name
                     ),

--- a/eo-runtime/src/main/java/org/eolang/PhLocated.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLocated.java
@@ -114,13 +114,13 @@ public final class PhLocated implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
-        this.origin.put(pos, object);
+    public boolean put(final int pos, final Phi object) {
+        return this.origin.put(pos, object);
     }
 
     @Override
-    public void put(final String name, final Phi object) {
-        this.origin.put(name, object);
+    public boolean put(final String name, final Phi object) {
+        return this.origin.put(name, object);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -71,17 +71,19 @@ public final class PhLogged implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
+    public boolean put(final int pos, final Phi object) {
         System.out.printf("%d.put(%d, %d)...\n", this.hashCode(), pos, object.hashCode());
-        this.origin.put(pos, object);
+        final boolean ret = this.origin.put(pos, object);
         System.out.printf("%d.put(%d, %d)!\n", this.hashCode(), pos, object.hashCode());
+        return ret;
     }
 
     @Override
-    public void put(final String name, final Phi object) {
+    public boolean put(final String name, final Phi object) {
         System.out.printf("%d.put(\"%s\", %d)...\n", this.hashCode(), name, object.hashCode());
-        this.origin.put(name, object);
+        final boolean ret = this.origin.put(name, object);
         System.out.printf("%d.put(\"%s\", %d)!\n", this.hashCode(), name, object.hashCode());
+        return ret;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNamed.java
@@ -84,13 +84,13 @@ final class PhNamed implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
-        this.origin.put(pos, object);
+    public boolean put(final int pos, final Phi object) {
+        return this.origin.put(pos, object);
     }
 
     @Override
-    public void put(final String nme, final Phi object) {
-        this.origin.put(nme, object);
+    public boolean put(final String nme, final Phi object) {
+        return this.origin.put(nme, object);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -111,13 +111,13 @@ class PhOnce implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi obj) {
-        this.object.get().put(pos, obj);
+    public boolean put(final int pos, final Phi obj) {
+        return this.object.get().put(pos, obj);
     }
 
     @Override
-    public void put(final String name, final Phi obj) {
-        this.object.get().put(name, obj);
+    public boolean put(final String name, final Phi obj) {
+        return this.object.get().put(name, obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -98,22 +98,20 @@ final class PhPackage implements Phi {
         if (phi instanceof PhPackage) {
             res = phi;
         } else {
-            res = new AtSetRho(
-                this.objects.get().get(key).copy(), this, key
-            ).get();
+            res = new AtSetRho(this.objects.get().get(key), this, key).get();
         }
         return res;
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
+    public boolean put(final int pos, final Phi object) {
         throw new IllegalStateException(
             String.format("Can't #put(%d, %s) to package object '%s'", pos, object, this.pkg)
         );
     }
 
     @Override
-    public void put(final String name, final Phi object) {
+    public boolean put(final String name, final Phi object) {
         throw new IllegalStateException(
             String.format("Can't #put(%s, %s) to package object '%s'", name, object, this.pkg)
         );

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -85,9 +85,9 @@ public final class PhSafe implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi object) {
+    public boolean put(final int pos, final Phi object) {
         try {
-            this.origin.put(pos, object);
+            return this.origin.put(pos, object);
         } catch (final ExFailure ex) {
             throw new EOerror.ExError(
                 new Data.ToPhi(EOerror.message(ex))
@@ -96,9 +96,9 @@ public final class PhSafe implements Phi {
     }
 
     @Override
-    public void put(final String name, final Phi object) {
+    public boolean put(final String name, final Phi object) {
         try {
-            this.origin.put(name, object);
+            return this.origin.put(name, object);
         } catch (final ExFailure ex) {
             throw new EOerror.ExError(
                 new Data.ToPhi(EOerror.message(ex))

--- a/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracedLocator.java
@@ -105,13 +105,17 @@ public final class PhTracedLocator implements Phi {
     }
 
     @Override
-    public void put(final int pos, final Phi obj) {
-        this.object.put(pos, obj);
+    public boolean put(final int pos, final Phi obj) {
+        return new PhTracedLocator.TracingWhileGetting<>(
+            () -> this.object.put(pos, obj)
+        ).get();
     }
 
     @Override
-    public void put(final String name, final Phi obj) {
-        this.object.put(name, obj);
+    public boolean put(final String name, final Phi obj) {
+        return new PhTracedLocator.TracingWhileGetting<>(
+            () -> this.object.put(name, obj)
+        ).get();
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -81,14 +81,14 @@ public interface Phi extends Term, Data {
         }
 
         @Override
-        public void put(final int pos, final Phi object) {
+        public boolean put(final int pos, final Phi object) {
             throw new IllegalStateException(
                 String.format("Can't #put(%d, %s) to Φ", pos, object)
             );
         }
 
         @Override
-        public void put(final String name, final Phi object) {
+        public boolean put(final String name, final Phi object) {
             throw new IllegalStateException(
                 String.format("Can't #put(%s, %s) to Φ", name, object)
             );
@@ -134,15 +134,17 @@ public interface Phi extends Term, Data {
      * Put object by position of the attribute.
      * @param pos The position of the attribute.
      * @param object The object to put
+     * @return Was attribute set
      */
-    void put(int pos, Phi object);
+    boolean put(int pos, Phi object);
 
     /**
      * Put object by name of the attribute.
      * @param name The name of the attribute.
      * @param object The object to put
+     * @return Was attribute set
      */
-    void put(String name, Phi object);
+    boolean put(String name, Phi object);
 
     /**
      * Get code locator of the phi.

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -73,6 +73,10 @@
         FALSE
 
 # Test.
+[] > malloc-pointer-uses-right-size
+  (malloc 10).pointer.size.eq 10 > @
+
+# Test.
 [] > malloc-pointer-cant-write-more-than-allocated
   (malloc 1).pointer > p
   try > @

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -114,7 +114,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void takesDifferentKidsEveryDispatch() {
+    void takesDifferentAbstractKidsEveryDispatch() {
         final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
             "Child attributes should be copied on every dispatch",
@@ -232,7 +232,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void copiesSetVoidAttribute() {
+    void copiesSetVoidAttributeOnCopy() {
         final Phi phi = new PhDefaultTest.Int();
         phi.put("void", new Data.ToPhi(10L));
         final Phi copy = phi.copy();
@@ -242,6 +242,25 @@ final class PhDefaultTest {
             Matchers.not(
                 Matchers.equalTo(copy.take("void"))
             )
+        );
+    }
+
+    @Test
+    void doesNotCopySetVoidAttributeWithRho() {
+        final Phi phi = new PhDefaultTest.Int();
+        phi.put("void", new Data.ToPhi(10L));
+        MatcherAssert.assertThat(
+            phi.take("void"),
+            Matchers.equalTo(phi.take("void"))
+        );
+    }
+
+    @Test
+    void doesNotCopyContextAttributeWithRho() {
+        final Phi phi = new PhDefaultTest.Int();
+        MatcherAssert.assertThat(
+            phi.take("context"),
+            Matchers.equalTo(phi.take("context"))
         );
     }
 


### PR DESCRIPTION
What's done:
1. `Phi` interface was slightly changed. Method `#put()` returns `boolean` now. It allows us to check whether attribute was set or not. Because there's no other way we can check if object has `\rho` or not.
2. There's a case where object has `\rho`, its copy is created but not used. It's not perfect but works and does not produce any unnecessary calculations because they're cached.

Closes: #3060

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances attribute classes in the EO language runtime by changing `void` methods to return `boolean`. 

### Detailed summary
- Changed `void` methods to `boolean` in various attribute classes for improved functionality.
- Added error handling and return statements to methods for better control flow and clarity.

> The following files were skipped due to too many changes: `eo-runtime/src/main/java/org/eolang/AtSetRho.java`, `eo-runtime/src/main/java/org/eolang/Phi.java`, `eo-runtime/src/test/java/org/eolang/PhDefaultTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->