### PR TITLE
fix(#3793): EOnumber$EOtimesTest fix

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOtimes.java
@@ -57,9 +57,13 @@ public final class EOnumber$EOtimes extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        final Double left = new Dataized(this.take(Attr.RHO)).asNumber();
+        final Double left = Expect.at(this, Attr.RHO)
+            .that(phi -> new Dataized(phi).asNumber())
+            .otherwise("must be a number")
+            .it();
         final Double right = Expect.at(this, "x")
             .that(phi -> new Dataized(phi).asNumber())
+            .otherwise("must be a number")
             .it();
         return new Data.ToPhi(left * right);
     }

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -114,7 +114,11 @@ public class Expect<T> {
                     );
                 } catch (final ExThat ex) {
                     throw new ExFailure(
-                        message,
+                        String.format(
+                            "%s %s",
+                            this.subject,
+                            message
+                        ),
                         ex
                     );
                 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOnumber$EOtimesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOnumber$EOtimesTest.java
@@ -48,7 +48,30 @@ import org.junit.jupiter.api.Test;
 final class EOnumber$EOtimesTest {
 
     @Test
-    void throwsCorrectError() {
+    void throwsCorrectErrorWhenRHOAttrIsWrong() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            new EOnumber$EOtimes(),
+                            Attr.RHO,
+                            new Data.ToPhi(true)
+                        ),
+                        "x",
+                        new Data.ToPhi(42)
+                    )
+                ).take(),
+                "Attr.RHO must be a number, not anything else"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute must be a number")
+        );
+    }
+
+    @Test
+    void throwsCorrectErrorWhenXAttrIsWrong() {
         MatcherAssert.assertThat(
             "the message in the error is correct",
             Assertions.assertThrows(
@@ -66,7 +89,7 @@ final class EOnumber$EOtimesTest {
                 ).take(),
                 "multiplies 3 by TRUE and fails with a proper message that explains what happened"
             ).getMessage(),
-            Matchers.containsString("number.times expects its second argument to be a number")
+            Matchers.equalTo("the 'x' attribute must be a number")
         );
     }
 }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOnumber$EOtimesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOnumber$EOtimesTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 final class EOnumber$EOtimesTest {
 
     @Test
-    void throwsCorrectErrorWhenRHOAttrIsWrong() {
+    void throwsCorrectErrorWhenRhoAttrIsWrong() {
         MatcherAssert.assertThat(
             "the message in the error is correct",
             Assertions.assertThrows(

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -128,13 +128,15 @@ final class ExpectTest {
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Expect<>("attr", () -> "string")
-                    .that(i -> {
-                        try {
-                            return Integer.parseInt(i);
-                        } catch (final NumberFormatException ex) {
-                            throw new ExFailure("Can't parse to integer", ex);
+                    .that(
+                        i -> {
+                            try {
+                                return Integer.parseInt(i);
+                            } catch (final NumberFormatException ex) {
+                                throw new ExFailure("Can't parse to integer", ex);
+                            }
                         }
-                    })
+                    )
                     .otherwise("must be an integer")
                     .it(),
                 "fails on 'that' because can not parse"

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -107,19 +107,39 @@ final class ExpectTest {
             "Take error message from 'otherwise', not from original error",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect<>("something", () -> 42.2)
-                    .must(i -> i > 0)
-                    .otherwise("must be positive")
+                () -> new Expect<>("attr", () -> 42.2)
                     .that(
                         i -> {
-                            throw new ExFailure("some error");
+                            throw new ExFailure("Some error in operation");
                         }
                     )
-                    .otherwise("something went wrong")
+                    .otherwise("must be converted to something")
                     .it(),
-                "fails on 'that'"
+                "fails on 'that' because of some internal error"
             ).getMessage(),
-            Matchers.equalTo("something went wrong")
+            Matchers.equalTo("attr must be converted to something")
+        );
+    }
+
+    @Test
+    void failsWithCorrectTraceWithExFailureInThatForParsing() {
+        MatcherAssert.assertThat(
+            "Take error message from 'otherwise', not from original error",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect<>("attr", () -> "string")
+                    .that(i -> {
+                        try {
+                            return Integer.parseInt(i);
+                        } catch (final NumberFormatException ex) {
+                            throw new ExFailure("Can't parse to integer", ex);
+                        }
+                    })
+                    .otherwise("must be an integer")
+                    .it(),
+                "fails on 'that' because can not parse"
+            ).getMessage(),
+            Matchers.equalTo("attr must be an integer")
         );
     }
 }


### PR DESCRIPTION
This PR should close #3793 issue

Fix `EOnumber$EOtimesTest` for using updated `Expect`
A bit update `Expect` for use subject in error messages for `that` method