### PR TITLE
bug(#4531): auto Phi formation in `vapplicationArgUnboundNext`

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -308,7 +308,7 @@ vapplicationArgUnboundCurrent
 // Ends on the next line
 vapplicationArgUnboundNext
     : formationNamed // vertical abstract object
-    | vapplicationHead oname? vapplicationArgs // vertical application
+    | vapplicationHead (oname | aphi)? vapplicationArgs // vertical application
     | reversed oname? vapplicationArgsReversed // reversed vertical application
     | (happlicationHead | happlicationReversedHead) happlicationTailScoped // scoped horizontal application
     ;

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -697,7 +697,11 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     public void enterVapplicationArgUnboundNext(
         final EoParser.VapplicationArgUnboundNextContext ctx
     ) {
-        // Nothing here
+        if (ctx.aphi() != null) {
+            this.startAutoPhiFormation(
+                ctx, ctx.vapplicationHead().getText()
+            );
+        }
     }
 
     @Override

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-with-nested-vapplication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/auto-phi-formation-with-nested-vapplication.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[not(@base) and @name='a🌵34' and o[2][@name='i' and @base='∅'] and o[3][@name='φ']]
+  - //o[@base='Φ.org.eolang.foo' and o[@base='ξ.a🌵34']]
+input: |
+  [] > main
+    foo > @
+      bar >> [i]
+        xyz


### PR DESCRIPTION
In this PR I’ve updated grammar for `vapplicationArgUnboundNext` to support auto Phi formations.

see #4531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Extended EO syntax support for vertical applications: the element after the head can now be either a name or an implicit φ, enabling automatic φ formation.
  - Improved parsing of nested vertical applications with auto-φ, reducing the need for explicit notation.
- Tests
  - Added a syntax test covering auto-φ formation within nested vertical applications to ensure correct parsing and structure.
- Chores
  - Minor parser behavior refinement to trigger auto-φ formation when applicable, with no breaking changes for existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->