### PR TITLE
Enable logs tests from `DataizedTest`

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -33,20 +33,16 @@ import java.util.stream.IntStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Dataized}.
  *
  * @since 0.22
- * @todo #2931:30min Enable the disabled tests. The tests were disabled after \rho attribute
- *  became immutable. Need to find out what's going on and resolve the tests.
  */
 final class DataizedTest {
 
     @Test
-    @Disabled
     void logsCorrectly() {
         final Logger log = Logger.getLogger("logsCorrectly");
         final Level before = log.getLevel();
@@ -68,7 +64,6 @@ final class DataizedTest {
     }
 
     @Test
-    @Disabled
     void logsWhenException() {
         final Logger log = Logger.getLogger("logsWhenException");
         final Level before = log.getLevel();
@@ -79,7 +74,7 @@ final class DataizedTest {
         final Phi wrong = new PhIncorrect(Phi.Φ);
         IntStream.range(0, 5).forEach(
             i -> Assertions.assertThrows(
-                IllegalStateException.class,
+                ExFailure.class,
                 () -> new Dataized(wrong).take(),
                 AtCompositeTest.TO_ADD_MESSAGE
             )

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -54,7 +54,7 @@ final class DataizedTest {
         log.setLevel(before);
         log.removeHandler(hnd);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            "Expected correct logs for object dataization",
             logs.get(0).getMessage(),
             Matchers.allOf(
                 Matchers.containsString("intν"),
@@ -76,14 +76,14 @@ final class DataizedTest {
             i -> Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Dataized(wrong).take(),
-                AtCompositeTest.TO_ADD_MESSAGE
+                "Expected failure with ExFailure exception on incorrect object dataization"
             )
         );
         new Dataized(new Data.ToPhi(1L), log).take();
         log.setLevel(before);
         log.removeHandler(hnd);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            "Expected correct logs for object dataization",
             logs.get(0).getMessage(),
             Matchers.allOf(
                 Matchers.containsString("intν"),


### PR DESCRIPTION
Closes #2978 

It looks like logging was fixed before. The only thing that was broken is that `PhDefault.delta` now throws `ExFailure` instead of `IllegalStateException`.