### PR TITLE
chore(#4165): fix yamllint warnings

### DIFF
--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -7,7 +7,7 @@ name: titles
   schedule:
     - cron: '0 * * * *'
   issues:
-    types: [opened]
+    types: [ opened ]
 jobs:
   titles:
     timeout-minutes: 15


### PR DESCRIPTION
This PR fixes a formatting issue in the `titles.yml` workflow file by adding spaces around the `types` array values.

Blocks #4165