### PR TITLE
bug(#4157): up lints to enable `anonymous-formation` lint

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.48</version>
+      <version>0.0.49</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -536,8 +536,8 @@
                 <exclude>pmd:/src/it.*</exclude>
                 <exclude>pmd:/src/test/resources/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
-                <exclude>xml:/src/test/resources/META-INF/maven/plugin.xml
-                </exclude>
+                <exclude>xml:/src/test/resources/META-INF/maven/plugin.xml</exclude>
+                <exclude>dependencies:org.hamcrest:hamcrest-core:jar:1.3:compile</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -241,6 +241,13 @@
                    in order to enable this lint.
                 -->
                 <lint>duplicate-names-in-diff-context</lint>
+                <!--
+                  @todo #4157:60min Enable `redundant-object` lint after several fixes.
+                   Currently, it has multiple false-positives, that are reported here:
+                   https://github.com/objectionary/lints/issues/606, https://github.com/objectionary/lints/issues/607,
+                   and https://github.com/objectionary/lints/issues/609. After all of them will
+                   be fixed, we should enable lint. Don't forget to enable it in the `test-compile` execution too.
+                -->
                 <lint>redundant-object</lint>
               </skipSourceLints>
               <keepBinaries>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -241,6 +241,7 @@
                    in order to enable this lint.
                 -->
                 <lint>duplicate-names-in-diff-context</lint>
+                <lint>redundant-object</lint>
               </skipSourceLints>
               <keepBinaries>
                 <glob>EOorg/package-info.class</glob>
@@ -274,12 +275,7 @@
               <ignoreRuntime>true</ignoreRuntime>
               <skipSourceLints>
                 <lint>unused-void-attr</lint>
-                <!--
-                  @todo #4148:35min Enable `anonymous-formation` lint after required fixes.
-                   We should enable `anonymous-formation` lint, right after these issues will resolved in
-                   linter: https://github.com/objectionary/lints/issues/561, https://github.com/objectionary/lints/issues/562.
-                -->
-                <lint>anonymous-formation</lint>
+                <lint>redundant-object</lint>
               </skipSourceLints>
               <skipProgramLints>
                 <!--

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -14,7 +14,6 @@
   rec-hash-code 0 0 > @
   input.as-bytes > input-as-bytes!
   input-as-bytes.size > size!
-  31.as-i64 > magic-number
 
   [acc index] > rec-hash-code
     if. > @
@@ -22,7 +21,7 @@
       acc.as-number
       rec-hash-code
         plus.
-          magic-number.times acc
+          31.as-i64.times acc
           as-i64.
             concat.
               00-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -6,7 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint many-free-attributes:36
++unlint many-void-attributes:36
 
 # Makes a kernel32.dll function call by name.
 #

--- a/eo-runtime/src/test/eo/org/eolang/go-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/go-tests.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > go-tests

--- a/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/io/malloc-as-output-tests.eo
@@ -29,5 +29,4 @@
     malloc.of > @
       2
       [m]
-        output.write 01-02-03 > @
-        malloc-as-output m > output
+        (malloc-as-output m).write 01-02-03 > @

--- a/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/integral-tests.eo
@@ -13,15 +13,14 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-calculates-lineal-integral
     close-to > @
-      lineal
+      as-number.
+        integral
+          x > [x]
+          1
+          10
+          15
       49.5
       0.0000001
-    as-number. > lineal
-      integral
-        x > [x]
-        1
-        10
-        15
 
     # Checks where given `value` is close to `operand` with given precision `err`.
     [value operand err] > close-to
@@ -40,15 +39,14 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-calculates-quadratic-integral
     close-to > @
-      quadratic
+      as-number.
+        integral
+          x.times x > [x]
+          1
+          10
+          100
       333
       0.0000001
-    as-number. > quadratic
-      integral
-        x.times x > [x]
-        1
-        10
-        100
 
     # Checks where given `value` is close to `operand` with given precision `err`.
     [value operand err] > close-to
@@ -67,15 +65,14 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-calculates-cube-integral
     close-to > @
-      cube
+      as-number.
+        integral
+          (x.times x).times x > [x]
+          1
+          10
+          100
       2499.75
       0.0000001
-    as-number. > cube
-      integral
-        (x.times x).times x > [x]
-        1
-        10
-        100
 
     # Checks where given `value` is close to `operand` with given precision `err`.
     [value operand err] > close-to

--- a/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/math/real-tests.eo
@@ -77,15 +77,13 @@
   [] +> tests-div-mod-compatibility
     eq. +> @
       plus.
-        remainder
+        (real dividend).mod divisor
         times.
           divisor
-          quotient
+          (dividend.div divisor).floor
       dividend
     -13 > dividend
     5 > divisor
-    (real dividend).mod divisor > remainder
-    (dividend.div divisor).floor > quotient
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks modulo: dividend < divisor.

--- a/eo-runtime/src/test/eo/org/eolang/number-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/number-tests.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > number-tests

--- a/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/seq-tests.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > seq-tests

--- a/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
@@ -76,7 +76,8 @@
           plus. > @
             x
             a.plus
-              (* 2 2).at i
+              ^.src.at i
+    * 2 2 > src
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-reducedi-long-int-array

--- a/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/structs/list-tests.eo
@@ -76,8 +76,7 @@
           plus. > @
             x
             a.plus
-              ^.src.at i
-    * 2 2 > src
+              (* 2 2).at i
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-reducedi-long-int-array

--- a/eo-runtime/src/test/eo/org/eolang/try-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/try-tests.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > try-tests


### PR DESCRIPTION
In this PR I've upgraded lints version to the latest release: `0.0.49`, and enabled `anonymous-formation` lint. Also, spotted a few new bugs regarding `inconsistent-args`, and newly introduced `redundant-object`.

closes #4157
History:
- **bug(#4157): no annonymous formations**
- **bug(#4157): inline**
- **bug(#4157): inline off**
- **bug(#4157): fixes**
