### PR TITLE
#3155: Added `eo-maven-plugin/lib`, `eo-runtime/lib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 .recommenders
 .mvn/wrapper/maven-wrapper.jar
 .factorypath
+eo-maven-plugin/lib
+eo-runtime/lib


### PR DESCRIPTION
Closes #3155


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new directories `eo-maven-plugin/lib` and `eo-runtime/lib` to the `.gitignore` file.

### Detailed summary
- Added `eo-maven-plugin/lib` to `.gitignore`
- Added `eo-runtime/lib` to `.gitignore`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->