### PR TITLE
feat(#3706): Found the Bug Related to Token Names

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -24,6 +24,7 @@
 package org.eolang.parser;
 
 import java.io.IOException;
+import java.util.List;
 import org.antlr.v4.runtime.Token;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
@@ -46,6 +47,24 @@ public final class EoIndentLexerTest {
      *  no longer need.
      */
     public static final String TO_ADD_MESSAGE = "TO ADD ASSERTION MESSAGE";
+
+    @Test
+    void emitsTabWithCorrectName() throws IOException {
+        MatcherAssert.assertThat(
+            "We expect the token to be a tab indentation with name 'TAB'",
+            new EoIndentLexer(new TextOf("\n  ")).getAllTokens().get(1).getText(),
+            Matchers.equalTo("TAB")
+        );
+    }
+
+    @Test
+    void emitsUntabWithCorrectName() throws IOException {
+        MatcherAssert.assertThat(
+            "We expect the token to be an untab indentation with name 'UNTAB'",
+            new EoIndentLexer(new TextOf("\n  \n  \n")).getAllTokens().get(3).getText(),
+            Matchers.is("UNTAB")
+        );
+    }
 
     @Test
     void emitsTab() throws IOException {

--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -24,6 +24,7 @@
 package org.eolang.parser;
 
 import java.io.IOException;
+import org.antlr.v4.runtime.Token;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -48,76 +49,54 @@ public final class EoIndentLexerTest {
 
     @Test
     void emitsTab() throws IOException {
-        final EoIndentLexer lexer = new EoIndentLexer(
-            new TextOf("\n  ")
-        );
+        final EoIndentLexer lexer = new EoIndentLexer(new TextOf("\n  "));
         lexer.nextToken();
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "We expect the first token to be a new line, whereas the next token is tab indentation",
             lexer.nextToken().getType(),
-            Matchers.is(
-                EoParser.TAB
-            )
+            Matchers.is(EoParser.TAB)
         );
     }
 
     @Test
     void ensuresGrammarFile() throws IOException {
-        final EoIndentLexer lexer = new EoIndentLexer(
-            new TextOf("")
-        );
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
-            lexer.getGrammarFileName(),
-            Matchers.is(
-                "Eo.g4"
-            )
+            "We expect to retrieve the correct grammar file name",
+            new EoIndentLexer(new TextOf("")).getGrammarFileName(),
+            Matchers.is("Eo.g4")
         );
     }
 
     @Test
     void emitsTabWhenEmptyLine() throws IOException {
-        final EoIndentLexer lexer = new EoIndentLexer(
-            new TextOf("\n\n  ")
-        );
+        final EoIndentLexer lexer = new EoIndentLexer(new TextOf("\n\n  "));
         lexer.nextToken();
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "We expect tab indentation to be emitted right after the first new line symbol",
             lexer.nextToken().getType(),
-            Matchers.is(
-                EoParser.TAB
-            )
+            Matchers.is(EoParser.TAB)
         );
     }
 
     @Test
     void emitsUntab() throws IOException {
-        final EoIndentLexer lexer = new EoIndentLexer(
-            new TextOf("\n  \n  \n")
-        );
+        final EoIndentLexer lexer = new EoIndentLexer(new TextOf("\n  \n  \n"));
         lexer.nextToken();
         lexer.nextToken();
         lexer.nextToken();
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "We expect untab indentation token to be emitted after the second new line symbol",
             lexer.nextToken().getType(),
-            Matchers.is(
-                EoParser.UNTAB
-            )
+            Matchers.is(EoParser.UNTAB)
         );
     }
 
     @Test
     void readsEmptyString() throws IOException {
-        final EoIndentLexer lexer = new EoIndentLexer(
-            new TextOf("")
-        );
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
-            lexer.nextToken().getType(),
-            Matchers.is(
-                EoParser.EOF
-            )
+            "We expect the lexer to return EOF token when the input is empty",
+            new EoIndentLexer(new TextOf("")).nextToken().getType(),
+            Matchers.is(EoParser.EOF)
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -24,8 +24,6 @@
 package org.eolang.parser;
 
 import java.io.IOException;
-import java.util.List;
-import org.antlr.v4.runtime.Token;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -29,6 +29,7 @@ import org.antlr.v4.runtime.Token;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -48,7 +49,17 @@ public final class EoIndentLexerTest {
      */
     public static final String TO_ADD_MESSAGE = "TO ADD ASSERTION MESSAGE";
 
+    /**
+     * Tests if the lexer emits a tab token with the correct name.
+     * @throws IOException In case if the input is invalid.
+     * @todo #3706:30min Fix the the name of the TAB token.
+     *  Currently {@link EoIndentLexer} emits TAB token with the name 'ZERO' instead of 'TAB'.
+     *  Fix the lexer to emit TAB token with the correct name.
+     *  This problem affects lexer error messages.
+     *  When this issue is fixed, remove the @Disabled annotation from the test.
+     */
     @Test
+    @Disabled
     void emitsTabWithCorrectName() throws IOException {
         MatcherAssert.assertThat(
             "We expect the token to be a tab indentation with name 'TAB'",
@@ -57,12 +68,22 @@ public final class EoIndentLexerTest {
         );
     }
 
+    /**
+     * Tests if the lexer emits an untab token with the correct name.
+     * @throws IOException In case if the input is invalid.
+     * @todo #3706:30min Fix the the name of the UNTAB token.
+     *  Currently {@link EoIndentLexer} emits UNTAB token with the name 'INT' instead of 'UNTAB'.
+     *  Fix the lexer to emit UNTAB token with the correct name.
+     *  This problem affects lexer error messages.
+     *  When this issue is fixed, remove the @Disabled annotation from the test.
+     */
     @Test
+    @Disabled
     void emitsUntabWithCorrectName() throws IOException {
         MatcherAssert.assertThat(
             "We expect the token to be an untab indentation with name 'UNTAB'",
             new EoIndentLexer(new TextOf("\n  \n  \n")).getAllTokens().get(3).getText(),
-            Matchers.is("UNTAB")
+            Matchers.equalTo("UNTAB")
         );
     }
 


### PR DESCRIPTION
In this PR I:

1. Added human-readable messages to all the tests inside `EoIndentLexerTest`.
2. Added two more disabled tests that show the problem with icorrect naming of `TAB/UNTAB` tokens.

Related to #3706.
