### PR TITLE
feat(#3415): `malloc.resize` introduced

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -25,8 +25,5 @@
 #  package name contains capital letter and such names are conventional.
 ---
 exclude_paths:
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/BindFuncCall.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/ListenFuncCall.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/AcceptFuncCall.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/SendFuncCall.java"
-  - "eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/RecvFuncCall.java"
+  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOresize.java"
+  - "eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOsize.java"

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -100,17 +100,23 @@
 
     # Allocated block in memory that provides an API for writing and reading.
     [id] > allocated
-      ^.size > size
       get > @
+      # Just get all the data from the allocated block in memory.
+      read 0 size > get
+
+      # Returns size of allocated block in memory.
+      [] > size /number
+
+      # Resizes allocated block in memory and returns `true`.
+      # Here `size` must be positive `number`.
+      # The `error` returned if failed to resize block in memory.
+      [size] > resize /true
 
       # Read `length` bytes with `offset` from the allocated block in memory.
       [offset length] > read /bytes
 
       # Write `data` with `offset` to the allocated block in memory.
       [offset data] > write /true
-
-      # Just get all the data from the allocated block in memory.
-      ^.read 0 ^.size > [] > get
 
       # Put `object` into the allocated block in memory. The `object` is supposed to be dataizable.
       [object] > put

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOread.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOread.java
@@ -58,12 +58,11 @@ public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements
 
     @Override
     public Phi lambda() throws Exception {
-        final int length = new Dataized(this.take("length")).asNumber().intValue();
         return new Data.ToPhi(
             Heaps.INSTANCE.read(
                 new Dataized(this.take(Attr.RHO).take("id")).asNumber().intValue(),
                 new Dataized(this.take("offset")).asNumber().intValue(),
-                length
+                new Dataized(this.take("length")).asNumber().intValue()
             )
         );
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOresize.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOresize.java
@@ -28,6 +28,7 @@
  */
 package EOorg.EOeolang; // NOPMD
 
+import org.eolang.AtVoid;
 import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Data;
@@ -38,33 +39,28 @@ import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
- * Malloc.of.φ object.
- * @since 0.36.0
+ * Malloc.of.allocated.resize object.
+ * @since 0.41.0
  * @checkstyle TypeNameCheck (5 lines)
  */
 @Versionized
-@XmirObject(oname = "malloc.of.@")
+@XmirObject(oname = "malloc.of.allocated.resize")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOφ extends PhDefault implements Atom {
+public final class EOmalloc$EOof$EOallocated$EOresize extends PhDefault implements Atom {
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    EOmalloc$EOof$EOallocated$EOresize() {
+        this.add("size", new AtVoid("size"));
+    }
+
     @Override
-    public Phi lambda() {
-        final Phi rho = this.take(Attr.RHO);
-        final int identifier = Heaps.INSTANCE.malloc(
-            this, new Dataized(rho.take("size")).asNumber().intValue()
+    public Phi lambda() throws Exception {
+        Heaps.INSTANCE.resize(
+            new Dataized(this.take(Attr.RHO).take("id")).asNumber().intValue(),
+            new Dataized(this.take("size")).asNumber().intValue()
         );
-        final Phi res;
-        try {
-            final Phi allocated = rho.take("allocated");
-            allocated.put("id", new Data.ToPhi((long) identifier));
-            final Phi scope = rho.take("scope").copy();
-            scope.put(0, allocated);
-            new Dataized(scope).take();
-            res = new Data.ToPhi(
-                Heaps.INSTANCE.read(identifier, 0, Heaps.INSTANCE.size(identifier))
-            );
-        } finally {
-            Heaps.INSTANCE.free(identifier);
-        }
-        return res;
+        return new Data.ToPhi(true);
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOsize.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOsize.java
@@ -38,33 +38,20 @@ import org.eolang.Versionized;
 import org.eolang.XmirObject;
 
 /**
- * Malloc.of.φ object.
- * @since 0.36.0
+ * Malloc.of.allocated.size object.
+ * @since 0.41.0
  * @checkstyle TypeNameCheck (5 lines)
  */
 @Versionized
-@XmirObject(oname = "malloc.of.@")
+@XmirObject(oname = "malloc.of.allocated.size")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOφ extends PhDefault implements Atom {
+public final class EOmalloc$EOof$EOallocated$EOsize extends PhDefault implements Atom {
     @Override
-    public Phi lambda() {
-        final Phi rho = this.take(Attr.RHO);
-        final int identifier = Heaps.INSTANCE.malloc(
-            this, new Dataized(rho.take("size")).asNumber().intValue()
+    public Phi lambda() throws Exception {
+        return new Data.ToPhi(
+            Heaps.INSTANCE.size(
+                new Dataized(this.take(Attr.RHO).take("id")).asNumber().intValue()
+            )
         );
-        final Phi res;
-        try {
-            final Phi allocated = rho.take("allocated");
-            allocated.put("id", new Data.ToPhi((long) identifier));
-            final Phi scope = rho.take("scope").copy();
-            scope.put(0, allocated);
-            new Dataized(scope).take();
-            res = new Data.ToPhi(
-                Heaps.INSTANCE.read(identifier, 0, Heaps.INSTANCE.size(identifier))
-            );
-        } finally {
-            Heaps.INSTANCE.free(identifier);
-        }
-        return res;
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
@@ -71,7 +71,7 @@ final class Heaps {
             if (this.blocks.containsKey(identifier)) {
                 throw new ExFailure(
                     String.format(
-                        "Can't allocate block in memory with identifier %d because it's already allocated",
+                        "Can't allocate block in memory with identifier '%d' because it's already allocated",
                         identifier
                     )
                 );
@@ -79,6 +79,55 @@ final class Heaps {
             this.blocks.put(identifier, new byte[size]);
         }
         return identifier;
+    }
+
+    /**
+     * Get size of allocated block in memory by provided identifier.
+     * @param identifier Identifier of block in memory
+     * @return Size
+     */
+    int size(final int identifier) {
+        synchronized (this.blocks) {
+            if (!this.blocks.containsKey(identifier)) {
+                throw new ExFailure(
+                    String.format(
+                        "Block in memory by identifier '%d' is not allocated, can't get size",
+                        identifier
+                    )
+                );
+            }
+            return this.blocks.get(identifier).length;
+        }
+    }
+
+    /**
+     * Resize allocated block in memory.
+     * @param identifier Identifier of block
+     * @param size New size
+     */
+    void resize(final int identifier, final int size) {
+        if (size < 0) {
+            throw new ExFailure(
+                String.format(
+                    "Can't change size of block in memory by identifier '%d' to negative '%d'",
+                    identifier, size
+                )
+            );
+        }
+        synchronized (this.blocks) {
+            if (!this.blocks.containsKey(identifier)) {
+                throw new ExFailure(
+                    String.format(
+                        "Block in memory by identifier '%d' is not allocated, can't get size",
+                        identifier
+                    )
+                );
+            }
+            final byte[] bytes = this.blocks.get(identifier);
+            final byte[] resized = new byte[size];
+            System.arraycopy(bytes, 0, resized, 0, Math.min(bytes.length, size));
+            this.blocks.put(identifier, resized);
+        }
     }
 
     /**
@@ -93,7 +142,7 @@ final class Heaps {
             if (!this.blocks.containsKey(identifier)) {
                 throw new ExFailure(
                     String.format(
-                        "Block in memory by identifier %d is not allocated, can't read",
+                        "Block in memory by identifier '%d' is not allocated, can't read",
                         identifier
                     )
                 );
@@ -102,7 +151,7 @@ final class Heaps {
             if (offset + length > bytes.length) {
                 throw new ExFailure(
                     String.format(
-                        "Can't read %d bytes from offset %d, because only %d are allocated",
+                        "Can't read '%d' bytes from offset '%d', because only '%d' are allocated",
                         length,
                         offset,
                         bytes.length
@@ -124,7 +173,7 @@ final class Heaps {
             if (!this.blocks.containsKey(identifier)) {
                 throw new ExFailure(
                     String.format(
-                        "Can't read a block in memory with identifier %d because it's not allocated",
+                        "Can't read a block in memory with identifier '%d' because it's not allocated",
                         identifier
                     )
                 );
@@ -134,7 +183,7 @@ final class Heaps {
             if (length < offset + data.length) {
                 throw new ExFailure(
                     String.format(
-                        "Can't write %d bytes with offset %d to the block with identifier %d, because only %d were allocated",
+                        "Can't write '%d' bytes with offset '%d' to the block with identifier '%d', because only '%d' were allocated",
                         data.length,
                         offset,
                         identifier,
@@ -169,7 +218,7 @@ final class Heaps {
             if (!this.blocks.containsKey(identifier)) {
                 throw new ExFailure(
                     String.format(
-                        "Can't free a block in memory with identifier %d because it's not allocated",
+                        "Can't free a block in memory with identifier '%d' because it's not allocated",
                         identifier
                     )
                 );

--- a/eo-runtime/src/main/rust/eo/Cargo.toml
+++ b/eo-runtime/src/main/rust/eo/Cargo.toml
@@ -1,3 +1,25 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 [package]
 name = "eo"
 version = "0.1.0"

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -210,3 +210,41 @@
               m.write 2 "Hello"
               b.put
                 (m.read 2 5).eq "Hello"
+
+# Test.
+[] > malloc-increases-block-size
+  malloc.of > @
+    1
+    [b]
+      malloc.for > @
+        01-02-03-04
+        [m] >>
+          seq > @
+            *
+              m.resize 6
+              ^.b.put
+                and.
+                  m.size.eq 6
+                  m.get.eq 01-02-03-04-00-00
+
+# Test.
+[] > malloc-decreases-block-size
+  malloc.of > @
+    1
+    [b]
+      malloc.for > @
+        01-02-03-04-05
+        [m] >>
+          seq > @
+            *
+              m.resize 3
+              ^.b.put
+                and.
+                  m.size.eq 3
+                  m.get.eq 01-02-03
+
+# Test.
+[] > throws-on-changing-size-to-negative
+  malloc.of > @
+    1
+    m.resize -1 > [m]

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -190,4 +190,87 @@ final class HeapsTest {
             AtCompositeTest.TO_ADD_MESSAGE
         );
     }
+
+    @Test
+    void throwsOnGettingSizeOfEmptyBlock() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> HeapsTest.HEAPS.size(new PhFake().hashCode()),
+            "Heaps should throw an exception if trying to get size on an empty block, but it didn't"
+        );
+    }
+
+    @Test
+    void returnsValidSize() {
+        final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
+        MatcherAssert.assertThat(
+            "Heaps should return valid size of allocated block, but it didn't",
+            HeapsTest.HEAPS.size(idx),
+            Matchers.equalTo(5)
+        );
+        HeapsTest.HEAPS.free(idx);
+    }
+
+    @Test
+    void throwsOnChangingSizeToNegative() {
+        final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> HeapsTest.HEAPS.resize(idx, -1),
+            "Heaps should throw an exception on trying to changing size to negative, but it didn't"
+        );
+        HeapsTest.HEAPS.free(idx);
+    }
+
+    @Test
+    void throwsOnChangeSizeOfEmtpyBlock() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> HeapsTest.HEAPS.resize(new PhFake().hashCode(), 10),
+            "Heaps should throw an exception on changing size of empty block, but it didn't"
+        );
+    }
+
+    @Test
+    void increasesSizeSuccessfully() {
+        final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
+        final byte[] bytes = {1, 2, 3, 4, 5};
+        HeapsTest.HEAPS.write(idx, 0, bytes);
+        HeapsTest.HEAPS.resize(idx, 7);
+        MatcherAssert.assertThat(
+            "Heaps should successfully increase size of allocated block, but it didn't",
+            HeapsTest.HEAPS.read(idx, 0, 7),
+            Matchers.equalTo(new byte[] {1, 2, 3, 4, 5, 0, 0})
+        );
+        HeapsTest.HEAPS.free(idx);
+    }
+
+    @Test
+    void decreasesSizeSuccessfully() {
+        final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
+        final byte[] bytes = {1, 2, 3, 4, 5};
+        HeapsTest.HEAPS.write(idx, 0, bytes);
+        HeapsTest.HEAPS.resize(idx, 3);
+        MatcherAssert.assertThat(
+            "Heaps should successfully decrease size of allocated block, but it didn't",
+            HeapsTest.HEAPS.read(idx, 0, 3),
+            Matchers.equalTo(new byte[] {1, 2, 3})
+        );
+        HeapsTest.HEAPS.free(idx);
+    }
+
+    @Test
+    void returnsValidSizeAfterDecreasing() {
+        final int idx = HeapsTest.HEAPS.malloc(new PhFake(), 5);
+        final byte[] bytes = {1, 2, 3, 4, 5};
+        HeapsTest.HEAPS.write(idx, 0, bytes);
+        HeapsTest.HEAPS.resize(idx, 3);
+        MatcherAssert.assertThat(
+            "Heaps should return valid size after decreasing, but it didn't",
+            HeapsTest.HEAPS.size(idx),
+            Matchers.equalTo(3)
+        );
+        HeapsTest.HEAPS.free(idx);
+    }
+
 }


### PR DESCRIPTION
Closes: #3415

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the memory allocation functionality in the `EOmalloc` module, specifically addressing resizing of memory blocks, adding size retrieval, and improving error handling in the `Heaps` class.

### Detailed summary
- Added `EOmalloc$EOof$EOallocated$EOsize` for retrieving the size of allocated blocks.
- Introduced `EOmalloc$EOof$EOallocated$EOresize` for resizing allocated blocks.
- Enhanced error messages in the `Heaps` class for clarity.
- Updated tests to cover new resizing and size retrieval functionalities.
- Improved handling of negative size resizing attempts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->