### PR TITLE
bug(#4381): enable `StrictXmirTest`

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,12 +27,7 @@ import org.xembly.Xembler;
  * Test case for {@link StrictXmir}.
  *
  * @since 0.5
- * @todo #4360:30min Enable `StrictXmir` tests after XMIR.xsd release.
- *  Now tests fail because the latest schema available
- *  <a href="https://www.eolang.org/XMIR.xsd">here</a> does not allow `@author` attribute in the
- *  `object` element. Let's enable the tests right after we release new version.
  */
-@Disabled
 final class StrictXmirTest {
 
     @Test


### PR DESCRIPTION
In this PR I've enabled `StrictXmirTest`, since all our XMIRs now have `@author` attribute.

closes #4381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled the test suite for strict XMIR validation by activating previously disabled tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->