### PR TITLE
return hash if tag is the hash

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/hash/ChText.java
@@ -75,6 +75,20 @@ public final class ChText implements CommitHash {
 
     @Override
     public String value() {
+        final String hash;
+        if (this.tag.matches("[0-9a-fA-F]{40}")) {
+            hash = this.tag;
+        } else {
+            hash = this.inside();
+        }
+        return hash;
+    }
+
+    /**
+     * Find and return Git SHA for the given tag (or throw if not found).
+     * @return The Git SHA
+     */
+    private String inside() {
         return new Unchecked<>(
             new Mapped<>(
                 Text::asString,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/hash/ChTextTest.java
@@ -115,4 +115,16 @@ final class ChTextTest {
             BinarizeParseTest.TO_ADD_MESSAGE
         );
     }
+
+    @Test
+    void readsHashByHash() {
+        MatcherAssert.assertThat(
+            "Hash must be itself, even if it's absent in the table",
+            new ChText(
+                () -> "",
+                "434868a411b9741fdd4f8a38a5c576e8733345c9"
+            ).value(),
+            Matchers.equalTo("434868a411b9741fdd4f8a38a5c576e8733345c9")
+        );
+    }
 }


### PR DESCRIPTION
This is necessary for eoc

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new test method for validating hash retrieval in the `ChText` class and updates the `value` method to correctly return a hash based on the tag's format.

### Detailed summary
- Added a new test method `readsHashByHash()` in `ChTextTest.java` to assert that a hash is returned correctly.
- Updated the `value()` method in `ChText.java` to check if the tag is a valid hash and return it or call the `inside()` method.
- Added a private method `inside()` in `ChText.java` to find and return the Git SHA for the given tag.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->