### PR TITLE
bug(#4132): `ObjectName.get()` throws exception if `/object/o/@name` is missing in XMIR

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ObjectName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ObjectName.java
@@ -46,7 +46,9 @@ public final class ObjectName implements Supplier<String> {
             .element("o")
             .attribute("name")
             .text()
-            .orElse("");
+            .orElseThrow(
+                () -> new IllegalStateException("XMIR should have '/object/o/@name' attribute")
+            );
         return this.xnav.element("object")
             .elements(Filter.withName("metas"))
             .findFirst()

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectNameTest.java
@@ -7,6 +7,7 @@ package org.eolang.parser;
 import com.jcabi.xml.XMLDocument;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
@@ -65,6 +66,40 @@ final class ObjectNameTest {
             ),
             retrieved,
             Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenNameIsMissing() {
+        Assertions.assertThrows(
+            Exception.class,
+            () -> new ObjectName(
+                new XMLDocument(
+                    new Xembler(
+                        new Directives().add("object")
+                            .add("metas")
+                            .add("meta")
+                            .add("head")
+                            .set("package")
+                            .up()
+                            .add("tail")
+                            .set("org.eolang.fail")
+                    ).xml()
+                )
+            ).get(),
+            "The exception is not thrown, thought XMIR is broken"
+        );
+    }
+
+    @Test
+    void doesNotThrowExceptionWhenNameIsPresentButPackageIsMissing() {
+        Assertions.assertDoesNotThrow(
+            () -> new ObjectName(
+                new XMLDocument(
+                    new Xembler(new Directives().add("object").add("o").attr("name", "foo")).xml()
+                )
+            ).get(),
+            "The exception was thrown, but it should not"
         );
     }
 }


### PR DESCRIPTION
In this PR I've updated `ObjectName.get()` to throw an exception, if `/object/o/@name` attribute is missing in the provided XMIR.

see #4132