### PR TITLE
bug(#4164): integration.yml passes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,4 +26,5 @@ jobs:
           key: ubuntu-surefire-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ubuntu-surefire-jdk-21-maven-
       - run: |
+          rm -rf ~/.m2/repo/org/eolang
           mvn clean install -PskipUTs --errors --batch-mode


### PR DESCRIPTION
In this PR I've resolved `integration.yml` failures, so now its passes.

see #4164