### PR TITLE
feat(#3936): Add 'post-comment' Workflow

### DIFF
--- a/.github/workflows/post-comment.yaml
+++ b/.github/workflows/post-comment.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: Post Benchmark Comment
+on:
+  workflow_run:
+    workflows: [ "Performance Regression Check" ]
+    types:
+      - completed
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Benchmark Comment
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post Comment on PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          issue: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message-path: |
+            benchmark-comment.md
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I added a simple workflow that runs on the `master` branch. Since it uses `workflow_run` event and runs on the `master` branch, `GITHUB_TOKEN` has read and write permissions. 
This allow it to post comments to PRs. 
Actually, we have only two steps here:
- Download the message for printing.
- Post this message to a PR.

By adding this workflow, we can provide benchmarking in a more secure environment without requiring `write` permissions.

Related to #3936
