### PR TITLE
fix(#4164): remove runtime dependency in SnippetIT to fix integration tests

### DIFF
--- a/eo-runtime/src/test/java/integration/SnippetIT.java
+++ b/eo-runtime/src/test/java/integration/SnippetIT.java
@@ -4,7 +4,6 @@
  */
 package integration;
 
-import com.jcabi.manifests.Manifests;
 import com.yegor256.MayBeSlow;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
@@ -57,15 +56,6 @@ final class SnippetIT {
                             "%s\n",
                             xtory.map().get("eo")
                         ).getBytes(StandardCharsets.UTF_8)
-                    );
-                f.dependencies()
-                    .append(
-                        "org.eolang",
-                        "eo-runtime",
-                        System.getProperty(
-                            "eo.version",
-                            Manifests.read("EO-Version")
-                        )
                     );
                 final String target;
                 if (xtory.map().containsKey("target")) {


### PR DESCRIPTION
Removes redundant dependency declaration in `SnippetIT` that was causing build failures in integration tests.

Closes #4164