### PR TITLE
#3941 more convenient `eo-maven-plugin` configuration in `Farea`

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AppendedPlugin.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AppendedPlugin.java
@@ -5,15 +5,16 @@
 package org.eolang.maven;
 
 import com.jcabi.manifests.Manifests;
+import com.yegor256.farea.Execution;
 import com.yegor256.farea.Farea;
-import com.yegor256.farea.Plugin;
 import java.io.IOException;
+import org.cactoos.Scalar;
 
 /**
  * Configures the EO Maven plugin within a {@link Farea}.
  * @since 0.52
  */
-final class EOplugin {
+final class AppendedPlugin implements Scalar<Execution> {
     /**
      * The Farea object.
      */
@@ -23,15 +24,12 @@ final class EOplugin {
      * Ctor.
      * @param farea The Farea
      */
-    EOplugin(final Farea farea) {
+    AppendedPlugin(final Farea farea) {
         this.farea = farea;
     }
 
-    /**
-     * Appends the EO Maven plugin.
-     * @return The plugin
-     */
-    public Plugin appendItself() throws IOException {
+    @Override
+    public Execution value() throws IOException {
         return this.farea.build()
             .plugins()
             .append(
@@ -41,6 +39,6 @@ final class EOplugin {
                     "eo.version",
                     Manifests.read("EO-Version")
                 )
-            );
+            ).execution();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoIT.java
@@ -163,8 +163,7 @@ final class AssembleMojoIT {
     }
 
     private static Execution appendItself(final Farea farea) throws IOException {
-        return new EOplugin(farea).appendItself()
-            .execution("tests")
+        return new AppendedPlugin(farea).value()
             .goals("register", "assemble");
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/AssembleMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -164,16 +163,7 @@ final class AssembleMojoIT {
     }
 
     private static Execution appendItself(final Farea farea) throws IOException {
-        return farea.build()
-            .plugins()
-            .append(
-                "org.eolang",
-                "eo-maven-plugin",
-                System.getProperty(
-                    "eo.version",
-                    Manifests.read("EO-Version")
-                )
-            )
+        return new EOplugin(farea).appendItself()
             .execution("tests")
             .goals("register", "assemble");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/EOplugin.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/EOplugin.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.manifests.Manifests;
+import com.yegor256.farea.Farea;
+import com.yegor256.farea.Plugin;
+import java.io.IOException;
+
+/**
+ * Configures the EO Maven plugin within a {@link Farea}.
+ * @since 0.52
+ */
+final class EOplugin {
+    /**
+     * The Farea object.
+     */
+    private final Farea farea;
+
+    /**
+     * Ctor.
+     * @param farea The Farea
+     */
+    EOplugin(final Farea farea) {
+        this.farea = farea;
+    }
+
+    /**
+     * Appends the EO Maven plugin.
+     * @return The plugin
+     */
+    public Plugin appendItself() throws IOException {
+        return this.farea.build()
+            .plugins()
+            .append(
+                "org.eolang",
+                "eo-maven-plugin",
+                System.getProperty(
+                    "eo.version",
+                    Manifests.read("EO-Version")
+                )
+            );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -83,16 +82,7 @@ final class LintMojoIT {
     }
 
     private static Execution appendItself(final Farea farea) throws IOException {
-        return farea.build()
-            .plugins()
-            .append(
-                "org.eolang",
-                "eo-maven-plugin",
-                System.getProperty(
-                    "eo.version",
-                    Manifests.read("EO-Version")
-                )
-            )
+        return new EOplugin(farea).appendItself()
             .execution("tests")
             .goals("register", "parse", "shake", "lint");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintMojoIT.java
@@ -82,8 +82,7 @@ final class LintMojoIT {
     }
 
     private static Execution appendItself(final Farea farea) throws IOException {
-        return new EOplugin(farea).appendItself()
-            .execution("tests")
+        return new AppendedPlugin(farea).value()
             .goals("register", "parse", "shake", "lint");
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoIT.java
@@ -31,8 +31,7 @@ final class ParseMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Simple object.\n[] > foo\n".getBytes()
                 );
-                new EOplugin(f).appendItself()
-                    .execution()
+                new AppendedPlugin(f).value()
                     .goals("register", "parse");
                 f.exec("compile", String.format("-Deo.cache=%s", temp.resolve("cache")));
                 MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParseMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -32,16 +31,7 @@ final class ParseMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Simple object.\n[] > foo\n".getBytes()
                 );
-                f.build()
-                    .plugins()
-                    .append(
-                        "org.eolang",
-                        "eo-maven-plugin",
-                        System.getProperty(
-                            "eo.version",
-                            Manifests.read("EO-Version")
-                        )
-                    )
+                new EOplugin(f).appendItself()
                     .execution()
                     .goals("register", "parse");
                 f.exec("compile", String.format("-Deo.cache=%s", temp.resolve("cache")));

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoIT.java
@@ -35,8 +35,7 @@ final class PrintMojoIT {
                         "the functionality of the corresponding object.\n[] > foo\n"
                     ).getBytes()
                 );
-                new EOplugin(f).appendItself()
-                    .execution()
+                new AppendedPlugin(f).value()
                     .goals("register", "parse");
                 f.exec("compile");
                 f.files()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PrintMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -36,16 +35,7 @@ final class PrintMojoIT {
                         "the functionality of the corresponding object.\n[] > foo\n"
                     ).getBytes()
                 );
-                f.build()
-                    .plugins()
-                    .append(
-                        "org.eolang",
-                        "eo-maven-plugin",
-                        System.getProperty(
-                            "eo.version",
-                            Manifests.read("EO-Version")
-                        )
-                    )
+                new EOplugin(f).appendItself()
                     .execution()
                     .goals("register", "parse");
                 f.exec("compile");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoIT.java
@@ -42,7 +42,7 @@ final class RegisterMojoIT {
                         "  \"Pull\" > @"
                     ).getBytes()
                 );
-                new EOplugin(f).appendItself();
+                new AppendedPlugin(f).value();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -82,7 +82,7 @@ final class RegisterMojoIT {
                         "  \"Resolve\" > @"
                     ).getBytes()
                 );
-                new EOplugin(f).appendItself();
+                new AppendedPlugin(f).value();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull", "eo:resolve");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -123,7 +123,7 @@ final class RegisterMojoIT {
                         "  \"42\" > @"
                     ).getBytes()
                 );
-                new EOplugin(f).appendItself();
+                new AppendedPlugin(f).value();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -185,7 +185,7 @@ final class RegisterMojoIT {
                         "  \"Hello\" > @"
                     ).getBytes()
                 );
-                new EOplugin(f).appendItself();
+                new AppendedPlugin(f).value();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RegisterMojoIT.java
@@ -4,14 +4,12 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import com.yegor256.farea.Farea;
 import com.yegor256.tojos.TjSmart;
-import java.io.IOException;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -44,7 +42,7 @@ final class RegisterMojoIT {
                         "  \"Pull\" > @"
                     ).getBytes()
                 );
-                RegisterMojoIT.configureFarea(f);
+                new EOplugin(f).appendItself();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -84,7 +82,7 @@ final class RegisterMojoIT {
                         "  \"Resolve\" > @"
                     ).getBytes()
                 );
