### PR TITLE
fix(#3213): convert normalized atoms with Lambda to applications

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnphiMojo.java
@@ -25,8 +25,8 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XSL;
-import com.jcabi.xml.XSLDocument;
+import com.yegor256.xsline.TrClasspath;
+import com.yegor256.xsline.Xsline;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,8 +37,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.experimental.Threads;
-import org.cactoos.io.ResourceOf;
-import org.cactoos.io.UncheckedInput;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -64,12 +62,14 @@ import org.xembly.Directives;
 )
 public final class UnphiMojo extends SafeMojo {
     /**
-     * Byte wrapping transformation.
+     * Unphi transformations.
      */
-    private static final XSL WRAP_BYTES = new XSLDocument(
-        new UncheckedInput(
-            new ResourceOf("org/eolang/maven/unphi/wrap-bytes.xsl")
-        ).stream()
+    private static final Xsline TRANSFORMATIONS = new Xsline(
+        new TrClasspath<>(
+            "/org/eolang/maven/unphi/wrap-bytes.xsl",
+            "/org/eolang/parser/wrap-method-calls.xsl",
+            "/org/eolang/maven/unphi/atoms-with-bound-attrs.xsl"
+        ).back()
     );
 
     /**
@@ -119,7 +119,7 @@ public final class UnphiMojo extends SafeMojo {
                                 String.format(".%s", TranspileMojo.EXT)
                             )
                         );
-                        final XML result = UnphiMojo.WRAP_BYTES.transform(
+                        final XML result = TRANSFORMATIONS.pass(
                             new PhiSyntax(
                                 phi.getFileName().toString().replace(".phi", ""),
                                 new TextOf(phi),

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/unphi/atoms-with-bound-attrs.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/unphi/atoms-with-bound-attrs.xsl
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="atoms-with-bound-attrs" version="2.0">
+  <!--
+  Convert such expression in XMIR:
+    x ↦ ⟦
+      text ↦ Φ.org.eolang.bytes (Δ ⤍ 48-65-6C-6C-6F-20-77-6F-72-6C-64-0A),
+      size ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-08),
+      λ ⤍ Lorg_eolang_io_stdout
+    ⟧
+  to this:
+    x ↦ Φ.org.eolang.io.stdout(
+      text ↦ Φ.org.eolang.bytes (Δ ⤍ 48-65-6C-6C-6F-20-77-6F-72-6C-64-0A),
+      size ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-08)
+    )
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="o[@abstract and @atom and starts-with(@atom, 'L') and @name and count(o[@base])&gt;0]">
+    <xsl:element name="o">
+      <xsl:attribute name="name" select="@name"/>
+      <xsl:attribute name="base">
+        <xsl:for-each select="tokenize(@atom,'_')">
+          <xsl:choose>
+            <xsl:when test="position()=1">
+              <xsl:value-of select="substring(., 2)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>.</xsl:text>
+              <xsl:value-of select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:attribute>
+      <xsl:for-each select="o">
+        <xsl:element name="o">
+          <xsl:for-each select="@*[name()!='name']">
+            <xsl:attribute name="{name()}" select="."/>
+          </xsl:for-each>
+          <xsl:attribute name="as" select="@name"/>
+          <xsl:copy-of select="*"/>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/atoms.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/atoms.yaml
@@ -21,8 +21,19 @@
 # SOFTWARE.
 ---
 tests:
-  - /program/objects/o[@name='main' and @atom='?' and @abstract]
+  - /program/objects/o[@name='main' and @atom='Lambda' and @abstract]
   - /program/objects/o[@name='outer' and @abstract]
-  - /program/objects/o[@name='outer' and @abstract]/o[@name='inner' and @atom='?' and @abstract]
-phi:
-  "{⟦main ↦ ⟦λ ⤍ Lambda⟧, outer ↦ ⟦inner ↦ ⟦λ ⤍ Lambda⟧⟧⟧}"
+  - /program/objects/o[@name='outer' and @abstract]/o[@name='inner' and @atom='Lambda' and @abstract]
+phi: |
+  {
+    ⟦
+      main ↦ ⟦
+        λ ⤍ Lambda
+      ⟧,
+      outer ↦ ⟦
+        inner ↦ ⟦
+          λ ⤍ Lambda
+        ⟧
+      ⟧
+    ⟧
+  }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/bindings.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/bindings.yaml
@@ -21,29 +21,13 @@
 # SOFTWARE.
 ---
 tests:
-  - /program/objects/o[@base='Q']
-  - /program/objects/o[@method and @base='.org']
-  - /program/objects/o[@method and @base='.eolang']
-  - /program/objects/o[@method and @base='.x']
-
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='Q']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.org' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.eolang' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.y' and @method and @as='attr']
-
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@name='z' and not(@base)]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='Q']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.org' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.eolang' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.w' and @method and @name='@']
-
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='Q']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.org' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.eolang' and @method]
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.bytes' and @method and @as='0']
-  - /program/objects/o[@method and @base='.x' and @name='xyz']/o[@base='.int' and @method and @as='five']/o[@base='.bytes' and @method and @as='0']/text()
+  - //o[@base='.x' and @name='xyz']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - //o[@base='.x' and @name='xyz']/o[@base='.y' and @as='attr']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - //o[@base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@name='z' and not(@base)]
+  - //o[@base='.x' and @name='xyz']/o[@abstract and @as='abs']/o[@base='.w' and @name='@']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - //o[@base='.x' and @name='xyz']/o[@base='.int' and @as='five']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - //o[@base='.x' and @name='xyz']/o[@base='.int' and @as='five']/o[@as='0' and @base='.bytes']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - //o[@base='.x' and @name='xyz']/o[@base='.int' and @as='five']/o[@as='0' and @base='.bytes']/o[@base='org.eolang.bytes' and @data and text()!='']
 phi: |-
   {
     ⟦

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/empty-bytes.yaml
@@ -21,9 +21,6 @@
 # SOFTWARE.
 ---
 tests:
-  - /program/objects/o[@base='Q']
-  - /program/objects/o[@base='.org' and @method]
-  - /program/objects/o[@base='.eolang' and @method]
-  - /program/objects/o[@base='.bytes' and @method and @name='empty']
-  - /program/objects/o[@base='.bytes' and @method and @name='empty' and o[@base='org.eolang.bytes' and not(text())]]
+  - /program/objects/o[@base='.bytes' and @name='empty']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
+  - /program/objects/o[@base='.bytes' and @name='empty']/o[@base='org.eolang.bytes' and @data]
 phi: "{⟦empty ↦ Φ.org.eolang.bytes(Δ ⤍ --)⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/normalized-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/normalized-atom.yaml
@@ -21,6 +21,27 @@
 # SOFTWARE.
 ---
 tests:
-  - /program/objects/o[@base='.bytes' and @name='bts']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
-  - /program/objects/o[@base='.bytes' and @name='bts']/o[@base='org.eolang.bytes' and text()='A2']
-phi: "{⟦bts ↦ Φ.org.eolang.bytes(Δ ⤍ A2-)⟧}"
+  - //o[@base='org.eolang.io.stdout' and not(@abstract) and @name='x']
+  - //o[@base='org.eolang.io.stdout' and not(@abstract) and @name='x']/o[@as='text' and @base='.bytes']
+  - //o[@base='org.eolang.io.stdout' and not(@abstract) and @name='x']/o[@as='size' and @base='.int']
+phi: |
+  {
+    ⟦
+      org ↦ ⟦
+        eolang ↦ ⟦
+          io ↦ ⟦
+            x ↦ ⟦
+              text ↦ Φ.org.eolang.bytes (Δ ⤍ 48-65-6C-6C-6F-20-77-6F-72-6C-64-0A),
+              size ↦ Φ.org.eolang.int(
+                as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 48-65-6C-6C-6F-20-77-6F-72-6C-64-0A)
+              ),
+              λ ⤍ Lorg_eolang_io_stdout
+            ⟧,
+            λ ⤍ Package
+          ⟧,
+          λ ⤍ Package
+        ⟧,
+        λ ⤍ Package
+      ⟧
+    ⟧
+  }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/package.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/package.yaml
@@ -22,9 +22,5 @@
 ---
 tests:
   - /program/metas/meta[head[text()='package'] and tail[text()='foo.bar.baz'] and part[text()='foo.bar.baz']]
-  - /program/objects/o[@abstract and @name='main']
-  - /program/objects/o[@abstract and @name='main']/o[@base='Q']
-  - /program/objects/o[@abstract and @name='main']/o[@base='.org' and @method]
-  - /program/objects/o[@abstract and @name='main']/o[@base='.eolang' and @method]
-  - /program/objects/o[@abstract and @name='main']/o[@base='.stdout' and @method and @name='@']
+  - //o[@abstract and @name='main']/o[@base='.stdout']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
 phi: "{⟦foo ↦ ⟦bar ↦ ⟦baz ↦ ⟦main ↦ ⟦φ ↦ Φ.org.eolang.stdout⟧, λ ⤍ Package⟧, λ ⤍ Package⟧, λ ⤍ Package⟧⟧}"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/specials.yaml
@@ -22,11 +22,9 @@
 ---
 tests:
   - /program/objects/o[@name='main']
-  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.^' and @method]/following-sibling::o[@base='.x' and @method and @name='x']
-
-  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.a' and @method and @name='a']
-
-  - /program/objects/o[@name='main']/o[@base='$']/following-sibling::o[@base='.@' and @method]/following-sibling::o[@base='.@' and @method and @name='phi']
+  - /program/objects/o[@abstract and @name='main']/o[@base='.x' and @name='x']/o[@base='.^']/o[@base='$']
+  - /program/objects/o[@abstract and @name='main']/o[@base='.a' and @name='a']/o[@base='.^']/o[@base='$']
+  - /program/objects/o[@abstract and @name='main']/o[@base='.@' and @name='phi']/o[@base='.@']/o[@base='$']
 eo: |
   [] > main
     ^.x > x

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-anonym-abstract.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-anonym-abstract.yaml
@@ -21,9 +21,8 @@
 # SOFTWARE.
 ---
 tests:
-  - //o[@name='test' and count(o)=2]
-  - //o[@name='test']/o[position()=1 and @abstract and not(@name)]
-  - //o[@name='test']/o[last() and @base='.plus' and @method]
+  - //o[@name='test' and @abstract]/o[@base='.plus' and @name='s']/o[position()=1 and @abstract and not(@name)]
+  - //o[@name='test' and @abstract]/o[@base='.plus' and @name='s']/o[position()>1 and @as='0' and @base='.int']/o[@base='.eolang']/o[@base='.org']/o[@base='Q']
 phi: |-
   {
     ⟦

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/with-data.yaml
@@ -21,12 +21,6 @@
 # SOFTWARE.
 ---
 tests:
-  - /program/objects/o[@base='Q']
-  - /program/objects/o[@base='.org' and @method]
-  - /program/objects/o[@base='.eolang' and @method]
-  - /program/objects/o[@base='.int' and @method and @name='five']
-  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='Q']
-  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.org' and @method]
-  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.eolang' and @method]
-  - /program/objects/o[@base='.int' and @method and @name='five']/o[@base='.bytes' and @method and @as='0' and o[@base='org.eolang.bytes' and text()='00 00 00 00 00 00 00 05']]
+  - //o[@name='five' and @base='.int']/o[@base='.eolang']
+  - //o[@name='five' and @base='.int']/o[@base='.bytes' and @as='0']
 phi: "{⟦five ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-05))⟧}"

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -316,7 +316,7 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
     @Override
     public void enterLambdaBinding(final PhiParser.LambdaBindingContext ctx) {
         if (!XePhiListener.LAMBDA_PACKAGE.equals(ctx.FUNCTION().getText())) {
-            this.objects().prop("atom", "?");
+            this.objects().prop("atom", ctx.FUNCTION().getText());
         }
     }
 


### PR DESCRIPTION
Ref: #3213 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates XML/XSL files and YAML test files in the `eo-maven-plugin` and `eo-parser` modules. 

### Detailed summary
- Updated XSL files for XML transformations
- Modified YAML test files for object properties
- Improved listener method in `XePhiListener.java`

> The following files were skipped due to too many changes: `eo-maven-plugin/src/test/resources/org/eolang/maven/unphi/bindings.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->