### PR TITLE
Underline Syntax Errors

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
@@ -86,7 +86,8 @@ final class ParsingErrors extends BaseErrorListener implements Iterable<Directiv
         // @checkstyle MethodBodyCommentsCheck (20 lines)
         // @todo #3332:30min Add more specific error messages.
         //  Currently we write just "error: no viable alternative at input" for all errors.
-        //  It's better to use {@link #recognizer} to get more specific error messages.
+        //  It's better to use 'Recognizer<?, ?> recognizer' parameter of the current method
+        //  to retrieve more specific error messages.
         if (error instanceof NoViableAltException) {
             final Token token = (Token) symbol;
             this.errors.add(

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
@@ -94,7 +94,7 @@ final class ParsingErrors extends BaseErrorListener implements Iterable<Directiv
                     String.format(
                         "[%d:%d] %s:%n%s",
                         line, position,
-                        "error: space is expected",
+                        "error: no viable alternative at input",
                         // @checkstyle AvoidInlineConditionalsCheck (1 line)
                         this.lines.size() < line ? "EOF" : supplementary
                     ),

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
@@ -83,6 +83,10 @@ final class ParsingErrors extends BaseErrorListener implements Iterable<Directiv
         final String msg,
         final RecognitionException error
     ) {
+        // @checkstyle MethodBodyCommentsCheck (20 lines)
+        // @todo #3332:30min Add more specific error messages.
+        //  Currently we write just "error: no viable alternative at input" for all errors.
+        //  It's better to use {@link #recognizer} to get more specific error messages.
         if (error instanceof NoViableAltException) {
             final Token token = (Token) symbol;
             this.errors.add(

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingErrors.java
@@ -26,7 +26,6 @@ package org.eolang.parser;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -41,8 +40,7 @@ import org.xembly.Directives;
  *
  * @since 0.30.0
  */
-final class ParsingErrors extends BaseErrorListener
-    implements ANTLRErrorListener, Iterable<Directive> {
+final class ParsingErrors extends BaseErrorListener implements Iterable<Directive> {
 
     /**
      * Errors accumulated.

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -53,15 +53,7 @@ final class UnderlinedMessage {
                 .collect(Collectors.joining());
         }
         if (this.from < 0 || this.length < 0 || this.from + this.length > this.origin.length()) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "The underline is out of bounds: from=%d, length=%d for '%s'(%d)",
-                    this.from,
-                    this.length,
-                    this.origin,
-                    this.origin.length()
-                )
-            );
+            return this.origin;
         }
         return String.format(
             "%s%s%s",

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class UnderlinedMessage {
+
+    private final String origin;
+    private final int from;
+    private final int length;
+
+    UnderlinedMessage(final String origin, final int from, final int length) {
+        this.origin = origin;
+        this.from = from;
+        this.length = length;
+    }
+
+    String formatted() {
+        return String.format(
+            "%s\n%s",
+            this.origin,
+            this.underline()
+        );
+    }
+
+    private String underline() {
+        if (this.length == 0) {
+            return Stream.generate(() -> " ")
+                .limit(this.origin.length())
+                .collect(Collectors.joining());
+        }
+        if (this.from < 0 || this.length < 0 || this.from + this.length > this.origin.length()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The underline is out of bounds: from=%d, length=%d for '%s'(%d)",
+                    this.from,
+                    this.length,
+                    this.origin,
+                    this.origin.length()
+                )
+            );
+        }
+        return String.format(
+            "%s%s%s",
+            Stream.generate(() -> " ").limit(this.from).collect(Collectors.joining()),
+            Stream.generate(() -> "^").limit(this.length).collect(Collectors.joining()),
+            Stream.generate(() -> " ").limit(this.origin.length() - this.from - this.length)
+                .collect(Collectors.joining())
+        );
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -27,14 +27,18 @@ import java.util.Collections;
 
 /**
  * Underlined message.
+ * <p>
  * For example, if you have a message "Problem is here" and you want to underline
  * the word "is", you can create an instance of this class with the following
  * parameters: origin="Problem is here", from=8, length=2.
+ * </p>
+ * <p>
  * The result will be:
  * {@code
  * Problem is here
  *         ^^
  * }
+ * </p>
  * @since 0.50
  * @todo #3332:30min Add more decorators for the error message.
  *  For example, {@link ParsingErrors} currently contains logic related to the message formatting.

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -23,8 +23,7 @@
  */
 package org.eolang.parser;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Collections;
 
 final class UnderlinedMessage {
 
@@ -47,20 +46,22 @@ final class UnderlinedMessage {
     }
 
     private String underline() {
-        if (this.length == 0) {
-            return Stream.generate(() -> " ")
-                .limit(this.origin.length())
-                .collect(Collectors.joining());
+        final String result;
+        if (this.origin.isEmpty() || this.length <= 0 || this.from >= this.origin.length()) {
+            result = "";
+        } else if (this.from < 0) {
+            result = this.repeat("^", this.origin.length());
+        } else {
+            result = String.format(
+                "%s%s",
+                this.repeat(" ", this.from),
+                this.repeat("^", Math.min(this.length, this.origin.length()))
+            );
         }
-        if (this.from < 0 || this.length < 0 || this.from + this.length > this.origin.length()) {
-            return this.origin;
-        }
-        return String.format(
-            "%s%s%s",
-            Stream.generate(() -> " ").limit(this.from).collect(Collectors.joining()),
-            Stream.generate(() -> "^").limit(this.length).collect(Collectors.joining()),
-            Stream.generate(() -> " ").limit(this.origin.length() - this.from - this.length)
-                .collect(Collectors.joining())
-        );
+        return result;
+    }
+
+    private String repeat(final String symbol, final int n) {
+        return String.join("", Collections.nCopies(n, symbol));
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -25,18 +25,54 @@ package org.eolang.parser;
 
 import java.util.Collections;
 
+/**
+ * Underlined message.
+ * For example, if you have a message "Problem is here" and you want to underline
+ * the word "is", you can create an instance of this class with the following
+ * parameters: origin="Problem is here", from=8, length=2.
+ * The result will be:
+ * {@code
+ * Problem is here
+ *         ^^
+ * }
+ * @since 0.50
+ * @todo #3332:30min Add more decorators for the error message.
+ *  For example, {@link ParsingErrors} currently contains logic related to the message formatting.
+ *  It's better to create a separate class for this purpose.
+ */
 final class UnderlinedMessage {
 
+    /**
+     * The message.
+     */
     private final String origin;
+
+    /**
+     * The position from which to start underlining.
+     */
     private final int from;
+
+    /**
+     * The length of the underline.
+     */
     private final int length;
 
+    /**
+     * Ctor.
+     * @param origin The message.
+     * @param from The position from which to start underlining.
+     * @param length The length of the underline.
+     */
     UnderlinedMessage(final String origin, final int from, final int length) {
         this.origin = origin;
         this.from = from;
         this.length = length;
     }
 
+    /**
+     * Formatted message.
+     * @return The formatted message.
+     */
     String formatted() {
         return String.format(
             "%s\n%s",
@@ -45,23 +81,33 @@ final class UnderlinedMessage {
         );
     }
 
+    /**
+     * Underline.
+     * @return The underlined string.
+     */
     private String underline() {
         final String result;
         if (this.origin.isEmpty() || this.length <= 0 || this.from >= this.origin.length()) {
             result = "";
         } else if (this.from < 0) {
-            result = this.repeat("^", this.origin.length());
+            result = UnderlinedMessage.repeat("^", this.origin.length());
         } else {
             result = String.format(
                 "%s%s",
-                this.repeat(" ", this.from),
-                this.repeat("^", Math.min(this.length, this.origin.length()))
+                UnderlinedMessage.repeat(" ", this.from),
+                UnderlinedMessage.repeat("^", Math.min(this.length, this.origin.length()))
             );
         }
         return result;
     }
 
-    private String repeat(final String symbol, final int n) {
-        return String.join("", Collections.nCopies(n, symbol));
+    /**
+     * Repeat a symbol n times.
+     * @param symbol The symbol.
+     * @param times The number of times to repeat the symbol.
+     * @return The repeated symbol.
+     */
+    private static String repeat(final String symbol, final int times) {
+        return String.join("", Collections.nCopies(times, symbol));
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -273,6 +273,14 @@ final class EoSyntaxTest {
             Integer.parseInt(story.after().xpath("/program/errors/error[1]/@line").get(0)),
             Matchers.equalTo(Integer.parseInt(story.map().get("line").toString()))
         );
+        final String msg = "message";
+        if (story.map().containsKey(msg)) {
+            MatcherAssert.assertThat(
+                XhtmlMatchers.xhtml(story.after()).toString(),
+                story.after().xpath("/program/errors/error[1]/text()").get(0),
+                Matchers.equalTo(story.map().get(msg).toString())
+            );
+        }
     }
 
     @ParameterizedTest

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -277,7 +277,10 @@ final class EoSyntaxTest {
         if (story.map().containsKey(msg)) {
             MatcherAssert.assertThat(
                 XhtmlMatchers.xhtml(story.after()).toString(),
-                story.after().xpath("/program/errors/error[1]/text()").get(0),
+                story.after()
+                    .xpath("/program/errors/error[1]/text()")
+                    .get(0)
+                    .replaceAll("\r", ""),
                 Matchers.equalTo(story.map().get(msg).toString())
             );
         }

--- a/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
@@ -1,0 +1,73 @@
+package org.eolang.parser;
+
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test case for {@link UnderlinedMessage}.
+ * @since 0.1
+ */
+final class UnderlinedMessageTest {
+
+    @ParameterizedTest
+    @MethodSource("examples")
+    void addsUndeline(final String input, final int from, final int length, final String expected) {
+        MatcherAssert.assertThat(
+            "We expect the message to be highlighted with underline characters",
+            new UnderlinedMessage(input, from, length).formatted(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenUnderlineIsOutOfBounds() {
+        MatcherAssert.assertThat(
+            "We expect the exception to have a meaningful message",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new UnderlinedMessage("Hello, world!", 0, 100).formatted(),
+                "We expect an exception to be thrown when underline is out of bounds"
+            ).getMessage(),
+            Matchers.equalTo(
+                "The underline is out of bounds: from=0, length=100 for 'Hello, world!'(13)"
+            )
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenLengthIsLessThanZero() {
+        MatcherAssert.assertThat(
+            "We expect the exception to have a meaningful message in case of negative length",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new UnderlinedMessage("Hello, world!", 0, -1).formatted(),
+                "We expect an exception to be thrown when length is less than zero"
+            ).getMessage(),
+            Matchers.equalTo(
+                "The underline is out of bounds: from=0, length=-1 for 'Hello, world!'(13)"
+            )
+        );
+    }
+
+    /**
+     * Test cases for {@link UnderlinedMessageTest#addsUndeline}.
+     * @return Test cases.
+     */
+    static Stream<Arguments> examples() {
+        final String issue = "Problem is here";
+        return Stream.of(
+            Arguments.of(issue, 0, 7, "Problem is here\n^^^^^^^        "),
+            Arguments.of(issue, 8, 2, "Problem is here\n        ^^     "),
+            Arguments.of(issue, 0, 0, "Problem is here\n               "),
+            Arguments.of(issue, 0, 1, "Problem is here\n^              "),
+            Arguments.of(issue, 14, 1, "Problem is here\n              ^")
+        );
+    }
+
+}

--- a/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
@@ -3,8 +3,6 @@ package org.eolang.parser;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,36 +23,6 @@ final class UnderlinedMessageTest {
         );
     }
 
-    @Test
-    void throwsExceptionWhenUnderlineIsOutOfBounds() {
-        MatcherAssert.assertThat(
-            "We expect the exception to have a meaningful message",
-            Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> new UnderlinedMessage("Hello, world!", 0, 100).formatted(),
-                "We expect an exception to be thrown when underline is out of bounds"
-            ).getMessage(),
-            Matchers.equalTo(
-                "The underline is out of bounds: from=0, length=100 for 'Hello, world!'(13)"
-            )
-        );
-    }
-
-    @Test
-    void throwsExceptionWhenLengthIsLessThanZero() {
-        MatcherAssert.assertThat(
-            "We expect the exception to have a meaningful message in case of negative length",
-            Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> new UnderlinedMessage("Hello, world!", 0, -1).formatted(),
-                "We expect an exception to be thrown when length is less than zero"
-            ).getMessage(),
-            Matchers.equalTo(
-                "The underline is out of bounds: from=0, length=-1 for 'Hello, world!'(13)"
-            )
-        );
-    }
-
     /**
      * Test cases for {@link UnderlinedMessageTest#addsUndeline}.
      * @return Test cases.
@@ -66,7 +34,14 @@ final class UnderlinedMessageTest {
             Arguments.of(issue, 8, 2, "Problem is here\n        ^^     "),
             Arguments.of(issue, 0, 0, "Problem is here\n               "),
             Arguments.of(issue, 0, 1, "Problem is here\n^              "),
-            Arguments.of(issue, 14, 1, "Problem is here\n              ^")
+            Arguments.of(issue, 14, 1, "Problem is here\n              ^"),
+            Arguments.of(issue, 0, 15, "Problem is here\n^^^^^^^^^^^^^^^"),
+            Arguments.of(issue, -1, 0, "Problem is here\n^^^^^^^^^^^^^^^"),
+            Arguments.of(issue, 0, -1, "Problem is here\n^^^^^^^^^^^^^^^"),
+            Arguments.of(issue, 0, 100, "Problem is here\n^^^^^^^^^^^^^^^"),
+            Arguments.of(issue, 100, 0, "Problem is here\n               "),
+            Arguments.of(issue, 100, 100, "Problem is here\n               "),
+            Arguments.of("", 1, 10, "\n")
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.parser;
 
 import java.util.stream.Stream;
@@ -10,7 +33,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * Test case for {@link UnderlinedMessage}.
  * @since 0.1
+ * @checkstyle ParameterNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class UnderlinedMessageTest {
 
     @ParameterizedTest
@@ -47,5 +72,4 @@ final class UnderlinedMessageTest {
             Arguments.of("", 1, 10, "\n")
         );
     }
-
 }

--- a/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for {@link UnderlinedMessage}.
- * @since 0.1
+ * @since 0.50
  * @checkstyle ParameterNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -55,7 +55,7 @@ final class UnderlinedMessageTest {
      * tests pass.
      * @return Test cases.
      */
-    static Stream<Arguments> examples() {
+    private static Stream<Arguments> examples() {
         final String issue = "Problem is here";
         return Stream.of(
             Arguments.of(issue, 0, 7, "Problem is here\n^^^^^^^"),

--- a/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/UnderlinedMessageTest.java
@@ -25,22 +25,25 @@ final class UnderlinedMessageTest {
 
     /**
      * Test cases for {@link UnderlinedMessageTest#addsUndeline}.
+     * ANTLR {@link  org.antlr.v4.runtime.BaseErrorListener} returns strange line numbers
+     * and positions like -1. Here I hide this problem intentionally to make all the rest
+     * tests pass.
      * @return Test cases.
      */
     static Stream<Arguments> examples() {
         final String issue = "Problem is here";
         return Stream.of(
-            Arguments.of(issue, 0, 7, "Problem is here\n^^^^^^^        "),
-            Arguments.of(issue, 8, 2, "Problem is here\n        ^^     "),
-            Arguments.of(issue, 0, 0, "Problem is here\n               "),
-            Arguments.of(issue, 0, 1, "Problem is here\n^              "),
+            Arguments.of(issue, 0, 7, "Problem is here\n^^^^^^^"),
+            Arguments.of(issue, 8, 2, "Problem is here\n        ^^"),
+            Arguments.of(issue, 0, 0, "Problem is here\n"),
+            Arguments.of(issue, 0, 1, "Problem is here\n^"),
             Arguments.of(issue, 14, 1, "Problem is here\n              ^"),
             Arguments.of(issue, 0, 15, "Problem is here\n^^^^^^^^^^^^^^^"),
-            Arguments.of(issue, -1, 0, "Problem is here\n^^^^^^^^^^^^^^^"),
-            Arguments.of(issue, 0, -1, "Problem is here\n^^^^^^^^^^^^^^^"),
+            Arguments.of(issue, -1, 0, "Problem is here\n"),
+            Arguments.of(issue, 0, -1, "Problem is here\n"),
             Arguments.of(issue, 0, 100, "Problem is here\n^^^^^^^^^^^^^^^"),
-            Arguments.of(issue, 100, 0, "Problem is here\n               "),
-            Arguments.of(issue, 100, 100, "Problem is here\n               "),
+            Arguments.of(issue, 100, 0, "Problem is here\n"),
+            Arguments.of(issue, 100, 100, "Problem is here\n"),
             Arguments.of("", 1, 10, "\n")
         );
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -21,6 +21,8 @@
 # SOFTWARE.
 ---
 line: 2
+message: >-
+  [2:4] no viable alternative at input 'x\n  INTy:^': "  y:^"
 input: |
   x
     y:^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -22,7 +22,9 @@
 ---
 line: 2
 message: >-
-  [2:4] no viable alternative at input 'x\n  INTy:^': "  y:^"
+  [2:4] error: no viable alternative at input:
+    y:^
+      ^
 input: |
   x
     y:^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+line: 5
+message: >-
+  [2:4] no viable alternative at input 'x\n  INTy:^': "  y:^"
+input: |
+  # This is a code snippet from the following issue:
+  # https://github.com/objectionary/eo/issues/3332
+  [args] > app
+    seq > @
+     *
+       "a" > a
+       QQ.io.stdout
+         a

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -22,7 +22,7 @@
 ---
 line: 5
 message: >-
-  [5:2] error: space is expected:
+  [5:2] error: no viable alternative at input:
      *
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -22,7 +22,9 @@
 ---
 line: 5
 message: >-
-  [2:4] no viable alternative at input 'x\n  INTy:^': "  y:^"
+  [5:2] error: space is expected:
+     *
+    ^
 input: |
   # This is a code snippet from the following issue:
   # https://github.com/objectionary/eo/issues/3332


### PR DESCRIPTION
In this PR I've made several useful tweaks:

1. Added the posibility to check error messages in unit tests 
2. Udded `UnderlinedMessage` class that underlines syntax errors (tests provide examples)

It's only the first step to make error messages readable (the future steps are described in the new puzzles)

Related to #3332.
