### PR TITLE
bug(#4126): test transpilation only for test attributes

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -703,34 +703,36 @@
       <xsl:if test="position()&gt;1">
         <xsl:value-of select="eo:eol(1)"/>
       </xsl:if>
-      <xsl:text>@Test</xsl:text>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>void </xsl:text>
-      <xsl:value-of select="replace(eo:escape-plus(@name), '-', '_')"/>
-      <xsl:text>() throws java.lang.Exception {</xsl:text>
-      <xsl:value-of select="eo:eol(2)"/>
-      <xsl:choose>
-        <xsl:when test="starts-with(eo:escape-plus(@name), 'throws')">
-          <xsl:text>Assertions.assertThrows(Exception.class, () -&gt; {</xsl:text>
-          <xsl:apply-templates select="." mode="dataized">
-            <xsl:with-param name="indent" select="3"/>
-          </xsl:apply-templates>
-          <xsl:text>;</xsl:text>
-          <xsl:value-of select="eo:eol(2)"/>
-          <xsl:text>});</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:text>Assertions.assertTrue(</xsl:text>
-          <xsl:apply-templates select="." mode="dataized">
-            <xsl:with-param name="indent" select="3"/>
-          </xsl:apply-templates>
-          <xsl:value-of select="eo:eol(2)"/>
-          <xsl:text>);</xsl:text>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:value-of select="eo:eol(1)"/>
-      <xsl:text>}</xsl:text>
-      <xsl:value-of select="eo:eol(0)"/>
+      <xsl:if test="starts-with(@name, '+')">
+        <xsl:text>@Test</xsl:text>
+        <xsl:value-of select="eo:eol(1)"/>
+        <xsl:text>void </xsl:text>
+        <xsl:value-of select="replace(eo:escape-plus(@name), '-', '_')"/>
+        <xsl:text>() throws java.lang.Exception {</xsl:text>
+        <xsl:value-of select="eo:eol(2)"/>
+        <xsl:choose>
+          <xsl:when test="starts-with(eo:escape-plus(@name), 'throws')">
+            <xsl:text>Assertions.assertThrows(Exception.class, () -&gt; {</xsl:text>
+            <xsl:apply-templates select="." mode="dataized">
+              <xsl:with-param name="indent" select="3"/>
+            </xsl:apply-templates>
+            <xsl:text>;</xsl:text>
+            <xsl:value-of select="eo:eol(2)"/>
+            <xsl:text>});</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Assertions.assertTrue(</xsl:text>
+            <xsl:apply-templates select="." mode="dataized">
+              <xsl:with-param name="indent" select="3"/>
+            </xsl:apply-templates>
+            <xsl:value-of select="eo:eol(2)"/>
+            <xsl:text>);</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:value-of select="eo:eol(1)"/>
+        <xsl:text>}</xsl:text>
+        <xsl:value-of select="eo:eol(0)"/>
+      </xsl:if>
     </xsl:for-each>
   </xsl:template>
   <!-- Dataize test -->

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/test-object-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/test-object-to-java.yaml
@@ -22,7 +22,7 @@ input: |
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] > tests
-    [] > compares-two-bools
+    [] +> compares-two-bools
       eq. > @
         true
         true

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-test.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-test.yaml
@@ -25,4 +25,4 @@ input: |
   [] > some-tests
     [] +> works
       1.eq 1 > @
-    false > [] > throws-on
+    false > [] +> throws-on

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
@@ -28,7 +28,7 @@ input: |
   # No comments.
   [] > a
     # No comments.
-    [] > b
+    [] +> b
       # No comments.
       [] > c
         d > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-as-tests-only-test-attributes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-as-tests-only-test-attributes.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/maven/transpile/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/tests.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java[contains(text(), '@Test')]
+  - //java[contains(text(), 'void runs_smoothly()')]
+  - //java[not(contains(text(), 'void some_other_method()'))]
+input: |
+  +tests
+
+  # Foo tests.
+  [] > foo-tests
+    # Test.
+    [] +> runs-smoothly
+      x > @
+    # Something else.
+    [] > some-other-method
+      boom > @

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -26,9 +26,6 @@ import org.xembly.Directives;
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @checkstyle MethodCountCheck (1300 lines)
  * @since 0.1
- * @todo #4096:60min Transpile object tree under test attribute into separate Java `*Test` class
- *  with the unit test to be run. Currently, we transpile all `o` into Java tests, while we should
- *  touch only newly introduced test attributes - (`o` with @name that starts with `+`).
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -29,10 +29,6 @@ import org.xembly.Directives;
  * @todo #4096:60min Transpile object tree under test attribute into separate Java `*Test` class
  *  with the unit test to be run. Currently, we transpile all `o` into Java tests, while we should
  *  touch only newly introduced test attributes - (`o` with @name that starts with `+`).
- * @todo #4096:35min Handle name translation from test attribute starts with `+` to Java test method.
- *  Now, we receiving `invalid method declaration;` when compiling transpiled Java tests, so we
- *  need to adjust name translation. After this will be fixed, don't forget to move all EO tests
- *  from `eo-runtime` to new test syntax.
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",


### PR DESCRIPTION
In this PR I've updated test transpilation in `to-java.xsl`, to map only test attributes to the `@Test` method in Java.

closes #4126
History:
- **bug(#4126): test**
- **bug(#4126): old puzzle**
- **bug(#4126): passes**
