### PR TITLE
Wrapped syscalls to get rid of out parameters

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -29,4 +29,9 @@
 
 # Makes a Unix syscall by name with POSIX interface.
 # See https://filippo.io/linux-syscall-table/
-[name args] > posix /int
+[name args] > posix
+  [] > @ /res
+
+  # Result that is returned by system call.
+  [code output] > res
+    output > @

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscall.java
@@ -34,12 +34,12 @@ import org.eolang.Phi;
  *
  * @since 0.40
  */
-public interface DispatchedNativeMethod {
+public interface DispatchedSyscall {
     /**
      * Makes native method call.
      *
      * @param params Native methods parameters.
      * @return Methods return code.
      */
-    int call(Phi... params);
+    Phi call(Phi... params);
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscallDefault.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscallDefault.java
@@ -38,11 +38,11 @@ import org.eolang.Phi;
  *
  * @since 0.40
  */
-public final class DispatchedNativeDefault implements DispatchedNativeMethod {
+public final class DispatchedSyscallDefault implements DispatchedSyscall {
     /**
      * Native library.
      */
-    private final Library lib;
+    private final SyscallLib lib;
 
     /**
      * Dispatched method.
@@ -54,7 +54,7 @@ public final class DispatchedNativeDefault implements DispatchedNativeMethod {
      * @param lib Library.
      * @param method Method.
      */
-    DispatchedNativeDefault(final Library lib, final Method method) {
+    DispatchedSyscallDefault(final SyscallLib lib, final Method method) {
         this.lib = lib;
         this.method = method;
     }
@@ -64,14 +64,14 @@ public final class DispatchedNativeDefault implements DispatchedNativeMethod {
      * @param lib Library.
      * @param name Method name.
      */
-    DispatchedNativeDefault(final Library lib, final String name) {
-        this(lib, DispatchedNativeDefault.findMethodUnsafe(name, lib));
+    DispatchedSyscallDefault(final SyscallLib lib, final String name) {
+        this(lib, DispatchedSyscallDefault.findMethodUnsafe(name, lib));
     }
 
     @Override
-    public int call(final Phi... params) {
+    public Phi call(final Phi... params) {
         try {
-            return (int) this.method.invoke(this.lib, this.prepareParams(params));
+            return (Phi) this.method.invoke(this.lib, this.prepareParams(params));
         } catch (final InvocationTargetException | IllegalAccessException ex) {
             throw new IllegalStateException(
                 String.format(
@@ -104,7 +104,7 @@ public final class DispatchedNativeDefault implements DispatchedNativeMethod {
      * @return Method.
      * @throws NoSuchMethodException if method not found.
      */
-    private static Method findMethod(final String name, final Library lib)
+    private static Method findMethod(final String name, final SyscallLib lib)
         throws NoSuchMethodException {
         for (final Method method : lib.getClass().getMethods()) {
             if (method.getName().equals(name)) {
@@ -113,7 +113,7 @@ public final class DispatchedNativeDefault implements DispatchedNativeMethod {
         }
         throw new NoSuchMethodException(
             String.format(
-                "Can't find syscall with name %s in class %s",
+                "Can't find syscall with name \"%s\" in class %s",
                 name,
                 lib.getClass().getName()
             )
@@ -126,9 +126,9 @@ public final class DispatchedNativeDefault implements DispatchedNativeMethod {
      * @param lib Native library.
      * @return Method.
      */
-    private static Method findMethodUnsafe(final String name, final Library lib) {
+    private static Method findMethodUnsafe(final String name, final SyscallLib lib) {
         try {
-            return DispatchedNativeDefault.findMethod(name, lib);
+            return DispatchedSyscallDefault.findMethod(name, lib);
         } catch (final NoSuchMethodException ex) {
             throw new IllegalArgumentException(
                 String.format("Can't find syscall with name \"%s\"", name),

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscallDefault.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedSyscallDefault.java
@@ -89,8 +89,18 @@ public final class DispatchedSyscallDefault implements DispatchedSyscall {
      * @return Prepared parameters.
      */
     private Object[] prepareParams(final Phi... params) {
-        final Object[] prepared = new Object[params.length];
         final Class<?>[] types = this.method.getParameterTypes();
+        if (types.length != params.length) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Expected %d parameters for method \"%s\", but was %d",
+                    types.length,
+                    this.method,
+                    params.length
+                )
+            );
+        }
+        final Object[] prepared = new Object[params.length];
         for (int iter = 0; iter < params.length; ++iter) {
             prepared[iter] = new Dataized(params[iter]).take(types[iter]);
         }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOposix$EOφ.java
@@ -27,29 +27,49 @@
  */
 package EOorg.EOeolang.EOsys; // NOPMD
 
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
 import org.eolang.Phi;
+import org.eolang.Versionized;
+import org.eolang.XmirObject;
 
 /**
- * Unix system call that uses library {@link CStdLib}.
+ * Unix syscall.
  *
  * @since 0.40
+ * @checkstyle TypeNameCheck (100 lines)
  */
-public final class DispatchedUnixSyscall implements DispatchedSyscall {
-    /**
-     * Origin {@link DispatchedSyscall}.
-     */
-    private final DispatchedSyscall origin;
-
-    /**
-     * Ctor.
-     * @param name Method name.
-     */
-    DispatchedUnixSyscall(final String name) {
-        this.origin = new DispatchedSyscallDefault(new PosixLibWithJna(), name);
-    }
+@Versionized
+@XmirObject(oname = "posix.@")
+@SuppressWarnings("PMD.AvoidDollarSigns")
+public final class EOposix$EOφ extends PhDefault implements Atom {
 
     @Override
-    public Phi call(final Phi... params) {
-        return this.origin.call(params);
+    public Phi lambda() throws Exception {
+        final Phi rho = this.take(Attr.RHO);
+        final Phi name = rho.take("name");
+        final Phi[] args = this.collectArgs();
+        return new DispatchedUnixSyscall(new Dataized(name).asString()).call(args);
+    }
+
+    /**
+     * Collects arguments for syscall from tuple.
+     *
+     * @return Array of arguments.
+     */
+    private Phi[] collectArgs() {
+        final Phi args = this.take(Attr.RHO).take("args");
+        final Phi retriever = args.take("at");
+        final int length = new Dataized(args.take("length")).asNumber().intValue();
+        final Phi[] arguments = new Phi[length];
+        for (long iter = 0; iter < length; ++iter) {
+            final Phi taken = retriever.copy();
+            taken.put(0, new Data.ToPhi(iter));
+            arguments[(int) iter] = taken;
+        }
+        return arguments;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLib.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLib.java
@@ -56,9 +56,8 @@ interface PosixLib extends SyscallLib {
      * The "read" syscall wrapper.
      *
      * @param descriptor File descriptor.
-     * @param buf Buffer.
      * @param size Number of bytes to be read.
-     * @return Process ID as "code" and empty object as "output".
+     * @return Process ID as "code" and buffer as "output".
      */
-    Phi read(Long descriptor, byte[] buf, Long size);
+    Phi read(Long descriptor, Long size);
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLib.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLib.java
@@ -27,56 +27,38 @@
  */
 package EOorg.EOeolang.EOsys; // NOPMD
 
-import org.eolang.AtVoid;
-import org.eolang.Atom;
-import org.eolang.Data;
-import org.eolang.Dataized;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
- * Unix syscall.
- *
+ * Posix syscalls interface for EO.
  * @since 0.40
- * @checkstyle TypeNameCheck (100 lines)
  */
-public final class EOposix extends PhDefault implements Atom {
+interface PosixLib extends SyscallLib {
 
     /**
-     * Ctor.
-     */
-    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public EOposix() {
-        this.add("name", new AtVoid("name"));
-        this.add("args", new AtVoid("args"));
-    }
-
-    @Override
-    public Phi lambda() throws Exception {
-        final Phi name = this.take("name");
-        final Phi[] args = this.collectArgs();
-        return new Data.ToPhi(
-            new DispatchedUnixSyscall(
-                new Dataized(name).asString()
-            ).call(args)
-        );
-    }
-
-    /**
-     * Collects arguments for syscall from tuple.
+     * The "getpid" syscall wrapper.
      *
-     * @return Array of arguments.
+     * @return EO object with return code as "code" and empty object as "output".
      */
-    private Phi[] collectArgs() {
-        final Phi args = this.take("args");
-        final Phi retriever = args.take("at");
-        final int length = new Dataized(args.take("length")).asNumber().intValue();
-        final Phi[] arguments = new Phi[length];
-        for (long iter = 0; iter < length; ++iter) {
-            final Phi taken = retriever.copy();
-            taken.put(0, new Data.ToPhi(iter));
-            arguments[(int) iter] = taken;
-        }
-        return arguments;
-    }
+    Phi getpid();
+
+    /**
+     * The "write" syscall wrapper.
+     *
+     * @param descriptor File descriptor.
+     * @param buf Buffer.
+     * @param size Number of bytes to be written.
+     * @return EO object with return code as "code" and empty object as "output".
+     */
+    Phi write(Long descriptor, String buf, Long size);
+
+    /**
+     * The "read" syscall wrapper.
+     *
+     * @param descriptor File descriptor.
+     * @param buf Buffer.
+     * @param size Number of bytes to be read.
+     * @return Process ID as "code" and empty object as "output".
+     */
+    Phi read(Long descriptor, byte[] buf, Long size);
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
@@ -77,7 +77,7 @@ public final class PosixLibWithJna implements PosixLib {
     public Phi read(final Long descriptor, final byte[] buf, final Long size) {
         final Phi res = new EOposix$EOres();
         res.put("code", new Data.ToPhi(this.lib.read(descriptor, buf, size)));
-        res.put("output", new PhDefault());
+        res.put("output", new Data.ToPhi(buf));
         return res;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
@@ -27,29 +27,57 @@
  */
 package EOorg.EOeolang.EOsys; // NOPMD
 
+import org.eolang.Data;
+import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
- * Unix system call that uses library {@link CStdLib}.
- *
+ * Posix syscalls implementation that uses {@link CStdLib}.
  * @since 0.40
  */
-public final class DispatchedUnixSyscall implements DispatchedSyscall {
+public final class PosixLibWithJna implements PosixLib {
     /**
-     * Origin {@link DispatchedSyscall}.
+     * C standard library with syscalls.
      */
-    private final DispatchedSyscall origin;
+    private final CStdLib lib;
 
     /**
      * Ctor.
-     * @param name Method name.
+     *
+     * @param lib C standard library with syscalls.
      */
-    DispatchedUnixSyscall(final String name) {
-        this.origin = new DispatchedSyscallDefault(new PosixLibWithJna(), name);
+    public PosixLibWithJna(final CStdLib lib) {
+        this.lib = lib;
+    }
+
+    /**
+     * Ctor.
+     */
+    public PosixLibWithJna() {
+        this(CStdLib.INSTANCE);
     }
 
     @Override
-    public Phi call(final Phi... params) {
-        return this.origin.call(params);
+    public Phi getpid() {
+        final Phi res = new EOposix$EOres();
+        res.put("code", new Data.ToPhi(this.lib.getpid()));
+        res.put("output", new PhDefault());
+        return res;
+    }
+
+    @Override
+    public Phi write(final Long descriptor, final String buf, final Long size) {
+        final Phi res = new EOposix$EOres();
+        res.put("code", new Data.ToPhi(this.lib.write(descriptor, buf, size)));
+        res.put("output", new PhDefault());
+        return res;
+    }
+
+    @Override
+    public Phi read(final Long descriptor, final byte[] buf, final Long size) {
+        final Phi res = new EOposix$EOres();
+        res.put("code", new Data.ToPhi(this.lib.read(descriptor, buf, size)));
+        res.put("output", new PhDefault());
+        return res;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java
@@ -59,7 +59,7 @@ public final class PosixLibWithJna implements PosixLib {
 
     @Override
     public Phi getpid() {
-        final Phi res = new EOposix$EOres();
+        final Phi res = Phi.Φ.take("org.eolang.sys").take("posix").take("res").copy();
         res.put("code", new Data.ToPhi(this.lib.getpid()));
         res.put("output", new PhDefault());
         return res;
@@ -67,15 +67,16 @@ public final class PosixLibWithJna implements PosixLib {
 
     @Override
     public Phi write(final Long descriptor, final String buf, final Long size) {
-        final Phi res = new EOposix$EOres();
+        final Phi res = Phi.Φ.take("org.eolang.sys").take("posix").take("res").copy();
         res.put("code", new Data.ToPhi(this.lib.write(descriptor, buf, size)));
         res.put("output", new PhDefault());
         return res;
     }
 
     @Override
-    public Phi read(final Long descriptor, final byte[] buf, final Long size) {
-        final Phi res = new EOposix$EOres();
+    public Phi read(final Long descriptor, final Long size) {
+        final Phi res = Phi.Φ.take("org.eolang.sys").take("posix").take("res").copy();
+        final byte[] buf = new byte[size.intValue()];
         res.put("code", new Data.ToPhi(this.lib.read(descriptor, buf, size)));
         res.put("output", new Data.ToPhi(buf));
         return res;

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/SyscallLib.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/SyscallLib.java
@@ -27,29 +27,9 @@
  */
 package EOorg.EOeolang.EOsys; // NOPMD
 
-import org.eolang.Phi;
-
 /**
- * Unix system call that uses library {@link CStdLib}.
- *
+ * General syscall library for EO.
  * @since 0.40
  */
-public final class DispatchedUnixSyscall implements DispatchedSyscall {
-    /**
-     * Origin {@link DispatchedSyscall}.
-     */
-    private final DispatchedSyscall origin;
-
-    /**
-     * Ctor.
-     * @param name Method name.
-     */
-    DispatchedUnixSyscall(final String name) {
-        this.origin = new DispatchedSyscallDefault(new PosixLibWithJna(), name);
-    }
-
-    @Override
-    public Phi call(final Phi... params) {
-        return this.origin.call(params);
-    }
+public interface SyscallLib {
 }

--- a/eo-runtime/src/test/eo/org/eolang/sys/posix-test.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/posix-test.eo
@@ -35,9 +35,10 @@
     os.is-windows
     true
     gt.
-      posix
-        "getpid"
-        tuple.empty
+      code.
+        posix
+          "getpid"
+          tuple.empty
       0
 
 # Test.
@@ -47,12 +48,13 @@
     os.is-windows
     true
     eq.
-      posix
-        "write"
-        *
-          1
-          msg
-          msg.length
+      code.
+        posix
+          "write"
+          *
+            1
+            msg
+            msg.length
       msg.length
 
 # Test.
@@ -62,10 +64,11 @@
     os.is-windows
     true
     eq.
-      posix
-        "read"
-        *
-          1
-          buf
-          buf.size
+      code.
+        posix
+          "read"
+          *
+            1
+            buf
+            buf.size
       -1

--- a/eo-runtime/src/test/eo/org/eolang/sys/posix-test.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/posix-test.eo
@@ -69,6 +69,5 @@
           "read"
           *
             1
-            buf
             buf.size
       -1

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/DispatchedUnixSyscallTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/DispatchedUnixSyscallTest.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang.EOsys; // NOPMD
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -109,11 +110,9 @@ final class DispatchedUnixSyscallTest {
     @DisabledOnOs(OS.WINDOWS)
     void invokesReadWithoutExceptions() {
         final int size = 3;
-        final byte[] buf = new byte[size];
         Assertions.assertDoesNotThrow(
             () -> new DispatchedUnixSyscall("read").call(
                 new Data.ToPhi(1L),
-                new Data.ToPhi(buf),
                 new Data.ToPhi(size)
             ),
             "Expected \"read\" syscall to be called without exceptions."
@@ -124,17 +123,23 @@ final class DispatchedUnixSyscallTest {
     @DisabledOnOs(OS.WINDOWS)
     void invokesReadFromStdoutWithError() {
         final int size = 3;
-        final byte[] buf = new byte[size];
+        final Phi result = new DispatchedUnixSyscall("read").call(
+            new Data.ToPhi(0L),
+            new Data.ToPhi(size)
+        );
         MatcherAssert.assertThat(
             "Expected \"read\" syscall to dispatched correctly",
             new Dataized(
-                new DispatchedUnixSyscall("read").call(
-                    new Data.ToPhi(1L),
-                    new Data.ToPhi(buf),
-                    new Data.ToPhi(size)
-                ).take("code")
+                result.take("code")
             ).take(Long.class),
             Matchers.equalTo((long) -1)
+        );
+        MatcherAssert.assertThat(
+            "Expected \"read\" syscall to dispatched correctly",
+            new Dataized(
+                result.take("output")
+            ).take(byte[].class).length,
+            Matchers.equalTo(size)
         );
     }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/DispatchedUnixSyscallTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/DispatchedUnixSyscallTest.java
@@ -28,6 +28,7 @@
 package EOorg.EOeolang.EOsys; // NOPMD
 
 import org.eolang.Data;
+import org.eolang.Dataized;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -66,8 +67,10 @@ final class DispatchedUnixSyscallTest {
     void invokesGetpidCorrectly() {
         MatcherAssert.assertThat(
             "Expected \"getpid\" syscall to dispatched correctly",
-            new DispatchedUnixSyscall("getpid").call(),
-            Matchers.equalTo(CStdLib.INSTANCE.getpid())
+            new Dataized(
+                new DispatchedUnixSyscall("getpid").call().take("code")
+            ).take(Long.class),
+            Matchers.equalTo((long) CStdLib.INSTANCE.getpid())
         );
     }
 
@@ -91,12 +94,14 @@ final class DispatchedUnixSyscallTest {
         final String msg = "Hello, world!\n";
         MatcherAssert.assertThat(
             "Expected \"write\" syscall to dispatched correctly",
-            new DispatchedUnixSyscall("write").call(
-                new Data.ToPhi(1L),
-                new Data.ToPhi(msg),
-                new Data.ToPhi((long) msg.length())
-            ),
-            Matchers.equalTo(msg.length())
+            new Dataized(
+                new DispatchedUnixSyscall("write").call(
+                    new Data.ToPhi(1L),
+                    new Data.ToPhi(msg),
+                    new Data.ToPhi((long) msg.length())
+                ).take("code")
+            ).take(Long.class),
+            Matchers.equalTo((long) msg.length())
         );
     }
 
@@ -122,12 +127,14 @@ final class DispatchedUnixSyscallTest {
         final byte[] buf = new byte[size];
         MatcherAssert.assertThat(
             "Expected \"read\" syscall to dispatched correctly",
-            new DispatchedUnixSyscall("read").call(
-                new Data.ToPhi(1L),
-                new Data.ToPhi(buf),
-                new Data.ToPhi(size)
-            ),
-            Matchers.equalTo(-1)
+            new Dataized(
+                new DispatchedUnixSyscall("read").call(
+                    new Data.ToPhi(1L),
+                    new Data.ToPhi(buf),
+                    new Data.ToPhi(size)
+                ).take("code")
+            ).take(Long.class),
+            Matchers.equalTo((long) -1)
         );
     }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/EOposixTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOsys/EOposixTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.condition.OS;
  * @since 0.40
  * @checkstyle TypeNameCheck (100 lines)
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOposixTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
@@ -60,7 +61,7 @@ final class EOposixTest {
                     ),
                     "args",
                     new EOtuple$EOempty()
-                )
+                ).take("code")
             ).take(Long.class),
             Matchers.equalTo(
                 Long.parseLong(
@@ -93,7 +94,7 @@ final class EOposixTest {
                     ),
                     "args",
                     args
-                )
+                ).take("code")
             ).take(Long.class),
             Matchers.equalTo(
                 (long) msg.length()


### PR DESCRIPTION
Related to #3236

<!-- start pr-codex -->

---

## PR-Codex overview
### PR Focus
Refactoring the EOsys POSIX interface for Unix syscalls.

### Detailed summary
- Removed unnecessary argument type in `posix` method.
- Added `res` object for system call results.
- Renamed `DispatchedNativeMethod` to `DispatchedSyscall`.
- Updated `DispatchedUnixSyscall` to implement `DispatchedSyscall`.
- Added `SyscallLib` interface for syscall operations.
- Updated method signatures in `PosixLib`.
- Refactored `EOposix` class and added versioning.
- Updated test assertions in `EOposixTest`.
- Added `PosixLibWithJna` implementation for JNA integration.

> The following files were skipped due to too many changes: `eo-runtime/src/main/java/EOorg/EOeolang/EOsys/PosixLibWithJna.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOsys/DispatchedNativeDefault.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->