### PR TITLE
fix(#4201): redirect error messages to stderr in runtime and tests

### DIFF
--- a/eo-integration-tests/src/test/resources/logback.xml
+++ b/eo-integration-tests/src/test/resources/logback.xml
@@ -5,6 +5,7 @@
 -->
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.out</target>
     <encoder>
       <pattern>%highlight(%-5level) %logger{15} - %msg%n</pattern>
     </encoder>

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("java:S5164")
 public final class Dataized {
     /**
-     * The object to datarize.
+     * The object to dataize.
      */
     private final Phi phi;
 

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -56,8 +56,7 @@ public final class Main {
      */
     public static void main(final String... args) throws Exception {
         Main.setup();
-        final List<String> opts = new ArrayList<>(args.length);
-        opts.addAll(Arrays.asList(args));
+        final List<String> opts = new ArrayList<>(Arrays.asList(args));
         while (!opts.isEmpty()) {
             final String opt = opts.get(0);
             if (Main.parse(opt)) {
@@ -151,9 +150,8 @@ public final class Main {
     /**
      * Run this opts.
      * @param opts The opts left
-     * @throws Exception If fails
      */
-    private static void run(final List<String> opts) throws Exception {
+    private static void run(final List<String> opts) {
         final String obj = opts.get(0);
         if (obj.isEmpty()) {
             throw new IllegalArgumentException(
@@ -187,13 +185,14 @@ public final class Main {
      * @throws IOException If fails
      */
     private static String version() throws IOException {
-        try (BufferedReader input =
-            new BufferedReader(
-                new InputStreamReader(
-                    Objects.requireNonNull(Main.class.getResourceAsStream("version.txt")),
-                    StandardCharsets.UTF_8
+        try (
+            BufferedReader input =
+                new BufferedReader(
+                    new InputStreamReader(
+                        Objects.requireNonNull(Main.class.getResourceAsStream("version.txt")),
+                        StandardCharsets.UTF_8
+                    )
                 )
-            )
         ) {
             return input.lines().findFirst().orElse("N/A");
         }

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -6,6 +6,7 @@ package org.eolang;
 
 import com.yegor256.Jaxec;
 import com.yegor256.Jhome;
+import com.yegor256.Result;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,7 +42,7 @@ final class MainTest {
     void printsVersion() {
         MatcherAssert.assertThat(
             "Prints its own version properly",
-            MainTest.exec("--version"),
+            MainTest.stderr("--version"),
             Matchers.allOf(
                 Matchers.containsString("."),
                 Matchers.not(Matchers.containsString(" "))
@@ -53,7 +54,7 @@ final class MainTest {
     void printsHelp() {
         MatcherAssert.assertThat(
             "Prints help summary properly",
-            MainTest.exec("--help"),
+            MainTest.stderr("--help"),
             Matchers.containsString("Usage: ")
         );
     }
@@ -62,7 +63,7 @@ final class MainTest {
     void deliversCleanOutput() {
         MatcherAssert.assertThat(
             "Incorrect output when dataizing \"true\" object",
-            MainTest.exec("org.eolang.true"),
+            MainTest.stderr("org.eolang.true"),
             Matchers.stringContainsInOrder(
                 String.format("%n---%n"),
                 "true",
@@ -75,7 +76,7 @@ final class MainTest {
     void executesJvmFullRun() {
         MatcherAssert.assertThat(
             "Incorrect verbose output when dataizing \"false\" object",
-            MainTest.exec("--verbose", "org.eolang.false"),
+            MainTest.stderr("--verbose", "org.eolang.false"),
             Matchers.allOf(
                 Matchers.containsString("EOLANG"),
                 Matchers.containsString("false")
@@ -87,7 +88,7 @@ final class MainTest {
     void executesJvmFullRunWithDashedObject() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.exec("--verbose", "as-bytes"),
+            MainTest.stderr("--verbose", "as-bytes"),
             Matchers.containsString("Couldn't find object 'Φ.as-bytes'")
         );
     }
@@ -96,7 +97,7 @@ final class MainTest {
     void executesJvmFullRinWithAttributeCall() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.exec("--verbose", "string$as-bytes"),
+            MainTest.stderr("--verbose", "string$as-bytes"),
             Matchers.containsString("Couldn't find object 'Φ.string$as-bytes'")
         );
     }
@@ -105,7 +106,7 @@ final class MainTest {
     void executesJvmFullRunWithError() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.exec("--verbose", "org.eolang.io.stdout"),
+            MainTest.stderr("--verbose", "org.eolang.io.stdout"),
             Matchers.containsString(
                 "Error in \"Φ.org.eolang.io.stdout.φ.Δ\" "
             )
@@ -116,7 +117,7 @@ final class MainTest {
     void executesWithObjectNotFoundException() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.exec("unavailable-name"),
+            MainTest.stderr("unavailable-name"),
             Matchers.containsString("Couldn't find object 'Φ.unavailable-name'")
         );
     }
@@ -176,8 +177,12 @@ final class MainTest {
         );
     }
 
-    private static String exec(final String... cmds) {
-        final String stdout = new Jaxec(
+    private static String stderr(final String... cmds) {
+        return MainTest.exec(cmds).stderr();
+    }
+
+    private static Result exec(final String... cmds) {
+        return new Jaxec(
             new Jhome().java().toString(),
             "-Dfile.encoding=UTF-8",
             "-Dsun.stdout.encoding=UTF-8",
@@ -185,14 +190,7 @@ final class MainTest {
             "-cp",
             System.getProperty("java.class.path"),
             Main.class.getCanonicalName()
-        ).with(cmds).withCheck(false).exec().stdout();
-        return stdout.replaceFirst(
-            String.format(
-                "Picked up .*%s",
-                System.lineSeparator()
-            ),
-            ""
-        );
+        ).with(cmds).withCheck(false).exec();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
       <dependency>
         <groupId>com.yegor256</groupId>
         <artifactId>jaxec</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
       </dependency>
       <dependency>
         <groupId>com.yegor256</groupId>


### PR DESCRIPTION
This PR redirects error messages to `stderr` instead of `stdout` (Jaxec lib fix) and updates related tests to verify error output. It also includes minor code improvements and dependency updates.

Closes #4201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message handling by ensuring program errors are now printed to standard error output instead of standard output.
  - Adjusted logging configuration to explicitly direct logs to standard output.

- **Tests**
  - Added a new integration test to verify that errors are correctly reported to standard error.
  - Updated tests to assert error messages in standard error output.
  - Refactored test code to centralize EO program compilation and reduce duplication.

- **Chores**
  - Upgraded the `jaxec` library dependency to version 0.4.1.
  - Minor documentation and code style improvements for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->