### PR TITLE
feat(#3744): Human-Readable Error Message for Prohibited Comment in an Object Definition

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoTest.java
@@ -146,7 +146,7 @@ final class LintMojoTest {
             new XMLDocument(
                 maven.result().get("target/2-shake/foo/x/main.xmir")
             ).nodes("//errors/error[@severity='critical']"),
-            Matchers.hasSize(1)
+            Matchers.hasSize(3)
         );
     }
 

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -47,7 +47,7 @@ metas
 // Objects
 // Ends on the next line
 objects
-    : (object EOL?)* object
+    : (object EOL?)+
     ;
 
 comment

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -69,8 +69,14 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
         this.lines = lines;
     }
 
-    // @checkstyle ParameterNumberCheck (10 lines)
+    // @checkstyle ParameterNumberCheck (20 lines)
+    // @checkstyle CyclomaticComplexityCheck (100 lines)
+    // @todo #3744:30min Simplify {@link EoParserErrors#syntaxError} method.
+    //  The method is too complex and has a high cognitive complexity. We need to simplify it.
+    //  Don't forget to remove the @checkstyle CyclomaticComplexityCheck annotation and
+    //  the @SuppressWarnings("PMD.CognitiveComplexity") annotation.
     @Override
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public void syntaxError(
         final Recognizer<?, ?> recognizer,
         final Object symbol,
@@ -121,9 +127,11 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             final String detailed;
             final String[] names = parser.getRuleNames();
             if (names[EoParser.RULE_program].equals(rule)) {
-                detailed = "We expected the program to end here but encountered something unexpected";
+                detailed =
+                    "We expected the program to end here but encountered something unexpected";
             } else if (names[EoParser.RULE_objects].equals(rule)) {
-                detailed = "We expected a list of objects here but encountered something unexpected";
+                detailed =
+                    "We expected a list of objects here but encountered something unexpected";
             } else {
                 detailed = msg;
             }

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -87,7 +87,7 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             );
         }
         final List<String> msgs = new ArrayList<>(0);
