### PR TITLE
fix(#3257): update jcabi-xml and fix tests

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -91,7 +91,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.29.1</version>
+      <!-- version from parent POM -->
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -91,7 +91,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <!-- version from parent POM -->
+      <version>0.29.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoTest.java
@@ -26,7 +26,10 @@ package org.eolang.maven;
 import com.yegor256.WeAreOnline;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -105,6 +108,16 @@ final class ParseMojoTest {
             base.relativize(target)
         ).apply(maven.programTojo().source(), target);
         target.toFile().delete();
+        Files.setLastModifiedTime(
+            cache.resolve(
+                Paths
+                    .get(ParseMojo.CACHE)
+                    .resolve(FakeMaven.pluginVersion())
+                    .resolve(hash.value())
+                    .resolve("foo/x/main.xmir")
+            ),
+            FileTime.fromMillis(System.currentTimeMillis() + 50_000)
+        );
         final String actual = String.format(
             "target/%s/foo/x/main.%s",
             ParseMojo.DIR,

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@ SOFTWARE.
       <dependency>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-xml</artifactId>
-        <version>0.29.0</version>
+        <version>0.29.1</version>
       </dependency>
       <dependency>
         <groupId>com.jcabi</groupId>


### PR DESCRIPTION
Ref: #3257

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `jcabi-xml` in `pom.xml`, adds new imports in `ParseMojoTest.java`, and modifies several test methods to improve error detection and handling. It also removes unused methods related to message parsing and regex creation.

### Detailed summary
- Updated `jcabi-xml` version from `0.29.0` to `0.29.1`.
- Added imports for `Files`, `Path`, and `FileTime` in `ParseMojoTest.java`.
- Enhanced error detection in `doesNotFailWithNoErrorsAndWarnings`, `detectsErrorsSuccessfully`, `detectsCriticalErrorsSuccessfully`, and `detectsWarningWithCorrespondingFlag` methods.
- Removed unused methods `getMessage` and `createRegEx` from `ParseMojoTest.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->