### PR TITLE
bug(#4234): enable `sparse-decoration` lint

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -252,13 +252,6 @@
                    be fixed, we should enable lint. Don't forget to enable it in the `test-compile` execution too.
                 -->
                 <lint>redundant-object</lint>
-                <!--
-                  @todo #4096:35min Enable `sparse-decoration` lint.
-                   After we merged EO tests together with their source objects, and removed
-                   `+tests` meta, we have complains about sparse-decoration. Let's adjust and
-                   enable it.
-                -->
-                <lint>sparse-decoration</lint>
               </skipSourceLints>
               <keepBinaries>
                 <glob>EOorg/package-info.class</glob>


### PR DESCRIPTION
In this PR I've enabled `sparse-decoration` lint, that functioning correctly after lints library upgrade.

closes #4234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to include an additional lint check during source linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->