### PR TITLE
bug(#4473): `range-of-numbers`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/structs/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/range-of-numbers.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27
 
-# Range of integers from `start` to `end` (soft border) with step = 1.
+# Range of numbers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will
 # be returned.
-[start end] > range-of-ints
+[start end] > range-of-numbers
   if. > @
     and.
       or.
@@ -29,35 +29,35 @@
     error "Some of the arguments are not integers"
 
   # Tests that simple range of integers from one to ten works correctly.
-  [] +> tests-simple-range-of-ints-from-one-to-ten
+  [] +> tests-simple-range-of-numbers-from-one-to-ten
     eq. > @
-      range-of-ints 1 10
+      range-of-numbers 1 10
       * 1 2 3 4 5 6 7 8 9
 
   # Tests that range of integers from ten to ten is empty.
-  [] +> tests-range-of-ints-from-ten-to-ten-is-empty
+  [] +> tests-range-of-numbers-from-ten-to-ten-is-empty
     is-empty. > @
-      range-of-ints 10 10
+      range-of-numbers 10 10
 
   # Tests that range of descending integers is empty.
-  [] +> tests-range-of-descending-ints-is-empty
+  [] +> tests-range-of-descending-numbers-is-empty
     is-empty. > @
-      range-of-ints 10 1
+      range-of-numbers 10 1
 
   # Tests that range of negative integers works correctly.
-  [] +> tests-range-of-negative-ints-works-as-well
+  [] +> tests-range-of-negative-numbers-works-as-well
     eq. > @
-      range-of-ints -5 0
+      range-of-numbers -5 0
       * -5 -4 -3 -2 -1
 
   # Tests that range throws error with non-integer start.
-  [] +> throws-on-range-of-ints-with-non-int-start
-    range-of-ints 1.2 3 > @
+  [] +> throws-on-range-of-numbers-with-non-number-start
+    range-of-numbers 1.2 3 > @
 
   # Tests that range throws error with non-integer end.
-  [] +> throws-on-range-of-ints-with-not-int-end
-    range-of-ints 1 2.5 > @
+  [] +> throws-on-range-of-numbers-with-not-number-end
+    range-of-numbers 1 2.5 > @
 
   # Tests that range throws error when neither start nor end are integers.
-  [] +> throws-on-range-of-not-ints
-    range-of-ints 1.5 5.2 > @
+  [] +> throws-on-range-of-not-numbers
+    range-of-numbers 1.5 5.2 > @


### PR DESCRIPTION
In this PR I've renamed `range-of-ints` object to `range-of-numbers` to avoid confusion, since we have `number.eo`, not `int.eo`.

see #4473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the public operator from “range-of-ints” to “range-of-numbers.” Behavior is unchanged; inputs remain integers. Update any usages to the new name.
* **Documentation**
  * Updated wording from “Range of integers” to “Range of numbers” for consistency with the new operator name.
* **Tests**
  * Updated test names and references to align with the renamed operator.
* **Chores**
  * Added license header and lint directive; no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->