### PR TITLE
fix(#3257): introduced benchmark for XSL + speeded up `add-default-package.xsl`

### DIFF
--- a/.github/.typos.toml
+++ b/.github/.typos.toml
@@ -21,4 +21,7 @@
 # SOFTWARE.
 
 [files]
-extend-exclude = ["eo-runtime/src/main/java/EOorg/EOeolang/EOfs/EOfile$EOis_directory.java"]
+extend-exclude = [
+    "eo-runtime/src/main/java/EOorg/EOeolang/EOfs/EOfile$EOis_directory.java",
+    "eo-parser/src/test/resources/org/eolang/parser/benchmark/native.xmir"
+]

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -137,6 +137,18 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
       <!-- version from parent POM -->

--- a/eo-parser/src/main/resources/org/eolang/parser/add-default-package.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-default-package.xsl
@@ -36,7 +36,19 @@ SOFTWARE.
     hello > @
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="o[@base and not(starts-with(@base, '.')) and not(contains(@base, '.')) and not(@ref) and not(@base = //meta[head='alias']/part[1]) and @base != '@' and @base != 'Q' and @base != '^' and @base != '&amp;' and @base != '$' and @base != '&lt;']">
+  <xsl:template match="o[@base]">
+    <xsl:apply-templates select="." mode="with-base"/>
+  </xsl:template>
+  <xsl:template match="o[not(@ref)]" mode="with-base">
+    <xsl:apply-templates select="." mode="no-refs"/>
+  </xsl:template>
+  <xsl:template match="o[not(contains(@base, '.'))]" mode="no-refs">
+    <xsl:apply-templates select="." mode="no-dots"/>
+  </xsl:template>
+  <xsl:template match="o[@base!='@' and @base!='Q' and @base!='^' and @base!='&amp;' and @base!='$' and @base!='&lt;']" mode="no-dots">
+    <xsl:apply-templates select="." mode="no-specials"/>
+  </xsl:template>
+  <xsl:template match="o[not(@base=/program/metas/meta[head='alias']/part[1])]" mode="no-specials">
     <xsl:copy>
       <xsl:attribute name="base">
         <xsl:text>org.eolang.</xsl:text>
@@ -45,7 +57,7 @@ SOFTWARE.
       <xsl:apply-templates select="node()|@* except @base"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="node()|@*">
+  <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>

--- a/eo-parser/src/test/java/org/eolang/parser/XslBenchmarkIT.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XslBenchmarkIT.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.StClasspath;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.cactoos.io.ResourceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for XSL transformations.
+ * @since 0.41
+ * @checkstyle DesignForExtensionCheck (100 lines)
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "PMD.JUnitTestClassShouldBeFinal",
+    "PMD.JUnit5TestShouldBePackagePrivate"
+})
+public class XslBenchmarkIT {
+    /**
+     * Pairs of XSL and worst XMIR for the XSL.
+     */
+    @Param("/org/eolang/parser/add-default-package.xsl|org/eolang/parser/benchmark/native.xmir")
+    private String pairs;
+
+    @Benchmark
+    public void apply() throws Exception {
+        final String[] pair = this.pairs.split("\\|");
+        new StClasspath(pair[0]).apply(
+            1, new XMLDocument(new ResourceOf(pair[1]).stream())
+        );
+    }
+
+    @Test
+    @SuppressWarnings("JTCOP.LineHitterRule")
+    void measuresXslTransformations() throws IOException {
+        Main.main(new String[0]);
+        Assertions.assertTrue(true, "Benchmark should executed");
+    }
+}


### PR DESCRIPTION
Ref: #3257

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `eo-parser` project by adding new dependencies for benchmarking and modifying XSL templates for better processing. It also introduces a benchmark test class and a new resource file for performance evaluation.

### Detailed summary
- Updated `.github/.typos.toml` to exclude an additional file.
- Added dependencies for `jmh-core` and `jmh-generator-annprocess` in `pom.xml`.
- Modified XSL templates in `add-default-package.xsl` for improved matching logic.
- Created `XslBenchmarkIT` class for benchmarking XSL transformations.
- Added `native.xmir` resource file for benchmark testing.

> The following files were skipped due to too many changes: `eo-parser/src/test/resources/org/eolang/parser/benchmark/native.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->