### PR TITLE
bug(#4129): identifier sorting in `TjsForeign.all()`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
@@ -13,6 +13,7 @@ import com.yegor256.tojos.Tojos;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -169,7 +170,9 @@ final class TjsForeign implements Closeable {
      * @return Collection of tojos.
      */
     Collection<TjForeign> all() {
-        return this.select(all -> true);
+        return this.select(all -> true).stream()
+            .sorted(Comparator.comparing(TjForeign::identifier))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
@@ -145,6 +145,19 @@ final class TjsForeignTest {
         );
     }
 
+    @Test
+    void selectsSortedTojos() {
+        this.tojos.add("foo");
+        this.tojos.add("bar");
+        this.tojos.add("xyz");
+        this.tojos.add("abc");
+        MatcherAssert.assertThat(
+            "Tojos are not sorted as expected",
+            this.tojos.all(),
+            Matchers.contains("abc", "bar", "foo", "xyz")
+        );
+    }
+
     @AfterEach
     void tearDown() throws IOException {
         this.tojos.close();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
@@ -6,7 +6,10 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.Func;
 import org.hamcrest.MatcherAssert;
@@ -153,7 +156,7 @@ final class TjsForeignTest {
         this.tojos.add("abc");
         MatcherAssert.assertThat(
             "Tojos are not sorted as expected",
-            this.tojos.all(),
+            this.tojos.all().stream().map(TjForeign::identifier).collect(Collectors.toList()),
             Matchers.contains("abc", "bar", "foo", "xyz")
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
@@ -6,9 +6,7 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.Func;


### PR DESCRIPTION
In this PR I've added Tojo sorting by their identifers, in `TjsForegin.all()` method.

closes #4129
History:
- **bug(#4129): test**
- **bug(#4129): sorted**
- **bug(#4129): clean for qulice**