-                RegisterMojoIT.configureFarea(f);
+                new EOplugin(f).appendItself();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull", "eo:resolve");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -125,7 +123,7 @@ final class RegisterMojoIT {
                         "  \"42\" > @"
                     ).getBytes()
                 );
-                RegisterMojoIT.configureFarea(f);
+                new EOplugin(f).appendItself();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -187,7 +185,7 @@ final class RegisterMojoIT {
                         "  \"Hello\" > @"
                     ).getBytes()
                 );
-                RegisterMojoIT.configureFarea(f);
+                new EOplugin(f).appendItself();
                 f.exec("eo:register", "eo:parse", "eo:shake", "eo:probe", "eo:pull");
                 f.files().file("src/main/eo/foo.eo").write(
                     String.join(
@@ -222,19 +220,6 @@ final class RegisterMojoIT {
                 );
             }
         );
-    }
-
-    private static void configureFarea(final Farea farea) throws IOException {
-        farea.build()
-            .plugins()
-            .append(
-                "org.eolang",
-                "eo-maven-plugin",
-                System.getProperty(
-                    "eo.version",
-                    Manifests.read("EO-Version")
-                )
-            );
     }
 
     private static TjSmart foreign(final Path path) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -77,16 +76,7 @@ final class ResolveMojoIT {
         farea.clean();
         farea.dependencies()
             .append("org.eolang", "eo-runtime", version);
-        farea.build()
-            .plugins()
-            .append(
-                "org.eolang",
-                "eo-maven-plugin",
-                System.getProperty(
-                    "eo.version",
-                    Manifests.read("EO-Version")
-                )
-            )
+        new EOplugin(farea).appendItself()
             .execution()
             .goals("resolve");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolveMojoIT.java
@@ -76,8 +76,7 @@ final class ResolveMojoIT {
         farea.clean();
         farea.dependencies()
             .append("org.eolang", "eo-runtime", version);
-        new EOplugin(farea).appendItself()
-            .execution()
+        new AppendedPlugin(farea).value()
             .goals("resolve");
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShakeMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShakeMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.MayBeSlow;
@@ -34,16 +33,7 @@ final class ShakeMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Check ShakeMojo.\n[] > foo\n".getBytes()
                 );
-                f.build()
-                    .plugins()
-                    .append(
-                        "org.eolang",
-                        "eo-maven-plugin",
-                        System.getProperty(
-                            "eo.version",
-                            Manifests.read("EO-Version")
-                        )
-                    )
+                new EOplugin(f).appendItself()
                     .execution()
                     .goals("register", "parse", "shake");
                 f.exec("compile");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShakeMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShakeMojoIT.java
@@ -33,8 +33,7 @@ final class ShakeMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Check ShakeMojo.\n[] > foo\n".getBytes()
                 );
-                new EOplugin(f).appendItself()
-                    .execution()
+                new AppendedPlugin(f).value()
                     .goals("register", "parse", "shake");
                 f.exec("compile");
             }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoIT.java
@@ -37,8 +37,7 @@ final class SodgMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Check SodgMojo.\n[] > foo\n".getBytes()
                 );
-                new EOplugin(f).appendItself()
-                    .execution()
+                new AppendedPlugin(f).value()
                     .goals("register", "parse", "shake", "sodg");
                 f.exec("compile");
                 MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SodgMojoIT.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -38,16 +37,7 @@ final class SodgMojoIT {
                 f.files().file("src/main/eo/foo.eo").write(
                     "# Check SodgMojo.\n[] > foo\n".getBytes()
                 );
-                f.build()
-                    .plugins()
-                    .append(
-                        "org.eolang",
-                        "eo-maven-plugin",
-                        System.getProperty(
-                            "eo.version",
-                            Manifests.read("EO-Version")
-                        )
-                    )
+                new EOplugin(f).appendItself()
                     .execution()
                     .goals("register", "parse", "shake", "sodg");
                 f.exec("compile");


### PR DESCRIPTION
Since our `Farea` configuration for the `eo-maven-plugin` in our integration tests is slightly different from the usual setup, we started having some repetitive code. In this PR, I added a class that simplifies the Farea configuration for the `eo-maven-plugin`, which should help eliminate the duplication

Ref: #3941