### PR TITLE
fix(#3851): Improve error message for invalid program definition

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -133,7 +133,7 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
         final String detailed;
         if (names[EoParser.RULE_program].equals(rule)) {
             detailed =
-                "We expected the program to end here but encountered something unexpected";
+                "Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct";
         } else if (names[EoParser.RULE_objects].equals(rule)) {
             detailed =
                 "We expected a list of objects here but encountered something unexpected";

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-with-rho.yaml
@@ -6,7 +6,7 @@ message: |-
   [2:4] error: 'Invalid bound object declaration'
     y:^
       ^
-  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [2:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     y:^
   ^^^^^
 input: |-

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-in-method.yaml
@@ -9,7 +9,7 @@ message: |-
   [5:12] error: 'Invalid bound object declaration'
       sprintwf
 
-  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [3:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     stdout > @
   ^^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-empty-lines.yaml
@@ -3,7 +3,7 @@
 ---
 line: 4
 message: |+
-  [4:0] error: 'We expected the program to end here but encountered something unexpected'
+  [4:0] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
 
 input: |
   # No comments.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -3,7 +3,7 @@
 ---
 line: 3
 message: |-
-  [3:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [3:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     # No comments.
   ^^^^^^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application-named.yaml
@@ -3,7 +3,7 @@
 ---
 line: 2
 message: |-
-  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [2:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     (1.add 1) > y
   ^^^^^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/simple-application.yaml
@@ -2,13 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 line: 2
-# @todo #3706:30min Unreadable error message if program declaration is invalid.
-#  Improve error message for the case when a program declaration is invalid.
-#  The error message should be more informative and should point to the exact
-#  place in the input where the error occurred. Moreover xml should be clear
-#  what to do to fix the error. 'simple-application-named.yaml' has the same issue.
 message: |-
-  [2:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [2:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     (1.add 1)
   ^^^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-spaces.yaml
@@ -15,7 +15,7 @@ message: |-
   [5:2] error: 'Invalid bound object declaration'
      *
     ^
-  [4:-1] error: 'We expected the program to end here but encountered something unexpected'
+  [4:-1] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
     seq > @
   ^^^^^^^^^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
@@ -3,7 +3,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: 'We expected the program to end here but encountered something unexpected'
+  [2:0] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
   .z
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-hmethod.yaml
@@ -3,7 +3,7 @@
 ---
 line: 2
 message: |-
-  [2:0] error: 'We expected the program to end here but encountered something unexpected'
+  [2:0] error: 'Expected a valid program definition (one or more meta declarations followed by an object list), but encountered unexpected construct'
   .z
   ^
 input: |


### PR DESCRIPTION
This pull request improves the error messages in the EO parser by providing more informative and clear descriptions when a program declaration is invalid. The updated messages now specify that a valid program definition is expected, consisting of one or more meta declarations followed by an object list, but an unexpected construct was encountered. 

 Closes #3851.