### PR TITLE
bug(#4417): `AutoName` in `XeEoListener#enterAname()`

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -927,14 +927,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterAname(final EoParser.AnameContext ctx) {
-        this.objects.enter().prop(
-            "name",
-            String.format(
-                "a\uD83C\uDF35%d%d",
-                ctx.getStart().getLine(),
-                ctx.getStart().getCharPositionInLine()
-            )
-        );
+        this.objects.enter().prop("name", new AutoName(ctx).asString());
         if (ctx.CONST() != null) {
             this.objects.prop("const");
         }

--- a/eo-parser/src/test/java/org/eolang/parser/AutoNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/AutoNameTest.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link AutoName}.
+ *
+ * @since 0.58.1
+ */
+final class AutoNameTest {
+
+    @Test
+    void generatesAutoNameForLineAndPos() {
+        MatcherAssert.assertThat(
+            "Auto name does not match with expected",
+            new AutoName(42, 13).asString(),
+            Matchers.equalTo("a\uD83C\uDF354213")
+        );
+    }
+}


### PR DESCRIPTION
In this PR I've updated `XeEoListener#enterAname()` to use `AutoName` object instead of local logic for auto name generation.

closes #4417