### PR TITLE
fix(#1426): probe and pull with cache

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/AssembleMojo.java
@@ -34,8 +34,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.set.SetOf;
-import org.eolang.maven.objectionary.Objectionaries;
-import org.eolang.maven.objectionary.ObjsDefault;
 
 /**
  * Pull all necessary EO XML files from Objectionary and parse them all.
@@ -67,6 +65,11 @@ public final class AssembleMojo extends SafeMojo {
     public static final String XMIR = "xmir";
 
     /**
+     * Source file extension.
+     */
+    public static final String EO = "eo";
+
+    /**
      * Output.
      * @checkstyle MemberNameCheck (7 lines)
      */
@@ -94,16 +97,6 @@ public final class AssembleMojo extends SafeMojo {
      */
     @Parameter
     private final Set<String> excludeBinaries = new SetOf<>();
-
-    /**
-     * Objectionaries.
-     * @checkstyle MemberNameCheck (6 lines)
-     * @checkstyle ConstantUsageCheck (5 lines)
-     */
-    private final Objectionaries objectionaries = new ObjsDefault(
-        () -> this.cache,
-        () -> this.session.getRequest().isUpdateSnapshots()
-    );
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MarkMojo.java
@@ -58,7 +58,7 @@ public final class MarkMojo extends SafeMojo {
         final Path home = this.targetDir.toPath().resolve(ResolveMojo.DIR);
         if (Files.exists(home)) {
             final Collection<String> deps = new DepDirs(home);
-            int found = 0;
+            long found = 0;
             for (final String dep : deps) {
                 final Path sub = home.resolve(dep).resolve(CopyMojo.DIR);
                 if (Files.exists(sub)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -83,11 +83,12 @@ public final class OptimizeMojo extends SafeMojo {
     @Override
     public void exec() {
         final Collection<ForeignTojo> tojos = this.scopedTojos().withXmir();
+        final Optimization optimization = this.optimization();
         final int total = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    tojo -> () -> this.optimized(tojo, this.optimization()),
+                    tojo -> () -> this.optimized(tojo, optimization),
                     new Filtered<>(
                         ForeignTojo::notOptimized,
                         tojos

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ProbeMojo.java
@@ -48,7 +48,6 @@ import org.eolang.maven.name.OnVersioned;
 import org.eolang.maven.objectionary.Objectionaries;
 import org.eolang.maven.objectionary.ObjsDefault;
 import org.eolang.maven.tojos.ForeignTojo;
-import org.eolang.maven.util.Rel;
 
 /**
  * Go through all `probe` metas in XMIR files, try to locate the
@@ -93,10 +92,7 @@ public final class ProbeMojo extends SafeMojo {
      * Objectionaries.
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Objectionaries objectionaries = new ObjsDefault(
-        () -> this.cache,
-        () -> this.session.getRequest().isUpdateSnapshots()
-    );
+    private final Objectionaries objectionaries = new ObjsDefault();
 
     @Override
     @SuppressWarnings("PMD.CognitiveComplexity")
@@ -133,14 +129,7 @@ public final class ProbeMojo extends SafeMojo {
                         .withDiscoveredAt(src);
                     probed.add(object);
                 }
-                tojo.withHash(
-                    new ChNarrow(
-                        new OnSwap(
-                            this.withVersions,
-                            new OnVersioned(tojo.identifier(), this.hash)
-                        ).hash()
-                    )
-                ).withProbed(count);
+                tojo.withProbed(count);
             }
             if (tojos.isEmpty()) {
                 if (this.scopedTojos().size() == 0) {
@@ -190,14 +179,12 @@ public final class ProbeMojo extends SafeMojo {
             ).iterator()
         );
         if (objects.isEmpty()) {
-            Logger.debug(
-                this, "Didn't find any probed objects in %s",
-                new Rel(file)
-            );
+            Logger.debug(this, "Didn't find any probed objects in %[file]s", file);
         } else {
             Logger.debug(
-                this, "Found %d probed objects in %s: %s",
-                objects.size(), new Rel(file), objects
+                this,
+                "Found %d probed objects in %[file]s: %s",
+                objects.size(), file, objects
             );
         }
         return objects;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ShakeMojo.java
@@ -80,11 +80,12 @@ public final class ShakeMojo extends SafeMojo {
     @Override
     void exec() {
         final Collection<ForeignTojo> tojos = this.scopedTojos().withOptimized();
+        final Optimization optimization = this.optimization();
         final int total = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    tojo -> () -> this.shaken(tojo, this.optimization()),
+                    tojo -> () -> this.shaken(tojo, optimization),
                     new Filtered<>(
                         ForeignTojo::notShaken,
                         tojos

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/VerifyMojo.java
@@ -80,11 +80,12 @@ public final class VerifyMojo extends SafeMojo {
     @Override
     void exec() {
         final Collection<ForeignTojo> tojos = this.scopedTojos().withShaken();
+        final Optimization optimization = this.optimization();
         final int total = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
-                    tojo -> () -> this.verified(tojo, this.optimization()),
+                    tojo -> () -> this.verified(tojo, optimization),
                     new Filtered<>(
                         ForeignTojo::notVerified,
                         tojos

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/CachePath.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/CachePath.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.fp;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/**
+ * Function that builds full path to file in global cache.
+ * @since 0.41
+ */
+public final class CachePath implements Supplier<Path> {
+    /**
+     * Cache base directory.
+     */
+    private final Path base;
+
+    /**
+     * Cache version.
+     */
+    private final String semver;
+
+    /**
+     * Git hash.
+     */
+    private final Supplier<String> hash;
+
+    /**
+     * Cache tail path.
+     */
+    private final Path tail;
+
+    /**
+     * Ctor.
+     * @param base Base cache directory
+     * @param semver Semver as part of absolute cache path
+     * @param hash Git hash as part of absolute cache path
+     * @param tail The last part of absolute cache path
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public CachePath(
+        final Path base, final String semver, final String hash, final Path tail
+    ) {
+        this(base, semver, () -> hash, tail);
+    }
+
+    /**
+     * Ctor.
+     * @param base Base cache directory
+     * @param semver Semver as part of absolute cache path
+     * @param hash Git hash as part of absolute cache path
+     * @param tail The last part of absolute cache path
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public CachePath(
+        final Path base, final String semver, final Supplier<String> hash, final Path tail
+    ) {
+        this.base = base;
+        this.semver = semver;
+        this.hash = hash;
+        this.tail = tail;
+    }
+
+    @Override
+    public Path get() {
+        return this.base.resolve(this.semver).resolve(this.hash.get()).resolve(this.tail);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/Footprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/Footprint.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.fp;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.BiFunc;
 
@@ -32,4 +33,6 @@ import org.cactoos.BiFunc;
  * @since 0.41.0
  */
 public interface Footprint extends BiFunc<Path, Path, Path> {
+    @Override
+    Path apply(Path source, Path target) throws IOException;
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpGenerated.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpGenerated.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.maven.fp;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.Func;
 import org.cactoos.scalar.ScalarOf;
@@ -46,7 +47,7 @@ public final class FpGenerated implements Footprint {
     }
 
     @Override
-    public Path apply(final Path source, final Path target) throws Exception {
+    public Path apply(final Path source, final Path target) throws IOException {
         return new Saved(new ScalarOf<>(this.content, source), target).value();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIfOlder.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIfOlder.java
@@ -23,15 +23,12 @@
  */
 package org.eolang.maven.fp;
 
-import com.jcabi.log.Logger;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.Func;
 
 /**
  * Footprint that behaves as first given wrapped {@link Footprint}
- * if provided target is older than source.
+ * if provided target exists and older than source.
  * Behaves as second given wrapped {@link Footprint} otherwise.
  * @since 0.41
  */
@@ -52,55 +49,18 @@ public final class FpIfOlder extends FpEnvelope {
      * @param second Second wrapped footprint
      */
     public FpIfOlder(
-        final Func<Path, Path> destination,
-        final Footprint first,
-        final Footprint second
+        final Func<Path, Path> destination, final Footprint first, final Footprint second
     ) {
         super(
-            new FpFork(
-                (source, target) -> {
-                    final Path dest = destination.apply(target);
-                    final boolean result;
-                    final boolean exists = dest.toFile().exists();
-                    if (exists) {
-                        result = FpIfOlder.isAfter(dest, source);
-                        if (result) {
-                            Logger.debug(
-                                FpIfOlder.class,
-                                "Target file %[file]s is older than source %[file]s",
-                                dest, source
-                            );
-                        } else {
-                            Logger.debug(
-                                FpIfOlder.class,
-                                "Target file %[file]s is newer than source %[file]s",
-                                dest, source
-                            );
-                        }
-                    } else {
-                        result = false;
-                        Logger.debug(
-                            FpIfOlder.class, "Target file %[file]s does not exist", dest
-                        );
-                    }
-                    return result;
-                },
-                first,
+            new FpIfTargetExists(
+                destination,
+                new FpIfTargetOlder(
+                    destination,
+                    first,
+                    second
+                ),
                 second
             )
-        );
-    }
-
-    /**
-     * Returns true if first given path is older in terms of last modified time.
-     * @param first First path to compare
-     * @param second Second path to compare
-     * @return True if first path is older that second path
-     * @throws IOException If fails to compare files
-     */
-    private static boolean isAfter(final Path first, final Path second) throws IOException {
-        return Files.getLastModifiedTime(first).toInstant().isAfter(
-            Files.getLastModifiedTime(second).toInstant()
         );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIfTargetOlder.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIfTargetOlder.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.maven.fp;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.cactoos.Func;
+
+/**
+ * Footprint that behaves like one of the given wrapped footprints depending on
+ * the result of comparison target and source in terms of last modified date.
+ * @since 0.41
+ */
+public final class FpIfTargetOlder extends FpEnvelope {
+    /**
+     * Ctor.
+     * @param destination Function that modifies result target path
+     * @param first First wrapped footprint
+     * @param second Second wrapped footprint
+     */
+    public FpIfTargetOlder(
+        final Func<Path, Path> destination, final Footprint first, final Footprint second
+    ) {
+        super(
+            new FpFork(
+                (source, target) -> {
+                    final Path dest = destination.apply(target);
+                    final boolean older = FpIfTargetOlder.isAfter(dest, source);
+                    if (older) {
+                        Logger.debug(
+                            FpIfTargetOlder.class,
+                            "Target file %[file]s is older than source %[file]s",
+                            dest, source
+                        );
+                    } else {
+                        Logger.debug(
+                            FpIfTargetOlder.class,
+                            "Target file %[file]s is newer than source %[file]s",
+                            dest, source
+                        );
+                    }
+                    return older;
+                },
+                first,
+                second
+            )
+        );
+    }
+
+    /**
+     * Returns true if first given path is older in terms of last modified time.
+     * @param first First path to compare
+     * @param second Second path to compare
+     * @return True if first path is older that second path
+     * @throws IOException If fails to compare files
+     */
+    private static boolean isAfter(final Path first, final Path second) throws IOException {
+        return Files.getLastModifiedTime(first).toInstant().isAfter(
+            Files.getLastModifiedTime(second).toInstant()
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIgnore.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpIgnore.java
@@ -23,30 +23,15 @@
  */
 package org.eolang.maven.fp;
 
-import java.io.IOException;
-import java.nio.file.Path;
-
 /**
- * Wrapper for footprint.
+ * Footprint that does not update target path.
  * @since 0.41
- * @checkstyle DesignForExtensionCheck (50 lines)
  */
-public class FpEnvelope implements Footprint {
-    /**
-     * Wrapped footprint.
-     */
-    private final Footprint origin;
-
+public final class FpIgnore extends FpEnvelope {
     /**
      * Ctor.
-     * @param footprint Wrapped footprint
      */
-    public FpEnvelope(final Footprint footprint) {
-        this.origin = footprint;
-    }
-
-    @Override
-    public Path apply(final Path source, final Path target) throws IOException {
-        return this.origin.apply(source, target);
+    public FpIgnore() {
+        super((source, target) -> target);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpUpdateBoth.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpUpdateBoth.java
@@ -23,30 +23,34 @@
  */
 package org.eolang.maven.fp;
 
-import java.io.IOException;
+import com.jcabi.log.Logger;
 import java.nio.file.Path;
+import java.util.function.Supplier;
+import org.cactoos.text.TextOf;
 
 /**
- * Wrapper for footprint.
+ * Footprint that updates target from content function and updates cache from target.
  * @since 0.41
- * @checkstyle DesignForExtensionCheck (50 lines)
  */
-public class FpEnvelope implements Footprint {
-    /**
-     * Wrapped footprint.
-     */
-    private final Footprint origin;
-
+public final class FpUpdateBoth extends FpEnvelope {
     /**
      * Ctor.
-     * @param footprint Wrapped footprint
+     * @param origin Original footprint that updates target from source
+     * @param cache Lazy path to cache
      */
-    public FpEnvelope(final Footprint footprint) {
-        this.origin = footprint;
-    }
-
-    @Override
-    public Path apply(final Path source, final Path target) throws IOException {
-        return this.origin.apply(source, target);
+    public FpUpdateBoth(final Footprint origin, final Supplier<Path> cache) {
+        super(
+            (source, target) -> {
+                final Path che = cache.get();
+                Logger.debug(
+                    FpUpdateBoth.class,
+                    "Updating target %[file]s and cache %[file]s from source %[file]s",
+                    target, che, source
+                );
+                origin.apply(source, target);
+                new Saved(new TextOf(target), che).value();
+                return target;
+            }
+        );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpUpdateFromCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/fp/FpUpdateFromCache.java
@@ -29,41 +29,24 @@ import java.util.function.Supplier;
 import org.cactoos.text.TextOf;
 
 /**
- * Footprint that works with cache.
- * If cache is older than source - update target from cache.
- * Update target and cache from source otherwise.
+ * Footprint that updates target from cache.
  * @since 0.41
  */
-public final class FpViaCache extends FpEnvelope {
-
+public final class FpUpdateFromCache extends FpEnvelope {
     /**
      * Ctor.
-     * @param footprint Wrapped original footprint that updates target from source
-     * @param cache Function that returns path to cache
+     * @param cache Lazy path to cache
      */
-    public FpViaCache(final Footprint footprint, final Supplier<Path> cache) {
+    public FpUpdateFromCache(final Supplier<Path> cache) {
         super(
-            new FpIfOlder(
-                target -> cache.get(),
-                (source, target) -> {
-                    Logger.debug(
-                        FpViaCache.class,
-                        "Updating only target %[file]s from source %[file]s",
-                        target, source
-                    );
-                    return new Saved(new TextOf(cache.get()), target).value();
-                },
-                (source, target) -> {
-                    Logger.debug(
-                        FpViaCache.class,
-                        "Updating target %[file]s and cache %[file]s from source %[file]s",
-                        target, cache.get(), source
-                    );
-                    footprint.apply(source, target);
-                    new Saved(new TextOf(target), cache.get()).value();
-                    return target;
-                }
-            )
+            (source, target) -> {
+                Logger.debug(
+                    FpUpdateFromCache.class,
+                    "Updating only target %[file]s from cache %[file]s",
+                    target, source
+                );
+                return new Saved(new TextOf(cache.get()), target).value();
+            }
         );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/name/OnReplaced.java
@@ -86,10 +86,7 @@ public final class OnReplaced implements ObjectName {
      * @param origin Origin object name.
      * @param all All hashes.
      */
-    public OnReplaced(
-        final ObjectName origin,
-        final Map<String, ? extends CommitHash> all
-    ) {
+    public OnReplaced(final ObjectName origin, final Map<String, ? extends CommitHash> all) {
         this(origin::toString, all);
     }
 
@@ -106,10 +103,7 @@ public final class OnReplaced implements ObjectName {
      * @param origin Raw string.
      * @param all All hashes.
      */
-    public OnReplaced(
-        final String origin,
-        final Map<String, ? extends CommitHash> all
-    ) {
+    public OnReplaced(final String origin, final Map<String, ? extends CommitHash> all) {
         this(() -> origin, all);
     }
 
@@ -118,18 +112,12 @@ public final class OnReplaced implements ObjectName {
      * @param origin Raw string as scalar.
      * @param all All hashes.
      */
-    OnReplaced(
-        final Scalar<String> origin,
-        final Map<String, ? extends CommitHash> all
-    ) {
+    OnReplaced(final Scalar<String> origin, final Map<String, ? extends CommitHash> all) {
         this.name = new DelimitedName(origin);
         this.concat = new Unchecked<>(
             () -> new DelimitedName(
                 this.name.title(),
-                this.name.label()
-                    .map(
-                        label -> this.hash().value()
-                    )
+                this.name.label().map(label -> this.hash().value())
             )
         );
         this.hashes = all;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/objectionary/ObjectsIndex.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
@@ -60,16 +59,14 @@ final class ObjectsIndex {
      */
     ObjectsIndex() {
         this(
-            new ScalarOf<Set<String>>(
-                () -> new SetOf<>(
+            () -> new SetOf<>(
+                new Mapped<>(
+                    ObjectsIndex::convert,
                     new Mapped<>(
-                        ObjectsIndex::convert,
-                        new Mapped<>(
-                            Text::asString,
-                            new Split(
-                                ObjectsIndex.asText(new URL(ObjectsIndex.HOME)),
-                                "\n"
-                            )
+                        Text::asString,
+                        new Split(
+                            ObjectsIndex.asText(new URL(ObjectsIndex.HOME)),
+                            "\n"
                         )
                     )
                 )
@@ -116,7 +113,8 @@ final class ObjectsIndex {
      */
     @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
     private static Text asText(final URL url) {
-        final String body = new Unchecked<>(() -> new TextOf(url).asString()).value();
-        return new TextOf(body);
+        return new TextOf(
+            new Unchecked<>(() -> new TextOf(url).asString())
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -104,6 +104,7 @@ final class ParseMojoTest {
             hash.value(),
             base.relativize(target)
         ).apply(maven.programTojo().source(), target);
+        
         final String actual = String.format(
             "target/%s/foo/x/main.%s",
             ParseMojo.DIR,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -89,6 +89,7 @@ final class ParseMojoTest {
     void parsesWithCache(@TempDir final Path temp) throws Exception {
         final Path cache = temp.resolve("cache");
         final FakeMaven maven = new FakeMaven(temp)
+            .with("plugin", FakeMaven.pluginDescriptor())
             .withProgram("invalid content")
             .with("cache", cache);
         final String expected = new UncheckedText(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -104,7 +104,6 @@ final class ParseMojoTest {
             hash.value(),
             base.relativize(target)
         ).apply(maven.programTojo().source(), target);
-        
         final String actual = String.format(
             "target/%s/foo/x/main.%s",
             ParseMojo.DIR,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeMojoTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapEntry;
 import org.eolang.maven.hash.ChCached;
-import org.eolang.maven.hash.ChPattern;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.ChText;
 import org.eolang.maven.hash.CommitHash;
@@ -62,7 +61,6 @@ final class ProbeMojoTest {
     private static final ObjectName STDOUT = new OnVersioned("org.eolang.io.stdout", "9c93528");
 
     @Test
-    @ExtendWith(WeAreOnline.class)
     void findsProbes(@TempDir final Path temp) throws Exception {
         final String expected = "5";
         MatcherAssert.assertThat(
@@ -88,11 +86,11 @@ final class ProbeMojoTest {
             new ResourceOf(tags),
             Paths.get("tags.txt")
         );
+        final String expected = "5";
         MatcherAssert.assertThat(
             String.format(
-                "The hash of the program should be equal to the hash of the commit for the '%s' tag. See '%s' file",
-                tag,
-                tags
+                "Number of objects that we should find during the probing phase should be equal %s",
+                expected
             ),
             new FakeMaven(temp)
                 .with(
@@ -104,27 +102,12 @@ final class ProbeMojoTest {
                 .withProgram(ProbeMojoTest.program())
                 .execute(new FakeMaven.Probe())
                 .programTojo()
-                .hash(),
-            Matchers.equalTo("mmmmmmm")
+                .probed(),
+            Matchers.equalTo(expected)
         );
     }
 
     @Test
-    void findsProbesViaOfflineHash(@TempDir final Path temp) throws IOException {
-        MatcherAssert.assertThat(
-            "The hash of the program tojo should be equal to the given hash pattern",
-            new FakeMaven(temp)
-                .with("hash", new ChPattern("*.*.*:abcdefg", "1.0.0"))
-                .withProgram(ProbeMojoTest.program())
-                .execute(new FakeMaven.Probe())
-                .programTojo()
-                .hash(),
-            Matchers.equalTo("abcdefg")
-        );
-    }
-
-    @Test
-    @ExtendWith(WeAreOnline.class)
     void findsProbesInOyRemote(@TempDir final Path temp) throws IOException {
         final String tag = "0.28.10";
         MatcherAssert.assertThat(
@@ -147,7 +130,6 @@ final class ProbeMojoTest {
     }
 
     @Test
-    @ExtendWith(WeAreOnline.class)
     void findsProbesWithVersionsInOneObjectionary(@TempDir final Path temp) throws IOException {
         final CommitHash hash = new CommitHashesMap.Fake().get("0.28.5");
         final FakeMaven maven = new FakeMaven(temp)
@@ -169,15 +151,9 @@ final class ProbeMojoTest {
             maven.programTojo().probed(),
             Matchers.equalTo("1")
         );
-        MatcherAssert.assertThat(
-            "Program tojo entry in tojos after probing should contain given hash",
-            maven.programTojo().hash(),
-            Matchers.equalTo(hash.value())
-        );
     }
 
     @Test
-    @ExtendWith(WeAreOnline.class)
     void findsProbesWithVersionsInDifferentObjectionaries(@TempDir final Path temp)
         throws IOException {
         final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
@@ -208,11 +184,6 @@ final class ProbeMojoTest {
             "Program tojo after probing should contain exactly two probed objects",
             maven.programTojo().probed(),
             Matchers.equalTo("2")
-        );
-        MatcherAssert.assertThat(
-            "Program tojo after probing should have given hash",
-            maven.programTojo().hash(),
-            Matchers.equalTo(first.value())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PullMojoTest.java
@@ -26,13 +26,18 @@ package org.eolang.maven;
 import com.yegor256.WeAreOnline;
 import com.yegor256.tojos.MnCsv;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.LinkedList;
 import java.util.Map;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapEntry;
+import org.cactoos.text.TextOf;
+import org.eolang.maven.fp.Saved;
 import org.eolang.maven.hash.ChCached;
+import org.eolang.maven.hash.ChNarrow;
 import org.eolang.maven.hash.ChPattern;
 import org.eolang.maven.hash.ChRemote;
 import org.eolang.maven.hash.ChText;
@@ -48,6 +53,7 @@ import org.eolang.maven.objectionary.OyRemote;
 import org.eolang.maven.util.HmBase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,8 +86,7 @@ final class PullMojoTest {
         maven.foreignTojos()
             .add(PullMojoTest.STDOUT)
             .withVersion("*.*.*");
-        maven.with("skip", false)
-            .execute(PullMojo.class);
+        maven.with("skip", false).execute(PullMojo.class);
         MatcherAssert.assertThat(
             BinarizeParseTest.TO_ADD_MESSAGE,
             PullMojoTest.exists(temp, PullMojoTest.STDOUT),
@@ -138,11 +143,6 @@ final class PullMojoTest {
         );
     }
 
-    /**
-     * Offline hash test.
-     *
-     * @param temp Temporary directory for test.
-     */
     @Test
     void pullsUsingOfflineHash(@TempDir final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
@@ -322,6 +322,98 @@ final class PullMojoTest {
                 line -> line.contains("Failed to pull object discovered at")
             ),
             "Log should contain info where failed to pull object was discovered at, but it does not"
+        );
+    }
+
+    @Test
+    void skipsAlreadyPulled(@TempDir final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .withHelloWorld()
+            .execute(new FakeMaven.Pull());
+        final Path path = maven.result().get(
+            String.format("target/%s/org/eolang/bytes.%s", PullMojo.DIR, AssembleMojo.EO)
+        );
+        final long mtime = path.toFile().lastModified();
+        maven.execute(PullMojo.class);
+        MatcherAssert.assertThat(
+            "PullMojo must skip pulling if source was already downloaded",
+            path.toFile().lastModified(),
+            Matchers.is(mtime)
+        );
+    }
+
+    @Test
+    void savesPulledResultsToCache(@TempDir final Path temp) throws IOException {
+        final Path cache = temp.resolve("cache");
+        final CommitHash hash = new ChCached(
+            new ChNarrow(
+                new ChRemote("master")
+            )
+        );
+        new FakeMaven(temp)
+            .withHelloWorld()
+            .with("cache", cache)
+            .with("hash", hash)
+            .execute(new FakeMaven.Pull());
+        MatcherAssert.assertThat(
+            "Pulled results must be saved to cache",
+            cache.resolve(PullMojo.CACHE)
+                .resolve(FakeMaven.pluginVersion())
+                .resolve(hash.value())
+                .resolve("org/eolang/bytes.eo")
+                .toFile(),
+            FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    void getsAlreadyPulledResultsFromCache(@TempDir final Path temp) throws Exception {
+        final TextOf cached = new TextOf(
+            new ResourceOf("org/eolang/maven/sum.eo")
+        );
+        final Path cache = temp.resolve("cache");
+        final String hash = "abcdef1";
+        new Saved(
+            cached,
+            cache
+                .resolve(PullMojo.CACHE)
+                .resolve(FakeMaven.pluginVersion())
+                .resolve(hash)
+                .resolve("org/eolang/io/stdout.eo")
+        ).value();
+        Files.setLastModifiedTime(
+            cache.resolve(
+                Paths
+                    .get(PullMojo.CACHE)
+                    .resolve(FakeMaven.pluginVersion())
+                    .resolve(hash)
+                    .resolve("org/eolang/io/stdout.eo")
+            ),
+            FileTime.fromMillis(System.currentTimeMillis() + 50_000)
+        );
+        new FakeMaven(temp)
+            .withProgram(
+                "# This is the default 64+ symbols comment in front of named abstract object.",
+                "[] > app",
+                "  QQ.io.stdout > @"
+            )
+            .with("hash", new CommitHash.ChConstant(hash))
+            .with("cache", cache)
+            .execute(new FakeMaven.Pull());
+        MatcherAssert.assertThat(
+            "PullMojo should take source from cache, but it does not",
+            new TextOf(
+                new HmBase(temp).load(
+                    Paths.get(
+                        String.format(
+                            "target/%s/org/eolang/io/stdout.%s",
+                            PullMojo.DIR,
+                            AssembleMojo.EO
+                        )
+                    )
+                ).asBytes()
+            ).asString(),
+            Matchers.is(cached.asString())
         );
     }
 


### PR DESCRIPTION
Ref: #1426

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `eo-maven-plugin` by refining the handling of file footprints, optimizing caching mechanisms, and improving error handling throughout various classes and methods.

### Detailed summary
- Changed `int found` to `long found` in `MarkMojo.java`.
- Updated method signatures to throw `IOException` instead of `Exception`.
- Introduced new classes: `FpIgnore`, `FpUpdateFromCache`, `FpUpdateBoth`, `FpIfTargetExists`, `FpIfReleased`.
- Removed unused `Objectionaries` cache logic from `AssembleMojo`.
- Enhanced logging and error handling in `ProbeMojo` and `PullMojo`.
- Simplified caching logic in `ObjsDefault` class.
- Improved tests in `ProbeMojoTest` and `PullMojoTest` for better coverage and reliability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->