### PR TITLE
#3047: Renamed to PhTraced

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOencaged$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOencaged$EOφ.java
@@ -31,7 +31,7 @@ import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Param;
 import org.eolang.PhDefault;
-import org.eolang.PhTracing;
+import org.eolang.PhTraced;
 import org.eolang.Phi;
 import org.eolang.Versionized;
 import org.eolang.XmirObject;
@@ -57,7 +57,7 @@ final class EOcage$EOencaged$EOφ extends PhDefault implements Atom {
         final int locator = Math.toIntExact(
             new Param(this.take(Attr.RHO), "locator").strong(Long.class)
         );
-        return new PhTracing(
+        return new PhTraced(
             Cages.INSTANCE.get(locator),
             locator
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOencaged$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOcage$EOencaged$EOφ.java
@@ -31,7 +31,7 @@ import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Param;
 import org.eolang.PhDefault;
-import org.eolang.PhTracedLocator;
+import org.eolang.PhTracing;
 import org.eolang.Phi;
 import org.eolang.Versionized;
 import org.eolang.XmirObject;
@@ -57,7 +57,7 @@ final class EOcage$EOencaged$EOφ extends PhDefault implements Atom {
         final int locator = Math.toIntExact(
             new Param(this.take(Attr.RHO), "locator").strong(Long.class)
         );
-        return new PhTracedLocator(
+        return new PhTracing(
             Cages.INSTANCE.get(locator),
             locator
         );

--- a/eo-runtime/src/main/java/org/eolang/PhTraced.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTraced.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
  * @since 0.36
  */
 @Versionized
-public final class PhTracing implements Phi {
+public final class PhTraced implements Phi {
 
     /**
      * Name of property that responsible for keeping max depth.
@@ -70,12 +70,12 @@ public final class PhTracing implements Phi {
      * @param object Encaged object
      * @param locator Locator of encaged object
      */
-    public PhTracing(final Phi object, final Integer locator) {
+    public PhTraced(final Phi object, final Integer locator) {
         this(
             object,
             locator,
             Integer.parseInt(
-                System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "100")
+                System.getProperty(PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "100")
             )
         );
     }
@@ -86,7 +86,7 @@ public final class PhTracing implements Phi {
      * @param locator Locator of encaged object
      * @param depth Max depth of cage recursion
      */
-    public PhTracing(final Phi object, final Integer locator, final int depth) {
+    public PhTraced(final Phi object, final Integer locator, final int depth) {
         this.object = object;
         this.locator = locator;
         this.depth = depth;
@@ -94,26 +94,26 @@ public final class PhTracing implements Phi {
 
     @Override
     public Phi copy() {
-        return new PhTracing(this.object.copy(), this.locator);
+        return new PhTraced(this.object.copy(), this.locator);
     }
 
     @Override
     public Phi take(final String name) {
-        return new PhTracing.TracingWhileGetting<>(
+        return new PhTraced.TracingWhileGetting<>(
             () -> this.object.take(name)
         ).get();
     }
 
     @Override
     public boolean put(final int pos, final Phi obj) {
-        return new PhTracing.TracingWhileGetting<>(
+        return new PhTraced.TracingWhileGetting<>(
             () -> this.object.put(pos, obj)
         ).get();
     }
 
     @Override
     public boolean put(final String name, final Phi obj) {
-        return new PhTracing.TracingWhileGetting<>(
+        return new PhTraced.TracingWhileGetting<>(
             () -> this.object.put(name, obj)
         ).get();
     }
@@ -183,19 +183,19 @@ public final class PhTracing implements Phi {
         }
 
         /**
-         * Increments counter of cage in the {@link PhTracing#DATAIZING_CAGES}.
+         * Increments counter of cage in the {@link PhTraced#DATAIZING_CAGES}.
          * @return New value in the map.
          */
         private Integer incrementCageCounter() {
-            return PhTracing.DATAIZING_CAGES.get().compute(
-                PhTracing.this.locator, (key, counter) -> {
+            return PhTraced.DATAIZING_CAGES.get().compute(
+                PhTraced.this.locator, (key, counter) -> {
                     final int ret = this.incremented(counter);
-                    if (ret > PhTracing.this.depth) {
+                    if (ret > PhTraced.this.depth) {
                         throw new ExFailure(
                             "The cage %s with locator %d has reached the maximum nesting depth = %d",
-                            PhTracing.this.object,
-                            PhTracing.this.locator,
-                            PhTracing.this.depth
+                            PhTraced.this.object,
+                            PhTraced.this.locator,
+                            PhTraced.this.depth
                         );
                     }
                     return ret;
@@ -221,19 +221,19 @@ public final class PhTracing implements Phi {
         }
 
         /**
-         * Decrements counter in the {@link PhTracing#DATAIZING_CAGES}.
+         * Decrements counter in the {@link PhTraced#DATAIZING_CAGES}.
          * @param incremented Current value of counter. This argument ensures
          *  temporal coupling with {@link TracingWhileGetting#incrementCageCounter} method.
          */
         private void decrementCageCounter(final int incremented) {
             final int decremented = incremented - 1;
             if (decremented == 0) {
-                PhTracing.DATAIZING_CAGES.get().remove(
-                    PhTracing.this.locator
+                PhTraced.DATAIZING_CAGES.get().remove(
+                    PhTraced.this.locator
                 );
             } else {
-                PhTracing.DATAIZING_CAGES.get().put(
-                    PhTracing.this.locator, decremented
+                PhTraced.DATAIZING_CAGES.get().put(
+                    PhTraced.this.locator, decremented
                 );
             }
         }

--- a/eo-runtime/src/main/java/org/eolang/PhTracing.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTracing.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
  * @since 0.36
  */
 @Versionized
-public final class PhTracedLocator implements Phi {
+public final class PhTracing implements Phi {
 
     /**
      * Name of property that responsible for keeping max depth.
@@ -70,12 +70,12 @@ public final class PhTracedLocator implements Phi {
      * @param object Encaged object
      * @param locator Locator of encaged object
      */
-    public PhTracedLocator(final Phi object, final Integer locator) {
+    public PhTracing(final Phi object, final Integer locator) {
         this(
             object,
             locator,
             Integer.parseInt(
-                System.getProperty(PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "100")
+                System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "100")
             )
         );
     }
@@ -86,7 +86,7 @@ public final class PhTracedLocator implements Phi {
      * @param locator Locator of encaged object
      * @param depth Max depth of cage recursion
      */
-    public PhTracedLocator(final Phi object, final Integer locator, final int depth) {
+    public PhTracing(final Phi object, final Integer locator, final int depth) {
         this.object = object;
         this.locator = locator;
         this.depth = depth;
@@ -94,26 +94,26 @@ public final class PhTracedLocator implements Phi {
 
     @Override
     public Phi copy() {
-        return new PhTracedLocator(this.object.copy(), this.locator);
+        return new PhTracing(this.object.copy(), this.locator);
     }
 
     @Override
     public Phi take(final String name) {
-        return new PhTracedLocator.TracingWhileGetting<>(
+        return new PhTracing.TracingWhileGetting<>(
             () -> this.object.take(name)
         ).get();
     }
 
     @Override
     public boolean put(final int pos, final Phi obj) {
-        return new PhTracedLocator.TracingWhileGetting<>(
+        return new PhTracing.TracingWhileGetting<>(
             () -> this.object.put(pos, obj)
         ).get();
     }
 
     @Override
     public boolean put(final String name, final Phi obj) {
-        return new PhTracedLocator.TracingWhileGetting<>(
+        return new PhTracing.TracingWhileGetting<>(
             () -> this.object.put(name, obj)
         ).get();
     }
@@ -183,19 +183,19 @@ public final class PhTracedLocator implements Phi {
         }
 
         /**
-         * Increments counter of cage in the {@link PhTracedLocator#DATAIZING_CAGES}.
+         * Increments counter of cage in the {@link PhTracing#DATAIZING_CAGES}.
          * @return New value in the map.
          */
         private Integer incrementCageCounter() {
-            return PhTracedLocator.DATAIZING_CAGES.get().compute(
-                PhTracedLocator.this.locator, (key, counter) -> {
+            return PhTracing.DATAIZING_CAGES.get().compute(
+                PhTracing.this.locator, (key, counter) -> {
                     final int ret = this.incremented(counter);
-                    if (ret > PhTracedLocator.this.depth) {
+                    if (ret > PhTracing.this.depth) {
                         throw new ExFailure(
                             "The cage %s with locator %d has reached the maximum nesting depth = %d",
-                            PhTracedLocator.this.object,
-                            PhTracedLocator.this.locator,
-                            PhTracedLocator.this.depth
+                            PhTracing.this.object,
+                            PhTracing.this.locator,
+                            PhTracing.this.depth
                         );
                     }
                     return ret;
@@ -221,19 +221,19 @@ public final class PhTracedLocator implements Phi {
         }
 
         /**
-         * Decrements counter in the {@link PhTracedLocator#DATAIZING_CAGES}.
+         * Decrements counter in the {@link PhTracing#DATAIZING_CAGES}.
          * @param incremented Current value of counter. This argument ensures
          *  temporal coupling with {@link TracingWhileGetting#incrementCageCounter} method.
          */
         private void decrementCageCounter(final int incremented) {
             final int decremented = incremented - 1;
             if (decremented == 0) {
-                PhTracedLocator.DATAIZING_CAGES.get().remove(
-                    PhTracedLocator.this.locator
+                PhTracing.DATAIZING_CAGES.get().remove(
+                    PhTracing.this.locator
                 );
             } else {
-                PhTracedLocator.DATAIZING_CAGES.get().put(
-                    PhTracedLocator.this.locator, decremented
+                PhTracing.DATAIZING_CAGES.get().put(
+                    PhTracing.this.locator, decremented
                 );
             }
         }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -40,7 +40,7 @@ import org.eolang.ExAbstract;
 import org.eolang.PhCopy;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
-import org.eolang.PhTracedLocator;
+import org.eolang.PhTracing;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
@@ -200,13 +200,13 @@ final class EOcageTest {
         @BeforeEach
         void setDepth() {
             System.setProperty(
-                PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
+                PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
             );
         }
 
         @AfterEach
         void clearDepth() {
-            System.clearProperty(PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME);
+            System.clearProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME);
         }
 
         @Test
@@ -244,7 +244,7 @@ final class EOcageTest {
         @Test
         void rewritesItselfToItselfViaDummy() {
             System.setProperty(
-                PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "2"
+                PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "2"
             );
             final Phi cage = EOcageTest.encaged(
                 new PhWith(new EOcageTest.Dummy(Phi.Φ), 0, new Data.ToPhi(1L))
@@ -282,8 +282,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is less than property %s = %s does not throw %s",
-                    PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -303,8 +303,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is equal to property %s = %s does not throw %s",
-                    PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -322,8 +322,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
-                    PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracedLocator.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -40,7 +40,7 @@ import org.eolang.ExAbstract;
 import org.eolang.PhCopy;
 import org.eolang.PhDefault;
 import org.eolang.PhMethod;
-import org.eolang.PhTracing;
+import org.eolang.PhTraced;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
@@ -200,13 +200,13 @@ final class EOcageTest {
         @BeforeEach
         void setDepth() {
             System.setProperty(
-                PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
+                PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, String.valueOf(MAX_DEPTH)
             );
         }
 
         @AfterEach
         void clearDepth() {
-            System.clearProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME);
+            System.clearProperty(PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME);
         }
 
         @Test
@@ -244,7 +244,7 @@ final class EOcageTest {
         @Test
         void rewritesItselfToItselfViaDummy() {
             System.setProperty(
-                PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "2"
+                PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME, "2"
             );
             final Phi cage = EOcageTest.encaged(
                 new PhWith(new EOcageTest.Dummy(Phi.Φ), 0, new Data.ToPhi(1L))
@@ -282,8 +282,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is less than property %s = %s does not throw %s",
-                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -303,8 +303,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is equal to property %s = %s does not throw %s",
-                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );
@@ -322,8 +322,8 @@ final class EOcageTest {
                 () -> new Dataized(cage).take(),
                 String.format(
                     "We expect that dataizing of nested cage which recursion depth is more than property %s = %s does not throw %s",
-                    PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
-                    System.getProperty(PhTracing.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
+                    PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME,
+                    System.getProperty(PhTraced.MAX_CAGE_RECURSION_DEPTH_PROPERTY_NAME),
                     ExAbstract.class
                 )
             );


### PR DESCRIPTION
Closes #3047

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor `PhTracedLocator` to `PhTraced` for clarity and consistency across classes.

### Detailed summary
- Renamed `PhTracedLocator` class to `PhTraced`
- Updated references to `PhTracedLocator` to `PhTraced`
- Modified property names for max cage recursion depth
- Refactored methods and variables for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->