### PR TITLE
bug(#3912): translate capital `E` to `e`

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/print/unhex-data.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/print/unhex-data.xsl
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unhex-data" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="unhex-data" version="2.0">
   <!--
     Performs the reverse operation of "/org/eolang/parser/stars-to-tuples.xsl"
   -->
@@ -57,7 +57,7 @@ SOFTWARE.
       <xsl:otherwise>
         <xsl:copy>
           <xsl:apply-templates select="@*"/>
-          <xsl:value-of select="eo:bytes-to-number($bytes)"/>
+          <xsl:value-of select="translate(xs:string(eo:bytes-to-number($bytes)), 'E', 'e')"/>
         </xsl:copy>
       </xsl:otherwise>
     </xsl:choose>

--- a/eo-parser/src/test/resources/org/eolang/parser/phi-packs/numbers-with-exponent.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/phi-packs/numbers-with-exponent.yaml
@@ -1,0 +1,44 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+input: |
+  # Hey.
+  [] > foo
+    4.294967295E9 > x
+sweet: |-
+  {⟦
+    foo ↦ ⟦
+      x ↦ 4.294967295e9
+    ⟧
+  ⟧}
+salty: |-
+  {
+    ⟦
+      foo ↦ ⟦
+        x ↦ Φ.org.eolang.number(
+          α0 ↦ Φ.org.eolang.bytes(
+            α0 ↦ ⟦ Δ ⤍ 41-EF-FF-FF-FF-E0-00-00 ⟧
+          )
+        )
+      ⟧
+    ⟧
+  }


### PR DESCRIPTION
Closes: #3912 