### PR TITLE
bug(#4484): idempotency attribute representation fixed

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -343,7 +343,7 @@
     <xsl:param name="indent"/>
     <xsl:param name="parent"/>
     <xsl:param name="context"/>
-    <xsl:if test="not(bound/o[@base='ξ.xi🌵'])">
+    <xsl:if test="not(bound/o[eo:idempotent(.)])">
       <xsl:variable name="name" select="eo:attr-name(@name, false())"/>
       <xsl:if test="not(@name)">
         <xsl:message terminate="yes">
@@ -515,7 +515,7 @@
     <xsl:value-of select="$name"/>
     <xsl:text> = </xsl:text>
     <xsl:choose>
-      <xsl:when test="o and not(count(o)=1 and eo:idempotent(.))">
+      <xsl:when test="o and not(count(o)=1) and o[1][eo:idempotent(.)]">
         <xsl:text>new </xsl:text>
         <xsl:value-of select="eo:loc-to-class(eo:escape-plus(@loc))"/>
       </xsl:when>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
@@ -18,6 +18,7 @@ asserts:
   - /object/class/java[contains(text(), 'private static class EOΦabcφα1 extends PhDefault')]
   - /object/class/tests[contains(text(), '((PhDefault) rr).add("φ",')]
   - /object/class/tests[contains(text(), '((PhDefault) r).add("c",')]
+  - /object/class/tests[not(contains(text(), '((PhDefault) r).add("xi🌵",'))]
   - /object/class/tests[contains(text(), 'this.add("b"')]
   - /object/class/tests[contains(text(), 'PhDefault rrr1 = new EOΦabcφα0();')]
   - /object/class/tests[contains(text(), 'PhDefault rrr2 = new EOΦabcφα1();')]

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -1001,7 +1001,7 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
             this.objects.prop("name", ctx.NAME().getText());
         }
         if (ctx.APOSTROPHE() != null) {
-            this.objects.start(ctx).prop("base", "ξ.xi🌵").leave();
+            this.objects.start(ctx).prop("base", "ξ").prop("name", "xi🌵").leave();
         }
     }
 
