### PR TITLE
bug(#4471): `MjParse` test for target regeneration

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -249,6 +249,35 @@ final class MjParseTest {
         );
     }
 
+    @Test
+    void parsesWithTargetCache(@Mktmp final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final File parsed = maven
+            .withHelloWorld()
+            .execute(new FakeMaven.Parse())
+            .result().get(String.format("target/%s/foo/x/main.%s", MjParse.DIR, MjAssemble.XMIR))
+            .toFile();
+        final long before = parsed.lastModified();
+        maven.execute(new FakeMaven.Parse());
+        final long after = parsed.lastModified();
+        maven.withProgram(
+            String.join(
+                "\n",
+                "[] > foo",
+                "  boom > @"
+            ),
+            "foo"
+        ).execute(new FakeMaven.Parse());
+        MatcherAssert.assertThat(
+            "Parser re-parsed sources, but it should not",
+            parsed.lastModified(),
+            Matchers.allOf(
+                Matchers.equalTo(before),
+                Matchers.equalTo(after)
+            )
+        );
+    }
+
     /**
      * The mojo that does nothing, but executes infinitely.
      * @since 0.29


### PR DESCRIPTION
In this PR I've added new test for `MjParse` that proves that `.xmir` files are not touched if the `.eo` source hasn't changed. So, for project-local sources (`/target`): `MjParse` does check timestamps between `.eo` and `.xmir`: if the `.xmir` is newer, it doesn’t re-parse. But for external `.eo` sources caching is handled via `~/.eo`.

see #4471