### PR TITLE
fix(#2925): fix typos in Phi grammar

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Phi.g4
@@ -32,8 +32,8 @@ bindings
 binding
     : alphaBinding
     | emptyBinding
-    | deltaBidning
-    | lambdaBidning
+    | deltaBinding
+    | lambdaBinding
     ;
 
 alphaBinding
@@ -56,11 +56,11 @@ emptyBinding
     : attribute ARROW EMPTY
     ;
 
-deltaBidning
+deltaBinding
     : DELTA DASHED_ARROW (BYTES | EMPTY)
     ;
 
-lambdaBidning
+lambdaBinding
     : LAMBDA DASHED_ARROW FUNCTION
     ;
 

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -287,7 +287,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterDeltaBidning(final PhiParser.DeltaBidningContext ctx) {
+    public void enterDeltaBinding(final PhiParser.DeltaBindingContext ctx) {
         if (ctx.EMPTY() != null) {
             throw new ParsingException(
                 "It's impossible to represent Δ ⤍ ∅ binding in EO",
@@ -306,19 +306,19 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     }
 
     @Override
-    public void exitDeltaBidning(final PhiParser.DeltaBidningContext ctx) {
+    public void exitDeltaBinding(final PhiParser.DeltaBindingContext ctx) {
         // Nothing here
     }
 
     @Override
-    public void enterLambdaBidning(final PhiParser.LambdaBidningContext ctx) {
+    public void enterLambdaBinding(final PhiParser.LambdaBindingContext ctx) {
         if (!XePhiListener.LAMBDA_PACKAGE.equals(ctx.FUNCTION().getText())) {
             this.objects().prop("atom");
         }
     }
 
     @Override
-    public void exitLambdaBidning(final PhiParser.LambdaBidningContext ctx) {
+    public void exitLambdaBinding(final PhiParser.LambdaBindingContext ctx) {
         // Nothing here
     }
 
@@ -410,7 +410,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
         return ctx.binding()
             .stream()
             .anyMatch(
-                context -> context.lambdaBidning() != null && context.lambdaBidning()
+                context -> context.lambdaBinding() != null && context.lambdaBinding()
                     .FUNCTION()
                     .getText()
                     .equals(XePhiListener.LAMBDA_PACKAGE)


### PR DESCRIPTION
Closes: #2925 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to correct misspelled identifiers and standardize method names in the `Phi.g4` and `XePhiListener.java` files.

### Detailed summary
- Fixed typos in `Phi.g4` file: `deltaBidning` -> `deltaBinding`, `lambdaBidning` -> `lambdaBinding`
- Renamed methods in `XePhiListener.java`: `DeltaBidning` -> `DeltaBinding`, `LambdaBidning` -> `LambdaBinding`
- Updated method references accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->