### PR TITLE
ci(#4144): pin jmh-benchmark-action to v1.0.3

### DIFF
--- a/.github/workflows/jmh-benchmark-action.yml
+++ b/.github/workflows/jmh-benchmark-action.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run JMH Benchmark Action
-        uses: volodya-lombrozo/jmh-benchmark-action@main
+        uses: volodya-lombrozo/jmh-benchmark-action@v1.0.3
         with:
           java-version: "11"
           base-ref: "master"


### PR DESCRIPTION
Updates `jmh-benchmark-action` workflow to use stable version `v1.0.3` instead of `main` branch.

Closes #4144