### PR TITLE
feat(#3756): Use a Single Format for All Error Messages

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -87,6 +87,7 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
                 )
             );
         }
+        final List<String> msgs = new ArrayList<>(0);
         if (error instanceof NoViableAltException || error instanceof InputMismatchException) {
             final Token token = (Token) symbol;
             final Parser parser = (Parser) recognizer;
@@ -102,49 +103,21 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             } else {
                 detailed = "no viable alternative at input";
             }
-            this.errors.add(
-                new ParsingException(
-                    String.format(
-                        "[%d:%d] %s: %s:%n%s",
-                        line,
-                        position,
-                        "error",
-                        detailed,
-                        new UnderlinedMessage(
-                            this.lines.line(line),
-                            position,
-                            Math.max(token.getStopIndex() - token.getStartIndex(), 1)
-                        ).formatted()
-                    ),
-                    error,
-                    line
-                )
+            msgs.add(new LocationMessage(line, position, detailed).formatted());
+            msgs.add(
+                new UnderlinedMessage(
+                    this.lines.line(line),
+                    position,
+                    Math.max(token.getStopIndex() - token.getStartIndex(), 1)
+                ).formatted()
             );
         } else if (Objects.isNull(error)) {
-            this.errors.add(
-                new ParsingException(
-                    String.format(
-                        "[%d:%d] %s: %s",
-                        line,
-                        position,
-                        "error",
-                        msg
-                    ),
-                    line
-                )
-            );
+            msgs.add(new LocationMessage(line, position, msg).formatted());
         } else {
-            this.errors.add(
-                new ParsingException(
-                    String.format(
-                        "[%d:%d] %s: \"%s\"",
-                        line, position, msg, this.lines.line(line)
-                    ),
-                    error,
-                    line
-                )
-            );
+            msgs.add(new LocationMessage(line, position, msg).formatted());
+            msgs.add(this.lines.line(line));
         }
+        this.errors.add(new ParsingException(msg, error, line));
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -102,16 +102,16 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             } else {
                 detailed = "no viable alternative at input";
             }
