### PR TITLE
bug(#4133): log all errors in `Threaded`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Threaded.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Threaded.java
@@ -34,7 +34,7 @@ final class Threaded<T> {
     private final Func<T, Integer> scalar;
 
     /**
-     * Logger.
+     * The logger.
      */
     private final Consumer<? super String> logger;
 
@@ -51,6 +51,7 @@ final class Threaded<T> {
      * Ctor.
      * @param src The sources
      * @param fun The function to run
+     * @param log The logger
      */
     Threaded(
         final Iterable<T> src, final Func<T, Integer> fun, final Consumer<? super String> log

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Threaded.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Threaded.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.maven;
 
+import com.jcabi.log.Logger;
+import java.util.function.Consumer;
 import org.cactoos.Func;
 import org.cactoos.experimental.Threads;
 import org.cactoos.iterable.Mapped;
@@ -32,13 +34,30 @@ final class Threaded<T> {
     private final Func<T, Integer> scalar;
 
     /**
+     * Logger.
+     */
+    private final Consumer<? super String> logger;
+
+    /**
      * Ctor.
      * @param src The sources
      * @param fun The function to run
      */
     Threaded(final Iterable<T> src, final Func<T, Integer> fun) {
+        this(src, fun, message -> Logger.error(Threaded.class, message));
+    }
+
+    /**
+     * Ctor.
+     * @param src The sources
+     * @param fun The function to run
+     */
+    Threaded(
+        final Iterable<T> src, final Func<T, Integer> fun, final Consumer<? super String> log
+    ) {
         this.sources = src;
         this.scalar = fun;
+        this.logger = log;
     }
 
     /**
@@ -56,13 +75,12 @@ final class Threaded<T> {
                             return this.scalar.apply(tojo);
                             // @checkstyle IllegalCatchCheck (1 line)
                         } catch (final Exception ex) {
-                            throw new IllegalStateException(
-                                String.format(
-                                    "Failed to process \"%s\" (%s)",
-                                    tojo, tojo.getClass().getCanonicalName()
-                                ),
-                                ex
+                            final String message = String.format(
+                                "Failed to process \"%s\" (%s)",
+                                tojo, tojo.getClass().getCanonicalName()
                             );
+                            this.logger.accept(message);
+                            throw new IllegalStateException(message, ex);
                         }
                     },
                     this.sources

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
@@ -4,13 +4,12 @@
  */
 package org.eolang.maven;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
-import org.apache.log4j.Logger;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -20,10 +19,15 @@ import org.junit.jupiter.api.Test;
  */
 final class ThreadedTest {
 
+    /**
+     * Logs all exceptions.
+     * @checkstyle IllegalCatchCheck (25 lines)
+     * @checkstyle MethodBodyCommentsCheck (25 lines)
+     */
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidThrowingRawExceptionTypes"})
     @Test
-    void reportsAllExceptionsInTheLogsOnFailure() {
-        final List<String> logs = new ListOf<>();
-        Exception thrown = null;
+    void logsAllExceptionsInTheLogsOnFailure() {
+        final List<String> logs = Collections.synchronizedList(new ListOf<>());
         try {
             new Threaded<>(
                 new ListOf<>(1, 2, 3),
@@ -32,8 +36,9 @@ final class ThreadedTest {
                 },
                 logs::add
             ).total();
-        } catch (final Exception exception) {
-            thrown = exception;
+            Assertions.fail("Expected exception to be thrown");
+        } catch (final Exception ignored) {
+            // Swallow the exception in order to do asserts
         }
         MatcherAssert.assertThat(
             "Logs don't have all failure messages, but they should",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.log4j.Logger;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Threaded}.
+ *
+ * @since 0.56.5
+ */
+final class ThreadedTest {
+
+    @Test
+    void reportsAllExceptionsInTheLogsOnFailure() {
+        final List<String> logs = new ListOf<>();
+        Exception thrown = null;
+        try {
+            new Threaded<>(
+                new ListOf<>(1, 2, 3),
+                input -> {
+                    throw new RuntimeException(String.format("Failure on: %d", input));
+                },
+                logs::add
+            ).total();
+        } catch (final Exception exception) {
+            thrown = exception;
+        }
+        MatcherAssert.assertThat(
+            "Logs don't have all failure messages, but they should",
+            logs,
+            Matchers.hasItems(
+                Matchers.containsString("Failed to process \"1\""),
+                Matchers.containsString("Failed to process \"2\""),
+                Matchers.containsString("Failed to process \"3\"")
+            )
+        );
+    }
+}


### PR DESCRIPTION
In this PR I've updated `Threaded` to log all errors in order to see all the thread failures.

see #4133
History:
- **bug(#4133): passes**
- **bug(#4133): clean for qulice**
