### PR TITLE
bug(#4241): enable SnippetIT, ReadmeSnippetsIT

### DIFF
--- a/eo-integration-tests/src/test/java/integration/ReadmeSnippetsIT.java
+++ b/eo-integration-tests/src/test/java/integration/ReadmeSnippetsIT.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +30,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Integration test for EO snippets in `README.md`.
  * @since 0.56.3
  */
-@Disabled
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class ReadmeSnippetsIT {
 

--- a/eo-integration-tests/src/test/java/integration/SnippetIT.java
+++ b/eo-integration-tests/src/test/java/integration/SnippetIT.java
@@ -22,19 +22,13 @@ import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Integration test for simple snippets.
  * @since 0.57
- * @todo #3480:30min Enable integration tests after new release 0.56.3 to Maven.
- *  Currently, integration tests fail because we are pulling eo-maven-plugin:0.56.2,
- *  which has org.eolang.Attr, which is removed now. Don't forget to enable {@link ReadmeSnippetsIT}
- *  too.
  */
-@Disabled
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
 final class SnippetIT {


### PR DESCRIPTION
In this pull I've enabled both `SnippetIT` and `ReadmeSnippetsIT`, since we released new version of EO-runtime: `0.56.4`.

closes #4241