### PR TITLE
fix(#3851): Correct line for TAB token 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ eo-runtime/measures.csv
 node_modules/
 target/
 xs3p.xsl_*
+.aider*

--- a/eo-parser/src/main/java/org/eolang/parser/EoIndentLexer.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoIndentLexer.java
@@ -143,7 +143,7 @@ final class EoIndentLexer extends EoLexer {
      */
     private void emitToken(final int type) {
         final CommonToken tkn = new CommonToken(type, EoParser.VOCABULARY.getSymbolicName(type));
-        tkn.setLine(this.getLine() + 1);
+        tkn.setLine(this.getLine());
         this.tokens.offer(tkn);
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -97,4 +97,13 @@ final class EoIndentLexerTest {
             Matchers.is(EoParser.EOF)
         );
     }
+
+    @Test
+    void emitsTabWithCorrectLine() throws IOException {
+        MatcherAssert.assertThat(
+            "We expect the token to be a tab indentation with line 2",
+            new EoIndentLexer(new TextOf("\n  ")).getAllTokens().get(1).getLine(),
+            Matchers.equalTo(2)
+        );
+    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -102,7 +102,11 @@ final class EoIndentLexerTest {
     void emitsTabWithCorrectLine() throws IOException {
         MatcherAssert.assertThat(
             "We expect the token to be a tab indentation with line 2",
-            new EoIndentLexer(new TextOf("\n  ")).getAllTokens().get(1).getLine(),
+            new EoIndentLexer(new TextOf("1.add 1 > x\n  (1.add 1) > y")).getAllTokens()
+                .stream().filter(token -> token.getType() == EoParser.TAB)
+                .findFirst()
+                .orElseThrow()
+                .getLine(),
             Matchers.equalTo(2)
         );
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: MIT
 ---
 line: 2
-message: |+
+message: |-
   [2:4] error: 'Invalid bound object declaration'
     y:^
       ^
-  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
-
+  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+    y:^
+  ^^^^^
 input: |-
   x
     y:^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -9,10 +9,9 @@ message: |-
   [5:12] error: 'Invalid bound object declaration'
       sprintwf
 
-  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
-      # a comment here is prohibited
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+    stdout > @
+  ^^^^^^^^^^^^
 input: |
   # No comments
   [args] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-line: 4
+line: 3
 message: |-
-  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
-    [] > inner
-  ^^^^^^^^^^^^
+  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+    # No comments.
+  ^^^^^^^^^^^^^^^^
 input: |
   # No comments.
   [] > test ?

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-line: 3
-message: |+
-  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
-
+line: 2
+message: |-
+  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+    (1.add 1) > y
+  ^^^^^^^^^^^^^^^
 input: |
   1.add 1 > x
     (1.add 1) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-line: 3
+line: 2
 # @todo #3706:30min Unreadable error message if program declaration is invalid.
 #  Improve error message for the case when a program declaration is invalid.
 #  The error message should be more informative and should point to the exact
 #  place in the input where the error occurred. Moreover xml should be clear
 #  what to do to fix the error. 'simple-application-named.yaml' has the same issue.
-message: |+
-  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
-
+message: |-
+  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+    (1.add 1)
+  ^^^^^^^^^^^
 input: |
   1.add 1 > x
     (1.add 1)

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/too-far-right-indent.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/too-far-right-indent.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-line: 5
+line: 4
 input: |
   # No comments
   [args] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -5,7 +5,7 @@ line: 5
 # @todo #3744:60min Error Message Duplicates.
 #  As you can see, we have multiple error messages that are the
 #  same. We should remove duplicates and keep only meaningful error messages.
-message: >-
+message: |-
   [5:2] error: 'Invalid object declaration'
      *
     ^
@@ -15,9 +15,9 @@ message: >-
   [5:2] error: 'Invalid bound object declaration'
      *
     ^
-  [5:-1] error: 'We expected the program to end here but encountered something unexpected'
-     *
-  ^^^^
+  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
+    seq > @
+  ^^^^^^^^^
 input: |
   # This is a code snippet from the following issue:
   # https://github.com/objectionary/eo/issues/3332


### PR DESCRIPTION
This pull request addresses a bug in the `EoIndentLexer` class where `TAB` token line numbers were being incorrectly incremented. Additionally, it updates test cases to reflect the corrected behavior and improves error message clarity across several YAML test cases. 

Related to #3851.