### PR TITLE
bug(#4286): enable MjLintTest, MjLintIT, MjTranspileTest

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintIT.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.52
  */
-@Disabled
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class, RandomProgramResolver.class})
 final class MjLintIT {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -15,12 +15,10 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
-import org.eolang.parser.OnDefault;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -28,12 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Test cases for {@link MjLint}.
  *
  * @since 0.31.0
- * @todo #4261:30min Enable MjLint tests after lints will migrate to the ObjectName implementation.
- *  Now, `lints` uses `org.eolang.parser.ObjectName` as class. Now its an interface, and
- *  `lints` should use {@link OnDefault} instead. Don't forget to enable lints in the
- *  {@link MjTranspileTest}, {@link MjLintIT} and `pom.xml` of `eo-runtime` as well.
  */
-@Disabled
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 @ExtendWith(MktmpResolver.class)
 @ExtendWith(RandomProgramResolver.class)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -27,7 +27,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +36,6 @@ import org.junit.jupiter.params.ParameterizedTest;
  *
  * @since 0.1
  */
-@Disabled
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 @ExtendWith(MktmpResolver.class)
 @ExtendWith(RandomProgramResolver.class)


### PR DESCRIPTION
In this PR I've enabled several tests after lints upgrade.

closes #4286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Re-enabled previously disabled test classes, allowing more integration and unit tests to run during the test phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->