### PR TITLE
feat(#4411): idempotency syntax

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -460,7 +460,7 @@ tarrow
 
 // Suffix
 suffix
-    : arrow (PHI | NAME)
+    : arrow (PHI | NAME) APOSTROPHE?
     ;
 
 arrow
@@ -541,6 +541,9 @@ HASH: '#'
     ;
 TILDE
     : '~'
+    ;
+APOSTROPHE
+    : '\''
     ;
 
 fragment INDENT

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1000,6 +1000,9 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         } else if (ctx.NAME() != null) {
             this.objects.prop("name", ctx.NAME().getText());
         }
+        if (ctx.APOSTROPHE() != null) {
+            this.objects.start(ctx).prop("base", "ξ.🌵").leave();
+        }
     }
 
     @Override

--- a/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
@@ -29,6 +29,10 @@
     <xsl:param name="o" as="element()"/>
     <xsl:sequence select="starts-with($o/@name, '+')"/>
   </xsl:function>
+  <xsl:function name="eo:idempotent" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:sequence select="$o/o[1]/@base = 'ξ.🌵'"/>
+  </xsl:function>
   <!-- BYTES TO STRING -->
   <xsl:function name="eo:bytes-to-string" as="xs:string">
     <xsl:param name="bytes" as="xs:string"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
@@ -71,7 +71,7 @@
     </xsl:apply-templates>
   </xsl:template>
   <!-- BASED -->
-  <xsl:template match="o[@base and not(eo:has-data(.))]" mode="head">
+  <xsl:template match="o[@base and not(@base='ξ.🌵') and not(eo:has-data(.))]" mode="head">
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
@@ -156,6 +156,9 @@
       </xsl:if>
       <xsl:if test="eo:atom(.)">
         <xsl:text> ?</xsl:text>
+      </xsl:if>
+      <xsl:if test="eo:idempotent(.)">
+        <xsl:text>'</xsl:text>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
@@ -6,6 +6,7 @@ package org.eolang.parser;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import org.cactoos.io.InputOf;
 import org.eolang.jucs.ClasspathSource;
@@ -14,7 +15,11 @@ import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link Xmir}.
@@ -35,6 +40,32 @@ final class XmirTest {
             ),
             xmir.toEO(),
             Matchers.equalTo(xtory.map().get("printed"))
+        );
+    }
+
+    @Test
+    void restoresApostropheForIdempotency() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Apostrophe is not restored, but should be",
+            new Xmir(
+                new XMLDocument(
+                    new Xembler(
+                        new Directives()
+                            .add("object")
+                            .add("o")
+                            .attr("base", "Q.org.eolang.start")
+                            .attr("name", "@")
+                            .add("o")
+                            .attr("base", "Q.org.eolang.random")
+                            .attr("name", "r")
+                            .add("o")
+                            .attr("base", "ξ.🌵")
+                    ).xml()
+                )
+            ).toEO(),
+            Matchers.containsString(
+                "random > r'"
+            )
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/idempotency.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/idempotency.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Q.org.eolang.foo' and @name='f' and o[not(@name) and @base='ξ.🌵']]
+input: |
+  # No comments.
+  [] > main
+    start > @
+      foo > f'

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:7] error: 'mismatched input '[' expecting '?''
+  [2:7] error: 'mismatched input '[' expecting {' ', '''}'
   [] > a [] > b [] > c [] > d hello world
          ^
 input: |


### PR DESCRIPTION
In this PR I've added new syntax for tracking object idempotency. Here is how it looks:

```eo
[] > main
  start > @
    foo > f'
```

Means that object `f` and its attributes are idempotent (have inner object with `@base='ξ.🌵'`).

see #4411