### PR TITLE
fix(#3251): remove unescaping in eo-runtime

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -195,6 +195,7 @@ public final class FakeMaven {
      * @return Workspace after executing Mojo.
      * @throws java.io.IOException If some problem with filesystem has happened.
      * @checkstyle ExecutableStatementCountCheck (100 lines)
+     * @checkstyle JavaNCSSCheck (100 lines)
      */
     public <T extends AbstractMojo> FakeMaven execute(final Class<T> mojo) throws IOException {
         if (this.defaults) {

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -188,5 +188,5 @@ public interface Data {
             }
             return phi;
         }
-   }
+    }
 }

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -173,9 +173,7 @@ public interface Data {
                     bytes = new BytesOf(((Number) obj).doubleValue()).take();
                 } else if (obj instanceof String) {
                     phi = eolang.take("string").copy();
-                    bytes = Data.ToPhi.unescapeJavaString(
-                        (String) obj
-                    ).getBytes(StandardCharsets.UTF_8);
+                    bytes = ((String) obj).getBytes(StandardCharsets.UTF_8);
                 } else {
                     throw new IllegalArgumentException(
                         String.format(
@@ -190,112 +188,5 @@ public interface Data {
             }
             return phi;
         }
-
-        /**
-         * Unescapes a string that contains standard Java escape sequences.
-         * <ul>
-         * <li><strong>&#92;b &#92;f &#92;n &#92;r &#92;t &#92;" &#92;'</strong> :
-         * BS, FF, NL, CR, TAB, double and single quote.</li>
-         * <li><strong>&#92;X &#92;XX &#92;XXX</strong> : Octal character
-         * specification (0 - 377, 0x00 - 0xFF).</li>
-         * <li><strong>&#92;uXXXX</strong> : Hexadecimal based Unicode character.</li>
-         * </ul>
-         * @param str A string optionally containing standard java escape sequences.
-         * @return The translated string
-         * @todo #3160:90min This method should be refactored because it has high cognitive
-         *  complexity and other problems. All {@code @checkstyle} warnings suppression and
-         *  {@code SuppressWarnings("PMD.WarningName")} annotations for this method should be
-         *  removed as a result of refactoring.
-         * @checkstyle CyclomaticComplexityCheck (100 lines)
-         * @checkstyle JavaNCSSCheck (100 lines)
-         * @checkstyle NestedIfDepthCheck (100 lines)
-         * @checkstyle ModifiedControlVariableCheck (100 lines)
-         */
-        @SuppressWarnings({
-            "PMD.AvoidReassigningLoopVariables",
-            "PMD.CognitiveComplexity",
-            "PMD.NPathComplexity"
-        })
-        private static String unescapeJavaString(final String str) {
-            final StringBuilder unescaped = new StringBuilder(str.length());
-            for (int idx = 0; idx < str.length(); ++idx) {
-                char chr = str.charAt(idx);
-                if (chr == '\\') {
-                    final char next;
-                    if (idx == str.length() - 1) {
-                        next = '\\';
-                    } else {
-                        next = str.charAt(idx + 1);
-                    }
-                    if (next >= '0' && next <= '7') {
-                        final StringBuilder code = new StringBuilder(String.valueOf(next));
-                        ++idx;
-                        if (idx < str.length() - 1 && str.charAt(idx + 1) >= '0'
-                            && str.charAt(idx + 1) <= '7') {
-                            code.append(str.charAt(idx + 1));
-                            ++idx;
-                            if (idx < str.length() - 1 && str.charAt(idx + 1) >= '0'
-                                && str.charAt(idx + 1) <= '7') {
-                                code.append(str.charAt(idx + 1));
-                                ++idx;
-                            }
-                        }
-                        unescaped.append((char) Integer.parseInt(code.toString(), 8));
-                        continue;
-                    }
-                    switch (next) {
-                        case '\\':
-                            break;
-                        case 'b':
-                            chr = '\b';
-                            break;
-                        case 'f':
-                            chr = '\f';
-                            break;
-                        case 'n':
-                            chr = '\n';
-                            break;
-                        case 'r':
-                            chr = '\r';
-                            break;
-                        case 't':
-                            chr = '\t';
-                            break;
-                        case '\"':
-                            chr = '\"';
-                            break;
-                        case '\'':
-                            chr = '\'';
-                            break;
-                        case 'u':
-                            if (idx >= str.length() - 5) {
-                                chr = 'u';
-                                break;
-                            }
-                            unescaped.append(
-                                Character.toChars(
-                                    Integer.parseInt(
-                                        String.join(
-                                            "",
-                                            String.valueOf(str.charAt(idx + 2)),
-                                            String.valueOf(str.charAt(idx + 3)),
-                                            String.valueOf(str.charAt(idx + 4)),
-                                            String.valueOf(str.charAt(idx + 5))
-                                        ),
-                                        16
-                                    )
-                                )
-                            );
-                            idx += 5;
-                            continue;
-                        default:
-                            break;
-                    }
-                    ++idx;
-                }
-                unescaped.append(chr);
-            }
-            return unescaped.toString();
-        }
-    }
+   }
 }

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -135,6 +135,18 @@
     0
 
 # Test.
+[] > unescapes-slashes
+  eq. > @
+    "x\\b\\f\\u\\r\\t\\n\\'"
+    78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+
+# Test.
+[] > unescapes-symbols
+  eq. > @
+    "\b\f\n\r\t\u27E6"
+    08-0C-0A-0D-09-E2-9F-A6
+
+# Test.
 [] > compiles-correctly-with-long-duplicate-names
   [] > long-object-name
     [] > long-object-name


### PR DESCRIPTION
Ref: #3251

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `Data.java` file by removing the `unescapeJavaString` method and updating its usage.

### Detailed summary
- Added `unescapes-slashes` and `unescapes-symbols` tests in `runtime-tests.eo`.
- Updated `Data.java` to use `getBytes` directly for `String` objects.
- Removed the `unescapeJavaString` method from `Data.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->