### PR TITLE
fix(#3082): added empty delta binding to bytes in phi

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -368,6 +368,14 @@ SOFTWARE.
           <xsl:value-of select="eo:comma(2, $tabs+1)"/>
         </xsl:if>
       </xsl:if>
+      <!-- Empty delta binding in org.eolang.bytes -->
+      <xsl:if test="$package=concat($program, '.', 'org.eolang') and $name='bytes'">
+        <xsl:value-of select="$delta"/>
+        <xsl:value-of select="$dashed-arrow"/>
+        <xsl:value-of select="$empty"/>
+        <xsl:value-of select="eo:comma(2, $tabs+1)"/>
+      </xsl:if>
+      <!-- Inner objects -->
       <xsl:for-each select="o">
         <xsl:value-of select="eo:comma(position(), $tabs+1)"/>
         <xsl:apply-templates select=".">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/bytes.yaml
@@ -66,6 +66,7 @@ phi: |
       org ↦ ⟦
         eolang ↦ ⟦
           bytes ↦ ⟦
+            Δ ⤍ ∅,
             eq ↦ ⟦
               λ ⤍ Lorg_eolang_bytes_eq,
               x ↦ ∅

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -289,20 +289,25 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     @Override
     public void enterDeltaBidning(final PhiParser.DeltaBidningContext ctx) {
         if (ctx.EMPTY() != null) {
-            throw new ParsingException(
-                "It's impossible to represent Δ ⤍ ∅ binding in EO",
-                new IllegalStateException(),
-                ctx.getStart().getLine()
-            );
+            if (!"org.eolang".equals(String.join(".", this.packages))
+                && !"bytes".equals(this.attributes.peek())
+            ) {
+                throw new ParsingException(
+                    "It's impossible to represent Δ ⤍ ∅ binding in EO",
+                    new IllegalStateException(),
+                    ctx.getStart().getLine()
+                );
+            }
+        } else {
+            this.objects()
+                .start()
+                .prop("data", "bytes")
+                .prop("base", "org.eolang.bytes");
+            if (!"--".equals(ctx.BYTES().getText())) {
+                this.objects().data(ctx.BYTES().getText().replaceAll("-", " ").trim());
+            }
+            this.objects().leave();
         }
-        this.objects()
-            .start()
-            .prop("data", "bytes")
-            .prop("base", "org.eolang.bytes");
-        if (!"--".equals(ctx.BYTES().getText())) {
-            this.objects().data(ctx.BYTES().getText().replaceAll("-", " ").trim());
-        }
-        this.objects().leave();
     }
 
     @Override


### PR DESCRIPTION
Closes: #3082

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of `Δ ⤍ ∅` binding in EO code generation.

### Detailed summary
- Improved handling of `Δ ⤍ ∅` binding in `XePhiListener.java`
- Updated condition check for package and attribute values
- Refactored code for better readability and maintainability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->