### PR TITLE
feat(#4107): Xnav ctor in ObjectName

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ObjectName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ObjectName.java
@@ -28,7 +28,15 @@ public final class ObjectName implements Supplier<String> {
      * @param xml XML
      */
     public ObjectName(final XML xml) {
-        this.xnav = new Xnav(xml.inner());
+        this(new Xnav(xml.inner()));
+    }
+
+    /**
+     * Ctor.
+     * @param nav Navigator
+     */
+    public ObjectName(final Xnav nav) {
+        this.xnav = nav;
     }
 
     @Override

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Tests for {@link ObjectName}.
+ *
+ * @since 0.56.1
+ */
+final class ObjectNameTest {
+
+    @Test
+    void retrievesSimpleName() throws ImpossibleModificationException {
+        final String expected = "foo";
+        final String retrieved = new ObjectName(
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("object").add("o").attr("name", expected)
+                ).xml()
+            )
+        ).get();
+        MatcherAssert.assertThat(
+            String.format(
+                "Retrieved name '%s' does not match with expected: '%s'",
+                retrieved, expected
+            ),
+            retrieved,
+            Matchers.equalTo(expected)
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
@@ -38,4 +38,33 @@ final class ObjectNameTest {
             Matchers.equalTo(expected)
         );
     }
+
+    @Test
+    void retrievesPackagedName() throws ImpossibleModificationException {
+        final String expected = "org.eolang.f.foo";
+        final String retrieved = new ObjectName(
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("object")
+                        .add("o").attr("name", "foo")
+                        .up()
+                        .add("metas")
+                        .add("meta")
+                        .add("head")
+                        .set("package")
+                        .up()
+                        .add("tail")
+                        .set("org.eolang.f")
+                ).xml()
+            )
+        ).get();
+        MatcherAssert.assertThat(
+            String.format(
+                "Retrieved name '%s' does not match with expected: '%s'",
+                retrieved, expected
+            ),
+            retrieved,
+            Matchers.equalTo(expected)
+        );
+    }
 }


### PR DESCRIPTION
In this pull I've added updated ctors in `org.eolang.parser.ObjectName`: now, primary ctor accepts `Xnav`, and secondary passes `XML`. Also, I added tests for `org.eolang.parser.ObjectName`.

closes #4107
History:
- **feat(#4107): xnav ctor, tests**
- **feat(#4107): package test**
