### PR TITLE
bug(#3892): clean build with xnav 0.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ SOFTWARE.
       <dependency>
         <groupId>com.github.volodya-lombrozo</groupId>
         <artifactId>xnav</artifactId>
-        <version>0.1.9</version>
+        <version>0.1.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
In this PR I've switched `xnav` back to version `0.1.8`. We should upgrade it after https://github.com/objectionary/lints/pull/311/ is released in `lints`.

closes #3892