### PR TITLE
fix(#3294): added `PhiMojo` fails on error flag

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/phi/to-phi.xsl
@@ -163,53 +163,57 @@ SOFTWARE.
   </xsl:function>
   <!-- Program -->
   <xsl:template match="program">
-    <phi>
-      <xsl:text>{</xsl:text>
-      <xsl:variable name="tabs" select="2"/>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:value-of select="$lb"/>
-      <xsl:value-of select="eo:eol(2)"/>
-      <xsl:variable name="has-package" select="metas/meta/head[text()='package']"/>
-      <xsl:variable name="package" select="metas/meta[head[text()='package']]/tail[1]"/>
-      <xsl:variable name="parts" select="tokenize($package,'\.')"/>
-      <xsl:variable name="length" select="string-length($package)-string-length(replace($package,'\.',''))"/>
-      <xsl:choose>
-        <xsl:when test="$has-package">
-          <xsl:for-each select="$parts">
-            <xsl:value-of select="."/>
-            <xsl:value-of select="$arrow"/>
-            <xsl:value-of select="$lb"/>
-            <xsl:value-of select="eo:eol($tabs+position())"/>
-          </xsl:for-each>
-          <xsl:apply-templates select="objects">
-            <xsl:with-param name="tabs" select="$tabs + $length + 1"/>
-            <xsl:with-param name="package">
-              <xsl:value-of select="$program"/>
-              <xsl:text>.</xsl:text>
-              <xsl:value-of select="$package"/>
-            </xsl:with-param>
-          </xsl:apply-templates>
-          <xsl:for-each select="$parts">
-            <xsl:value-of select="eo:comma(2, $tabs + $length + 2 - position())"/>
-            <xsl:value-of select="$lambda"/>
-            <xsl:value-of select="$dashed-arrow"/>
-            <xsl:text>Package</xsl:text>
-            <xsl:value-of select="eo:eol($tabs + $length + 1 - position())"/>
-            <xsl:value-of select="$rb"/>
-          </xsl:for-each>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:apply-templates select="objects">
-            <xsl:with-param name="tabs" select="$tabs"/>
-            <xsl:with-param name="package" select="$program"/>
-          </xsl:apply-templates>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:value-of select="$rb"/>
-      <xsl:value-of select="eo:eol(0)"/>
-      <xsl:text>}</xsl:text>
-    </phi>
+    <program>
+      <xsl:copy-of select="./sheets"/>
+      <xsl:copy-of select="./errors"/>
+      <phi>
+        <xsl:text>{</xsl:text>
+        <xsl:variable name="tabs" select="2"/>
+        <xsl:value-of select="eo:eol(1)"/>
+        <xsl:value-of select="$lb"/>
+        <xsl:value-of select="eo:eol(2)"/>
+        <xsl:variable name="has-package" select="metas/meta/head[text()='package']"/>
+        <xsl:variable name="package" select="metas/meta[head[text()='package']]/tail[1]"/>
+        <xsl:variable name="parts" select="tokenize($package,'\.')"/>
+        <xsl:variable name="length" select="string-length($package)-string-length(replace($package,'\.',''))"/>
+        <xsl:choose>
+          <xsl:when test="$has-package">
+            <xsl:for-each select="$parts">
+              <xsl:value-of select="."/>
+              <xsl:value-of select="$arrow"/>
+              <xsl:value-of select="$lb"/>
+              <xsl:value-of select="eo:eol($tabs+position())"/>
+            </xsl:for-each>
+            <xsl:apply-templates select="objects">
+              <xsl:with-param name="tabs" select="$tabs + $length + 1"/>
+              <xsl:with-param name="package">
+                <xsl:value-of select="$program"/>
+                <xsl:text>.</xsl:text>
+                <xsl:value-of select="$package"/>
+              </xsl:with-param>
+            </xsl:apply-templates>
+            <xsl:for-each select="$parts">
+              <xsl:value-of select="eo:comma(2, $tabs + $length + 2 - position())"/>
+              <xsl:value-of select="$lambda"/>
+              <xsl:value-of select="$dashed-arrow"/>
+              <xsl:text>Package</xsl:text>
+              <xsl:value-of select="eo:eol($tabs + $length + 1 - position())"/>
+              <xsl:value-of select="$rb"/>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="objects">
+              <xsl:with-param name="tabs" select="$tabs"/>
+              <xsl:with-param name="package" select="$program"/>
+            </xsl:apply-templates>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:value-of select="eo:eol(1)"/>
+        <xsl:value-of select="$rb"/>
+        <xsl:value-of select="eo:eol(0)"/>
+        <xsl:text>}</xsl:text>
+      </phi>
+    </program>
   </xsl:template>
   <!-- Objects  -->
   <xsl:template match="objects">

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -240,6 +240,7 @@ public final class FakeMaven {
             this.params.putIfAbsent("offline", false);
             this.params.putIfAbsent("phiOptimize", false);
             this.params.putIfAbsent("phiFailOnCritical", true);
+            this.params.putIfAbsent("phiFailOnError", true);
             this.params.putIfAbsent("phiSkipFailed", false);
             this.params.putIfAbsent(
                 "eoPortalDir",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/specials.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/phi/yaml/specials.yaml
@@ -24,14 +24,14 @@ eo: |
   # This is the default 64+ symbols comment in front of named abstract object.
   [] > main
     ^.x > x
-    $.a > a
+    $.a > b
     @.@ > phi
 phi: |-
   {
     ⟦
       main ↦ ⟦
         x ↦ ξ.ρ.x,
-        a ↦ ξ.a,
+        b ↦ ξ.a,
         phi ↦ ξ.φ.φ
       ⟧
     ⟧

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -168,7 +168,7 @@ final class PhPackageTest {
             () -> (Runnable) () -> {
                 try {
                     latch.await();
-                    basket.add(System.identityHashCode(pckg.take("goto")));
+                    basket.add(System.identityHashCode(pckg.take("go")));
                 } catch (final InterruptedException exception) {
                     Thread.currentThread().interrupt();
                     throw new IllegalStateException(


### PR DESCRIPTION
Ref: #3294

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce a new parameter `phiFailOnError` in `PhiMojo` to control error handling behavior.

### Detailed summary
- Added `phiFailOnError` parameter to `PhiMojo` class
- Updated logic in `PhiMojo` to handle errors based on `phiFailOnError` value
- Modified tests to cover error handling scenarios

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->