### PR TITLE
bug(#3362): log more information in MjResolve

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Central.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Central.java
@@ -97,10 +97,17 @@ final class Central implements BiConsumer<Dependency, Path> {
         } catch (final MojoExecutionException ex) {
             throw new IllegalStateException(ex);
         }
-        Logger.info(
-            this, "%s:%s:%s:%s unpacked to %[file]s",
-            dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getVersion(), path
-        );
+        if (dep.getClassifier() != null) {
+            Logger.info(
+                this, "%s:%s:%s:%s unpacked to %[file]s",
+                dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getVersion(), path
+            );
+        } else {
+            Logger.info(
+                this, "%s:%s:%s unpacked to %[file]s",
+                dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), path
+            );
+        }
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -137,8 +137,8 @@ public final class MjResolve extends MjSafe {
                 Logger.warn(this, "No new files after unpacking of %s!", dep);
             } else {
                 Logger.info(
-                    this, "Found %d new file(s) after unpacking of %s",
-                    files, dep
+                    this, "Found %d new file(s) (%d MB) after unpacking of %s",
+                    files, MjResolve.folderSizeInMb(dest), dep
                 );
             }
             total = 1;
@@ -245,5 +245,28 @@ public final class MjResolve extends MjSafe {
                 .findFirst();
         }
         return res;
+    }
+
+    /**
+     * Folder size in megabytes.
+     * @param path Folder
+     * @return Folder size
+     * @throws IOException if I/O fails
+     */
+    private static long folderSizeInMb(final Path path) throws IOException {
+        try (Stream<Path> paths = Files.walk(path)) {
+            return paths.filter(Files::isRegularFile).mapToLong(
+                p -> {
+                    try {
+                        return Files.size(p);
+                    } catch (final IOException exception) {
+                        throw new IllegalStateException(
+                            String.format("Failed to calculate size in %s", p),
+                            exception
+                        );
+                    }
+                }
+            ).sum() / 1024L / 1024L;
+        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveIT.java
@@ -48,8 +48,8 @@ final class MjResolveIT {
     }
 
     @Test
-    void resolvesJarWithEmptyClassifier(@Mktmp final Path temp) throws IOException {
-        final String version = "0.39.0";
+    void logsJarWithEmptyClassifierCorrectly(@Mktmp final Path temp) throws IOException {
+        final String version = "0.52.0";
         new Farea(temp).together(
             f -> {
                 MjResolveIT.configureFarea(f, version);
@@ -57,7 +57,7 @@ final class MjResolveIT {
                 MatcherAssert.assertThat(
                     "Classifier should not be displayed, if its absent",
                     f.log().content(),
-                    Matchers.containsString("org.eolang:eo-runtime:0.39.0 unpacked to")
+                    Matchers.containsString("org.eolang:eo-runtime:0.52.0 unpacked to")
                 );
             }
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveIT.java
@@ -48,6 +48,22 @@ final class MjResolveIT {
     }
 
     @Test
+    void resolvesJarWithEmptyClassifier(@Mktmp final Path temp) throws IOException {
+        final String version = "0.39.0";
+        new Farea(temp).together(
+            f -> {
+                MjResolveIT.configureFarea(f, version);
+                f.exec("process-classes");
+                MatcherAssert.assertThat(
+                    "Classifier should not be displayed, if its absent",
+                    f.log().content(),
+                    Matchers.containsString("org.eolang:eo-runtime:0.39.0 unpacked to")
+                );
+            }
+        );
+    }
+
+    @Test
     void removesOldJarFile(@Mktmp final Path temp) throws IOException {
         final String version = "0.38.0";
         new Farea(temp).together(


### PR DESCRIPTION
In this PR I've added more information to `MjResolve` logging: unpacked JAR folder size in megabytes. Also, added NULL-check for dependency classifier in `Central.java`, in order to get rid of NULL logging.

see #3362
History:
- **bug(#3362): present classifier**
- **bug(#3362): folderSizeInMb**
