### PR TITLE
feat: Add inner helpful classes in `Expect`

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -210,4 +210,63 @@ public class Expect<T> {
         }
     }
 
+    /**
+     * Transform Expect to Number
+     *
+     * @since 0.51
+     */
+    public static class Number {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public Number(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        public Double it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).asNumber())
+                .otherwise("must be a number")
+                .it();
+        }
+    }
+
+    /**
+     * Transform Expect to Integer
+     *
+     * @since 0.51
+     */
+    public static class Integer {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public Integer(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        public java.lang.Integer it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).asNumber())
+                .otherwise("must be a number")
+                .must(number -> number % 1 == 0)
+                .otherwise("must be an integer")
+                .that(Double::intValue)
+                .it();
+        }
+    }
+
 }

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -165,7 +165,7 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    private static class ExMust extends RuntimeException {
+    private static final class ExMust extends RuntimeException {
         /**
          * Ctor.
          * @param cause Exception cause
@@ -182,7 +182,7 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    private static class ExThat extends RuntimeException {
+    private static final class ExThat extends RuntimeException {
         /**
          * Ctor.
          * @param cause Exception cause
@@ -199,7 +199,7 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    private static class ExOtherwise extends RuntimeException {
+    private static final class ExOtherwise extends RuntimeException {
         /**
          * Ctor.
          * @param cause Exception cause
@@ -211,11 +211,12 @@ public class Expect<T> {
     }
 
     /**
-     * Transform Expect to Number
+     * Transform Expect to Number.
      *
      * @since 0.51
      */
-    public static class Number {
+    @SuppressWarnings("PMD.ShortMethodName")
+    public static final class Number {
 
         /**
          * Expect.
@@ -230,6 +231,11 @@ public class Expect<T> {
             this.expect = expect;
         }
 
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
         public Double it() {
             return this.expect
                 .that(phi -> new Dataized(phi).asNumber())
@@ -239,11 +245,12 @@ public class Expect<T> {
     }
 
     /**
-     * Transform Expect to Integer
+     * Transform Expect to Integer.
      *
      * @since 0.51
      */
-    public static class Integer {
+    @SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
+    public static final class Integer {
 
         /**
          * Expect.
@@ -258,6 +265,11 @@ public class Expect<T> {
             this.expect = expect;
         }
 
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
         public java.lang.Integer it() {
             return this.expect
                 .that(phi -> new Dataized(phi).asNumber())
@@ -265,6 +277,45 @@ public class Expect<T> {
                 .must(number -> number % 1 == 0)
                 .otherwise("must be an integer")
                 .that(Double::intValue)
+                .it();
+        }
+    }
+
+    /**
+     * Transform Expect to NonNegativeInteger.
+     *
+     * @since 0.51
+     */
+    @SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
+    public static final class NonNegativeInteger {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public NonNegativeInteger(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
+        public java.lang.Integer it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).asNumber())
+                .otherwise("must be a number")
+                .must(number -> number % 1 == 0)
+                .otherwise("must be an integer")
+                .that(Double::intValue)
+                .must(integer -> integer >= 0)
+                .otherwise("must be greater or equal to zero")
                 .it();
         }
     }

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * @param <T> The type of result
  * @since 0.41.0
  */
-@SuppressWarnings("PMD.ShortMethodName")
+@SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
 public class Expect<T> {
 
     /**
@@ -215,7 +215,6 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    @SuppressWarnings("PMD.ShortMethodName")
     public static final class Number {
 
         /**
@@ -249,7 +248,6 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    @SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
     public static final class Integer {
 
         /**
@@ -286,7 +284,6 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    @SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
     public static final class NonNegativeInteger {
 
         /**

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * @param <T> The type of result
  * @since 0.41.0
  */
-@SuppressWarnings({"PMD.ShortMethodName", "PMD.UnnecessaryFullyQualifiedName"})
+@SuppressWarnings("PMD.ShortMethodName")
 public class Expect<T> {
 
     /**
@@ -248,7 +248,7 @@ public class Expect<T> {
      *
      * @since 0.51
      */
-    public static final class Integer {
+    public static final class Int {
 
         /**
          * Expect.
@@ -259,7 +259,7 @@ public class Expect<T> {
          * Ctor.
          * @param expect Expect
          */
-        public Integer(final Expect<Phi> expect) {
+        public Int(final Expect<Phi> expect) {
             this.expect = expect;
         }
 
@@ -268,7 +268,7 @@ public class Expect<T> {
          * @return The token
          * @checkstyle MethodNameCheck (5 lines)
          */
-        public java.lang.Integer it() {
+        public Integer it() {
             return this.expect
                 .that(phi -> new Dataized(phi).asNumber())
                 .otherwise("must be a number")
@@ -280,11 +280,12 @@ public class Expect<T> {
     }
 
     /**
-     * Transform Expect to NonNegativeInteger.
+     * Transform Expect to Natural number.
+     * Natural number is integer greater or equal to zero.
      *
      * @since 0.51
      */
-    public static final class NonNegativeInteger {
+    public static final class Natural {
 
         /**
          * Expect.
@@ -295,7 +296,7 @@ public class Expect<T> {
          * Ctor.
          * @param expect Expect
          */
-        public NonNegativeInteger(final Expect<Phi> expect) {
+        public Natural(final Expect<Phi> expect) {
             this.expect = expect;
         }
 
@@ -304,7 +305,7 @@ public class Expect<T> {
          * @return The token
          * @checkstyle MethodNameCheck (5 lines)
          */
-        public java.lang.Integer it() {
+        public Integer it() {
             return this.expect
                 .that(phi -> new Dataized(phi).asNumber())
                 .otherwise("must be a number")

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -192,7 +192,7 @@ final class ExpectTest {
             "inner class Integer throws error for not a number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect.Integer(
+                () -> new Expect.Int(
                     Expect.at(
                         new PhWith(
                             new PhDefault(),
@@ -214,7 +214,7 @@ final class ExpectTest {
             "inner class Integer throws error for not an integer number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect.Integer(
+                () -> new Expect.Int(
                     Expect.at(
                         new PhWith(
                             new PhDefault(),
@@ -236,7 +236,7 @@ final class ExpectTest {
             "inner class NonNegativeInteger throws error for not a number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect.NonNegativeInteger(
+                () -> new Expect.Natural(
                     Expect.at(
                         new PhWith(
                             new PhDefault(),
@@ -258,7 +258,7 @@ final class ExpectTest {
             "inner class NonNegativeInteger throws error for not an integer number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect.NonNegativeInteger(
+                () -> new Expect.Natural(
                     Expect.at(
                         new PhWith(
                             new PhDefault(),
@@ -280,7 +280,7 @@ final class ExpectTest {
             "inner class NonNegativeInteger throws error for a negative integer",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Expect.NonNegativeInteger(
+                () -> new Expect.Natural(
                     Expect.at(
                         new PhWith(
                             new PhDefault(),

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class ExpectTest {
 
     @Test
@@ -226,6 +227,72 @@ final class ExpectTest {
                 "fails with correct error message while transform Phi to Integer"
             ).getMessage(),
             Matchers.equalTo("the 'ρ' attribute (42.23) must be an integer")
+        );
+    }
+
+    @Test
+    void failsInTransformingToNonNegativeIntegerForNotNumber() {
+        MatcherAssert.assertThat(
+            "inner class NonNegativeInteger throws error for not a number",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.NonNegativeInteger(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(true)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to NonNegativeInteger"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute must be a number")
+        );
+    }
+
+    @Test
+    void failsInTransformingToNonNegativeIntegerForNotInteger() {
+        MatcherAssert.assertThat(
+            "inner class NonNegativeInteger throws error for not an integer number",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.NonNegativeInteger(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(42.23)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to NonNegativeInteger"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute (42.23) must be an integer")
+        );
+    }
+
+    @Test
+    void failsInTransformingToNonNegativeIntegerForNegative() {
+        MatcherAssert.assertThat(
+            "inner class NonNegativeInteger throws error for a negative integer",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.NonNegativeInteger(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(-42)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to NonNegativeInteger"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute (-42) must be greater or equal to zero")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -163,4 +163,70 @@ final class ExpectTest {
         );
     }
 
+    @Test
+    void failsInTransformingToNumberForNotNumber() {
+        MatcherAssert.assertThat(
+            "inner class Number working throws error if attr is not a number",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.Number(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(true)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to Number"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute must be a number")
+        );
+    }
+
+    @Test
+    void failsInTransformingToIntegerForNotNumber() {
+        MatcherAssert.assertThat(
+            "inner class Integer throws error for not a number",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.Integer(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(true)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to Integer"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute must be a number")
+        );
+    }
+
+    @Test
+    void failsInTransformingToIntegerForNotInteger() {
+        MatcherAssert.assertThat(
+            "inner class Integer throws error for not an integer number",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.Integer(
+                    Expect.at(
+                        new PhWith(
+                            new PhDefault(),
+                            Attr.RHO,
+                            new Data.ToPhi(42.23)
+                        ),
+                        Attr.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to Integer"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute (42.23) must be an integer")
+        );
+    }
+
 }


### PR DESCRIPTION
Ref: #3461

Inner classes help to encapsulate the logic of using Expect and make it easier.

Before:
```java
Expect.at(this, Attr.RHO)
    .that(phi -> new Dataized(phi).asNumber())
    .otherwise("must be a number")
    .it();
```
After:
```java
new Expect.Number(Expect.at(this, Attr.RHO)).it();
```

Ref to [comment](https://github.com/objectionary/eo/issues/3461#issuecomment-2597667500)
