### PR TITLE
#2827: Solved issue with thread-unsafety of CommitHashesText

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -44,7 +44,6 @@ final class CommitHashesText extends TextEnvelope {
      */
     private static final String HOME = "https://home.objectionary.com/tags.txt";
 
-
     /**
      * Cache.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.cactoos.Text;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.Sticky;
+import org.cactoos.text.Synced;
 import org.cactoos.text.TextEnvelope;
 import org.cactoos.text.TextOf;
 
@@ -47,21 +48,13 @@ final class CommitHashesText extends TextEnvelope {
     private static final String HOME = "https://home.objectionary.com/tags.txt";
 
     /**
-     * Thread-unsafe cache. Access to this field must be performed with
-     *  synchronization.
-     */
-    private static final Text THREAD_UNSAFE_CACHE = new Sticky(
-        CommitHashesText.asText(CommitHashesText.HOME)
-    );
-
-    /**
      * Cache.
      */
-    private static final Text CACHE = () -> {
-        synchronized (CommitHashesText.THREAD_UNSAFE_CACHE) {
-            return THREAD_UNSAFE_CACHE.asString();
-        }
-    };
+    private static final Text CACHE = new Synced(
+        new Sticky(
+            CommitHashesText.asText(CommitHashesText.HOME)
+        )
+    );
 
     /**
      * Constructor.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -47,11 +47,21 @@ final class CommitHashesText extends TextEnvelope {
     private static final String HOME = "https://home.objectionary.com/tags.txt";
 
     /**
-     * Cache.
+     * Thread-unsafe cache. Access to this field must be performed with
+     *  synchronization.
      */
-    private static final Text CACHE = new Sticky(
+    private static final Text THREAD_UNSAFE_CACHE = new Sticky(
         CommitHashesText.asText(CommitHashesText.HOME)
     );
+
+    /**
+     * Cache.
+     */
+    private static final Text CACHE = () -> {
+        synchronized (CommitHashesText.THREAD_UNSAFE_CACHE) {
+            return THREAD_UNSAFE_CACHE.asString();
+        }
+    };
 
     /**
      * Constructor.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -44,6 +44,7 @@ final class CommitHashesText extends TextEnvelope {
      */
     private static final String HOME = "https://home.objectionary.com/tags.txt";
 
+
     /**
      * Cache.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -26,10 +26,7 @@ package org.eolang.maven.hash;
 import com.jcabi.aspects.RetryOnFailure;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
-import org.cactoos.Text;
 import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.Sticky;
-import org.cactoos.text.Synced;
 import org.cactoos.text.TextEnvelope;
 import org.cactoos.text.TextOf;
 
@@ -51,7 +48,6 @@ final class CommitHashesText extends TextEnvelope {
      * Cache.
      */
     private static final String CACHE = CommitHashesText.asText(CommitHashesText.HOME);
-
 
     /**
      * Constructor.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/CommitHashesText.java
@@ -50,17 +50,14 @@ final class CommitHashesText extends TextEnvelope {
     /**
      * Cache.
      */
-    private static final Text CACHE = new Synced(
-        new Sticky(
-            CommitHashesText.asText(CommitHashesText.HOME)
-        )
-    );
+    private static final String CACHE = CommitHashesText.asText(CommitHashesText.HOME);
+
 
     /**
      * Constructor.
      */
     CommitHashesText() {
-        super(CommitHashesText.CACHE);
+        super(() -> CommitHashesText.CACHE);
     }
 
     /**
@@ -69,10 +66,9 @@ final class CommitHashesText extends TextEnvelope {
      * @return The body of the web page
      */
     @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
-    private static Text asText(final String url) {
-        final String body = new Unchecked<>(
+    private static String asText(final String url) {
+        return new Unchecked<>(
             () -> new TextOf(new URL(url)).asString()
         ).value();
-        return new TextOf(body);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Test case for {@link CommitHashesText}.
  *
  * @since 0.37.0
- * @todo #3122:60min Enable the test CommitHashesTextTest#isThreadSafe
+ * @todo #3122:60min Add "Reload" to the test CommitHashesTextTest#isThreadSafe
  *  when issue about "Reload" annotation will be solved.
  *  We need to reinitialize some static fields of the class
  *  before the test will be executed.
@@ -55,7 +55,6 @@ final class CommitHashesTextTest {
         );
     }
 
-    @Disabled
     @Test
     void isThreadSafe() {
         final int threads = 200;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -24,15 +24,10 @@
 package org.eolang.maven.hash;
 
 import com.yegor256.WeAreOnline;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.cactoos.Scalar;
+import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -56,31 +51,21 @@ final class CommitHashesTextTest {
     }
 
     @Test
-    void isThreadSafe() throws ExecutionException, InterruptedException, TimeoutException {
+    void isThreadSafe() {
         final int threads = 200;
         boolean nonulls = true;
-        final ExecutorService service = Executors.newFixedThreadPool(threads);
-        final CountDownLatch latch = new CountDownLatch(1);
-        final Collection<Future<Boolean>> futures = new ArrayList<>(threads);
-        try {
-            for (int thread = 0; thread < threads; ++thread) {
-                futures.add(
-                    service.submit(
-                        () -> new CommitHashesText().asString() != null
-                    )
-                );
-            }
-            latch.countDown();
-            for (final Future<Boolean> fun : futures) {
-                nonulls &= fun.get(1, TimeUnit.SECONDS);
-            }
-            MatcherAssert.assertThat(
-                "Can be used in different threads without NPE",
-                nonulls,
-                Matchers.equalTo(true)
-            );
-        } finally {
-            service.shutdownNow();
+        for (final boolean bool: new Threads<>(
+            threads,
+            Stream.generate(
+                () -> (Scalar<Boolean>) () -> new CommitHashesText().asString() != null
+            ).limit(threads).collect(Collectors.toList())
+            )) {
+            nonulls &= bool;
         }
+        MatcherAssert.assertThat(
+            "Can be used in different threads without NPE",
+            nonulls,
+            Matchers.equalTo(true)
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -80,7 +80,7 @@ final class CommitHashesTextTest {
                 Matchers.equalTo(true)
             );
         } finally {
-            service.shutdown();
+            service.shutdownNow();
         }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -30,7 +30,6 @@ import org.cactoos.Scalar;
 import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -37,11 +37,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Test case for {@link CommitHashesText}.
  *
+ * @since 0.37.0
  * @todo #3122:60min Enable the test CommitHashesTextTest#isThreadSafe
  *  when issue about "Reload" annotation will be solved.
  *  We need to reinitialize some static fields of the class
  *  before the test will be executed.
- * @since 0.37.0
  */
 final class CommitHashesTextTest {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -57,11 +57,9 @@ final class CommitHashesTextTest {
     void isThreadSafe() throws ExecutionException, InterruptedException {
         final int threads = 200;
         boolean nonulls = true;
-        final ExecutorService service =
-            Executors.newFixedThreadPool(threads);
+        final ExecutorService service = Executors.newFixedThreadPool(threads);
         final CountDownLatch latch = new CountDownLatch(1);
-        final Collection<Future<Boolean>> futures =
-            new ArrayList<>(threads);
+        final Collection<Future<Boolean>> futures = new ArrayList<>(threads);
         for (int thread = 0; thread < threads; ++thread) {
             futures.add(
                 service.submit(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -30,12 +30,17 @@ import org.cactoos.Scalar;
 import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link CommitHashesText}.
  *
+ * @todo #3122:60min Enable the test CommitHashesTextTest#isThreadSafe
+ *  when issue about "Reload" annotation will be solved.
+ *  We need to reinitialize some static fields of the class
+ *  before the test will be executed.
  * @since 0.37.0
  */
 final class CommitHashesTextTest {
@@ -50,6 +55,7 @@ final class CommitHashesTextTest {
         );
     }
 
+    @Disabled
     @Test
     void isThreadSafe() {
         final int threads = 200;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -31,6 +31,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -54,7 +57,7 @@ final class CommitHashesTextTest {
     }
 
     @Test
-    void isThreadSafe() throws ExecutionException, InterruptedException {
+    void isThreadSafe() throws ExecutionException, InterruptedException, TimeoutException {
         final int threads = 200;
         boolean nonulls = true;
         final ExecutorService service = Executors.newFixedThreadPool(threads);
@@ -69,12 +72,13 @@ final class CommitHashesTextTest {
         }
         latch.countDown();
         for (final Future<Boolean> fun : futures) {
-            nonulls &= fun.get();
+            nonulls &= fun.get(1, TimeUnit.SECONDS);
         }
         MatcherAssert.assertThat(
             "Can be used in different threads without NPE",
             nonulls,
             Matchers.equalTo(true)
         );
+        service.shutdown();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -24,15 +24,6 @@
 package org.eolang.maven.hash;
 
 import com.yegor256.WeAreOnline;
-import org.cactoos.Scalar;
-import org.cactoos.experimental.Threads;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
@@ -40,8 +31,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link CommitHashesText}.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/CommitHashesTextTest.java
@@ -54,7 +54,7 @@ final class CommitHashesTextTest {
     }
 
     @Test
-    void isUsedBeUsedByManyThreads() throws ExecutionException, InterruptedException {
+    void isThreadSafe() throws ExecutionException, InterruptedException {
         final int threads = 200;
         boolean nonulls = true;
         final ExecutorService service =


### PR DESCRIPTION
Closes #2827

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `CommitHashesText` class by replacing `org.cactoos.Text` with `java.lang.String` for simplicity and efficiency.

### Detailed summary
- Replaced `org.cactoos.Text` with `java.lang.String` in `CommitHashesText` class
- Updated constructor to use lambda expression for initializing `CACHE`
- Changed `asText` method return type to `java.lang.String`
- Added a test method `isThreadSafe` to check thread safety of `CommitHashesText`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->