### PR TITLE
bug(#4190): `OyCached`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
@@ -37,7 +37,7 @@ public final class MjProbe extends MjSafe {
      */
     @SuppressWarnings("PMD.ImmutableField")
     private Objectionary objectionary = new OyIndexed(
-        new OyRemote(this.hash)
+        new OyCached(new OyRemote(this.hash))
     );
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -41,7 +41,7 @@ public final class MjPull extends MjSafe {
      */
     @SuppressWarnings("PMD.ImmutableField")
     private Objectionary objectionary = new OyIndexed(
-        new OyRemote(this.hash)
+        new OyCached(new OyRemote(this.hash))
     );
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -45,7 +45,7 @@ final class OyCached implements Objectionary {
 
     @Override
     public Input get(final String name) throws IOException {
-        this.cache.computeIfAbsent(
+        return this.cache.computeIfAbsent(
             name, key -> {
                 try {
                     return this.origin.get(name);
@@ -57,7 +57,6 @@ final class OyCached implements Objectionary {
                 }
             }
         );
-        return this.cache.get(name);
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.cactoos.Input;
+
+/**
+ * Cached Objectionary.
+ * @since 0.56.10
+ */
+final class OyCached implements Objectionary {
+
+    /**
+     * The origin.
+     */
+    private final Objectionary origin;
+
+    /**
+     * Cache.
+     */
+    private final Map<String, Input> cache;
+
+    /**
+     * Ctor.
+     * @param oby The objectionary
+     */
+    OyCached(final Objectionary oby) {
+        this(oby, new ConcurrentHashMap<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param oby The objectionary
+     */
+    OyCached(final Objectionary oby, final Map<String, Input> che) {
+        this.origin = oby;
+        this.cache = che;
+    }
+
+    @Override
+    public Input get(final String name) throws IOException {
+        if (!this.cache.containsKey(name)) {
+            this.cache.put(name, this.origin.get(name));
+        }
+        return this.cache.get(name);
+    }
+
+    @Override
+    public boolean contains(final String name) throws IOException {
+        return this.cache.containsKey(name) || this.origin.contains(name);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -44,9 +44,18 @@ final class OyCached implements Objectionary {
 
     @Override
     public Input get(final String name) throws IOException {
-        if (!this.cache.containsKey(name)) {
-            this.cache.put(name, this.origin.get(name));
-        }
+        this.cache.computeIfAbsent(
+            name, key -> {
+                try {
+                    return this.origin.get(name);
+                } catch (final IOException exception) {
+                    throw new IllegalStateException(
+                        "An error occurred during the access to the origin objectionary",
+                        exception
+                    );
+                }
+            }
+        );
         return this.cache.get(name);
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -21,7 +21,7 @@ final class OyCached implements Objectionary {
     private final Objectionary origin;
 
     /**
-     * Cache.
+     * The cache.
      */
     private final Map<String, Input> cache;
 
@@ -36,6 +36,7 @@ final class OyCached implements Objectionary {
     /**
      * Ctor.
      * @param oby The objectionary
+     * @param che The cache
      */
     OyCached(final Objectionary oby, final Map<String, Input> che) {
         this.origin = oby;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -17,6 +17,7 @@ import org.cactoos.io.InputWithFallback;
 
 /**
  * The simple HTTP Objectionary server.
+ * <p>This class is supposed to be used together with {@link OyCached}.</p>
  *
  * @since 0.1
  */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.util.Map;
+import org.cactoos.Input;
+import org.cactoos.io.InputOf;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OyCached}.
+ * @since 0.56.10
+ */
+final class OyCachedTest {
+
+    @Test
+    void returnsFromCacheWhileOriginDoesNotHaveIt() throws IOException {
+        final String key = "foo";
+        final InputOf expected = new InputOf("bar");
+        MatcherAssert.assertThat(
+            String.format(
+                "The input was not retrieved by the '%s' key from cache",
+                key
+            ),
+            new OyCached(
+                new Objectionary.Fake(),
+                new MapOf<>(key, expected)
+            ).get(key),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void goesToOriginWhenCacheDoesNotHaveIt() throws IOException {
+        final Input expected = new InputOf("Hello from origin!");
+        MatcherAssert.assertThat(
+            "The retrieved input does not match with expected",
+            new OyCached(
+                new Objectionary.Fake(nme -> expected), new MapOf<>()
+            ).get("foo"),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void savesInCacheWhenCacheDoesNotHaveIt() throws IOException {
+        final String key = "jeff";
+        final Input value = new InputOf("[] > jeff");
+        final Map<String, Input> cache = new MapOf<>();
+        new OyCached(new Objectionary.Fake(nme -> value), cache).get(key);
+        MatcherAssert.assertThat(
+            "The retrieved content from origin should be saved in cache, but it was not",
+            cache,
+            Matchers.hasEntry(key, value)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -79,7 +79,8 @@ final class OyCachedTest {
         MatcherAssert.assertThat(
             "We expect that all values are equal to the same content",
             new Together<>(30, thread -> objectionary.get("parallel"))
-                .asList().stream().allMatch(input -> input.equals(content))
+                .asList().stream().allMatch(input -> input.equals(content)),
+            Matchers.equalTo(true)
         );
         final int expected = 1;
         MatcherAssert.assertThat(


### PR DESCRIPTION
In this PR I've added class for cached objectionary - `OyCache`. Also, added several unit tests, including one for concurrent environment.

see #4190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a caching layer to objectionary access, improving performance by reducing redundant remote lookups.

- **Documentation**
  - Updated documentation to clarify usage of remote objectionary with the new caching feature.

- **Tests**
  - Introduced comprehensive tests to ensure correct and thread-safe caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->