### PR TITLE
fix(#3163): `while` logic is fixed

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -29,22 +29,15 @@
 # While.
 [condition body] > while
   if. > @
-    condition.as-bool
-    start 0
+    (condition 0).as-bool
+    loop 0
     false
 
-  # First loop iteration that does not check condition.
-  [index] > start
-    seq > @
-      *
-        ^.body index
-        ^.loop (index.plus 1)
-
-  # Recursive
+  # Recursive loop.
   [index] > loop
     ^.body index > current
     if. > @
-      ^.condition.as-bool
+      (^.condition (index.plus 1)).as-bool
       seq
         *
           current

--- a/eo-runtime/src/test/eo/org/eolang/while-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/while-tests.eo
@@ -27,10 +27,21 @@
 +version 0.0.0
 
 # Test.
+[] > while-dataizes-only-first-cycle
+  eq. > @
+    0
+    malloc.for
+      42
+      [m]
+        while > @
+          i.eq 0 > [i]
+          m.put i > [i]
+
+# Test.
 [] > simple-while-with-false-first
   not. > @
     while > res
-      false
+      false > [i]
       true > [i]
 
 # Test.
@@ -40,7 +51,7 @@
       true
       [m]
         while > @
-          m
+          m > [i]
           m.put false > [i]
     false
 
@@ -51,7 +62,7 @@
       0
       [m]
         while > @
-          2.gt m
+          2.gt m > [i]
           m.put (m.as-int.plus 1) > [i]
     3
 
@@ -59,7 +70,7 @@
 [] > last-while-dataization-object-with-false-condition
   not. > @
     while
-      1.gt 2
+      1.gt 2 > [i]
       true > [i]
 
 # Test.
@@ -78,7 +89,7 @@
               acc.as-int.plus
                 arr.at 0
             while
-              max.gt iter
+              max.gt iter > [i]
               [i]
                 seq > @
                   *
@@ -100,7 +111,7 @@
         0
         [iter]
           while > @
-            max.gt iter
+            max.gt iter > [i]
             [i]
               seq > @
                 *
@@ -122,7 +133,7 @@
         0
         [iter]
           while > @
-            []
+            [i]
               if. > @
                 max.gt iter
                 seq
@@ -149,7 +160,7 @@
         0
         [iter]
           while > @
-            []
+            [i]
               if. > @
                 max.gt iter
                 seq


### PR DESCRIPTION
What's done:
1. `while` does not dataize the first step if the first condition is `true`
2. `while` expects condition to have index

Closes: #3163 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `while` loop logic in the `eo-runtime` module and add test cases in `while-tests.eo`.

### Detailed summary
- Refactored `while` loop logic in `eo-runtime`
- Added test cases for `while` loop in `while-tests.eo`
- Improved handling of loop conditions and iterations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->