### PR TITLE
bug(#4475): `write-larger-data-than-provided-block` test for `malloc-as-output`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -67,3 +67,17 @@
       2
       [m]
         (malloc-as-output m).write 01-02-03 > @
+
+  # @todo #4475:35min Enable `writes-larger-data-than-provided-block` test after resizing will be implemented.
+  #  If the provided memory block is not large enough for the data to write, a runtime error
+  #  happens, however we can use `malloc.of.allocated.resized` to increase the size of the block.
+  [] +> writes-larger-data-than-provided-block
+    eq. > @
+      malloc.of
+        2
+        [mem]
+          seq > @
+            *
+              (malloc-as-output mem).write 01-02-03
+              mem
+      01-02-03

--- a/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/org/eolang/io/malloc-as-output.eo
@@ -71,7 +71,7 @@
   # @todo #4475:35min Enable `writes-larger-data-than-provided-block` test after resizing will be implemented.
   #  If the provided memory block is not large enough for the data to write, a runtime error
   #  happens, however we can use `malloc.of.allocated.resized` to increase the size of the block.
-  [] +> writes-larger-data-than-provided-block
+  [] > writes-larger-data-than-provided-block
     eq. > @
       malloc.of
         2


### PR DESCRIPTION
start of #4475