### PR TITLE
Replace TO_ADD_MESSAGE with meaningful assert messages in EoIndentLexerTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoIndentLexerTest.java
@@ -17,16 +17,6 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 final class EoIndentLexerTest {
-    /**
-     * Empty message for JUnit Assertions.
-     *
-     * @todo #2297:60m Replace all appearances of {@link EoIndentLexerTest#TO_ADD_MESSAGE} field in
-     *  eo-parser with meaningful assert messages. Don't forget to remove
-     *  {@link EoIndentLexerTest#TO_ADD_MESSAGE} field and remove public modifier from this class if
-     *  no longer need.
-     */
-    public static final String TO_ADD_MESSAGE = "TO ADD ASSERTION MESSAGE";
-
     @Test
     void emitsTabWithCorrectName() throws IOException {
         MatcherAssert.assertThat(

--- a/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ObjectsTest.java
@@ -24,7 +24,7 @@ final class ObjectsTest {
         objs.data("xxx");
         objs.leave();
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "Failed to parse object: expected /o with line=9, pos=10, x='y', text='xxx'",
             new XMLDocument(new Xembler(objs).domQuietly()),
             XhtmlMatchers.hasXPaths(
                 "/o",
@@ -46,7 +46,7 @@ final class ObjectsTest {
         objs.leave();
         objs.leave();
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "Failed to parse nested objects: expected text 'yyy' under /o/o",
             new XMLDocument(new Xembler(objs).domQuietly()),
             XhtmlMatchers.hasXPaths(
                 "/o",
@@ -65,7 +65,7 @@ final class ObjectsTest {
         objs.enter();
         objs.prop("z", "a");
         MatcherAssert.assertThat(
-            EoIndentLexerTest.TO_ADD_MESSAGE,
+            "Failed to re-enter previous object and set property 'z=a' on root <o>",
             new XMLDocument(new Xembler(objs).domQuietly()),
             XhtmlMatchers.hasXPaths(
                 "/o/o",


### PR DESCRIPTION
Replaced all occurrences of EoIndentLexerTest#TO_ADD_MESSAGE with meaningful assert messages in tests across eo-parser.

Closes #3131