### PR TITLE
feat(#3251): introduced `e`, `pi`, `numbers` and `integral` objects from `eo-math`

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -27,3 +27,4 @@
 exclude_paths:
   - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
   - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
+  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/package-info.java"

--- a/eo-runtime/src/main/eo/org/eolang/math/angle.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/angle.eo
@@ -20,10 +20,51 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++alias org.eolang.math.pi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# The angle.
+[value] > angle
+  value > @
+  # Converts this from radians to degrees
+  angle > in-degrees
+    div.
+      ^.times 180.0
+      pi
+  # Converts this from degrees to radians
+  angle > in-radians
+    div.
+      $.times pi
+      180.0
+
+  # Sine of current angle.
+  # Please note, that `sin` is calculated from the angle in radians.
+  [] > sin /number
+
+  # Cosine of current angle.
+  # Please note, that `cos` is calculated from the angle in radians.
+  [] > cos /number
+
+  # Tangent of current angle.
+  # Please note, that `tan` is calculated from the angle in radians.
+  [] > tan
+    ^.cos > cosine!
+    if. > @
+      cosine.eq 0
+      nan
+      ^.sin.div cosine
+
+  # Cotangent of current angle.
+  # Please note, that `ctan` is calculated from the angle in radians.
+  [] > ctan
+    ^.sin > sine!
+    if. > @
+      sine.eq 0
+      nan
+      ^.cos.div sine
+

--- a/eo-runtime/src/main/eo/org/eolang/math/e.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/e.eo
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# The Euler's number
+2.7182818284590452354 > e

--- a/eo-runtime/src/main/eo/org/eolang/math/integral.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/integral.eo
@@ -1,0 +1,73 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Counts integral from `a` to `b`.
+# Here `func` is integration function, `a` is an upper limit,
+# `b` is bottom limit, `n` is the number of partitions of the integration interval.
+[fun a b n] > integral
+  [a b] > subsection
+    times. > @
+      div.
+        b.minus a
+        6.0
+      plus.
+        ^.fun a
+        plus.
+          times.
+            4.0
+            ^.fun
+              times.
+                0.5
+                a.plus b
+          ^.fun b
+  as-number. > @
+    malloc.of
+      8
+      [sum] >>
+        malloc.for > @
+          ^.a
+          [left] >>
+            ^.^.b > right
+            ((right.minus left).div ^.^.n).as-number > step
+            while > @
+              [i] >>
+                if. > @
+                  (^.left.as-number.plus ^.step).lt ^.right
+                  seq
+                    *
+                      ^.^.sum.put
+                        ^.^.sum.as-number.plus
+                          ^.^.^.subsection
+                            ^.left.as-number
+                            ^.left.as-number.plus ^.step
+                      ^.left.put
+                        ^.left.as-number.plus ^.step
+                      true
+                  false
+              true > [i]

--- a/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
@@ -20,10 +20,45 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++alias org.eolang.structs.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# Sequence of numbers.
+# Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.
+[sequence] > numbers
+  sequence > @
+
+  # Find max element in the numbers sequence.
+  [] > max
+    list ^.sequence > lst
+    if. > @
+      lst.is-empty
+      error "Can't get max number from empty sequence"
+      reduced.
+        lst
+        negative-infinity
+        [max item]
+          if. > @
+            item.as-number.gt max
+            item
+            max
+
+  # Find min element in the numbers sequence.
+  [] > min
+    list ^.sequence > lst
+    if. > @
+      lst.is-empty
+      error "Can't get min number from empty sequence"
+      reduced.
+        lst
+        positive-infinity
+        [min item]
+          if. > @
+            min.gt item.as-number
+            item
+            min

--- a/eo-runtime/src/main/eo/org/eolang/math/pi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/pi.eo
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.math
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
+
+# The PI number
+3.14159265358979323846 > pi

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOmath; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Angle.cos.
+ *
+ * @since 0.40
+ * @checkstyle TypeNameCheck (100 lines)
+ */
+@XmirObject(oname = "angle.cos")
+public final class EOangle$EOcos extends PhDefault implements Atom {
+    @Override
+    public Phi lambda() throws Exception {
+        return new Data.ToPhi(
+            Math.cos(new Dataized(this.take(Attr.RHO)).asNumber())
+        );
+    }
+}

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java
@@ -43,6 +43,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "angle.sin")
+@SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOangle$EOsin extends PhDefault implements Atom {
     @Override
     public Phi lambda() throws Exception {

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package EOorg.EOeolang.EOmath; // NOPMD
+
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Angle.sin.
+ *
+ * @since 0.40
+ * @checkstyle TypeNameCheck (100 lines)
+ */
+@XmirObject(oname = "angle.sin")
+public final class EOangle$EOsin extends PhDefault implements Atom {
+    @Override
+    public Phi lambda() throws Exception {
+        return new Data.ToPhi(
+            Math.sin(new Dataized(this.take(Attr.RHO)).asNumber())
+        );
+    }
+}

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/package-info.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmath/package-info.java
@@ -22,33 +22,11 @@
  * SOFTWARE.
  */
 
-/*
+/**
+ * EO runtime, Math.
+ *
+ * @since 0.40
  * @checkstyle PackageNameCheck (4 lines)
  * @checkstyle TrailingCommentCheck (3 lines)
  */
 package EOorg.EOeolang.EOmath; // NOPMD
-
-import org.eolang.Atom;
-import org.eolang.Attr;
-import org.eolang.Data;
-import org.eolang.Dataized;
-import org.eolang.PhDefault;
-import org.eolang.Phi;
-import org.eolang.XmirObject;
-
-/**
- * Angle.cos.
- *
- * @since 0.40
- * @checkstyle TypeNameCheck (100 lines)
- */
-@XmirObject(oname = "angle.cos")
-@SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOangle$EOcos extends PhDefault implements Atom {
-    @Override
-    public Phi lambda() throws Exception {
-        return new Data.ToPhi(
-            Math.cos(new Dataized(this.take(Attr.RHO)).asNumber())
-        );
-    }
-}

--- a/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
@@ -20,10 +20,46 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++alias org.eolang.math.pi
++alias org.eolang.math.angle
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.math
++version 0.0.0
+
+# Test.
+[] > sin-zero
+  eq. > @
+    (angle 0).sin
+    0
+
+# Test.
+[] > sin-pi-div-2
+  eq. > @
+    (angle (pi.div 2)).sin
+    1
+
+# Test.
+[] > sin-pi-floored
+  eq. > @
+    (angle pi).sin.floor
+    0
+
+# Test.
+[] > cos-zero
+  eq. > @
+    (angle 0).cos
+    1
+
+# Test.
+[] > cos-pi-div-2-floored
+  eq. > @
+    (angle (pi.div 2)).cos.floor
+    0
+
+# Test.
+[] > cos-pi
+  eq. > @
+    (angle pi).cos
+    -1

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -62,10 +62,24 @@
       1
       10
       100
-  calculates-lineal-integral.close-to > @
+  close-to > @
     quadratic
     333
     0.0000001
+
+  # Checks where given `value` is close to `operand` with given precision `err`.
+  [value operand err] > close-to
+    lte. > @
+      minus.
+        abs
+          value.minus operand
+        err
+      0
+    [value] > abs
+      if. > @
+        value.gte 0
+        value
+        value.neg
 
 # Test.
 [] > calculates-cube-integral
@@ -75,7 +89,21 @@
       1
       10
       100
-  calculates-lineal-integral.close-to > @
+  close-to > @
     cube
     2499.75
     0.0000001
+
+  # Checks where given `value` is close to `operand` with given precision `err`.
+  [value operand err] > close-to
+    lte. > @
+      minus.
+        abs
+          value.minus operand
+        err
+      0
+    [value] > abs
+      if. > @
+        value.gte 0
+        value
+        value.neg

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -20,10 +20,62 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++alias org.eolang.math.integral
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.math
++version 0.0.0
+
+# Test.
+[] > calculates-lineal-integral
+  as-number. > lineal
+    integral
+      x > [x]
+      1
+      10
+      15
+  close-to > @
+    lineal
+    49.5
+    0.0000001
+
+  # Checks where given `value` is close to `operand` with given precision `err`.
+  [value operand err] > close-to
+    lte. > @
+      minus.
+        abs
+          value.minus operand
+        err
+      0
+    [value] > abs
+      if. > @
+        value.gte 0
+        value
+        value.neg
+
+# Test.
+[] > calculates-quadratic-integral
+  as-number. > quadratic
+    integral
+      x.times x > [x]
+      1
+      10
+      100
+  calculates-lineal-integral.close-to > @
+    quadratic
+    333
+    0.0000001
+
+# Test.
+[] > calculates-cube-integral
+  as-number. > cube
+    integral
+      (x.times x).times x > [x]
+      1
+      10
+      100
+  calculates-lineal-integral.close-to > @
+    cube
+    2499.75
+    0.0000001

--- a/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
@@ -20,10 +20,63 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #1326:30min Enable only necessary tests. Several checks
-#  are not available for the project. For example a lot of
-#  package name contains capital letter and such names are conventional.
----
-exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOsin.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmath/EOangle$EOcos.java"
++alias org.eolang.math.numbers
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.math
++version 0.0.0
+
+# Test.
+(numbers *).max > [] > throws-on-taking-max-from-empty-sequence-of-numbers
+
+# Test.
+(numbers *).min > [] > throws-on-taking-min-from-empty-sequence-of-numbers
+
+# Test.
+[] > max-of-one-item-array
+  eq. > @
+    (numbers (* 42)).max
+    42
+
+# Test.
+[] > min-of-one-item-array
+  eq. > @
+    (numbers (* 42)).min
+    42
+
+# Test.
+[] > max-of-array-is-first
+  eq. > @
+    (numbers (* 25 12 -2)).max
+    25
+
+# Test.
+[] > max-of-array-is-in-the-center
+  eq. > @
+    (numbers (* 12 25 -2)).max
+    25
+
+# Test.
+[] > max-of-array-is-last
+  eq. > @
+    (numbers (* 12 -2 25)).max
+    25
+
+# Test.
+[] > min-of-array-is-first
+  eq. > @
+    (numbers (* -2 25 12)).min
+    -2
+
+# Test.
+[] > min-of-array-is-in-the-center
+  eq. > @
+    (numbers (* 12 -2 25)).min
+    -2
+
+# Test.
+[] > min-of-array-is-last
+  eq. > @
+    (numbers (* 12 25 -2)).min
+    -2


### PR DESCRIPTION
Ref: #3251

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the EOmath package in the EO runtime, adding trigonometric functions and constants.

### Detailed summary
- Added `EOangle$EOsin` and `EOangle$EOcos` classes for sine and cosine functions
- Added `pi.eo` file with the PI constant
- Added `e.eo` file with the Euler's number constant

> The following files were skipped due to too many changes: `eo-runtime/src/main/eo/org/eolang/math/numbers.eo`, `eo-runtime/src/main/eo/org/eolang/math/integral.eo`, `eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo`, `eo-runtime/src/main/eo/org/eolang/math/angle.eo`, `eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->