### PR TITLE
bug(#4474): simple `auto-phi` formation from `just`

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -38,7 +38,7 @@ object
 // Objects that may be used inside abstract object
 // Ends on the next line
 bound
-    : commentOptional (application | ((method | just) onameOrTname) EOL)
+    : commentOptional (application | ((method | just) (onameOrTname | aphi)) EOL)
     ;
 
 tbound

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -157,10 +157,8 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterBound(final EoParser.BoundContext ctx) {
-        if (ctx.just() != null && ctx.aphi() != null) {
-            if (ctx.just().finisher() != null) {
-                this.startAutoPhiFormation(ctx, ctx.just().finisher().getText());
-            }
+        if (ctx.just() != null && ctx.aphi() != null && ctx.just().finisher() != null) {
+            this.startAutoPhiFormation(ctx, ctx.just().finisher().getText());
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -164,7 +164,9 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void exitBound(final EoParser.BoundContext ctx) {
-        // Nothing here
+        if (ctx.just() != null && ctx.aphi() != null && ctx.just().finisher() != null) {
+            this.objects.leave().leave();
+        }
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -157,7 +157,11 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
 
     @Override
     public void enterBound(final EoParser.BoundContext ctx) {
-        // Nothing here
+        if (ctx.just() != null && ctx.aphi() != null) {
+            if (ctx.just().finisher() != null) {
+                this.startAutoPhiFormation(ctx, ctx.just().finisher().getText());
+            }
+        }
     }
 
     @Override

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/simple-auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/simple-auto-phi-formation.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[not(@base) and @name='a🌵32' and o[@name='φ' and @base='ξ.ρ.true']]
+input: |
+  # No comments.
+  [] > main
+    true >> [x]


### PR DESCRIPTION
In this PR I've made possible to parse `auto-phi` formation (`aphi`) from `just`.

see #4474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser accepts auto‑phi formation in bound expressions after method/just, and now auto‑creates the expected φ structure when applicable.

* **Tests**
  * Added a syntax test that verifies error‑free parsing and the correct φ object structure for auto‑phi formation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->