### PR TITLE
benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,69 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+name: benchmark
+on:
+  push:
+    branches:
+      - master
+    paths-ignore: [ 'paper/**', 'sandbox/**' ]
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  benchmark:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ubuntu-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ubuntu-jdk-21-maven-
+      - run: mvn clean test --errors --batch-mode
+      - run: |
+          set -x
+          sum=$(
+            printf "\`\`\`text\n"
+            awk -F ',' '{ arr[$1]+=$2 } END { for (key in arr) printf("%s\t%s\n", key, arr[key])}' eo-runtime/target/eo/xsl-measures.csv | sort -g -k 2 | tac | column -t
+            printf "\`\`\`\n\n"
+            echo "The results were calculated in [this GHA job][benchmark-gha]"
+            echo "on $(date +'%Y-%m-%d') at $(date +'%H:%M'),"
+            echo "on $(uname) with $(nproc --all) CPUs."
+          )
+          export sum
+          perl -i -0777 -pe 's/(?<=<!-- benchmark_begin -->).*(?=<!-- benchmark_end -->)/\n\n$ENV{sum}\n\n/gs;' README.md
+          url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          export url
+          perl -i -0777 -pe 's/(?<=\[benchmark-gha\]: ).*(?=\n)/$ENV{url}/gs;' README.md
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          branch: benchmark
+          commit-message: 'new benchmark results'
+          delete-branch: true
+          title: 'New benchmarking results'
+          assignees: yegor256
+          base: master

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore: [ 'paper/**', 'sandbox/**' ]
+    paths-ignore: [ 'README.md', 'paper/**', 'sandbox/**' ]
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ Play with more examples [here](https://github.com/objectionary/sandbox).
 Read about integration with Maven,
 [here](https://github.com/objectionary/eo/tree/master/eo-maven-plugin).
 
+## Benchmark
+
+There is some benchmarking here:
+
+<!-- benchmark_begin -->
+...
+<!-- benchmark_end -->
+
 ## How to Contribute
 
 Fork repository, make changes, then send us
@@ -262,3 +270,4 @@ to enhance the performance of EO components:
 [![YourKit](https://www.yourkit.com/images/yklogo.png)](https://www.yourkit.com)
 
 [cargo]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+[benchmark-gha]: https://github.com/objectionary/hone-maven-plugin/actions/runs/11683609818

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OptimizeMojo.java
@@ -26,6 +26,7 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.TrLambda;
 import java.nio.file.Path;
 import java.util.Collection;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -42,6 +43,7 @@ import org.eolang.maven.optimization.Optimization;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.TojoHash;
 import org.eolang.parser.ParsingTrain;
+import org.eolang.parser.StMeasured;
 
 /**
  * Optimize XML files.
@@ -141,7 +143,13 @@ public final class OptimizeMojo extends SafeMojo {
         final Optimization opt;
         if (this.trackOptimizationSteps) {
             opt = new OptSpy(
-                new ParsingTrain(),
+                new TrLambda(
+                    new ParsingTrain(),
+                    shift -> new StMeasured(
+                        shift,
+                        this.targetDir.toPath().resolve("xsl-measures.csv")
+                    )
+                ),
                 this.targetDir.toPath().resolve(OptimizeMojo.STEPS)
             );
         } else {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TranspileMojo.java
@@ -31,6 +31,7 @@ import com.yegor256.xsline.StClasspath;
 import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.TrJoined;
+import com.yegor256.xsline.TrLambda;
 import com.yegor256.xsline.Train;
 import java.io.File;
 import java.io.IOException;
@@ -63,6 +64,7 @@ import org.eolang.maven.optimization.Optimization;
 import org.eolang.maven.tojos.AttributeNotFoundException;
 import org.eolang.maven.tojos.ForeignTojo;
 import org.eolang.maven.tojos.TojoHash;
+import org.eolang.parser.StMeasured;
 
 /**
  * Transpile.
@@ -233,7 +235,13 @@ public final class TranspileMojo extends SafeMojo {
      */
     private Optimization transpilation() {
         return new OptSpy(
-            TranspileMojo.TRAIN,
+            new TrLambda(
+                TranspileMojo.TRAIN,
+                shift -> new StMeasured(
+                    shift,
+                    this.targetDir.toPath().resolve("xsl-measures.csv")
+                )
+            ),
             this.targetDir.toPath().resolve(TranspileMojo.PRE)
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/StMeasured.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StMeasured.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Shift that measures and saves stats into a file.
+ *
+ * @since 0.30
+ */
+public final class StMeasured implements Shift {
+
+    /**
+     * Origin shift.
+     */
+    private final Shift origin;
+
+    /**
+     * Log file.
+     */
+    private final Path path;
+
+    /**
+     * Ctor.
+     * @param shift Origin shift
+     * @param log Log file
+     */
+    public StMeasured(final Shift shift, final Path log) {
+        this.origin = shift;
+        this.path = log;
+    }
+
+    @Override
+    public String uid() {
+        return this.origin.uid();
+    }
+
+    @Override
+    @SuppressWarnings("PMD.PrematureDeclaration")
+    public XML apply(final int position, final XML xml) {
+        final long start = System.currentTimeMillis();
+        final XML out = this.origin.apply(position, xml);
+        try {
+            Files.write(
+                this.path,
+                String.format(
+                    "%s,%d\n",
+                    this.origin.uid(),
+                    System.currentTimeMillis() - start
+                ).getBytes(),
+                StandardOpenOption.APPEND,
+                StandardOpenOption.CREATE
+            );
+        } catch (final IOException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces benchmarking functionality to the `eo-maven-plugin`, adds a new `StMeasured` class for performance measurement, and updates the GitHub Actions workflow to automate benchmarking results collection and reporting.

### Detailed summary
- Added `## Benchmark` section in `README.md`.
- Introduced `StMeasured` class in `eo-parser/src/main/java/org/eolang/parser/` for measuring performance.
- Updated `OptimizeMojo.java` and `TranspileMojo.java` to use `TrLambda` with `StMeasured`.
- Created a new GitHub Actions workflow in `.github/workflows/benchmark.yml` for automated benchmarking.
- Adjusted `README.md` to include links to benchmark results.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->