### PR TITLE
feat(#3934): spdx meta instead of `<license/>` node

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.38</version>
+      <version>0.0.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
@@ -257,10 +257,16 @@ public final class LintMojo extends SafeMojo {
      * @param xmir The XML before linting
      * @param counts Counts of errors, warnings, and critical
      * @return XML after linting
+     * @todo #3934:35min Remove .without() from Program to enable `unknown-metas`
+     *  and `unsorted-metas` lints. Currently we disabled them since lints does not
+     *  support `+spdx` meta yet. Once <a href="https://github.com/objectionary/lints/issues/354">this</a>
+     *  issue will be resolved, we should enable all lints.
      */
     private static XML linted(final XML xmir, final ConcurrentHashMap<Severity, Integer> counts) {
         final Directives dirs = new Directives();
-        final Collection<Defect> defects = new Program(xmir).defects();
+        final Collection<Defect> defects = new Program(xmir).without(
+            "unknown-metas", "unsorted-metas"
+        ).defects();
         if (!defects.isEmpty()) {
             dirs.xpath("/program").addIf("errors").strict(1);
             LintMojo.embed(xmir, defects);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/mess.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/mess.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -8,7 +8,7 @@ tokens { TAB, UNTAB }
 
 // Entry point
 program
-    : license? metas? objects EOF
+    : metas? objects EOF
     ;
 
 // Double EOL
@@ -16,9 +16,9 @@ eop : EOL EOL
     ;
 
 // Licence
-license
-    : (COMMENTARY EOL)* COMMENTARY eop
-    ;
+//comments
+//    : (COMMENTARY EOL)* COMMENTARY eop
+//    ;
 
 // Metas
 metas

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -104,23 +104,23 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         // Nothing here
     }
 
-    @Override
-    public void enterLicense(final EoParser.LicenseContext ctx) {
-        this.dirs.addIf("license").set(
-            new Joined(
-                "\n",
-                new Mapped<>(
-                    cmt -> cmt.getText().substring(1).trim(),
-                    ctx.COMMENTARY()
-                )
-            )
-        ).up();
-    }
+//    @Override
+//    public void enterComments(final EoParser.CommentsContext ctx) {
+//        this.dirs.addIf("comments").set(
+//            new Joined(
+//                "\n",
+//                new Mapped<>(
+//                    cmt -> cmt.getText().substring(1).trim(),
+//                    ctx.COMMENTARY()
+//                )
+//            )
+//        ).up();
+//    }
 
-    @Override
-    public void exitLicense(final EoParser.LicenseContext ctx) {
-        // Nothing here
-    }
+//    @Override
+//    public void exitComments(final EoParser.CommentsContext ctx) {
+//        // Nothing here
+//    }
 
     @Override
     public void enterMetas(final EoParser.MetasContext ctx) {

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -16,8 +16,6 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.commons.text.StringEscapeUtils;
-import org.cactoos.iterable.Mapped;
-import org.cactoos.text.Joined;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -103,24 +101,6 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     public void exitEop(final EoParser.EopContext ctx) {
         // Nothing here
     }
-
-//    @Override
-//    public void enterComments(final EoParser.CommentsContext ctx) {
-//        this.dirs.addIf("comments").set(
-//            new Joined(
-//                "\n",
-//                new Mapped<>(
-//                    cmt -> cmt.getText().substring(1).trim(),
-//                    ctx.COMMENTARY()
-//                )
-//            )
-//        ).up();
-//    }
-
-//    @Override
-//    public void exitComments(final EoParser.CommentsContext ctx) {
-//        // Nothing here
-//    }
 
     @Override
     public void enterMetas(final EoParser.MetasContext ctx) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/full-syntax.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/full-syntax.yaml
@@ -4,7 +4,6 @@
 sheets: [ ]
 asserts:
   - /program[not(errors)]
-  - /program/license[text()!='']
   - /program/metas[count(meta)=4]
   - /program/metas/meta[head='foo' and tail='']
   - //o[@base='Q.org.eolang.true']
@@ -18,10 +17,6 @@ asserts:
   - //o[@atom and @name='atom' and count(o)=2 and o[@name='a']]
   - //o[@atom='org.eolang.number']
 input: |
-  # The purpose of this test case is to make
-  # sure all possible syntax scenarios can
-  # be parsed by the ANTLR
-
   +alias org.example.foo
   +alias Test Test
   +bar Some text

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/leap-year.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/leap-year.yaml
@@ -7,11 +7,6 @@ asserts:
   - /program/objects[count(o)=1]
   - //o[@base='.and']
 input: |
-  # This program is from the EOLANG original paper
-  # and must produce a working command line tool
-  #
-  # License is MIT
-
   +alias org.eolang.io.stdin
   +alias org.eolang.io.stdout
   +alias org.eolang.txt.scanner

--- a/eo-parser/src/test/resources/org/eolang/parser/factorial.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/factorial.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 [n] > f
   if. > @
     n.lt 1

--- a/eo-parser/src/test/resources/org/eolang/parser/fibonacci.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/fibonacci.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +meta This is just a test META
 +meta2 And yet another one
 

--- a/eo-parser/src/test/resources/org/eolang/parser/phi-packs/bool-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/phi-packs/bool-tests.yaml
@@ -2,28 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 input: |
-  # The MIT License (MIT)
-  #
-  # Copyright (c) 2016-2025 Objectionary.com
-  #
-  # Permission is hereby granted, free of charge, to any person obtaining a copy
-  # of this software and associated documentation files (the "Software"), to deal
-  # in the Software without restriction, including without limitation the rights
-  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  # copies of the Software, and to permit persons to whom the Software is
-  # furnished to do so, subject to the following conditions:
-  #
-  # The above copyright notice and this permission notice shall be included
-  # in all copies or substantial portions of the Software.
-  #
-  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  # FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  # SOFTWARE.
-
   +architect yegor256@gmail.com
   +home https://github.com/objectionary/eo
   +tests

--- a/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/idiomatic.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/idiomatic.yaml
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 origin: |
-  # This is the license part
-  # of the program
-
   +meta1
   +meta2 short
   +meta2 long tail
@@ -33,9 +30,6 @@ origin: |
             "hello, 大家!"
 
 printed: |
-  # This is the license part
-  # of the program
-
   +meta1
   +meta2 short
   +meta2 long tail

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/cti.eo
+++ b/eo-runtime/src/main/eo/org/eolang/cti.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/cti.eo
+++ b/eo-runtime/src/main/eo/org/eolang/cti.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/dataized.eo
+++ b/eo-runtime/src/main/eo/org/eolang/dataized.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/dataized.eo
+++ b/eo-runtime/src/main/eo/org/eolang/dataized.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/error.eo
+++ b/eo-runtime/src/main/eo/org/eolang/error.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/error.eo
+++ b/eo-runtime/src/main/eo/org/eolang/error.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/false.eo
+++ b/eo-runtime/src/main/eo/org/eolang/false.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/false.eo
+++ b/eo-runtime/src/main/eo/org/eolang/false.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.os

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.os

--- a/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.getenv

--- a/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.getenv

--- a/eo-runtime/src/main/eo/org/eolang/go.eo
+++ b/eo-runtime/src/main/eo/org/eolang/go.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/go.eo
+++ b/eo-runtime/src/main/eo/org/eolang/go.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/i16.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i16.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/i16.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i16.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/i32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i32.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/i32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i32.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/i64.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i64.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/i64.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i64.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/console.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/console.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/io/console.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/console.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.console
 +alias org.eolang.sys.line-separator
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.console
 +alias org.eolang.sys.line-separator
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/math/angle.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/angle.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/math/angle.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/angle.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/math/e.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/e.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/e.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/e.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/integral.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/integral.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/integral.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/integral.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/math/pi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/pi.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/pi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/pi.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/math/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/real.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.e
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/math/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/real.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.e
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/nan.eo
+++ b/eo-runtime/src/main/eo/org/eolang/nan.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/nan.eo
+++ b/eo-runtime/src/main/eo/org/eolang/nan.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/net/socket.eo
+++ b/eo-runtime/src/main/eo/org/eolang/net/socket.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/net/socket.eo
+++ b/eo-runtime/src/main/eo/org/eolang/net/socket.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/number.eo
+++ b/eo-runtime/src/main/eo/org/eolang/number.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/number.eo
+++ b/eo-runtime/src/main/eo/org/eolang/number.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/seq.eo
+++ b/eo-runtime/src/main/eo/org/eolang/seq.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/seq.eo
+++ b/eo-runtime/src/main/eo/org/eolang/seq.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/string.eo
+++ b/eo-runtime/src/main/eo/org/eolang/string.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/string.eo
+++ b/eo-runtime/src/main/eo/org/eolang/string.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs

--- a/eo-runtime/src/main/eo/org/eolang/structs/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/map.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.hash-code-of
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf

--- a/eo-runtime/src/main/eo/org/eolang/structs/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/map.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.hash-code-of
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf

--- a/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/structs/range.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/structs/range.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/structs/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/set.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/org/eolang/structs/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/set.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32

--- a/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/sys/os.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/os.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/sys/os.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/os.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys

--- a/eo-runtime/src/main/eo/org/eolang/true.eo
+++ b/eo-runtime/src/main/eo/org/eolang/true.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/true.eo
+++ b/eo-runtime/src/main/eo/org/eolang/true.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/try.eo
+++ b/eo-runtime/src/main/eo/org/eolang/try.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/try.eo
+++ b/eo-runtime/src/main/eo/org/eolang/try.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex

--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.fs.file
 +alias org.eolang.fs.path
 +alias org.eolang.fs.tmpdir

--- a/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.fs.file
 +alias org.eolang.fs.path
 +alias org.eolang.fs.tmpdir

--- a/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.fs.path
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.fs.path
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/go-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/go-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/go-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/go-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.bytes-as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.bytes-as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.dead-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.dead-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.dead-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.dead-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.input-length
 +alias org.eolang.io.malloc-as-output

--- a/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.input-length
 +alias org.eolang.io.malloc-as-output

--- a/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.malloc-as-output
 +alias org.eolang.io.tee-input

--- a/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.malloc-as-output
 +alias org.eolang.io.tee-input

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.angle
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.angle
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.integral
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.integral
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.numbers
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.numbers
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.random
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.random
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.math.e
 +alias org.eolang.math.pi
 +alias org.eolang.math.real

--- a/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.math.e
 +alias org.eolang.math.pi
 +alias org.eolang.math.real

--- a/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/number-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/number-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/number-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/number-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/string-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/string-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/string-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/string-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.hash-code-of
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.hash-code-of
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.range-of-ints
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.range-of-ints
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.set
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.set
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.sys.os
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com

--- a/eo-runtime/src/test/eo/org/eolang/try-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/try-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/try-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/try-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +alias org.eolang.txt.sscanf

--- a/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +alias org.eolang.txt.sscanf

--- a/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
 +alias org.eolang.txt.text

--- a/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
 +alias org.eolang.txt.text

--- a/eo-runtime/src/test/eo/org/eolang/while-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/while-tests.eo
@@ -1,3 +1,5 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/eo-runtime/src/test/eo/org/eolang/while-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/while-tests.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
       <dependency>
         <groupId>com.github.volodya-lombrozo</groupId>
         <artifactId>xnav</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.10</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -301,6 +301,19 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>jcabi-xcop</id>
+            <phase>none</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>pw.krejci</groupId>
         <artifactId>jmh-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -302,19 +302,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>jcabi-xcop</id>
-            <phase>none</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>pw.krejci</groupId>
         <artifactId>jmh-maven-plugin</artifactId>
         <version>0.2.2</version>


### PR DESCRIPTION
In this PR I've removed license as a commentary text from `.eo` program source, and as the result `<license/>` node from XMIR. License was replaced with `+spdx` meta.

closes #3934
History:
- **feat(#3934): remove license**
- **feat(#3934): off license node**
- **feat(#3934): +spdx**
- **feat(#3934): redundant**
