### PR TITLE
bug(#4108): `XeEoListener` saves indentation in nested comments

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1135,14 +1135,20 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             this.dirs.push().xpath("/object").addIf("comments").add("comment").set(
                 comment.stream().map(
                     context -> {
-                        final int sub;
+                        final String result;
                         final String text = context.COMMENTARY().getText();
-                        if (text.length() > 1) {
-                            sub = 2;
+                        if (text.isEmpty()) {
+                            result = "";
                         } else {
-                            sub = 1;
+                            final int sub;
+                            if (text.length() > 1 && text.charAt(1) == ' ') {
+                                sub = 2;
+                            } else {
+                                sub = 1;
+                            }
+                            result = context.COMMENTARY().getText().substring(sub);
                         }
-                        return context.COMMENTARY().getText().substring(sub);
+                        return result;
                     }
                 ).collect(Collectors.joining("\\n"))
             ).attr("line", stop.getLine() + 1).pop();

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -1134,7 +1135,16 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         if (!comment.isEmpty()) {
             this.dirs.push().xpath("/object").addIf("comments").add("comment").set(
                 comment.stream().map(
-                    context -> context.COMMENTARY().getText().substring(1).trim()
+                    context -> {
+                        final int sub;
+                        final String text = context.COMMENTARY().getText();
+                        if (text.length() > 1) {
+                            sub = 2;
+                        } else {
+                            sub = 1;
+                        }
+                        return context.COMMENTARY().getText().substring(sub);
+                    }
                 ).collect(Collectors.joining("\\n"))
             ).attr("line", stop.getLine() + 1).pop();
         }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -404,6 +404,25 @@ final class EoSyntaxTest {
         );
     }
 
+    @Test
+    void parsesEmptyComment() throws IOException {
+        MatcherAssert.assertThat(
+            "Parsed empty comments in XMIR should be empty as well",
+            new Xnav(
+                new EoSyntax(
+                    new InputOf(
+                        String.join(
+                            "\n",
+                            "#",
+                            "[] > foo"
+                        )
+                    )
+                ).parsed().inner()
+            ).element("object").element("comments").element("comment").text().get(),
+            Matchers.emptyString()
+        );
+    }
+
     /**
      * Prepare naughty strings.
      * @return Stream of strings

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.xml.sax.SAXParseException;
@@ -384,8 +385,15 @@ final class EoSyntaxTest {
         );
     }
 
-    @Test
-    void savesIndentationInComments() throws IOException {
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "#   Indented comment is here 守规矩!,\\n  Indented comment is here 守规矩!",
+            "#     More indentation,\\n    More indentation",
+            "#       This is how it works!,\\n      This is how it works!"
+        }
+    )
+    void savesIndentationInComments(final String comment, final String parsed) throws IOException {
         MatcherAssert.assertThat(
             "Parsed comments in XMIR should respect indentation",
             new Xnav(
@@ -394,13 +402,13 @@ final class EoSyntaxTest {
                         String.join(
                             "\n",
                             "# Top comment.",
-                            "#   Indented comment is here, 守规矩!",
+                            comment,
                             "[] > foo"
                         )
                     )
                 ).parsed().inner()
             ).element("object").element("comments").element("comment").text().get(),
-            Matchers.equalTo("Top comment.\\n  Indented comment is here, 守规矩!")
+            Matchers.equalTo(String.format("Top comment.%s", parsed))
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -385,7 +385,7 @@ final class EoSyntaxTest {
     }
 
     @Test
-    void parsesCommentsWithIndentedNestedCommentsProperly() throws IOException {
+    void savesIndentationInComments() throws IOException {
         MatcherAssert.assertThat(
             "Parsed comments in XMIR should respect indentation",
             new Xnav(
@@ -394,13 +394,13 @@ final class EoSyntaxTest {
                         String.join(
                             "\n",
                             "# Top comment.",
-                            "#  Indented comment is here, 守规矩!",
+                            "#   Indented comment is here, 守规矩!",
                             "[] > foo"
                         )
                     )
                 ).parsed().inner()
             ).element("object").element("comments").element("comment").text().get(),
-            Matchers.equalTo("Top comment.\\n Indented comment is here, 守规矩!")
+            Matchers.equalTo("Top comment.\\n  Indented comment is here, 守规矩!")
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -385,31 +385,23 @@ final class EoSyntaxTest {
     }
 
     @Test
-    void parsesCommentsWithLeadingCommentsProperly() throws IOException {
-        final Xnav xml = new Xnav(
-            new EoSyntax(
-                new InputOf(
-                    String.join(
-                        "\n",
-                        "# First comment.",
-                        "  # Indented comment.",
-                        "[] > foo"
-                    )
-                )
-            ).parsed().inner()
-        );
-        final String comments = xml.element("object").element("comments").element("comment").text()
-            .get();
-        final String expected = "First comment.\\nIndented comment.";
+    void parsesCommentsWithIndentedNestedCommentsProperly() throws IOException {
         MatcherAssert.assertThat(
-            String.format(
-                "EO parsed: %s, but comments: '%s' don't match with expected: '%s'",
-                xml, comments, expected
-            ),
-            comments,
-            Matchers.equalTo(expected)
+            "Parsed comments in XMIR should respect indentation",
+            new Xnav(
+                new EoSyntax(
+                    new InputOf(
+                        String.join(
+                            "\n",
+                            "# Top comment.",
+                            "#  Indented comment is here, 守规矩!",
+                            "[] > foo"
+                        )
+                    )
+                ).parsed().inner()
+            ).element("object").element("comments").element("comment").text().get(),
+            Matchers.equalTo("Top comment\n  Indented comment is here, 守规矩!")
         );
-
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -400,7 +400,7 @@ final class EoSyntaxTest {
                     )
                 ).parsed().inner()
             ).element("object").element("comments").element("comment").text().get(),
-            Matchers.equalTo("Top comment\n  Indented comment is here, 守规矩!")
+            Matchers.equalTo("Top comment.\\n Indented comment is here, 守规矩!")
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -384,6 +384,34 @@ final class EoSyntaxTest {
         );
     }
 
+    @Test
+    void parsesCommentsWithLeadingCommentsProperly() throws IOException {
+        final Xnav xml = new Xnav(
+            new EoSyntax(
+                new InputOf(
+                    String.join(
+                        "\n",
+                        "# First comment.",
+                        "  # Indented comment.",
+                        "[] > foo"
+                    )
+                )
+            ).parsed().inner()
+        );
+        final String comments = xml.element("object").element("comments").element("comment").text()
+            .get();
+        final String expected = "First comment.\\nIndented comment.";
+        MatcherAssert.assertThat(
+            String.format(
+                "EO parsed: %s, but comments: '%s' don't match with expected: '%s'",
+                xml, comments, expected
+            ),
+            comments,
+            Matchers.equalTo(expected)
+        );
+
+    }
+
     /**
      * Prepare naughty strings.
      * @return Stream of strings


### PR DESCRIPTION
In this PR I've updated `XeEoListener` to preserve indentation in the nested comments, while parsing to XMIR.

see #4108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of comment text to better preserve indentation and formatting, including support for empty comments.

* **Tests**
  * Added tests to verify correct preservation of comment indentation and handling of empty comments during parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->