### PR TITLE
feat(#3935): print debug info for 'post-comment' workflow

### DIFF
--- a/.github/workflows/post-comment.yaml
+++ b/.github/workflows/post-comment.yaml
@@ -13,6 +13,12 @@ jobs:
   post-comment:
     runs-on: ubuntu-latest
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Show PR Number
+        run: echo "The PR number is ${{ github.event.workflow_run.pull_requests[0].number }}"
       - name: Download Benchmark Comment
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
'post-comment' workflow prints comments into a wrong PR. I've added some debug info that will help to investigate the problem.

Related to: #3935
