### PR TITLE
feat(#3957): Mention `xcop` in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ before sending us your pull request please run full Maven build:
 mvn clean install -Pqulice
 ```
 
-You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
+You will need [Maven 3.3+](https://maven.apache.org), Java 11+ and
+[xcop](https://github.com/yegor256/xcop) 0.8.0+ installed.
 
 ## Special thanks
 

--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ before sending us your pull request please run full Maven build:
 mvn clean install -Pqulice
 ```
 
-You will need [Maven 3.3+](https://maven.apache.org), Java 11+ and
-[xcop](https://github.com/yegor256/xcop) 0.8.0+ installed.
+You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
+Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure 
+it is version `0.8.0`+.
 
 ## Special thanks
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ mvn clean install -Pqulice
 ```
 
 You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
-Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure 
+Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure
 it is version `0.8.0`+.
 
 ## Special thanks


### PR DESCRIPTION
Since we need `xcop` to be installed before building the project, we need to mention it in the docs.
Moreover, recent bugs show that we need at least `0.8.0` version of `xcop` to build the project.

Closes: #3957