-            msgs.add(new LocationMessage(line, position, detailed).formatted());
+            msgs.add(new MsgLocated(line, position, detailed).formatted());
             msgs.add(
-                new UnderlinedMessage(
+                new MsgUnderlined(
                     this.lines.line(line),
                     position,
                     Math.max(token.getStopIndex() - token.getStartIndex(), 1)
                 ).formatted()
             );
         } else {
-            msgs.add(new LocationMessage(line, position, msg).formatted());
+            msgs.add(new MsgLocated(line, position, msg).formatted());
             msgs.add(this.lines.line(line));
         }
         this.errors.add(new ParsingException(error, line, msgs));

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -106,7 +106,8 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
                 new ParsingException(
                     String.format(
                         "[%d:%d] %s: %s:%n%s",
-                        line, position,
+                        line,
+                        position,
                         "error",
                         detailed,
                         new UnderlinedMessage(
@@ -123,7 +124,11 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             this.errors.add(
                 new ParsingException(
                     String.format(
-                        "[%d:%d] %s: %s", line, position, "error", msg
+                        "[%d:%d] %s: %s",
+                        line,
+                        position,
+                        "error",
+                        msg
                     ),
                     line
                 )

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -26,7 +26,6 @@ package org.eolang.parser;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.InputMismatchException;
 import org.antlr.v4.runtime.NoViableAltException;
@@ -111,13 +110,11 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
                     Math.max(token.getStopIndex() - token.getStartIndex(), 1)
                 ).formatted()
             );
-        } else if (Objects.isNull(error)) {
-            msgs.add(new LocationMessage(line, position, msg).formatted());
         } else {
             msgs.add(new LocationMessage(line, position, msg).formatted());
             msgs.add(this.lines.line(line));
         }
-        this.errors.add(new ParsingException(msg, error, line));
+        this.errors.add(new ParsingException(error, line, msgs));
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/GeneralErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/GeneralErrors.java
@@ -87,12 +87,10 @@ final class GeneralErrors extends BaseErrorListener implements Iterable<ParsingE
     ) {
         this.errors.add(
             new ParsingException(
-                String.format(
-                    "[%d:%d] %s: \"%s\"",
-                    line, position, msg, this.lines.line(line)
-                ),
                 error,
-                line
+                line,
+                new LocationMessage(line, position, msg).formatted(),
+                this.lines.line(line)
             )
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/GeneralErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/GeneralErrors.java
@@ -89,7 +89,7 @@ final class GeneralErrors extends BaseErrorListener implements Iterable<ParsingE
             new ParsingException(
                 error,
                 line,
-                new LocationMessage(line, position, msg).formatted(),
+                new MsgLocated(line, position, msg).formatted(),
                 this.lines.line(line)
             )
         );

--- a/eo-parser/src/main/java/org/eolang/parser/LocationMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LocationMessage.java
@@ -23,6 +23,10 @@
  */
 package org.eolang.parser;
 
+/**
+ * Error message that includes the location of the error.
+ * @since 0.50
+ */
 final class LocationMessage {
 
     /**
@@ -57,6 +61,6 @@ final class LocationMessage {
      * @return The formatted error message.
      */
     String formatted() {
-        return String.format("[%d:%d] error: \"%s\"", this.line, this.position, this.message);
+        return String.format("[%d:%d] error: '%s'", this.line, this.position, this.message);
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LocationMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LocationMessage.java
@@ -23,63 +23,40 @@
  */
 package org.eolang.parser;
 
-import java.util.List;
-
-/**
- * When parsing fails.
- *
- * @since 0.1
- */
-public final class ParsingException extends RuntimeException {
+final class LocationMessage {
 
     /**
-     * Serialization marker.
+     * The line where the error occurred.
      */
-    private static final long serialVersionUID = -3043426132301042201L;
+    private final int line;
 
     /**
-     * The place.
+     * The position in the line where the error occurred.
      */
-    private final int place;
+    private final int position;
+
+    /**
+     * The error message.
+     */
+    private final String message;
 
     /**
      * Ctor.
-     * @param msgs Messages
-     * @param cause The cause
-     * @param line The place
-     * @since 0.1
+     * @param line The line where the error occurred.
+     * @param position The position in the line where the error occurred.
+     * @param message The error message.
      */
-    ParsingException(final List<String> msgs, final Exception cause, final int line) {
-        this(String.join("\n", msgs), cause, line);
-    }
-
-
-    /**
-     * Ctor.
-     * @param msg Message
-     * @param line The place
-     */
-    ParsingException(final String msg, final int line) {
-        this(msg, null, line);
+    LocationMessage(final int line, final int position, final String message) {
+        this.line = line;
+        this.position = position;
+        this.message = message;
     }
 
     /**
-     * Ctor.
-     * @param msg Message
-     * @param cause Cause of failure
-     * @param line The place
+     * Formats the error message.
+     * @return The formatted error message.
      */
-    ParsingException(final String msg, final Exception cause, final int line) {
-        super(msg, cause);
-        this.place = line;
+    String formatted() {
+        return String.format("[%d:%d] error: \"%s\"", this.line, this.position, this.message);
     }
-
-    /**
-     * Get the place.
-     * @return Line
-     */
-    public int line() {
-        return this.place;
-    }
-
 }

--- a/eo-parser/src/main/java/org/eolang/parser/MsgLocated.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MsgLocated.java
@@ -27,7 +27,7 @@ package org.eolang.parser;
  * Error message that includes the location of the error.
  * @since 0.50
  */
-final class LocationMessage {
+final class MsgLocated {
 
     /**
      * The line where the error occurred.
@@ -50,7 +50,7 @@ final class LocationMessage {
      * @param position The position in the line where the error occurred.
      * @param message The error message.
      */
-    LocationMessage(final int line, final int position, final String message) {
+    MsgLocated(final int line, final int position, final String message) {
         this.line = line;
         this.position = position;
         this.message = message;

--- a/eo-parser/src/main/java/org/eolang/parser/MsgUnderlined.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MsgUnderlined.java
@@ -41,7 +41,7 @@ import java.util.Collections;
  * </p>
  * @since 0.50
  */
-final class UnderlinedMessage {
+final class MsgUnderlined {
 
     /**
      * The message.
@@ -64,7 +64,7 @@ final class UnderlinedMessage {
      * @param from The position from which to start underlining.
      * @param length The length of the underline.
      */
-    UnderlinedMessage(final String origin, final int from, final int length) {
+    MsgUnderlined(final String origin, final int from, final int length) {
         this.origin = origin;
         this.from = from;
         this.length = length;
@@ -91,12 +91,12 @@ final class UnderlinedMessage {
         if (this.origin.isEmpty() || this.length <= 0 || this.from >= this.origin.length()) {
             result = "";
         } else if (this.from < 0) {
-            result = UnderlinedMessage.repeat("^", this.origin.length());
+            result = MsgUnderlined.repeat("^", this.origin.length());
         } else {
             result = String.format(
                 "%s%s",
-                UnderlinedMessage.repeat(" ", this.from),
-                UnderlinedMessage.repeat("^", Math.min(this.length, this.origin.length()))
+                MsgUnderlined.repeat(" ", this.from),
+                MsgUnderlined.repeat("^", Math.min(this.length, this.origin.length()))
             );
         }
         return result;

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
@@ -44,32 +44,34 @@ public final class ParsingException extends RuntimeException {
 
     /**
      * Ctor.
-     * @param msgs Messages
-     * @param cause The cause
-     * @param line The place
-     * @since 0.1
-     */
-    ParsingException(final List<String> msgs, final Exception cause, final int line) {
-        this(String.join("\n", msgs), cause, line);
-    }
-
-
-    /**
-     * Ctor.
-     * @param msg Message
-     * @param line The place
-     */
-    ParsingException(final String msg, final int line) {
-        this(msg, null, line);
-    }
-
-    /**
-     * Ctor.
-     * @param msg Message
      * @param cause Cause of failure
      * @param line The place
+     * @param msgs Messages
      */
-    ParsingException(final String msg, final Exception cause, final int line) {
+    ParsingException(final Exception cause, final int line, final String... msgs) {
+        this(cause, line, List.of(msgs));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param cause The cause
+     * @param line The place
+     * @param msgs Messages
+     * @since 0.1
+     */
+    ParsingException(final Exception cause, final int line, final List<String> msgs) {
+        this(cause, line, String.join("\n", msgs));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param cause Cause of failure
+     * @param line The place
+     * @param msg Message
+     */
+    ParsingException(final Exception cause, final int line, final String msg) {
         super(msg, cause);
         this.place = line;
     }
@@ -81,5 +83,4 @@ public final class ParsingException extends RuntimeException {
     public int line() {
         return this.place;
     }
-
 }

--- a/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
@@ -45,7 +45,7 @@ public final class ParsingException extends RuntimeException {
      * @param msg Message
      * @param line The place
      */
-    public ParsingException(final String msg, final int line) {
+    ParsingException(final String msg, final int line) {
         this(msg, null, line);
     }
 
@@ -55,7 +55,7 @@ public final class ParsingException extends RuntimeException {
      * @param cause Cause of failure
      * @param line The place
      */
-    public ParsingException(final String msg, final Exception cause, final int line) {
+    ParsingException(final String msg, final Exception cause, final int line) {
         super(msg, cause);
         this.place = line;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
+++ b/eo-parser/src/main/java/org/eolang/parser/UnderlinedMessage.java
@@ -40,9 +40,6 @@ import java.util.Collections;
  * }
  * </p>
  * @since 0.50
- * @todo #3332:30min Add more decorators for the error message.
- *  For example, {@link GeneralErrors} currently contains logic related to the message formatting.
- *  It's better to create a separate class for this purpose.
  */
 final class UnderlinedMessage {
 

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -298,9 +298,8 @@ public final class XePhiListener implements PhiListener, Iterable<Directive> {
                 && !"bytes".equals(this.attributes.peek())
             ) {
                 throw new ParsingException(
-                    "It's impossible to represent Δ ⤍ ∅ binding in EO",
-                    new IllegalStateException(),
-                    ctx.getStart().getLine()
+                    new IllegalStateException(), ctx.getStart().getLine(),
+                    "It's impossible to represent Δ ⤍ ∅ binding in EO"
                 );
             }
         } else {

--- a/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
@@ -31,25 +31,25 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Test case for {@link UnderlinedMessage}.
+ * Test case for {@link MsgUnderlined}.
  * @since 0.50
  * @checkstyle ParameterNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class UnderlinedMessageTest {
+final class MsgUnderlinedTest {
 
     @ParameterizedTest
     @MethodSource("examples")
     void addsUndeline(final String input, final int from, final int length, final String expected) {
         MatcherAssert.assertThat(
             "We expect the message to be highlighted with underline characters",
-            new UnderlinedMessage(input, from, length).formatted(),
+            new MsgUnderlined(input, from, length).formatted(),
             Matchers.equalTo(expected)
         );
     }
 
     /**
-     * Test cases for {@link UnderlinedMessageTest#addsUndeline}.
+     * Test cases for {@link MsgUnderlinedTest#addsUndeline}.
      * ANTLR {@link  org.antlr.v4.runtime.BaseErrorListener} returns strange line numbers
      * and positions like -1. Here I hide this problem intentionally to make all the rest
      * tests pass.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: >-
-  [2:4] error: Invalid object declaration:
+  [2:4] error: 'Invalid object declaration'
     y:^
       ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: |-
-  [2:7] error: Invalid object declaration:
+  [2:7] error: 'Invalid object declaration'
   [] > a [] > b [] > c [] > d hello world
          ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -25,7 +25,7 @@ line: 5
 #  comment. The error message should be updated to point to the exact position
 #  of the comment.
 message: |
-  [5:12] error: Invalid object declaration:
+  [5:12] error: 'Invalid object declaration'
       sprintwf
 input: |
   # No comments

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -25,8 +25,9 @@ line: 4
 #  Cryptic error message is returned when there are two empty lines between metas.
 #  The error message should be more informative and should highlight the exact location
 #  of the error.
-message: |-
-  [4:0] error: extraneous input '\n' expecting {COMMENTARY, 'Q', 'QQ', '*', '$', '[', '(', '@', '^', BYTES, STRING, INT, FLOAT, HEX, NAME, TEXT}
+message: |
+  [4:0] error: 'extraneous input '\n' expecting {COMMENTARY, 'Q', 'QQ', '*', '$', '[', '(', '@', '^', BYTES, STRING, INT, FLOAT, HEX, NAME, TEXT}'
+
 input: |
   # No comments.
   [args] > one

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
@@ -22,7 +22,7 @@
 ---
 line: 1
 message: |-
-  [1:10] error: Invalid meta declaration:
+  [1:10] error: 'Invalid meta declaration'
   +meta with  spaces
             ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:0] error: Invalid object declaration:
+  [3:0] error: 'Invalid object declaration'
   +meta other
   ^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/missing-empty-line-after-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/missing-empty-line-after-metas.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:0] error: Invalid meta declaration:
+  [3:0] error: 'Invalid meta declaration'
   [] > main
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -22,7 +22,7 @@
 ---
 line: 4
 message: |-
-  [4:-1] error: Invalid program declaration:
+  [4:-1] error: 'Invalid program declaration'
     [] > inner
   ^^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:-1] error: Invalid program declaration:
+  [3:-1] error: 'Invalid program declaration'
   EOF
   ^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
@@ -27,7 +27,7 @@ line: 3
 #  place in the input where the error occurred. Moreover it should be clear
 #  what to do to fix the error. 'simple-application-named.yaml' has the same issue.
 message: |-
-  [3:-1] error: Invalid program declaration:
+  [3:-1] error: 'Invalid program declaration'
   EOF
   ^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -22,7 +22,7 @@
 ---
 line: 5
 message: >-
-  [5:2] error: Invalid object declaration:
+  [5:2] error: 'Invalid object declaration'
      *
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: Invalid program declaration:
+  [2:0] error: 'Invalid program declaration'
   .z
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: Invalid program declaration:
+  [2:0] error: 'Invalid program declaration'
   .z
   ^
 input: |


### PR DESCRIPTION
Created one more class `LocationMessage` that is used as a default error message:
```
[2:0] error: 'Invalid program declaration'
```
It simply adds line and column where an error occured.

___
PS. Now we have two classes `UnderlinedMessage` and `LocationMessage`. They both have the same structure and similar methods. So, we can create an interface for them.
Moreover, we can change their names to `MsgUnderlined` and `MsgLocation`. I haven't done it in this PR in order to keep its size in some borders.
But we can change it during the PR review.

Closes: #3756.
