### PR TITLE
feat(#3977): lints up `0.0.42`

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.39</version>
+      <version>0.0.42</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
@@ -260,7 +260,7 @@ public final class LintMojo extends SafeMojo {
      * @param counts Counts of errors, warnings, and critical
      * @return XML after linting
      * @todo #3977:25min Enable `unlint-non-existing-defect` lint.
-     *  Currently its disabled because of <a href="https://github.com/objectionary/lints/issues/354">this</a>
+     *  Currently its disabled because of <a href="https://github.com/objectionary/lints/issues/385">this</a>
      *  bug. Once issue will be resolved, we should enable this lint. Don't forget to enable
      *  this lint in WPA scope too.
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
@@ -160,7 +160,8 @@ public final class LintMojo extends SafeMojo {
         for (final Map.Entry<String, Path> ent : paths.entrySet()) {
             pkg.put(ent.getKey(), new XMLDocument(ent.getValue()));
         }
-        final Collection<Defect> defects = new Programs(pkg).defects();
+        final Collection<Defect> defects = new Programs(pkg)
+            .without("unlint-non-existing-defect").defects();
         for (final Defect defect : defects) {
             counts.compute(defect.severity(), (sev, before) -> before + 1);
             LintMojo.embed(
@@ -266,7 +267,7 @@ public final class LintMojo extends SafeMojo {
     private static XML linted(final XML xmir, final ConcurrentHashMap<Severity, Integer> counts) {
         final Directives dirs = new Directives();
         final Collection<Defect> defects = new Program(xmir).without(
-            "unknown-metas", "unsorted-metas"
+            "unlint-non-existing-defect"
         ).defects();
         if (!defects.isEmpty()) {
             dirs.xpath("/program").addIf("errors").strict(1);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LintMojo.java
@@ -259,10 +259,10 @@ public final class LintMojo extends SafeMojo {
      * @param xmir The XML before linting
      * @param counts Counts of errors, warnings, and critical
      * @return XML after linting
-     * @todo #3934:35min Remove .without() from Program to enable `unknown-metas`
-     *  and `unsorted-metas` lints. Currently we disabled them since lints does not
-     *  support `+spdx` meta yet. Once <a href="https://github.com/objectionary/lints/issues/354">this</a>
-     *  issue will be resolved, we should enable all lints.
+     * @todo #3977:25min Enable `unlint-non-existing-defect` lint.
+     *  Currently its disabled because of <a href="https://github.com/objectionary/lints/issues/354">this</a>
+     *  bug. Once issue will be resolved, we should enable this lint. Don't forget to enable
+     *  this lint in WPA scope too.
      */
     private static XML linted(final XML xmir, final ConcurrentHashMap<Severity, Integer> counts) {
         final Directives dirs = new Directives();

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/cti.eo
+++ b/eo-runtime/src/main/eo/org/eolang/cti.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Compile Time Instruction (CTI).
 #

--- a/eo-runtime/src/main/eo/org/eolang/dataized.eo
+++ b/eo-runtime/src/main/eo/org/eolang/dataized.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result
 # `bytes`.

--- a/eo-runtime/src/main/eo/org/eolang/error.eo
+++ b/eo-runtime/src/main/eo/org/eolang/error.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 +unlint rt-without-atoms
 +unlint empty-object

--- a/eo-runtime/src/main/eo/org/eolang/false.eo
+++ b/eo-runtime/src/main/eo/org/eolang/false.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # The object is a FALSE boolean state.

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.os
@@ -10,6 +8,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.

--- a/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/tmpdir.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.getenv
@@ -8,6 +6,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Temporary directory.
 # For Unix/MacOS uses the path supplied by the first environment variable

--- a/eo-runtime/src/main/eo/org/eolang/go.eo
+++ b/eo-runtime/src/main/eo/org/eolang/go.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/eo-runtime/src/main/eo/org/eolang/i16.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i16.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/i32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i32.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/i64.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i64.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized

--- a/eo-runtime/src/main/eo/org/eolang/io/console.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/console.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
@@ -7,6 +5,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Dead input is an input that reads from nowhere and always
 # returns empty sequence of bytes `--`.

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-output.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Dead output is an output that writes to nowhere.
 [] > dead-output

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length

--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.

--- a/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdin.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +alias org.eolang.sys.line-separator
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +package org.eolang.io
 +version 0.0.0
 +unlint unit-test-missing
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `stdin` object is a convenient wrapper on `console` object
 # which is used as input only and allows to read the data from console.

--- a/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/stdout.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `stdout` object is convenient wrapper on `console` object which
 # uses it as output only and allows to print given argument to console as `string`:

--- a/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 +unlint decorated-formation

--- a/eo-runtime/src/main/eo/org/eolang/math/angle.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/angle.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,6 +7,8 @@
 +version 0.0.0
 +unlint rt-without-atoms
 +unlint empty-object
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.

--- a/eo-runtime/src/main/eo/org/eolang/math/e.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/e.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
 +version 0.0.0
 +unlint unit-test-missing
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The Euler's number.
 # A fundamental mathematical constant approximately equal to 2.7182818284590452354.

--- a/eo-runtime/src/main/eo/org/eolang/math/integral.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/integral.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Counts integral from `a` to `b`.
 # Here `func` is integration function, `a` is an upper limit,

--- a/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/numbers.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/eo-runtime/src/main/eo/org/eolang/math/pi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/pi.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Returns an approximate PI number.

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
@@ -7,6 +5,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Generates a pseudo-random number.
 [seed] > random

--- a/eo-runtime/src/main/eo/org/eolang/math/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/real.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.e
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/nan.eo
+++ b/eo-runtime/src/main/eo/org/eolang/nan.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/eo-runtime/src/main/eo/org/eolang/net/socket.eo
+++ b/eo-runtime/src/main/eo/org/eolang/net/socket.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
@@ -8,6 +6,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.net
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Socket.

--- a/eo-runtime/src/main/eo/org/eolang/number.eo
+++ b/eo-runtime/src/main/eo/org/eolang/number.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/eo-runtime/src/main/eo/org/eolang/seq.eo
+++ b/eo-runtime/src/main/eo/org/eolang/seq.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Sequence.
 # The object, when being dataized, dataizes all provided

--- a/eo-runtime/src/main/eo/org/eolang/string.eo
+++ b/eo-runtime/src/main/eo/org/eolang/string.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.

--- a/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/bytes-as-array.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Represents sequence of bytes as array.
 # Here `bts` is `bytes` objects, the return value is `tuple` where

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Hash code - the pseudo-unique float numeric
 # representation of an object.

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.

--- a/eo-runtime/src/main/eo/org/eolang/structs/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/map.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.hash-code-of
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
@@ -7,6 +5,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.

--- a/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/eo-runtime/src/main/eo/org/eolang/structs/range.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/eo-runtime/src/main/eo/org/eolang/structs/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/set.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which

--- a/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/getenv.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
@@ -7,6 +5,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Get environment variable as `string`.

--- a/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/line-separator.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Returns the system-dependent line separator string.

--- a/eo-runtime/src/main/eo/org/eolang/sys/os.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/os.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,6 +5,8 @@
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 +unlint decorated-formation

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint many-free-attributes
 +unlint rt-without-atoms
 +unlint empty-object

--- a/eo-runtime/src/main/eo/org/eolang/true.eo
+++ b/eo-runtime/src/main/eo/org/eolang/true.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # The object is a TRUE boolean state.

--- a/eo-runtime/src/main/eo/org/eolang/try.eo
+++ b/eo-runtime/src/main/eo/org/eolang/try.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 +unlint decorated-formation

--- a/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sprintf.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/sscanf.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
 +rt jvm org.eolang:eo-runtime:0.0.0
 +rt node eo2js-runtime:0.0.0
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint rt-without-atoms
 +unlint empty-object
 

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
@@ -9,6 +7,8 @@
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Text.
 # A sequence of characters representing words, sentences, or data.

--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:

--- a/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bool-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/cti-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/dataized-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/dir-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/file-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.file
 +alias org.eolang.fs.path
 +alias org.eolang.fs.tmpdir
@@ -10,6 +8,8 @@
 +tests
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/path-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.fs.path
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/fs/tmpdir-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/go-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/go-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i16-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i32-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/i64-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/bytes-as-input-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-makes-an-input-from-bytes-and-reads

--- a/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/console-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-input-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.dead-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-reads-empty-bytes

--- a/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/dead-output-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.dead-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/input-length-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.input-length
 +alias org.eolang.io.malloc-as-output
@@ -9,6 +7,8 @@
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/stdout-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/tee-input-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.malloc-as-output
 +alias org.eolang.io.tee-input
@@ -8,6 +6,8 @@
 +tests
 +package org.eolang.io
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/malloc-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/angle-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.angle
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.integral
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/numbers-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.numbers
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/random-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.random
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.e
 +alias org.eolang.math.pi
 +alias org.eolang.math.real
@@ -8,6 +6,8 @@
 +tests
 +package org.eolang.math
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/nan-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/negative-infinity-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Equal to.

--- a/eo-runtime/src/test/eo/org/eolang/number-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/number-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/positive-infinity-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Equal to.

--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 +unlint unit-test-without-phi
 +unlint decorated-formation

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/string-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/string-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/bytes-as-array-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/hash-code-of-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.hash-code-of
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/map-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-of-ints-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range-of-ints
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/range-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/set-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.set
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/switch-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/os-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/posix-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.sys
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/sys/win32-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com
@@ -7,6 +5,8 @@
 +tests
 +package org.eolang.sys
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/try-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/try-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/tuple-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/regex-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sprintf-tests.eo
@@ -1,13 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 +unlint wrong-sprintf-arguments
++unlint sprintf-without-formatters
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-prints-simple-string

--- a/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/sscanf-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +alias org.eolang.txt.sscanf
@@ -8,6 +6,8 @@
 +tests
 +package org.eolang.txt
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/txt/text-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
 +alias org.eolang.txt.text
@@ -8,6 +6,8 @@
 +tests
 +package org.eolang.txt
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/test/eo/org/eolang/while-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/while-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.


### PR DESCRIPTION
In this PR I've updated `lints` version to `0.0.42`.

closes #3977
History:
- **feat(#3977): lints up**
- **feat(#3977): puzzle**
