### PR TITLE
bug(#4372): proper `HOME` translation to compact array FQN

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/CompactArrayFqn.java
+++ b/eo-parser/src/main/java/org/eolang/parser/CompactArrayFqn.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.stream.Collectors;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.cactoos.Text;
+
+/**
+ * Fully Qualified Name for compact arrays.
+ * @since 0.57.2
+ */
+final class CompactArrayFqn implements Text {
+
+    /**
+     * Context.
+     */
+    private final EoParser.CompactArrayContext context;
+
+    /**
+     * Ctor.
+     * @param input Input
+     */
+    CompactArrayFqn(final String input) {
+        this(
+            new EoParser(new CommonTokenStream(new EoLexer(CharStreams.fromString(input))))
+                .compactArray()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param ctx Context
+     */
+    CompactArrayFqn(final EoParser.CompactArrayContext ctx) {
+        this.context = ctx;
+    }
+
+    @Override
+    public String asString() {
+        final String name = this.context.NAME().stream()
+            .map(ParseTree::getText)
+            .collect(Collectors.joining("."));
+        final String fqn;
+        if (this.context.HOME() == null) {
+            fqn = name;
+        } else {
+            fqn = String.format("Q.org.eolang.%s", name);
+        }
+        final String base;
+        if (this.context.XI() == null) {
+            base = fqn;
+        } else {
+            base = String.format("%s.%s", this.context.XI().getText(), fqn);
+        }
+        return base;
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
-import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.commons.text.StringEscapeUtils;
 import org.xembly.Directive;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -566,21 +566,8 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         } else {
             count = 0;
         }
-        final String name = ctx.NAME().stream().map(ParseTree::getText).collect(Collectors.joining("."));;
-        final String fqn;
-        if (ctx.HOME() == null) {
-            fqn = name;
-        } else {
-            fqn = String.format("Q.org.eolang.%s", name);
-        }
-        final String base;
-        if (ctx.XI() == null) {
-            base = fqn;
-        } else {
-            base = String.format("%s.%s", ctx.XI().getText(), fqn);
-        }
         this.objects.start(ctx)
-            .prop("base", base)
+            .prop("base", new CompactArrayFqn(ctx).asString())
             .prop("before-star", count);
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -566,7 +566,13 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         } else {
             count = 0;
         }
-        final String fqn = ctx.NAME().stream().map(ParseTree::getText).collect(Collectors.joining("."));
+        final String name = ctx.NAME().stream().map(ParseTree::getText).collect(Collectors.joining("."));;
+        final String fqn;
+        if (ctx.HOME() == null) {
+            fqn = name;
+        } else {
+            fqn = String.format("Q.org.eolang.%s", name);
+        }
         final String base;
         if (ctx.XI() == null) {
             base = fqn;

--- a/eo-parser/src/test/java/org/eolang/parser/CompactArrayFqnTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/CompactArrayFqnTest.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CompactArrayFqn}.
+ *
+ * @since 0.57.2
+ */
+final class CompactArrayFqnTest {
+
+    @Test
+    void buildsFqnForSimpleName() {
+        MatcherAssert.assertThat(
+            "FQN of the compact array does not match with expected",
+            new CompactArrayFqn("foo *1").asString(),
+            Matchers.equalTo("foo")
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/CompactArrayFqnTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/CompactArrayFqnTest.java
@@ -6,7 +6,8 @@ package org.eolang.parser;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link CompactArrayFqn}.
@@ -15,12 +16,24 @@ import org.junit.jupiter.api.Test;
  */
 final class CompactArrayFqnTest {
 
-    @Test
-    void buildsFqnForSimpleName() {
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "foo *1,foo",
+            "QQ.foo.bar *42,Q.org.eolang.foo.bar",
+            "QQ.nan *52,Q.org.eolang.nan",
+            "$.seq *1,$.seq"
+        }
+    )
+    void buildsFqnForSimpleName(final String compact, final String expected) {
+        final String fqn = new CompactArrayFqn(compact).asString();
         MatcherAssert.assertThat(
-            "FQN of the compact array does not match with expected",
-            new CompactArrayFqn("foo *1").asString(),
-            Matchers.equalTo("foo")
+            String.format(
+                "FQN of the compact array: '%s' does not match with expected value: '%s'",
+                fqn, expected
+            ),
+            fqn,
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/sugared-array-with-suffixed-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/sugared-array-with-suffixed-name.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Q.org.eolang.txt.sprintf']/o[@base='Q.org.eolang.x']
+  - //o[@base='Q.org.eolang.txt.sprintf']//o[@base='Q.org.eolang.y']
+input: |
+  # No comments.
+  [] > app
+    QQ.txt.sprintf *1 > @
+      x
+      y


### PR DESCRIPTION
In this PR I've updated `XeEoListener#enterCompactArray` to properly translate `HOME` in the compact array FQN. Also added several tests, including EO syntax test pack and `CompactArrayFqnTest` with FQN translation specifics.

see #4372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for generating fully qualified names for compact arrays, improving handling of array notation in EO code.

* **Tests**
  * Added parameterized tests to ensure correct conversion of compact array notation to fully qualified names.
  * Included a new YAML test resource to verify parsing and structure of sugared arrays with suffixed names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->