### PR TITLE
`text.split` returns tuple of strings

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -383,9 +383,10 @@
       if. > @
         ^.len.eq current
         accum.with > with-substr
-          ^.self-as-bytes.slice
-            start
-            current.minus start
+          string
+            ^.self-as-bytes.slice
+              start
+              current.minus start
         if.
           eq.
             ^.delim

--- a/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
@@ -286,6 +286,17 @@
     (text "hello").up-cased
 
 # Test.
+[] > splits-and-returns-strings
+  eq. > @
+    length.
+      at.
+        split.
+          text "hello world!"
+          " "
+        1
+    6
+
+# Test.
 [] > converts-text-with-upper-letters-to-upper-case
   eq. > @
     "HELLO"


### PR DESCRIPTION
#3508 bug fix

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces modifications to the `text.eo` file to enhance string manipulation, particularly focusing on substring extraction. Additionally, it adds new tests in `text-tests.eo` to verify the functionality of string splitting and uppercasing.

### Detailed summary
- In `text.eo`:
  - Changed the method of substring extraction by introducing `string` and modifying the slice and subtraction logic.
- In `text-tests.eo`:
  - Added tests for splitting strings and checking upper-case conversions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->