### PR TITLE
bug(#3481): removed redundant rhos in whole `eo-runtime` + optimized some objects

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -31,18 +31,20 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 [file] > dir
+  $ > as-dir
   $.file > @
   true > is-directory
 
   # Makes a directory together with all required
   # parent directories and returns the created directory.
   [] > made
-    if. > @
-      ^.exists
-      ^
-      seq *
-        mkdir
+    as-dir. > @
+      if.
+        ^.exists
         ^
+        seq *
+          mkdir
+          ^
 
     # Makes a directory together with all required
     # parent directories.
@@ -59,40 +61,38 @@
   # Deletes directory and all files in it, recursively.
   # Returns the deleted directory.
   [] > deleted
-    (^.walk "**").at.^ > walked
-    walked.length > len!
-    if. > @
-      ^.exists
-      seq *
-        rec-delete walked 0
+    as-dir. > @
+      if.
+        ^.exists
+        seq *
+          rec-delete (walk "**").as-tuple
+          ^
         ^
-      ^
 
     # Deletes files and directories in current directory recursively.
     # Returns `true`.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of `dir` object.
-    [tup index] > rec-delete
+    [tup] > rec-delete
       if. > @
-        ^.len.eq index
+        tup.length.eq 0
         true
         seq *
-          tup.value.deleted.exists
-          ^.rec-delete
-            tup.prev
-            index.plus 1
+          tup.value.deleted
+          rec-delete tup.prev
 
   # Creates an empty temporary file in the current directory.
   [] > tmpfile
-    if. > @
-      ^.exists
-      QQ.fs.file
-        string touch.as-bytes
-      error
-        sprintf
-          "Directory %s does not exist, can't create temporary file"
-          * ^.path
+    as-file. > @
+      if.
+        ^.exists
+        QQ.fs.file
+          touch.as-bytes
+        error
+          sprintf
+            "Directory %s does not exist, can't create temporary file"
+            * path
 
     # Creates an empty temporary file in the current directory and
     # returns absolute path to it as `string`.
@@ -107,4 +107,4 @@
     error > @
       sprintf
         "The file %s is a directory, can't open for I/O operations"
-        * ^.path
+        * path

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -78,9 +78,9 @@
         ^.len.eq index
         true
         seq *
-          tup.tail.deleted.exists
+          tup.value.deleted.exists
           ^.rec-delete
-            tup.head
+            tup.prev
             index.plus 1
 
   # Creates an empty temporary file in the current directory.

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -92,7 +92,7 @@
         error
           sprintf
             "Directory %s does not exist, can't create temporary file"
-            * path
+            * file
 
     # Creates an empty temporary file in the current directory and
     # returns absolute path to it as `string`.
@@ -107,4 +107,4 @@
     error > @
       sprintf
         "The file %s is a directory, can't open for I/O operations"
-        * path
+        * file

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -31,7 +31,10 @@
 
 # The file object in the filesystem.
 [path] > file
+  $ > as-file
   $.path > @
+  # Convert the `file` to the `path`.
+  (QQ.fs.path path).determined > as-path
 
   # Returns `true` if current file is a directory, returns `false` otherwise.
   [] > is-directory /org.eolang.bool
@@ -43,12 +46,13 @@
   # If current file does not exist - create an empty file
   # in filesystem and returns it.
   [] > touched
-    if. > @
-      ^.exists
-      ^
-      seq *
-        touch
+    as-file. > @
+      if.
+        exists
         ^
+        seq *
+          touch
+          ^
 
     # Creates new empty file.
     #
@@ -59,12 +63,13 @@
   # If current file exists - deletes it and returns it.
   # If current file does not exist - just returns it.
   [] > deleted
-    if. > @
-      ^.exists
-      seq *
-        delete
+    as-file. > @
+      if.
+        exists
+        seq *
+          delete
+          ^
         ^
-      ^
 
     # Deletes the file and returns `true`.
     #
@@ -77,8 +82,8 @@
 
   # Move current file to `target`, making and returning a new `file` from it.
   [target] > moved
-    QQ.fs.file > @
-      string move.as-bytes
+    as-file. > @
+      file move
 
     # Tries to move file from `^.path` to `target`
     # and returns path of moved file as `string`.
@@ -87,9 +92,6 @@
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of `file` object.
     [] > move /org.eolang.string
-
-  # Convert the `file` to the `path`.
-  (QQ.fs.path ^.path).determined > [] > as-path
 
   # Opens the file.
   #
@@ -124,12 +126,12 @@
   # closes the file stream and returns an original file object.
   [mode scope] > open
     mode > access!
-    access.eq "r" > read
-    access.eq "w" > write
-    access.eq "a" > append
-    access.eq "r+" > read-write
-    access.eq "w+" > write-read
-    access.eq "a+" > read-append
+    (access.eq "r").as-bool > read
+    (access.eq "w").as-bool > write
+    (access.eq "a").as-bool > append
+    (access.eq "r+").as-bool > read-write
+    (access.eq "w+").as-bool > write-read
+    (access.eq "a+").as-bool > read-append
     as-bool. > can-read
       or.
         read.or read-write
@@ -144,31 +146,32 @@
       read.or read-write
     as-bool. > truncate
       write.or write-read
-    if. > @
-      can-read.not.and can-write.not
-      error "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+    as-file. > @
       if.
-        ^.exists.not
+        can-read.not.and can-write.not
+        error "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
         if.
-          must-exists
-          error
-            sprintf
-              "File must exist for given access mod: '%s'"
-              * access
-          seq *
-            ^.touched.touch
-            process-file
-            ^
-        if.
-          truncate
-          seq *
-            ^.deleted.delete
-            ^.touched.touch
-            process-file
-            ^
-          seq *
-            process-file
-            ^
+          exists.not
+          if.
+            must-exists
+            error
+              sprintf
+                "File must exist for given access mod: '%s'"
+                * access
+            seq *
+              touched.touch
+              process-file
+              ^
+          if.
+            truncate
+            seq *
+              deleted.delete
+              touched.touch
+              process-file
+              ^
+            seq *
+              process-file
+              ^
 
     # Process current file in the provided scope.
     #
@@ -191,14 +194,14 @@
       # Returns new instance of `input-block` with `buffer` read from file, or
       # returns `error` if access mode does not allow reading operations.
       [size] > read
-        ((input-block --).read size).self > @
+        ((input-block --).read size).this > @
 
         # File input block
         #
         # Attention! The object is for internal usage only, please
         # don't use the object programmatically outside of `file` object.
         [buffer] > input-block
-          $ > self
+          $ > this
           buffer > @
 
           # Read `size` amount of bytes from file input stream.
@@ -206,18 +209,18 @@
           # returns `error` if provided access mode does not allow reading operations.
           [size] > read
             ^.^.read-bytes size > read-bytes!
-            self. > @
+            this. > @
               if.
-                ^.^.^.^.can-read.not
+                can-read.not
                 [] >>
-                  $ > self
+                  $ > this
                   error > @
                     sprintf
                       "Can't read from file with provided access mode '%s'"
-                      * ^.^.^.^.^.access
+                      * access
                 seq *
                   read-bytes
-                  ^.^.input-block read-bytes
+                  input-block read-bytes
 
         # Bytes read from file input stream
         #
@@ -231,14 +234,14 @@
       # Returns new instance of `output-block` ready to write again, or
       # returns an error if provided access mode does not allow writing operations.
       [buffer] > write
-        (output-block.write buffer).self > @
+        (output-block.write buffer).this > @
 
         # File output block.
         #
         # Attention! The object is for internal usage only, please
         # don't use the object programmatically outside of `file` object.
         [] > output-block
-          $ > self
+          $ > this
           true > @
 
           # Write given `buffer` to file output stream.
@@ -247,18 +250,18 @@
           # Returns new instance of `output-block` ready to write again, or
           # returns an error if provided access mode does not allow writing operations.
           [buffer] > write
-            self. > @
+            this. > @
               if.
-                ^.^.^.^.can-write.not
+                can-write.not
                 [] >>
-                  $ > self
+                  $ > this
                   error > @
                     sprintf
                       "Can't write to file with provided access mode '%s'"
-                      * ^.^.^.^.^.access
+                      * access
                 seq *
-                  ^.^.written-bytes buffer
-                  ^.^.output-block
+                  written-bytes buffer
+                  output-block
 
         # Bytes written to file output stream.
         #

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -107,8 +107,8 @@
               if.
                 and.
                   accum.length.gt 0
-                  (accum.tail.eq "..").not
-                accum.head
+                  (accum.value.eq "..").not
+                accum.prev
                 if.
                   ^.is-absolute.not
                   accum.with segment
@@ -362,8 +362,8 @@
                 if.
                   and.
                     accum.length.gt 0
-                    (accum.tail.eq "..").not
-                  accum.head
+                    (accum.value.eq "..").not
+                  accum.prev
                   if.
                     and.
                       ^.is-root-relative.not

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.fs.dir
++alias org.eolang.fs.file
 +alias org.eolang.sys.os
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
@@ -47,13 +49,13 @@
     string > joined-path
       as-bytes.
         joined.
-          text ^.separator
+          text separator
           paths
     normalized. > @
       if.
         os.is-windows
-        ^.win32 joined-path
-        ^.posix joined-path
+        win32 joined-path
+        posix joined-path
 
   # The system-dependent default name-separator character.
   # On UNIX systems the value of this field is "/";
@@ -61,30 +63,30 @@
   [] > separator
     if. > @
       os.is-windows
-      ^.win32.separator
-      ^.posix.separator
+      win32.separator
+      posix.separator
 
   # POSIX specified path.
   # A standardized way to represent file or directory locations in a Unix-like system.
   [uri] > posix
     $ > determined
     "/" > separator
-    (QQ.fs.file uri).size.^ > as-file
-    (QQ.fs.dir (QQ.fs.file uri)).made.^ > as-dir
+    (file uri).as-file > as-file
+    (dir (QQ.fs.file uri)).as-dir > as-dir
     uri > @
 
     # Returns `true` if current path is absolute - starts with '/' char.
     [] > is-absolute
       and. > @
-        ^.uri.length.gt 0
-        (^.uri.as-bytes.slice 0 1).eq ^.separator
+        uri.length.gt 0
+        (uri.as-bytes.slice 0 1).eq separator
 
     # Return new `path` with normalized uri.
     # Normalization includes:
     # - converting multiple slashes into a single slash.
     # - resolving "." (current directory) and ".."  (parent directory) segments.
     [] > normalized
-      ^.uri.as-bytes > uri-as-bytes
+      uri > uri-as-bytes!
       ^.is-absolute.as-bool > is-absolute
       and. > has-trailing-slash
         uri-as-bytes.size.gt 0
@@ -92,14 +94,14 @@
           uri-as-bytes.slice
             uri-as-bytes.size.plus -1
             1
-          ^.separator
+          separator
       joined. > path
-        text ^.separator
+        text separator
         reduced.
           list
             split.
-              text ^.uri
-              ^.separator
+              text uri
+              separator
           *
           [accum segment] >>
             if. > @
@@ -110,7 +112,7 @@
                   (accum.value.eq "..").not
                 accum.prev
                 if.
-                  ^.is-absolute.not
+                  is-absolute.not
                   accum.with segment
                   accum
               if.
@@ -121,19 +123,19 @@
                 accum.with segment
       as-bytes. > normalized
         if.
-          ^.uri.length.eq 0
+          uri.length.eq 0
           "."
           concat.
             if.
               is-absolute
-              ^.separator.concat path
+              separator.concat path
               path
             if.
               has-trailing-slash
-              ^.separator
+              separator
               --
       determined. > @
-        ^.^.posix
+        posix
           if.
             normalized.eq "//"
             "/"
@@ -157,15 +159,15 @@
     [other] > resolved
       other.as-bytes > other-as-bytes
       normalized. > @
-        ^.^.posix
+        posix
           string
             if.
-              (other-as-bytes.slice 0 1).eq ^.separator
+              (other-as-bytes.slice 0 1).eq separator
               other-as-bytes
               concat.
                 concat.
-                  ^.uri
-                  ^.separator
+                  uri
+                  separator
                 other-as-bytes
 
     # Takes the base name from the provided `path`, for example:
@@ -184,11 +186,11 @@
     # is "/" (regular slash) in Unix OS:
     # With the `path` "/tmp/var/hello\world" `base-name` returns `hello\world`.
     [] > basename
-      ^.uri > pth!
+      uri > pth!
       text > txt
         string pth
       plus. > slice-start-idx!
-        txt.last-index-of ^.separator
+        txt.last-index-of separator
         1
       string > @
         if.
@@ -217,7 +219,7 @@
     # and returns substring after "." if it's found.
     # If it's not - empty string is returned.
     [] > extname
-      ^.basename > base!
+      basename > base!
       text > txt
         string base
       txt.last-index-of "." > slice-start-idx!
@@ -250,10 +252,10 @@
     # is "/" (regular slash) in Unix OS:
     # With the `path` "/tmp/v\a\r/hello" `dir-name` returns `/tmp/v\a\r`.
     [] > dirname
-      ^.uri > pth!
+      uri > pth!
       text > txt
         string pth
-      txt.last-index-of ^.separator > len!
+      txt.last-index-of separator > len!
       string > @
         if.
           or.
@@ -283,8 +285,8 @@
     [uri] > validated
       $ > determined
       ^.separator > separator
-      (QQ.fs.file uri).size.^ > as-file
-      (QQ.fs.dir (QQ.fs.file uri)).made.^ > as-dir
+      (file uri).as-file > as-file
+      (dir (file uri)).as-dir > as-dir
       uri > @
 
       # Returns `true` if given `uri` is drive relative which means it
@@ -297,7 +299,7 @@
         uri > uri-as-bytes!
         and. > @
           uri-as-bytes.size.gt 0
-          (uri-as-bytes.slice 0 1).eq ^.separator
+          (uri-as-bytes.slice 0 1).eq separator
 
       # Replaces slashes '/' with valid windows separator '\'.
       [uri] > separated-correctly
@@ -306,7 +308,7 @@
           string uri-as-bytes
         pth.replaced > replaced!
           regex "/\\//"
-          ^.separator
+          separator
         if. > @
           (pth.index-of path.posix.separator).eq -1
           string uri-as-bytes
@@ -321,10 +323,10 @@
           uri-as-bytes.size.eq 0
           false
           or.
-            ^.is-root-relative uri-as-bytes
+            is-root-relative uri-as-bytes
             and.
               uri-as-bytes.size.gt 1
-              ^.is-drive-relative uri-as-bytes
+              is-drive-relative uri-as-bytes
 
       # Return new `path` with normalized uri.
       # Normalization includes:
@@ -332,7 +334,7 @@
       # - resolving "." (current directory) and ".."  (parent directory) segments.
       # - handling of drive letters in Windows.
       [] > normalized
-        ^.uri > uri-as-bytes!
+        uri > uri-as-bytes!
         (^.is-drive-relative uri-as-bytes).as-bool > is-drive-relative
         (^.is-root-relative uri-as-bytes).as-bool > is-root-relative
         if. > driveless!
@@ -347,9 +349,9 @@
             uri-as-bytes.slice
               uri-as-bytes.size.plus -1
               1
-            ^.separator
+            separator
         joined. > path!
-          text ^.separator
+          text separator
           reduced.
             list
               split.
@@ -366,8 +368,8 @@
                   accum.prev
                   if.
                     and.
-                      ^.is-root-relative.not
-                      ^.is-drive-relative.not
+                      is-root-relative.not
+                      is-drive-relative.not
                     accum.with segment
                     accum
                 if.
@@ -385,23 +387,23 @@
                 if.
                   is-drive-relative
                   if.
-                    (driveless.slice 0 1).eq ^.separator
-                    ^.uri.slice 0 3
-                    ^.uri.slice 0 2
+                    (driveless.slice 0 1).eq separator
+                    uri.slice 0 3
+                    uri.slice 0 2
                   if.
                     is-root-relative
-                    ^.separator
+                    separator
                     --
                 path
               if.
                 has-trailing-slash
-                ^.separator
+                separator
                 --
         determined. > @
-          ^.^.validated
+          validated
             if.
               normalized.eq "\\\\"
-              ^.separator
+              separator
               string normalized
 
       # Resolves `other` path against `^.uri` and returns as new `path` from it.
@@ -426,12 +428,12 @@
       # |--------------------|----------------|-------------------|
       # URI Resolution Rules.
       [other] > resolved
-        ^.uri > uri-as-bytes!
-        ^.separated-correctly other > valid-other!
+        uri > uri-as-bytes!
+        separated-correctly other > valid-other!
         (^.is-drive-relative valid-other).as-bool > other-is-drive-relative
         (^.is-root-relative valid-other).as-bool > other-is-root-relative
         normalized. > @
-          ^.^.validated
+          validated
             string
               if.
                 other-is-drive-relative
@@ -439,7 +441,7 @@
                 if.
                   other-is-root-relative
                   if.
-                    ^.is-drive-relative uri-as-bytes
+                    is-drive-relative uri-as-bytes
                     concat.
                       uri-as-bytes.slice 0 2
                       valid-other
@@ -447,7 +449,7 @@
                   concat.
                     concat.
                       uri-as-bytes
-                      ^.separator
+                      separator
                     valid-other
 
       # Takes the base name from the provided `path`, for example:
@@ -466,11 +468,11 @@
       # is "/" (regular slash) in Unix OS:
       # With the `path` "/tmp/var/hello\world" `base-name` returns `hello\world`.
       [] > basename
-        ^.uri > pth!
+        uri > pth!
         text > txt
           string pth
         plus. > slice-start-idx!
-          txt.last-index-of ^.separator
+          txt.last-index-of separator
           1
         string > @
           if.
@@ -499,7 +501,7 @@
       # and returns substring after "." if it's found.
       # If it's not - empty string is returned.
       [] > extname
-        ^.basename > base!
+        basename > base!
         text > txt
           string base
         txt.last-index-of "." > slice-start-idx!
@@ -528,10 +530,10 @@
       # |------------------------------|--------------------|
       # Extracting Directory Names from File Paths.
       [] > dirname
-        ^.uri > pth!
+        uri > pth!
         text > txt
           string pth
-        txt.last-index-of ^.separator > len!
+        txt.last-index-of separator > len!
         string > @
           if.
             or.

--- a/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
@@ -39,37 +39,39 @@
 # takes the first environment variable in the list TMP, TEMP, USERPROFILE.
 # If none of these are found, it returns the Windows directory (C:\Windows).
 [] > tmpdir
-  dir > @
-    file
-      string
-        [] > os-tmp-dir!
-          getenv "TMPDIR" > tmpdir!
-          getenv "TMP" > tmp!
-          getenv "TEMP" > temp!
-          getenv "TEMPDIR" > tempdir!
-          getenv "USERPROFILE" > userprofile!
-          if. > @
-            os.is-windows
-            if.
-              tmp.eq ""
+  as-dir. > @
+    dir
+      file
+        string
+          [] > os-tmp-dir!
+            getenv "TMPDIR" > tmpdir!
+            getenv "TMP" > tmp!
+            getenv "TEMP" > temp!
+            getenv "TEMPDIR" > tempdir!
+            getenv "USERPROFILE" > userprofile!
+            -- > empty
+            if. > @
+              os.is-windows
               if.
-                temp.eq ""
+                tmp.eq empty
                 if.
-                  userprofile.eq ""
-                  "C:\\Windows"
-                  userprofile
-                temp
-              tmp
-            if.
-              tmpdir.eq ""
-              if.
-                tmp.eq ""
-                if.
-                  temp.eq ""
+                  temp.eq empty
                   if.
-                    tempdir.eq ""
-                    "/tmp"
-                    tempdir
+                    userprofile.eq empty
+                    "C:\\Windows"
+                    userprofile
                   temp
                 tmp
-              tmpdir
+              if.
+                tmpdir.eq empty
+                if.
+                  tmp.eq empty
+                  if.
+                    temp.eq empty
+                    if.
+                      tempdir.eq empty
+                      "/tmp"
+                      tempdir
+                    temp
+                  tmp
+                tmpdir

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -80,15 +80,9 @@
       as-i64.
         if.
           os.is-windows
-          milliseconds.
-            win32
-              "GetSystemTime"
-              * win32.system-time
+          (win32 "GetSystemTime" *).milliseconds
           []
-            output. > timeval
-              posix
-                "gettimeofday"
-                * posix.timeval
+            (posix "gettimeofday" *).output > timeval
             plus. > @
               timeval.tv-sec.times 1000
               as-number.

--- a/eo-runtime/src/main/eo/org/eolang/seq.eo
+++ b/eo-runtime/src/main/eo/org/eolang/seq.eo
@@ -34,7 +34,7 @@
     true
     if.
       steps.length.eq 1
-      steps.tail
+      steps.value
       loop steps
   steps.length.plus -1 > last-index!
 
@@ -46,8 +46,8 @@
     if. > @
       and.
         tup.length.gt 1
-        loop tup.head
-      tup.tail
+        loop tup.prev
+      tup.value
       or.
-        (dataized tup.tail).as-bool.eq --
+        (dataized tup.value).as-bool.eq --
         tup.length.eq last-index

--- a/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
@@ -29,15 +29,14 @@
 # Here `bts` is `bytes` objects, the return value is `tuple` where
 # each element is one `byte`.
 [bts] > bytes-as-array
-  bts.size > bytes-size!
-  slice-byte > @
-    *
-    0
+  bts > dataized-bts!
+  dataized-bts.size > bytes-size!
+  slice-byte * 0 > @
 
   [tup index] > slice-byte
     if. > @
-      index.lt ^.bytes-size
-      ^.slice-byte
-        tup.with (^.bts.slice index 1)
-        index.plus 1
+      index.lt bytes-size
+      slice-byte
+        tup.with (bts.slice index 1)
+        (index.plus 1).as-number
       tup

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -38,7 +38,7 @@
 
   [acc index] > rec-hash-code
     if. > @
-      index.eq ^.size
+      index.eq size
       acc.as-number
       rec-hash-code
         plus.

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -40,11 +40,11 @@
     if. > @
       index.eq ^.size
       acc.as-number
-      ^.rec-hash-code
+      rec-hash-code
         plus.
-          ^.magic-number.times acc
+          magic-number.times acc
           as-i64.
             concat.
               00-00-00-00-00-00-00
-              ^.input-as-bytes.slice index 1
-        index.plus 1
+              input-as-bytes.slice index 1
+        (index.plus 1).as-number

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -43,10 +43,10 @@
   [index item] > withi
     concat. > @
       with.
-        ^.head index
+        head index
         item
-      ^.tail
-        ^.origin.length.minus index
+      tail
+        origin.length.minus index
 
   # Reduce with index from "start" using the function "func".
   # Here "func" must be an abstract object with three free attributes.
@@ -166,26 +166,35 @@
   # Returns index of the first particular item in list.
   # If the list has no this item, index-of returns -1.
   [wanted] > index-of
-    reducedi > @
-      -1
-      [accum item index] >>
-        if. > @
-          and.
-            -1.eq accum
-            item.eq wanted
-          index
-          accum
+    number > @
+      rec-index-of origin
+
+    [tup] > rec-index-of
+      rec-index-of tup.prev > next!
+      if. > @
+        tup.length.eq 0
+        -1
+        if.
+          next.eq -1
+          if.
+            tup.value.eq wanted
+            tup.prev.length
+            -1
+          next
 
   # Returns index of the last particular item in list.
   # If the list has no this item, returns -1.
   [wanted] > last-index-of
-    reducedi > @
-      -1
-      [accum item index] >>
-        if. > @
-          item.eq wanted
-          index
-          accum
+    rec-last-index-of origin > @
+
+    [tup] > rec-last-index-of
+      if. > @
+        tup.length.eq 0
+        -1
+        if.
+          tup.value.eq wanted
+          tup.prev.length
+          rec-last-index-of tup.prev
 
   # Returns `true` if the list contains `element`.
   # Otherwise, `false`.
@@ -231,30 +240,26 @@
     filteredi > @
       func item > [item index] >>
 
-  # Get the first `index` elements from the start of the list. todo
+  # Get the first `index` elements from the start of the list.
   [index] > head
     index > idx!
-    switch > @
-      *
-        *
-          0.eq idx
-          list *
-        *
-          0.gt idx
-          ^.tail index.as-number.neg
-        *
-          ^.origin.length.lte idx
+    if. > @
+      idx.eq 0
+      list *
+      if.
+        0.gt idx
+        tail (number idx).neg
+        if.
+          (number idx).gte origin.length
           ^
-        *
-          true
           list
-            ^.reducedi
-              *
-              [accum item index] >>
-                if. > @
-                  index.gte ^.idx
-                  accum
-                  accum.with item
+            rec-head origin
+
+    [tup] > rec-head
+      if. > @
+        tup.length.eq idx
+        tup
+        rec-head tup.prev
 
   # Get the last `index` elements from the end of the list.
   [index] > tail

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -53,33 +53,31 @@
   # The first one for the accumulator, the second one
   # for the element of the collection and the third one for the index.
   [start func] > reducedi
-    ^.origin.length > origin-len!
     if. > @
-      0.eq origin-len
+      is-empty
       start
-      rec-reduced start 0.as-bytes
+      rec-reducedi origin
 
-    [accum index] > rec-reduced
-      index.as-number > idx-as-number
-      1.plus idx-as-number > next-index!
+    [tup] > rec-reducedi
       if. > @
-        next-index.eq ^.origin-len
-        ^.func > accumulated
-          accum
-          ^.^.origin.at idx-as-number
-          idx-as-number
-        ^.rec-reduced
-          accumulated
-          next-index
+        tup.length.eq 1
+        func
+          start
+          tup.value
+          0
+        func
+          rec-reducedi tup.prev
+          tup.value
+          tup.prev.length
 
   # Reduce from "start" using the function "func".
   # Here "func" must be an abstract object with two free attributes.
   # The first one for the accumulator, the second one for the element
   # of the collection.
   [start func] > reduced
-    ^.reducedi > @
+    reducedi > @
       start
-      ^.func accum item > [accum item idx] >>
+      func accum item > [accum item idx] >>
 
   # Map with index. Here "func" must be an abstract
   # object with two free attributes. The first
@@ -87,19 +85,18 @@
   # for the index.
   [func] > mappedi
     list > @
-      ^.reducedi
+      reducedi
         *
         [accum item idx] >>
-          with. > @
-            accum
-            ^.func item idx
+          accum.with > @
+            func item idx
 
   # Map without index. Here "func" must be an abstract
   # object with one free attribute, for the element
   # of the collection.
   [func] > mapped
-    ^.mappedi > @
-      ^.func item > [item idx] >>
+    mappedi > @
+      func item > [item idx] >>
 
   # For each collection element dataize the object
   # Here "func" must be an abstract object with
@@ -107,39 +104,39 @@
   # collection and its index.
   # The result of `func` must be dataizable.
   [func] > eachi
-    ^.reducedi > @
+    reducedi > @
       true
       [acc item index] >>
         seq * > @
           acc
-          ^.func item index
+          func item index
 
   # For each collection element dataize the object
   # Here "func" must be an abstract object with
   # one free attribute, the element of the collection.
   [func] > each
-    ^.eachi > @
-      ^.func item > [item index] >>
+    eachi > @
+      func item > [item index] >>
 
   # Create a new list without the i-th element.
   [i] > withouti
     list > @
-      ^.reducedi
+      reducedi
         *
         [accum item idx] >>
           if. > @
-            ^.i.eq idx
+            i.eq idx
             accum
             accum.with item
 
   # Create a new list without the `element` which is `.eq` to given one.
   [element] > without
     list > @
-      ^.reduced
+      reduced
         *
         [accum item] >>
           if. > @
-            ^.element.eq item
+            element.eq item
             accum
             accum.with item
 
@@ -148,46 +145,45 @@
   [other] > eq
     and. > @
       eq.
-        ^.origin.length
+        origin.length
         other.length
-      ^.reducedi
+      rec-eq origin other
+
+    [first second] > rec-eq
+      if. > @
+        first.length.eq 0
         true
-        [accum item idx] >>
-          and. > @
-            accum
-            eq.
-              item
-              ^.other.at idx
+        and.
+          first.value.eq second.value
+          rec-eq first.prev second.prev
 
   # Concatenates current list with given one.
   [passed] > concat
-    reduced. > @
-      list
-        passed
+    (list passed).reducedi > @
       ^
-      accum.with item > [accum item]
+      accum.with item > [accum item index]
 
   # Returns index of the first particular item in list.
   # If the list has no this item, index-of returns -1.
   [wanted] > index-of
-    ^.reducedi > @
+    reducedi > @
       -1
       [accum item index] >>
         if. > @
           and.
             -1.eq accum
-            item.eq ^.wanted
+            item.eq wanted
           index
           accum
 
   # Returns index of the last particular item in list.
   # If the list has no this item, returns -1.
   [wanted] > last-index-of
-    ^.reducedi > @
+    reducedi > @
       -1
       [accum item index] >>
         if. > @
-          item.eq ^.wanted
+          item.eq wanted
           index
           accum
 
@@ -197,7 +193,7 @@
     not. > @
       eq.
         -1
-        ^.index-of element
+        index-of element
 
   # Returns a new list sorted via `.lt` method.
   # @todo #3251:30min The object does not work. After moving `list` object
@@ -213,23 +209,18 @@
   # for the index. The result of dataization
   # the `func` should be boolean, that is `true` or `false`.
   [func] > filteredi
-    ^.origin.length > origin-length!
     list > @
-      rec-filtered 0.as-bytes *
+      rec-filteredi origin
 
-    [idx-as-bytes accum] > rec-filtered
-      ^.^.origin > original
-      idx-as-bytes.as-number > index
-      ^.^.origin.at index > item
+    [tup] > rec-filteredi
+      rec-filteredi tup.prev > next
       if. > @
-        idx-as-bytes.eq ^.origin-length
-        accum
-        ^.rec-filtered
-          (1.plus index).as-bytes
-          if.
-            ^.func item index
-            accum.with item
-            accum
+        tup.length.eq 0
+        *
+        if.
+          func tup.value tup.prev.length
+          next.with tup.value
+          next
 
   # Filter list without index with the function `func`.
   # Here `func` must be an abstract object
@@ -237,10 +228,10 @@
   # The result of dataization the `func`
   # should be boolean, that is `true` or `false`.
   [func] > filtered
-    ^.filteredi > @
-      ^.func item > [item index] >>
+    filteredi > @
+      func item > [item index] >>
 
-  # Get the first `index` elements from the start of the list.
+  # Get the first `index` elements from the start of the list. todo
   [index] > head
     index > idx!
     switch > @
@@ -268,15 +259,15 @@
   # Get the last `index` elements from the end of the list.
   [index] > tail
     index > idx!
-    ^.origin.length.minus idx.as-number > start!
+    origin.length.minus idx > start!
     if. > @
       0.gt start
       ^
       list
-        ^.reducedi
+        reducedi
           *
           [accum item idx] >>
             if. > @
-              idx.gte ^.start
+              idx.gte start
               accum.with item
               accum

--- a/eo-runtime/src/main/eo/org/eolang/structs/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/map.eo
@@ -30,39 +30,39 @@
 +unlint broken-ref
 
 # Hash-map.
-# Here `pairs` must be a `tuple` of `tuple`s where each sub-tuple consists of 2
-# elements - key and value.
-# Key must be a dataizable object, value may be any object.
+# Here `pairs` must be a `tuple` of `map.entry` object.
+# The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
 [pairs] > map
-  initialized. > @
+  this. > @
     [] >>
-      ^.pairs.length > pairs-size!
-      ^.initialized > @
-        if.
-          pairs-size.eq 0
-          *
-          rec-rebuild
+      initialized > @
+        as-tuple.
+          if.
+            pairs.length.eq 0
             *
-            0
-            list *
+            entries.
+              rec-rebuild
+                pairs
 
-      [accum index hashes] > rec-rebuild
-        ^.^.pairs.at index > entry
-        hash-code-of entry.key > hash!
+      [entries hashes] > couple
+        $ > this
+
+      [tup] > rec-rebuild
+        hash-code-of tup.value.key > hash!
+        (rec-rebuild tup.prev).this > prev
         if. > @
-          ^.pairs-size.eq index
-          accum
-          ^.rec-rebuild
-            if.
-              hashes.contains hash
-              accum
-              accum.with
+          tup.length.eq 0
+          couple * (list *)
+          if.
+            prev.hashes.contains hash
+            prev
+            couple
+              prev.entries.with
                 [] >>
-                  ^.entry.key > key
-                  ^.entry.value > value
+                  tup.value.key > key
+                  tup.value.value > value
                   ^.hash > hash
-            index.plus 1
-            hashes.with hash
+              prev.hashes.with hash
 
   # Hash map entry.
   # Here 'key' is an object which is used to find `value` is hash map.
@@ -73,26 +73,22 @@
 
   # Initialized hash map with rebuilt entries.
   [entries] > initialized
-    $ > initialized
+    $ > this
     entries.length > size
-
     # Returns `list` of all keys in hash map.
     # Keys order is not guaranteed.
-    [] > keys
-      mapped. > @
-        list ^.entries
-        entry.key > [entry]
-
+    mapped. > keys
+      list entries
+      entry.key > [entry]
     # Returns `list` of all values in hash map.
     # Values order is not guaranteed.
-    [] > values
-      mapped. > @
-        list ^.entries
-        entry.value > [entry]
+    mapped. > values
+      list entries
+      entry.value > [entry]
 
     # Returns `true` if hash map has object by given `key`.
     # Here `key` must be dataizable.
-    (^.found key).exists > [key] > has
+    (found key).exists > [key] > has
 
     # Tries to find object in hash map by given `key`.
     # Here `key` must be dataizable.
@@ -115,54 +111,57 @@
     [key] > found
       hash-code-of key > hash!
       if. > @
-        ^.size.eq 0
+        size.eq 0
         not-found
-        rec-key-search
-          not-found
-          0
+        rec-key-search entries
 
-      [found index] > rec-key-search
-        ^.^.entries.at index > entry
+      [tup] > rec-key-search
+        (rec-key-search tup.prev).this > prev
         if. > @
-          or.
-            found.exists
-            ^.^.size.eq index
-          found
-          ^.rec-key-search
+          tup.length.eq 0
+          not-found
+          if.
+            prev.exists
+            prev
             if.
-              ^.hash.eq entry.hash
-              [] (true > exists) (^.entry.value > get) >>
-              found
-            index.plus 1
+              tup.value.hash.eq hash
+              [] >>
+                $ > this
+                true > exists
+                tup.value.value > get
+              not-found
 
       [] > not-found
+        $ > this
         false > exists
         error > get
           sprintf
             "Object by hash code %d from given key does not exists"
-            * ^.hash
+            * hash
 
     # Returns the new `map` with added object
     # Replaces if there was one before.
     [key value] > with
       hash-code-of key > hash!
-      map.initialized > @
-        with.
-          origin.
-            filtered.
-              list ^.entries
-              (^.hash.eq entry.hash).not > [entry] >>
-          [] >>
-            ^.key > key
-            ^.value > value
-            ^.hash > hash
+      this. > @
+        map.initialized
+          with.
+            origin.
+              filtered.
+                list entries
+                (hash.eq entry.hash).not > [entry] >>
+            [] >>
+              ^.key > key
+              ^.value > value
+              ^.hash > hash
 
     # Returns a new `map`, without element with the given `key`
     # Returns the `map` itself, if there was no item with this `key`.
     [key] > without
       hash-code-of key > hash!
-      map.initialized > @
-        origin.
-          filtered.
-            list ^.entries
-            (^.hash.eq entry.hash).not > [entry] >>
+      this. > @
+        map.initialized
+          origin.
+            filtered.
+              list entries
+              (hash.eq entry.hash).not > [entry] >>

--- a/eo-runtime/src/main/eo/org/eolang/structs/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/set.eo
@@ -29,7 +29,7 @@
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set
-  initialized. > @
+  this. > @
     initialized
       map
         list
@@ -39,23 +39,24 @@
         .origin
 
   # Initialized set with rebuilt unique sequence.
-  [map] > initialized
-    $ > initialized
-    $.map.keys > @
-    $.map.size > size
+  [mp] > initialized
+    $ > this
+    mp.keys > @
+    mp.size > size
 
     # Append new `item` to set. It must be possible to get
     # hash code of `item` so `item` must be dataizable.
     [item] > with
-      set.initialized > @
-        ^.map.with item true
+      this. > @
+        set.initialized
+          mp.with item true
 
     # Remove `item` from `set`. If `item` is not present,
     # the set wont be changed.
     [item] > without
-      set.initialized > @
-        ^.map.without item
+      this. > @
+        set.initialized
+          mp.without item
 
     # Check if given `item` exists in set.
-    [item] > has
-      ^.map.has item > @
+    mp.has item > [item] > has

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -46,7 +46,6 @@
   # Timeval structure for "gettimeofday" syscall.
   # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.
   [tv-sec tv-usec] > timeval
-    $ > self
 
   # The posix `sockaddr_in` structure.
   [sin-family sin-port sin-addr] > sockaddr-in

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -52,7 +52,6 @@
 
   # Structure for "GetSystemTime" function call.
   [year month day day-of-week hour minute second milliseconds] > system-time
-    $ > self
 
   # The win32 `sockaddr_in` structure.
   [sin-family sin-port sin-addr] > sockaddr-in

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -27,23 +27,24 @@
 
 # Tuple.
 # An ordered, immutable collection of elements.
-[head tail length] > tuple
-  $ > self
+[prev value length] > tuple
+  $ > as-tuple
 
   # Empty tuple.
   # A tuple with no elements. When dataized, it represents an immutable, empty collection.
   [] > empty
     $ > empty
+    $ > as-tuple
     0 > length
-    error "Can't get head from the empty tuple" > head
-    error "Can't get tail from the empty tuple" > tail
+    error "Can't get prev from the empty tuple" > prev
+    error "Can't get value from the empty tuple" > value
 
     # Take one element from the tuple, at the given position.
     error "Can't get an object from the empty tuple" > [i] > at
 
     # Create a new tuple with this element added to the end of it.
     [x] > with
-      self. > @
+      as-tuple. > @
         tuple
           ^
           x
@@ -66,12 +67,12 @@
     [tup] > at-fast
       if. > @
         (tup.length.plus -1).eq index
-        tup.tail
-        at-fast tup.head
+        tup.value
+        at-fast tup.prev
 
   # Create a new tuple with this element added to the end of it.
   [x] > with
-    self. > @
+    as-tuple. > @
       tuple
         ^
         x

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -35,6 +35,8 @@
   [] > empty
     $ > empty
     0 > length
+    error "Can't get head from the empty tuple" > head
+    error "Can't get tail from the empty tuple" > tail
 
     # Take one element from the tuple, at the given position.
     error "Can't get an object from the empty tuple" > [i] > at

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -119,7 +119,7 @@
     if. > joined-bts!
       items.length.eq 0
       --
-      with-delimiter items.tail items.head
+      with-delimiter items.value items.prev
     text > @
       string joined-bts
 
@@ -130,10 +130,10 @@
         with-delimiter
           concat.
             concat.
-              dataized tup.tail
+              dataized tup.value
               delimiter
             acc
-          tup.head
+          tup.prev
 
   # Returns `text` repeated `times` times.
   # If `times` < 0 - an error is returned.
@@ -235,51 +235,56 @@
           origin-bts.slice 0 found
 
     [idx] > rec-index-of
-      eq. > contains
+      eq. > includes
         origin-bts.slice idx substring-size
         substring-bts
       if. > @
         end.eq idx
         if.
-          contains
+          includes
           idx
           -1
         if.
-          contains
+          includes
           idx
           rec-index-of (idx.plus 1).as-number
 
   # Returns last index of `substring` in current `text`.
   # If no element was found, it returns -1.
   [substring] > last-index-of
-    (string origin.as-bytes).length > self-len!
-    string > substr
-      substring > substr-as-bytes!
-    substr.length > sub-len!
+    origin > origin-bts!
+    substring > substring-bts!
+    origin-bts.size > origin-size!
+    substring-bts.size > substring-size!
+    rec-index-of > found!
+      (number origin-size).minus substring-size
     if. > @
       or.
-        (number sub-len).gt self-len
-        and.
-          sub-len.eq self-len
-          (substr.eq origin).not
+        or.
+          (number substring-size).gt origin-size
+          and.
+            substring-size.eq origin-size
+            (substring-bts.eq origin-bts).not
+        found.eq -1
       -1
-      rec-index-of-substr
-        (number self-len).minus (number sub-len)
+      length.
+        string
+          origin-bts.slice 0 found
 
-    [idx] > rec-index-of-substr
+    [idx] > rec-index-of
+      eq. > includes
+        origin-bts.slice idx substring-size
+        substring-bts
       if. > @
         0.eq idx
         if.
-          eq. > contains
-            substr
-            slice idx sub-len
+          includes
           idx
           -1
         if.
-          contains
+          includes
           idx
-          rec-index-of-substr
-            idx.plus -1
+          rec-index-of (idx.plus -1).as-number
 
   # Returns the `text` in upper case.
   [] > up-cased
@@ -397,14 +402,14 @@
 
   # Returns the original `text` as `number`.
   [] > as-number
-    sscanf "%f" origin > scanned
+    (sscanf "%f" origin).as-tuple > scanned
     if. > @
       scanned.length.eq 0
       error
         sprintf
           "Can't convert text %s to number"
           * origin
-      scanned.tail
+      scanned.value
 
   # Returns a `tuple` of `strings`, separated by a given `delimiter`.
   [delimiter] > split
@@ -438,7 +443,7 @@
             current.plus 1
 
   # Returns concatenation of all `other` strings.
-  # Here `other` must be a `tuple` of `strings`.
+  # Here `others` must be a `tuple` of `strings`.
   [others] > chained
     if. > @
       0.eq others.length

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -57,91 +57,94 @@
 
   # Returns `text` trimmed from left side.
   [] > trimmed-left
-    origin.length > len!
+    origin > bts!
+    bts.size > len!
     first-non-space-index 0 > idx!
+    20- > space
     if. > @
       0.eq len
       ^
-      slice
-        idx
-        (number len).minus (number idx)
+      text
+        string
+          bts.slice
+            idx
+            (number len).minus idx
 
     [index] > first-non-space-index
-      origin.slice index 1 > char!
+      bts.slice index 1 > char!
       if. > @
         len.eq index
         index
         if.
-          " ".eq char
-          first-non-space-index
-            index.plus 1
+          char.eq space
+          first-non-space-index (index.plus 1).as-number
           index
 
   # Returns `text` trimmed from right side.
   [] > trimmed-right
-    origin.length > len!
+    origin > bts!
+    bts.size > len!
+    20- > space
     if. > @
       0.eq len
       ^
-      slice
-        0
-        first-non-space-index
-          (number len).plus -1
+      text
+        string
+          bts.slice
+            0
+            first-non-space-index
+              (number len).plus -1
 
     [index] > first-non-space-index
-      origin.slice index 1 > char!
+      bts.slice index 1 > char!
       if. > @
         -1.eq index
         0
         if.
-          " ".eq char
-          first-non-space-index
-            index.plus -1
+          char.eq space
+          first-non-space-index (index.plus -1).as-number
           index.plus 1
 
   # Returns `text` trimmed from both sides.
   [] > trimmed
     if. > @
-      0.eq ^.length
+      0.eq origin.as-bytes.size
       ^
-      trimmed-right.
-        trimmed-left.
-          ^
+      trimmed-left.trimmed-right
 
   # Joins `items`, which is a `tuple` of strings, using current `string`
   # as a delimiter.
   [items] > joined
     origin > delimiter!
-    items.at 0 > first
-    items.length > len!
-    if. > not-empty!
-      1.eq len
-      first
-      concat.
-        first.as-bytes
-        with-delimiter "".as-bytes 1
+    if. > joined-bts!
+      items.length.eq 0
+      --
+      with-delimiter items.tail items.head
     text > @
-      if.
-        0.eq len
-        ""
-        string not-empty
+      string joined-bts
 
-    [acc index] > with-delimiter
+    [acc tup] > with-delimiter
       if. > @
-        len.eq index
+        tup.length.eq 0
         acc
         with-delimiter
-          acc.concat
-            delimiter.concat
-              items.at index
-          index.plus 1
+          concat.
+            concat.
+              dataized tup.tail
+              delimiter
+            acc
+          tup.head
 
   # Returns `text` repeated `times` times.
   # If `times` < 0 - an error is returned.
   # If `times` == 0 - an original text is returned.
   [times] > repeated
-    origin.as-bytes > bts!
+    origin > bts!
     times > amount!
+    if. > repeated-bytes!
+      0.eq amount
+      --
+      rec-repeated bts 1
     if. > @
       0.gt amount
       error
@@ -149,11 +152,7 @@
           "Can't repeat text %d times"
           * amount
       text
-        if.
-          0.eq amount
-          ""
-          string
-            rec-repeated bts 1
+        string repeated-bytes
 
     [accum index] > rec-repeated
       if. > @
@@ -161,59 +160,94 @@
         accum
         rec-repeated
           accum.concat bts
-          index.plus 1
+          (index.plus 1).as-number
 
   # Checks if current `text` contains given `substring`.
   [substring] > contains
-    not. > @
-      eq.
-        -1
-        index-of substring
+    origin > origin-bts!
+    substring > substring-bts!
+    origin-bts.size > origin-size!
+    substring-bts.size > substring-size!
+    (number origin-size).minus substring-size > end!
+    and. > @
+      (number origin-size).gte substring-size
+      or.
+        and.
+          origin-size.eq substring-size
+          origin-bts.eq substring-bts
+        rec-contains 0
+
+    [idx] > rec-contains
+      eq. > includes
+        origin-bts.slice idx substring-size
+        substring-bts
+      if. > @
+        end.eq idx
+        includes
+        or.
+          includes
+          rec-contains (idx.plus 1).as-number
 
   # Checks that current `text` ends with given `substring`.
   [substring] > ends-with
-    substring > substr!
-    eq. > @
-      index-of substr
-      ^.length.minus substr.size
+    origin > origin-bts!
+    substring > substring-bts!
+    origin-bts.size > origin-size!
+    substring-bts.size > substring-size!
+    and. > @
+      (number substring-size).lte origin-size
+      eq.
+        origin-bts.slice
+          (number origin-size).minus substring-size
+          substring-size
+        substring-bts
 
   # Checks that current `text` starts with given `substring`.
   [substring] > starts-with
-    eq. > @
-      0
-      index-of substring
+    origin > origin-bts!
+    substring > substring-bts!
+    origin-bts.size > origin-size!
+    substring-bts.size > substring-size!
+    and. > @
+      (number substring-size).lte origin-size
+      (origin-bts.slice 0 substring-size).eq substring-bts
 
   # Returns index of `substring` in current `text`.
   # If no `substring` was found, it returns -1.
   [substring] > index-of
-    (string origin.as-bytes).length > self-len!
-    string > substr
-      substring > substr-as-bytes!
-    substr.length > sub-len!
-    (number self-len).minus (number sub-len) > end!
+    origin > origin-bts!
+    substring > substring-bts!
+    origin-bts.size > origin-size!
+    substring-bts.size > substring-size!
+    (number origin-size).minus substring-size > end!
+    rec-index-of 0 > found!
     if. > @
       or.
-        (number sub-len).gt self-len
-        and.
-          sub-len.eq self-len
-          (substr.eq origin).not
+        or.
+          (number substring-size).gt origin-size
+          and.
+            substring-size.eq origin-size
+            (substring-bts.eq origin-bts).not
+        found.eq -1
       -1
-      rec-index-of-substr 0
+      length.
+        string
+          origin-bts.slice 0 found
 
-    [idx] > rec-index-of-substr
+    [idx] > rec-index-of
+      eq. > contains
+        origin-bts.slice idx substring-size
+        substring-bts
       if. > @
         end.eq idx
         if.
-          eq. > contains
-            substr
-            slice idx sub-len
+          contains
           idx
           -1
         if.
           contains
           idx
-          rec-index-of-substr
-            idx.plus 1
+          rec-index-of (idx.plus 1).as-number
 
   # Returns last index of `substring` in current `text`.
   # If no element was found, it returns -1.

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -414,7 +414,7 @@
   # Returns a `tuple` of `strings`, separated by a given `delimiter`.
   [delimiter] > split
     delimiter > delim!
-    origin.as-bytes > self-as-bytes
+    origin > self-as-bytes!
     self-as-bytes.size > len!
     if. > @
       len.eq 0
@@ -430,17 +430,16 @@
               start
               current.minus start
         if.
-          eq.
-            delim
+          delim.eq
             self-as-bytes.slice current 1
           rec-split
             with-substr
-            current.plus 1
-            current.plus 1
+            (current.plus 1).as-number
+            (current.plus 1).as-number
           rec-split
             accum
             start
-            current.plus 1
+            (current.plus 1).as-number
 
   # Returns concatenation of all `other` strings.
   # Here `others` must be a `tuple` of `strings`.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Posix/GettimeofdaySyscall.java
@@ -58,7 +58,7 @@ public final class GettimeofdaySyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final GettimeofdaySyscall.Timeval timeval = new GettimeofdaySyscall.Timeval();
         result.put(0, new Data.ToPhi(CStdLib.INSTANCE.gettimeofday(timeval, null)));
-        final Phi struct = params[0].take("self");
+        final Phi struct = this.posix.take("timeval");
         struct.put(0, new Data.ToPhi(timeval.sec));
         struct.put(1, new Data.ToPhi(timeval.usec));
         result.put(1, struct);

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsys/Win32/GetSystemTimeFuncCall.java
@@ -60,7 +60,7 @@ public final class GetSystemTimeFuncCall implements Syscall {
         final GetSystemTimeFuncCall.SystemTime time = new GetSystemTimeFuncCall.SystemTime();
         Kernel32.INSTANCE.GetSystemTime(time);
         result.put(0, new Data.ToPhi(true));
-        final Phi struct = params[0].take("self");
+        final Phi struct = this.win.take("system-time");
         struct.put(0, new Data.ToPhi(time.year));
         struct.put(1, new Data.ToPhi(time.month));
         struct.put(2, new Data.ToPhi(time.day));

--- a/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
@@ -30,10 +30,13 @@
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bound-tmpfile-does-not-recreates-file
-  tmpdir.tmpfile > f
-  f.path.eq f.path > @
+  tmpdir.tmpfile.as-file > f
+  QQ.io.stdout > @
+    QQ.txt.sprintf
+      "%s %s\n"
+      * f.path f.path
 
-# test.
+# This unit test is supposed to check the functionality of the corresponding object.
 [] > makes-new-directory
   (tmpdir.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
   and. > @

--- a/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
@@ -31,10 +31,7 @@
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bound-tmpfile-does-not-recreates-file
   tmpdir.tmpfile.as-file > f
-  QQ.io.stdout > @
-    QQ.txt.sprintf
-      "%s %s\n"
-      * f.path f.path
+  f.path.eq f.path > @
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > makes-new-directory

--- a/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
@@ -33,21 +33,21 @@
 [] > sscanf-with-string
   eq. > @
     "hello"
-    tail.
+    value.
       sscanf "%s" "hello"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-int
   eq. > @
     33
-    tail.
+    value.
       sscanf "%d" "33"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-float
   eq. > @
     0.24
-    tail.
+    value.
       sscanf "%f" "0.24"
 
 # This unit test is supposed to check the functionality of the corresponding object.
@@ -67,28 +67,28 @@
 [] > sscanf-with-string-with-ending
   eq. > @
     "hello"
-    tail.
+    value.
       sscanf "%s!" "hello!"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-complex-string
   eq. > @
     "test"
-    tail.
+    value.
       sscanf "some%sstring" "someteststring"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-complex-int
   eq. > @
     734987259
-    tail.
+    value.
       sscanf "!%d!" "!734987259!"
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-complex-float
   eq. > @
     1991.01
-    tail.
+    value.
       sscanf "this will be=%f" "this will be=1991.01"
 
 # This unit test is supposed to check the functionality of the corresponding object.


### PR DESCRIPTION
Closes: #3481 

In this PR I removed all unnecessary `^.` in whole `eo-runtime` and improved some algorithms in certain objects, for example in `list` and `text`. Now they work much faster