### PR TITLE
bug(#4466): parsing compliant with XMIR XSD

### DIFF
--- a/eo-integration-tests/pom.xml
+++ b/eo-integration-tests/pom.xml
@@ -23,6 +23,14 @@
       <artifactId>eo-parser</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--
+      This dependency is required by eo-parser's XML processing libraries.
+    -->
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
     <dependency>
       <!--
       This dependency is required by the javadoc plugin. In the eo-runtime,

--- a/eo-integration-tests/pom.xml
+++ b/eo-integration-tests/pom.xml
@@ -19,6 +19,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.eolang</groupId>
+      <artifactId>eo-parser</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <!--
       This dependency is required by the javadoc plugin. In the eo-runtime,
       we use classes from this JAR, but can't have it as a normal dependency.

--- a/eo-integration-tests/src/test/java/integration/XmirIT.java
+++ b/eo-integration-tests/src/test/java/integration/XmirIT.java
@@ -5,6 +5,8 @@
 package integration;
 
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.MayBeSlow;
+import com.yegor256.WeAreOnline;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -12,23 +14,28 @@ import java.nio.file.Paths;
 import org.eolang.parser.StrictXmir;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration test for checking validity of parsed EO as XMIR documents.
  *
  * @since 0.58.3
  */
-final class XmirValidationIT {
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class XmirIT {
 
     @Test
-    void checksWithXsd() throws IOException {
+    @ExtendWith(WeAreOnline.class)
+    @ExtendWith(MayBeSlow.class)
+    void validatesWithXsd() throws IOException {
         Files.walk(
-                Paths.get("").toAbsolutePath().getParent()
-                    .resolve("eo-runtime")
-                    .resolve("target")
-                    .resolve("eo")
-                    .resolve("1-parse")
-            ).filter(Files::isRegularFile)
+            Paths.get("").toAbsolutePath().getParent()
+                .resolve("eo-runtime")
+                .resolve("target")
+                .resolve("eo")
+                .resolve("1-parse")
+            )
+            .filter(Files::isRegularFile)
             .forEach(
                 xmir -> {
                     try {

--- a/eo-integration-tests/src/test/java/integration/XmirValidationIT.java
+++ b/eo-integration-tests/src/test/java/integration/XmirValidationIT.java
@@ -33,9 +33,7 @@ final class XmirValidationIT {
                 xmir -> {
                     try {
                         Assertions.assertDoesNotThrow(
-                            new StrictXmir(
-                                new XMLDocument(xmir)
-                            )::inner,
+                            new StrictXmir(new XMLDocument(xmir))::inner,
                             "validation should pass as normal"
                         );
                     } catch (final FileNotFoundException exception) {

--- a/eo-integration-tests/src/test/java/integration/XmirValidationIT.java
+++ b/eo-integration-tests/src/test/java/integration/XmirValidationIT.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package integration;
+
+import com.jcabi.xml.XMLDocument;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.eolang.parser.StrictXmir;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for checking validity of parsed EO as XMIR documents.
+ *
+ * @since 0.58.3
+ */
+final class XmirValidationIT {
+
+    @Test
+    void checksWithXsd() throws IOException {
+        Files.walk(
+                Paths.get("").toAbsolutePath().getParent()
+                    .resolve("eo-runtime")
+                    .resolve("target")
+                    .resolve("eo")
+                    .resolve("1-parse")
+            ).filter(Files::isRegularFile)
+            .forEach(
+                xmir -> {
+                    try {
+                        Assertions.assertDoesNotThrow(
+                            new StrictXmir(
+                                new XMLDocument(xmir)
+                            )::inner,
+                            "validation should pass as normal"
+                        );
+                    } catch (final FileNotFoundException exception) {
+                        throw new IllegalStateException(
+                            String.format("Failed to find XMIR for %s", xmir), exception
+                        );
+                    }
+                }
+            );
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -233,7 +233,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     @Override
     public void exitAtom(final EoParser.AtomContext ctx) {
         this.objects.enter()
-            .start(ctx.getStart().getLine(), ctx.getStop().getCharPositionInLine() - 1)
+            .start(ctx.getStart().getLine(), 0)
             .prop("name", "λ")
             .leave()
             .leave();
@@ -963,7 +963,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     public void enterTname(final EoParser.TnameContext ctx) {
         this.objects.enter();
         if (ctx.PHI() != null) {
-            this.objects.prop("name", ctx.PHI().getText());
+            this.objects.prop("name", "φ");
         } else if (ctx.NAME() != null) {
             this.objects.prop(
                 "name",

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -316,7 +316,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
         if (ctx.NAME() != null) {
             name = ctx.NAME().getText();
         } else if (ctx.PHI() != null) {
-            name = ctx.PHI().getText();
+            name = "φ";
         } else {
             name = "";
         }

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -64,7 +64,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="α[0-9]+|φ|[a-z]\S*|λ"/>
+      <xs:pattern value="α[0-9]+|φ|[a-z+]\S*|λ"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="fqn">

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='λ' and not(@pos='-2')]
+input: |
+  [format read] > sscanf ?
+    [] +> tests-sscanf-with-string
+      eq. > @
+        "hello"
+        head.
+          sscanf "%s" "hello"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@name='λ' and not(@pos='-2')]
+  - //o[@name='λ' and @pos='0']
 input: |
   [format read] > sscanf ?
     [] +> tests-sscanf-with-string

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/phi-attribute.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/phi-attribute.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.is-nan' and @name="φ"]
+  - //o[not(@name='@')]
+input: |
+  # Real.
+  [] > real
+    [] +> tests-sqrt-check-nan-input
+      is-nan. +> @
+        sqrt.
+          real nan

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/phi-attribute-incorrect-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/phi-attribute-incorrect-name.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+errors: 2
+document: |
+  <object author="eo-parser">
+    <o line="2" name="real" pos="0">
+      <o line="3" name="+tests-sqrt-check-nan-input" pos="2">
+         <o base=".is-nan" line="4" name="@" pos="4">
+            <o base=".sqrt" line="5" pos="6">
+               <o base="Φ.real" line="6" pos="8">
+                  <o as="α0" base="Φ.org.eolang.nan" line="6" pos="13"/>
+               </o>
+            </o>
+         </o>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
In this PR I've adjusted parsing of XMIR in `eo-parser`, to be fully compliant with `XMIR.xsd`, introduced several tests, including integration test for XMIR validation of runtime objects.

see #4466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Attribute names can now start with “+” in XMIR.
- Bug Fixes
  - Corrected atom position anchoring for more accurate source mapping.
  - Unified handling of the φ attribute name to ensure consistent parsing.
- Tests
  - Added an integration test to validate generated XMIR against the schema.
  - Added parser test cases for φ attributes and atom behavior.
- Chores
  - Added required XML and parser dependencies to integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->