### PR TITLE
Replace PhCompositeTest.TO_ADD_MESSAGE with meaningful assert messages

### DIFF
--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -29,7 +29,7 @@ final class EObytesEOconcatTest {
     @Test
     void concatenatesBytes() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Concatenation of byte arrays should produce 'привет mr. ㄤㄠ!', but it didn't",
             new Dataized(
                 new PhWith(
                     Phi.Φ.take("org.eolang.string"),

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOconcatTest.java
@@ -11,7 +11,6 @@ package EOorg.EOeolang; // NOPMD
 
 import org.eolang.Data;
 import org.eolang.Dataized;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
@@ -47,7 +47,7 @@ final class EOerrorTest {
                     new Data.ToPhi("intentional error")
                 )
             ).take(),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Expected EOerror to throw ExError when dataized, but it didn't"
         );
     }
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
@@ -16,7 +16,6 @@ import org.eolang.Dataized;
 import org.eolang.ExAbstract;
 import org.eolang.PhCached;
 import org.eolang.PhComposite;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhCopy;
 import org.eolang.PhDefault;
 import org.eolang.PhWith;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -55,7 +55,7 @@ final class EOmallocTest {
                     dummy
                 )
             ).take(),
-            "Should throw an exception on attempting to use RrrorDummy, but it didn't"
+            "Should throw an exception on attempting to use ErrorDummy, but it didn't"
         );
         Assertions.assertThrows(
             ExAbstract.class,

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -13,7 +13,6 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
 import org.eolang.PhComposite;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhCopy;
 import org.eolang.PhDefault;
 import org.eolang.PhVoid;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -32,17 +32,15 @@ final class EOmallocTest {
     @Test
     void freesMemory() {
         final Dummy dummy = new Dummy();
-        new Dataized(
+        ized(
             EOmallocTest.allocated(
                 new Data.ToPhi(1L),
                 dummy
             )
-        ).take();
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> Heaps.INSTANCE.free((int) dummy.id),
-            PhCompositeTest.TO_ADD_MESSAGE
-        );
+        ).take().s.assertThrows(
+            () -> Heaps.INSTANCE.free((int) dummy.id), 
+            "Heaps should throw an exception on attempt to free already freed memory, but it didn't"
+            );
     }
 
     @Test
@@ -56,12 +54,12 @@ final class EOmallocTest {
                     dummy
                 )
             ).take(),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Should throw an exception on attempting to use RrrorDummy, but it didn't"
         );
         Assertions.assertThrows(
             ExAbstract.class,
             () -> Heaps.INSTANCE.free((int) dummy.id),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on attempting to free already freed memory after failure, but it didn't"
         );
     }
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -32,15 +32,17 @@ final class EOmallocTest {
     @Test
     void freesMemory() {
         final Dummy dummy = new Dummy();
-        ized(
+        new Dataized(
             EOmallocTest.allocated(
                 new Data.ToPhi(1L),
                 dummy
             )
-        ).take().s.assertThrows(
-            () -> Heaps.INSTANCE.free((int) dummy.id), 
+        ).take();
+        Assertions.assertThrows(
+            ExAbstract.class,
+            () -> Heaps.INSTANCE.free((int) dummy.id),
             "Heaps should throw an exception on attempt to free already freed memory, but it didn't"
-            );
+        );
     }
 
     @Test

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
@@ -34,7 +34,7 @@ final class EOnumberTest {
     @Test
     void hasDifferentHashes() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Hashes of the two instances should differ, but they didn't",
             new Data.ToPhi(42L).hashCode(),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(42L).hashCode()))
         );
@@ -43,7 +43,7 @@ final class EOnumberTest {
     @Test
     void hasHashEvenWithoutData() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Object without data should have positive hash, but it didn't",
             new EOnumber().hashCode(),
             Matchers.greaterThan(0)
         );
