### PR TITLE
fix(#3195): PhiMojo skips failed

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -239,6 +239,8 @@ public final class FakeMaven {
             this.params.putIfAbsent("rewriteBinaries", true);
             this.params.putIfAbsent("offline", false);
             this.params.putIfAbsent("phiOptimize", false);
+            this.params.putIfAbsent("phiFailOnCritical", true);
+            this.params.putIfAbsent("phiSkipFailed", false);
             this.params.putIfAbsent(
                 "eoPortalDir",
                 new File("../eo-runtime/src/main/rust/eo")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PhiMojoTest.java
@@ -80,6 +80,62 @@ final class PhiMojoTest {
         );
     }
 
+    @Test
+    void doesNotFailOnCritical(@TempDir final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp)
+                .with("phiFailOnCritical", false)
+                .withProgram(
+                    "# This is the default 64+ symbols comment in front of named abstract object.",
+                    "[] > with-duplicates",
+                    "  true > x",
+                    "  false > x"
+                )
+                .execute(new FakeMaven.Phi()),
+            "PhiMojo should not fail on critical errors with 'phiFailsOnCritical' = false"
+        );
+    }
+
+    @Test
+    void skipsFailedOnCriticalError(@TempDir final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp)
+                .with("phiFailOnCritical", true)
+                .with("phiSkipFailed", true)
+                .withProgram(
+                    "# This is the default 64+ symbols comment in front of named abstract object.",
+                    "[] > with-duplicates",
+                    "  true > x",
+                    "  false > x"
+                )
+                .execute(new FakeMaven.Phi()),
+            "PhiMojo should not fail on critical errors with 'phiSkipFailed' = true"
+        );
+    }
+
+    @Test
+    void doesNotSaveSkippedFile(@TempDir final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "Skipped file should not be saved after PhiMojo is done",
+            new FakeMaven(temp)
+                .with("phiFailOnCritical", true)
+                .with("phiSkipFailed", true)
+                .withProgram(
+                    "# This is the default 64+ symbols comment in front of named abstract object.",
+                    "[] > with-duplicates",
+                    "  true > x",
+                    "  false > x"
+                )
+                .execute(new FakeMaven.Phi())
+                .result(),
+            Matchers.not(
+                Matchers.hasKey(
+                    String.format("target/phi/foo/x/main.%s", PhiMojo.EXT)
+                )
+            )
+        );
+    }
+
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/phi/xmir", glob = "**.xmir")
     void convertsXmirsToPhiWithoutErrorsWithOptimizations(


### PR DESCRIPTION
Ref: #3195 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `PhiMojo` functionality by adding options to control critical error behavior and skipping failed files.

### Detailed summary
- Added `phiFailOnCritical` and `phiSkipFailed` parameters to control critical error behavior.
- Added tests for `phiFailOnCritical` and `phiSkipFailed` functionalities.
- Updated `PhiMojo` to handle critical errors and skip failed files accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->