### PR TITLE
bug(#4262): test story for applications as test attributes

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
@@ -5,13 +5,18 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - /object/o[@name='foo'][count(o)=2]
+  - /object/o[@name='foo'][count(o)=3]
   - /object/o[@name='foo']/o[@base='Q.org.eolang.true' and @name='+test-works']
   - /object/o[@name='foo']/o[@base='Q.org.eolang.false' and @name='+always-fails']
+  - /object/o[@name='foo']/o[@base='.eq' and @name='+compares-something']
 input: |-
   # Foo.
   [] > foo
     # Unit test.
     true +> test-works
-    # Unit test
+    # Unit test.
     false +> always-fails
+    # Unit test.
+    eq. +> compares-something
+      "foo"
+      "bar"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='foo'][count(o)=2]
+  - /object/o[@name='foo']/o[@base='Q.org.eolang.true' and @name='+test-works']
+  - /object/o[@name='foo']/o[@base='Q.org.eolang.false' and @name='+always-fails']
+input: |-
+  # Foo.
+  [] > foo
+    # Unit test.
+    true +> test-works
+    # Unit test
+    false +> always-fails


### PR DESCRIPTION
In this PR I've added parse story for checking parsing of applications as test attributes.

see #4262
History:
- **bug(#4262): simple application passes**
- **bug(#4262): .eq**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test resource to validate EO parser behavior with unit test scenarios, including checks for object structure and expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->