### PR TITLE
Fix link to index in 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
   <body>
     <p>
       Oops, the page you are looking for is not here.
-      Start with the <a href="index.html">/index.html</a>.
+      Start with the <a href="/index.html">/index.html</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes a broken link in the `404.html` page by adding a missing slash to the href attribute. 

### Detailed summary
- Fixed broken link in `404.html` page by adding a missing slash before `index.html` in the href attribute.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->