### PR TITLE
feat(#3343): Allow Partial XMIR Printing

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
@@ -110,4 +110,59 @@ public interface Xmir {
                 .get(0);
         }
     }
+
+    final class Simplified implements Xmir {
+
+        /**
+         * Train of transformations.
+         */
+        private static final Train<Shift> TRAIN = new TrDefault<>(
+            new StClasspath("/org/eolang/parser/explicit-data.xsl"),
+            new StUnhex(),
+            new StClasspath("/org/eolang/parser/wrap-method-calls.xsl")
+        );
+
+        /**
+         * Default xmir-to-eo XSL transformation.
+         */
+        private static final String TO_EO = "/org/eolang/parser/xmir-to-eo-simplified.xsl";
+
+        /**
+         * The XML.
+         */
+        private final XML xml;
+
+        /**
+         * Result to-EO transformation.
+         */
+        private final String xsl;
+
+        /**
+         * Ctor.
+         * @param src The source
+         */
+        public Simplified(final XML src) {
+            this(src, Xmir.Simplified.TO_EO);
+        }
+
+        /**
+         * Ctor.
+         * @param src The source
+         * @param classpath To-EO transformation classpath
+         */
+        public Simplified(final XML src, final String classpath) {
+            this.xml = src;
+            this.xsl = classpath;
+        }
+
+        @Override
+        public String toEO() {
+            final XML pass = new Xsline(
+                Simplified.TRAIN.with(
+                    new StClasspath(this.xsl)
+                )
+            ).pass(this.xml);
+            return pass.xpath("eo/text()").get(0);
+        }
+    }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
@@ -34,6 +34,7 @@ import org.eolang.parser.StUnhex;
 /**
  * Prints XMIR to EO.
  * @since 0.35.0
+ * @checkstyle JavadocStyleCheck (200 lines)
  */
 public interface Xmir {
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
@@ -113,7 +113,33 @@ public interface Xmir {
 
     /**
      * Simplified xmir that allows printing of small parts EO.
-     *
+     * <p>
+     * This printer is important in cases when you need to print only some parts of EO
+     * without having the whole EO document.
+     * </p>
+     * <p>
+     * For example, instead of generating the full structure of EO document like the following
+     * {@code
+     * <program>
+     *    <objects>
+     *        <o base=".plus">
+     *           <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+     *           <o base="int" data="bytes">00 00 00 00 00 00 00 02</o>
+     *        </o>
+     *    </objects>
+     * </program>
+     * }
+     * You can generate only the part of the EO document that you need like the following
+     * {@code
+     * <o base=".plus">
+     *     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+     *     <o base="int" data="bytes">00 00 00 00 00 00 00 02</o>
+     * </o>
+     * }
+     * </p>
+     * It significantly simplifies the process of printing EO, especially in tests.
+     * You can read more about the problem right
+     * <a href="https://github.com/objectionary/eo/issues/3343">here</a>
      * @since 0.40
      */
     final class Simplified implements Xmir {

--- a/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/xmir/Xmir.java
@@ -111,6 +111,11 @@ public interface Xmir {
         }
     }
 
+    /**
+     * Simplified xmir that allows printing of small parts EO.
+     *
+     * @since 0.40
+     */
     final class Simplified implements Xmir {
 
         /**
@@ -123,32 +128,32 @@ public interface Xmir {
         );
 
         /**
-         * Default xmir-to-eo XSL transformation.
+         * Default xmir-to-eo-simplified XSL transformation.
          */
         private static final String TO_EO = "/org/eolang/parser/xmir-to-eo-simplified.xsl";
 
         /**
-         * The XML.
+         * The XML to transform.
          */
         private final XML xml;
 
         /**
-         * Result to-EO transformation.
+         * Transformation.
          */
         private final String xsl;
 
         /**
-         * Ctor.
-         * @param src The source
+         * Constructor.
+         * @param src The source to transform.
          */
         public Simplified(final XML src) {
             this(src, Xmir.Simplified.TO_EO);
         }
 
         /**
-         * Ctor.
-         * @param src The source
-         * @param classpath To-EO transformation classpath
+         * Constructor.
+         * @param src The source to transform.
+         * @param classpath Transformation classpath.
          */
         public Simplified(final XML src, final String classpath) {
             this.xml = src;
@@ -157,12 +162,8 @@ public interface Xmir {
 
         @Override
         public String toEO() {
-            final XML pass = new Xsline(
-                Simplified.TRAIN.with(
-                    new StClasspath(this.xsl)
-                )
-            ).pass(this.xml);
-            return pass.xpath("eo/text()").get(0);
+            return new Xsline(Simplified.TRAIN.with(new StClasspath(this.xsl)))
+                .pass(this.xml).xpath("eo/text()").get(0);
         }
     }
 }

--- a/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-simplified.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/xmir-to-eo-simplified.xsl
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="xmir-to-eo-simplified" version="2.0">
+  <!--
+  This one maps XMIR to EO original syntax in straight notation.
+  It's used in Xmir.java class.
+  -->
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:variable name="eol" select="'&#10;'"/>
+  <xsl:variable name="comment">
+    <xsl:text># This is the default 64+ symbols comment in front of named abstract object.</xsl:text>
+    <xsl:value-of select="$eol"/>
+  </xsl:variable>
+  <xsl:output method="text" encoding="UTF-8"/>
+  <!-- ROOT -->
+  <xsl:template match="/">
+    <eo>
+      <xsl:apply-templates/>
+    </eo>
+  </xsl:template>
+  <!-- PROGRAM -->
+  <xsl:template match="program">
+    <xsl:apply-templates select="license"/>
+    <xsl:apply-templates select="metas[meta]"/>
+    <xsl:apply-templates select="objects"/>
+  </xsl:template>
+  <!-- LICENCE -->
+  <xsl:template match="license">
+    <xsl:for-each select="tokenize(., $eol)">
+      <xsl:text># </xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:value-of select="$eol"/>
+    </xsl:for-each>
+    <xsl:if test="text()">
+      <xsl:value-of select="$eol"/>
+    </xsl:if>
+  </xsl:template>
+  <!-- METAS -->
+  <xsl:template match="metas">
+    <xsl:apply-templates select="meta"/>
+    <xsl:value-of select="$eol"/>
+  </xsl:template>
+  <!-- META -->
+  <xsl:template match="meta">
+    <xsl:text>+</xsl:text>
+    <xsl:value-of select="head"/>
+    <xsl:if test="not(empty(tail/text()))">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="tail"/>
+    </xsl:if>
+    <xsl:value-of select="$eol"/>
+  </xsl:template>
+  <!-- OBJECTS -->
+  <xsl:template match="objects">
+    <xsl:apply-templates select="o"/>
+  </xsl:template>
+  <!-- OBJECT, NOT FREE ATTRIBUTE -->
+  <xsl:template match="o[not(eo:attr(.))]">
+    <xsl:param name="indent" select="''"/>
+    <xsl:choose>
+      <!-- METHOD -->
+      <xsl:when test="starts-with(@base,'.')">
+        <xsl:apply-templates select="o[position()=1]">
+          <xsl:with-param name="indent" select="$indent"/>
+        </xsl:apply-templates>
+        <xsl:value-of select="$indent"/>
+        <xsl:apply-templates select="." mode="head">
+          <xsl:with-param name="indent" select="$indent"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="." mode="tail"/>
+        <xsl:value-of select="$eol"/>
+        <xsl:apply-templates select="o[position()&gt;1 and not(eo:attr(.))]">
+          <xsl:with-param name="indent" select="concat('  ', $indent)"/>
+        </xsl:apply-templates>
+      </xsl:when>
+      <!-- NOT METHOD -->
+      <xsl:otherwise>
+        <!--IF NOT THE FIRST TOP OBJECT -->
+        <xsl:if test="position()&gt;1 and parent::objects">
+          <xsl:value-of select="$eol"/>
+        </xsl:if>
+        <xsl:value-of select="$indent"/>
+        <xsl:apply-templates select="." mode="head">
+          <xsl:with-param name="indent" select="$indent"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="." mode="tail"/>
+        <xsl:value-of select="$eol"/>
+        <xsl:apply-templates select="o[not(eo:attr(.))]">
+          <xsl:with-param name="indent" select="concat('  ', $indent)"/>
+        </xsl:apply-templates>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!-- BASED -->
+  <xsl:template match="o[not(@data) and @base]" mode="head">
+    <xsl:choose>
+      <!-- NOT OPTIMIZED TUPLE -->
+      <xsl:when test="@star">
+        <xsl:text>*</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="@base"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!-- ABSTRACT OR ATOM -->
+  <xsl:template match="o[not(@data) and not(@base)]" mode="head">
+    <xsl:param name="indent"/>
+    <xsl:if test="@name">
+      <xsl:value-of select="$comment"/>
+      <xsl:value-of select="$indent"/>
+    </xsl:if>
+    <xsl:text>[</xsl:text>
+    <xsl:for-each select="o[eo:attr(.)]">
+      <xsl:if test="position()&gt;1">
+        <xsl:text> </xsl:text>
+      </xsl:if>
+      <xsl:value-of select="@name"/>
+    </xsl:for-each>
+    <xsl:text>]</xsl:text>
+  </xsl:template>
+  <!-- TAIL: SUFFIX, NAME, CONST, ATOM -->
+  <xsl:template match="o" mode="tail">
+    <xsl:if test="@as">
+      <xsl:text>:</xsl:text>
+      <xsl:value-of select="@as"/>
+    </xsl:if>
+    <xsl:if test="@name">
+      <xsl:text> &gt; </xsl:text>
+      <xsl:value-of select="@name"/>
+      <xsl:if test="@const">
+        <xsl:text>!</xsl:text>
+      </xsl:if>
+      <xsl:if test="@atom">
+        <xsl:text> /</xsl:text>
+        <xsl:value-of select="@atom"/>
+      </xsl:if>
+    </xsl:if>
+  </xsl:template>
+  <!-- DATA -->
+  <xsl:template match="o[@data]" mode="head">
+    <xsl:choose>
+      <xsl:when test="@data='string'">
+        <xsl:text>"</xsl:text>
+        <xsl:value-of select="text()"/>
+        <xsl:text>"</xsl:text>
+      </xsl:when>
+      <xsl:when test="@data='number'">
+        <xsl:value-of select="text()"/>
+      </xsl:when>
+      <xsl:when test="@data='bytes'">
+        <xsl:choose>
+          <xsl:when test="empty(text())">
+            <xsl:text>--</xsl:text>
+          </xsl:when>
+          <xsl:when test="string-length(text())=2">
+            <xsl:value-of select="text()"/>
+            <xsl:text>-</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="replace(text(), ' ', '-')"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message terminate="yes">
+          <xsl:text>Invalid data attribute: </xsl:text>
+          <xsl:value-of select="@data"/>
+        </xsl:message>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
@@ -26,6 +26,7 @@ package org.eolang.parser.xmir;
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Function;
@@ -34,6 +35,8 @@ import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.yaml.snakeyaml.Yaml;
 
@@ -83,6 +86,51 @@ final class XmirTest {
             ),
             map.get(key),
             Matchers.equalTo(eolang)
+        );
+    }
+
+    @Test
+    void failsToPrintPartialXmirWithDefault() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Xmir.Default(
+                new XMLDocument(
+                    String.join(
+                        "\n",
+                        " <o base='.minus'>",
+                        "    <o base='int' data='bytes' >00 00 00 00 00 00 00 03</o>",
+                        "    <o base='int' data='bytes' >00 00 00 00 00 00 00 04</o>",
+                        " </o>"
+                    )
+                )
+            ).toEO()
+        );
+    }
+
+    @Test
+    void printsPartialXmirWithSimplified() {
+        MatcherAssert.assertThat(
+            new Xmir.Simplified(
+                new XMLDocument(
+                    String.join(
+                        "\n",
+                        " <o base='.plus'>",
+                        "    <o base='int' data='bytes'>00 00 00 00 00 00 00 01</o>",
+                        "    <o base='int' data='bytes'>00 00 00 00 00 00 00 02</o>",
+                        " </o>"
+                    )
+                )
+            ).toEO(),
+            Matchers.equalTo(
+                String.join(
+                    "\n",
+                    "int",
+                    "  00-00-00-00-00-00-00-01",
+                    ".plus",
+                    "  int",
+                    "    00-00-00-00-00-00-00-02\n"
+                )
+            )
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/xmir/XmirTest.java
@@ -103,13 +103,17 @@ final class XmirTest {
                         " </o>"
                     )
                 )
-            ).toEO()
+            ).toEO(),
+            String.format("Should fail to print partial XMIR with %s", Xmir.Default.class)
         );
     }
 
     @Test
     void printsPartialXmirWithSimplified() {
         MatcherAssert.assertThat(
+            String.format(
+                "We expect that %s will print the partial XMIR correctly", Xmir.Simplified.class
+            ),
             new Xmir.Simplified(
                 new XMLDocument(
                     String.join(


### PR DESCRIPTION
In this PR I added `Xmir.Simplified` that can print partial XMIR documents to EO.

Closes: #3343.
History:
- **feat(#3343): add Simplified printer to XMIR**
- **feat(#3343): fix all qulice suggestions**

<!-- start pr-codex -->

---

## PR-Codex overview
The PR introduces a new `Simplified` class in `Xmir` for partial XMIR printing. It includes tests and XSLT transformations for simplified EO printing.

### Detailed summary
- Added `Simplified` class for partial XMIR printing in `Xmir`
- Implemented tests for `Simplified` and `Default` classes
- Added XSLT transformation for simplified EO printing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->