### PR TITLE
fix(#3257): try to speedup PhiMojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -155,11 +155,12 @@ public final class PhiMojo extends SafeMojo {
     /**
      * Translate one XMIR file to .phi file.
      * @param xmir The XMIR file
-     * @param position Its position in the entire pack
      * @param xsline Chain of XSL transformations
+     * @param position Its position in the entire pack
      * @param total How many files are there
      * @return How many files translated (either 1 or 0)
      * @throws Exception If fails
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     private int translate(final Path xmir, final Xsline xsline, final int position, final int total)
         throws Exception {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiMojo.java
@@ -46,8 +46,7 @@ import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
 import org.cactoos.number.SumOf;
 import org.cactoos.text.TextOf;
-import org.eolang.maven.util.HmBase;
-import org.eolang.maven.util.Home;
+import org.eolang.maven.footprint.Saved;
 import org.eolang.maven.util.Walk;
 import org.eolang.parser.ParsingTrain;
 import org.eolang.parser.Schema;
@@ -127,13 +126,14 @@ public final class PhiMojo extends SafeMojo {
         final AtomicInteger passed = new AtomicInteger();
         final Walk walk = new Walk(this.phiInputDir.toPath());
         final int total = walk.size();
+        final Xsline xsline = new Xsline(this.train());
         final int count = new SumOf(
             new Threads<>(
                 Runtime.getRuntime().availableProcessors(),
                 new Mapped<>(
                     xmir -> () -> {
                         final int position = passed.addAndGet(1);
-                        return this.translate(xmir, position, total);
+                        return this.translate(xmir, xsline, position, total);
                     },
                     walk
                 )
@@ -156,23 +156,20 @@ public final class PhiMojo extends SafeMojo {
      * Translate one XMIR file to .phi file.
      * @param xmir The XMIR file
      * @param position Its position in the entire pack
+     * @param xsline Chain of XSL transformations
      * @param total How many files are there
      * @return How many files translated (either 1 or 0)
      * @throws Exception If fails
      */
-    private int translate(final Path xmir, final int position, final int total)
+    private int translate(final Path xmir, final Xsline xsline, final int position, final int total)
         throws Exception {
-        final Home home = new HmBase(this.phiOutputDir);
-        final Train<Shift> train = this.train();
         final long start = System.currentTimeMillis();
         Logger.debug(
             this,
             "Processing XMIR (#%d/%d): %[file]s (%[size]s)...",
             position, total, xmir, xmir.toFile().length()
         );
-        final XML xml = new XMLDocument(
-            new TextOf(xmir).asString()
-        );
+        final XML xml = new XMLDocument(new TextOf(xmir).asString());
         new Schema(xml).check();
         final Path relative = Paths.get(
             this.phiInputDir.toPath().relativize(xmir).toString().replace(
@@ -181,31 +178,26 @@ public final class PhiMojo extends SafeMojo {
             )
         );
         int amount;
+        final Path target = this.phiOutputDir.toPath().resolve(relative);
         try {
-            home.save(PhiMojo.translated(train, xml), relative);
+            new Saved(PhiMojo.translated(xsline, xml), target).value();
             Logger.info(
                 this,
                 "Translated to phi (#%d/%d): %[file]s (%[size]s) -> %[file]s (%[size]s) in %[ms]s",
                 position, total, xmir,
                 xmir.toFile().length(),
                 relative,
-                this.phiOutputDir.toPath().resolve(relative).toFile().length(),
+                target.toFile().length(),
                 System.currentTimeMillis() - start
             );
             amount = 1;
         } catch (final ImpossibleToPhiTranslationException ex) {
-            Logger.debug(
-                this,
-                "XML is not translatable to phi:\n%s",
-                xml.toString()
-            );
+            Logger.debug(this, "XML is not translatable to phi:\n%s", xml.toString());
             throw new IllegalStateException(
-                String.format("Couldn't translate %s to phi", xmir),
-                ex
+                String.format("Couldn't translate %s to phi", xmir), ex
             );
         } catch (final IllegalArgumentException ex) {
-            if (ex.getCause() instanceof TerminationException
-                && this.phiSkipFailed) {
+            if (ex.getCause() instanceof TerminationException && this.phiSkipFailed) {
                 Logger.info(
                     this,
                     "%[file]s failed on critical error, but skipped because phiSkipFailed=true",
@@ -249,14 +241,14 @@ public final class PhiMojo extends SafeMojo {
 
     /**
      * Translate given xmir to phi calculus expression.
-     * @param train Train that optimize and translates given xmir
+     * @param xsline Chain of XSL optimizations and transformations
      * @param xmir Text of xmir
      * @return Translated xmir
      * @throws ImpossibleToPhiTranslationException If fails to translate given XMIR to phi
      */
-    private static String translated(final Train<Shift> train, final XML xmir)
+    private static String translated(final Xsline xsline, final XML xmir)
         throws ImpossibleToPhiTranslationException {
-        final XML translated = new Xsline(train).pass(xmir);
+        final XML translated = xsline.pass(xmir);
         Logger.debug(PhiMojo.class, "XML after translation to phi:\n%s", translated);
         final List<String> phi = translated.xpath("program/phi/text()");
         if (phi.isEmpty()) {


### PR DESCRIPTION
Ref: #3257

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `exec` method in the `PhiMojo` class by integrating a new `Xsline` object for handling XSL transformations during the translation of XMIR files to PHI files. It improves the method's parameters and logging for better clarity and functionality.

### Detailed summary
- Replaced `HmBase` and `Home` imports with `Saved` from `org.eolang.maven.footprint`.
- Introduced `Xsline` object for XSL transformations.
- Updated `translate` method signature to include `Xsline`.
- Modified logic in `translate` to utilize `Saved` for saving translated files.
- Enhanced logging for translation progress and errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->