### PR TITLE
bug(#3265): divided shift method in `BytesRaw`

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/BytesOf.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesOf.java
@@ -42,22 +42,6 @@ public final class BytesOf implements Bytes {
 
     /**
      * Ctor.
-     * @param bytes Bytes.
-     */
-    public BytesOf(final Bytes bytes) {
-        this.bytes = bytes;
-    }
-
-    /**
-     * Ctor.
-     * @param data Data.
-     */
-    public BytesOf(final byte[] data) {
-        this(new BytesRaw(Arrays.copyOf(data, data.length)));
-    }
-
-    /**
-     * Ctor.
      * @param str UTF-8 Text.
      */
     public BytesOf(final String str) {
@@ -94,6 +78,22 @@ public final class BytesOf implements Bytes {
      */
     public BytesOf(final double number) {
         this(ByteBuffer.allocate(Double.BYTES).putDouble(number).array());
+    }
+
+    /**
+     * Ctor.
+     * @param data Data.
+     */
+    public BytesOf(final byte[] data) {
+        this(new BytesRaw(Arrays.copyOf(data, data.length)));
+    }
+
+    /**
+     * Ctor.
+     * @param bytes Bytes.
+     */
+    public BytesOf(final Bytes bytes) {
+        this.bytes = bytes;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -30,10 +30,6 @@ import java.util.Arrays;
  * Bytes to be created from byte array only.
  *
  * @since 0.1.0
- * @todo #3239:90min Method {@link BytesOf#shift} should be refactored to get rid of
- *  {@code @SuppressWarnings("PMD.CognitiveComplexity")} warning. You can
- *  check description of this rules here
- *  <a href="https://pmd.github.io/pmd/pmd_rules_java_design">pmd.github.io</a>
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 final class BytesRaw implements Bytes {
@@ -92,43 +88,17 @@ final class BytesRaw implements Bytes {
     }
 
     @Override
-    @SuppressWarnings("PMD.CognitiveComplexity")
     public Bytes shift(final int bits) {
-        // @checkstyle MethodBodyCommentsCheck (3 lines)
-        // @checkstyle NestedIfDepthCheck (40 lines)
         final byte[] bytes = this.take();
         final int mod = Math.abs(bits) % Byte.SIZE;
         final int offset = Math.abs(bits) / Byte.SIZE;
+        final Bytes shifted;
         if (bits < 0) {
-            final byte carry = (byte) ((0x01 << mod) - 1);
-            for (int index = 0; index < bytes.length; index += 1) {
-                final int source = index + offset;
-                if (source >= bytes.length) {
-                    bytes[index] = 0;
-                } else {
-                    byte dst = (byte) (bytes[source] << mod);
-                    if (source + 1 < bytes.length) {
-                        dst |= (byte) (bytes[source + 1] >>> (Byte.SIZE - mod) & (carry & 0xFF));
-                    }
-                    bytes[index] = dst;
-                }
-            }
+            shifted = BytesRaw.shiftLeft(bytes, mod, offset);
         } else {
-            final byte carry = (byte) (0xFF << (Byte.SIZE - mod));
-            for (int index = bytes.length - 1; index >= 0; index -= 1) {
-                final int source = index - offset;
-                if (source < 0) {
-                    bytes[index] = 0;
-                } else {
-                    byte dst = (byte) ((0xff & bytes[source]) >>> mod);
-                    if (source - 1 >= 0) {
-                        dst |= (byte) (bytes[source - 1] << (Byte.SIZE - mod) & (carry & 0xFF));
-                    }
-                    bytes[index] = dst;
-                }
-            }
+            shifted = BytesRaw.shiftRight(bytes, mod, offset);
         }
-        return new BytesOf(bytes);
+        return shifted;
     }
 
     @Override
@@ -223,6 +193,54 @@ final class BytesRaw implements Bytes {
     @Override
     public int hashCode() {
         return Arrays.hashCode(this.data);
+    }
+
+    /**
+     * Shift bytes to the left.
+     * @param bytes Bytes
+     * @param mod Mod
+     * @param offset Offset
+     * @return Shifted bytes
+     */
+    private static Bytes shiftLeft(final byte[] bytes, final int mod, final int offset) {
+        final byte carry = (byte) ((0x01 << mod) - 1);
+        for (int index = 0; index < bytes.length; index += 1) {
+            final int source = index + offset;
+            if (source >= bytes.length) {
+                bytes[index] = 0;
+            } else {
+                byte dst = (byte) (bytes[source] << mod);
+                if (source + 1 < bytes.length) {
+                    dst |= (byte) (bytes[source + 1] >>> (Byte.SIZE - mod) & (carry & 0xFF));
+                }
+                bytes[index] = dst;
+            }
+        }
+        return new BytesOf(bytes);
+    }
+
+    /**
+     * Shift bytes to the right.
+     * @param bytes Bytes
+     * @param mod Mod
+     * @param offset Offset
+     * @return Shifted bytes
+     */
+    private static Bytes shiftRight(final byte[] bytes, final int mod, final int offset) {
+        final byte carry = (byte) (0xFF << (Byte.SIZE - mod));
+        for (int index = bytes.length - 1; index >= 0; index -= 1) {
+            final int source = index - offset;
+            if (source < 0) {
+                bytes[index] = 0;
+            } else {
+                byte dst = (byte) ((0xff & bytes[source]) >>> mod);
+                if (source - 1 >= 0) {
+                    dst |= (byte) (bytes[source - 1] << (Byte.SIZE - mod) & (carry & 0xFF));
+                }
+                bytes[index] = dst;
+            }
+        }
+        return new BytesOf(bytes);
     }
 
     /**


### PR DESCRIPTION
Closes: #3265 