### PR TITLE
fix(#3188): improved `PhiMojo`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -27,8 +27,9 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.xsline.Shift;
-import com.yegor256.xsline.StClasspath;
+import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
+import com.yegor256.xsline.TrJoined;
 import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.File;
@@ -92,6 +93,7 @@ public final class PhiMojo extends SafeMojo {
      * in {@link OptimizeMojo} and here.
      * @checkstyle MemberNameCheck (5 lines)
      */
+    @Parameter(property = "eo.phiOptimize", required = true, defaultValue = "true")
     @SuppressWarnings("PMD.ImmutableField")
     private boolean phiOptimize = true;
 
@@ -175,7 +177,15 @@ public final class PhiMojo extends SafeMojo {
     private static String translated(final Train<Shift> train, final XML xmir)
         throws ImpossibleToPhiTranslationException {
         final XML translated = new Xsline(
-            train.with(new StClasspath("/org/eolang/maven/phi/to-phi.xsl"))
+            new TrJoined<>(
+                train,
+                new TrClasspath<>(
+                    "/org/eolang/parser/critical-errors/duplicate-names.xsl",
+                    "/org/eolang/maven/phi/incorrect-inners.xsl",
+                    "/org/eolang/parser/fail-on-critical.xsl",
+                    "/org/eolang/maven/phi/to-phi.xsl"
+                ).back()
+            )
         ).pass(xmir);
         Logger.debug(PhiMojo.class, "XML after translation to phi:\n%s", translated);
         final List<String> phi = translated.xpath("phi/text()");

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/incorrect-inners.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/incorrect-inners.xsl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="incorrect-inners" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/program/errors">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:for-each select="//o[count(o)&gt;0 and not(@base) and not(@abstract) and not(@atom)]">
+        <xsl:element name="error">
+          <xsl:attribute name="check">
+            <xsl:text>incorrect-inners</xsl:text>
+          </xsl:attribute>
+          <xsl:attribute name="line">
+            <xsl:choose>
+              <xsl:when test="@line">
+                <xsl:value-of select="@line"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>No line</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>critical</xsl:text>
+          </xsl:attribute>
+          <xsl:text>Element can't have child elements if it does not have 'base' or 'abstract' attribute</xsl:text>
+          <xsl:if test="@name">
+            <xsl:text>. Name of the object - </xsl:text>
+            <xsl:value-of select="@name"/>
+          </xsl:if>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -24,7 +24,6 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="to-phi" version="2.0">
   <xsl:output encoding="UTF-8" method="text"/>
-  <xsl:import href="/org/eolang/parser/_datas.xsl"/>
   <!-- Variables -->
   <xsl:variable name="aliases" select="program/metas/meta/part[last()]"/>
   <xsl:variable name="xi">

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
@@ -68,9 +68,25 @@ final class PhiMojoTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/phi/xmir", glob = "**.xmir")
-    void convertsXmirsToPhiWithoutErrors(final String xmir, @TempDir final Path temp)
-        throws IOException {
-        final FakeMaven maven = new FakeMaven(temp);
+    void convertsXmirsToPhiWithoutErrorsWithoutOptimizations(
+        final String xmir,
+        @TempDir final Path temp
+    ) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp).with("phiOptimize", false);
+        new HmBase(temp).save(xmir, Paths.get("target/2-optimize/test.xmir"));
+        Assertions.assertDoesNotThrow(
+            () -> maven.execute(PhiMojo.class),
+            BinarizeParseTest.TO_ADD_MESSAGE
+        );
+    }
+
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/phi/xmir", glob = "**.xmir")
+    void convertsXmirsToPhiWithoutErrorsWithOptimizations(
+        final String xmir,
+        @TempDir final Path temp
+    ) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp).with("phiOptimize", true);
         new HmBase(temp).save(xmir, Paths.get("target/2-optimize/test.xmir"));
         Assertions.assertDoesNotThrow(
             () -> maven.execute(PhiMojo.class),

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/B.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/B.xmir
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<program dob="2024-05-16T14:27:19.832605Z"
+         ms="1715869639840"
+         name="j$B"
+         revision="0.0.0"
+         time="2024-05-16T14:27:19.832605Z"
+         version="0.0.0">
+   <listing>yv66vgAAADcAHAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAkHAAoMAAsADAEAFm9yZy9lb2xhbmcvYmVuY2htYXJrL0IBAAFmAQAYTG9yZy9lb2xhbmcvYmVuY2htYXJrL0Y7CwAOAA8HABAMABEAEgEAFm9yZy9lb2xhbmcvYmVuY2htYXJrL0YBAANmb28BAAMoKUkBABsoTG9yZy9lb2xhbmcvYmVuY2htYXJrL0Y7KVYBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAGExvcmcvZW9sYW5nL2JlbmNobWFyay9COwEAA2JhcgEAClNvdXJjZUZpbGUBAAZCLmphdmEAIAAIAAIAAAABABIACwAMAAAAAgAAAAUAEwABABQAAABGAAIAAgAAAAoqtwABKiu1AAexAAAAAgAVAAAADgADAAAAHAAEAB0ACQAeABYAAAAWAAIAAAAKABcAGAAAAAAACgALAAwAAQAAABkAEgABABQAAAA2AAIAAQAAAAwqtAAHuQANAQAFYKwAAAACABUAAAAGAAEAAAAgABYAAAAMAAEAAAAMABcAGAAAAAEAGgAAAAIAGw==</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.benchmark</tail>
+         <part>org.eolang.benchmark</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$B">
+         <o base="int" data="bytes" name="version">00 00 00 00 00 00 00 37</o>
+         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
+         <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" name="interfaces" star=""/>
+         <o base="field" name="j$f">
+            <o base="int" data="bytes" name="access-j$f" line="999">00 00 00 00 00 00 00 12</o>
+            <o base="string" data="bytes" name="descriptor-j$f" line="999">4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 46 3B</o>
+            <o base="string" data="bytes" name="signature-j$f" line="999"/>
+            <o base="class" data="bytes" name="value-j$f" scope="nullable" line="999"/>
+         </o>
+         <o abstract="" name="new">
+            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+            <o base="string" data="bytes" name="descriptor">28 4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 46 3B 29 56</o>
+            <o base="string" data="bytes" name="signature"/>
+            <o base="tuple" name="exceptions" star=""/>
+            <o base="some" name="maxs">
+               <o base="int" data="bytes" name="stack" line="999">00 00 00 00 00 00 00 02</o>
+               <o base="int" data="bytes" name="locals" line="999">00 00 00 00 00 00 00 02</o>
+            </o>
+            <o abstract="" name="arg__Lorg/eolang/benchmark/F;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes">32 39 36 64 34 31 30 33 2D 31 64 35 37 2D 34 38 33 36 2D 62 63 38 37 2D 37 63 35 63 32 62 61 30 37 30 31 63</o>
+                  <o base=".super" scope="()V">
+                     <o base="$" scope="descriptor=java.lang.Object"/>
+                  </o>
+                  <o base="label" data="bytes">66 64 63 64 31 64 63 62 2D 37 37 35 62 2D 34 64 32 30 2D 62 31 39 61 2D 37 66 32 32 34 37 32 32 31 36 31 64</o>
+                  <o base=".writefield">
+                     <o base=".f"
+                        scope="descriptor=Lorg/eolang/benchmark/F;|name=f|owner=org/eolang/benchmark/B">
+                        <o base="$" scope="descriptor=java.lang.Object"/>
+                     </o>
+                     <o base="local1" scope="descriptor=Lorg/eolang/benchmark/F;|type=local"/>
+                  </o>
+                  <o base="label" data="bytes">33 36 64 66 62 33 62 66 2D 32 31 33 39 2D 34 39 63 36 2D 62 61 63 36 2D 62 66 61 32 33 30 61 38 65 38 62 39</o>
+                  <o base="opcode" line="999" name="RETURN">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes">32 61 31 35 30 64 31 64 2D 32 39 65 65 2D 34 66 61 62 2D 62 38 35 61 2D 66 37 62 32 64 33 32 36 64 36 39 61</o>
+               </o>
+            </o>
+         </o>
+         <o abstract="" name="j$bar">
+            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+            <o base="string" data="bytes" name="descriptor">28 29 49</o>
+            <o base="string" data="bytes" name="signature"/>
+            <o base="tuple" name="exceptions" star=""/>
+            <o base="some" name="maxs">
+               <o base="int" data="bytes" name="stack" line="999">00 00 00 00 00 00 00 02</o>
+               <o base="int" data="bytes" name="locals" line="999">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes">32 39 65 63 38 31 37 34 2D 32 64 39 64 2D 34 35 35 37 2D 39 61 32 64 2D 62 33 62 33 34 30 63 33 66 38 31 62</o>
+                  <o base=".plus">
+                     <o base=".foo"
+                        scope="descriptor=()I|interfaced=true|name=foo|owner=org/eolang/benchmark/F|type=interface">
+                        <o base=".getfield">
+                           <o base=".f"
+                              scope="descriptor=Lorg/eolang/benchmark/F;|name=f|owner=org/eolang/benchmark/B|type=field">
+                              <o base="$" scope="descriptor=java.lang.Object"/>
+                           </o>
+                        </o>
+                     </o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 02</o>
+                  </o>
+                  <o base="opcode" line="999" name="IRETURN">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
+                  </o>
+                  <o base="label" data="bytes">36 66 38 37 34 65 38 32 2D 63 39 65 37 2D 34 62 30 33 2D 62 65 64 32 2D 62 66 32 34 30 33 64 64 33 65 32 38</o>
+               </o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/OriginalException.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/OriginalException.xmir
@@ -22,12 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<program dob="2024-03-13T13:49:54.999144Z"
-         ms="1710337794999"
-         name="j$OriginalException"
-         revision="0.0.0"
-         time="2024-03-13T13:49:54.999144Z"
-         version="0.0.0">
+<program dob="2024-03-13T13:49:54.999144Z" ms="1710337794999" name="j$OriginalException" revision="0.0.0" time="2024-03-13T13:49:54.999144Z" version="0.0.0">
   <listing>yv66vgAAADQAFwoAAgADBwAEDAAFAAYBABpqYXZhL2xhbmcvUnVudGltZUV4Y2VwdGlvbgEABjxpbml0PgEAFShMamF2YS9sYW5nL1N0cmluZzspVgoAAgAIDAAFAAkBACooTGphdmEvbGFuZy9TdHJpbmc7TGphdmEvbGFuZy9UaHJvd2FibGU7KVYHAAsBAChvcmcvZW9sYW5nL2luaGVyaXRhbmNlL09yaWdpbmFsRXhjZXB0aW9uAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBACpMb3JnL2VvbGFuZy9pbmhlcml0YW5jZS9PcmlnaW5hbEV4Y2VwdGlvbjsBAAdtZXNzYWdlAQASTGphdmEvbGFuZy9TdHJpbmc7AQAFY2F1c2UBABVMamF2YS9sYW5nL1Rocm93YWJsZTsBAApTb3VyY2VGaWxlAQAWT3JpZ2luYWxFeGNlcHRpb24uamF2YQAgAAoAAgAAAAAAAgABAAUABgABAAwAAAA+AAIAAgAAAAYqK7cAAbEAAAACAA0AAAAKAAIAAAAdAAUAHgAOAAAAFgACAAAABgAPABAAAAAAAAYAEQASAAEAAQAFAAkAAQAMAAAASQADAAMAAAAHKisstwAHsQAAAAIADQAAAAoAAgAAACEABgAiAA4AAAAgAAMAAAAHAA8AEAAAAAAABwARABIAAQAAAAcAEwAUAAIAAQAVAAAAAgAW</listing>
   <errors/>
   <sheets/>
@@ -54,37 +49,6 @@ SOFTWARE.
       <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
       <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 74 69 6D 65 45 78 63 65 70 74 69 6F 6E</o>
       <o base="tuple" name="interfaces" star=""/>
-      <o abstract="" name="new">
-        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
-        <o base="string" data="bytes" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
-        <o base="string" data="bytes" name="signature"/>
-        <o base="tuple" name="exceptions" star=""/>
-        <o abstract="" name="arg__Ljava/lang/String;__0"/>
-        <o base="seq" name="@">
-          <o base="tuple" star="">
-            <o base="label" data="bytes">35 32 62 66 66 37 36 30 2D 34 62 63 38 2D 34 37 61 64 2D 62 63 35 65 2D 34 38 38 32 33 32 65 64 66 30 35 37</o>
-            <o base="opcode" line="999" name="ALOAD-8C">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-            </o>
-            <o base="opcode" line="999" name="ALOAD-8D">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-            </o>
-            <o base="opcode" line="999" name="INVOKESPECIAL-8E">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
-              <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 74 69 6D 65 45 78 63 65 70 74 69 6F 6E</o>
-              <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
-              <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
-            </o>
-            <o base="label" data="bytes">65 62 61 62 36 62 36 36 2D 61 31 30 66 2D 34 65 35 32 2D 38 66 64 64 2D 34 64 66 35 33 62 62 37 38 61 31 62</o>
-            <o base="opcode" line="999" name="RETURN-8F">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
-            </o>
-            <o base="label" data="bytes">34 64 66 65 61 32 63 39 2D 37 37 65 30 2D 34 64 36 65 2D 38 31 63 38 2D 65 66 65 34 65 38 62 31 61 37 61 64</o>
-          </o>
-        </o>
-      </o>
       <o abstract="" name="new">
         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
         <o base="string" data="bytes" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 54 68 72 6F 77 61 62 6C 65 3B 29 56</o>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/SomeException.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/SomeException.xmir
@@ -62,36 +62,6 @@ SOFTWARE.
       </o>
       <o abstract="" name="new">
         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
-        <o base="string" data="bytes" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
-        <o base="string" data="bytes" name="signature"/>
-        <o base="tuple" name="exceptions" star=""/>
-        <o abstract="" name="arg__Ljava/lang/String;__0"/>
-        <o base="seq" name="@">
-          <o base="tuple" star="">
-            <o base="label" data="bytes">65 31 35 31 61 36 34 65 2D 30 64 39 37 2D 34 66 64 34 2D 62 37 61 34 2D 63 64 35 35 30 35 61 63 39 65 37 31</o>
-            <o base="opcode" line="999" name="ALOAD-83">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-            </o>
-            <o base="opcode" line="999" name="ALOAD-84">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-            </o>
-            <o base="opcode" line="999" name="INVOKESPECIAL-85">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
-              <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 69 6E 68 65 72 69 74 61 6E 63 65 2F 4F 72 69 67 69 6E 61 6C 45 78 63 65 70 74 69 6F 6E</o>
-              <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
-              <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
-            </o>
-            <o base="opcode" line="999" name="RETURN-86">
-              <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
-            </o>
-            <o base="label" data="bytes">66 33 30 35 34 34 63 65 2D 39 38 61 30 2D 34 32 30 62 2D 62 38 36 61 2D 30 61 38 66 38 34 35 31 32 63 37 34</o>
-          </o>
-        </o>
-      </o>
-      <o abstract="" name="new">
-        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
         <o base="string" data="bytes" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 54 68 72 6F 77 61 62 6C 65 3B 29 56</o>
         <o base="string" data="bytes" name="signature"/>
         <o base="tuple" name="exceptions" star=""/>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/Top$TopInnerInstance.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/Top$TopInnerInstance.xmir
@@ -60,46 +60,6 @@ SOFTWARE.
             <o base="string" data="bytes"/>
             <o base="string" data="bytes"/>
          </o>
-         <o abstract="" name="new">
-            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 02</o>
-            <o base="string" data="bytes" name="descriptor">28 4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 69 6E 6E 65 72 63 6C 61 73 73 65 73 2F 54 6F 70 3B 29 56</o>
-            <o base="string" data="bytes" name="signature"/>
-            <o base="tuple" name="exceptions" star=""/>
-            <o abstract="" name="arg__Lorg/eolang/innerclasses/Top;__0"/>
-            <o base="seq" name="@">
-               <o base="tuple" star="">
-                  <o base="label" data="bytes">35 31 37 37 30 31 32 31 2D 66 36 31 32 2D 34 32 35 37 2D 61 36 37 38 2D 35 35 38 61 39 33 33 62 37 33 38 61</o>
-                  <o base="opcode" line="999" name="ALOAD-56">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-                  </o>
-                  <o base="opcode" line="999" name="ALOAD-57">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-                  </o>
-                  <o base="opcode" line="999" name="PUTFIELD-58">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B5</o>
-                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 69 6E 6E 65 72 63 6C 61 73 73 65 73 2F 54 6F 70 24 54 6F 70 49 6E 6E 65 72 49 6E 73 74 61 6E 63 65</o>
-                     <o base="string" data="bytes">74 68 69 73 24 30</o>
-                     <o base="string" data="bytes">4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 69 6E 6E 65 72 63 6C 61 73 73 65 73 2F 54 6F 70 3B</o>
-                  </o>
-                  <o base="opcode" line="999" name="ALOAD-59">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESPECIAL-5A">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
-                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
-                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
-                     <o base="string" data="bytes">28 29 56</o>
-                  </o>
-                  <o base="opcode" line="999" name="RETURN-5B">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
-                  </o>
-                  <o base="label" data="bytes">66 63 63 64 64 61 35 31 2D 39 34 65 32 2D 34 33 30 37 2D 39 39 35 34 2D 35 33 65 62 61 38 61 61 63 37 62 66</o>
-               </o>
-            </o>
-         </o>
          <o abstract="" name="j$print">
             <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
             <o base="string" data="bytes" name="descriptor">28 29 56</o>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/Top$TopInnerStatic.xmir
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/Top$TopInnerStatic.xmir
@@ -54,31 +54,6 @@ SOFTWARE.
          <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
          <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
          <o base="tuple" name="interfaces" star=""/>
-         <o abstract="" name="new">
-            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 02</o>
-            <o base="string" data="bytes" name="descriptor">28 29 56</o>
-            <o base="string" data="bytes" name="signature"/>
-            <o base="tuple" name="exceptions" star=""/>
-            <o base="seq" name="@">
-               <o base="tuple" star="">
-                  <o base="label" data="bytes">34 38 38 31 37 37 61 64 2D 66 32 30 61 2D 34 62 36 65 2D 61 38 61 34 2D 35 63 35 64 61 63 34 62 31 39 37 61</o>
-                  <o base="opcode" line="999" name="ALOAD-64">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESPECIAL-65">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
-                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
-                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
-                     <o base="string" data="bytes">28 29 56</o>
-                  </o>
-                  <o base="opcode" line="999" name="RETURN-66">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
-                  </o>
-                  <o base="label" data="bytes">32 38 37 61 66 38 63 34 2D 66 30 34 32 2D 34 31 36 38 2D 38 36 30 66 2D 37 39 66 36 61 34 64 35 62 33 36 32</o>
-               </o>
-            </o>
-         </o>
          <o abstract="" name="j$print">
             <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
             <o base="string" data="bytes" name="descriptor">28 29 56</o>


### PR DESCRIPTION
What's done:
 1. Added ability to change `phiOptimize` flag 
 2. `PhiMojo` fails on critical errors

Ref: #3188 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the EO Maven plugin and PhiMojo test methods. It adds new test cases with and without optimizations, updates XSL files, and refactors class imports.

### Detailed summary
- Updated test methods in `PhiMojoTest.java` for optimizations.
- Refactored class imports in `PhiMojo.java`.
- Added new XSL file `incorrect-inners.xsl`.
- Updated XMIR files in the test resources.

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/OriginalException.xmir`, `eo-maven-plugin/src/test/resources/org/eolang/maven/phi/xmir/B.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->