### PR TITLE
bug(#4260): wrap `ObjectName.get()` exception into XMIR error

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -171,12 +171,11 @@ public final class MjParse extends MjSafe {
      * @param check Check name
      * @param message Error message
      * @param document Document
-     * @return Document with applied errors
      */
-    private static Node applyError(
+    private static void applyError(
         final String check, final String message, final Node document
     ) {
-        return new Xembler(
+        new Xembler(
             new Directives()
                 .xpath("/object")
                 .addIf("errors")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -151,10 +151,10 @@ public final class MjParse extends MjSafe {
         try {
             name = new ObjectName(xmir).get();
         } catch (final IllegalStateException exception) {
-            MjParse.applyErrors("mandatory-object-name", exception.getMessage(), document);
+            MjParse.applyError("mandatory-object-name", exception.getMessage(), document);
         }
         if (!name.equals(identifier)) {
-            MjParse.applyErrors(
+            MjParse.applyError(
                 "validate-object-name",
                 String.format(
                     "Tojo identifier '%s' does not match to result object name '%s'", identifier,
@@ -167,13 +167,13 @@ public final class MjParse extends MjSafe {
     }
 
     /**
-     * Apply errors to the document.
+     * Apply error to the document.
      * @param check Check name
      * @param message Error message
      * @param document Document
      * @return Document with applied errors
      */
-    private static Node applyErrors(
+    private static Node applyError(
         final String check, final String message, final Node document
     ) {
         return new Xembler(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -211,6 +211,25 @@ final class MjParseTest {
         );
     }
 
+    @Test
+    void addsErrorsWhenObjectNameFails(@Mktmp final Path temp) throws IOException {
+        final XMLDocument actual = new XMLDocument(
+            new FakeMaven(temp)
+                .withProgram("# App.")
+                .execute(new FakeMaven.Parse())
+                .result()
+                .get("target/1-parse/foo/x/main.xmir")
+        );
+        MatcherAssert.assertThat(
+            "Errors are not present in the resulted XMIR, but they should",
+            actual,
+            XhtmlMatchers.hasXPaths(
+                "//error[@severity='critical']",
+                "//error[text()=\"XMIR should have '/object/o/@name' attribute\"]"
+            )
+        );
+    }
+
     /**
      * The mojo that does nothing, but executes infinitely.
      * @since 0.29

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -213,16 +213,15 @@ final class MjParseTest {
 
     @Test
     void addsErrorsWhenObjectNameFails(@Mktmp final Path temp) throws IOException {
-        final XMLDocument actual = new XMLDocument(
-            new FakeMaven(temp)
-                .withProgram("# App.")
-                .execute(new FakeMaven.Parse())
-                .result()
-                .get("target/1-parse/foo/x/main.xmir")
-        );
         MatcherAssert.assertThat(
             "Errors are not present in the resulted XMIR, but they should",
-            actual,
+            new XMLDocument(
+                new FakeMaven(temp)
+                    .withProgram("# App.")
+                    .execute(new FakeMaven.Parse())
+                    .result()
+                    .get("target/1-parse/foo/x/main.xmir")
+            ),
             XhtmlMatchers.hasXPaths(
                 "//error[@severity='critical']",
                 "//error[text()=\"XMIR should have '/object/o/@name' attribute\"]"


### PR DESCRIPTION
In this PR I've updated `MjParse` to catch exception from `ObjectName.get()` and add it as error in the resulted XMIR.

see #4260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error reporting to clearly indicate critical issues when an object name is missing or invalid during parsing.
- **Tests**
  - Added a test to ensure critical errors are properly flagged when parsing fails due to missing object names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->