### PR TITLE
bug(#4444): enable `auto-phi` snippet

### DIFF
--- a/eo-integration-tests/src/test/resources/org/eolang/snippets/auto-phi.yaml
+++ b/eo-integration-tests/src/test/resources/org/eolang/snippets/auto-phi.yaml
@@ -2,28 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# @todo #4426:60min Enable `auto-phi` after nested object representation in auto phi will be fixed.
-#  Currently, this snippet fails, because we have duplication in the generated representation of
-#  auto Phi object: application assigned to '@' (`ξ.ρ.m.get.eq` in this example) contains itself
-#  in the first as attribute `α0`, together with nested attribute - reference to void attribute
-#  (`ξ.i`). We must fix this nesting, and enable the test. This XMIR is problematic:
-#  <o line="10" name="a🌵108" pos="8">
-#    <o base="∅" line="10" name="i" pos="24"/>
-#    <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
-#      <o as="α0" base="ξ.ρ.m.get.eq" line="10" pos="13">
-#        <o as="α0" base="ξ.i" line="10"/>
-#        <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
-#      </o>
-#    </o>
-#  </o>
-#  The correct XMIR should be this:
-#  <o line="10" name="a🌵108" pos="8">
-#    <o base="∅" line="10" name="i" pos="24"/>
-#    <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
-#      <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
-#    </o>
-#  </o>
-skip: true
 out: []
 file: org/eolang/snippets/auto.eo
 args: ["org.eolang.snippets.auto"]

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-auto-phi-formations.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-auto-phi-formations.yaml
@@ -11,8 +11,8 @@ sheets:
   - /org/eolang/maven/transpile/to-java.xsl
 asserts:
   - /object[not(errors)]
-  - //java[contains(text(), 'Phi r1 = new PhMethod(h, "a🌵44");')]
-  - //java[contains(text(), 'Phi r2 = new PhMethod(h, "a🌵54");')]
+  - //java[contains(text(), 'Phi r1 = new PhMethod(h, "ap🌵44");')]
+  - //java[contains(text(), 'Phi r2 = new PhMethod(h, "ap🌵54");')]
 input: |
   # Foo.
   [] > main

--- a/eo-parser/src/main/java/org/eolang/parser/AutoName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/AutoName.java
@@ -23,17 +23,31 @@ final class AutoName implements Text {
      */
     private final int position;
 
-    AutoName(final ParserRuleContext context) {
-        this(context.getStart().getLine(), context.getStart().getCharPositionInLine());
-    }
+    /**
+     * Extra symbol.
+     */
+    private final String extra;
 
     AutoName(final int lne, final int pos) {
+        this(lne, pos, "");
+    }
+
+    AutoName(final ParserRuleContext context) {
+        this(context, "");
+    }
+
+    AutoName(final ParserRuleContext context, final String extra) {
+        this(context.getStart().getLine(), context.getStart().getCharPositionInLine(), extra);
+    }
+
+    AutoName(final int lne, final int pos, final String extr) {
         this.line = lne;
         this.position = pos;
+        this.extra = extr;
     }
 
     @Override
     public String asString() {
-        return String.format("a\uD83C\uDF35%d%d", this.line, this.position);
+        return String.format("a%s\uD83C\uDF35%d%d", this.extra, this.line, this.position);
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -102,7 +102,8 @@ public final class EoSyntax implements Syntax {
                     "/org/eolang/parser/parse/roll-bases.xsl",
                     "/org/eolang/parser/parse/cti-adds-errors.xsl",
                     "/org/eolang/parser/parse/decorate.xsl",
-                    "/org/eolang/parser/parse/add-as-attributes-inside-application.xsl"
+                    "/org/eolang/parser/parse/add-as-attributes-inside-application.xsl",
+                    "/org/eolang/parser/parse/auto-phi-formation-restruct.xsl"
                 ).back(),
                 new TrDefault<>(new StHex())
             )

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1196,7 +1196,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
      */
     private void startAutoPhiFormation(final ParserRuleContext ctx, final String application) {
         this.startAbstract(ctx)
-            .enter().prop("name", new AutoName(ctx).asString())
+            .enter().prop("name", new AutoName(ctx, "p").asString())
             .start(ctx)
             .prop("base", String.format("ξ.ρ.%s", application))
             .prop("name", "φ");

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/auto-phi-formation-restruct.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/auto-phi-formation-restruct.xsl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="auto-phi-formation-restruct" version="2.0">
+  <!--
+    Here, we're taking all the auto-phi formations, and transform from this structure:
+    ```
+    <o line="10" name="a🌵108" pos="8">
+      <o base="∅" line="10" name="i" pos="24"/>
+      <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
+        <o as="α0" base="ξ.ρ.m.get.eq" line="10" pos="13">
+          <o as="α0" base="ξ.i" line="10"/>
+          <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
+        </o>
+      </o>
+    </o>
+    ```
+    to this:
+    ```
+    <o line="10" name="a🌵108" pos="8">
+      <o base="∅" line="10" name="i" pos="24"/>
+      <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
+        <o as="α0" base="ξ.i" line="10"/>
+        <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
+      </o>
+    </o>
+    ```
+  -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="o[@base and @name='φ' and ancestor::o[contains(@name,'a🌵')]]">
+    <xsl:variable name="inner" select="descendant::o[@base = current()/@base][1]"/>
+    <xsl:choose>
+      <xsl:when test="$inner">
+        <xsl:apply-templates select="$inner" mode="promote">
+          <xsl:with-param name="outer-name" select="@name"/>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="o" mode="promote">
+    <xsl:param name="outer-name"/>
+    <xsl:copy>
+      <xsl:copy-of select="@*[name()!='name']"/>
+      <xsl:attribute name="name">
+        <xsl:value-of select="$outer-name"/>
+      </xsl:attribute>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/auto-phi-formation-restruct.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/auto-phi-formation-restruct.xsl
@@ -7,33 +7,32 @@
   <!--
     Here, we're taking all the auto-phi formations, and transform from this structure:
     ```
-    <o line="10" name="a🌵108" pos="8">
+    <o line="10" name="ap🌵108" pos="8">
       <o base="∅" line="10" name="i" pos="24"/>
       <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
         <o as="α0" base="ξ.ρ.m.get.eq" line="10" pos="13">
-          <o as="α0" base="ξ.i" line="10"/>
-          <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
+          <o as="α0" base="Φ.org.eolang.number" line="10" pos="17".../>
+          <o as="α1" base="ξ.i" line="10"/>
         </o>
       </o>
     </o>
     ```
     to this:
     ```
-    <o line="10" name="a🌵108" pos="8">
+    <o line="10" name="ap🌵108" pos="8">
       <o base="∅" line="10" name="i" pos="24"/>
       <o base="ξ.ρ.m.get.eq" line="10" name="φ" pos="8">
-        <o as="α0" base="ξ.i" line="10"/>
-        <o as="α1" base="Φ.org.eolang.number" line="10" pos="17".../>
+        <o as="α0" base="Φ.org.eolang.number" line="10" pos="17".../>
       </o>
     </o>
     ```
   -->
   <xsl:template match="@*|node()">
     <xsl:copy>
-      <xsl:apply-templates select="@*|node()" />
+      <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="o[@base and @name='φ' and ancestor::o[contains(@name,'a🌵')]]">
+  <xsl:template match="o[@base and @name='φ' and ancestor::o[contains(@name,'ap🌵')]]">
     <xsl:variable name="inner" select="descendant::o[@base = current()/@base][1]"/>
     <xsl:choose>
       <xsl:when test="$inner">
@@ -43,7 +42,7 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:copy>
-          <xsl:apply-templates select="@*|node()" />
+          <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
       </xsl:otherwise>
     </xsl:choose>
@@ -58,4 +57,6 @@
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>
+  <!-- Remove redundant ξ.X for void atributes, located inside the auto-phi formation -->
+  <xsl:template match="o[starts-with(@base,'ξ.') and ancestor::o[contains(@name,'ap🌵')][descendant::o[@base='∅' and @name=substring-after(current()/@base,'ξ.')]]]"/>
 </xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-from-simple-application.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵44' and o[@name='φ' and @base='ξ.ρ.true']]
+  - //o[not(@base) and @name='ap🌵44' and o[@name='φ' and @base='ξ.ρ.true']]
 input: |
   # No comments.
   [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,10 +5,12 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵78' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
-  - //o[not(@base) and @name='a🌵88' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
-  - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵78']]
-  - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵88']]
+  - //o[not(@base) and @name='ap🌵78' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
+  - //o[not(@base) and @name='ap🌵88' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
+  - //o[@base='ξ.ρ.m.get.eq' and count(o)=1]
+  - //o[@base='ξ.ρ.m.put' and count(o)=1]
+  - //o[@base='Φ.org.eolang.while' and o[@base='ξ.ap🌵78']]
+  - //o[@base='Φ.org.eolang.while' and o[@base='ξ.ap🌵88']]
 input: |
   # No comments.
   [n] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,8 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵78' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']]
-  - //o[not(@base) and @name='a🌵88' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']]
+  - //o[not(@base) and @name='a🌵78' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
+  - //o[not(@base) and @name='a🌵88' and o[1][@name='i' and @base='∅'] and o[2][@name='φ']/o[1][@base='Φ.org.eolang.number']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵78']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵88']]
 input: |


### PR DESCRIPTION
In this PR I've fixed auto-phi formation parsing, and enabled `auto-phi` snippet.

closes #4444