### PR TITLE
fix(#3147): lowercased auto generated name

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/print/samples/auto-named-abstract.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/print/samples/auto-named-abstract.yaml
@@ -27,10 +27,12 @@ origin: |
 
 straight: |
   x > first
-    [] >>
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > auto-named-attr-at-2-4
       5 > five
 
 reversed: |
   x > first
-    [] >>
+    # This is the default 64+ symbols comment in front of named abstract object.
+    [] > auto-named-attr-at-2-4
       5 > five

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1103,7 +1103,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
             .prop(
                 "name",
                 String.format(
-                    "OBJ-%d-%d",
+                    "auto-named-attr-at-%d-%d",
                     ctx.getStart().getLine(),
                     ctx.getStart().getCharPositionInLine()
                 )

--- a/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-reversed.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-reversed.xsl
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="xmir-to-eo-reversed" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="xmir-to-eo-reversed" version="2.0">
   <!--
   This one maps XMIR to EO original syntax in reversed notation.
   It's used in XmirReversed.java class.
@@ -34,11 +34,6 @@ SOFTWARE.
     <xsl:value-of select="$eol"/>
   </xsl:variable>
   <xsl:output method="text" encoding="UTF-8"/>
-  <!-- Check if given name is auto-generated -->
-  <xsl:function name="eo:is-auto-generated" as="xs:boolean">
-    <xsl:param name="name"/>
-    <xsl:sequence select="starts-with($name,'OBJ-')"/>
-  </xsl:function>
   <!-- PROGRAM -->
   <xsl:template match="program">
     <eo>
@@ -113,7 +108,7 @@ SOFTWARE.
   <!-- ABSTRACT OR ATOM -->
   <xsl:template match="o[not(@data) and not(@base)]" mode="head">
     <xsl:param name="indent"/>
-    <xsl:if test="@name and not(eo:is-auto-generated(@name))">
+    <xsl:if test="@name">
       <xsl:value-of select="$comment"/>
       <xsl:value-of select="$indent"/>
     </xsl:if>
@@ -133,24 +128,15 @@ SOFTWARE.
       <xsl:value-of select="@as"/>
     </xsl:if>
     <xsl:if test="@name">
-      <xsl:choose>
-        <!-- Auto-generated name -->
-        <xsl:when test="eo:is-auto-generated(@name)">
-          <xsl:text> &gt;&gt;</xsl:text>
-        </xsl:when>
-        <!-- Regular case -->
-        <xsl:otherwise>
-          <xsl:text> &gt; </xsl:text>
-          <xsl:value-of select="@name"/>
-          <xsl:if test="@const">
-            <xsl:text>!</xsl:text>
-          </xsl:if>
-          <xsl:if test="@atom">
-            <xsl:text> /</xsl:text>
-            <xsl:value-of select="@atom"/>
-          </xsl:if>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:text> &gt; </xsl:text>
+      <xsl:value-of select="@name"/>
+      <xsl:if test="@const">
+        <xsl:text>!</xsl:text>
+      </xsl:if>
+      <xsl:if test="@atom">
+        <xsl:text> /</xsl:text>
+        <xsl:value-of select="@atom"/>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
   <!-- DATA -->

--- a/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo.xsl
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="xmir-to-eo" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="xmir-to-eo" version="2.0">
   <!--
   This one maps XMIR to EO original syntax in straight notation.
   It's used in Xmir.java class.
@@ -34,11 +34,6 @@ SOFTWARE.
     <xsl:value-of select="$eol"/>
   </xsl:variable>
   <xsl:output method="text" encoding="UTF-8"/>
-  <!-- Check if given name is auto-generated -->
-  <xsl:function name="eo:is-auto-generated" as="xs:boolean">
-    <xsl:param name="name"/>
-    <xsl:sequence select="starts-with($name,'OBJ-')"/>
-  </xsl:function>
   <!-- PROGRAM -->
   <xsl:template match="program">
     <eo>
@@ -129,7 +124,7 @@ SOFTWARE.
   <!-- ABSTRACT OR ATOM -->
   <xsl:template match="o[not(@data) and not(@base)]" mode="head">
     <xsl:param name="indent"/>
-    <xsl:if test="@name and not(eo:is-auto-generated(@name))">
+    <xsl:if test="@name">
       <xsl:value-of select="$comment"/>
       <xsl:value-of select="$indent"/>
     </xsl:if>
@@ -149,24 +144,15 @@ SOFTWARE.
       <xsl:value-of select="@as"/>
     </xsl:if>
     <xsl:if test="@name">
-      <xsl:choose>
-        <!-- Auto-generated name -->
-        <xsl:when test="eo:is-auto-generated(@name)">
-          <xsl:text> &gt;&gt;</xsl:text>
-        </xsl:when>
-        <!-- Regular case -->
-        <xsl:otherwise>
-          <xsl:text> &gt; </xsl:text>
-          <xsl:value-of select="@name"/>
-          <xsl:if test="@const">
-            <xsl:text>!</xsl:text>
-          </xsl:if>
-          <xsl:if test="@atom">
-            <xsl:text> /</xsl:text>
-            <xsl:value-of select="@atom"/>
-          </xsl:if>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:text> &gt; </xsl:text>
+      <xsl:value-of select="@name"/>
+      <xsl:if test="@const">
+        <xsl:text>!</xsl:text>
+      </xsl:if>
+      <xsl:if test="@atom">
+        <xsl:text> /</xsl:text>
+        <xsl:value-of select="@atom"/>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
   <!-- DATA -->

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-conflict-with-auto-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/catches/catches-conflict-with-auto-name.yaml
@@ -20,19 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 ---
-origin: |
-  x > first
-    [] >>
-      5 > five
-
-straight: |
-  x > first
-    # This is the default 64+ symbols comment in front of named abstract object.
-    [] > auto-named-attr-at-2-4
-      5 > five
-
-reversed: |
-  x > first
-    # This is the default 64+ symbols comment in front of named abstract object.
-    [] > auto-named-attr-at-2-4
-      5 > five
+# @todo #3147:30min Make duplicate names catcher more powerful. This test pack is disabled now
+#  because names duplication is not caught here. It happens because of "duplicate-names.xsl" thinks
+#  that abstract objects in the tests are on the different levels. Syntactically they are, but
+#  semantically they're not. So we need to make this duplicate catcher more powerful, enable the
+#  test by removing "skip: true" line and make sure it works.
+skip: true
+xsls:
+  - /org/eolang/parser/critical-errors/duplicate-names.xsl
+tests:
+  - /program/errors[count(error)=1]
+eo: |
+  # This is the default 64+ symbols comment in front of abstract object.
+  [] > main
+    x > f
+      [] >>
+    # This is the default 64+ symbols comment in front of abstract object.
+    [] > auto-named-attr-at-4-6

--- a/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/auto-named-abstract.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/packs/syntax/auto-named-abstract.yaml
@@ -23,9 +23,9 @@
 xsls: [ ]
 tests:
   - //errors[count(error)=0]
-  - //o[@abstract and starts-with(@name,'OBJ-') and o[@name='five']]
-  - //o[@abstract and starts-with(@name,'OBJ-') and o[@name='ten']]
-  - //o[@abstract and starts-with(@name,'OBJ-') and @as='hello' and o[@name='eleven']]
+  - //o[@abstract and @name='auto-named-attr-at-2-4' and o[@name='five']]
+  - //o[@abstract and @name='auto-named-attr-at-4-2' and o[@name='ten']]
+  - //o[@abstract and @name='auto-named-attr-at-8-10' and @as='hello' and o[@name='eleven']]
 eo: |
   x > first
     [] >>

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  * Test cases for {@link EOcage}.
  * @since 0.19
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOcageTest {
     @Test
     void encagesViaApplication() {

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (4 lines)
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 public final class EOintTest {
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 public final class EOmallocTest {
     @Test
     void freesMemory() {

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  * @checkstyle TypeNameCheck (2 lines)
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOtupleEOatTest {
 
     @Test


### PR DESCRIPTION
Now auto generated name has the next format: `auto-named-attr-at-X-Y` where X - line, Y - position

Ref: #3147

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates naming conventions in various test classes and YAML files to use `auto-named-attr-at` instead of `OBJ`. It also refactors XSL files to remove auto-generated name checks.

### Detailed summary
- Updated naming conventions in test classes and YAML files
- Removed auto-generated name checks in XSL files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->