### PR TITLE
chore: don't use 'test' suffix in test names

### DIFF
--- a/eo-runtime/src/test/java/integration/JarIT.java
+++ b/eo-runtime/src/test/java/integration/JarIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Integration test that runs simple EO program from packaged jar.
  * @since 0.54
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
 final class JarIT {
     @Test

--- a/eo-runtime/src/test/java/integration/PhiUnphiIT.java
+++ b/eo-runtime/src/test/java/integration/PhiUnphiIT.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.1
  * @checkstyle MethodLengthCheck (500 lines)
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
 final class PhiUnphiIT {
 
     @Test
     @ExtendWith(MayBeSlow.class)
     @ExtendWith(WeAreOnline.class)
-    void runsTestsAfterPhiAndUnphi(final @Mktmp Path temp) throws IOException {
+    void runsAfterPhiAndUnphi(final @Mktmp Path temp) throws IOException {
         new Farea(temp).together(
             f -> {
                 f.files().file("src/main").save(

--- a/eo-runtime/src/test/java/integration/SnippetIT.java
+++ b/eo-runtime/src/test/java/integration/SnippetIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  * Integration test for simple snippets.
  * @since 0.1
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
 final class SnippetIT {
     @ParameterizedTest


### PR DESCRIPTION
It's illegal to use 'test' noun in the test names.

Comes from: https://github.com/volodya-lombrozo/jtcop/issues/501