### PR TITLE
less references to `\rho`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/i16.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i16.eo
@@ -45,24 +45,24 @@
 
   # Returns `true` if `$` < `x`.
   # Here `x` must be an `i16` object.
-  ^.as-i32.lt x.as-i16.as-i32 > [x] > lt
+  as-i32.lt x.as-i16.as-i32 > [x] > lt
 
   # Returns `true` if `$` <= `x`.
   # Here `x` must be an `i16` object.
-  ^.as-i32.lte x.as-i16.as-i32 > [x] > lte
+  as-i32.lte x.as-i16.as-i32 > [x] > lte
 
   # Returns `true` if `$` > `x`.
   # Here `x` must be an `i16` object.
-  ^.as-i32.gt x.as-i16.as-i32 > [x] > gt
+  as-i32.gt x.as-i16.as-i32 > [x] > gt
 
   # Returns `true` if `$` >= `x`.
   # Here `x` must be an `i16` object.
-  ^.as-i32.gte x.as-i16.as-i32 > [x] > gte
+  as-i32.gte x.as-i16.as-i32 > [x] > gte
 
   # Multiplication of `$` and `x`.
   # Here `x` must be an `i16` object.
   [x] > times
-    (^.as-i32.times x.as-i16.as-i32).as-bytes > bts
+    (as-i32.times x.as-i16.as-i32).as-bytes > bts
     bts.slice 0 2 > left
     bts.slice 2 2 > right
     if. > @
@@ -77,7 +77,7 @@
   # Sum of `$` and `x`.
   # Here `x` must be an `i16` object.
   [x] > plus
-    (^.as-i32.plus x.as-i16.as-i32).as-bytes > bts
+    (as-i32.plus x.as-i16.as-i32).as-bytes > bts
     bts.slice 0 2 > left
     bts.slice 2 2 > right
     if. > @
@@ -91,14 +91,14 @@
 
   # Subtraction between `$` and `x`.
   # Here `x` must be an `i16` object.
-  ^.plus x.as-i16.neg > [x] > minus
+  plus x.as-i16.neg > [x] > minus
 
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `i16` object.
   # An `error` is returned if or `x` is equal to 0.
   [x] > div
     x.as-i16 > x-as-i16
-    (^.as-i32.div x-as-i16.as-i32).as-bytes > bts
+    (as-i32.div x-as-i16.as-i32).as-bytes > bts
     bts.slice 0 2 > left
     bts.slice 2 2 > right
     00-00 > zero
@@ -107,7 +107,7 @@
       error
         sprintf
           "Can't divide %d by i16 zero"
-          * ^.as-i32.as-i64.as-number
+          * as-i32.as-i64.as-number
       if.
         or.
           left.eq zero

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -41,7 +41,7 @@
 
   # Obtain the length of the tuple.
   [] > length
-    ^.head.length.plus 1 > len!
+    head.length.plus 1 > len!
     number len > @
 
   # Take one element from the tuple, at the given position.
@@ -61,7 +61,7 @@
 
     [tup len] > at-fast
       if. > @
-        (len.plus -1).gt ^.index
+        (len.plus -1).gt index
         ^.at-fast
           tup.head
           len.plus -1

--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -62,9 +62,9 @@
   # Attention! The object is for internal usage only. Please don't use
   # the object programmatically outside of `while` object.
   [index] > loop
-    ^.body index > current
+    body index > current
     if. > @
-      (^.condition (index.plus 1)).as-bool
+      (condition (index.plus 1)).as-bool
       seq
         *
           current


### PR DESCRIPTION
see #3481

removed a bit of redundant `^.`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the use of the `^` operator in various `eo` files, which indicates accessing the parent scope. The changes streamline code by directly referencing the properties and methods without the need for the parent context.

### Detailed summary
- In `while.eo`, removed `^` from `body` and `condition` references.
- In `tuple.eo`, removed `^` from `head.length` and `index` comparisons.
- In `i16.eo`, removed `^` from multiple comparisons and arithmetic operations (`lt`, `lte`, `gt`, `gte`, `times`, `plus`, `minus`, `div`).
- Adjusted error handling message to remove `^` in the error message formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->