### PR TITLE
may have fixed the race

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -61,23 +61,17 @@ final class AtRho implements Attr {
 
     @Override
     public Phi get() {
-        if (this.rho.get() == null) {
+        final Phi phi = this.rho.get();
+        if (phi == null) {
             throw new ExUnset(
                 String.format("The \"%s\" attribute is not set", Attr.RHO)
             );
         }
-        return this.rho.get();
+        return phi;
     }
 
     @Override
     public boolean put(final Phi phi) {
-        final boolean ret;
-        if (this.rho.get() == null) {
-            this.rho.set(phi);
-            ret = true;
-        } else {
-            ret = false;
-        }
-        return ret;
+        return this.rho.compareAndSet(null, phi);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -72,6 +72,6 @@ final class AtRho implements Attr {
 
     @Override
     public boolean put(final Phi phi) {
-        return this.rho.compareAndSet(null, phi);
+        return this.rho.get() == null && this.rho.compareAndSet(null, phi);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -90,7 +90,7 @@ public final class AtVoid implements Attr {
 
     @Override
     public boolean put(final Phi phi) {
-        if (!this.object.compareAndSet(null, phi)) {
+        if (this.object.get() != null || !this.object.compareAndSet(null, phi)) {
             throw new ExReadOnly(
                 String.format(
                     "This void attribute \"%s\" is already set, can't reset",

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -90,9 +90,7 @@ public final class AtVoid implements Attr {
 
     @Override
     public boolean put(final Phi phi) {
-        if (this.object.get() == null) {
-            this.object.set(phi);
-        } else {
+        if (!this.object.compareAndSet(null, phi)) {
             throw new ExReadOnly(
                 String.format(
                     "This void attribute \"%s\" is already set, can't reset",


### PR DESCRIPTION
If these objects are used inside Atomic, we can assume that they must be thread-safe.
You can't do a check/write, because during the check, the state may change and there will already be an object there. Using synchronization primitives such as:
Acquire/Release (volatile read/write) and CAS you can avoid this, only this way and no other way (or use a locking mechanism that is high level) 