### PR TITLE
bug(#4425): Auto Phi formations available in vertical applications

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -128,7 +128,7 @@ void: NAME
 // - vertical
 // Ends on the next line
 application
-    : happlicationExtendedOrAphi onameOrTname EOL
+    : happlicationExtended onameOrTname EOL
     | vapplication
     ;
 
@@ -158,11 +158,7 @@ happlicationExtended
 
 // Application with auto-Phi formation
 onlyAphi
-    : happlicationHeadExtended happlicationTail aphi?
-    ;
-
-happlicationExtendedOrAphi
-    : happlicationExtended | onlyAphi
+    : happlicationHeadExtended happlicationTail aphi
     ;
 
 // Auto-Phi formation
@@ -283,7 +279,7 @@ vapplicationArgBound
 // Vertical application arguments with bindings
 // Ends on the current line
 vapplicationArgBoundCurrent
-    : LB happlicationExtendedOrAphi RB as oname? // horizontal application
+    : LB happlicationExtended RB as oname? // horizontal application
     | commentOptional LB hanonym RB as fname? // horizontal anonym object
     | (just | method) as oname? // just an object reference | method
     ;
@@ -299,14 +295,15 @@ vapplicationArgBoundNext
 // Vertical application arguments without bindings
 // Ends on the next line
 vapplicationArgUnbound
-    : vapplicationArgUnboundCurrent EOL
+    : onlyAphi EOL
+    | vapplicationArgUnboundCurrent aphi? EOL
     | vapplicationArgUnboundNext
     ;
 
 // Vertical application arguments without bindings
 // Ends on the current line
 vapplicationArgUnboundCurrent
-    : happlicationExtendedOrAphi oname? // horizontal application
+    : happlicationExtended oname? // horizontal application
     | commentOptional hanonym fname? // horizontal anonym object
     | (just | method) oname? // just an object reference or method
     ;
@@ -424,6 +421,7 @@ finisher
     : NAME
     | PHI
     | RHO
+// can >> [NAME] finish the statement?
     ;
 
 // Reversed notation

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -674,16 +674,6 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         }
     }
 
-    private void startAutoPhiFormation(final ParserRuleContext ctx, final String application) {
-        this.startAbstract(ctx)
-            .enter().prop("name", new AutoName(ctx).asString())
-            .start(ctx)
-            .prop(
-                "base", String.format("$.%s", application)
-            )
-            .prop("name", "@");
-    }
-
     @Override
     public void exitVapplicationArgUnbound(final EoParser.VapplicationArgUnboundContext ctx) {
         this.objects.leave();
@@ -1205,6 +1195,19 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             this.errors.add(new ParsingError(ctx, msg).cause());
         }
         return String.format("α%d", index);
+    }
+
+    /**
+     * Start new Auto Phi formation, from an application.
+     * @param ctx Context
+     * @param application Application base
+     */
+    private void startAutoPhiFormation(final ParserRuleContext ctx, final String application) {
+        this.startAbstract(ctx)
+            .enter().prop("name", new AutoName(ctx).asString())
+            .start(ctx)
+            .prop("base", String.format("$.%s", application))
+            .prop("name", "@");
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+#  - //o[not(@base) and @name='a🌵78' and o[@name='@']]
+#  - //o[not(@base) and @name='a🌵88' and o[@name='@']]
+input: |
+  # No comments.
+  [] > main
+    foo > app
+      true >> [x]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
@@ -5,8 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-#  - //o[not(@base) and @name='a🌵78' and o[@name='@']]
-#  - //o[not(@base) and @name='a🌵88' and o[@name='@']]
+  - //o[not(@base) and @name='a🌵44' and o[@name='@' and @base='$.true']]
 input: |
   # No comments.
   [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-phi-in-test-attributes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-phi-in-test-attributes.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 4
 message: |-
-  [4:19] error: 'Invalid object declaration'
+  [4:18] error: 'Invalid object declaration'
       5.plus 5 >> [] +> test
-                     ^
+                    ^
 input: |-
   # No comments.
   [] > x


### PR DESCRIPTION
In this PR I've made Auto Phi formation syntax reusable across both application types: horizontal and vertical. Now Auto Phi formation is part of the syntax of vertical application, and reused via `vapplicationArgs` in horizontal one.

see #4425