### PR TITLE
bug(#1946): `DpsOfflineRuntime` with `resolveInCentral` in `MjResolve`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsOfflineRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsOfflineRuntime.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.manifests.Manifests;
+import java.util.Collection;
+import java.util.Iterator;
+import org.cactoos.list.ListOf;
+
+/**
+ * Dependencies together with offline EO runtime dependency.
+ * @since 0.56.5
+ */
+final class DpsOfflineRuntime implements Dependencies {
+
+    /**
+     * All dependencies.
+     */
+    private final Iterable<Dep> all;
+
+    /**
+     * Ctor.
+     * @param dlg All dependencies
+     */
+    DpsOfflineRuntime(final Iterable<Dep> dlg) {
+        this.all = dlg;
+    }
+
+    @Override
+    public Iterator<Dep> iterator() {
+        final Collection<Dep> deps = new ListOf<>(this.all);
+        deps.add(
+            new Dep().withGroupId("org.eolang")
+                .withArtifactId("eo-runtime")
+                .withVersion(Manifests.read("EO-Version"))
+        );
+        return deps.iterator();
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -5,15 +5,12 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import com.jcabi.manifests.Manifests;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,7 +19,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.Func;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
 import org.cactoos.text.Joined;
 
@@ -74,7 +70,9 @@ public final class MjResolve extends MjSafe {
 
     /**
      * Resolve dependencies in central or not.
+     * @checkstyle MemberNameCheck (7 lines)
      */
+    @SuppressWarnings("PMD.ImmutableField")
     private boolean resolveInCentral = true;
 
     @Override
@@ -224,19 +222,7 @@ public final class MjResolve extends MjSafe {
                 if (this.resolveInCentral) {
                     deps = new DpsWithRuntime(deps);
                 } else {
-                    final List<Dep> all = new ListOf<>(deps);
-                    all.add(
-                        new Dep().withGroupId("org.eolang")
-                            .withArtifactId("eo-runtime")
-                            .withVersion(Manifests.read("EO-Version"))
-                    );
-                    deps = new Dependencies() {
-                        @Override
-                        public Iterator<Dep> iterator() {
-                            return all.iterator();
-                        }
-                    };
-                    // DpsOfflineRuntime
+                    deps = new DpsOfflineRuntime(deps);
                 }
             }
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DpsOfflineRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DpsOfflineRuntimeTest.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DpsOfflineRuntime}.
+ *
+ * @since 0.56.5
+ */
+final class DpsOfflineRuntimeTest {
+
+    @Test
+    void addsCurrentEoDependency() {
+        MatcherAssert.assertThat(
+            "Offline EO runtime dependency does not match with expected",
+            new DpsOfflineRuntime(new ListOf<>()),
+            Matchers.hasItem(
+                Matchers.hasToString(
+                    Matchers.containsString("org.eolang:eo-runtime:1.0-SNAPSHOT")
+                )
+            )
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -183,6 +183,7 @@ final class FakeMaven {
             this.params.putIfAbsent("ignoreVersionConflicts", false);
             this.params.putIfAbsent("ignoreTransitive", true);
             this.params.putIfAbsent("central", new DummyCentral());
+            this.params.putIfAbsent("resolveInCentral", false);
             this.params.putIfAbsent("placed", this.workspace.resolve(placed).toFile());
             this.params.putIfAbsent("placedFormat", "json");
             this.params.putIfAbsent(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
@@ -6,7 +6,6 @@ package org.eolang.maven;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
-import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -175,7 +174,6 @@ final class MjPlaceTest {
      * @throws IOException If fails
      */
     @Test
-    @ExtendWith(WeAreOnline.class)
     void placesAllEoRuntimeClasses(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -6,7 +6,6 @@ package org.eolang.maven;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
-import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.1
  */
-@ExtendWith(WeAreOnline.class)
 @ExtendWith(MktmpResolver.class)
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class MjResolveTest {


### PR DESCRIPTION
In this PR I've introduced `DpsOfflineRuntime` together with `resolveInCentral` field to remove trips to Maven Central in the unit tests of `eo-maven-plugin`, especially in`MjPlaceTest`, `MjResolveTest`.

see #1946
History:
- **bug(#1946): resolveInCentral**
- **bug(#1946): DpsOfflineRuntime**
