### PR TITLE
fix(#4050): Fix XMIR -> PHI transformation by adding formation for each data object

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi-packs/inline-application.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi-packs/inline-application.yaml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: MIT
 ---
 asserts:
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α0' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes' and text()='48-65-6C-6C-6F']
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α1' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes' and text()='77-6F-72-6C-64']
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α2' and @base='.plus']/o[1][@base='Q.org.eolang.number' and not(@as)]/o[@base='Q.org.eolang.bytes' and text()='40-45-00-00-00-00-00-00']
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α2' and @base='.plus']/o[@base='Q.org.eolang.number' and @as='α0']/o[@base='Q.org.eolang.bytes' and text()='40-41-80-00-00-00-00-00']
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α3' and @base='.some']/o[1][@base='Q.org.eolang.number' and not(@as)]/o[@base='Q.org.eolang.bytes' and text()='40-3F-19-99-99-99-99-9A']
-  - //o[@base='Q.foo' and @name='xyz']/o[@as='α3' and @base='.some']/o[@base='Q.y' and @as='α0']/o[@base='Q.org.eolang.number' and @as='α0']/o[@base='Q.org.eolang.bytes' and text()='40-26-00-00-00-00-00-00']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α0' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes']/o[text()='48-65-6C-6C-6F']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α1' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes']/o[text()='77-6F-72-6C-64']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α2' and @base='.plus']/o[1][@base='Q.org.eolang.number' and not(@as)]/o[@base='Q.org.eolang.bytes']/o[text()='40-45-00-00-00-00-00-00']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α2' and @base='.plus']/o[@base='Q.org.eolang.number' and @as='α0']/o[@base='Q.org.eolang.bytes']/o[text()='40-41-80-00-00-00-00-00']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α3' and @base='.some']/o[1][@base='Q.org.eolang.number' and not(@as)]/o[@base='Q.org.eolang.bytes']/o[text()='40-3F-19-99-99-99-99-9A']
+  - //o[@base='Q.foo' and @name='xyz']/o[@as='α3' and @base='.some']/o[@base='Q.y' and @as='α0']/o[@base='Q.org.eolang.number' and @as='α0']/o[@base='Q.org.eolang.bytes']/o[text()='40-26-00-00-00-00-00-00']
 phi: |-
   {
     ⟦

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi-packs/pretty-data.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/unphi-packs/pretty-data.yaml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 asserts:
-  - //o[@name='five' and @base='Q.org.eolang.number']/o[@base='Q.org.eolang.bytes' and text()='40-14-00-00-00-00-00-00']
-  - //o[@name='hello' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes' and text()='48-65-6C-6C-6F']
+  - //o[@name='five' and @base='Q.org.eolang.number']/o[@base='Q.org.eolang.bytes']/o[text()='40-14-00-00-00-00-00-00']
+  - //o[@name='hello' and @base='Q.org.eolang.string']/o[@base='Q.org.eolang.bytes']/o[text()='48-65-6C-6C-6F']
 phi: "{⟦five ↦ 5, hello ↦ \"Hello\"⟧}"

--- a/eo-parser/src/main/java/org/eolang/parser/Phi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Phi.java
@@ -56,6 +56,14 @@ public class Phi {
 
     /**
      * Ctor.
+     * @param source PHI source code.
+     */
+    public Phi(final String source) {
+        this(new TextOf(source));
+    }
+
+    /**
+     * Ctor.
      * @param source PHI source code
      */
     public Phi(final Text source) {

--- a/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XePhiListener.java
@@ -429,14 +429,15 @@ final class XePhiListener implements PhiListener, Iterable<Directive> {
                 ).getBytes(StandardCharsets.UTF_8)
             );
         }
+        final int line = ctx.getStart().getLine();
+        final int pos = ctx.getStart().getCharPositionInLine() + base.length() + 1;
         this.objects()
             .prop("base", base)
-            .start(
-                ctx.getStart().getLine(),
-                ctx.getStart().getCharPositionInLine() + base.length() + 1
-            )
+            .start(line, pos)
             .prop("base", "Q.org.eolang.bytes")
+            .start(line, pos)
             .data(data.get())
+            .leave()
             .leave();
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Xmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Xmir.java
@@ -65,6 +65,7 @@ public final class Xmir implements XML {
     private static final Xsline FOR_PHI = new Xsline(
         new TrFull(
             new TrDefault<>(
+                new StFlatBytes(),
                 Xmir.UNHEX,
                 new StClasspath(
                     "/org/eolang/parser/phi/to-phi.xsl",

--- a/eo-parser/src/test/java/org/eolang/parser/PhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/PhiTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link Phi}.
+ * @since 0.56
+ */
+final class PhiTest {
+
+    @Test
+    void appliesUnphiTransformationOnNumbers() throws IOException {
+        MatcherAssert.assertThat(
+            "We should see preserve all bytes after PHI/UNPHI transformations",
+            new Phi(new Xmir(new EoSyntax("1 > phi").parsed()).toPhi()).unphi(),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Q.org.eolang.number']/o[@base='Q.org.eolang.bytes']/o[text()='3F-F0-00-00-00-00-00-00']"
+            )
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
@@ -14,6 +14,7 @@ import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
 /**
@@ -66,6 +67,16 @@ final class XmirTest {
             ),
             xmir.toSaltyPhi(),
             Matchers.equalTo(xtory.map().get("salty"))
+        );
+    }
+
+    @Test
+    void preservesNumbersInPhiRepresentation() throws IOException {
+        final String phi = this.asXmir("1 > foo\n").toPhi();
+        MatcherAssert.assertThat(
+            String.format("Phi expression should contain the data, but it doesn't: %n%s", phi),
+            phi,
+            Matchers.containsString("foo ↦ 1")
         );
     }
 

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -3,10 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns:eo="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:eo="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eolang</groupId>


### PR DESCRIPTION
This PR fixes the issue with PHI printing. Now, when we print PHI expressions from XMIR, we add extra object (formation) to all data objects.  

Closes #4050.