### PR TITLE
Task #3132: Removing AtCompositeTest.TO_ADD_MESSAGE

### DIFF
--- a/eo-runtime/src/test/java/EOorg/EOeolang/CagesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/CagesTest.java
@@ -27,7 +27,6 @@
  */
 package EOorg.EOeolang;
 
-import org.eolang.AtCompositeTest;
 import org.eolang.Data;
 import org.eolang.ExFailure;
 import org.eolang.PhFake;
@@ -48,7 +47,7 @@ class CagesTest {
         final int locator = Cages.INSTANCE.init(phi);
         Assertions.assertDoesNotThrow(
             () -> Cages.INSTANCE.get(locator),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the first time initialization will be done"
         );
     }
 
@@ -58,7 +57,7 @@ class CagesTest {
         Cages.INSTANCE.init(phi);
         Assertions.assertDoesNotThrow(
             () -> Cages.INSTANCE.init(phi),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the reinitialization will be done"
         );
     }
 
@@ -69,7 +68,7 @@ class CagesTest {
         final int locator = Cages.INSTANCE.init(first);
         Cages.INSTANCE.encage(locator, second);
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the encage with locator will be done",
             Cages.INSTANCE.get(locator).hashCode(),
             Matchers.equalTo(second.hashCode())
         );
@@ -81,17 +80,17 @@ class CagesTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.encage(phi.hashCode(), phi),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the encage when object was initialized will be done"
         );
     }
 
     @Test
-    void failsToEncageObjectOfDifferentForma() {
+    void failsToEncageObjectOfDifferentFormat() {
         final int locator = Cages.INSTANCE.init(new PhFake());
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.encage(locator, new Data.ToPhi(5L)),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the encage with object of different format will be done"
         );
     }
 
@@ -100,7 +99,7 @@ class CagesTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.get(new PhFake().hashCode()),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect that getting of not initialization object will be done"
         );
     }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/CagesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/CagesTest.java
