### PR TITLE
feat(#4096): special syntax for test attributes via `+`

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -37,7 +37,6 @@ commentMandatory
 object
     : commentMandatory masterBody
     | bound
-    | tests?
     ;
 
 // Objects that may be used inside abstract object
@@ -403,29 +402,8 @@ suffix
     : arrow (PHI | NAME)
     ;
 
-// Object tests
-tests
-    : (test)*
-    ;
-
-// Test attribute
-test
-    : tformation
-//  | bound
-    ;
-
-// Test attribute formation
-tformation
-    : voids tname innersOrEol
-    ;
-
-// Test attribute name
-tname
-    : SPACE PLUS ARROW SPACE (NAME)
-    ;
-
 arrow
-    : SPACE ARROW SPACE
+    : SPACE PLUS? ARROW SPACE
     ;
 
 // Simple scope

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -37,6 +37,7 @@ commentMandatory
 object
     : commentMandatory masterBody
     | bound
+    | tests?
     ;
 
 // Objects that may be used inside abstract object
@@ -400,6 +401,27 @@ oname
 // Suffix
 suffix
     : arrow (PHI | NAME)
+    ;
+
+// Object tests
+tests
+    : (test)*
+    ;
+
+// Test attribute
+test
+    : tformation
+//  | bound
+    ;
+
+// Test attribute formation
+tformation
+    : voids tname innersOrEol
+    ;
+
+// Test attribute name
+tname
+    : SPACE PLUS ARROW SPACE (NAME)
     ;
 
 arrow

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -71,7 +71,9 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             .append(new DrProgram())
             .append(new DrListing(ctx))
             .xpath("/object")
-            .strict(1);
+            .strict(1)
+            .add("tests")
+            .up();
     }
 
     @Override
@@ -862,8 +864,9 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             if (ctx.arrow().PLUS() != null) {
                 System.out.println(ctx.NAME());
                 // mark append test to tests
+            } else {
+                this.objects.prop("name", ctx.NAME().getText());
             }
-            this.objects.prop("name", ctx.NAME().getText());
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -29,6 +29,10 @@ import org.xembly.Directives;
  * @todo #4096:60min Transpile object tree under test attribute into separate Java `*Test` class
  *  with the unit test to be run. Currently, we transpile all `o` into Java tests, while we should
  *  touch only newly introduced test attributes - (`o` with @name that starts with `+`).
+ * @todo #4096:35min Handle name translation from test attribute starts with `+` to Java test method.
+ *  Now, we receiving `invalid method declaration;` when compiling transpiled Java tests, so we
+ *  need to adjust name translation. After this will be fixed, don't forget to move all EO tests
+ *  from `eo-runtime` to new test syntax.
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -26,6 +26,9 @@ import org.xembly.Directives;
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @checkstyle MethodCountCheck (1300 lines)
  * @since 0.1
+ * @todo #4096:60min Transpile object tree under test attribute into separate Java `*Test` class
+ *  with the unit test to be run. Currently, we transpile all `o` into Java tests, while we should
+ *  touch only newly introduced test attributes - (`o` with @name that starts with `+`).
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",
@@ -71,9 +74,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             .append(new DrProgram())
             .append(new DrListing(ctx))
             .xpath("/object")
-            .strict(1)
-            .add("tests")
-            .up();
+            .strict(1);
     }
 
     @Override
@@ -862,8 +863,10 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             this.objects.prop("name", ctx.PHI().getText());
         } else if (ctx.NAME() != null) {
             if (ctx.arrow().PLUS() != null) {
-                System.out.println(ctx.NAME());
-                // mark append test to tests
+                this.objects.prop(
+                    "name",
+                    String.format("%s%s", ctx.arrow().PLUS().getText(), ctx.NAME().getText())
+                );
             } else {
                 this.objects.prop("name", ctx.NAME().getText());
             }

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -859,6 +859,10 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         if (ctx.PHI() != null) {
             this.objects.prop("name", ctx.PHI().getText());
         } else if (ctx.NAME() != null) {
+            if (ctx.arrow().PLUS() != null) {
+                System.out.println(ctx.NAME());
+                // mark append test to tests
+            }
             this.objects.prop("name", ctx.NAME().getText());
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
@@ -4,9 +4,8 @@
 sheets: [ ]
 asserts:
   - /object[not(errors)]
-  - /object[tests]
-  - //o[not(@name='fibo-5th-equals-to-seven')]
-  - //o[not(@name='fibo-2nd-equals-to-one')]
+  - //o[@name='+fibo-5th-equals-to-seven']
+  - //o[@name='+fibo-2nd-equals-to-one']
 input: |
   # No comments.
   [n] > fibo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: [ ]
+asserts:
+  - /object[not(errors)]
+input: |
+  # No comments.
+  [n] > fibo
+    if. > @
+      n.lt 2
+      1
+      plus.
+        fibo (n.minus 1)
+        fibo (n.minus 2)
+
+    [] +> fibo-5th-equals-to-seven
+      eq. > @
+        7
+        fibo 5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
@@ -4,6 +4,9 @@
 sheets: [ ]
 asserts:
   - /object[not(errors)]
+  - /object[tests]
+  - //o[not(@name='fibo-5th-equals-to-seven')]
+  - //o[not(@name='fibo-2nd-equals-to-one')]
 input: |
   # No comments.
   [n] > fibo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
@@ -18,3 +18,6 @@ input: |
       eq. > @
         7
         fibo 5
+    eq. +> fibo-2nd-equals-to-one
+      1
+      fibo 2


### PR DESCRIPTION
In this PR I've implemented first step for new syntax for test attributes - now we distinguish them from "feature" objects using `+` prefix in `@name` XMIR attribute of `o` node.

see #4096
History:
- **feat(#4096): parses tests**
- **feat(#4096): embed PLUS**
- **feat(#4096): parses no errors**
- **feat(#4096): parses non-abstract**
- **feat(#4096): not objects**
- **feat(#4096): syntax, puzzle as next step**
