### PR TITLE
feat(#3251): `tee-input` + `input-length` objects introduced

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Dead input is an input that reads from nowhere and always
+# returns empty sequence of bytes `--`.
+[] > dead-input
+  # Read `size` amount of bytes from nowhere.
+  # Returns new instance of `input-block`.
+  [size] > read
+    input-block > @
+
+    # Dead input block.
+    #
+    # Attention! The object is for internal usage only, please don't use the object
+    # programmatically outside of `dead-input` object.
+    [] > input-block
+      -- > @
+
+      # Read `size` amount of bytes from nowhere.
+      # Returns new instance of `input-block`.
+      ^.^.input-block > [size] > read

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Dead output is an output that writes to nowhere.
+[] > dead-output
+  # Writes given `buffer` to nowhere.
+  # Returns new instance of `output-block`.
+  [buffer] > write
+    output-block > @
+
+    # Dead output block.
+    #
+    # Attention! The object is for internal usage only, please don't use the object
+    # programmatically outside of `dead-output` object.
+    [] > output-block
+      true > @
+
+      # Writes given `buffer` to nowhere.
+      # Returns new instance of `output-block`.
+      ^.^.output-block > [buffer] > write

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.console
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Reads all the bytes from provided `input` and returns its length.
+[input] > input-length
+  4096 > chunk
+  rec-read input 0 > @
+
+  [input length] > rec-read
+    (input.read ^.chunk).read.^ > read-bytes
+    if. > @
+      read-bytes.size.eq 0
+      length
+      ^.rec-read
+        read-bytes
+        length.plus read-bytes.size

--- a/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
@@ -1,0 +1,77 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Tee input is an input that reads from provided `input`,
+# writes to provided `output` and behaves as provided `input`.
+# To copy bytes input to memory you can do:
+# ```
+# malloc.of > copied
+#   5
+#   [m]
+#     read. > @
+#       tee-input
+#         bytes-as-input 01-02-03-04-05
+#         malloc-as-output m
+#       5
+# ```
+# After dataization `copied` is equal to `01-02-03-04-05` which are read
+# from memory.
+[input output] > tee-input
+  # Read `size` amount of bytes from `input`.
+  # Returns new instance of `input-block` with set
+  # `input` ready to be read, `output` ready to be written and bytes `buffer`.
+  [size] > read
+    ((input-block ^.input ^.output --).read size).self > @
+
+    # Tee-input block.
+    #
+    # Attention! The object is for internal usage only, please don't use the object
+    # programmatically outside of `tee-input` object.
+    #
+    # Here `input` is an input ready to be read,
+    # `output` is an output ready to be written,
+    # `buffer` is a sequence of bytes that got from previous reading.
+    [input output buffer] > input-block
+      $ > self
+      buffer > @
+
+      # Read `size` amount of bytes from `input`.
+      # Returns new instance of `input-block` with set
+      # `input` ready to be read, `output` ready to be written and bytes `buffer`.
+      [size] > read
+        (^.input.read size).read.^ > read-bytes
+        (^.output.write read-bytes).write.^ > written-bytes
+        self. > @
+          seq
+            *
+              written-bytes
+              ^.^.input-block
+                read-bytes
+                written-bytes
+                read-bytes.as-bytes

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
@@ -30,7 +30,7 @@
 # Test.
 [] > reads-empty-bytes
   dead-input.read 10 > i1
-  i2.read 10 > i2
+  i1.read 10 > i2
   and. > @
     i1.eq --
     i2.eq --

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.dead-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.io
++version 0.0.0
+
+# Test.
+[] > reads-empty-bytes
+  dead-input.read 10 > i1
+  i2.read 10 > i2
+  and. > @
+    i1.eq --
+    i2.eq --

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.dead-output
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.io
++version 0.0.0
+
+# Test.
+dead-output.write 01-02-03 > [] > writes-bytes-to-nowhere

--- a/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
@@ -1,0 +1,50 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.input-length
++alias org.eolang.io.bytes-as-input
++alias org.eolang.io.tee-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.io
++version 0.0.0
+
+# Test.
+[] > reads-all-bytes-and-returns-length
+  eq. > @
+    input-length
+      bytes-as-input
+        01-02-03-04-05-06-07-08-09-10
+    10
+
+# Test.
+[] > copies-all-bytes-to-output-and-returns-length
+  eq. > @
+    malloc.of
+      10
+      [m]
+        input-length > @
+          tee-input
+            bytes-as-input 01-02-03-04-05-06-07-08-09-10
+            malloc-as-output m
+    01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
@@ -23,6 +23,7 @@
 +alias org.eolang.io.input-length
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.tee-input
++alias org.eolang.io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
@@ -1,0 +1,79 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.io.tee-input
++alias org.eolang.io.bytes-as-input
++alias org.eolang.io.malloc-as-output
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.io
++version 0.0.0
+
+# Test.
+[] > reads-from-bytes-and-writes-to-memory
+  eq. > @
+    malloc.of
+      5
+      [m]
+        read. > @
+          tee-input
+            bytes-as-input 01-02-03-04-05
+            malloc-as-output m
+          5
+    01-02-03-04-05
+
+# Test.
+[] > reads-from-bytes-and-writes-to-memory-by-portions
+  eq. > @
+    malloc.of
+      5
+      [m]
+        tee-input > tee
+          bytes-as-input 01-02-03-04-05
+          malloc-as-output m
+        tee.read 2 > i1
+        i1.read 2 > i2
+        i2.read 1 > @
+    01-02-03-04-05
+
+# Test.
+[] > reads-from-bytes-and-writes-to-two-memory-blocks
+  eq. > @
+    malloc.of
+      6
+      [m1]
+        malloc.of > @
+          5
+          [m2] >>
+            seq > @
+              *
+                read.
+                  tee-input
+                    tee-input
+                      bytes-as-input 01-02-03-04-05
+                      malloc-as-output m2
+                    malloc-as-output ^.m1
+                  5
+                ^.m1.write 5 2A-
+    01-02-03-04-05-2A
+


### PR DESCRIPTION
Ref: #3251

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds licensing information and architectural details to multiple EO files. It also introduces new objects like `dead-input` and `dead-output`.

### Detailed summary
- Added licensing information to various files
- Introduced `dead-input` and `dead-output` objects
- Included architectural details and package information

> The following files were skipped due to too many changes: `eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo`, `eo-runtime/src/main/eo/org/eolang/io/tee-input.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->