-        if (error instanceof NoViableAltException || error instanceof InputMismatchException) {
+        if (error instanceof NoViableAltException) {
             final Token token = (Token) symbol;
             final Parser parser = (Parser) recognizer;
             final String rule = parser.getRuleInvocationStack().get(0);
@@ -105,6 +105,24 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
                 detailed = "Invalid object declaration";
             } else {
                 detailed = "no viable alternative at input";
+            }
+            msgs.add(new MsgLocated(line, position, detailed).formatted());
+            msgs.add(
+                new MsgUnderlined(
+                    this.lines.line(line),
+                    position,
+                    Math.max(token.getStopIndex() - token.getStartIndex(), 1)
+                ).formatted()
+            );
+        } else if (error instanceof InputMismatchException) {
+            final Token token = (Token) symbol;
+            final Parser parser = (Parser) recognizer;
+            final String rule = parser.getRuleInvocationStack().get(0);
+            final String detailed;
+            if (parser.getRuleNames()[EoParser.RULE_program].equals(rule)) {
+                detailed = "Unexpected part of the program";
+            } else {
+                detailed = msg;
             }
             msgs.add(new MsgLocated(line, position, detailed).formatted());
             msgs.add(

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -99,6 +99,8 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
                 detailed = "Invalid meta declaration";
             } else if (names[EoParser.RULE_program].equals(rule)) {
                 detailed = "Invalid program declaration";
+            } else if (names[EoParser.RULE_slave].equals(rule)) {
+                detailed = "Invalid objects declaration that may be used inside abstract object";
             } else {
                 detailed = "no viable alternative at input";
             }

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -119,8 +119,11 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             final Parser parser = (Parser) recognizer;
             final String rule = parser.getRuleInvocationStack().get(0);
             final String detailed;
-            if (parser.getRuleNames()[EoParser.RULE_program].equals(rule)) {
+            final String[] names = parser.getRuleNames();
+            if (names[EoParser.RULE_program].equals(rule)) {
                 detailed = "Unexpected part of the program";
+            } else if (names[EoParser.RULE_objects].equals(rule)) {
+                detailed = "We expected a list of objects here, but found something else";
             } else {
                 detailed = msg;
             }

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -94,13 +94,15 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             final String[] names = parser.getRuleNames();
             final String detailed;
             if (names[EoParser.RULE_objects].equals(rule)) {
-                detailed = "Invalid object declaration";
+                detailed = "Invalid object list declaration";
             } else if (names[EoParser.RULE_metas].equals(rule)) {
                 detailed = "Invalid meta declaration";
             } else if (names[EoParser.RULE_program].equals(rule)) {
                 detailed = "Invalid program declaration";
             } else if (names[EoParser.RULE_slave].equals(rule)) {
                 detailed = "Invalid objects declaration that may be used inside abstract object";
+            } else if (names[EoParser.RULE_object].equals(rule)) {
+                detailed = "Invalid object declaration";
             } else {
                 detailed = "no viable alternative at input";
             }

--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -121,9 +121,9 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
             final String detailed;
             final String[] names = parser.getRuleNames();
             if (names[EoParser.RULE_program].equals(rule)) {
-                detailed = "Unexpected part of the program";
+                detailed = "We expected the program to end here but encountered something unexpected";
             } else if (names[EoParser.RULE_objects].equals(rule)) {
-                detailed = "We expected a list of objects here, but found something else";
+                detailed = "We expected a list of objects here but encountered something unexpected";
             } else {
                 detailed = msg;
             }

--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -61,6 +61,6 @@ final class Lines {
                 .map(UncheckedText::new)
                 .map(UncheckedText::asString);
         }
-        return result.orElse("EOF");
+        return result.orElse("");
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -28,8 +28,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.swing.text.html.Option;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
@@ -280,11 +282,16 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    @SuppressWarnings("PMD.ConfusingTernary")
     public void enterAtom(final EoParser.AtomContext ctx) {
-        this.startObject(ctx)
-            .prop("atom", ctx.type().typeFqn().getText())
-            .leave();
+        final EoParser.TypeFqnContext fqn = ctx.type().typeFqn();
+        if (fqn == null) {
+            this.errors.add(XeEoListener.error(ctx, "Atom must have a type"));
+            this.startObject(ctx).leave();
+        } else {
+            this.startObject(ctx)
+                .prop("atom", fqn.getText())
+                .leave();
+        }
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -28,10 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.swing.text.html.Option;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
@@ -1263,7 +1261,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
      * Create parsing exception from given context.
      * @param ctx Context
      * @param msg Error message
-     * @return Parsing exception from current context
+     * @return Parsing exception from the current context
      */
     private static ParsingException error(final ParserRuleContext ctx, final String msg) {
         return new ParsingException(

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -89,7 +89,7 @@ final class EoSyntaxTest {
             "[] > x-н, 1\n"
         );
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "EO syntax is broken, but listing should be printed",
             XhtmlMatchers.xhtml(
                 new String(
                     new EoSyntax(
@@ -100,7 +100,7 @@ final class EoSyntaxTest {
                 )
             ),
             XhtmlMatchers.hasXPaths(
-                "/program/errors[count(error)=2]",
+                "/program/errors[count(error)=3]",
                 String.format("/program[listing='%s']", src)
             )
         );

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -279,10 +279,10 @@ final class EoSyntaxTest {
         if (story.map().containsKey(msg)) {
             MatcherAssert.assertThat(
                 XhtmlMatchers.xhtml(story.after()).toString(),
-                story.after()
-                    .xpath("/program/errors/error[1]/text()")
-                    .get(0)
-                    .replaceAll("\r", ""),
+                String.join(
+                    "\n",
+                    story.after().xpath("/program/errors/error/text()")
+                ).replaceAll("\r", ""),
                 Matchers.equalTo(story.map().get(msg).toString())
             );
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: >-
-  [2:4] error: 'Invalid object declaration'
+  [2:4] error: 'Invalid objects declaration that may be used inside abstract object'
     y:^
       ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -21,10 +21,13 @@
 # SOFTWARE.
 ---
 line: 2
-message: >-
+message: |-
   [2:4] error: 'Invalid objects declaration that may be used inside abstract object'
     y:^
       ^
+  [3:-1] error: 'Unexpected part of the program'
+  EOF
+  ^^^
 input: |
   x
     y:^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -21,13 +21,12 @@
 # SOFTWARE.
 ---
 line: 2
-message: |-
+message: |+
   [2:4] error: 'Invalid objects declaration that may be used inside abstract object'
     y:^
       ^
-  [3:-1] error: 'Unexpected part of the program'
-  EOF
-  ^^^
-input: |
+  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+
+input: |-
   x
     y:^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -25,7 +25,6 @@ message: |-
   [2:0] error: 'Atom must have a type'
   [] > a [] > b [] > c [] > d hello world
   ^^^^^^^
-  
   [2:7] error: 'mismatched input '[' expecting '/''
   [] > a [] > b [] > c [] > d hello world
          ^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -22,9 +22,9 @@
 ---
 line: 2
 message: |-
-  [2:7] error: 'Invalid object declaration'
+  [2:0] error: 'Atom must have a type'
   [] > a [] > b [] > c [] > d hello world
-         ^
+  ^^^^^^^
 input: |
   # No comments
   [] > a [] > b [] > c [] > d hello world

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -25,6 +25,10 @@ message: |-
   [2:0] error: 'Atom must have a type'
   [] > a [] > b [] > c [] > d hello world
   ^^^^^^^
+  
+  [2:7] error: 'mismatched input '[' expecting '/''
+  [] > a [] > b [] > c [] > d hello world
+         ^
 input: |
   # No comments
   [] > a [] > b [] > c [] > d hello world

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -31,7 +31,7 @@ message: |-
   [5:12] error: 'Invalid objects declaration that may be used inside abstract object'
       sprintwf
   
-  [4:-1] error: 'Unexpected part of the program'
+  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
       # a comment here is prohibited
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -24,9 +24,17 @@ line: 5
 # @todo #3706:30min The error message doesn't highlight the exact position of the
 #  comment. The error message should be updated to point to the exact position
 #  of the comment.
-message: |
+message: |-
   [5:12] error: 'Invalid object declaration'
       sprintwf
+  
+  [5:12] error: 'Invalid objects declaration that may be used inside abstract object'
+      sprintwf
+  
+  [4:-1] error: 'Unexpected part of the program'
+      # a comment here is prohibited
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 input: |
   # No comments
   [args] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -24,10 +24,10 @@ line: 5
 message: |-
   [5:12] error: 'Invalid object declaration'
       sprintwf
-  
+
   [5:12] error: 'Invalid objects declaration that may be used inside abstract object'
       sprintwf
-  
+
   [4:-1] error: 'We expected the program to end here but encountered something unexpected'
       # a comment here is prohibited
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -21,9 +21,6 @@
 # SOFTWARE.
 ---
 line: 5
-# @todo #3706:30min The error message doesn't highlight the exact position of the
-#  comment. The error message should be updated to point to the exact position
-#  of the comment.
 message: |-
   [5:12] error: 'Invalid object declaration'
       sprintwf

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -25,7 +25,7 @@ line: 4
 #  Cryptic error message is returned when there are two empty lines between metas.
 #  The error message should be more informative and should highlight the exact location
 #  of the error.
-message: |
+message: |+
   [4:0] error: 'Invalid program declaration'
 
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -26,7 +26,7 @@ line: 4
 #  The error message should be more informative and should highlight the exact location
 #  of the error.
 message: |
-  [4:0] error: 'extraneous input '\n' expecting {COMMENTARY, 'Q', 'QQ', '*', '$', '[', '(', '@', '^', BYTES, STRING, INT, FLOAT, HEX, NAME, TEXT}'
+  [4:0] error: 'Invalid program declaration'
 
 input: |
   # No comments.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -26,7 +26,7 @@ line: 4
 #  The error message should be more informative and should highlight the exact location
 #  of the error.
 message: |+
-  [4:0] error: 'Invalid program declaration'
+  [4:0] error: 'Unexpected part of the program'
 
 input: |
   # No comments.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -26,7 +26,7 @@ line: 4
 #  The error message should be more informative and should highlight the exact location
 #  of the error.
 message: |+
-  [4:0] error: 'Unexpected part of the program'
+  [4:0] error: 'We expected the program to end here but encountered something unexpected'
 
 input: |
   # No comments.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:0] error: 'We expected a list of objects here, but found something else'
+  [3:0] error: 'We expected a list of objects here but encountered something unexpected'
   +meta other
   ^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:0] error: 'Invalid object list declaration'
+  [3:0] error: 'We expected a list of objects here, but found something else'
   +meta other
   ^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-line-between-metas.yaml
@@ -22,7 +22,7 @@
 ---
 line: 3
 message: |-
-  [3:0] error: 'Invalid object declaration'
+  [3:0] error: 'Invalid object list declaration'
   +meta other
   ^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -22,7 +22,7 @@
 ---
 line: 4
 message: |-
-  [4:-1] error: 'Invalid program declaration'
+  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
     [] > inner
   ^^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
@@ -21,10 +21,9 @@
 # SOFTWARE.
 ---
 line: 3
-message: |-
-  [3:-1] error: 'Invalid program declaration'
-  EOF
-  ^^^
+message: |+
+  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+
 input: |
   1.add 1 > x
     (1.add 1) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
@@ -26,10 +26,9 @@ line: 3
 #  The error message should be more informative and should point to the exact
 #  place in the input where the error occurred. Moreover it should be clear
 #  what to do to fix the error. 'simple-application-named.yaml' has the same issue.
-message: |-
-  [3:-1] error: 'Invalid program declaration'
-  EOF
-  ^^^
+message: |+
+  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+
 input: |
   1.add 1 > x
     (1.add 1)

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -21,7 +21,13 @@
 # SOFTWARE.
 ---
 line: 5
+# @todo #3744:60min Error Message Duplicates.
+#  As you can see, we have multiple error messages that are the
+#  same. We should remove duplicates and keep only meaningful error messages.
 message: >-
+  [5:2] error: 'Invalid object declaration'
+     *
+    ^
   [5:2] error: 'Invalid object declaration'
      *
     ^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -25,6 +25,12 @@ message: >-
   [5:2] error: 'Invalid object declaration'
      *
     ^
+  [5:2] error: 'Invalid objects declaration that may be used inside abstract object'
+     *
+    ^
+  [5:-1] error: 'We expected the program to end here but encountered something unexpected'
+     *
+  ^^^^
 input: |
   # This is a code snippet from the following issue:
   # https://github.com/objectionary/eo/issues/3332

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: 'Invalid program declaration'
+  [2:0] error: 'We expected the program to end here but encountered something unexpected'
   .z
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
@@ -22,7 +22,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: 'Invalid program declaration'
+  [2:0] error: 'We expected the program to end here but encountered something unexpected'
   .z
   ^
 input: |


### PR DESCRIPTION
Another approach for the same problem that I tried to solve recently:
https://github.com/objectionary/eo/pull/3802

Actually, in this PR I change the `objects` rule definition from:

```antlr
objects
    : (object EOL?)* object
    ;
```

to:

```antlr
objects
    : (object EOL?)+
    ;
```

It helps to catch a more inforamtive parsing errors (see tests with examples.)

Closes: #3744
