### PR TITLE
fix(#3807): Fix the Bug in `EoSyntax` Related to Tuples Data

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -77,6 +77,12 @@ import org.xembly.Xembler;
 public final class EoSyntax implements Syntax {
     /**
      * Set of optimizations that builds canonical XMIR from parsed EO.
+     * @todo #3807:90min Refactor EoSyntax transformations to make them less coupled.
+     *  Currently most of these transformations are strongly coupled.
+     *  For example, `stars-to-tuples`, `StHex` and `explicit-data` are
+     *  dependent on each other. Moreover, the order of transformations
+     *  matters. We need to refactor these transformations to make them
+     *  more independent and order-agnostic if possible.
      */
     private static final Function<XML, XML> CANONICAL = new Xsline(
         new TrFull(
@@ -93,11 +99,13 @@ public final class EoSyntax implements Syntax {
                     "/org/eolang/parser/parse/expand-qqs.xsl",
                     "/org/eolang/parser/parse/expand-aliases.xsl",
                     "/org/eolang/parser/parse/resolve-aliases.xsl",
-                    "/org/eolang/parser/parse/add-default-package.xsl",
+                    "/org/eolang/parser/parse/add-default-package.xsl"
+                ).back(),
+                new TrDefault<>(new StHex()),
+                new TrClasspath<>(
                     "/org/eolang/parser/parse/explicit-data.xsl",
                     "/org/eolang/parser/parse/roll-bases.xsl"
-                ).back(),
-                new TrDefault<>(new StHex())
+                ).back()
             )
         )
     )::pass;

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -83,6 +83,12 @@ public final class EoSyntax implements Syntax {
      *  dependent on each other. Moreover, the order of transformations
      *  matters. We need to refactor these transformations to make them
      *  more independent and order-agnostic if possible.
+     * @todo #3807:90min Remove `explicit-data` transfomation.
+     *  we can try to remove explicit-data.xsl because we can generate the proper structure
+     *  with data (with inner 'o' element) everywhere right away,
+     *  without relaying on future transformations.
+     *  This issue comes from this comment:
+     *  https://github.com/objectionary/eo/pull/4041/files#r2014131951
      */
     private static final Function<XML, XML> CANONICAL = new Xsline(
         new TrFull(

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -83,7 +83,7 @@ public final class EoSyntax implements Syntax {
      *  dependent on each other. Moreover, the order of transformations
      *  matters. We need to refactor these transformations to make them
      *  more independent and order-agnostic if possible.
-     * @todo #3807:90min Remove `explicit-data` transfomation.
+     * @todo #3807:90min Remove `explicit-data` transformation.
      *  we can try to remove explicit-data.xsl because we can generate the proper structure
      *  with data (with inner 'o' element) everywhere right away,
      *  without relaying on future transformations.

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/stars-to-tuples.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/stars-to-tuples.xsl
@@ -53,7 +53,6 @@
           <xsl:element name="o">
             <xsl:attribute name="base" select="'Q.org.eolang.number'"/>
             <xsl:element name="o">
-              <xsl:attribute name="base" select="'Q.org.eolang.bytes'"/>
               <xsl:attribute name="hex"/>
               <xsl:value-of select="count(o)"/>
             </xsl:element>

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -211,6 +211,19 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void parsesCanonicalEoProgram() throws Exception {
+        MatcherAssert.assertThat(
+            "We expect that all of the bytes contain a formation with data",
+            new EoSyntax(
+                new TextOf(
+                    new ResourceOf("org/eolang/parser/canonical.eo")
+                ).asString()
+            ).parsed(),
+            Matchers.not(XhtmlMatchers.hasXPath("//o[@base='Q.org.eolang.bytes' and not(o)]"))
+        );
+    }
+
+    @Test
     void parsesMethodCalls() throws IOException {
         MatcherAssert.assertThat(
             EoIndentLexerTest.TO_ADD_MESSAGE,

--- a/eo-parser/src/test/java/org/eolang/parser/StHexTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StHexTest.java
@@ -34,13 +34,15 @@ final class StHexTest {
             new Xsline(new StHex()).pass(
                 new XMLDocument(
                     String.format(
-                        "<p><o base='Q.org.eolang.number'><o base='Q.org.eolang.bytes' hex=''>%s</o></o></p>",
+                        "<p><o base='Q.org.eolang.number'><o base='Q.org.eolang.bytes'><o hex=''>%s</o></o></o></p>",
                         number
                     )
                 )
             ),
             Matchers.allOf(
-                XhtmlMatchers.hasXPath(String.format("//o[text()='%s']", bytes)),
+                XhtmlMatchers.hasXPath(
+                    String.format("//o[@base='Q.org.eolang.bytes']/o[text()='%s']", bytes)
+                ),
                 XhtmlMatchers.hasXPath("/p[not(//o[@hex])]")
             )
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/canonical.eo
+++ b/eo-parser/src/test/resources/org/eolang/parser/canonical.eo
@@ -1,0 +1,28 @@
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Times table, which is a canonical example of EO program.
+# This file was originally copied from:
+# https://github.com/objectionary/lints/blob/101d9a18a956f688d1b0ac9cc554fa5acbc345d4/src/test/resources/org/eolang/lints/canonical.eo
+[args] > canonical
+  malloc.for > @
+    0
+    [x] >>
+      seq > @
+        *
+          x.put 2
+          while
+            x.as-number.lt 6 > [i] >>
+            [i] >>
+              seq > @
+                *
+                  QQ.io.stdout
+                    QQ.txt.sprintf
+                      "%d x %d = %d\n"
+                      *
+                        ^.x
+                        ^.x
+                        ^.x.as-number.times ^.x
+                  ^.x.put
+                    ^.x.as-number.plus 1
+          true


### PR DESCRIPTION
This pull request fixes the bug in `EoSyntax` class. `EoSyntax` generated  `bytes` objects without a formation inside:

```xml
<o base="Q.org.eolang.number">
  <o base="Q.org.eolang.bytes">40-00-00-00-00-00-00-00</o>
</o>
```

The PR fixes the `stars-to-tuples.xsl` transformation and introduces a new test case to ensure the parsing of canonical EO programs. Thus, now we generate the following xmir:

```xml
<o base="Q.org.eolang.number">
  <o base="Q.org.eolang.bytes"><o>40-00-00-00-00-00-00-00</o></o>
</o>
``` 

Related to #3807.

Originally this bug has been found here: https://github.com/objectionary/lints/pull/434#issuecomment-2751006953