### PR TITLE
ISSUE-4502 Add shifted functionality to list.eo

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/structs/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/structs/list.eo
@@ -934,7 +934,7 @@
         list
           * 8 2 3 4 5
         2
-      list * 3 4 5
+      * 3 4 5
   
   # Tests that shifted will work if the shift parameter is greater than the list length.
   [] +> tests-shifted-with-shift-greater-than-length
@@ -943,4 +943,4 @@
         list
           * 8 2 3 4 5
         6
-      list *
+      *


### PR DESCRIPTION
Add a shifting feature to address issue https://github.com/objectionary/eo/issues/4502

- Leveraged the existing slice function
- Add two tests to verify the behavior for the shift variable is less than length and another test when the shift variable is greater than length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a shifted operation for lists that returns a sublist after removing the first N elements.
  - Supports edge cases: when N is greater than or equal to the list length, it returns an empty list.

- Tests
  - Added tests verifying shifted with N less than the list length returns remaining elements.
  - Added tests verifying shifted with N greater than or equal to the list length returns an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->