@@ -1146,7 +1146,10 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
      * @return Xembly objects after creating abstract object
      */
     private Objects startAbstract(final ParserRuleContext ctx) {
-        return this.objects.start(ctx).start(ctx).prop("base", "ξ.xi🌵").leave().leave();
+        return this.objects.start(ctx).start(ctx)
+            .prop("base", "ξ")
+            .prop("name", "xi🌵")
+            .leave().leave();
     }
 
     private Objects startTest(final ParserRuleContext ctx) {

--- a/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
@@ -31,7 +31,7 @@
   </xsl:function>
   <xsl:function name="eo:idempotent" as="xs:boolean">
     <xsl:param name="o" as="element()"/>
-    <xsl:sequence select="$o/o[1]/@base = 'ξ.xi🌵'"/>
+    <xsl:sequence select="$o/o[1]/@base = 'ξ' and $o/o[1]/@name = 'xi🌵'"/>
   </xsl:function>
   <!-- BYTES TO STRING -->
   <xsl:function name="eo:bytes-to-string" as="xs:string">

--- a/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
@@ -31,7 +31,7 @@
   </xsl:function>
   <xsl:function name="eo:idempotent" as="xs:boolean">
     <xsl:param name="o" as="element()"/>
-    <xsl:sequence select="$o/o[1]/@base = 'ξ' and $o/o[1]/@name = 'xi🌵'"/>
+    <xsl:sequence select="$o/@base = 'ξ' and $o/@name = 'xi🌵'"/>
   </xsl:function>
   <!-- BYTES TO STRING -->
   <xsl:function name="eo:bytes-to-string" as="xs:string">

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/move-voids-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/move-voids-up.xsl
@@ -18,13 +18,13 @@
   <xsl:template match="o[o[not(eo:void(.))]/following-sibling::o[eo:void(.)]]" mode="with-diff-attrs">
     <xsl:element name="o">
       <xsl:apply-templates select="@*"/>
-      <xsl:for-each select="o[@base='ξ.xi🌵']">
+      <xsl:for-each select="o[@base='ξ' and @name='xi🌵']">
         <xsl:copy-of select="."/>
       </xsl:for-each>
       <xsl:for-each select="o[eo:void(.)]">
         <xsl:copy-of select="."/>
       </xsl:for-each>
-      <xsl:for-each select="o[not(eo:void(.)) and not(@base='ξ.xi🌵')]">
+      <xsl:for-each select="o[not(eo:void(.)) and not(@base='ξ' and @name='xi🌵')]">
         <xsl:apply-templates select="."/>
       </xsl:for-each>
     </xsl:element>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/move-voids-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/move-voids-up.xsl
@@ -18,13 +18,13 @@
   <xsl:template match="o[o[not(eo:void(.))]/following-sibling::o[eo:void(.)]]" mode="with-diff-attrs">
     <xsl:element name="o">
       <xsl:apply-templates select="@*"/>
-      <xsl:for-each select="o[@base='ξ' and @name='xi🌵']">
+      <xsl:for-each select="o[eo:idempotent(.)]">
         <xsl:copy-of select="."/>
       </xsl:for-each>
       <xsl:for-each select="o[eo:void(.)]">
         <xsl:copy-of select="."/>
       </xsl:for-each>
-      <xsl:for-each select="o[not(eo:void(.)) and not(@base='ξ' and @name='xi🌵')]">
+      <xsl:for-each select="o[not(eo:void(.)) and not(eo:idempotent(.))]">
         <xsl:apply-templates select="."/>
       </xsl:for-each>
     </xsl:element>

--- a/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
@@ -66,12 +66,12 @@
     </xsl:apply-templates>
     <xsl:apply-templates select="." mode="tail"/>
     <xsl:value-of select="$eol"/>
-    <xsl:apply-templates select="o[not(eo:void(.)) and not(@base='ξ.xi🌵')]">
+    <xsl:apply-templates select="o[not(eo:void(.)) and not(@base='ξ' and @name='xi🌵')]">
       <xsl:with-param name="indent" select="concat('  ', $indent)"/>
     </xsl:apply-templates>
   </xsl:template>
   <!-- BASED -->
-  <xsl:template match="o[@base and not(@base='ξ.xi🌵') and not(eo:has-data(.))]" mode="head">
+  <xsl:template match="o[@base and not(@base='ξ' and @name='xi🌵') and not(eo:has-data(.))]" mode="head">
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">

--- a/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
@@ -66,12 +66,12 @@
     </xsl:apply-templates>
     <xsl:apply-templates select="." mode="tail"/>
     <xsl:value-of select="$eol"/>
-    <xsl:apply-templates select="o[not(eo:void(.)) and not(@base='ξ' and @name='xi🌵')]">
+    <xsl:apply-templates select="o[not(eo:void(.)) and not(eo:idempotent(.))]">
       <xsl:with-param name="indent" select="concat('  ', $indent)"/>
     </xsl:apply-templates>
   </xsl:template>
   <!-- BASED -->
-  <xsl:template match="o[@base and not(@base='ξ' and @name='xi🌵') and not(eo:has-data(.))]" mode="head">
+  <xsl:template match="o[@base and not(eo:idempotent(.)) and not(eo:has-data(.))]" mode="head">
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
@@ -160,7 +160,7 @@
       <xsl:if test="eo:atom(.)">
         <xsl:text> ?</xsl:text>
       </xsl:if>
-      <xsl:if test="eo:idempotent(.)">
+      <xsl:if test="o[1][eo:idempotent(.)]">
         <xsl:text>'</xsl:text>
       </xsl:if>
     </xsl:if>

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -187,8 +187,8 @@ final class EoSyntaxTest {
             XhtmlMatchers.hasXPaths(
                 "/object[count(o)=1]",
                 "/object/o[count(o)=3]",
-                "/object/o[@name='base' and o[1][@base='ξ.xi\uD83C\uDF35']]",
-                "/object/o[@name='base' and o[3][@name='f' and o[1][@base='ξ.xi\uD83C\uDF35']]]"
+                "/object/o[@name='base' and o[1][@base='ξ' and @name='xi\uD83C\uDF35']]",
+                "/object/o[@name='base' and o[3][@name='f' and o[1][@base='ξ' and @name='xi\uD83C\uDF35']]]"
             )
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/XmirTest.java
@@ -59,7 +59,8 @@ final class XmirTest {
                             .attr("base", "Φ.org.eolang.random")
                             .attr("name", "r")
                             .add("o")
-                            .attr("base", "ξ.xi🌵")
+                            .attr("base", "ξ")
+                            .attr("name", "xi🌵")
                     ).xml()
                 )
             ).toEO(),

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/stars-to-tuples.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/stars-to-tuples.yaml
@@ -7,7 +7,7 @@ sheets:
   - /org/eolang/parser/parse/stars-to-tuples.xsl
 asserts:
   - /object/o[count(o)=9]
