### PR TITLE
feat(#3251): introduced `random` object via syscalls from `eo-math`

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -25,9 +25,5 @@
 #  package name contains capital letter and such names are conventional.
 ---
 exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOi64$EOas_number.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOi64$EOdiv.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOi64$EOgt.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOi64$EOplus.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOi64$EOtimes.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOas_i64.java"
+  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java"
+  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java"

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java
@@ -68,7 +68,6 @@ public final class ParsingTrain extends TrEnvelope {
     private static final String[] SHEETS = {
         "/org/eolang/parser/errors/not-empty-atoms.xsl",
         "/org/eolang/parser/critical-errors/duplicate-names.xsl",
-        "/org/eolang/parser/errors/many-free-attributes.xsl",
         "/org/eolang/parser/errors/broken-aliases.xsl",
         "/org/eolang/parser/errors/duplicate-aliases.xsl",
         "/org/eolang/parser/errors/global-nonames.xsl",

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -30,14 +30,14 @@
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
 
-# Random number.
+# Pseudo random number.
 [seed] > random
+  $ > fixed
   # Get float value for current `seed`.
   # Divide `seed` to maximum possible value of the `seed` which is 1 << 53
   div. > @
     seed.as-number
     00-20-00-00-00-00-00-00.as-i64.as-number
-
   # Next random.
   # Formula is based on linear congruential pseudorandom number generator, as defined by
   # D. H. Lehmer and described by Donald E. Knuth in The Art of Computer Programming, Volume 2,
@@ -45,17 +45,16 @@
   # Magic numbers are taken from Java implementation. 48 lower bits are considered.
   # `next` = (`seed` * 25214903917 + 11) & ((1 << 48) - 1).
   # Here `00-0F-FF-FF-FF-FF-FF-FF` is pre calculated `(1 << 48) - 1`.
-  [] > next
-    as-number. > @
-      random >
-        as-number.
-          as-i64.
-            and.
-              as-i64.
-                plus.
-                  ^.seed.times 25214903917
-                  11
-              00-0F-FF-FF-FF-FF-FF-FF
+  fixed. > next
+    random
+      as-number.
+        as-i64.
+          and.
+            as-i64.
+              plus.
+                seed.times 25214903917
+                11
+            00-0F-FF-FF-FF-FF-FF-FF
 
   # New random with pseudo-random seed.
   [] > pseudo
@@ -83,9 +82,9 @@
       as-i64.
         if.
           os.is-windows
-          (win32 "GetSystemTime").milliseconds
+          (win32 "GetSystemTime" *).milliseconds
           []
-            (posix "gettimeofday").output > timeval
+            (posix "gettimeofday" *).output > timeval
             plus. > @
               timeval.tv-sec.times 1000
               as-number.

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -1,0 +1,92 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.sys.os
++alias org.eolang.sys.posix
++alias org.eolang.sys.win32
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Random number.
+[seed] > random
+  # Get float value for current `seed`.
+  # Divide `seed` to maximum possible value of the `seed` which is 1 << 53
+  div. > @
+    seed.as-number
+    00-20-00-00-00-00-00-00.as-i64.as-number
+
+  # Next random.
+  # Formula is based on linear congruential pseudorandom number generator, as defined by
+  # D. H. Lehmer and described by Donald E. Knuth in The Art of Computer Programming, Volume 2,
+  # Third edition: Seminumerical Algorithms, section 3.2.1.
+  # Magic numbers are taken from Java implementation. 48 lower bits are considered.
+  # `next` = (`seed` * 25214903917 + 11) & ((1 << 48) - 1).
+  # Here `00-0F-FF-FF-FF-FF-FF-FF` is pre calculated `(1 << 48) - 1`.
+  [] > next
+    as-number. > @
+      random >
+        as-number.
+          as-i64.
+            and.
+              as-i64.
+                plus.
+                  ^.seed.times 25214903917
+                  11
+              00-0F-FF-FF-FF-FF-FF-FF
+
+  # New random with pseudo-random seed.
+  [] > pseudo
+    35 > const-1
+    53 > const-2
+    17 > const-3
+    00-00-00-00-00-00-00-01 > one
+    random time-seed > @
+    as-number. > time-seed
+      plus.
+        as-i64.
+          and.
+            time-bytes.left const-1
+            ((one.left const-2).as-i64.minus one).as-bytes
+        plus.
+          as-i64.
+            and.
+              time-bytes.left const-3
+              ((one.left const-1).as-i64.minus one).as-bytes
+          as-i64.
+            and.
+              time-bytes
+              ((one.left const-3).as-i64.minus one).as-bytes
+    as-bytes. > time-bytes
+      as-i64.
+        if.
+          os.is-windows
+          (win32 "GetSystemTime").milliseconds
+          []
+            (posix "gettimeofday").output > timeval
+            plus. > @
+              timeval.tv-sec.times 1000
+              as-number.
+                timeval.tv-usec.as-i64.div 1000.as-i64

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -82,9 +82,15 @@
       as-i64.
         if.
           os.is-windows
-          (win32 "GetSystemTime" *).milliseconds
+          milliseconds.
+            win32
+              "GetSystemTime"
+              * win32.system-time
           []
-            (posix "gettimeofday" *).output > timeval
+            output. > timeval
+              posix
+                "gettimeofday"
+                * posix.timeval
             plus. > @
               timeval.tv-sec.times 1000
               as-number.

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -42,3 +42,4 @@
   # Timeval structure for "gettimeofday" syscall.
   # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.
   [tv-sec tv-usec] > timeval
+    $ > self

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -28,29 +28,7 @@
 +version 0.0.0
 
 # Makes a Unix syscall by name with POSIX interface.
-# See https://filippo.io/linux-syscall-table/
-#
-# Supported syscalls:
-# 1. getpid - get process identification
-#    - Arguments:
-#    - Returns:
-#      * code - process identification number (number)
-#      * output - []
-# 2. write - write bytes to file descriptor
-#    - Arguments:
-#      * descriptor (number)
-#      * buffer to write (bytes)
-#      * buffer size to write (number)
-#    - Returns:
-#      * code - written bytes count (number)
-#      * output - []
-# 3. read - read bytes from file descriptor
-#    - Arguments:
-#      * descriptor (number)
-#      * buffer size to read (number)
-#    - Returns:
-#      * code - read bytes count (number)
-#      * output - read bytes (bytes)
+# See https://filippo.io/linux-syscall-table/.
 [name args] > posix
   0 > stdin-fileno
   1 > stdout-fileno
@@ -60,3 +38,7 @@
   [code output] > return
     $ > called
     output > @
+
+  # Timeval structure for "gettimeofday" syscall.
+  # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.
+  [tv-sec tv-usec] > timeval

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -45,3 +45,4 @@
 
   # Structure for "GetSystemTime" function call.
   [year month day day-of-week hour minute second milliseconds] > system-time
+    $ > self

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -33,25 +33,6 @@
 # Windows API Index (https://learn.microsoft.com/en-us/windows/win32/api/index).
 # Use the search functionality to look up specific functions, such as CreateFile, ReadFile,
 # WriteFile, etc.
-#
-# Supported functions:
-# 1. WriteFile
-#    - Documentation: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile
-#    - Arguments:
-#      * descriptor (number)
-#      * buffer to write (bytes)
-#      * buffer size to write (number)
-#    - Returns:
-#      * code - written bytes count (number)
-#      * output - []
-# 2. ReadFile
-#    - Documentation: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
-#    - Arguments:
-#      * descriptor (number)
-#      * buffer size to read (number)
-#    - Returns:
-#      * code - read bytes count (number)
-#      * output - read bytes (bytes)
 [name args] > win32
   -10 > std-input-handle
   -11 > std-output-handle
@@ -61,3 +42,6 @@
   [code output] > return
     $ > called
     output > @
+
+  # Structure for "GetSystemTime" function call.
+  [year month day day-of-week hour minute second milliseconds] > system-time

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOposix$EOφ.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang.EOsys; // NOPMD
 
 import EOorg.EOeolang.EOsys.Posix.GetenvSyscall;
 import EOorg.EOeolang.EOsys.Posix.GetpidSyscall;
+import EOorg.EOeolang.EOsys.Posix.GettimeofdaySyscall;
 import EOorg.EOeolang.EOsys.Posix.ReadSyscall;
 import EOorg.EOeolang.EOsys.Posix.WriteSyscall;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ public final class EOposix$EOφ extends PhDefault implements Atom {
         EOposix$EOφ.SYS_CALLS.put("read", ReadSyscall::new);
         EOposix$EOφ.SYS_CALLS.put("write", WriteSyscall::new);
         EOposix$EOφ.SYS_CALLS.put("getenv", GetenvSyscall::new);
+        EOposix$EOφ.SYS_CALLS.put("gettimeofday", GettimeofdaySyscall::new);
     }
 
     @Override

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOwin32$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/EOwin32$EOφ.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang.EOsys; // NOPMD
 
 import EOorg.EOeolang.EOsys.Win32.GetCurrentProcessIdFuncCall;
 import EOorg.EOeolang.EOsys.Win32.GetEnvironmentVariableFuncCall;
+import EOorg.EOeolang.EOsys.Win32.GetSystemTimeFuncCall;
 import EOorg.EOeolang.EOsys.Win32.ReadFileFuncCall;
 import EOorg.EOeolang.EOsys.Win32.WriteFileFuncCall;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ public final class EOwin32$EOφ extends PhDefault implements Atom {
         EOwin32$EOφ.FUNCTIONS.put("ReadFile", ReadFileFuncCall::new);
         EOwin32$EOφ.FUNCTIONS.put("WriteFile", WriteFileFuncCall::new);
         EOwin32$EOφ.FUNCTIONS.put("GetEnvironmentVariable", GetEnvironmentVariableFuncCall::new);
+        EOwin32$EOφ.FUNCTIONS.put("GetSystemTime", GetSystemTimeFuncCall::new);
     }
 
     @Override

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/CStdLib.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/CStdLib.java
@@ -29,6 +29,7 @@ package EOorg.EOeolang.EOsys.Posix; // NOPMD
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 
 /**
  * C standard library with unix syscalls.
@@ -122,4 +123,12 @@ public interface CStdLib extends Library {
      * @return Name of the environment variable
      */
     String getenv(String name);
+
+    /**
+     * Get current time.
+     * @param timeval Timevalue
+     * @param timezone Timezone
+     * @return Zero on success, -1 on error
+     */
+    int gettimeofday(GettimeofdaySyscall.Timeval timeval, Pointer timezone);
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -28,8 +28,8 @@
  */
 package EOorg.EOeolang.EOsys.Posix; // NOPMD
 
-import com.sun.jna.Structure;
 import EOorg.EOeolang.EOsys.Syscall;
+import com.sun.jna.Structure;
 import java.util.Arrays;
 import java.util.List;
 import org.eolang.Data;
@@ -68,8 +68,9 @@ public final class GettimeofdaySyscall implements Syscall {
     /**
      * Timeval structure.
      * @since 0.40.0
+     * @checkstyle VisibilityModifierCheck (30 lines)
      */
-    public static class Timeval extends Structure {
+    public static final class Timeval extends Structure {
         /**
          * Seconds since Jan. 1, 1970
          */
@@ -81,7 +82,7 @@ public final class GettimeofdaySyscall implements Syscall {
         public long usec;
 
         @Override
-        protected List<String> getFieldOrder() {
+        public List<String> getFieldOrder() {
             return Arrays.asList("sec", "usec");
         }
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -58,10 +58,9 @@ public final class GettimeofdaySyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final GettimeofdaySyscall.Timeval timeval = new GettimeofdaySyscall.Timeval();
         result.put(0, new Data.ToPhi(CStdLib.INSTANCE.gettimeofday(timeval, null)));
-        final Phi struct = this.posix.take("timeval").copy();
-        struct.put("tv-sec", new Data.ToPhi(timeval.sec));
-        struct.put("tv-usec", new Data.ToPhi(timeval.usec));
-        result.put(1, struct);
+        params[0].put(0, new Data.ToPhi(timeval.sec));
+        params[0].put(1, new Data.ToPhi(timeval.usec));
+        result.put(1, params[0]);
         return result;
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOsys.Posix; // NOPMD
+
+import com.sun.jna.Structure;
+import EOorg.EOeolang.EOsys.Syscall;
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.Data;
+import org.eolang.Phi;
+
+/**
+ * Gettimeofday syscall.
+ * @since 0.40
+ */
+public final class GettimeofdaySyscall implements Syscall {
+    /**
+     * Posix object.
+     */
+    private final Phi posix;
+
+    /**
+     * Ctor.
+     * @param posix Posix object
+     */
+    public GettimeofdaySyscall(final Phi posix) {
+        this.posix = posix;
+    }
+
+    @Override
+    public Phi make(final Phi... params) {
+        final Phi result = this.posix.take("return").copy();
+        final GettimeofdaySyscall.Timeval timeval = new GettimeofdaySyscall.Timeval();
+        result.put(0, new Data.ToPhi(CStdLib.INSTANCE.gettimeofday(timeval, null)));
+        final Phi struct = this.posix.take("timeval").copy();
+        struct.put("tv-sec", new Data.ToPhi(timeval.sec));
+        struct.put("tv-usec", new Data.ToPhi(timeval.usec));
+        result.put(1, struct);
+        return result;
+    }
+
+    /**
+     * Timeval structure.
+     * @since 0.40.0
+     */
+    static class Timeval extends Structure {
+        /**
+         * Seconds since Jan. 1, 1970
+         */
+        public long sec;
+
+        /**
+         * Microseconds since Jan. 1, 1970
+         */
+        public long usec;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("sec", "usec");
+        }
+    }
+}

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -58,9 +58,10 @@ public final class GettimeofdaySyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final GettimeofdaySyscall.Timeval timeval = new GettimeofdaySyscall.Timeval();
         result.put(0, new Data.ToPhi(CStdLib.INSTANCE.gettimeofday(timeval, null)));
-        params[0].put(0, new Data.ToPhi(timeval.sec));
-        params[0].put(1, new Data.ToPhi(timeval.usec));
-        result.put(1, params[0]);
+        final Phi struct = params[0].take("self");
+        struct.put(0, new Data.ToPhi(timeval.sec));
+        struct.put(1, new Data.ToPhi(timeval.usec));
+        result.put(1, struct);
         return result;
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -69,7 +69,7 @@ public final class GettimeofdaySyscall implements Syscall {
      * Timeval structure.
      * @since 0.40.0
      */
-    static class Timeval extends Structure {
+    public static class Timeval extends Structure {
         /**
          * Seconds since Jan. 1, 1970
          */

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -28,8 +28,8 @@
  */
 package EOorg.EOeolang.EOsys.Win32; // NOPMD
 
-import com.sun.jna.Structure;
 import EOorg.EOeolang.EOsys.Syscall;
+import com.sun.jna.Structure;
 import java.util.Arrays;
 import java.util.List;
 import org.eolang.Data;
@@ -76,8 +76,9 @@ public final class GetSystemTimeFuncCall implements Syscall {
     /**
      * System time structure.
      * @since 0.40.0
+     * @checkstyle VisibilityModifierCheck (100 lines)
      */
-    public static class SystemTime extends Structure {
+    public static final class SystemTime extends Structure {
         /**
          * Year.
          */
@@ -90,6 +91,7 @@ public final class GetSystemTimeFuncCall implements Syscall {
 
         /**
          * Day of week.
+         * @checkstyle MemberNameCheck (5 lines)
          */
         public short dayOfWeek;
 
@@ -119,7 +121,7 @@ public final class GetSystemTimeFuncCall implements Syscall {
         public short milliseconds;
 
         @Override
-        protected List<String> getFieldOrder() {
+        public List<String> getFieldOrder() {
             return Arrays.asList(
                 "year",
                 "month",

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -60,15 +60,16 @@ public final class GetSystemTimeFuncCall implements Syscall {
         final GetSystemTimeFuncCall.SystemTime time = new GetSystemTimeFuncCall.SystemTime();
         Kernel32.INSTANCE.GetSystemTime(time);
         result.put(0, new Data.ToPhi(true));
-        params[0].put(0, new Data.ToPhi(time.year));
-        params[0].put(1, new Data.ToPhi(time.month));
-        params[0].put(2, new Data.ToPhi(time.day));
-        params[0].put(3, new Data.ToPhi(time.dayOfWeek));
-        params[0].put(4, new Data.ToPhi(time.hour));
-        params[0].put(5, new Data.ToPhi(time.minute));
-        params[0].put(6, new Data.ToPhi(time.second));
-        params[0].put(7, new Data.ToPhi(time.milliseconds));
-        result.put(1, params[0]);
+        final Phi struct = params[0].take("self");
+        struct.put(0, new Data.ToPhi(time.year));
+        struct.put(1, new Data.ToPhi(time.month));
+        struct.put(2, new Data.ToPhi(time.day));
+        struct.put(3, new Data.ToPhi(time.dayOfWeek));
+        struct.put(4, new Data.ToPhi(time.hour));
+        struct.put(5, new Data.ToPhi(time.minute));
+        struct.put(6, new Data.ToPhi(time.second));
+        struct.put(7, new Data.ToPhi(time.milliseconds));
+        result.put(1, struct);
         return result;
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -1,0 +1,135 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOsys.Win32; // NOPMD
+
+import com.sun.jna.Structure;
+import EOorg.EOeolang.EOsys.Syscall;
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.Data;
+import org.eolang.Phi;
+
+/**
+ * GetSystemTime kernel32 function call.
+ * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtime">here for details</a>
+ * @since 0.40.0
+ */
+public final class GetSystemTimeFuncCall implements Syscall {
+    /**
+     * Win32 object.
+     */
+    private final Phi win;
+
+    /**
+     * Ctor.
+     * @param win Win32 object
+     */
+    public GetSystemTimeFuncCall(final Phi win) {
+        this.win = win;
+    }
+
+    @Override
+    public Phi make(final Phi... params) {
+        final Phi result = this.win.take("return").copy();
+        final GetSystemTimeFuncCall.SystemTime time = new GetSystemTimeFuncCall.SystemTime();
+        Kernel32.INSTANCE.GetSystemTime(time);
+        result.put(0, new Data.ToPhi(true));
+        final Phi struct = this.win.take("system-time").copy();
+        struct.put("year", new Data.ToPhi(time.year));
+        struct.put("month", new Data.ToPhi(time.month));
+        struct.put("day", new Data.ToPhi(time.day));
+        struct.put("day-of-week", new Data.ToPhi(time.dayOfWeek));
+        struct.put("hour", new Data.ToPhi(time.hour));
+        struct.put("minute", new Data.ToPhi(time.minute));
+        struct.put("second", new Data.ToPhi(time.second));
+        struct.put("milliseconds", new Data.ToPhi(time.milliseconds));
+        result.put(1, struct);
+        return result;
+    }
+
+    /**
+     * System time structure.
+     * @since 0.40.0
+     */
+    static class SystemTime extends Structure {
+        /**
+         * Year.
+         */
+        public short year;
+
+        /**
+         * Month.
+         */
+        public short month;
+
+        /**
+         * Day of week.
+         */
+        public short dayOfWeek;
+
+        /**
+         * Day.
+         */
+        public short day;
+
+        /**
+         * Hour.
+         */
+        public short hour;
+
+        /**
+         * Minute.
+         */
+        public short minute;
+
+        /**
+         * Second.
+         */
+        public short second;
+
+        /**
+         * Milliseconds.
+         */
+        public short milliseconds;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList(
+                "year",
+                "month",
+                "day",
+                "dayOfWeek",
+                "hour",
+                "minute",
+                "second",
+                "milliseconds"
+            );
+        }
+    }
+}

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -77,7 +77,7 @@ public final class GetSystemTimeFuncCall implements Syscall {
      * System time structure.
      * @since 0.40.0
      */
-    static class SystemTime extends Structure {
+    public static class SystemTime extends Structure {
         /**
          * Year.
          */

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -60,16 +60,15 @@ public final class GetSystemTimeFuncCall implements Syscall {
         final GetSystemTimeFuncCall.SystemTime time = new GetSystemTimeFuncCall.SystemTime();
         Kernel32.INSTANCE.GetSystemTime(time);
         result.put(0, new Data.ToPhi(true));
-        final Phi struct = this.win.take("system-time").copy();
-        struct.put("year", new Data.ToPhi(time.year));
-        struct.put("month", new Data.ToPhi(time.month));
-        struct.put("day", new Data.ToPhi(time.day));
-        struct.put("day-of-week", new Data.ToPhi(time.dayOfWeek));
-        struct.put("hour", new Data.ToPhi(time.hour));
-        struct.put("minute", new Data.ToPhi(time.minute));
-        struct.put("second", new Data.ToPhi(time.second));
-        struct.put("milliseconds", new Data.ToPhi(time.milliseconds));
-        result.put(1, struct);
+        params[0].put(0, new Data.ToPhi(time.year));
+        params[0].put(1, new Data.ToPhi(time.month));
+        params[0].put(2, new Data.ToPhi(time.day));
+        params[0].put(3, new Data.ToPhi(time.dayOfWeek));
+        params[0].put(4, new Data.ToPhi(time.hour));
+        params[0].put(5, new Data.ToPhi(time.minute));
+        params[0].put(6, new Data.ToPhi(time.second));
+        params[0].put(7, new Data.ToPhi(time.milliseconds));
+        result.put(1, params[0]);
         return result;
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/Kernel32.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/Kernel32.java
@@ -192,4 +192,10 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * @checkstyle MethodNameCheck (5 lines)
      */
     int GetCurrentProcessId();
+
+    /**
+     * Retrieves the current system date and time in Coordinated Universal Time (UTC) format.
+     * @param time System time structure
+     */
+    void GetSystemTime(GetSystemTimeFuncCall.SystemTime time);
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/Kernel32.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/Kernel32.java
@@ -36,6 +36,8 @@ import com.sun.jna.win32.W32APIOptions;
 /**
  * Interface definitions for <code>kernel32.dll</code>.
  * @since 0.40
+ * @checkstyle MethodNameCheck (1000 lines)
+ * @checkstyle ParameterNumberCheck (1000 lines)
  */
 @SuppressWarnings("PMD.MethodNamingConventions")
 public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
@@ -48,7 +50,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * Get a handle to specified standard device.
      * @param handle The standard device identifier
      * @return A handle to the specified standard device (standard input, output, or error)
-     * @checkstyle MethodNameCheck (5 lines)
      */
     HANDLE GetStdHandle(int handle);
 
@@ -60,7 +61,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      *  information
      * @see <a href="https://msdn.microsoft.com/en-us/library/ms686244(v=vs.85).aspx">SetStdHandle
      *  documentation</a>
-     * @checkstyle MethodNameCheck (5 lines)
      */
     boolean SetStdHandle(int std, HANDLE handle);
 
@@ -71,7 +71,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * @return If the function succeeds, the return value is nonzero. If the function fails, the
      *  return value is zero. To get extended error information, call {@code GetLastError}.
      * @see <A HREF="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx">CloseHandle</A>
-     * @checkstyle MethodNameCheck (5 lines)
      */
     boolean CloseHandle(HANDLE handle);
 
@@ -90,8 +89,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * @return If the function succeeds, the return value is nonzero (TRUE). If the function fails,
      *  or is completing asynchronously, the return value is zero (FALSE). To get extended error
      *  information, call the GetLastError function.
-     * @checkstyle MethodNameCheck (5 lines)
-     * @checkstyle ParameterNumberCheck (20 lines)
      */
     boolean WriteFile(
         HANDLE handle,
@@ -118,8 +115,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * @return If the function succeeds, the return value is nonzero (TRUE). If
      *  the function fails, or is completing asynchronously, the return
      *  value is zero (FALSE).
-     * @checkstyle MethodNameCheck (5 lines)
-     * @checkstyle ParameterNumberCheck (20 lines)
      */
     boolean ReadFile(
         HANDLE handle,
@@ -151,8 +146,6 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      *  succeeds. If a file does not exist before the call, GetLastError returns 0 (zero). If the
      *  function fails, the return value is INVALID_HANDLE_VALUE. To get extended error information,
      *  call GetLastError.
-     * @checkstyle MethodNameCheck (5 lines)
-     * @checkstyle ParameterNumberCheck (20 lines)
      */
     HANDLE CreateFile(
         String name,
@@ -182,14 +175,12 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      *  terminating null character and the contents of buffer are
      *  undefined. If the function fails, the return value is zero. To
      *  get extended error information, call GetLastError.
-     *  @checkstyle MethodNameCheck (5 lines)
      */
     int GetEnvironmentVariable(String name, char[] buffer, int size);
 
     /**
      * This function returns the process identifier of the calling process.
      * @return The return value is the process identifier of the calling process.
-     * @checkstyle MethodNameCheck (5 lines)
      */
     int GetCurrentProcessId();
 

--- a/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.math.random
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.math
++version 0.0.0
+
+# Test.
+[] > random-with-seed
+  random 51 > r
+  not. > @
+    eq.
+      r.next
+      r.next.next
+
+# Test.
+[] > seeded-randoms-are-equal
+  eq. > @
+    (random 1654).next.next.next
+    (random 1654).next.next.next
+
+# Test.
+[] > random-is-in-range
+  (random 123).fixed > r
+  and. > @
+    and.
+      and.
+        r.lt 1
+        (r.lt 0).not
+      and.
+        r.next.lt 1
+        (r.next.lt 0).not
+    and.
+      r.next.next.lt 1
+      (r.next.next.lt 0).not
+
+# Test.
+[] > two-random-numbers-not-equal
+  not. > @
+    random.pseudo.eq random.pseudo


### PR DESCRIPTION
Ref: #3251

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `gettimeofday` syscall functionality to the EOsys.Posix module. 

### Detailed summary
- Added `gettimeofday` syscall to `CStdLib` interface.
- Implemented `GettimeofdaySyscall` in `EOsys.Posix`.
- Updated documentation in `random.eo` and `GettimeofdaySyscall.java`.

> The following files were skipped due to too many changes: `eo-runtime/src/main/eo/org/eolang/math/random.eo`, `eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/Kernel32.java`, `eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->