### PR TITLE
fix(#3257): optimize some xsls

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/add-refs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/add-refs.xsl
@@ -32,7 +32,13 @@ SOFTWARE.
   global or just a mistake.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="o[@base and not(starts-with(@base, '.')) and @base!='$' and @base!='^']">
+  <xsl:template match="o[@base]">
+    <xsl:apply-templates select="." mode="with-base"/>
+  </xsl:template>
+  <xsl:template match="o[not(starts-with(@base, '.'))]" mode="with-base">
+    <xsl:apply-templates select="." mode="no-dots"/>
+  </xsl:template>
+  <xsl:template match="o[@base!='$' and @base!='^']" mode="no-dots">
     <xsl:variable name="current" select="."/>
     <xsl:copy>
       <xsl:variable name="parent" select="ancestor::*[o[@name=$current/@base]][1]"/>
@@ -76,7 +82,7 @@ SOFTWARE.
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="node()|@*">
+  <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/external-weak-typed-atoms.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/external-weak-typed-atoms.xsl
@@ -24,7 +24,7 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="external-weak-typed-atoms" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="package" select="//metas/meta[head='package'][1]/part"/>
+  <xsl:variable name="package" select="/program/metas/meta[head='package'][1]/part"/>
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/explicit-data.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/explicit-data.xsl
@@ -61,9 +61,12 @@ SOFTWARE.
       </a>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:template match="//o[@data and not(@base='org.eolang.bytes' or @base='bytes')]">
+  <xsl:template match="o[@data]">
+    <xsl:apply-templates select="." mode="with-data"/>
+  </xsl:template>
+  <xsl:template match="o[not(@base='org.eolang.bytes' or @base='bytes')]" mode="with-data">
     <xsl:choose>
-      <xsl:when test="parent::*[$literal-objects/text()=@base or ($reversed/text()=@base and o[@base='.eolang' and o[@base='.org' and o[@base='Q']]])]">
+      <xsl:when test="parent::*[$literal-objects/text()=@base or ($reversed/text()=@base and o[1][@base='.eolang' and o[1][@base='.org' and o[1][@base='Q']]])]">
         <o base="org.eolang.bytes">
           <xsl:attribute name="data">
             <xsl:value-of select="./@data"/>
@@ -91,20 +94,10 @@ SOFTWARE.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-  <xsl:template match="//o[((@base='.bytes' and o[@base='.eolang' and o[@base='.org' and o[@base='Q']]]) or @base='org.eolang.bytes') and o[last() and @data]]">
-    <o base="org.eolang.bytes">
-      <xsl:for-each select="@*[name()!='data' and name()!='base']">
-        <xsl:attribute name="{name()}">
-          <xsl:value-of select="."/>
-        </xsl:attribute>
-      </xsl:for-each>
-      <xsl:attribute name="data">
-        <xsl:text>bytes</xsl:text>
-      </xsl:attribute>
-      <xsl:value-of select="o[@data]/text()"/>
-    </o>
+  <xsl:template match="o[@base='bytes']" mode="with-data">
+    <xsl:apply-templates select="." mode="base-bytes"/>
   </xsl:template>
-  <xsl:template match="//o[@base='bytes' and @data and @ref]">
+  <xsl:template match="o[@ref]" mode="base-bytes">
     <o base="org.eolang.bytes">
       <xsl:for-each select="@*[name()!='data' and name()!='base']">
         <xsl:attribute name="{name()}">
@@ -117,7 +110,20 @@ SOFTWARE.
       <xsl:value-of select="text()"/>
     </o>
   </xsl:template>
-  <xsl:template match="node()|@*">
+  <xsl:template match="o[((@base='.bytes' and o[@base='.eolang' and o[@base='.org' and o[@base='Q']]]) or @base='org.eolang.bytes') and o[last() and @data]]">
+    <o base="org.eolang.bytes">
+      <xsl:for-each select="@*[name()!='data' and name()!='base']">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:attribute name="data">
+        <xsl:text>bytes</xsl:text>
+      </xsl:attribute>
+      <xsl:value-of select="o[@data]/text()"/>
+    </o>
+  </xsl:template>
+  <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/resolve-aliases.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/resolve-aliases.xsl
@@ -32,7 +32,13 @@ SOFTWARE.
   If some alias is badly formatted, a runtime error is issued.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="o[not(@ref) and @base and not(contains(@base, '.'))]">
+  <xsl:template match="o[@base]">
+    <xsl:apply-templates select="." mode="with-base"/>
+  </xsl:template>
+  <xsl:template match="o[not(@ref)]" mode="with-base">
+    <xsl:apply-templates select="." mode="with-ref"/>
+  </xsl:template>
+  <xsl:template match="o[not(contains(@base, '.'))]" mode="with-ref">
     <xsl:variable name="o" select="."/>
     <xsl:copy>
       <xsl:attribute name="base">
@@ -60,7 +66,7 @@ SOFTWARE.
       <xsl:apply-templates select="node()|@* except @base"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="node()|@*">
+  <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/stars-to-tuples.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/stars-to-tuples.xsl
@@ -24,7 +24,7 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="stars-to-tuples" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template match="//o[@star]">
+  <xsl:template match="o[@star]">
     <xsl:choose>
       <xsl:when test="count(o)=0">
         <xsl:choose>

--- a/eo-parser/src/main/resources/org/eolang/parser/warnings/unit-test-without-phi.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/warnings/unit-test-without-phi.xsl
@@ -27,7 +27,7 @@ SOFTWARE.
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="/program[//meta[head='junit' or head='tests']]/objects/o[@abstract][count(o[@name='@'])=0]">
+      <xsl:for-each select="/program[metas/meta[head='tests']]/objects/o[@abstract][count(o[@name='@'])=0]">
         <xsl:element name="error">
           <xsl:attribute name="check">
             <xsl:text>unit-test-without-phi</xsl:text>

--- a/eo-parser/src/test/java/org/eolang/parser/XslBenchmarkIT.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XslBenchmarkIT.java
@@ -62,7 +62,11 @@ public class XslBenchmarkIT {
     /**
      * Pairs of XSL and worst XMIR for the XSL.
      */
-    @Param("/org/eolang/parser/add-default-package.xsl|org/eolang/parser/benchmark/native.xmir")
+    @Param({
+        "/org/eolang/parser/add-default-package.xsl|org/eolang/parser/benchmark/native.xmir",
+        "/org/eolang/parser/add-refs.xsl|org/eolang/parser/benchmark/native.xmir",
+        "/org/eolang/parser/explicit-data.xsl|org/eolang/parser/benchmark/native.xmir"
+    })
     private String pairs;
 
     @Benchmark


### PR DESCRIPTION
Ref: #3257 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining XSL templates in various files to enhance the matching criteria and processing logic for XML elements, particularly those related to the `o` element with attributes such as `@star`, `@base`, and `@data`.

### Detailed summary
- Changed match patterns for `o` elements in `stars-to-tuples.xsl` and `unit-test-without-phi.xsl`.
- Updated `@Param` annotation in `XslBenchmarkIT.java` to include additional XSL files.
- Modified variable selection logic in `external-weak-typed-atoms.xsl`.
- Enhanced template matching for `o` elements in `resolve-aliases.xsl` and `add-refs.xsl`.
- Improved data handling in `explicit-data.xsl` with new modes for templates.
- Streamlined matching logic for `o` elements with specific attributes across several files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->