### PR TITLE
fix(#4203): Enable probes test and fix XSL selector for probes

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
@@ -60,7 +60,7 @@
   <!-- ENTRY POINT 1 - no metas -->
   <xsl:template match="/object[not(metas)]">
     <xsl:variable name="candidates" as="element()*">
-      <xsl:apply-templates select="//o[eo:abstract(.)]/o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
+      <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
     </xsl:variable>
     <xsl:variable name="probes" select="distinct-values($candidates/text())[not(eo:contains-any-of(., ('$', '^', '@'))) and not(.='Q')]"/>
     <xsl:copy>
@@ -77,7 +77,7 @@
   <!-- ENTRY POINT 2 - metas exists -->
   <xsl:template match="/object/metas">
     <xsl:variable name="candidates" as="element()*">
-      <xsl:apply-templates select="//o[eo:abstract(.)]/o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
+      <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
     </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
@@ -19,7 +19,6 @@ import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,11 +27,6 @@ import org.junit.jupiter.params.ParameterizedTest;
  * Test cases for {@link Probes}.
  *
  * @since 0.53
- * @todo #4203:90min Enable {@link ProbesTest#findsProbesInSimpleProgram()} Test.
- *  This test is currently disabled because it fails.
- *  We should investigate the cause of the failure and enable the test.
- *  Originally this issue affected the integration tests,
- *  <a href="https://github.com/objectionary/eo/issues/4203">here</a>
  */
 final class ProbesTest {
 
@@ -113,7 +107,6 @@ final class ProbesTest {
     }
 
     @Test
-    @Disabled
     void findsProbesInSimpleProgram() throws IOException {
         MatcherAssert.assertThat(
             "We should find 6 objects in the program",
@@ -126,7 +119,17 @@ final class ProbesTest {
                     )
                 ).parsed()
             ),
-            Matchers.iterableWithSize(6)
+            Matchers.allOf(
+                Matchers.iterableWithSize(6),
+                Matchers.hasItems(
+                    "org",
+                    "org.eolang",
+                    "org.eolang.io",
+                    "org.eolang.io.stdout",
+                    "org.eolang.string",
+                    "org.eolang.bytes"
+                )
+            )
         );
     }
 


### PR DESCRIPTION
This PR fixes the probe detection logic in `add-probes.xsl` and enables the previously disabled test `findsProbesInSimpleProgram()` to verify proper detection of probes.

By some reason, we searched for probes only in objects that have an abstract parent object. In other words we could find probes in this EO program:

```eo
[] > simple
  QQ.io.stdout > @
    "Hello, world!"
```

and couldn't in this:

```eo
+alias QQ.io.stdout
stdout "Hello, world!" > simple
```

Closes #4239, #4203