### PR TITLE
bug(#4214): `XMLDocument#xpath()` to `Xnav#path()` in `EoSyntaxTest#checksTypoPacks`

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
 import org.cactoos.io.InputOf;
@@ -45,10 +46,6 @@ import org.xml.sax.SAXParseException;
  * Test case for {@link EoSyntax}.
  *
  * @since 0.1
- * @todo #4052:35min Replace XML.xpath() with Xnav.path().
- *  Currently, in {@link EoSyntaxTest#checksTypoPacks} its blocked by attribute parsing issue in
- *  Xnav. Please check <a href="https://github.com/volodya-lombrozo/xnav/issues/119">this</a> issue
- *  for more details. Once it will be resolved, we should proceed with the replacement.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class EoSyntaxTest {
@@ -250,14 +247,16 @@ final class EoSyntaxTest {
             )
         );
         Assumptions.assumeTrue(story.map().get("skip") == null);
+        final Xnav after = new Xnav(story.after().inner());
         MatcherAssert.assertThat(
             "We expect the error with correct line number was found",
-            XhtmlMatchers.xhtml(story.after().toString()),
-            XhtmlMatchers.hasXPaths("/object/errors/error/@line")
+            after.path("/object/errors/error/@line").findAny().isPresent(),
+            Matchers.equalTo(true)
         );
         MatcherAssert.assertThat(
-            XhtmlMatchers.xhtml(story.after()).toString(),
-            story.after().xpath("/object/errors/error/@line"),
+            after.toString(),
+            after.path("/object/errors/error/@line").map(line -> line.text().get())
+                .collect(Collectors.toList()),
             Matchers.hasItem(story.map().get("line").toString())
         );
         final String msg = "message";
@@ -266,7 +265,8 @@ final class EoSyntaxTest {
                 XhtmlMatchers.xhtml(story.after()).toString(),
                 String.join(
                     "\n",
-                    story.after().xpath("/object/errors/error/text()")
+                    after.path("/object/errors/error").map(error -> error.text().get())
+                        .collect(Collectors.toList())
                 ).replaceAll("\r", ""),
                 Matchers.containsString(story.map().get(msg).toString())
             );


### PR DESCRIPTION
Replaced the last occurrence of `XMLDocument#xpath()` with `Xnav#path()`.

closes #4214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Tests
  - Migrated assertions to a newer XML navigation approach for verifying syntax errors.
  - Improved robustness of error line extraction and message checks.
  - Normalized line breaks to reduce platform-specific flakiness.
- Refactor
  - Streamlined test setup to reuse parsed output for multiple checks, improving clarity and maintainability.
- Documentation
  - Removed obsolete inline comments in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->