### PR TITLE
bug(#3686): introduced `malloc.copy`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -118,6 +118,14 @@
       # The `error` returned if failed to resize block in memory.
       [new-size] > resized /org.eolang.malloc.of.allocated
 
+      # Reads the data from block in memory with with offset `source` and `length` and writes
+      # to the block with offset `target`.
+      # Returns `true` on success, or `error` on failure.
+      [source target length] > copy
+        ^.write > @
+          target
+          ^.read source length
+
       # Read `length` bytes with `offset` from the allocated block in memory.
       [offset length] > read /org.eolang.bytes
 

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -276,6 +276,15 @@
         m.get.eq 01-02-02-03-05
 
 # This unit test is supposed to check the functionality of the corresponding object.
+[] > copies-data-from-start-to-end
+  malloc.for > @
+    01-02-03-04-05-06
+    [m]
+      and. > @
+        m.copy 0 3 3
+        m.get.eq 01-02-03-01-02-03
+
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > throws-on-copying-with-wrong-source
   malloc.for > @
     0

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -265,3 +265,30 @@
 [] > malloc-empty-is-empty
   malloc.empty > @
     m.size.eq 0 > [m]
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > copies-data-inside-itself
+  malloc.for > @
+    01-02-03-04-05
+    [m]
+      and. > @
+        m.copy 1 2 2
+        m.get.eq 01-02-02-03-05
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-copying-with-wrong-source
+  malloc.for > @
+    0
+    m.copy 9 1 1 > [m]
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-copying-with-wrong-target
+  malloc.for > @
+    0
+    m.copy 3 9 1 > [m]
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-copying-with-wrong-length
+  malloc.for > @
+    0
+    m.copy 3 1 9 > [m]


### PR DESCRIPTION
Closes: #3686 