### PR TITLE
refactor(#4238): move probe tests from MjProbeTest to ProbesTest

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -9,48 +9,20 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Path;
-import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
-import org.eolang.jucs.ClasspathSource;
-import org.eolang.parser.EoSyntax;
-import org.eolang.xax.XtSticky;
-import org.eolang.xax.XtYaml;
-import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link MjProbe}.
  *
  * @since 0.28.11
- * @todo #4226:30min Move {@link  MjProbeTest#checksProbePacks(String)} to eo-runtime.
- *  This test checks the functionality related to the `eo-runtime` module only.
- *  There is no need to keep it in the `eo-maven-plugin` module since it doesn't touch
- *  the eo-maven-plugin functionality.
  */
 @ExtendWith(WeAreOnline.class)
 @ExtendWith(MktmpResolver.class)
 final class MjProbeTest {
-
-    @ParameterizedTest
-    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
-    void checksProbePacks(final String yaml) {
-        MatcherAssert.assertThat(
-            "passed without exceptions",
-            new XtSticky(
-                new XtYaml(
-                    yaml,
-                    eo -> new EoSyntax(
-                        new InputOf(String.format("%s\n", eo))
-                    ).parsed()
-                )
-            ),
-            new XtoryMatcher()
-        );
-    }
 
     @Test
     void findsProbesViaOfflineHashFile(@Mktmp final Path temp) throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
@@ -9,12 +9,20 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
+import org.eolang.xax.XtSticky;
+import org.eolang.xax.XtYaml;
+import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test cases for {@link Probes}.
@@ -27,6 +35,26 @@ import org.junit.jupiter.api.io.TempDir;
  *  <a href="https://github.com/objectionary/eo/issues/4203">here</a>
  */
 final class ProbesTest {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/probe-packs/", glob = "**.yaml")
+    void checksProbePacks(final String yaml) throws IOException {
+        final Xtory xtory = new XtSticky(new XtYaml(yaml));
+        final List<String> expected = Optional.ofNullable(
+            (List<String>) xtory.map().get("probes")
+        ).orElse(Collections.emptyList());
+        final Probes actual = new Probes(new EoSyntax(xtory.map().get("eo").toString()).parsed());
+        MatcherAssert.assertThat(
+            "We should find the same number of probes as in the YAML file",
+            actual,
+            Matchers.iterableWithSize(expected.size())
+        );
+        MatcherAssert.assertThat(
+            "Probes should match the ones in the YAML file",
+            actual,
+            Matchers.containsInAnyOrder(expected.toArray(new String[0]))
+        );
+    }
 
     @Test
     void findsProbes() throws IOException {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-to-empty.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-to-empty.yaml
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-sheets:
-  - /org/eolang/maven/probe/add-probes.xsl
-asserts:
-  - /object[not(errors)]
-  - //metas[count(.//meta[head/text()='probe'])=2]
-input: |
+probes:
+  - 'foo'
+  - 'foo.boom'
+eo: |
   # No comments.
   [] > app
     Q.foo.boom > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes.yaml
@@ -2,22 +2,27 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-sheets:
-  - /org/eolang/maven/probe/add-probes.xsl
-asserts:
-  - /object[not(errors)]
-  - //metas[count(.//meta[head/text()='probe'])=19]
-  - //meta[head/text()='probe' and tail/text()='Q.org' and part/text()='Q.org']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang' and part/text()='Q.org.eolang']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt' and part/text()='Q.org.eolang.txt']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt.sprintf' and part/text()='Q.org.eolang.txt.sprintf']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.txt.text' and part/text()='Q.org.eolang.txt.text']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car' and part/text()='Q.org.eolang.car']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine' and part/text()='Q.org.eolang.car.engine']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.car.engine.start' and part/text()='Q.org.eolang.car.engine.start']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.stdout.and' and part/text()='Q.org.eolang.stdout.and']
-  - //meta[head/text()='probe' and tail/text()='Q.org.eolang.stdout.and.or' and part/text()='Q.org.eolang.stdout.and.or']
-input: |
+probes:
+  - 'org'
+  - 'org.eolang'
+  - 'org.eolang.txt'
+  - 'org.eolang.txt.sprintf'
+  - 'org.eolang.txt.text'
+  - 'org.eolang.car'
+  - 'org.eolang.car.engine'
+  - 'org.eolang.car.engine.start'
+  - 'org.eolang.stdout.and'
+  - 'org.eolang.stdout.and.or'
+  - 'org.eolang.string'
+  - 'org.eolang.bytes'
+  - 'org.eolang.stdout'
+  - 'org.eolang.sprintf'
+  - 'org.eolang.n'
+  - 'org.eolang.true'
+  - 'org.eolang.number'
+  - 'org.eolang.memory'
+  - 'org.eolang.fibonacci'
+eo: |
   +home https://github.com/objectionary/eo
   +package org.eolang.custom
   +version 0.0.0

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/adds-no-probes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/adds-no-probes.yaml
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-sheets:
-  - /org/eolang/maven/probe/add-probes.xsl
-asserts:
-  - /object[not(errors)]
-  - /object[not(metas)]
-input: |
+probes:
+eo: |
   # No comments.
   [] > app

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/probes-to-anonym-abstract.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/probes-to-anonym-abstract.yaml
@@ -2,15 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-sheets:
-  - /org/eolang/maven/probe/add-probes.xsl
-asserts:
-  - /object[not(errors)]
-  - /object/metas[count(meta[head='probe'])=3]
-  - /object/metas/meta[head='probe' and tail='Q.org']
-  - /object/metas/meta[head='probe' and tail='Q.org.eolang']
-  - /object/metas/meta[head='probe' and tail='Q.org.eolang.int']
-input: |
+probes:
+  - 'org'
+  - 'org.eolang'
+  - 'org.eolang.int'
+eo: |
   # No comments.
   [] > test
     ([] (^ > x)).plus.minus > s


### PR DESCRIPTION
Moves probe pack tests from `MjProbeTest` to `ProbesTest` and updates test resources to use direct probe lists instead of XSL assertions.

Closes #4238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test resources to use a simplified YAML format, listing expected probes directly alongside EO source code.
  - Added a new parameterized test to validate probe detection against the updated YAML resources.
  - Removed an older parameterized test that previously used a more complex resource format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->