### PR TITLE
fix(#4115): update jeo-maven-plugin version and add IDE runner to XmirBench

### DIFF
--- a/eo-parser/src/test/java/benchmarks/XmirBench.java
+++ b/eo-parser/src/test/java/benchmarks/XmirBench.java
@@ -17,6 +17,9 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * Benchmark for XMIR to EO and to Phi transformations.
@@ -38,6 +41,24 @@ public class XmirBench {
      * Large XMIR document.
      */
     private static final XML XMIR = new LargeXmir("noname", "com/sun/jna/Klass.class").xml();
+
+    /**
+     * This main method allows to run the benchmark from IDE.
+     * To run benchmarks using Maven, use the command:
+     * <p>{@code
+     *   mvn jmh:benchmark
+     * }</p>
+     * @param args Arguments.
+     * @throws RunnerException If something goes wrong.
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static void main(final String[] args) throws RunnerException {
+        new Runner(
+            new OptionsBuilder()
+                .include(XmirBench.class.getSimpleName())
+                .build()
+        ).run();
+    }
 
     @Benchmark
     public void xmirToEO() {

--- a/eo-parser/src/test/java/fixtures/LargeXmir.java
+++ b/eo-parser/src/test/java/fixtures/LargeXmir.java
@@ -93,7 +93,7 @@ public final class LargeXmir {
                     );
                 f.build()
                     .plugins()
-                    .append("org.eolang", "jeo-maven-plugin", "0.7.2")
+                    .append("org.eolang", "jeo-maven-plugin", "0.10.0")
                     .execution("default")
                     .phase("process-classes")
                     .goals("disassemble");


### PR DESCRIPTION
Updates `XmirBench` to use the latest `jeo-maven-plugin` version (0.10.0) and adds IDE runner support for benchmarks.

Closes #4115