### PR TITLE
feat(objectionary#4498): added `slice` method in `QQ.structs.list`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -849,7 +849,7 @@
         -1
       * 23 0 0
 
-  # Tests that slice with end grater than length works correctly.
+  # Tests that slice with end greater than length works correctly.
   [] +> tests-slice-with-end-gt-length
     eq. > @
       slice.
@@ -879,7 +879,7 @@
         -9
       list *
 
-  # Tests that slice with start grater than or equal end (both positive) returns an empty list.
+  # Tests that slice with start greater than or equal end (both positive) returns an empty list.
   [] +> tests-slice-with-start-gte-end-both-positive
     eq. > @
       slice.
@@ -889,7 +889,7 @@
         0
       list *
 
-  # Tests that slice with start grater than or equal end (both negative) returns an empty list.
+  # Tests that slice with start greater than or equal end (both negative) returns an empty list.
   [] +> tests-slice-with-start-gte-end-both-negative
     eq. > @
       slice.
@@ -899,7 +899,7 @@
         -5
       list *
 
-  # Tests that slice with negative start grater than or equal end returns an empty list.
+  # Tests that slice with negative start greater than or equal end returns an empty list.
   [] +> tests-slice-with-negative-start-gte-end
     eq. > @
       slice.
@@ -909,7 +909,7 @@
         3
       list *
 
-  # Tests that slice with start grater than or equal negative end returns an empty list.
+  # Tests that slice with start greater than or equal negative end returns an empty list.
   [] +> tests-slice-with-start-gte-negative-end
     eq. > @
       slice.


### PR DESCRIPTION
In this RP, I added the `slice` method to the `QQ.structs.list`, which is similar in functionality to the JavaScript method of the same name. The `slice` method retrieves a sublist from `start` index to `end` index (not inclusive). The method also supports negative indexing.

**Resolves**: #4498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added list slicing: returns a sublist from start (inclusive) to end (exclusive).
  - Supports negative indices (wraps from end), clamps out-of-range values, and returns an empty list when start >= end.

- Tests
  - Added comprehensive tests covering basic slicing, negative indices, oversized bounds, start/end ordering edge cases, and mixed scenarios.

- Chores
  - Updated top-level module metadata and public declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->