@@ -52,7 +52,7 @@ final class EOnumberTest {
     @Test
     void hasDifferentHash() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Hashes of the two instances should differ, but they didn't",
             new EOnumber().hashCode(),
             Matchers.not(new Data.ToPhi(0L).hashCode())
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
@@ -12,7 +12,6 @@ package EOorg.EOeolang; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhWith;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -75,7 +75,7 @@ final class EOtryTest {
     @Test
     void worksWithoutException() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Main threw an exception",
             new Dataized(
                 new PhWith(
                     new PhWith(
@@ -102,7 +102,7 @@ final class EOtryTest {
         trier.put(2, new Data.ToPhi(true));
         new Dataized(trier).take();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "EOtry dataized body more than once",
             main.count,
             Matchers.equalTo(1)
         );

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -13,7 +13,6 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.PhComposite;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhDefault;
 import org.eolang.PhSafe;
 import org.eolang.PhVoid;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -38,7 +38,7 @@ final class HeapsTest {
         final int idx = HeapsTest.HEAPS.malloc(new HeapsTest.PhFake(), 10);
         Assertions.assertDoesNotThrow(
             () -> HeapsTest.HEAPS.read(idx, 0, 10),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should successfully read from allocated memory, but it didn't"
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -50,7 +50,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.malloc(phi, 10),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on attempting to allocate already allocated memory, but it didn't"
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -59,7 +59,7 @@ final class HeapsTest {
     void allocatesAndReadsEmptyBytes() {
         final int idx = HeapsTest.HEAPS.malloc(new HeapsTest.PhFake(), 5);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Heaps should return empty bytes after memory allocation, but it didn't",
             HeapsTest.HEAPS.read(idx, 0, 5),
             Matchers.equalTo(new byte[] {0, 0, 0, 0, 0})
         );
@@ -72,7 +72,7 @@ final class HeapsTest {
         final byte[] bytes = {1, 2, 3, 4, 5};
         HeapsTest.HEAPS.write(idx, 0, bytes);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Heaps should successfully read exactly same bytes that were written, but it didn't",
             HeapsTest.HEAPS.read(idx, 0, bytes.length),
             Matchers.equalTo(bytes)
         );
@@ -84,7 +84,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(new HeapsTest.PhFake().hashCode(), 0, new byte[] {0x01}),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on writing to an unallocated block, but it didn't"
         );
     }
 
@@ -93,7 +93,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(new HeapsTest.PhFake().hashCode(), 0, 1),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on reading from an unallocated block, but it didn't"
         );
     }
 
@@ -103,7 +103,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(idx, 1, 3),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on out-of-bounds read, but it didn't"
         );
     }
 
@@ -112,7 +112,7 @@ final class HeapsTest {
         final int idx = HeapsTest.HEAPS.malloc(new HeapsTest.PhFake(), 5);
         HeapsTest.HEAPS.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Heaps should successfully read correct slice when reading with offset and length, but it didn't",
             HeapsTest.HEAPS.read(idx, 1, 3),
             Matchers.equalTo(new byte[] {2, 3, 4})
         );
@@ -125,7 +125,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(idx, 0, bytes),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on writing more bytes than allocated size, but it didn't"
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -137,7 +137,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.write(idx, 1, bytes),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on writing past allocated block using offset, but it didn't"
         );
         HeapsTest.HEAPS.free(idx);
     }
@@ -148,7 +148,7 @@ final class HeapsTest {
         HeapsTest.HEAPS.write(idx, 0, new byte[] {1, 1, 3, 4, 5});
         HeapsTest.HEAPS.write(idx, 2, new byte[] {2, 2});
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Heaps should return correct bytes after partial overwrite, but it didn't",
             HeapsTest.HEAPS.read(idx, 0, 5),
             Matchers.equalTo(new byte[] {1, 1, 2, 2, 5})
         );
@@ -162,7 +162,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.read(idx, 0, 5),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on reading from a freed block, but it didn't"
         );
     }
 
@@ -171,7 +171,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.free(new HeapsTest.PhFake().hashCode()),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Heaps should throw an exception on attempting to free a non-existent block, but it didn't"
         );
     }
 
