### PR TITLE
fix(#3093): added URL to exception message of `OyRemote`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/OyRemote.java
@@ -74,7 +74,8 @@ public final class OyRemote implements Objectionary {
             input -> {
                 throw new IOException(
                     String.format(
-                        "EO object '%s' is not found in this GitHub repository: https://github.com/objectionary/home. This means that you either misspelled the name of it or simply referred to your own local object somewhere in your code as if it was an object of 'org.eolang' package. Check the sources and make sure you always use +alias meta when you refer to an object outside of 'org.eolang', even if this object belongs to your package.",
+                        "EO object '%s' is not found in this GitHub repository: https://github.com/objectionary/home by url: %s. This means that you either misspelled the name of it or simply referred to your own local object somewhere in your code as if it was an object of 'org.eolang' package. Check the sources and make sure you always use +alias meta when you refer to an object outside of 'org.eolang', even if this object belongs to your package.",
+                        url,
                         name
                     ),
                     input


### PR DESCRIPTION
Closes: #3093 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve the error message in `OyRemote.java` by adding the URL of the missing EO object.

### Detailed summary
- Updated error message in `OyRemote.java` to include the URL of the missing EO object.
- Improved clarity for developers encountering missing EO objects.
- Emphasized the importance of using +alias meta when referring to objects outside 'org.eolang'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->