### PR TITLE
feat(#3743): Add Error Location for Custom Errors

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParsingException.java
@@ -44,6 +44,15 @@ public final class ParsingException extends RuntimeException {
 
     /**
      * Ctor.
+     * @param line The place
+     * @param msgs Messages
+     */
+    ParsingException(final int line, final String... msgs) {
+        this(new IllegalStateException("Parsing error"), line, List.of(msgs));
+    }
+
+    /**
+     * Ctor.
      * @param cause Cause of failure
      * @param line The place
      * @param msgs Messages

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -25,6 +25,7 @@ package org.eolang.parser;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -82,6 +83,8 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
      */
     private final Map<ParserRuleContext, String> errors;
 
+    private final List<ParsingException> newerrors;
+
     /**
      * Ctor.
      *
@@ -91,6 +94,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
         this.name = name;
         this.dirs = new Directives();
         this.errors = new HashMap<>(0);
+        this.newerrors = new ArrayList<>(0);
         this.objects = new Objects.ObjXembly();
         this.start = System.nanoTime();
     }
@@ -106,18 +110,33 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     @Override
     public void exitProgram(final EoParser.ProgramContext ctx) {
         this.dirs.xpath("/program").strict(1);
-        if (!this.errors.isEmpty()) {
-            this.dirs.addIf("errors").strict(1);
-            for (final Map.Entry<ParserRuleContext, String> error : this.errors.entrySet()) {
-                this.dirs
-                    .add("error")
-                    .attr("check", "eo-parser")
-                    .attr("line", error.getKey().getStart().getLine())
-                    .attr("severity", "critical")
-                    .set(error.getValue());
-            }
-            this.dirs.up().up();
+//        if (!this.errors.isEmpty()) {
+//            this.dirs.addIf("errors").strict(1);
+//            for (final Map.Entry<ParserRuleContext, String> error : this.errors.entrySet()) {
+//                this.dirs
+//                    .add("error")
+//                    .attr("check", "eo-parser")
+//                    .attr("line", error.getKey().getStart().getLine())
+//                    .attr("severity", "critical")
+//                    .set(error.getValue());
+//            }
+//            this.dirs.up().up();
+//        }
+
+        if (!this.newerrors.isEmpty()) {
+            this.dirs.append(new DrErrors(this.newerrors));
+//            this.dirs.addIf("errors").strict(1);
+//            for (final Map.Entry<ParserRuleContext, String> error : this.errors.entrySet()) {
+//                this.dirs
+//                    .add("error")
+//                    .attr("check", "eo-parser")
+//                    .attr("line", error.getKey().getStart().getLine())
+//                    .attr("severity", "critical")
+//                    .set(error.getValue());
+//            }
+//            this.dirs.up().up();
         }
+
         this.dirs
             .attr("ms", (System.nanoTime() - this.start) / (1000L * 1000L))
             .up();
@@ -483,12 +502,16 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterHapplicationTailReversedFirst(final EoParser.HapplicationTailReversedFirstContext ctx) {
+    public void enterHapplicationTailReversedFirst(
+        final EoParser.HapplicationTailReversedFirstContext ctx
+    ) {
         this.objects.enter();
     }
 
     @Override
-    public void exitHapplicationTailReversedFirst(final EoParser.HapplicationTailReversedFirstContext ctx) {
+    public void exitHapplicationTailReversedFirst(
+        final EoParser.HapplicationTailReversedFirstContext ctx
+    ) {
         this.objects.leave();
     }
 
@@ -573,12 +596,16 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterVapplicationArgBoundCurrent(final EoParser.VapplicationArgBoundCurrentContext ctx) {
+    public void enterVapplicationArgBoundCurrent(
+        final EoParser.VapplicationArgBoundCurrentContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void exitVapplicationArgBoundCurrent(final EoParser.VapplicationArgBoundCurrentContext ctx) {
+    public void exitVapplicationArgBoundCurrent(
+        final EoParser.VapplicationArgBoundCurrentContext ctx
+    ) {
         // Nothing here
     }
 
@@ -603,22 +630,30 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterVapplicationArgUnboundCurrent(final EoParser.VapplicationArgUnboundCurrentContext ctx) {
+    public void enterVapplicationArgUnboundCurrent(
+        final EoParser.VapplicationArgUnboundCurrentContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void exitVapplicationArgUnboundCurrent(final EoParser.VapplicationArgUnboundCurrentContext ctx) {
+    public void exitVapplicationArgUnboundCurrent(
+        final EoParser.VapplicationArgUnboundCurrentContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void enterVapplicationArgUnboundNext(final EoParser.VapplicationArgUnboundNextContext ctx) {
+    public void enterVapplicationArgUnboundNext(
+        final EoParser.VapplicationArgUnboundNextContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void exitVapplicationArgUnboundNext(final EoParser.VapplicationArgUnboundNextContext ctx) {
+    public void exitVapplicationArgUnboundNext(
+        final EoParser.VapplicationArgUnboundNextContext ctx
+    ) {
         // Nothing here
     }
 
@@ -707,12 +742,16 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterVapplicationArgHanonymBoundBody(final EoParser.VapplicationArgHanonymBoundBodyContext ctx) {
+    public void enterVapplicationArgHanonymBoundBody(
+        final EoParser.VapplicationArgHanonymBoundBodyContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void exitVapplicationArgHanonymBoundBody(final EoParser.VapplicationArgHanonymBoundBodyContext ctx) {
+    public void exitVapplicationArgHanonymBoundBody(
+        final EoParser.VapplicationArgHanonymBoundBodyContext ctx
+    ) {
         // Nothing here
     }
 
@@ -865,12 +904,16 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterVmethodHeadApplicationTail(final EoParser.VmethodHeadApplicationTailContext ctx) {
+    public void enterVmethodHeadApplicationTail(
+        final EoParser.VmethodHeadApplicationTailContext ctx
+    ) {
         // Nothing here
     }
 
     @Override
-    public void exitVmethodHeadApplicationTail(final EoParser.VmethodHeadApplicationTailContext ctx) {
+    public void exitVmethodHeadApplicationTail(
+        final EoParser.VmethodHeadApplicationTailContext ctx
+    ) {
         // Nothing here
     }
 
@@ -1040,7 +1083,13 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
         } else {
             final int index = Integer.parseInt(ctx.INT().getText());
             if (index < 0) {
-                this.errors.put(ctx, "Object binding can't be negative");
+                this.newerrors.add(
+                    new ParsingException(
+                        ctx.getStart().getLine(),
+                        "Object binding can't be negative"
+                    )
+                );
+//                this.errors.put(ctx, "Object binding can't be negative");
             }
             has = String.format("α%d", index);
         }
@@ -1095,7 +1144,13 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
         } else {
             base = "unknown";
             data = ctx::getText;
-            this.errors.put(ctx, String.format("Unknown data type: %s", ctx.getText()));
+            this.newerrors.add(
+                new ParsingException(
+                    ctx.getStart().getLine(),
+                    String.format("Unknown data type: %s", ctx.getText())
+                )
+            );
+//            this.errors.put(ctx, String.format("Unknown data type: %s", ctx.getText()));
         }
         this.objects.prop("base", base).data(data.get());
     }

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1112,22 +1112,13 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
                     text.substring(1, text.length() - 1)
                 ).getBytes(StandardCharsets.UTF_8)
             );
-        } else if (ctx.TEXT() != null) {
+        } else {
             base = "string";
             final int indent = ctx.getStart().getCharPositionInLine();
             data = new BytesToHex(
                 StringEscapeUtils.unescapeJava(
                     XeEoListener.trimMargin(text, indent)
                 ).getBytes(StandardCharsets.UTF_8)
-            );
-        } else {
-            base = "unknown";
-            data = ctx::getText;
-            this.errors.add(
-                new ParsingException(
-                    ctx.getStart().getLine(),
-                    String.format("Unknown data type: %s", ctx.getText())
-                )
             );
         }
         this.objects.prop("base", base).data(data.get());

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -32,8 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.commons.text.StringEscapeUtils;
@@ -1086,14 +1088,34 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
                 this.newerrors.add(
                     new ParsingException(
                         ctx.getStart().getLine(),
-                        "Object binding can't be negative"
+                        new MsgLocated(
+                            ctx.getStart().getLine(),
+                            ctx.getStart().getCharPositionInLine(),
+                            "Object binding can't be negative"
+                        ).formatted(),
+                        new MsgUnderlined(
+                            this.line(ctx),
+                            ctx.getStart().getCharPositionInLine(),
+                            ctx.getText().length()
+                        ).formatted()
                     )
                 );
-//                this.errors.put(ctx, "Object binding can't be negative");
             }
             has = String.format("α%d", index);
         }
         this.objects.prop("as", has);
+    }
+
+    private String line(ParserRuleContext ctx) {
+        final Token start1 = ctx.start;
+        final int lineNumber = start1.getLine();
+        final CharStream stream = start1.getInputStream();
+        String[] lines = stream.toString().split("\n");
+        if (lineNumber > 0 && lineNumber <= lines.length) {
+            return lines[lineNumber - 1]; // Lines are 1-based
+        } else {
+            throw new IllegalArgumentException("Line number out of bounds");
+        }
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1232,7 +1232,7 @@ public final class XeEoListener implements EoListener, Iterable<Directive> {
         final int number = token.getLine();
         final String[] lines = token.getInputStream().toString().split("\n");
         if (number > 0 && number <= lines.length) {
-            return lines[number - 1]; // Lines are 1-based
+            return lines[number - 1];
         } else {
             throw new IllegalArgumentException(
                 String.format(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
@@ -22,9 +22,9 @@
 ---
 line: 4
 message: |-
-  [4:4] error: 'Object binding can't be negative'
+  [4:6] error: 'Object binding can't be negative'
       42:-1
-         ^
+        ^^^
 input: |
   # No comments
   [] > foo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
@@ -21,11 +21,10 @@
 # SOFTWARE.
 ---
 line: 4
-# @todo #3706:30min Add exact location of the error in the message.
-#  This message is already quite clear, but it would be better if it included
-#  the exact location of the error.
 message: |-
-  Object binding can't be negative
+  [4:4] error: 'Object binding can't be negative'
+      42:-1
+         ^
 input: |
   # No comments
   [] > foo


### PR DESCRIPTION
In this PR I added location and helpful information to custom parsing errors.

Was:
```
Object binding can't be negative
```

Become:
```
[4:6] error: 'Object binding can't be negative'
    42:-1
      ^^^
```

Closes: #3743.
