### PR TITLE
fix(#4099): make CommitHashesText and ChCached thread-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ eo-runtime/measures.csv
 node_modules/
 target/
 xs3p.xsl_*
+.aidy
+/.aidy/

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChCached.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
 
 /**
@@ -25,7 +26,7 @@ final class ChCached implements CommitHash {
      * @param delegate Delegate
      */
     ChCached(final CommitHash delegate) {
-        this.delegate = new Unchecked<>(new Sticky<>(delegate::value));
+        this.delegate = new Unchecked<>(new Synced<>(new Sticky<>(delegate::value)));
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
@@ -8,7 +8,9 @@ import com.jcabi.aspects.RetryOnFailure;
 import com.jcabi.log.Logger;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
+import org.cactoos.Text;
 import org.cactoos.text.Sticky;
+import org.cactoos.text.Synced;
 import org.cactoos.text.TextEnvelope;
 import org.cactoos.text.TextOf;
 
@@ -31,7 +33,15 @@ final class CommitHashesText extends TextEnvelope {
      * Constructor.
      */
     CommitHashesText() {
-        super(new Sticky(CommitHashesText::asText));
+        this(CommitHashesText::asText);
+    }
+
+    /**
+     * Constructor.
+     * @param source Text source.
+     */
+    private CommitHashesText(final Text source) {
+        super(new Synced(new Sticky(source)));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
@@ -30,10 +30,11 @@ final class CommitHashesTextTest {
 
     @Test
     void isThreadSafe() {
+        final CommitHashesText text = new CommitHashesText();
         MatcherAssert.assertThat(
             "Can be used in different threads without NPE",
             new Together<>(
-                thread -> new CommitHashesText().asString() != null
+                thread -> text.asString() != null
             ),
             Matchers.not(Matchers.hasItems(false))
         );


### PR DESCRIPTION
This PR fixes thread safety issues in `ChCached` and `CommitHashesText` by adding proper synchronization to prevent NPEs in concurrent environments.

Closes #4099