### PR TITLE
feat(#3536): comments separated by newlines in parsed XMIR

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -31,7 +31,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1300,7 +1300,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
             this.dirs.push().xpath("/program").addIf("comments").add("comment").set(
                 comment.stream().map(
                     context -> context.COMMENTARY().getText().substring(1).trim()
-                ).collect(Collectors.joining("\n"))
+                ).collect(Collectors.joining("\\n"))
             ).attr("line", stop.getLine() + 1).pop();
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1300,9 +1300,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
             this.dirs.push().xpath("/program").addIf("comments").add("comment").set(
                 comment.stream().map(
                     context -> context.COMMENTARY().getText().substring(1).trim()
-                ).map(
-                    text -> String.format("%s\\n", text)
-                ).collect(Collectors.joining(""))
+                ).collect(Collectors.joining("\n"))
             ).attr("line", stop.getLine() + 1).pop();
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -1298,12 +1299,11 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     private void putComment(final List<EoParser.CommentContext> comment, final Token stop) {
         if (!comment.isEmpty()) {
             this.dirs.push().xpath("/program").addIf("comments").add("comment").set(
-                String.join(
-                    "",
-                    comment.stream().map(
-                        context -> context.COMMENTARY().getText().substring(1).trim()
-                    ).collect(Collectors.joining(""))
-                )
+                comment.stream().map(
+                    context -> context.COMMENTARY().getText().substring(1).trim()
+                ).map(
+                    text -> String.format("%s\\n", text)
+                ).collect(Collectors.joining(""))
             ).attr("line", stop.getLine() + 1).pop();
         }
     }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -35,7 +35,6 @@ import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -288,7 +287,7 @@ final class EoSyntaxTest {
                 xml, comments, expected
             ),
             comments,
-            new IsEqual<>(expected)
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -282,7 +282,7 @@ final class EoSyntaxTest {
             )
         ).parsed();
         final String comments = xml.xpath("/program/comments/comment/text()").get(0);
-        final String expected = "Foo.\nBar.\nXyz.";
+        final String expected = "Foo.\\nBar.\\nXyz.";
         MatcherAssert.assertThat(
             String.format(
                 "EO parsed: %s, but comments: '%s' don't match with expected: '%s'",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -268,7 +268,6 @@ final class EoSyntaxTest {
     }
 
     @Test
-    @Disabled
     void printsSyntaxWithComments() throws IOException {
         final XML xml = new EoSyntax(
             new InputOf(

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -35,6 +35,7 @@ import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -263,6 +264,31 @@ final class EoSyntaxTest {
             xml.toString(),
             Integer.parseInt(xml.xpath("/program/errors/error[1]/@line").get(0)),
             Matchers.equalTo(Integer.parseInt(map.get("line").toString()))
+        );
+    }
+
+    @Test
+    void printsSyntaxWithComments() throws IOException {
+        final XML xml = new EoSyntax(
+            new InputOf(
+                String.join(
+                    "\n",
+                    "# Foo.",
+                    "# Bar.",
+                    "# Xyz.",
+                    "[] > foo"
+                )
+            )
+        ).parsed();
+        final String comments = xml.xpath("/program/comments/comment/text()").get(0);
+        final String expected = "Foo.\\nBar.\\nXyz.\\n";
+        MatcherAssert.assertThat(
+            String.format(
+                "EO parsed: %s, but comments: '%s' don't match with expected: '%s'",
+                xml, comments, expected
+            ),
+            comments,
+            new IsEqual<>(expected)
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -37,6 +37,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -267,6 +268,7 @@ final class EoSyntaxTest {
     }
 
     @Test
+    @Disabled
     void printsSyntaxWithComments() throws IOException {
         final XML xml = new EoSyntax(
             new InputOf(
@@ -280,7 +282,7 @@ final class EoSyntaxTest {
             )
         ).parsed();
         final String comments = xml.xpath("/program/comments/comment/text()").get(0);
-        final String expected = "Foo.\\nBar.\\nXyz.\\n";
+        final String expected = "Foo.\nBar.\nXyz.";
         MatcherAssert.assertThat(
             String.format(
                 "EO parsed: %s, but comments: '%s' don't match with expected: '%s'",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -37,7 +37,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
In this pull I've updated EO comments parsing logic by adding separation of the each comment by newline (`\n`) in XMIR.

closes #3536
History:
- **feat(#3536): test case**
- **feat(#3536): static**
- **feat(#3536): \n**
- **feat(#3536): clean for qulice**
