### PR TITLE
fix(#2962): better `self-naming` check

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/errors/self-naming.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/self-naming.xsl
@@ -32,17 +32,17 @@ SOFTWARE.
   <!-- $.x > x -->
   <xsl:function name="eo:with-this" as="xs:boolean">
     <xsl:param name="object"/>
-    <xsl:sequence select="$object/@base=concat('.', $object/@name) and $object/@method and $object/preceding-sibling::o[@base='$']"/>
+    <xsl:sequence select="$object/@base=concat('.', $object/@name) and $object/@method and $object/preceding-sibling::o[1][@base='$']"/>
   </xsl:function>
   <!-- x.method any > x -->
   <xsl:function name="eo:with-method" as="xs:boolean">
     <xsl:param name="object"/>
-    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[@base=$object/@name]"/>
+    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[1][@base=$object/@name]"/>
   </xsl:function>
   <!-- $.x.method any > x -->
   <xsl:function name="eo:with-method-and-this" as="xs:boolean">
     <xsl:param name="object"/>
-    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[@base=concat('.',$object/@name) and @method and preceding-sibling::o[@base='$']]"/>
+    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[1][@base=concat('.',$object/@name) and @method and preceding-sibling::o[1][@base='$']]"/>
   </xsl:function>
   <xsl:template match="/program/errors">
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/self-naming.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/self-naming.xsl
@@ -22,12 +22,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="self-naming" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="self-naming" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
+  <!-- x > x -->
+  <xsl:function name="eo:base-eq-name" as="xs:boolean">
+    <xsl:param name="object"/>
+    <xsl:sequence select="$object/@base=$object/@name"/>
+  </xsl:function>
+  <!-- $.x > x -->
+  <xsl:function name="eo:with-this" as="xs:boolean">
+    <xsl:param name="object"/>
+    <xsl:sequence select="$object/@base=concat('.', $object/@name) and $object/@method and $object/preceding-sibling::o[@base='$']"/>
+  </xsl:function>
+  <!-- x.method any > x -->
+  <xsl:function name="eo:with-method" as="xs:boolean">
+    <xsl:param name="object"/>
+    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[@base=$object/@name]"/>
+  </xsl:function>
+  <!-- $.x.method any > x -->
+  <xsl:function name="eo:with-method-and-this" as="xs:boolean">
+    <xsl:param name="object"/>
+    <xsl:sequence select="starts-with($object/@base,'.') and $object/@method and $object/preceding-sibling::o[@base=concat('.',$object/@name) and @method and preceding-sibling::o[@base='$']]"/>
+  </xsl:function>
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="//o[@name and @base and @base=@name]">
+      <xsl:for-each select="//o[@name and @base and (eo:base-eq-name(.) or eo:with-this(.) or eo:with-method(.) or eo:with-method-and-this(.))]">
         <xsl:element name="error">
           <xsl:attribute name="check">
             <xsl:text>self-naming</xsl:text>

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-method-and-this.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-method-and-this.yaml
@@ -1,0 +1,9 @@
+xsls:
+  - /org/eolang/parser/errors/self-naming.xsl
+tests:
+  - /program/errors[count(error[@severity='error'])=1]
+  - /program/errors/error[@line='3']
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > first
+    $.a.plus 1 > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-method.yaml
@@ -1,0 +1,9 @@
+xsls:
+  - /org/eolang/parser/errors/self-naming.xsl
+tests:
+  - /program/errors[count(error[@severity='error'])=1]
+  - /program/errors/error[@line='3']
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > first
+    a.plus 1 > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-this.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-self-naming-with-this.yaml
@@ -1,0 +1,9 @@
+xsls:
+  - /org/eolang/parser/errors/self-naming.xsl
+tests:
+  - /program/errors[count(error[@severity='error'])=1]
+  - /program/errors/error[@line='3']
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > first
+    $.a > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-no-catch.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-no-catch.yaml
@@ -1,0 +1,14 @@
+xsls:
+  - /org/eolang/parser/errors/self-naming.xsl
+tests:
+  - /program/errors[count(error)=0]
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > first
+    5.plus a > a
+    ^.size > size
+  # This is the default 64+ symbols comment in front of abstract object.
+  [size] > more
+    # This is the default 64+ symbols comment in front of abstract object.
+    [] > inner
+      ^.size > size

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-with-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-with-argument.yaml
@@ -1,0 +1,8 @@
+xsls:
+  - /org/eolang/parser/errors/self-naming.xsl
+tests:
+  - /program/errors[count(error)=0]
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > first
+    5.plus a > a

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-with-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/self-naming-with-argument.yaml
@@ -1,8 +1,0 @@
-xsls:
-  - /org/eolang/parser/errors/self-naming.xsl
-tests:
-  - /program/errors[count(error)=0]
-eo: |
-  # This is the default 64+ symbols comment in front of abstract object.
-  [] > first
-    5.plus a > a


### PR DESCRIPTION
`self-naming.xsl` check is improved, added new [test cases](https://github.com/objectionary/eo/issues/2962#issuecomment-2054166652)

Closes: #2962 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance error handling in the EO parser by introducing new functions and updating XSLT stylesheets.

### Detailed summary
- Added new XSLT functions for error checking
- Updated XSLT stylesheet for error handling
- Updated test YAML files for error scenarios

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->