### PR TITLE
bug(#4192): redundant-object lint enabled

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -250,7 +250,6 @@
                    and https://github.com/objectionary/lints/issues/609. After all of them will
                    be fixed, we should enable lint. Don't forget to enable it in the `test-compile` execution too.
                 -->
-                <lint>redundant-object</lint>
                 <!--
                   @todo #4096:35min Enable `sparse-decoration` lint.
                    After we merged EO tests together with their source objects, and removed

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -244,13 +244,6 @@
                 -->
                 <lint>duplicate-names-in-diff-context</lint>
                 <!--
-                  @todo #4157:60min Enable `redundant-object` lint after several fixes.
-                   Currently, it has multiple false-positives, that are reported here:
-                   https://github.com/objectionary/lints/issues/606, https://github.com/objectionary/lints/issues/607,
-                   and https://github.com/objectionary/lints/issues/609. After all of them will
-                   be fixed, we should enable lint. Don't forget to enable it in the `test-compile` execution too.
-                -->
-                <!--
                   @todo #4096:35min Enable `sparse-decoration` lint.
                    After we merged EO tests together with their source objects, and removed
                    `+tests` meta, we have complains about sparse-decoration. Let's adjust and

--- a/eo-runtime/src/main/eo/org/eolang/bytes.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bytes.eo
@@ -7,6 +7,13 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:23
++unlint redundant-object:24
++unlint redundant-object:28
++unlint redundant-object:47
++unlint redundant-object:57
++unlint redundant-object:67
++unlint redundant-object:428
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,
@@ -385,11 +392,9 @@
   [] +> tests-concat-bools-as-bytes
     eq. > @
       concat.
-        b1
-        b2
+        true.as-bytes
+        false.as-bytes
       01-00
-    true.as-bytes > b1
-    false.as-bytes > b2
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-concat-with-empty

--- a/eo-runtime/src/main/eo/org/eolang/false.eo
+++ b/eo-runtime/src/main/eo/org/eolang/false.eo
@@ -5,7 +5,8 @@
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
-+unlint no-attribute-formation:11
++unlint no-attribute-formation:12
++unlint redundant-object:14
 
 # The object is a FALSE boolean state.
 [] > false

--- a/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/dir.eo
@@ -8,6 +8,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
 
 # Directory in the file system.
 # Apparently every directory is a file.

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -11,6 +11,16 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:28
++unlint redundant-object:30
++unlint redundant-object:150
++unlint redundant-object:164
++unlint redundant-object:166
++unlint redundant-object:198
++unlint redundant-object:212
++unlint redundant-object:238
++unlint redundant-object:254
++unlint redundant-object:331
 
 # The file object in the filesystem.
 [path] > file
@@ -592,7 +602,6 @@
     .open
       "a+"
       [f]
-        o1.write "!" > @
-        f.write "Hello, world" > o1
+        (f.write "Hello, world").write "!" > @
     .size
     .eq 13 > @

--- a/eo-runtime/src/main/eo/org/eolang/fs/file.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/file.eo
@@ -11,16 +11,17 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object:28
-+unlint redundant-object:30
-+unlint redundant-object:150
-+unlint redundant-object:164
-+unlint redundant-object:166
-+unlint redundant-object:198
-+unlint redundant-object:212
-+unlint redundant-object:238
-+unlint redundant-object:254
-+unlint redundant-object:331
++unlint redundant-object:29
++unlint redundant-object:31
++unlint redundant-object:151
++unlint redundant-object:165
++unlint redundant-object:167
++unlint redundant-object:199
++unlint redundant-object:213
++unlint redundant-object:239
++unlint redundant-object:255
++unlint redundant-object:332
++unlint redundant-object:594
 
 # The file object in the filesystem.
 [path] > file
@@ -590,8 +591,7 @@
                   *
                     f.write "Hello, world"
                     ^.m.put i2
-                f.read 7 > i1
-                i1.read 5 > i2
+                (f.read 7).read 5 > i2
             m
     .eq "world" > @
 

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -10,11 +10,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object:52
 +unlint redundant-object:56
-+unlint redundant-object:57
-+unlint redundant-object:266
-+unlint redundant-object:269
++unlint redundant-object:58
++unlint redundant-object:59
++unlint redundant-object:268
++unlint redundant-object:270
++unlint redundant-object:271
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.

--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -10,6 +10,11 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:52
++unlint redundant-object:56
++unlint redundant-object:57
++unlint redundant-object:266
++unlint redundant-object:269
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
@@ -407,10 +412,10 @@
           validated
             string
               if.
-                other-is-drive-relative
+                (^.is-drive-relative valid-other).as-bool
                 valid-other
                 if.
-                  other-is-root-relative
+                  (^.is-root-relative valid-other).as-bool
                   if.
                     is-drive-relative uri-as-bytes
                     concat.
@@ -424,8 +429,6 @@
                     valid-other
         uri > uri-as-bytes!
         separated-correctly other > valid-other!
-        (^.is-drive-relative valid-other).as-bool > other-is-drive-relative
-        (^.is-root-relative valid-other).as-bool > other-is-root-relative
 
       # Takes the base name from the provided `path`, for example:
       # |------------------------------|---------------|

--- a/eo-runtime/src/main/eo/org/eolang/go.eo
+++ b/eo-runtime/src/main/eo/org/eolang/go.eo
@@ -4,6 +4,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:53
++unlint redundant-object:58
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/eo-runtime/src/main/eo/org/eolang/i16.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i16.eo
@@ -7,6 +7,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/org/eolang/i32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i32.eo
@@ -7,6 +7,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/org/eolang/i64.eo
+++ b/eo-runtime/src/main/eo/org/eolang/i64.eo
@@ -7,6 +7,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/bytes-as-input.eo
@@ -4,6 +4,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:47
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized
@@ -78,10 +79,7 @@
           i1.eq 01-02-03-04
           i2.eq 05-06-07-08
         i3.eq F5-F6
-      i4.eq --
-    bytes-as-input > i
-      01-02-03-04-05-06-07-08-F5-F6
-    i.read 4 > i1
+      (i3.read 2).eq --
+    (bytes-as-input 01-02-03-04-05-06-07-08-F5-F6).read 4 > i1
     i1.read 4 > i2
     i2.read 4 > i3
-    i3.read 2 > i4

--- a/eo-runtime/src/main/eo/org/eolang/io/console.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/console.eo
@@ -7,6 +7,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:82
++unlint redundant-object:95
++unlint redundant-object:122
++unlint redundant-object:138
++unlint redundant-object:151
++unlint redundant-object:178
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/dead-input.eo
@@ -28,6 +28,5 @@
   [] +> tests-reads-empty-bytes
     and. > @
       i1.eq --
-      i2.eq --
+      (i1.read 10).eq --
     dead-input.read 10 > i1
-    i1.read 10 > i2

--- a/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/input-length.eo
@@ -11,7 +11,6 @@
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length
   rec-read input 0 > @
-  4096 > chunk
 
   [input length] > rec-read
     if. > @
@@ -20,7 +19,7 @@
       rec-read
         read-bytes
         length.plus read-bytes.size
-    (input.read chunk).read.^ > read-bytes
+    (input.read 4096).read.^ > read-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-reads-all-bytes-and-returns-length

--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -4,6 +4,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:43
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.
@@ -58,11 +59,8 @@
         [mem]
           seq > @
             *
-              o2.write 08-09-A0
+              (((malloc-as-output mem).write 01-02-03).write 04-05-06-07).write 08-09-A0
               mem
-          malloc-as-output mem > out
-          out.write 01-02-03 > o1
-          o1.write 04-05-06-07 > o2
       01-02-03-04-05-06-07-08-09-A0
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/tee-input.eo
@@ -6,6 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:43
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.
@@ -76,13 +77,13 @@
         [m]
           seq > @
             *
-              i2.read 1
+              tee-input
+                bytes-as-input 01-02-03-04-05
+                malloc-as-output m
+              .read 2
+              .read 2
+              .read 1
               m
-          tee-input > tee
-            bytes-as-input 01-02-03-04-05
-            malloc-as-output m
-          tee.read 2 > i1
-          i1.read 2 > i2
       01-02-03-04-05
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/main/eo/org/eolang/malloc.eo
+++ b/eo-runtime/src/main/eo/org/eolang/malloc.eo
@@ -6,6 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:204
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may

--- a/eo-runtime/src/main/eo/org/eolang/math/angle.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/angle.eo
@@ -7,6 +7,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:24
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -7,6 +7,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:21
++unlint redundant-object:29
++unlint redundant-object:44
 
 # Generates a pseudo-random number.
 [seed] > random

--- a/eo-runtime/src/main/eo/org/eolang/math/random.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/random.eo
@@ -46,7 +46,7 @@
         as-i64.
           and.
             time-bytes.left const-1
-            ((one.left const-2).as-i64.minus one).as-bytes
+            ((one.left 53).as-i64.minus one).as-bytes
         plus.
           as-i64.
             and.
@@ -66,7 +66,6 @@
             as-number.
               timeval.tv-usec.as-i64.div 1000.as-i64
     35 > const-1
-    53 > const-2
     17 > const-3
     00-00-00-00-00-00-00-01 > one
 

--- a/eo-runtime/src/main/eo/org/eolang/math/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/math/real.eo
@@ -8,6 +8,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:17
 
 # Returns a floating point number.
 [num] > real

--- a/eo-runtime/src/main/eo/org/eolang/nan.eo
+++ b/eo-runtime/src/main/eo/org/eolang/nan.eo
@@ -4,6 +4,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/negative-infinity.eo
@@ -4,6 +4,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/eo-runtime/src/main/eo/org/eolang/net/socket.eo
+++ b/eo-runtime/src/main/eo/org/eolang/net/socket.eo
@@ -9,6 +9,11 @@
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint redundant-object:102
++unlint redundant-object:133
++unlint redundant-object:163
++unlint redundant-object:350
++unlint redundant-object:450
 
 # Socket.
 #

--- a/eo-runtime/src/main/eo/org/eolang/number.eo
+++ b/eo-runtime/src/main/eo/org/eolang/number.eo
@@ -6,6 +6,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:25
++unlint redundant-object:28
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/org/eolang/positive-infinity.eo
@@ -4,6 +4,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/eo-runtime/src/main/eo/org/eolang/runtime.eo
+++ b/eo-runtime/src/main/eo/org/eolang/runtime.eo
@@ -8,6 +8,7 @@
 +unlint cti
 +unlint incorrect-unlint
 +unlint unlint-non-existing-defect
++unlint redundant-object
 
 # Runtime.
 # @todo #4235:35min Move all tests from `runtime.eo` to other objects.

--- a/eo-runtime/src/main/eo/org/eolang/string.eo
+++ b/eo-runtime/src/main/eo/org/eolang/string.eo
@@ -5,6 +5,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:94
++unlint redundant-object:110
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.
@@ -211,8 +213,7 @@
   # The smile emoji is F0-9F-98-80 in bytes. Here we check if string.length fails if it faces
   # incomplete 4 byte character.
   [] +> throws-on-taking-length-of-incomplete-n4-byte-character
-    should-be-smile.length > @
-    string F0-9F-98 > should-be-smile
+    (string F0-9F-98).length > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-compares-two-different-string-types

--- a/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/hash-code-of.eo
@@ -31,10 +31,8 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-hash-code-of-bools-is-number
     and. > @
-      true-code.as-bytes.size.eq 8
-      false-code.as-bytes.size.eq 8
-    hash-code-of true > true-code
-    hash-code-of false > false-code
+      (hash-code-of true).as-bytes.size.eq 8
+      (hash-code-of false).as-bytes.size.eq 8
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-hash-code-of-int-is-int

--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -6,6 +6,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:25
++unlint redundant-object:393
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.
@@ -322,8 +325,7 @@
           plus. > @
             x
             a.plus
-              ^.src.at i
-    * 2 2 > src
+              (* 2 2).at i
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-reducedi-long-int-array
@@ -470,10 +472,9 @@
     eq. > @
       withouti.
         list
-          * "smthg" 27 nested
+          * "smthg" 27 (* 3 2 1)
         2
       * "smthg" 27
-    * 3 2 1 > nested
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-without
@@ -508,12 +509,10 @@
       eq.
         list3
         * 1 2 3
-    list (* 0 1) > list1
-    list (* 2 3) > list2
     withouti. > list3
       concat.
-        list1
-        list2
+        list (* 0 1)
+        list (* 2 3)
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/eo-runtime/src/main/eo/org/eolang/structs/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/map.eo
@@ -7,6 +7,19 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:40
++unlint redundant-object:53
++unlint redundant-object:68
++unlint redundant-object:69
++unlint redundant-object:72
++unlint redundant-object:77
++unlint redundant-object:120
++unlint redundant-object:121
++unlint redundant-object:122
++unlint redundant-object:127
++unlint redundant-object:128
++unlint redundant-object:129
++unlint redundant-object:146
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.

--- a/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range-of-ints.eo
@@ -5,6 +5,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:27
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/eo-runtime/src/main/eo/org/eolang/structs/range.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range.eo
@@ -5,6 +5,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/eo-runtime/src/main/eo/org/eolang/structs/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/set.eo
@@ -6,6 +6,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:26
++unlint redundant-object:27
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/eo-runtime/src/main/eo/org/eolang/switch.eo
+++ b/eo-runtime/src/main/eo/org/eolang/switch.eo
@@ -4,6 +4,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:44
++unlint redundant-object:46
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which

--- a/eo-runtime/src/main/eo/org/eolang/sys/os.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/os.eo
@@ -7,6 +7,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Represents the current operating system.
 [] > os

--- a/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/posix.eo
@@ -7,6 +7,16 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:29
++unlint redundant-object:30
++unlint redundant-object:31
++unlint redundant-object:32
++unlint redundant-object:33
++unlint redundant-object:34
++unlint redundant-object:37
++unlint redundant-object:45
++unlint redundant-object:46
++unlint redundant-object:105
 
 # Makes a Unix syscall by `name` with POSIX interface.
 # Here `args` is a `org.eolang.tuple` of arguments required for

--- a/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
+++ b/eo-runtime/src/main/eo/org/eolang/sys/win32.eo
@@ -7,7 +7,19 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint many-void-attributes:37
++unlint many-void-attributes:49
++unlint redundant-object:34
++unlint redundant-object:35
++unlint redundant-object:36
++unlint redundant-object:37
++unlint redundant-object:38
++unlint redundant-object:39
++unlint redundant-object:40
++unlint redundant-object:41
++unlint redundant-object:42
++unlint redundant-object:46
++unlint redundant-object:53
++unlint redundant-object:66
 
 # Makes a kernel32.dll function call by name.
 #
@@ -38,14 +50,13 @@
 
   # The win32 `sockaddr_in` structure.
   [sin-family sin-port sin-addr] > sockaddr-in
-    00-00-00-00-00-00-00-00 > sin-zero
     plus. > size
       plus.
         plus.
           sin-family.size
           sin-port.size
         sin-addr.size
-      sin-zero.size
+      00-00-00-00-00-00-00-00.size
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-returns-valid-win32-inet-addr-for-localhost

--- a/eo-runtime/src/main/eo/org/eolang/true.eo
+++ b/eo-runtime/src/main/eo/org/eolang/true.eo
@@ -4,8 +4,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:14
 +unlint unit-test-missing
-+unlint no-attribute-formation:11
++unlint no-attribute-formation:12
 
 # The object is a TRUE boolean state.
 [] > true

--- a/eo-runtime/src/main/eo/org/eolang/tuple.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tuple.eo
@@ -4,6 +4,11 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:16
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:24
++unlint redundant-object:25
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
@@ -6,6 +6,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:55
++unlint redundant-object:63
++unlint redundant-object:88
++unlint redundant-object:89
++unlint redundant-object:90
++unlint redundant-object:99
 
 # Regular expression in Perl format.
 # Here `expression` is a string pattern.

--- a/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/regex.eo
@@ -8,9 +8,9 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55
 +unlint redundant-object:63
-+unlint redundant-object:88
 +unlint redundant-object:89
 +unlint redundant-object:90
++unlint redundant-object:92
 +unlint redundant-object:99
 
 # Regular expression in Perl format.

--- a/eo-runtime/src/main/eo/org/eolang/txt/text.eo
+++ b/eo-runtime/src/main/eo/org/eolang/txt/text.eo
@@ -9,6 +9,11 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:24
++unlint redundant-object:27
++unlint redundant-object:29
++unlint redundant-object:31
++unlint redundant-object:292
 
 # Text.
 # A sequence of characters representing words, sentences, or data.

--- a/eo-runtime/src/main/eo/org/eolang/while.eo
+++ b/eo-runtime/src/main/eo/org/eolang/while.eo
@@ -4,6 +4,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:66
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:


### PR DESCRIPTION
In this PR I've fixed several `redundant-object` warnings, and enabled the lint.

closes #4192
History:
- **bug(#4192): redundant-object fixed**
- **bug(#4192): redundant-object fixed more**