-  - /object/o[@name='main' and o[1][@base='ξ.xi🌵']]
+  - /object/o[@name='main' and o[1][@base='ξ' and @name='xi🌵']]
   - /object/o[count(//o[@star])=0]
   # first
   - //o[@base='Φ.org.eolang.tuple.empty' and @line=3 and @name='xs']

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/anonymous-more.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/anonymous-more.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object/o[count(o)=4]
-  - //o[@base='ξ.xi🌵']
+  - //o[@base='ξ' and @name='xi🌵']
 input: |
   # Main.
   [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/anonymous.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/anonymous.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - //object/o[count(o)=4]
-  - //o[@base='ξ.xi🌵']
+  - //o[@base='ξ' and @name='xi🌵']
   - //o[@base='ξ.x.plus' and @name='a']
   - //o[@base='Φ.org.eolang.number' and @name='φ' and o[@base="Φ.org.eolang.bytes"]/o[starts-with(text(), '40-14')]]
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
@@ -6,7 +6,7 @@ sheets: []
 asserts:
   - /object[not(errors)]
   - /object/o[@name='foo'][count(o)=4]
-  - /object/o[@name='foo' and o[1][@base='ξ.xi🌵']]
+  - /object/o[@name='foo' and o[1][@base='ξ' and @name='xi🌵']]
   - /object/o[@name='foo']/o[@base='Φ.org.eolang.true' and @name='+test-works']
   - /object/o[@name='foo']/o[@base='Φ.org.eolang.false' and @name='+always-fails']
   - /object/o[@name='foo']/o[@base='.eq' and @name='+compares-something']

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
@@ -6,10 +6,10 @@ sheets: []
 asserts:
   - /object[not(errors)]
   - /object/o[count(o)=5]
-  - /object/o[@name='foo']/o[@base='ξ.xi🌵']
-  - /object/o[@name='foo']/o[@name='+test-1']/o[not(@base='ξ.xi🌵')]
-  - /object/o[@name='foo']/o[@name='+test-2']/o[not(@base='ξ.xi🌵')]
-  - /object/o[@name='foo']/o[@name='+test-3']/o[not(@base='ξ.xi🌵')]
+  - /object/o[@name='foo']/o[@base='ξ' and @name='xi🌵']
+  - /object/o[@name='foo']/o[@name='+test-1']/o[not(@name='xi🌵')]
+  - /object/o[@name='foo']/o[@name='+test-2']/o[not(@base='xi🌵')]
+  - /object/o[@name='foo']/o[@name='+test-3']/o[not(@base='xi🌵')]
   - /object/o[@name='foo']/o[@name='λ']
 input: |-
   # Foo atom together with the tests.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,8 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵78' and o[1][@base='ξ.xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
-  - //o[not(@base) and @name='a🌵88' and o[1][@base='ξ.xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
+  - //o[not(@base) and @name='a🌵78' and o[1][@name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
+  - //o[not(@base) and @name='a🌵88' and o[1][@name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵78']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵88']]
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation.yaml
@@ -5,8 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='a🌵78' and o[1][@name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
-  - //o[not(@base) and @name='a🌵88' and o[1][@name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
+  - //o[not(@base) and @name='a🌵78' and o[1][@base='ξ' and @name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
+  - //o[not(@base) and @name='a🌵88' and o[1][@base='ξ' and @name='xi🌵'] and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵78']]
   - //o[@base='Φ.org.eolang.while' and o[@base='ξ.a🌵88']]
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/empty-vs-free.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/empty-vs-free.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@name='foo' and count(o)=3 and o[1][@base='ξ.xi🌵']]
+  - //o[@name='foo' and count(o)=3 and o[1][@base='ξ' and @name='xi🌵']]
   - //o[@name='x']
   - //o[@name='y' and not(@base)]
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-idempotency.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-idempotency.yaml
@@ -5,9 +5,9 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='foo' and o[1][@base='ξ.xi🌵'] and o[2][@base='∅' and @name='f']]
-  - //o[not(@base) and @name='bar' and o[1][@base='ξ.xi🌵'] and o[2][@base='∅' and @name='a']]
-  - //o[not(@base) and @name='xyz' and o[1][@base='ξ.xi🌵'] and o[2][@base='∅' and @name='w']]
+  - //o[not(@base) and @name='foo' and o[1][@base='ξ' and @name='xi🌵'] and o[2][@base='∅' and @name='f']]
+  - //o[not(@base) and @name='bar' and o[1][@base='ξ' and @name='xi🌵'] and o[2][@base='∅' and @name='a']]
+  - //o[not(@base) and @name='xyz' and o[1][@base='ξ' and @name='xi🌵'] and o[2][@base='∅' and @name='w']]
 input: |
   [f] > foo
     [a] > bar

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/idempotency.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/idempotency.yaml
@@ -5,7 +5,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@base='Φ.org.eolang.foo' and @name='f' and o[not(@name) and @base='ξ.xi🌵']]
+  - //o[@base='Φ.org.eolang.foo' and @name='f' and o[@base='ξ.xi🌵']]
+  - //o[@base='ξ' and @name='xi🌵']
 input: |
   # No comments.
   [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/numbers.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/numbers.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/o[@name='main']/o[@base='ξ.xi🌵']
+  - /object/o[@name='main']/o[@base='ξ' and @name='xi🌵']
   - /object/o[count(o)=8]
 input: |
   # Main.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/scopes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/scopes.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - //o[not(@base) and count(o)=2 and @name='aliases' and o[1][@base='ξ.xi🌵']]
+  - //o[not(@base) and count(o)=2 and @name='aliases' and o[1][@base='ξ' and @name='xi🌵']]
 input: |
   # No comments.
   [] > aliases


### PR DESCRIPTION
In this PR I've fixed the representation of idempotency attribute. From:

```xml
<o base='ξ.xi🌵'/>
```

To:

```xml
<o base='ξ' name='xi🌵'/>
```

see #4484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved idempotent-object handling across parsing, printing and transpilation to correct traversal and instantiation decisions.

- Refactor
  - Standardized representation of special/internal markers by splitting combined identifiers into separate base and name attributes.

- Tests
  - Updated many assertions to match the new representation and traversal logic.
  - Added a negative assertion to ensure certain constructs are not produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->