### PR TITLE
fix(#3222): extened logs on pull

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PullMojo.java
@@ -125,8 +125,18 @@ public final class PullMojo extends SafeMojo {
                     )
                 );
                 names.add(name);
-                tojo.withSource(this.pull(name).toAbsolutePath())
-                    .withHash(new ChNarrow(name.hash()));
+                try {
+                    tojo.withSource(this.pull(name).toAbsolutePath())
+                        .withHash(new ChNarrow(name.hash()));
+                } catch (final IOException exception) {
+                    throw new IOException(
+                        String.format(
+                            "Failed to pull object discovered at %s",
+                            tojo.discoveredAt()
+                        ),
+                        exception
+                    );
+                }
             }
             Logger.info(
                 this,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/tojos/ForeignTojo.java
@@ -37,7 +37,7 @@ import org.eolang.maven.util.Rel;
  *
  * @since 0.30
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 public final class ForeignTojo {
 
     /**
@@ -135,6 +135,14 @@ public final class ForeignTojo {
      */
     public String probed() {
         return this.attribute(ForeignTojos.Attribute.PROBED);
+    }
+
+    /**
+     * The discovered at location.
+     * @return The discovered at.
+     */
+    public String discoveredAt() {
+        return this.attribute(ForeignTojos.Attribute.DISCOVERED_AT);
     }
 
     /**


### PR DESCRIPTION
Closes: #3222 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `PullMojo` class and adds a new method in `ForeignTojo`. It also introduces a test to validate error logging functionality.

### Detailed summary
- Improved error handling in `PullMojo` by handling exceptions when pulling objects.
- Added a new method `discoveredAt()` in `ForeignTojo` class to get the discovered location.
- Introduced a test to verify error logging functionality in `PullMojo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->