### PR TITLE
test(#3807): Add disabled test for XMIR bytes with anonymous abstract object

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -384,45 +384,4 @@ final class EoSyntaxTest {
             Matchers.equalTo(expected)
         );
     }
-
-    /**
-     * Compiles XMIR bytes with an anonymous abstract object.
-     * @throws IOException If something goes wrong.
-     * @todo #3807:60m XMIR format for bytes with data should be fixed.
-     *  Current representation of org.eolang.bytes with data in XMIR is wrong,
-     *  we miss one anonymous abstract object.
-     *  When we add the missing anonymous abstract object, we should remove
-     *  the @Disabled annotation from this test.
-     */
-    @Test
-    @Disabled
-    void compilesXmirBytesWithAnonymousAbstractObject() throws IOException {
-        final XML xmir = new EoSyntax(
-            "bytes-with-anonymous-abstract-object",
-            new InputOf(
-                String.join(
-                    "\n",
-                    "# No comments.",
-                    "bytes > app",
-                    "  00-00-00-00"
-                )
-            )
-        ).parsed();
-        MatcherAssert.assertThat(
-            String.join(
-                "\n",
-                "XMIR should contain the anonymous abstract object for bytes. Expected: ",
-                "<o base='bytes' name='app'>",
-                "  <o base='bytes'>",
-                "    <o>00-00-00-00</o> <!-- Anonymous object -->",
-                "  </o>",
-                "</o>",
-                String.format("Actual XMIR is:\n%s", xmir)
-            ),
-            xmir,
-            XhtmlMatchers.hasXPath(
-                "/program/objects/o[@base='Q.org.eolang.bytes' and @name='app']/o[@base='Q.org.eolang.bytes']/o[text()='00-00-00-00']"
-            )
-        );
-    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -384,4 +384,45 @@ final class EoSyntaxTest {
             Matchers.equalTo(expected)
         );
     }
+
+    /**
+     * Compiles XMIR bytes with an anonymous abstract object.
+     * @throws IOException If something goes wrong.
+     * @todo #3807:60m XMIR format for bytes with data should be fixed.
+     *  Current representation of org.eolang.bytes with data in XMIR is wrong,
+     *  we miss one anonymous abstract object.
+     *  When we add the missing anonymous abstract object, we should remove
+     *  the @Disabled annotation from this test.
+     */
+    @Test
+    @Disabled
+    void compilesXmirBytesWithAnonymousAbstractObject() throws IOException {
+        final XML xmir = new EoSyntax(
+            "bytes-with-anonymous-abstract-object",
+            new InputOf(
+                String.join(
+                    "\n",
+                    "# No comments.",
+                    "bytes > app",
+                    "  00-00-00-00"
+                )
+            )
+        ).parsed();
+        MatcherAssert.assertThat(
+            String.join(
+                "\n",
+                "XMIR should contain the anonymous abstract object for bytes. Expected: ",
+                "<o base='bytes' name='app'>",
+                "  <o base='bytes'>",
+                "    <o>00-00-00-00</o> <!-- Anonymous object -->",
+                "  </o>",
+                "</o>",
+                String.format("Actual XMIR is:\n%s", xmir)
+            ),
+            xmir,
+            XhtmlMatchers.hasXPath(
+                "/program/objects/o[@base='Q.org.eolang.bytes' and @name='app']/o[@base='Q.org.eolang.bytes']/o[text()='00-00-00-00']"
+            )
+        );
+    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  * @since 0.5
  */
 final class XmirTest {
+
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/parser/print-packs/yaml", glob = "**.yaml")
     void printsToEo(final String pack) throws IOException {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-in-number-with-anonymous-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-in-number-with-anonymous-object.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+skip: true
+sheets: [ ]
+asserts:
+  - /program[not(errors)]
+  - /program/objects/o[@base='Q.org.eolang.number' and @name='zero']/o[@base='Q.org.eolang.bytes']/o[text()='00-00-00-00-00-00-00-00']
+input: |
+  # No comments.
+  0 > zero

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-in-string-with-anonymous-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-in-string-with-anonymous-object.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+skip: true
+sheets: [ ]
+asserts:
+  - /program[not(errors)]
+  - /program/objects/o[@base='Q.org.eolang.string' and @name='string-bytes']/o[@base='Q.org.eolang.bytes']/o[text()='62-79-74-65-73']
+input: |
+  # No comments.
+  "bytes" > string-bytes

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-with-anonymous-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bytes-with-anonymous-object.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# @todo #3807:60m XMIR format for bytes with data should be fixed.
+#  Current representation of org.eolang.bytes with data in XMIR is wrong,
+#  we miss one anonymous abstract object.
+#  When we add the missing anonymous abstract object, we should remove
+#  the `skip` property from this test.
+#  The same should be done for the test `bytes-in-number-with-anonymous-object.yaml`
+#  and `bytes-in-string-with-anonymous-object.yaml`.
+skip: true
+sheets: [ ]
+asserts:
+  - /program[not(errors)]
+  - /program/objects/o[@base='Q.org.eolang.bytes' and @name='app']/o[@base='Q.org.eolang.bytes']/o[text()='00-00-00-00']
+input: |
+  # No comments.
+  bytes > app
+    00-00-00-00


### PR DESCRIPTION
This pull request introduces a new test case in `EoSyntaxTest` to verify the correct compilation of bytes to XMIR with an anonymous abstract object. The test is currently disabled due to an existing issue with the XMIR format, which is missing an anonymous abstract object for bytes. 

Related to #3807