@@ -180,7 +180,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> HeapsTest.HEAPS.size(new HeapsTest.PhFake().hashCode()),
-            "Heaps should throw an exception if trying to get size on an empty block, but it didn't"
+            "Heaps should throw an exception on trying to get size of an empty block, but it didn't"
         );
     }
 

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -12,7 +12,6 @@ package EOorg.EOeolang; // NOPMD
 import java.util.function.Supplier;
 import org.eolang.ExFailure;
 import org.eolang.PhComposite;
-import org.eolang.PhCompositeTest;
 import org.eolang.PhDefault;
 import org.eolang.PhVoid;
 import org.eolang.Phi;

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -24,7 +24,7 @@ final class BytesOfTest {
         final String text = "abc";
         final Bytes bytes = new BytesOf(text);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Double negation should return the original value, but it didn't",
             bytes.not().not(),
             Matchers.equalTo(new BytesOf(text))
         );
@@ -34,7 +34,7 @@ final class BytesOfTest {
     void negatesOnce() {
         final Bytes bytes = new BytesOf(-128L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Negation should give the correct value, but it didn't",
             bytes.not(),
             Matchers.equalTo(new BytesOf(127L))
         );
@@ -44,7 +44,7 @@ final class BytesOfTest {
     void checksAnd() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "'And' operation with opposite values should give 0, but it didn't",
             bytes.and(bytes.not()),
             Matchers.equalTo(new BytesOf(0L))
         );
@@ -54,7 +54,7 @@ final class BytesOfTest {
     void checksOr() {
         final Bytes bytes = new BytesOf(127L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "'Or' operation with opposite values should give -1, but it didn't",
             bytes.or(bytes.not()),
             Matchers.equalTo(new BytesOf(-1L))
         );
@@ -63,7 +63,7 @@ final class BytesOfTest {
     @Test
     void checksPositiveInfinity() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Dividing by 0 should give a positive infinity, but it didn't",
             new BytesOf(1.0d / 0.0d).asNumber(),
             Matchers.equalTo(Double.POSITIVE_INFINITY)
         );
@@ -72,7 +72,7 @@ final class BytesOfTest {
     @Test
     void checksNegativeInfinity() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Dividing by 0 should give a negative infinity, but it didn't",
             new BytesOf(-1.0d / 0.0d).asNumber(Double.class),
             Matchers.equalTo(Double.NEGATIVE_INFINITY)
         );
@@ -82,7 +82,7 @@ final class BytesOfTest {
     void checksXor() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "'Xor' operation should give correct value, but it didn't",
             bytes.xor(new BytesOf(-512L)),
             Matchers.equalTo(new BytesOf(-1024L))
         );
@@ -92,7 +92,7 @@ final class BytesOfTest {
     void checksAsNumberLong() {
         final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Bytes as long number must be equals to correct number, but it didn't",
             bytes.asNumber(Long.class),
             Matchers.equalTo(512L)
         );
@@ -104,7 +104,7 @@ final class BytesOfTest {
         Assertions.assertThrows(
             ExFailure.class,
             bytes::asNumber,
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Converting non-numeric bytes to number should throw, but it didn't"
         );
     }
 
@@ -121,7 +121,7 @@ final class BytesOfTest {
     void checksShift(final long num, final int bits, final long expected) {
         final Bytes bytes = new BytesOf(num);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            String.format("%d >> %d should result in %d, but it didn't", num, bits, expected),
             bytes.shift(bits).asNumber(Long.class),
             Matchers.equalTo(expected)
         );
@@ -143,7 +143,7 @@ final class BytesOfTest {
         final Bytes bytes = new BytesOf((int) num);
         final int actual = bytes.sshift(bits).asNumber(Integer.class);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            String.format("%d >> %d (arithmetic shift) should result in %d, but it didn't", num, bits, expected),
             actual,
             Matchers.equalTo((int) expected)
         );
@@ -155,7 +155,7 @@ final class BytesOfTest {
         Assertions.assertThrows(
             UnsupportedOperationException.class,
             () -> bytes.sshift(-1),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Integer.MAX_VALUE << 1 should throw exception, but it didn't"
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -17,7 +17,7 @@ final class DataTest {
     @Test
     void comparesVertex() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Hash codes of two Data.ToPhi instances with the same value should differ, but they didn't",
             new Data.ToPhi(42L).hashCode(),
             Matchers.not(
                 Matchers.equalTo(
@@ -30,22 +30,22 @@ final class DataTest {
     @Test
     void comparesTwoDatas() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Data.ToPhi instances with the same long value should differ, but they didn't",
             new Data.ToPhi(1L),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(1L)))
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Data.ToPhi instances with the same string value should differ, but they didn't",
             new Data.ToPhi("Welcome"),
             Matchers.not(Matchers.equalTo(new Data.ToPhi("Welcome")))
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Data.ToPhi instances with the same double value should differ, but they didn't",
             new Data.ToPhi(2.18d),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(2.18d)))
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Data.ToPhi instances with the same byte array value should differ, but they didn't",
             new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}),
             Matchers.not(Matchers.equalTo(new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f})))
         );

--- a/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
@@ -20,7 +20,7 @@ final class ExInterruptedTest {
         Assertions.assertThrows(
             ExInterrupted.class,
             () -> new Dataized(phi.take(Phi.PHI)).take(),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "EOthrow should throw when dataized, but it didn't"
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
@@ -27,7 +27,7 @@ class JavaPathTest {
     })
     void convertsToString(final String name, final String expected) {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            String.format("JavaPath should convert '%s' to '%s', but it didn't", name, expected),
             new JavaPath(name).toString(),
             Matchers.equalTo(expected)
         );

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -137,7 +137,7 @@ final class MainTest {
             )
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Reading stream should produce a non-empty line, but it didn't",
             reader.readLine().length(),
             Matchers.greaterThan(0)
         );
@@ -158,7 +158,7 @@ final class MainTest {
             )
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Reading stream should produce a line longer ther 1 character, but it didn't",
             reader.readLine().length(),
             Matchers.greaterThan(1)
         );
@@ -167,7 +167,7 @@ final class MainTest {
     @Test
     void readsBytesCorrectly() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Reading stream should produce a byte of next character, but it didn't",
             new ByteArrayInputStream(
                 "··\uD835\uDD38➜Φ".getBytes(
                     StandardCharsets.UTF_8

--- a/eo-runtime/src/test/java/org/eolang/PhCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCompositeTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.16
  */
 @SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
-public final class PhCompositeTest {
+final class PhCompositeTest {
 
     @Test
     void decoratesUncheckedException() {

--- a/eo-runtime/src/test/java/org/eolang/PhCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCompositeTest.java
@@ -18,16 +18,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 public final class PhCompositeTest {
 
-    /**
-     * Empty message for JUnit Assertions.
-     *
-     * @todo #2297:60m Replace all appearances of {@link PhCompositeTest#TO_ADD_MESSAGE} field in
-     *  eo-runtime with meaningful assert messages. Don't forget to remove
-     *  {@link PhCompositeTest#TO_ADD_MESSAGE} field and remove public modifier from this class if
-     *  no longer need.
-     */
-    public static final String TO_ADD_MESSAGE = "TO ADD ASSERTION MESSAGE";
-
     @Test
     void decoratesUncheckedException() {
         Assertions.assertThrows(
@@ -38,7 +28,7 @@ public final class PhCompositeTest {
                     throw new IllegalStateException("intended unchecked");
                 }
             ).take(0),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "PhComposite must decorate unchecked exception correctly, but it didn't"
         );
     }
 
@@ -47,7 +37,7 @@ public final class PhCompositeTest {
         final Phi rnd = new Rnd();
         final Phi phi = new PhMethod(rnd, Phi.LAMBDA);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Generated phi should be same on second access, but it didn't",
             new Dataized(phi).asNumber(),
             Matchers.equalTo(
                 new Dataized(phi).asNumber()

--- a/eo-runtime/src/test/java/org/eolang/PhCopyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCopyTest.java
@@ -18,7 +18,7 @@ final class PhCopyTest {
     @Test
     void makesObjectCopy() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "PhCopy should produce the number equal to the original's dataized number, but it didn't",
             new Dataized(
                 new PhCopy(new Data.ToPhi(1))
             ).asNumber(),
@@ -30,7 +30,7 @@ final class PhCopyTest {
     void hasTheSameFormaAsCopied() {
         final Phi phi = new Data.ToPhi(1);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Copy of Phi should have the same forma as the original, but it didn't",
             phi.forma(),
             Matchers.equalTo(
                 phi.copy().forma()

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -225,7 +225,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.Int();
         phi.put(PhDefaultTest.VOID_ATT, new Data.ToPhi(10L));
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Void attribute should not be copied with rho, but it did",
             phi.take(PhDefaultTest.VOID_ATT),
             Matchers.equalTo(phi.take(PhDefaultTest.VOID_ATT))
         );
@@ -235,7 +235,7 @@ final class PhDefaultTest {
     void doesNotCopyContextAttributeWithRho() {
         final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Context attribute should not be copied with rho, but it did",
             phi.take("context"),
             Matchers.equalTo(phi.take("context"))
         );
@@ -247,12 +247,12 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             ExAbstract.class,
             () -> phi.take(Phi.PHI),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Phi should not be accessible without setting void attribute, but it did"
         );
         phi.put(PhDefaultTest.VOID_ATT, new Data.ToPhi(10L));
         Assertions.assertDoesNotThrow(
             () -> phi.take(Phi.PHI),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Phi should be accessible after setting void attribute, but it didn't"
         );
     }
 
@@ -272,7 +272,7 @@ final class PhDefaultTest {
     void makesObjectIdentity() {
         final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Object should have a hashCode greater then 0, but it didn't",
             phi.hashCode(),
             Matchers.greaterThan(0)
         );
@@ -298,7 +298,7 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             ExAbstract.class,
             () -> new PhSafe(new Data.ToPhi("Hey")).take("missing-attr"),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Accessing a missing attribute should fail, but it didn't"
         );
     }
 
@@ -309,7 +309,7 @@ final class PhDefaultTest {
         phi.put(0, new Data.ToPhi(data));
         final Phi copy = phi.copy();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Copied Phi should contain the same data, but it didn't",
             new Dataized(copy).asString(),
             Matchers.equalTo(data)
         );
@@ -323,7 +323,7 @@ final class PhDefaultTest {
         Assertions.assertThrows(
             ExReadOnly.class,
             () -> phi.put(0, num),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Setting void attribute more than once should fail, but it didn't"
         );
     }
 
@@ -332,7 +332,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.EndlessRecursion();
         PhDefaultTest.EndlessRecursion.count = 2;
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Dataization should discover the infinite recursion, but it didn't",
             new Dataized(phi).asNumber(),
             Matchers.equalTo(0.0)
         );
@@ -343,7 +343,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.RecursivePhi();
         PhDefaultTest.RecursivePhi.count = 3;
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Dataization should discover the infinite recursion, but it didn't",
             new Dataized(phi).asNumber(),
             Matchers.equalTo(0.0)
         );
@@ -354,7 +354,7 @@ final class PhDefaultTest {
         final Phi phi = new PhDefaultTest.RecursivePhiViaNew();
         PhDefaultTest.RecursivePhiViaNew.count = 3;
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Does not cache phi via new recursively",
             new Dataized(phi).asNumber(),
             Matchers.equalTo(0.0)
         );
@@ -368,7 +368,7 @@ final class PhDefaultTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should not be read multiple times, but it was",
             new Dataized(new PhMethod(phi, "count")).asNumber(),
             Matchers.equalTo(1.0)
         );
@@ -377,7 +377,7 @@ final class PhDefaultTest {
     @Test
     void hasTheSameFormaWithBoundedData() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Bounded data objects should have the same forma, but they didn't",
             new Data.ToPhi(5L).forma(),
             Matchers.equalTo(new Data.ToPhi(6).forma())
         );
@@ -405,7 +405,7 @@ final class PhDefaultTest {
     void hasDifferentFormaWithBoundedMethod() {
         final Phi five = new Data.ToPhi(5L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi and bounded method result should have different formas, but they were the same",
             five.forma(),
             Matchers.not(
                 Matchers.equalTo(
@@ -422,7 +422,7 @@ final class PhDefaultTest {
     @Test
     void hasTheSameFormaWithDifferentInstances() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Similar Phis with different data should have the same forma, but they didn't",
             new PhWith(
                 new Data.ToPhi(5L).take(PhDefaultTest.PLUS_ATT).copy(),
                 "x",
@@ -464,7 +464,7 @@ final class PhDefaultTest {
             0, new Data.ToPhi(1.2)
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Random value should be the same on second access, but it wasn't",
             new Dataized(rnd).asNumber(),
             Matchers.equalTo(new Dataized(rnd).asNumber())
         );

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -19,7 +19,7 @@ final class PhLoggedTest {
     @Test
     void copiesOrigin() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Copy of PhLogged should return the original Phi, but it didn't",
             new PhLogged(Phi.Φ).copy(),
             Matchers.equalTo(Phi.Φ)
         );
@@ -28,7 +28,7 @@ final class PhLoggedTest {
     @Test
     void returnsOriginHashCode() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "HashCode of PhLogged should return the original hashCode, but it didn't",
             new PhLogged(Phi.Φ).hashCode(),
             Matchers.equalTo(Phi.Φ.hashCode())
         );
@@ -37,7 +37,7 @@ final class PhLoggedTest {
     @Test
     void equalsToOrigin() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "PhLogged should be equlas to the original Phi, but it didn't",
             new PhLogged(Phi.Φ),
             Matchers.equalTo(Phi.Φ)
         );
@@ -47,7 +47,7 @@ final class PhLoggedTest {
     void getsOriginLocator() {
         final Phi phi = Phi.Φ;
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Locator of PhLogged should be equlas to the original, but it didn't",
             new PhLogged(phi).locator(),
             Matchers.equalTo(phi.locator())
         );

--- a/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
@@ -18,7 +18,7 @@ final class PhMethodTest {
     void comparesTwoObjects() {
         final Phi num = new Data.ToPhi(1L);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Calling the same method twice should produce different objects, but it didn't",
             num.take("plus"),
             Matchers.not(Matchers.equalTo(num.take("plus")))
         );
@@ -33,7 +33,7 @@ final class PhMethodTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should be calculated only once, but it didn't",
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -48,7 +48,7 @@ final class PhMethodTest {
             new Dataized(phi).take();
         }
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Foo should be calculated only once, but it wasn't",
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -60,7 +60,7 @@ final class PhMethodTest {
         final Phi phi = new PhMethod(dummy, "neg");
         new Dataized(phi).take();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Neg should be calculated only once, but it wasn't",
             dummy.count,
             Matchers.equalTo(1)
         );
@@ -70,7 +70,7 @@ final class PhMethodTest {
     void hasDifferentFormasWithOwnMethod() {
         final Phi dummy = new Dummy();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Forma of PhMethod should be differ from original, but it wasn't",
             dummy.forma(),
             Matchers.not(
                 Matchers.equalTo(

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -32,7 +32,7 @@ final class PhPackageTest {
     @Test
     void copiesObject() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Every take() should return new instance, but it didn't",
             Phi.Φ.take("org.eolang.seq"),
             Matchers.not(
                 Matchers.equalTo(
@@ -70,7 +70,7 @@ final class PhPackageTest {
         final Phi eolang = Phi.Φ.take("org.eolang");
         final Phi seq = eolang.take("seq");
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            String.format("The %s attribute must be set to object inside package on dispatch", Phi.RHO),
             seq.take(Phi.RHO),
             Matchers.equalTo(eolang)
         );
@@ -79,7 +79,7 @@ final class PhPackageTest {
     @Test
     void findsLongClass() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Package should resolve class with '$' in the name, but it didn't",
             Phi.Φ.take("org.eolang.bytes$eq").copy(),
             Matchers.instanceOf(Phi.class)
         );
@@ -91,7 +91,7 @@ final class PhPackageTest {
         final Phi parent = new PhPackage(PhPackageTest.DEFAULT_PACKAGE);
         final Phi actual = parent.take(attribute);
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            String.format("Attribute '%s' should be instance of %s, but it wasn't", attribute, expected.getSimpleName()),
             actual,
             Matchers.instanceOf(expected)
         );
@@ -102,7 +102,7 @@ final class PhPackageTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new PhPackage(PhPackageTest.DEFAULT_PACKAGE).take("failed"),
-            PhCompositeTest.TO_ADD_MESSAGE
+            "Should throw if object cannot be instantiated, but it was"
         );
     }
 
@@ -128,7 +128,7 @@ final class PhPackageTest {
     @Test
     void returnsLocator() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "locator of the DEFAULT_PACKAGE must be ?:?:?, but is wasn't",
             new PhPackage(PhPackageTest.DEFAULT_PACKAGE).locator(),
             Matchers.equalTo("?:?:?")
         );

--- a/eo-runtime/src/test/java/org/eolang/PhWithTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhWithTest.java
@@ -25,7 +25,7 @@ final class PhWithTest {
             0, new Data.ToPhi(1L)
         );
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "PhWith should be equal to itself, but it didn't",
             dummy, Matchers.equalTo(dummy)
         );
     }
@@ -33,7 +33,7 @@ final class PhWithTest {
     @Test
     void takesMethod() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "PhWith should preserve inner method result from Dataized string, but it didn't",
             new Dataized(
                 new Data.ToPhi("Hello, world!")
             ).asString(),
@@ -45,7 +45,7 @@ final class PhWithTest {
     void passesToSubObject() {
         final Phi dummy = new PhWithTest.Dummy();
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "PhWith should pass attribute to sub-object and calculate correctly, but it didn't",
             new Dataized(
                 new PhWith(
                     new PhCopy(new PhMethod(dummy, "plus")),
@@ -66,7 +66,7 @@ final class PhWithTest {
             new Together<>(
                 thread -> {
                     MatcherAssert.assertThat(
-                        PhCompositeTest.TO_ADD_MESSAGE,
+                        "Attribute 'foo' should return the same string that was passed to Phi, but it didn't",
                         new Dataized(ref.take(attr)).asString(),
                         Matchers.is(data)
                     );
@@ -81,7 +81,7 @@ final class PhWithTest {
     void hasTheSameFormaWithBoundAttribute() {
         final Phi dummy = new DummyWithAtFree("x");
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "forma of PhWith with bound attribute should be same as forma of original, but it didn't",
             dummy.forma(),
             Matchers.equalTo(
                 new PhWith(dummy, "x", new Data.ToPhi(5L)).forma()

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -18,7 +18,7 @@ final class PhiTest {
     @Test
     void takesPackage() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should resolve and invoke method from org.eolang.io.stdout package, but it didn't",
             new Dataized(
                 new PhCopy(
                     new PhMethod(
@@ -49,7 +49,7 @@ final class PhiTest {
     @Test
     void takesStandardPackage() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should resolve and invoke method from org.eolang.io.stdout package, but it didn't",
             new Dataized(
                 new PhCopy(
                     new PhMethod(
@@ -68,7 +68,7 @@ final class PhiTest {
     @Test
     void takesDirectly() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should resolve nested attribute org.eolang.nan.gt and return false, but it didn't",
             new Dataized(
                 Phi.Φ.take("org").take("eolang").take("nan").take("gt")
             ).asBool(),
@@ -79,7 +79,7 @@ final class PhiTest {
     @Test
     void getsLocation() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should return correct locator, but it didn't",
             new PhSafe(
                 Phi.Φ,
                 "foobar",
@@ -95,7 +95,7 @@ final class PhiTest {
     @Test
     void getsForma() {
         MatcherAssert.assertThat(
-            PhCompositeTest.TO_ADD_MESSAGE,
+            "Phi should return correct forma, but it didn't",
             new PhSafe(
                 Phi.Φ,
                 "foobar",


### PR DESCRIPTION
Replaced all occurrences of PhCompositeTest#TO_ADD_MESSAGE with meaningful assert messages in tests across eo-runtime.

Closes #4240