### PR TITLE
refactor(#4226): extract probes logic from MjProbe to separate class

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
@@ -4,24 +4,14 @@
  */
 package org.eolang.maven;
 
-import com.github.lombrozo.xnav.Filter;
-import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
-import com.jcabi.xml.XMLDocument;
-import com.yegor256.xsline.Shift;
-import com.yegor256.xsline.StClasspath;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.cactoos.iterable.IterableOf;
-import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
 
 /**
@@ -39,12 +29,6 @@ import org.cactoos.list.ListOf;
     threadSafe = true
 )
 public final class MjProbe extends MjSafe {
-    /**
-     * Shift that adds probes.
-     */
-    private static final Shift ADD_PROBES = new StClasspath(
-        "/org/eolang/maven/probe/add-probes.xsl"
-    );
 
     /**
      * Objectionary.
@@ -110,7 +94,7 @@ public final class MjProbe extends MjSafe {
             tojos,
             tojo -> {
                 final Path src = tojo.xmir();
-                final Collection<String> objects = this.probes(src);
+                final Collection<String> objects = new ListOf<>(new Probes(src));
                 if (!objects.isEmpty()) {
                     Logger.debug(this, "Probing object(s): %s", objects);
                 }
@@ -127,85 +111,5 @@ public final class MjProbe extends MjSafe {
                 return count;
             }
         ).total();
-    }
-
-    /**
-     * Find all probes found in the provided XML file.
-     *
-     * @param file The .xmir file
-     * @return List of foreign objects found
-     */
-    private Collection<String> probes(final Path file) throws FileNotFoundException {
-        final long start = System.currentTimeMillis();
-        final Collection<String> objects = new ListOf<>(
-            new Mapped<>(
-                MjProbe::noPrefix,
-                MjProbe.metas(file)
-            ).iterator()
-        );
-        if (objects.isEmpty()) {
-            Logger.debug(this, "Didn't find any probed objects in %[file]s", file);
-        } else {
-            Logger.debug(
-                this,
-                "Found %d probed objects in %[file]s in %[ms]s: %s",
-                objects.size(), file,
-                System.currentTimeMillis() - start,
-                objects
-            );
-        }
-        return objects;
-    }
-
-    /**
-     * Return metas for probing.
-     * The equivalent xpath is:
-     * "/object/metas/meta[head/text()='probe' or head/text()='also']/tail[not(text()='')]/text()"
-     * @param file XML file
-     * @return Metas to probe
-     */
-    private static Iterable<String> metas(final Path file) throws FileNotFoundException {
-        return new IterableOf<>(
-            new Xnav(MjProbe.ADD_PROBES.apply(0, new XMLDocument(file)).inner())
-                .element("object")
-                .elements(Filter.withName("metas"))
-                .findFirst()
-                .map(
-                    metas -> metas.elements(
-                        Filter.all(
-                            Filter.withName("meta"),
-                            meta -> {
-                                final Optional<String> head = new Xnav(meta)
-                                    .element("head")
-                                    .text();
-                                return head.map(
-                                    text -> "probe".equals(text) || "also".equals(text)
-                                ).orElse(false);
-                            }
-                        )
-                    )
-                    .map(meta -> meta.element("tail").text().orElse(""))
-                    .filter(meta -> !meta.isEmpty())
-                )
-                .orElse(Stream.of())
-                .iterator()
-        );
-    }
-
-    /**
-     * Trim Q prefix.
-     * Q.a.b.c -> a.b
-     * a.b.c -> a.b.c
-     * @param obj Full object name
-     * @return Trimmed object name
-     */
-    private static String noPrefix(final String obj) {
-        final String result;
-        if (obj.length() > 1 && "Q.".equals(obj.substring(0, 2))) {
-            result = obj.substring(2);
-        } else {
-            result = obj;
-        }
-        return result;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probes.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probes.java
@@ -37,7 +37,7 @@ final class Probes implements Iterable<String> {
     /**
      * Xmir file where probes are searched.
      */
-    private XML xmir;
+    private final XML xmir;
 
     /**
      * Constructor.
@@ -96,7 +96,7 @@ final class Probes implements Iterable<String> {
 
     /**
      * Trim Q prefix.
-     * Q.a.b.c -> a.b
+     * Q.a.b.c -> a.b.c
      * a.b.c -> a.b.c
      * @param obj Full object name
      * @return Trimmed object name

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probes.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probes.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xml;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.StClasspath;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.Mapped;
+
+/**
+ * Possible objects.
+ * This class represent a list of possible objects that were detected in
+ * a XMIR file.
+ *
+ * @since 0.53
+ */
+final class Probes implements Iterable<String> {
+
+    /**
+     * Shift that adds probes.
+     */
+    private static final Shift ADD_PROBES = new StClasspath(
+        "/org/eolang/maven/probe/add-probes.xsl"
+    );
+
+    /**
+     * Xmir file where probes are searched.
+     */
+    private XML xmir;
+
+    /**
+     * Constructor.
+     * @param path Path to XMIR file
+     * @throws FileNotFoundException If the file is not found
+     */
+    Probes(final Path path) throws FileNotFoundException {
+        this(new XMLDocument(path));
+    }
+
+    /**
+     * Constructor.
+     * @param xmir XMIR file where probes are searched
+     */
+    Probes(final XML xmir) {
+        this.xmir = xmir;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return new Mapped<>(Probes::noPrefix, this.metas()).iterator();
+    }
+
+    /**
+     * Return metas for probing.
+     * The equivalent xpath is:
+     * "/object/metas/meta[head/text()='probe' or head/text()='also']/tail[not(text()='')]/text()"
+     * @return Metas to probe
+     */
+    private Iterable<String> metas() {
+        return new IterableOf<>(
+            new Xnav(Probes.ADD_PROBES.apply(0, this.xmir).inner())
+                .element("object")
+                .elements(Filter.withName("metas"))
+                .findFirst()
+                .map(
+                    all -> all.elements(Filter.all(Filter.withName("meta"), Probes::probeOrAlso))
+                        .map(meta -> meta.element("tail").text().orElse(""))
+                        .filter(meta -> !meta.isEmpty())
+                )
+                .orElse(Stream.of())
+                .iterator()
+        );
+    }
+
+    /**
+     * Check if the meta is a 'probe' or 'also'.
+     * @param meta Meta XML element
+     * @return True if the meta is a 'probe' or 'also', false otherwise
+     */
+    private static Boolean probeOrAlso(final Xml meta) {
+        return new Xnav(meta).element("head").text()
+            .map(text -> "probe".equals(text) || "also".equals(text))
+            .orElse(false);
+    }
+
+    /**
+     * Trim Q prefix.
+     * Q.a.b.c -> a.b
+     * a.b.c -> a.b.c
+     * @param obj Full object name
+     * @return Trimmed object name
+     */
+    private static String noPrefix(final String obj) {
+        final String result;
+        if (obj.length() > 1 && "Q.".equals(obj.substring(0, 2))) {
+            result = obj.substring(2);
+        } else {
+            result = obj;
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -9,72 +9,20 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Path;
-import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
-import org.eolang.jucs.ClasspathSource;
-import org.eolang.parser.EoSyntax;
-import org.eolang.xax.XtSticky;
-import org.eolang.xax.XtYaml;
-import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link MjProbe}.
  *
  * @since 0.28.11
- * @todo #4203:90min Make {@link MjProbeTest} To Check Probes
- *  Currently, this test case only checks the number of probes found
- *  but does not verify the actual content of the probes.
- *  It would be beneficial to enhance this test to
- *  check the actual probes found.
- * @todo #4203:90min Enable {@link MjProbeTest#findsProbesInSimpleProgram(Path)} Test.
- *  This test is currently disabled because it fails.
- *  We should investigate the cause of the failure and enable the test.
- *  Originally this issue affected the integration tests,
- *  <a href="https://github.com/objectionary/eo/issues/4203">here</a>
  */
 @ExtendWith(WeAreOnline.class)
 @ExtendWith(MktmpResolver.class)
 final class MjProbeTest {
-    @Test
-    void findsProbes(@Mktmp final Path temp) throws Exception {
-        final String expected = "11";
-        MatcherAssert.assertThat(
-            String.format(
-                "Number of objects that we should find during the probing phase should be equal %s",
-                expected
-            ),
-            new FakeMaven(temp)
-                .with("foreignFormat", "json")
-                .withProgram(MjProbeTest.program())
-                .execute(new FakeMaven.Probe())
-                .programTojo()
-                .probed(),
-            Matchers.equalTo(expected)
-        );
-    }
-
-    @ParameterizedTest
-    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
-    void checksProbePacks(final String yaml) {
-        MatcherAssert.assertThat(
-            "passed without exceptions",
-            new XtSticky(
-                new XtYaml(
-                    yaml,
-                    eo -> new EoSyntax(
-                        new InputOf(String.format("%s\n", eo))
-                    ).parsed()
-                )
-            ),
-            new XtoryMatcher()
-        );
-    }
 
     @Test
     void findsProbesViaOfflineHashFile(@Mktmp final Path temp) throws IOException {
@@ -96,49 +44,6 @@ final class MjProbeTest {
                 .execute(new FakeMaven.Probe())
                 .programTojo()
                 .probed(),
-            Matchers.equalTo(expected)
-        );
-    }
-
-    @Test
-    @Disabled
-    void findsProbesInSimpleProgram(@Mktmp final Path temp) throws IOException {
-        final String found = new FakeMaven(temp)
-            .withProgram(
-                "+alias QQ.io.stdout\n",
-                "stdout \"Hello, world!\" > simple"
-            )
-            .execute(new FakeMaven.Probe())
-            .programTojo().probed();
-        final String expected = "6";
-        MatcherAssert.assertThat(
-            String.format(
-                "We should find %s objects in simple program, but %s found",
-                expected, found
-            ),
-            found,
-            Matchers.equalTo(expected)
-        );
-    }
-
-    @Test
-    void findsProbesInSimpleProgramWithComment(@Mktmp final Path temp) throws IOException {
-        final String found = new FakeMaven(temp)
-            .withProgram(
-                "# No comments.",
-                "[] > simple",
-                "  QQ.io.stdout > @",
-                "    \"Hello, world!\""
-            ).execute(new FakeMaven.Probe())
-            .programTojo()
-            .probed();
-        final String expected = "6";
-        MatcherAssert.assertThat(
-            String.format(
-                "We should find %s objects in simple program without comments, but %s found",
-                expected, found
-            ),
-            found,
             Matchers.equalTo(expected)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -9,20 +9,48 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Path;
+import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
+import org.eolang.jucs.ClasspathSource;
+import org.eolang.parser.EoSyntax;
+import org.eolang.xax.XtSticky;
+import org.eolang.xax.XtYaml;
+import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link MjProbe}.
  *
  * @since 0.28.11
+ * @todo #4226:30min Move {@link  MjProbeTest#checksProbePacks(String)} to eo-runtime.
+ *  This test checks the functionality related to the `eo-runtime` module only.
+ *  There is no need to keep it in the `eo-maven-plugin` module since it doesn't touch
+ *  the eo-maven-plugin functionality.
  */
 @ExtendWith(WeAreOnline.class)
 @ExtendWith(MktmpResolver.class)
 final class MjProbeTest {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
+    void checksProbePacks(final String yaml) {
+        MatcherAssert.assertThat(
+            "passed without exceptions",
+            new XtSticky(
+                new XtYaml(
+                    yaml,
+                    eo -> new EoSyntax(
+                        new InputOf(String.format("%s\n", eo))
+                    ).parsed()
+                )
+            ),
+            new XtoryMatcher()
+        );
+    }
 
     @Test
     void findsProbesViaOfflineHashFile(@Mktmp final Path temp) throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.cactoos.io.InputOf;
+import org.eolang.jucs.ClasspathSource;
+import org.eolang.parser.EoSyntax;
+import org.eolang.xax.XtSticky;
+import org.eolang.xax.XtYaml;
+import org.eolang.xax.XtoryMatcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Test cases for {@link Probes}.
+ *
+ * @since 0.53
+ * @todo #4226:30min Move {@link  ProbesTest#checksProbePacks(String)} to eo-runtime.
+ *  This test checks the functionality related to the `eo-runtime` module only.
+ *  There is no need to keep it in the `eo-maven-plugin` module since it doesn't touch
+ *  the eo-maven-plugin functionality.
+ * @todo #4203:90min Enable {@link ProbesTest#findsProbesInSimpleProgram()} Test.
+ *  This test is currently disabled because it fails.
+ *  We should investigate the cause of the failure and enable the test.
+ *  Originally this issue affected the integration tests,
+ *  <a href="https://github.com/objectionary/eo/issues/4203">here</a>
+ */
+final class ProbesTest {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
+    void checksProbePacks(final String yaml) {
+        MatcherAssert.assertThat(
+            "passed without exceptions",
+            new XtSticky(
+                new XtYaml(
+                    yaml,
+                    eo -> new EoSyntax(
+                        new InputOf(String.format("%s\n", eo))
+                    ).parsed()
+                )
+            ),
+            new XtoryMatcher()
+        );
+    }
+
+    @Test
+    void findsProbes() throws IOException {
+        MatcherAssert.assertThat(
+            "We should find 11 objects in the program, but not",
+            new Probes(ProbesTest.xmir()),
+            Matchers.allOf(
+                Matchers.iterableWithSize(11),
+                Matchers.hasItems(
+                    "org.eolang.while",
+                    "org",
+                    "org.eolang",
+                    "org.eolang.io",
+                    "org.eolang.io.stdout",
+                    "org.eolang.txt",
+                    "org.eolang.txt.sprintf",
+                    "org.eolang.string",
+                    "org.eolang.bytes",
+                    "org.eolang.number",
+                    "org.eolang.number.plus"
+                )
+            )
+        );
+    }
+
+    @Test
+    void findsProbesInFile(@TempDir final Path tmp) throws IOException {
+        final Path xmir = tmp.resolve("simple.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    "\n",
+                    "# No comments.",
+                    "[] > simple",
+                    "  QQ.io.stdout > @",
+                    "    \"Hello, world!\""
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "We should find 6 objects in simple program, but not",
+            new Probes(xmir),
+            Matchers.allOf(
+                Matchers.iterableWithSize(6),
+                Matchers.hasItems(
+                    "org",
+                    "org.eolang",
+                    "org.eolang.io",
+                    "org.eolang.io.stdout",
+                    "org.eolang.string",
+                    "org.eolang.bytes"
+                )
+            )
+        );
+    }
+
+    @Test
+    @Disabled
+    void findsProbesInSimpleProgram() throws IOException {
+        MatcherAssert.assertThat(
+            "We should find 6 objects in the program",
+            new Probes(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+alias QQ.io.stdout\n",
+                        "stdout \"Hello, world!\" > simple"
+                    )
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(6)
+        );
+    }
+
+    private static XML xmir() throws IOException {
+        return new EoSyntax(
+            String.join(
+                "\n",
+                new String[]{
+                    "+package foo.x",
+                    "+also while\n",
+                    "# No comments.",
+                    "[] > main",
+                    "  QQ.io.stdout > @",
+                    "    QQ.txt.sprintf",
+                    "      \"I am %d years old\"",
+                    "      plus.",
+                    "        1337",
+                    "        228",
+                }
+            )
+        ).parsed();
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
@@ -9,27 +9,17 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.cactoos.io.InputOf;
-import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
-import org.eolang.xax.XtSticky;
-import org.eolang.xax.XtYaml;
-import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test cases for {@link Probes}.
  *
  * @since 0.53
- * @todo #4226:30min Move {@link  ProbesTest#checksProbePacks(String)} to eo-runtime.
- *  This test checks the functionality related to the `eo-runtime` module only.
- *  There is no need to keep it in the `eo-maven-plugin` module since it doesn't touch
- *  the eo-maven-plugin functionality.
  * @todo #4203:90min Enable {@link ProbesTest#findsProbesInSimpleProgram()} Test.
  *  This test is currently disabled because it fails.
  *  We should investigate the cause of the failure and enable the test.
@@ -37,23 +27,6 @@ import org.junit.jupiter.params.ParameterizedTest;
  *  <a href="https://github.com/objectionary/eo/issues/4203">here</a>
  */
 final class ProbesTest {
-
-    @ParameterizedTest
-    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
-    void checksProbePacks(final String yaml) {
-        MatcherAssert.assertThat(
-            "passed without exceptions",
-            new XtSticky(
-                new XtYaml(
-                    yaml,
-                    eo -> new EoSyntax(
-                        new InputOf(String.format("%s\n", eo))
-                    ).parsed()
-                )
-            ),
-            new XtoryMatcher()
-        );
-    }
 
     @Test
     void findsProbes() throws IOException {


### PR DESCRIPTION
Refactors probe detection logic into a dedicated `Probes` class and simplifies `MjProbe`. Removes outdated test cases and adds new focused tests for probe functionality.

Closes #4226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new mechanism for extracting EO object probes from XMIR files, now encapsulated in a dedicated component.
- **Refactor**
  - Streamlined internal logic for probe extraction, delegating responsibilities to a new component for improved maintainability.
- **Tests**
  - Added comprehensive tests for the new probe extraction mechanism.
  - Removed outdated and redundant tests related to the previous implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->