### PR TITLE
Fix invalid sonar warning related to other version of java

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,7 +41,7 @@ jobs:
           packages: scheme-basic geometry xcolor naive-ebnf microtype etoolbox
       - uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 17
           distribution: 'zulu'
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Related to #2251

The problem was with [this sonar check](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&id=com.objectionary%3Aeo&open=AY01BA3nH0SOYJTj9Ipi). This problem should not have occurred, because in our project we use the java 8 version, but the `close` method in the `ExecutorService` is implemented only in java 19. 

Before I tried to change java version using sonar.java.source (https://github.com/objectionary/eo/pull/2900) but it didn't help.

According to [this issue](https://community.sonarsource.com/t/java-rule-s2095-bug-reported-for-java-util-concurexecutorservice-even-though-sonar-java-source-is-17/109431) the only way to make analysis work for specific java version is to use jdk of this particular version.

I tried this on my on my fork of eo and it worked:
- this is result of workflow before changing version https://github.com/c71n93/eo/actions/runs/9190608753/job/25275192434
- and this is after https://github.com/c71n93/eo/actions/runs/9191135531/job/25276898445

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Java version from 20 to 17 in the Sonar workflow.

### Detailed summary
- Updated Java version in Sonar workflow from 20 to 17.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->