### PR TITLE
Add testing profiles(solves invoker-maven-plugin invocation when -DskipITs is set)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -47,7 +47,7 @@ jobs:
       - run: |
           # Clean the test classes to avoid caching issues and prepare testing environment
           # without running the tests
-          mvn clean install -Pqulice -DskipTests -DskipITs -Dinvoker.skip=true
+          mvn clean install -Pqulice -PskipTests
           # Find script
           SCRIPT=${GITHUB_WORKSPACE}/src/test/scripts/test-repetition.sh
           # Check that script is exists

--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -43,5 +43,5 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn install -DskipTests -Dinvoker.skip -Phone
+      - run: mvn install -PskipTests -Phone
       - run: mvn test -Phone -pl :eo-runtime

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,4 +44,4 @@ jobs:
           key: ubuntu-surefire-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ubuntu-surefire-jdk-21-maven-
       - run: |
-          mvn clean install -DskipUTs --errors --batch-mode
+          mvn clean install -PskipUTs --errors --batch-mode

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -57,4 +57,4 @@ jobs:
       - uses: JesseTG/rm@v1.0.3
         with:
           path: ~/.m2/repository/org/eolang
-      - run: mvn clean install -DskipITs --errors --batch-mode
+      - run: mvn clean install -PskipITs --errors --batch-mode

--- a/.github/workflows/qulice.yml
+++ b/.github/workflows/qulice.yml
@@ -43,4 +43,4 @@ jobs:
           path: ~/.m2/repository
           key: ubuntu-qulice-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ubuntu-qulice-jdk-21-maven-
-      - run: mvn clean verify -DskipTests -DskipITs -Pqulice --errors --batch-mode
+      - run: mvn clean verify -PskipTests -Pqulice --errors --batch-mode

--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -149,19 +149,14 @@ Here `fibonacci` is the name of the desired integration test, `-DskipTests` is u
 
 It is sometime necessary to temporarily disable the integration tests (for example for introducing
 braking changes into plugin or EO runtime). This can be achieved by disabling `maven-invoker-plugin`
-execution within `eo-maven-plugin/pom.xml`:
+using profile:
 
-```xml
-<plugins>
-  ...
-  <plugin>
-    <artifactId>maven-invoker-plugin</artifactId>
-    <version>0.49.2</version>
-    <configuration>
-        <skipInstallation>true</skipInstallation>
-        <skipInvocation>true</skipInvocation>
-    </configuration>
-  </plugin>
-  ...
-</plugins>  
+```shell
+mvn clean install -PskipITs
+```
+
+or by setting skipITs property:
+
+```shell
+mvn clean install -DskipITs
 ```

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -299,8 +299,8 @@ SOFTWARE.
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration combine.self="override">
-          <skipInstallation>${skipTests}</skipInstallation>
-          <skipInvocation>${skipTests}</skipInvocation>
+          <skipInstallation>${skipITs}</skipInstallation>
+          <skipInvocation>${skipITs}</skipInvocation>
           <pomExcludes/>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,40 @@ SOFTWARE.
   </build>
   <profiles>
     <profile>
+      <id>skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>true</skipITs>
+        <skipUTs>true</skipUTs>
+      </properties>
+    </profile>
+    <profile>
+      <id>skipITs</id>
+      <activation>
+        <property>
+          <name>skipITs</name>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>true</skipITs>
+      </properties>
+    </profile>
+    <profile>
+      <id>skipUTs</id>
+      <activation>
+        <property>
+          <name>skipUTs</name>
+        </property>
+      </activation>
+      <properties>
+        <skipUTs>true</skipUTs>
+      </properties>
+    </profile>
+    <profile>
       <id>qulice</id>
       <build>
         <plugins>


### PR DESCRIPTION
To achieve [this](https://github.com/objectionary/eo/issues/3696#issuecomment-2554040718) logic I added profiles as I mentioned in [comment](https://github.com/objectionary/eo/issues/3711#issuecomment-2558749735). 
Profile activates if corresponding property is set, so there are no need to rewrite any action scripts.
 I.E:
-DskipTests -> -PskipTests
-DskipITs -> -PskipITs
-DskipUTs -> -PskipUTs

(-PskipITs and PskipUTs is kind of useless, but i added them to uniformity with -PskipTests)


