### PR TITLE
bug(#4386): auto named formation with `\phi` object inside

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -436,7 +436,12 @@ onameOrTname
 
 // Object name
 oname
-    : suffix CONST?
+    : (suffix CONST?) | aphi
+    ;
+
+// Auto named assigned to PHI (`@`).
+aphi
+    : SPACE ARROW ARROW SPACE voids
     ;
 
 tname

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -128,7 +128,7 @@ void: NAME
 // - vertical
 // Ends on the next line
 application
-    : happlicationExtended onameOrTname EOL
+    : happlicationExtendedOrAphi onameOrTname EOL
     | vapplication
     ;
 
@@ -152,10 +152,20 @@ happlicationReversedHead
 // Extended horizontal application
 // The head can contain elements in horizontal or vertical notations
 happlicationExtended
-    : happlicationHeadExtended happlicationTail aphi?
+    : happlicationHeadExtended happlicationTail
     | happlicationReversed
     ;
 
+// Application with auto-Phi formation
+onlyAphi
+    : happlicationHeadExtended happlicationTail aphi?
+    ;
+
+happlicationExtendedOrAphi
+    : happlicationExtended | onlyAphi
+    ;
+
+// Auto-Phi formation
 aphi
     : SPACE ARROW ARROW SPACE voids
     ;
@@ -273,7 +283,7 @@ vapplicationArgBound
 // Vertical application arguments with bindings
 // Ends on the current line
 vapplicationArgBoundCurrent
-    : LB happlicationExtended RB as oname? // horizontal application
+    : LB happlicationExtendedOrAphi RB as oname? // horizontal application
     | commentOptional LB hanonym RB as fname? // horizontal anonym object
     | (just | method) as oname? // just an object reference | method
     ;
@@ -296,7 +306,7 @@ vapplicationArgUnbound
 // Vertical application arguments without bindings
 // Ends on the current line
 vapplicationArgUnboundCurrent
-    : happlicationExtended oname? // horizontal application
+    : happlicationExtendedOrAphi oname? // horizontal application
     | commentOptional hanonym fname? // horizontal anonym object
     | (just | method) oname? // just an object reference or method
     ;

--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -152,8 +152,12 @@ happlicationReversedHead
 // Extended horizontal application
 // The head can contain elements in horizontal or vertical notations
 happlicationExtended
-    : happlicationHeadExtended happlicationTail
+    : happlicationHeadExtended happlicationTail aphi?
     | happlicationReversed
+    ;
+
+aphi
+    : SPACE ARROW ARROW SPACE voids
     ;
 
 // Reversed horizontal application
@@ -436,12 +440,7 @@ onameOrTname
 
 // Object name
 oname
-    : (suffix CONST?) | aphi
-    ;
-
-// Auto named assigned to PHI (`@`).
-aphi
-    : SPACE ARROW ARROW SPACE voids
+    : suffix CONST?
     ;
 
 tname

--- a/eo-parser/src/main/java/org/eolang/parser/AutoName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/AutoName.java
@@ -1,0 +1,35 @@
+package org.eolang.parser;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.cactoos.Text;
+
+/**
+ * Auto name for abstract object.
+ * @since 0.57.4
+ */
+final class AutoName implements Text {
+
+    /**
+     * The line number.
+     */
+    private final int line;
+
+    /**
+     * The Position in line.
+     */
+    private final int position;
+
+    AutoName(final ParserRuleContext context) {
+        this(context.getStart().getLine(), context.getStart().getCharPositionInLine());
+    }
+
+    AutoName(final int lne, final int pos) {
+        this.line = lne;
+        this.position = pos;
+    }
+
+    @Override
+    public String asString() {
+        return String.format("a\uD83C\uDF35%d%d", this.line, this.position);
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/AutoName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/AutoName.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
 package org.eolang.parser;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -372,6 +372,32 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
+    public void enterOnlyAphi(final EoParser.OnlyAphiContext ctx) {
+        this.startAbstract(ctx)
+            .enter().prop("name", new AutoName(ctx).asString())
+            .start(ctx)
+            .prop(
+                "base", String.format("$.%s", ctx.happlicationHeadExtended().getText())
+            )
+            .prop("name", "@");
+    }
+
+    @Override
+    public void exitOnlyAphi(final EoParser.OnlyAphiContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterHapplicationExtendedOrAphi(final EoParser.HapplicationExtendedOrAphiContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void exitHapplicationExtendedOrAphi(final EoParser.HapplicationExtendedOrAphiContext ctx) {
+        // Nothing here
+    }
+
+    @Override
     public void enterAphi(final EoParser.AphiContext ctx) {
         // Nothing here
     }
@@ -483,23 +509,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterHapplicationTail(final EoParser.HapplicationTailContext ctx) {
-        if (ctx.getParent() instanceof EoParser.HapplicationExtendedContext) {
-            final EoParser.HapplicationExtendedContext parent =
-                (EoParser.HapplicationExtendedContext) ctx.getParent();
-            if (parent.aphi() == null) {
-                this.objects.enter();
-            } else {
-                this.startAbstract(ctx)
-                    .enter().prop("name", new AutoName(ctx).asString())
-                    .start(ctx)
-                    .prop(
-                        "base", String.format("$.%s", parent.happlicationHeadExtended().getText())
-                    )
-                    .prop("name", "@");
-            }
-        } else {
-            this.objects.enter();
-        }
+        this.objects.enter();
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -363,9 +363,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterHapplicationExtended(final EoParser.HapplicationExtendedContext ctx) {
-//        if (ctx.aphi() != null) {
-//            this.startAbstract(ctx);
-//        }
+        // Nothing here
     }
 
     @Override
@@ -375,8 +373,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterAphi(final EoParser.AphiContext ctx) {
-        // where am I? -> create new auto named abstract here
-//        this.objects.enter().prop("name", "auto");
+        // Nothing here
     }
 
     @Override
@@ -487,13 +484,17 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     @Override
     public void enterHapplicationTail(final EoParser.HapplicationTailContext ctx) {
         if (ctx.getParent() instanceof EoParser.HapplicationExtendedContext) {
-            final EoParser.HapplicationExtendedContext parent = (EoParser.HapplicationExtendedContext) ctx.getParent();
+            final EoParser.HapplicationExtendedContext parent =
+                (EoParser.HapplicationExtendedContext) ctx.getParent();
             if (parent.aphi() == null) {
                 this.objects.enter();
             } else {
-                this.startAbstract(ctx).enter().prop(
-                    "name", new AutoName(ctx).asString()
-                );
+                this.startAbstract(ctx).enter().prop("name", new AutoName(ctx).asString())
+                    .start(ctx)
+                    .prop(
+                        "base", String.format("$.%s", parent.happlicationHeadExtended().getText())
+                    )
+                    .prop("name", "@");
             }
         } else {
             this.objects.enter();
@@ -503,10 +504,6 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     @Override
     public void exitHapplicationTail(final EoParser.HapplicationTailContext ctx) {
         this.objects.leave();
-//        final EoParser.HapplicationExtendedContext parent = (EoParser.HapplicationExtendedContext) ctx.getParent();
-//        if (parent.aphi() == null) {
-//            this.objects.leave();
-//        }
     }
 
     @Override
@@ -969,43 +966,6 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             this.objects.enter().prop("const").leave();
         }
     }
-
-//    @Override
-//    public void enterAphi(final EoParser.AphiContext ctx) {
-//        this.objects.enter()
-//            .prop(
-//                "name",
-//                String.format(
-//                    "a\uD83C\uDF35%d%d",
-//                    ctx.getStart().getLine(),
-//                    ctx.getStart().getCharPositionInLine()
-//                )
-//            )
-//            .enter()
-//            .prop("base", "∅")
-//            .prop("name", "i")
-//            .leave()
-//            .leave();
-        // remove bases
-        // random name + assign an object to its '@'
-        // m.get.eq 42 >> [i]:
-        // [i] >>
-        // [i] > $random
-        //   m.get.eq 42 > @
-        // <o base="$.m.get.eq" line="7" name="a🌵719" pos="13">
-        //  <o as="α0" base="$.i" line="7"/>
-        //  <o as="α1" base="Q.org.eolang.number" line="7" pos="17">
-        //    <o as="α0" base="Q.org.eolang.bytes" line="7" pos="17">
-        //      <o as="α0" line="7" pos="17">40-45-00-00-00-00-00-00</o>
-        //    </o>
-        //  </o>
-        // </o>
-//    }
-
-//    @Override
-//    public void exitAphi(final EoParser.AphiContext ctx) {
-//        // Nothing here
-//    }
 
     @Override
     public void enterTname(final EoParser.TnameContext ctx) {

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -489,7 +489,8 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             if (parent.aphi() == null) {
                 this.objects.enter();
             } else {
-                this.startAbstract(ctx).enter().prop("name", new AutoName(ctx).asString())
+                this.startAbstract(ctx)
+                    .enter().prop("name", new AutoName(ctx).asString())
                     .start(ctx)
                     .prop(
                         "base", String.format("$.%s", parent.happlicationHeadExtended().getText())

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -943,6 +943,15 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
+    public void enterAphi(final EoParser.AphiContext ctx) {
+    }
+
+    @Override
+    public void exitAphi(final EoParser.AphiContext ctx) {
+        // Nothing here
+    }
+
+    @Override
     public void enterTname(final EoParser.TnameContext ctx) {
         this.objects.enter();
         if (ctx.PHI() != null) {

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -363,11 +363,24 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterHapplicationExtended(final EoParser.HapplicationExtendedContext ctx) {
-        // Nothing here
+//        if (ctx.aphi() != null) {
+//            this.startAbstract(ctx);
+//        }
     }
 
     @Override
     public void exitHapplicationExtended(final EoParser.HapplicationExtendedContext ctx) {
+        // Nothing here
+    }
+
+    @Override
+    public void enterAphi(final EoParser.AphiContext ctx) {
+        // where am I? -> create new auto named abstract here
+//        this.objects.enter().prop("name", "auto");
+    }
+
+    @Override
+    public void exitAphi(final EoParser.AphiContext ctx) {
         // Nothing here
     }
 
@@ -473,12 +486,27 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterHapplicationTail(final EoParser.HapplicationTailContext ctx) {
-        this.objects.enter();
+        if (ctx.getParent() instanceof EoParser.HapplicationExtendedContext) {
+            final EoParser.HapplicationExtendedContext parent = (EoParser.HapplicationExtendedContext) ctx.getParent();
+            if (parent.aphi() == null) {
+                this.objects.enter();
+            } else {
+                this.startAbstract(ctx).enter().prop(
+                    "name", new AutoName(ctx).asString()
+                );
+            }
+        } else {
+            this.objects.enter();
+        }
     }
 
     @Override
     public void exitHapplicationTail(final EoParser.HapplicationTailContext ctx) {
         this.objects.leave();
+//        final EoParser.HapplicationExtendedContext parent = (EoParser.HapplicationExtendedContext) ctx.getParent();
+//        if (parent.aphi() == null) {
+//            this.objects.leave();
+//        }
     }
 
     @Override
@@ -942,14 +970,42 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         }
     }
 
-    @Override
-    public void enterAphi(final EoParser.AphiContext ctx) {
-    }
+//    @Override
+//    public void enterAphi(final EoParser.AphiContext ctx) {
+//        this.objects.enter()
+//            .prop(
+//                "name",
+//                String.format(
+//                    "a\uD83C\uDF35%d%d",
+//                    ctx.getStart().getLine(),
+//                    ctx.getStart().getCharPositionInLine()
+//                )
+//            )
+//            .enter()
+//            .prop("base", "∅")
+//            .prop("name", "i")
+//            .leave()
+//            .leave();
+        // remove bases
+        // random name + assign an object to its '@'
+        // m.get.eq 42 >> [i]:
+        // [i] >>
+        // [i] > $random
+        //   m.get.eq 42 > @
+        // <o base="$.m.get.eq" line="7" name="a🌵719" pos="13">
+        //  <o as="α0" base="$.i" line="7"/>
+        //  <o as="α1" base="Q.org.eolang.number" line="7" pos="17">
+        //    <o as="α0" base="Q.org.eolang.bytes" line="7" pos="17">
+        //      <o as="α0" line="7" pos="17">40-45-00-00-00-00-00-00</o>
+        //    </o>
+        //  </o>
+        // </o>
+//    }
 
-    @Override
-    public void exitAphi(final EoParser.AphiContext ctx) {
-        // Nothing here
-    }
+//    @Override
+//    public void exitAphi(final EoParser.AphiContext ctx) {
+//        // Nothing here
+//    }
 
     @Override
     public void enterTname(final EoParser.TnameContext ctx) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,8 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵716' and o[@name='@']]
-  - //o[not(@base) and @name='a🌵813' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵78' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵88' and o[@name='@']]
 input: |
   # No comments.
   [n] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,8 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵719' and o[@name='@']]
-  - //o[not(@base) and @name='a🌵816' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵716' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵813' and o[@name='@']]
 input: |
   # No comments.
   [n] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+input: |
+  # No comments.
+  [n] > app
+    malloc.of > @
+      8
+      [m]
+        while > @
+          m.get.eq 42 >> [i]
+          m.put 42 >> [i]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,6 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
+  - //o[not(@base) and @name='a🌵719' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵816' and o[@name='@']]
 input: |
   # No comments.
   [n] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-phi-in-test-attributes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-phi-in-test-attributes.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:19] error: 'Invalid object declaration'
+      5.plus 5 >> [] +> test
+                     ^
+input: |-
+  # No comments.
+  [] > x
+    start > @
+      5.plus 5 >> [] +> test


### PR DESCRIPTION
In this PR I've added syntax possibility to create auto name formations with inner object assigned to `@`, from the application.

see #4386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for automatic phi formation in EO code, enabling automatic recognition and naming of specific object patterns based on source position.

* **Tests**
  * Added test cases to verify correct parsing, formation, and error handling of automatically named phi objects and invalid object declarations in EO code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->