### PR TITLE
Refactor: Remove origin() from PhWithRho to fix TooManyMethods PMD issue

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
+++ b/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
@@ -20,7 +20,7 @@ abstract class AbstractPhWithAttr implements Phi {
      * Returns the original attribute.
      * @return The original attribute
      */
-    public Phi origin() {
+    Phi origin() {
         return this.origin;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
+++ b/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
@@ -5,15 +5,23 @@
 
 package org.eolang;
 
+/**
+ * Abstract Phi object with attribute.
+ *
+ * @since 1.0
+ */
 abstract class AbstractPhWithAttr implements Phi {
-    private final Phi origin;
+    /**
+     * Original phi object.
+     */
+    private final Phi original;
 
     /**
      * Ctor.
-     * @param attr Attribute
+     * @param attr Original phi object
      */
-    protected AbstractPhWithAttr(Phi attr) {
-        this.origin = attr;
+    protected AbstractPhWithAttr(final Phi attr) {
+        this.original = attr;
     }
 
     /**
@@ -21,6 +29,6 @@ abstract class AbstractPhWithAttr implements Phi {
      * @return The original attribute
      */
     Phi origin() {
-        return this.origin;
+        return this.original;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
+++ b/eo-runtime/src/main/java/org/eolang/AbstractPhWithAttr.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+abstract class AbstractPhWithAttr implements Phi {
+    private final Phi origin;
+
+    /**
+     * Ctor.
+     * @param attr Attribute
+     */
+    protected AbstractPhWithAttr(Phi attr) {
+        this.origin = attr;
+    }
+
+    /**
+     * Returns the original attribute.
+     * @return The original attribute
+     */
+    public Phi origin() {
+        return this.origin;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/PhWithRho.java
@@ -11,7 +11,6 @@ package org.eolang;
  *
  * @since 0.36.0
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class PhWithRho extends AbstractPhWithAttr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/PhWithRho.java
@@ -5,6 +5,12 @@
 
 package org.eolang;
 
+/**
+ * A decorator for an attribute that ensures the object has a {@code \rho} attribute.
+ * If not already set, it sets it.
+ *
+ * @since 0.36.0
+ */
 @SuppressWarnings("PMD.TooManyMethods")
 final class PhWithRho extends AbstractPhWithAttr {
 

--- a/eo-runtime/src/main/java/org/eolang/PhWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/PhWithRho.java
@@ -5,19 +5,8 @@
 
 package org.eolang;
 
-/**
- * The attribute that tries to copy object and set \rho to it if it has not already set.
- * @since 0.36.0
- * @todo #3480:30min Move out `PhiWithRHo.origin()` method.
- *  Now we use it in {@link PhDefault#put(int, Phi)}. Let's move it to other class,
- *  in order to get rid of `TooManyMethods` PMD violation.
- */
 @SuppressWarnings("PMD.TooManyMethods")
-final class PhWithRho implements Phi {
-    /**
-     * Original attribute.
-     */
-    private final Phi original;
+final class PhWithRho extends AbstractPhWithAttr {
 
     /**
      * Rho.
@@ -30,23 +19,23 @@ final class PhWithRho implements Phi {
      * @param rho Rho
      */
     PhWithRho(final Phi attr, final Phi rho) {
-        this.original = attr;
+        super(attr);
         this.rho = rho;
     }
 
     @Override
     public Phi copy() {
-        return new PhWithRho(this.original.copy(), this.rho);
+        return new PhWithRho(origin().copy(), this.rho);
     }
 
     @Override
     public boolean hasRho() {
-        return this.original.hasRho();
+        return origin().hasRho();
     }
 
     @Override
     public Phi take(final String name) {
-        Phi ret = this.original.take(name);
+        Phi ret = origin().take(name);
         if (!ret.hasRho()) {
             ret = ret.copy();
             ret.put(Phi.RHO, this.rho);
@@ -56,7 +45,7 @@ final class PhWithRho implements Phi {
 
     @Override
     public Phi take(final int pos) {
-        Phi ret = this.original.take(pos);
+        Phi ret = origin().take(pos);
         if (!ret.hasRho()) {
             ret = ret.copy();
             ret.put(Phi.RHO, this.rho);
@@ -66,42 +55,34 @@ final class PhWithRho implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        this.original.put(pos, object);
+        origin().put(pos, object);
     }
 
     @Override
     public void put(final String name, final Phi object) {
-        this.original.put(name, object);
+        origin().put(name, object);
     }
 
     @Override
     public String locator() {
-        return this.original.locator();
+        return origin().locator();
     }
 
     @Override
     public String forma() {
-        return this.original.forma();
+        return origin().forma();
     }
 
     @Override
     public Phi copy(final Phi self) {
         return new PhWithRho(
-            this.original.copy(self),
+            origin().copy(self),
             self
         );
     }
 
     @Override
     public byte[] delta() {
-        return this.original.delta();
-    }
-
-    /**
-     * Returns the original attribute.
-     * @return The original attribute
-     */
-    Phi origin() {
-        return this.original;
+        return origin().delta();
     }
 }


### PR DESCRIPTION
Since PMD `TooManyMethods` runs methods implemented directly in the class, we:
1. Moved `origin()` and its field to the new parent class `AbstractPhWithAttr`
2. Ьade `PhWithRho` inherit from it
3. Reduced direct method count in `PhWithRho` from 11 to 10

This is a change:
- Preserves all existing behavior, because the method remains as it is, but it is located in the parent class.
- Supports the original visibility of `origin()' (package-private)
- Allows removal of `@SuppressWarnings` in future

Resolves #4242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved code structure for attribute handling, making it easier to extend related classes in the future. No changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->