@@ -48,7 +48,7 @@ class CagesTest {
         final int locator = Cages.INSTANCE.init(phi);
         Assertions.assertDoesNotThrow(
             () -> Cages.INSTANCE.get(locator),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -58,7 +58,7 @@ class CagesTest {
         Cages.INSTANCE.init(phi);
         Assertions.assertDoesNotThrow(
             () -> Cages.INSTANCE.init(phi),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -69,7 +69,7 @@ class CagesTest {
         final int locator = Cages.INSTANCE.init(first);
         Cages.INSTANCE.encage(locator, second);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             Cages.INSTANCE.get(locator).hashCode(),
             Matchers.equalTo(second.hashCode())
         );
@@ -81,7 +81,7 @@ class CagesTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.encage(phi.hashCode(), phi),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -91,7 +91,7 @@ class CagesTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.encage(locator, new Data.ToPhi(5L)),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -100,7 +100,7 @@ class CagesTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Cages.INSTANCE.get(new PhFake().hashCode()),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOas_phiTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOas_phiTest.java
@@ -27,11 +27,9 @@
  */
 package EOorg.EOeolang;
 
-import org.eolang.AtCompositeTest;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhWith;
-import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -47,7 +45,7 @@ final class EOas_phiTest {
     @Test
     void printsAndReturns() {
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect that print will be done",
             new Dataized(
                 new PhWith(
                     new EOas_phi(),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOas_phiTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOas_phiTest.java
@@ -47,7 +47,7 @@ final class EOas_phiTest {
     @Test
     void printsAndReturns() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new EOas_phi(),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -58,7 +58,7 @@ final class EObytesEOconcatTest {
             "as-string"
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(String.class),
             Matchers.equalTo("привет mr. ㄤㄠ!")
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -27,7 +27,6 @@
  */
 package EOorg.EOeolang;
 
-import org.eolang.AtCompositeTest;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhMethod;
@@ -58,7 +57,7 @@ final class EObytesEOconcatTest {
             "as-string"
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the bytes concat will be done",
             new Dataized(phi).take(String.class),
             Matchers.equalTo("привет mr. ㄤㄠ!")
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -64,7 +64,7 @@ final class EOcageTest {
     void encagesViaApplication() {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(1L)
         );
@@ -75,7 +75,7 @@ final class EOcageTest {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         EOcageTest.encageTo(cage, new Data.ToPhi(2L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -90,7 +90,7 @@ final class EOcageTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(new PhMethod(cage, "x")).take(Long.class),
             Matchers.equalTo(1L)
         );
@@ -102,7 +102,7 @@ final class EOcageTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(new PhMethod(cage, "x")).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -114,7 +114,7 @@ final class EOcageTest {
         final Phi second = first.copy();
         EOcageTest.encageTo(second, new Data.ToPhi(2L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(first).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -124,13 +124,13 @@ final class EOcageTest {
     void writesAndRewritesPrimitive() {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(1L)
         );
         EOcageTest.encageTo(cage, new Data.ToPhi(5L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(5L)
         );
@@ -142,7 +142,7 @@ final class EOcageTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> EOcageTest.encageTo(cage, new Data.ToPhi("Hello world")),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -158,7 +158,7 @@ final class EOcageTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> EOcageTest.encageTo(cage, ten),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -170,7 +170,7 @@ final class EOcageTest {
                 EOcageTest.encaged(dummy),
                 new PhWith(new PhCopy(dummy), "x", new Data.ToPhi("Hello world"))
             ),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -230,7 +230,7 @@ final class EOcageTest {
             );
             final int threads = 500;
             MatcherAssert.assertThat(
-                AtCompositeTest.TO_ADD_MESSAGE,
+                AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
                 new SumOf(
                     new Threads<>(
                         threads,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 import org.cactoos.Scalar;
 import org.cactoos.experimental.Threads;
 import org.cactoos.number.SumOf;
-import org.eolang.AtCompositeTest;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Data;
@@ -64,7 +63,7 @@ final class EOcageTest {
     void encagesViaApplication() {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the encage via application will be done",
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(1L)
         );
@@ -75,7 +74,7 @@ final class EOcageTest {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         EOcageTest.encageTo(cage, new Data.ToPhi(2L));
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the encage and free afterwards will be done",
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -90,7 +89,7 @@ final class EOcageTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the encage will be done",
             new Dataized(new PhMethod(cage, "x")).take(Long.class),
             Matchers.equalTo(1L)
         );
@@ -102,7 +101,7 @@ final class EOcageTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the overwrite of object will be done",
             new Dataized(new PhMethod(cage, "x")).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -114,7 +113,7 @@ final class EOcageTest {
         final Phi second = first.copy();
         EOcageTest.encageTo(second, new Data.ToPhi(2L));
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the encage of object for copying will be done",
             new Dataized(first).take(Long.class),
             Matchers.equalTo(2L)
         );
@@ -124,13 +123,13 @@ final class EOcageTest {
     void writesAndRewritesPrimitive() {
         final Phi cage = EOcageTest.encaged(new Data.ToPhi(1L));
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the writing of primitive will be done",
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(1L)
         );
         EOcageTest.encageTo(cage, new Data.ToPhi(5L));
         MatcherAssert.assertThat(
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            "We expect the rewriting of primitive will be done",
             new Dataized(cage).take(Long.class),
             Matchers.equalTo(5L)
         );
@@ -142,7 +141,7 @@ final class EOcageTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> EOcageTest.encageTo(cage, new Data.ToPhi("Hello world")),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the writing of formed differently primitive will be done"
         );
     }
 
@@ -158,7 +157,7 @@ final class EOcageTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> EOcageTest.encageTo(cage, ten),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the writing of bounded method will be done"
         );
     }
 
@@ -170,7 +169,7 @@ final class EOcageTest {
                 EOcageTest.encaged(dummy),
                 new PhWith(new PhCopy(dummy), "x", new Data.ToPhi("Hello world"))
             ),
-            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            "We expect the writing of bounded copy of different base will be done"
         );
     }
 
@@ -230,7 +229,7 @@ final class EOcageTest {
             );
             final int threads = 500;
             MatcherAssert.assertThat(
-                AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+                "Dataizes concurrent threads failed",
                 new SumOf(
                     new Threads<>(
                         threads,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
@@ -64,7 +64,7 @@ final class EOerrorTest {
                     new Data.ToPhi("intentional error")
                 )
             ).take(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -79,7 +79,7 @@ final class EOerrorTest {
         }
         assert error != null;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             error.toString(),
             Matchers.containsString(
                 new VerboseBytesAsStringTest.ArgumentsUtils().toString(cnst)

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOeqTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOeqTest.java
@@ -60,7 +60,7 @@ final class EOintEOeqTest {
             0, right
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(eql).take(Boolean.class),
             Matchers.equalTo(false)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOltTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOltTest.java
@@ -53,7 +53,7 @@ final class EOintEOltTest {
         final Phi less = left.take("lt");
         less.put(0, right);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(less).take(Boolean.class),
             Matchers.equalTo(false)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOminusTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOminusTest.java
@@ -57,7 +57,7 @@ final class EOintEOminusTest {
             0, right
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(sub).take(Long.class),
             Matchers.equalTo(29L)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOnegTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOnegTest.java
@@ -52,7 +52,7 @@ final class EOintEOnegTest {
         final Phi left = new Data.ToPhi(42L);
         final Phi neg = new PhMethod(left, "neg");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(neg).take(Long.class),
             Matchers.equalTo(-42L)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOplusTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintEOplusTest.java
@@ -50,7 +50,7 @@ final class EOintEOplusTest {
         final Phi add = left.take("plus");
         add.put(0, right);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(add).take(Long.class),
             Matchers.equalTo(55L)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOintTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOintTest.java
@@ -48,7 +48,7 @@ public final class EOintTest {
         final Phi left = new Data.ToPhi(42L);
         final Phi right = new Data.ToPhi(42L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             left.hashCode(),
             Matchers.not(Matchers.equalTo(right.hashCode()))
         );
@@ -58,7 +58,7 @@ public final class EOintTest {
     void hasHashEvenWithoutData() {
         final Phi phi = new EOint();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             phi.hashCode(),
             Matchers.greaterThan(0)
         );
@@ -69,7 +69,7 @@ public final class EOintTest {
         final Phi raw = new EOint();
         final Phi initialized = new Data.ToPhi(0L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             raw.hashCode(),
             Matchers.not(initialized.hashCode())
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdinTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdinTest.java
@@ -63,7 +63,7 @@ final class EOstdinTest {
     @AfterAll
     static void restoreSystemInput() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             System.in,
             Matchers.equalTo(EOstdinTest.DEFAULT_STDIN)
         );
@@ -91,7 +91,7 @@ final class EOstdinTest {
         final Phi phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         final String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(expected)
         );
@@ -104,7 +104,7 @@ final class EOstdinTest {
         final Phi phi = new PhCopy(new EOstdin());
         final String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(expected)
         );
@@ -117,7 +117,7 @@ final class EOstdinTest {
         final Phi phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         final String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(expected)
         );
@@ -132,7 +132,7 @@ final class EOstdinTest {
             () -> new Dataized(phi).take(String.class)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(error.enclosure()).take(String.class),
             Matchers.containsString(
                 "There is no line in the standard input stream to consume"
@@ -144,7 +144,7 @@ final class EOstdinTest {
     @Test
     void dataizesEmptyStdin(final StdIn stdin) {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(new EOstdin()).take(String.class),
             Matchers.equalTo(System.lineSeparator())
         );
@@ -159,7 +159,7 @@ final class EOstdinTest {
         final Phi phi = new PhCopy(new EOstdin());
         final String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(first + second + third)
         );
@@ -174,21 +174,21 @@ final class EOstdinTest {
         Phi phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(first)
         );
         phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(second)
         );
         phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(third)
         );
@@ -202,21 +202,21 @@ final class EOstdinTest {
         Phi phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         String actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(first)
         );
         phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo("")
         );
         phi = new PhMethod(new PhCopy(new EOstdin()), "next-line");
         actual = new Dataized(phi).take(String.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo(third)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java
@@ -67,7 +67,7 @@ public final class EOstdoutTest {
         stdout.put(0, ret);
         new Dataized(stdout).take(Boolean.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             stream.toString(),
             Matchers.equalTo("Hello")
         );
@@ -82,7 +82,7 @@ public final class EOstdoutTest {
             format
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Boolean.class),
             Matchers.equalTo(true)
         );
@@ -108,7 +108,7 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             stream.toString(),
             Matchers.equalTo(str)
         );
@@ -134,7 +134,7 @@ public final class EOstdoutTest {
             )
         ).take();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             stream.toString(),
             Matchers.equalTo(str)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -59,7 +59,7 @@ public final class EOmallocTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.free((int) dummy.id),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -73,12 +73,12 @@ public final class EOmallocTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> new Dataized(phi).take(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.free((int) dummy.id),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOseqTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOseqTest.java
@@ -46,7 +46,7 @@ public final class EOseqTest {
     @Test
     public void calculatesAndReturns() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new EOseq(),
@@ -67,7 +67,7 @@ public final class EOseqTest {
     @Test
     public void calculatesAndReturnsObject() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new EOseq(),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOasBytesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOasBytesTest.java
@@ -49,7 +49,7 @@ final class EOstringEOasBytesTest {
         final Phi str = new Data.ToPhi("Hello, друг!");
         final Phi phi = str.take("as-bytes");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(byte[].class).length,
             Matchers.equalTo(16)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOsliceTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOstringEOsliceTest.java
@@ -58,7 +58,7 @@ final class EOstringEOsliceTest {
             new Data.ToPhi(1L)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(String.class),
             Matchers.equalTo("ㄤ")
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOstringTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOstringTest.java
@@ -51,7 +51,7 @@ final class EOstringTest {
     void comparesTwoEqualStrings() {
         final String txt = "Hello, друг!";
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new PhMethod(new Data.ToPhi(txt), "eq"),
@@ -65,7 +65,7 @@ final class EOstringTest {
     @Test
     void comparesTwoDifferentStrings() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new PhMethod(new Data.ToPhi("Hello, друг!"), "eq"),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -51,7 +51,7 @@ public final class EOtryTest {
     @Test
     public void catchesException() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new PhWith(
@@ -83,7 +83,7 @@ public final class EOtryTest {
             new Data.ToPhi(true)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(body).take(String.class),
             Matchers.containsString("it is broken")
         );
@@ -92,7 +92,7 @@ public final class EOtryTest {
     @Test
     public void worksWithoutException() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new PhWith(
@@ -119,7 +119,7 @@ public final class EOtryTest {
         trier.put(2, new Data.ToPhi(true));
         new Dataized(trier).take();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             main.count,
             Matchers.equalTo(1)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java
@@ -65,12 +65,12 @@ final class EOtupleEOatTest {
         final Phi get = tuple.take("at").copy();
         get.put(0, idx);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(get).take(String.class),
             Matchers.equalTo(txt)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(get).take(String.class),
             Matchers.equalTo(txt)
         );
@@ -79,12 +79,12 @@ final class EOtupleEOatTest {
     @Test
     void checksNegativeIndex() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(this.get(-1L)).take(String.class),
             Matchers.equalTo("second")
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(this.get(-2L)).take(String.class),
             Matchers.equalTo("first")
         );
@@ -95,7 +95,7 @@ final class EOtupleEOatTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> new Dataized(this.get(-3L)).take(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -111,7 +111,7 @@ final class EOtupleEOatTest {
             "args", copy
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Long.class),
             Matchers.equalTo(10L)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -52,7 +52,7 @@ public final class HeapsTest {
         final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 10);
         Assertions.assertDoesNotThrow(
             () -> HeapsTest.HEAPS.read(idx, 0, 10),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -64,7 +64,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.malloc(phi, 10),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -73,7 +73,7 @@ public final class HeapsTest {
     void allocatesAndReadsEmptyBytes() {
         final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             HeapsTest.HEAPS.read(idx, 0, 5),
             Matchers.equalTo(new byte[] {0, 0, 0, 0, 0})
         );
@@ -86,7 +86,7 @@ public final class HeapsTest {
         final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
         HeapsTest.HEAPS.write(idx, 0, bytes);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             HeapsTest.HEAPS.read(idx, 0, bytes.length),
             Matchers.equalTo(bytes)
         );
@@ -98,7 +98,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(new PhFake().hashCode(), 0, new byte[] {0x01}),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -107,7 +107,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(new PhFake().hashCode(), 0, 1),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -117,7 +117,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(idx, 1, 3),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -126,7 +126,7 @@ public final class HeapsTest {
         final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
         HeapsTest.HEAPS.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             HeapsTest.HEAPS.read(idx, 1, 3),
             Matchers.equalTo(new byte[] {2, 3, 4})
         );
@@ -139,7 +139,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(idx, 0, bytes),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -151,7 +151,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(idx, 1, bytes),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -162,7 +162,7 @@ public final class HeapsTest {
         HeapsTest.HEAPS.write(idx, 0, new byte[] {1, 1, 3, 4, 5});
         HeapsTest.HEAPS.write(idx, 2, new byte[] {2, 2});
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             HeapsTest.HEAPS.read(idx, 0, 5),
             Matchers.equalTo(new byte[] {1, 1, 2, 2, 5})
         );
@@ -176,7 +176,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(idx, 0, 5),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -185,7 +185,7 @@ public final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.free(new PhFake().hashCode()),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -44,7 +44,8 @@ public final class AtCompositeTest {
      * eo-runtime for getting failed assert messages with class and test
      */
     public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER =
-        () -> String.format("Failed %s.%s",
+        () -> String.format(
+            "Failed %s.%s",
             Thread.currentThread().getStackTrace()[2].getClassName(),
             Thread.currentThread().getStackTrace()[2].getMethodName()
         );

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -52,28 +52,28 @@ public final class AtCompositeTest {
     @Test
     void decoratesCheckedException() {
         Assertions.assertThrows(
-                ExFailure.class,
-                () -> new AtComposite(
-                        Phi.Φ,
-                        self -> {
-                            throw new InstantiationException("intended checked");
-                        }
-                ).get(),
-                FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            ExFailure.class,
+            () -> new AtComposite(
+                Phi.Φ,
+                self -> {
+                    throw new InstantiationException("intended checked");
+                }
+            ).get(),
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
     @Test
     void decoratesUncheckedException() {
         Assertions.assertThrows(
-                IllegalStateException.class,
-                () -> new AtComposite(
-                        Phi.Φ,
-                        self -> {
-                            throw new IllegalStateException("intended unchecked");
-                        }
-                ).get(),
-                FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+            IllegalStateException.class,
+            () -> new AtComposite(
+                Phi.Φ,
+                self -> {
+                    throw new IllegalStateException("intended unchecked");
+                }
+            ).get(),
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -82,11 +82,11 @@ public final class AtCompositeTest {
         final Phi rnd = new Rnd();
         final Phi phi = new PhMethod(rnd, Attr.LAMBDA);
         MatcherAssert.assertThat(
-                FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
-                new Dataized(phi).take(Double.class),
-                Matchers.equalTo(
-                        new Dataized(phi).take(Double.class)
-                )
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+            new Dataized(phi).take(Double.class),
+            Matchers.equalTo(
+                new Dataized(phi).take(Double.class)
+            )
         );
     }
 
@@ -102,11 +102,11 @@ public final class AtCompositeTest {
         Rnd() {
             super();
             this.add(
-                    Attr.LAMBDA,
-                    new AtComposite(
-                            this,
-                            rho -> new Data.ToPhi(new SecureRandom().nextDouble())
-                    )
+                Attr.LAMBDA,
+                new AtComposite(
+                    this,
+                    rho -> new Data.ToPhi(new SecureRandom().nextDouble())
+                )
             );
         }
     }

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -24,6 +24,9 @@
 package org.eolang;
 
 import java.security.SecureRandom;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -37,14 +40,15 @@ import org.junit.jupiter.api.Test;
 public final class AtCompositeTest {
 
     /**
-     * Empty message for JUnit Assertions.
+     * Supplier for failed assert messages.
      *
-     * @todo #2297:60m Replace all appearances of {@link AtCompositeTest#TO_ADD_MESSAGE} field in
-     *  eo-runtime with meaningful assert messages. Don't forget to remove
-     *  {@link AtCompositeTest#TO_ADD_MESSAGE} field and remove public modifier from this class if
-     *  no longer need.
+     * {@link AtCompositeTest#FAILED_ASSERT_MESSAGE_SUPPLIER} field in
+     *  eo-runtime for getting failed assert messages with class and test
      */
-    public static final String TO_ADD_MESSAGE = "TO ADD ASSERTION MESSAGE";
+    public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER =
+            () -> "Failed " + Thread.currentThread().getStackTrace()[2].getClassName()
+                    + '.'
+                    + Thread.currentThread().getStackTrace()[2].getMethodName();
 
     @Test
     void decoratesCheckedException() {
@@ -56,7 +60,7 @@ public final class AtCompositeTest {
                     throw new InstantiationException("intended checked");
                 }
             ).get(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -70,7 +74,7 @@ public final class AtCompositeTest {
                     throw new IllegalStateException("intended unchecked");
                 }
             ).get(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -79,7 +83,7 @@ public final class AtCompositeTest {
         final Phi rnd = new Rnd();
         final Phi phi = new PhMethod(rnd, Attr.LAMBDA);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Double.class),
             Matchers.equalTo(
                 new Dataized(phi).take(Double.class)

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -43,9 +43,11 @@ public final class AtCompositeTest {
      * {@link AtCompositeTest#FAILED_ASSERT_MESSAGE_SUPPLIER} field in
      * eo-runtime for getting failed assert messages with class and test
      */
-    public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER = () -> String.format("Failed %s.%s",
-        Thread.currentThread().getStackTrace()[2].getClassName(),
-        Thread.currentThread().getStackTrace()[2].getMethodName());
+    public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER =
+        () -> String.format("Failed %s.%s",
+            Thread.currentThread().getStackTrace()[2].getClassName(),
+            Thread.currentThread().getStackTrace()[2].getMethodName()
+        );
 
     @Test
     void decoratesCheckedException() {

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -24,9 +24,7 @@
 package org.eolang;
 
 import java.security.SecureRandom;
-import java.util.Optional;
 import java.util.function.Supplier;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -41,40 +39,39 @@ public final class AtCompositeTest {
 
     /**
      * Supplier for failed assert messages.
-     *
+     * <p>
      * {@link AtCompositeTest#FAILED_ASSERT_MESSAGE_SUPPLIER} field in
-     *  eo-runtime for getting failed assert messages with class and test
+     * eo-runtime for getting failed assert messages with class and test
      */
-    public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER =
-            () -> "Failed " + Thread.currentThread().getStackTrace()[2].getClassName()
-                    + '.'
-                    + Thread.currentThread().getStackTrace()[2].getMethodName();
+    public static final Supplier<String> FAILED_ASSERT_MESSAGE_SUPPLIER = () -> String.format("Failed %s.%s",
+        Thread.currentThread().getStackTrace()[2].getClassName(),
+        Thread.currentThread().getStackTrace()[2].getMethodName());
 
     @Test
     void decoratesCheckedException() {
         Assertions.assertThrows(
-            ExFailure.class,
-            () -> new AtComposite(
-                Phi.Φ,
-                self -> {
-                    throw new InstantiationException("intended checked");
-                }
-            ).get(),
-            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+                ExFailure.class,
+                () -> new AtComposite(
+                        Phi.Φ,
+                        self -> {
+                            throw new InstantiationException("intended checked");
+                        }
+                ).get(),
+                FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
     @Test
     void decoratesUncheckedException() {
         Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new AtComposite(
-                Phi.Φ,
-                self -> {
-                    throw new IllegalStateException("intended unchecked");
-                }
-            ).get(),
-            FAILED_ASSERT_MESSAGE_SUPPLIER.get()
+                IllegalStateException.class,
+                () -> new AtComposite(
+                        Phi.Φ,
+                        self -> {
+                            throw new IllegalStateException("intended unchecked");
+                        }
+                ).get(),
+                FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -83,16 +80,17 @@ public final class AtCompositeTest {
         final Phi rnd = new Rnd();
         final Phi phi = new PhMethod(rnd, Attr.LAMBDA);
         MatcherAssert.assertThat(
-            FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
-            new Dataized(phi).take(Double.class),
-            Matchers.equalTo(
-                new Dataized(phi).take(Double.class)
-            )
+                FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
+                new Dataized(phi).take(Double.class),
+                Matchers.equalTo(
+                        new Dataized(phi).take(Double.class)
+                )
         );
     }
 
     /**
      * Rnd.
+     *
      * @since 1.0
      */
     private static class Rnd extends PhDefault {
@@ -102,11 +100,11 @@ public final class AtCompositeTest {
         Rnd() {
             super();
             this.add(
-                Attr.LAMBDA,
-                new AtComposite(
-                    this,
-                    rho -> new Data.ToPhi(new SecureRandom().nextDouble())
-                )
+                    Attr.LAMBDA,
+                    new AtComposite(
+                            this,
+                            rho -> new Data.ToPhi(new SecureRandom().nextDouble())
+                    )
             );
         }
     }

--- a/eo-runtime/src/test/java/org/eolang/AtLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtLoggedTest.java
@@ -26,6 +26,7 @@ package org.eolang;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
@@ -87,7 +88,7 @@ class AtLoggedTest {
     @Test
     void convertsToStringAsOrigin() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.logged.toString(),
             Matchers.equalTo(this.origin.toString())
         );
@@ -96,7 +97,7 @@ class AtLoggedTest {
     @Test
     void convertsToPhiTermAsOrigin() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.logged.φTerm(),
             Matchers.equalTo(this.origin.φTerm())
         );
@@ -106,12 +107,12 @@ class AtLoggedTest {
     void copiesWithLogging() {
         this.logged.copy(Phi.Φ);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.copy()...", this.label))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.copy()!", this.label))
         );
@@ -120,17 +121,17 @@ class AtLoggedTest {
     @Test
     void getsWithLogging() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.logged.get(),
             Matchers.equalTo(this.origin.get())
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.get()...", this.label))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.get()!", this.label))
         );
@@ -140,12 +141,12 @@ class AtLoggedTest {
     void putsWithLogging() {
         this.put.put(Phi.Φ);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.put()...", this.label))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             this.log(),
             Matchers.containsString(String.format("  %s.put()!", this.label))
         );

--- a/eo-runtime/src/test/java/org/eolang/AtNamedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtNamedTest.java
@@ -44,7 +44,7 @@ final class AtNamedTest {
             () -> phi.take("x").take("anything")
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(error.enclosure()).take(String.class),
             Matchers.allOf(
                 Matchers.containsString(

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -42,7 +42,7 @@ final class BytesOfTest {
         final String text = "abc";
         final Bytes bytes = new BytesOf(text);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.not().not(),
             Matchers.equalTo(new BytesOf(text))
         );
@@ -52,7 +52,7 @@ final class BytesOfTest {
     void negatesOnce() {
         final Bytes bytes = new BytesOf(-128L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.not(),
             Matchers.equalTo(new BytesOf(127L))
         );
@@ -62,7 +62,7 @@ final class BytesOfTest {
     void checksAnd() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.and(bytes.not()),
             Matchers.equalTo(new BytesOf(0L))
         );
@@ -72,7 +72,7 @@ final class BytesOfTest {
     void checksOr() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.or(bytes.not()),
             Matchers.equalTo(new BytesOf(-1L))
         );
@@ -81,7 +81,7 @@ final class BytesOfTest {
     @Test
     void checksPositiveInfinity() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new BytesOf(1.0d / 0.0d).asNumber(Double.class),
             Matchers.equalTo(Double.POSITIVE_INFINITY)
         );
@@ -90,7 +90,7 @@ final class BytesOfTest {
     @Test
     void checksNegativeInfinity() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new BytesOf(-1.0d / 0.0d).asNumber(Double.class),
             Matchers.equalTo(Double.NEGATIVE_INFINITY)
         );
@@ -100,7 +100,7 @@ final class BytesOfTest {
     void checksXor() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.xor(new BytesOf(-512L)),
             Matchers.equalTo(new BytesOf(-1024L))
         );
@@ -110,7 +110,7 @@ final class BytesOfTest {
     void checksAsNumberLong() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.asNumber(Long.class),
             Matchers.equalTo(512L)
         );
@@ -122,7 +122,7 @@ final class BytesOfTest {
         Assertions.assertThrows(
             UnsupportedOperationException.class,
             () -> bytes.asNumber(Long.class),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -139,7 +139,7 @@ final class BytesOfTest {
     void checksShift(final long num, final int bits, final long expected) {
         final Bytes bytes = new BytesOf(num);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             bytes.shift(bits).asNumber(Long.class),
             Matchers.equalTo(expected)
         );
@@ -161,7 +161,7 @@ final class BytesOfTest {
         final Bytes bytes = new BytesOf((int) num);
         final int actual = bytes.sshift(bits).asNumber(Integer.class);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.equalTo((int) expected)
         );
@@ -173,7 +173,7 @@ final class BytesOfTest {
         Assertions.assertThrows(
             UnsupportedOperationException.class,
             () -> bytes.sshift(-1),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -38,7 +38,7 @@ final class DataTest {
     @Test
     void printsByteArray() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(new byte[] {(byte) 0x01, (byte) 0xf2}).toString(),
             Matchers.containsString("01-F2")
         );
@@ -47,7 +47,7 @@ final class DataTest {
     @Test
     void printsEmptyByteArray() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(new byte[0]).toString(),
             Matchers.containsString("--")
         );
@@ -78,7 +78,7 @@ final class DataTest {
     @Test
     void comparesVertex() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(42L).hashCode(),
             Matchers.not(
                 Matchers.equalTo(
@@ -91,22 +91,22 @@ final class DataTest {
     @Test
     void comparesTwoDatas() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(1L),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(1L)))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi("Welcome"),
             Matchers.not(Matchers.equalTo(new Data.ToPhi("Welcome")))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(2.18d),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(2.18d)))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f})))
         );

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -117,7 +117,7 @@ final class DataizedTest {
         log.setLevel(before);
         log.removeHandler(hnd);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             logs.size(),
             Matchers.equalTo(1)
         );
@@ -148,7 +148,7 @@ final class DataizedTest {
         log.setLevel(before);
         log.removeHandler(hnd);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             logs.size(),
             Matchers.greaterThan(1)
         );

--- a/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
@@ -39,7 +39,7 @@ public class ExInterruptedTest {
         Assertions.assertThrows(
             ExInterrupted.class,
             () -> new Dataized(phi.take(Attr.PHI)).take(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
@@ -47,7 +47,7 @@ class JavaPathTest {
     })
     void convertsToString(final String name, final String expected) {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new JavaPath(name).toString(),
             Matchers.equalTo(expected)
         );

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -46,7 +46,7 @@ final class MainTest {
     @Test
     void printsVersion() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("--version"),
             Matchers.allOf(
                 Matchers.containsString("."),
@@ -58,7 +58,7 @@ final class MainTest {
     @Test
     void printsHelp() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("--help"),
             Matchers.containsString("Usage: ")
         );
@@ -93,7 +93,7 @@ final class MainTest {
     @Test
     void executesJvmFullRunWithDashedObject() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("--verbose", "as-bytes"),
             Matchers.allOf(
                 Matchers.containsString("Loading class EOas_bytes"),
@@ -105,7 +105,7 @@ final class MainTest {
     @Test
     void executesJvmFullRinWithAttributeCall() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("--verbose", "string$as-bytes"),
             Matchers.allOf(
                 Matchers.containsString("Loading class EOstring$EOas_bytes"),
@@ -117,7 +117,7 @@ final class MainTest {
     @Test
     void executesJvmFullRunWithError() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("--verbose", "org.eolang.io.stdout"),
             Matchers.containsString("Error at \"EOorg.EOeolang.EOio.EOstdout#text\" attribute")
         );
@@ -126,7 +126,7 @@ final class MainTest {
     @Test
     void executesWithObjectNotFoundException() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             MainTest.exec("unavailable-name"),
             Matchers.containsString("Can not find 'unavailable-name' object")
         );
@@ -147,7 +147,7 @@ final class MainTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             reader.readLine().length(),
             Matchers.greaterThan(0)
         );
@@ -168,7 +168,7 @@ final class MainTest {
             )
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             reader.readLine().length(),
             Matchers.greaterThan(1)
         );
@@ -177,7 +177,7 @@ final class MainTest {
     @Test
     void readsBytesCorrectly() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new ByteArrayInputStream(
                 "··\uD835\uDD38➜Φ".getBytes(
                     StandardCharsets.UTF_8

--- a/eo-runtime/src/test/java/org/eolang/PhCopyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCopyTest.java
@@ -37,7 +37,7 @@ final class PhCopyTest {
     @Test
     void makesObjectCopy() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhCopy(new Data.ToPhi(1L))
             ).take(Long.class),
@@ -49,7 +49,7 @@ final class PhCopyTest {
     void hasTheSameFormaAsCopied() {
         final Phi phi = new Data.ToPhi(1L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             phi.forma(),
             Matchers.equalTo(
                 phi.copy().forma()

--- a/eo-runtime/src/test/java/org/eolang/PhDataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDataTest.java
@@ -36,7 +36,7 @@ public class PhDataTest {
     @Test
     void addsApplicationWithDelta() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhData(Phi.Φ, new byte[] {1, 2, 3}).φTerm(),
             Matchers.containsString("(Δ ↦ 01-02-03)")
         );
@@ -46,7 +46,7 @@ public class PhDataTest {
     void returnsData() {
         final byte[] data = new byte[] {0x2A, 0x3B};
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhData(new PhDefault(), data).delta(),
             Matchers.equalTo(data)
         );

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -239,7 +239,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.Int();
         phi.put("void", new Data.ToPhi(10L));
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             phi.take("void"),
             Matchers.equalTo(phi.take("void"))
         );
@@ -249,7 +249,7 @@ final class PhDefaultTest {
     void doesNotCopyContextAttributeWithRho() {
         final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             phi.take("context"),
             Matchers.equalTo(phi.take("context"))
         );
@@ -261,12 +261,12 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> phi.take(Attr.PHI),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
         phi.put("void", new Data.ToPhi(10L));
         Assertions.assertDoesNotThrow(
             () -> phi.take(Attr.PHI),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -286,7 +286,7 @@ final class PhDefaultTest {
     void makesObjectIdentity() {
         final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             phi.hashCode(),
             Matchers.greaterThan(0)
         );
@@ -303,7 +303,7 @@ final class PhDefaultTest {
             ).limit(threads).collect(Collectors.toList())
         ).forEach(objects::add);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             objects,
             Matchers.hasSize(threads)
         );
@@ -314,7 +314,7 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             EOerror.ExError.class,
             () -> new Data.ToPhi("Hey").take("missing-attr"),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -325,7 +325,7 @@ final class PhDefaultTest {
         phi.put(0, new Data.ToPhi(data));
         final Phi copy = phi.copy();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(copy).take(String.class),
             Matchers.equalTo(data)
         );
@@ -339,7 +339,7 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             ExReadOnly.class,
             () -> phi.put(0, num),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -348,7 +348,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.EndlessRecursion();
         PhDefaultTest.EndlessRecursion.count = 2;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Long.class),
             Matchers.equalTo(0L)
         );
@@ -359,7 +359,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.RecursivePhi();
         PhDefaultTest.RecursivePhi.count = 3;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Long.class),
             Matchers.equalTo(0L)
         );
@@ -370,7 +370,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.RecursivePhiViaNew();
         PhDefaultTest.RecursivePhiViaNew.count = 3;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(phi).take(Long.class),
             Matchers.equalTo(0L)
         );
@@ -384,7 +384,7 @@ final class PhDefaultTest {
         copy.take("plus");
         phi.take("plus");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             PhDefaultTest.Dummy.count,
             Matchers.equalTo(1)
         );
@@ -398,7 +398,7 @@ final class PhDefaultTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(new PhMethod(phi, "count")).take(Long.class),
             Matchers.equalTo(1L)
         );
@@ -407,7 +407,7 @@ final class PhDefaultTest {
     @Test
     void hasTheSameFormaWithBoundedData() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(5L).forma(),
             Matchers.equalTo(new Data.ToPhi(6L).forma())
         );
@@ -417,7 +417,7 @@ final class PhDefaultTest {
     void hasDifferentFormaWithBoundedMethod() {
         final Phi five = new Data.ToPhi(5L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             five.forma(),
             Matchers.not(
                 Matchers.equalTo(
@@ -434,7 +434,7 @@ final class PhDefaultTest {
     @Test
     void hasTheSameFormaWithDifferentInstances() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhWith(
                 new Data.ToPhi(5L).take("plus").copy(),
                 "x",
@@ -465,7 +465,7 @@ final class PhDefaultTest {
             0, new Data.ToPhi(1.2)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(rnd).take(Double.class),
             Matchers.equalTo(new Dataized(rnd).take(Double.class))
         );
@@ -474,7 +474,7 @@ final class PhDefaultTest {
     @Test
     void injectsDeltaIntoTerm() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Data.ToPhi(new byte[] {0x01, 0x02, 0x03}).φTerm(),
             Matchers.containsString("Δ ↦ 01-02-03")
         );

--- a/eo-runtime/src/test/java/org/eolang/PhLocatedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLocatedTest.java
@@ -38,7 +38,7 @@ class PhLocatedTest {
     void savesLocationAfterCopying() {
         final Phi located = new PhLocated(new Data.ToPhi(0L), 123, 124, "qwerty");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             located.copy().locator(),
             Matchers.equalTo(located.locator())
         );

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -38,7 +38,7 @@ class PhLoggedTest {
     @Test
     void convertsToOriginTerm() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(Phi.Φ).φTerm(),
             Matchers.is(Phi.Φ.φTerm())
         );
@@ -47,7 +47,7 @@ class PhLoggedTest {
     @Test
     void copiesOrigin() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(Phi.Φ).copy(),
             Matchers.equalTo(Phi.Φ)
         );
@@ -56,7 +56,7 @@ class PhLoggedTest {
     @Test
     void returnsOriginHashCode() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(Phi.Φ).hashCode(),
             Matchers.equalTo(Phi.Φ.hashCode())
         );
@@ -65,7 +65,7 @@ class PhLoggedTest {
     @Test
     void equalsToOrigin() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(Phi.Φ),
             Matchers.equalTo(Phi.Φ)
         );
@@ -75,7 +75,7 @@ class PhLoggedTest {
     void getsOriginLocator() {
         final Phi phi = Phi.Φ;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(phi).locator(),
             Matchers.equalTo(phi.locator())
         );
@@ -85,7 +85,7 @@ class PhLoggedTest {
     void convertsToString() {
         final Phi phi = Phi.Φ;
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLogged(phi).toString(),
             Matchers.equalTo(phi.toString())
         );

--- a/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
@@ -38,7 +38,7 @@ final class PhMethodTest {
     void comparesTwoObjects() {
         final Phi num = new Data.ToPhi(1L);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             num.take("plus"),
             Matchers.not(Matchers.equalTo(num.take("plus")))
         );
@@ -47,7 +47,7 @@ final class PhMethodTest {
     @Test
     void convertsSafeToString() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhMethod(Phi.Φ, "hello").toString(),
             Matchers.endsWith(".hello")
         );
@@ -62,7 +62,7 @@ final class PhMethodTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -77,7 +77,7 @@ final class PhMethodTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -89,7 +89,7 @@ final class PhMethodTest {
         final Phi phi = new PhMethod(dummy, "neg");
         new Dataized(phi).take();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -99,7 +99,7 @@ final class PhMethodTest {
     void hasDifferentFormasWithOwnMethod() {
         final Phi dummy = new Dummy();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy.forma(),
             Matchers.not(
                 Matchers.equalTo(

--- a/eo-runtime/src/test/java/org/eolang/PhNamedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhNamedTest.java
@@ -37,12 +37,12 @@ final class PhNamedTest {
     @Test
     void comparesTwoObjects() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhNamed(new Data.ToPhi(1L), ""),
             Matchers.not(Matchers.equalTo(new PhNamed(new Data.ToPhi(1L), "")))
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhNamed(new Data.ToPhi(1L), ""),
             Matchers.not(Matchers.equalTo(new PhNamed(new Data.ToPhi(42L), "")))
         );

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -57,7 +57,7 @@ final class PhPackageTest {
     @Test
     void copiesObject() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             Phi.Φ.take("org").take("eolang").take("seq"),
             Matchers.not(
                 Matchers.equalTo(
@@ -72,7 +72,7 @@ final class PhPackageTest {
         final Phi eolang = Phi.Φ.take("org").take("eolang");
         final Phi seq = eolang.take("seq");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             seq.take(Attr.RHO),
             Matchers.equalTo(eolang)
         );
@@ -81,7 +81,7 @@ final class PhPackageTest {
     @Test
     void findsLongClass() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             Phi.Φ.take("org")
                 .take("eolang")
                 .take("bytes$eq").copy(),
@@ -95,7 +95,7 @@ final class PhPackageTest {
         final Phi parent = new PhPackage(PhPackageTest.DEFAULT_PACKAGE);
         final Phi actual = parent.take(attribute);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             Matchers.instanceOf(expected)
         );
@@ -106,7 +106,7 @@ final class PhPackageTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new PhPackage(PhPackageTest.DEFAULT_PACKAGE).take("failed"),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -115,7 +115,7 @@ final class PhPackageTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new PhPackage(PhPackageTest.DEFAULT_PACKAGE).copy(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -124,14 +124,14 @@ final class PhPackageTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new PhPackage(PhPackageTest.DEFAULT_PACKAGE).forma(),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
     @Test
     void convertsToPhiTerm() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhPackage(PhPackageTest.DEFAULT_PACKAGE).φTerm(),
             Matchers.equalTo("Φ.org.eolang")
         );
@@ -140,7 +140,7 @@ final class PhPackageTest {
     @Test
     void returnsLocator() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhPackage(PhPackageTest.DEFAULT_PACKAGE).locator(),
             Matchers.equalTo("?:?")
         );
@@ -149,7 +149,7 @@ final class PhPackageTest {
     @Test
     void convertsToString() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhPackage(PhPackageTest.DEFAULT_PACKAGE).toString(),
             Matchers.equalTo("Φ.org.eolang")
         );
@@ -180,7 +180,7 @@ final class PhPackageTest {
         service.shutdown();
         if (service.awaitTermination(1, TimeUnit.SECONDS)) {
             MatcherAssert.assertThat(
-                AtCompositeTest.TO_ADD_MESSAGE,
+                AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
                 basket.size(),
                 Matchers.equalTo(threads)
             );

--- a/eo-runtime/src/test/java/org/eolang/PhWithTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhWithTest.java
@@ -45,7 +45,7 @@ final class PhWithTest {
             0, new Data.ToPhi(1L)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy, Matchers.equalTo(dummy)
         );
     }
@@ -53,7 +53,7 @@ final class PhWithTest {
     @Test
     void takesMethod() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new Data.ToPhi("Hello, world!")
             ).take(String.class),
@@ -65,7 +65,7 @@ final class PhWithTest {
     void passesToSubObject() {
         final Phi dummy = new PhWithTest.Dummy();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhWith(
                     new PhCopy(new PhMethod(dummy, "plus")),
@@ -80,7 +80,7 @@ final class PhWithTest {
     void printsToString() {
         final Phi dummy = new PhWithTest.Dummy();
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhWith(
                 new PhCopy(new PhMethod(dummy, "plus")),
                 0, new Data.ToPhi(1L)
@@ -96,14 +96,14 @@ final class PhWithTest {
         final Phi ref = new PhWith(new DummyWithAtFree(attr), 0, new Data.ToPhi(data));
         final Func<Phi, Boolean> actual = phi -> {
             MatcherAssert.assertThat(
-                AtCompositeTest.TO_ADD_MESSAGE,
+                AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
                 new Dataized(phi.take(attr)).take(String.class),
                 Matchers.is(data)
             );
             return true;
         };
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             actual,
             new RunsInThreads<>(
                 ref,
@@ -116,7 +116,7 @@ final class PhWithTest {
     void hasTheSameFormaWithBoundAttribute() {
         final Phi dummy = new DummyWithAtFree("x");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             dummy.forma(),
             Matchers.equalTo(
                 new PhWith(dummy, "x", new Data.ToPhi(5L)).forma()

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -37,7 +37,7 @@ final class PhiTest {
     @Test
     void takesPackage() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhCopy(
                     new PhMethod(
@@ -68,7 +68,7 @@ final class PhiTest {
     @Test
     void takesStandardPackage() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 new PhCopy(
                     new PhMethod(
@@ -87,7 +87,7 @@ final class PhiTest {
     @Test
     void takesDirectly() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(
                 Phi.Φ.take("org").take("eolang").take("nan").take("gt")
             ).take(Boolean.class),
@@ -98,7 +98,7 @@ final class PhiTest {
     @Test
     void getsLocation() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new PhLocated(
                 Phi.Φ,
                 123,

--- a/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java
@@ -59,7 +59,7 @@ final class UniverseDefaultTest {
         final Phi phi = new DummyWithAt(Phi.Φ);
         final UniverseDefault universe = new UniverseDefault(phi);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             universe.find(
                 String.format("%s.%s.%s", "$", UniverseDefaultTest.ABSTRACT_ATT, Attr.RHO)
             ),
@@ -74,7 +74,7 @@ final class UniverseDefaultTest {
         final Phi phi = new DummyWithStructure();
         final UniverseDefault universe = new UniverseDefault(phi);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             universe.find(
                 String.format(
                     "$.%s.%s.%s.%s",
@@ -96,7 +96,7 @@ final class UniverseDefaultTest {
         final UniverseDefault universe = new UniverseDefault(Phi.Φ, indexed);
         final int vertex = universe.find("Q.org.eolang.seq");
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             indexed.get(vertex).getClass(),
             Matchers.equalTo(EOseq.class)
         );
@@ -109,7 +109,7 @@ final class UniverseDefaultTest {
             () -> new UniverseDefault(
                 new DummyWithStructure()
             ).find("$.wrong-name"),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -122,7 +122,7 @@ final class UniverseDefaultTest {
             "$.".concat(UniverseDefaultTest.VALUE_ATT)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             universe.dataize(vertex),
             Matchers.equalTo(new BytesOf(1L).take())
         );
@@ -135,7 +135,7 @@ final class UniverseDefaultTest {
             () -> new UniverseDefault(
                 new DummyWithStructure()
             ).dataize(-1),
-            AtCompositeTest.TO_ADD_MESSAGE
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()
         );
     }
 
@@ -147,12 +147,12 @@ final class UniverseDefaultTest {
         final int origin = universe.find("$");
         final int copy = universe.copy(origin);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             copy,
             Matchers.not(origin)
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             universe.dataize(copy),
             Matchers.equalTo(
                 universe.dataize(origin)
@@ -168,7 +168,7 @@ final class UniverseDefaultTest {
         final int copy = universe.copy(eobytes);
         universe.put(copy, UniverseDefaultTest.DATA);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(indexed.get(copy)).take(),
             Matchers.equalTo(
                 UniverseDefaultTest.DATA
@@ -188,7 +188,7 @@ final class UniverseDefaultTest {
             dummy.hashCode(), copy, UniverseDefaultTest.ABSTRACT_ATT
         );
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Dataized(dummy.take(UniverseDefaultTest.ABSTRACT_ATT)).take(),
             Matchers.equalTo(
                 UniverseDefaultTest.DATA

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -41,7 +41,7 @@ public final class VerboseBytesAsStringTest {
     @MethodSource("getTestSources")
     void representsString(final Object object) {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new VerboseBytesAsString(VerboseBytesAsStringTest.toBytes(object)).get(),
             Matchers.containsString(
                 new VerboseBytesAsStringTest.ArgumentsUtils().toString(object)

--- a/eo-runtime/src/test/java/org/eolang/VerticesTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerticesTest.java
@@ -45,7 +45,7 @@ final class VerticesTest {
     @Test
     void makesNext() {
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             new Vertices().next(),
             Matchers.greaterThan(0)
         );
@@ -68,7 +68,7 @@ final class VerticesTest {
         );
         new Threads<>(threads, tasks).forEach(hashes::add);
         MatcherAssert.assertThat(
-            AtCompositeTest.TO_ADD_MESSAGE,
+            AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get(),
             hashes.size(),
             Matchers.equalTo(threads)
         );


### PR DESCRIPTION
TODO: 
replace all appearances of AtCompositeTest.TO_ADD_MESSAGE field in eo-runtime with meaningful assert messages 
and don't forget to remove public modifier from this class if no longer need.

DONE:
1) Moved from AtCompositeTest.TO_ADD_MESSAGE to AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER in tests because of more reasonable assert message.

2) Didn't created own FAILED_ASSERT_MESSAGE_SUPPLIER in every test class because of boilerplate. 
It doesn't make any sense.

3) Left public modifier for AtCompositeTest because it reuses in other tests.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test assertions in multiple test files to use `AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()` instead of `AtCompositeTest.TO_ADD_MESSAGE`.

### Detailed summary
- Replaced `AtCompositeTest.TO_ADD_MESSAGE` with `AtCompositeTest.FAILED_ASSERT_MESSAGE_SUPPLIER.get()` in multiple test files for improved test assertion messages.

> The following files were skipped due to too many changes: `eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdoutTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/EOtupleEOatTest.java`, `eo-runtime/src/test/java/org/eolang/PhMethodTest.java`, `eo-runtime/src/test/java/org/eolang/PhLoggedTest.java`, `eo-runtime/src/test/java/org/eolang/DataTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/CagesTest.java`, `eo-runtime/src/test/java/org/eolang/PhWithTest.java`, `eo-runtime/src/test/java/org/eolang/AtCompositeTest.java`, `eo-runtime/src/test/java/org/eolang/AtLoggedTest.java`, `eo-runtime/src/test/java/org/eolang/MainTest.java`, `eo-runtime/src/test/java/org/eolang/UniverseDefaultTest.java`, `eo-runtime/src/test/java/org/eolang/PhPackageTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/EOcageTest.java`, `eo-runtime/src/test/java/org/eolang/BytesOfTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java`, `eo-runtime/src/test/java/EOorg/EOeolang/EOio/EOstdinTest.java`, `eo-runtime/src/test/java/org/eolang/PhDefaultTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->