### PR TITLE
chore(ci): remove duplicate license

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -6,8 +6,6 @@ extend-exclude = [
     "eo-runtime/src/main/java/EOorg/EOeolang/EOfs/EOfile$EOis_directory.java",
     "eo-parser/src/test/resources/org/eolang/parser/benchmark/native.xmir"
 ]
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
 
 [default]
 extend-ignore-identifiers-re = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the typos configuration by removing redundant SPDX header comments from the configuration file to streamline maintenance.
  * No changes to the existing rules or behavior.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->