### PR TITLE
bug(#4139): `validate-objects-count` does not issue error on `o` absence

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-objects-count.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-objects-count.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/object">
     <xsl:variable name="error" as="element()*">
-      <xsl:if test="count(o)!=1">
+      <xsl:if test="count(o)!=1 and count(o)!=0">
         <xsl:element name="error">
           <xsl:attribute name="check" select="'validate-objects-count'"/>
           <xsl:attribute name="line" select="if (o[2]/@line) then o[2]/@line else 0"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-objects-count.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-objects-count.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/object">
     <xsl:variable name="error" as="element()*">
-      <xsl:if test="count(o)!=1 and count(o)!=0">
+      <xsl:if test="count(o)&gt;1">
         <xsl:element name="error">
           <xsl:attribute name="check" select="'validate-objects-count'"/>
           <xsl:attribute name="line" select="if (o[2]/@line) then o[2]/@line else 0"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
@@ -7,3 +7,4 @@ asserts:
   - /object[not(errors)]
 document: |
   <object/>
+

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+asserts:
+  - /object/errors[count(error[@severity='critical'])=0]
+document: |
+  <object/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
@@ -7,4 +7,3 @@ asserts:
   - /object[not(errors)]
 document: |
   <object/>
-

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/ignores-validation-of-objects-count-when-no-objects.yaml
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 sheets:
-  - /org/eolang/parser/parse/vars-float-up.xsl
   - /org/eolang/parser/parse/validate-objects-count.xsl
 asserts:
-  - /object/errors[count(error[@severity='critical'])=0]
+  - /object[not(errors)]
 document: |
   <object/>


### PR DESCRIPTION
In this PR I've updated `validate-objects-count` to do not issue error, if there is no `o` in the XMIR.

see #4139
History:
- **bug(#4139): test**
- **bug(#4139): passes**
- **bug(#4139): just gt**
