### PR TITLE
feat(objectionary#4505): OyRemote.contains can work with directories too

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -69,6 +69,9 @@ public final class MjPull extends MjSafe {
         final String hsh = this.hash.value();
         for (final TjForeign tojo : tojos) {
             final String object = tojo.identifier();
+            if (this.objectionary.isDirectory(object)) {
+                continue;
+            }
             try {
                 tojo.withSource(this.pulled(object, base, hsh))
                     .withHash(new ChNarrow(this.hash));

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
@@ -35,6 +35,15 @@ interface Objectionary {
     boolean contains(String name) throws IOException;
 
     /**
+     * Checks whether a provided object is a directory.
+     *
+     * @param name Object name.
+     * @return Boolean: "true" if directory, "false" if not.
+     * @throws IOException If fails to fetch.
+     */
+    boolean isDirectory(String name) throws IOException;
+
+    /**
      * Objectionary with lambda-function Ctor-s for testing.
      *
      * @since 0.28.11
@@ -52,6 +61,11 @@ interface Objectionary {
          * Function that emulates 'contains()' method in {@link Objectionary}.
          */
         private final Func<? super String, Boolean> container;
+
+        /**
+         * Function that emulates 'isDirectory' method in {@link Objectionary}.
+         */
+        private final Func<? super String, Boolean> checker;
 
         /**
          * Ctor.
@@ -76,7 +90,8 @@ interface Objectionary {
         Fake(final Func<? super String, ? extends Input> gett) {
             this(
                 gett,
-                s -> true
+                s -> true,
+                s -> false
             );
         }
 
@@ -85,13 +100,16 @@ interface Objectionary {
          *
          * @param gett Lambda func for get()
          * @param cont Lambda func for contains()
+         * @param chckr Lambda func for isDirectory()
          */
         Fake(
             final Func<? super String, ? extends Input> gett,
-            final Func<? super String, Boolean> cont
+            final Func<? super String, Boolean> cont,
+            final Func<? super String, Boolean> chckr
         ) {
             this.getter = gett;
             this.container = cont;
+            this.checker = chckr;
         }
 
         @Override
@@ -102,6 +120,11 @@ interface Objectionary {
         @Override
         public boolean contains(final String name) {
             return new Unchecked<>(() -> this.container.apply(name)).value();
+        }
+
+        @Override
+        public boolean isDirectory(final String name) {
+            return new Unchecked<>(() -> this.checker.apply(name)).value();
         }
 
         @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -21,9 +21,14 @@ final class OyCached implements Objectionary {
     private final Objectionary origin;
 
     /**
-     * The cache.
+     * The cache for programs.
      */
-    private final Map<String, Input> cache;
+    private final Map<String, Input> programs;
+
+    /**
+     * The cache for directories.
+     */
+    private final Map<String, Boolean> directories;
 
     /**
      * Ctor.
@@ -36,16 +41,28 @@ final class OyCached implements Objectionary {
     /**
      * Ctor.
      * @param oby The objectionary
-     * @param che The cache
+     * @param progs The cache for programs
      */
-    OyCached(final Objectionary oby, final Map<String, Input> che) {
+    OyCached(final Objectionary oby, final Map<String, Input> progs) {
+        this(oby, progs, new ConcurrentHashMap<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param oby The objectionary
+     * @param progs The cache for programs
+     * @param dirs The cache for directories
+     */
+    OyCached(final Objectionary oby, final Map<String, Input> progs,
+        final Map<String, Boolean> dirs) {
         this.origin = oby;
-        this.cache = che;
+        this.programs = progs;
+        this.directories = dirs;
     }
 
     @Override
     public Input get(final String name) throws IOException {
-        return this.cache.computeIfAbsent(
+        final Input obj = this.programs.computeIfAbsent(
             name, key -> {
                 try {
                     return this.origin.get(name);
@@ -57,10 +74,31 @@ final class OyCached implements Objectionary {
                 }
             }
         );
+        if (obj != null) {
+            this.directories.put(name, false);
+        }
+        return obj;
     }
 
     @Override
     public boolean contains(final String name) throws IOException {
-        return this.cache.containsKey(name) || this.origin.contains(name);
+        return this.programs.containsKey(name) || this.directories.containsKey(name)
+            || this.origin.contains(name);
+    }
+
+    @Override
+    public boolean isDirectory(final String name) throws IOException {
+        return this.directories.computeIfAbsent(
+            name, key -> {
+                try {
+                    return this.origin.isDirectory(name);
+                } catch (final IOException exception) {
+                    throw new IllegalStateException(
+                        "An error occurred during the access to the origin objectionary",
+                        exception
+                    );
+                }
+            }
+        );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyIndexed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyIndexed.java
@@ -66,4 +66,23 @@ final class OyIndexed implements Objectionary {
         }
         return result;
     }
+
+    // @checkstyle IllegalCatchCheck (7 line)
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @Override
+    public boolean isDirectory(final String name) throws IOException {
+        boolean result;
+        try {
+            result = !this.index.contains(name) && this.delegate.isDirectory(name);
+        } catch (final Exception ex) {
+            Logger.warn(
+                this,
+                "Failed to check object %s in objectionary index: %[exception]s",
+                name,
+                ex
+            );
+            result = this.delegate.isDirectory(name);
+        }
+        return result;
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -51,7 +51,7 @@ final class MjProbeTest {
     @Test
     void findsProbesInOyRemote(@Mktmp final Path temp) throws IOException {
         final String tag = "0.50.0";
-        final String expected = "6";
+        final String expected = "10";
         final String found = new FakeMaven(temp)
             .with("tag", tag)
             .with("objectionary", new OyRemote(new ChRemote(tag)))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -89,4 +89,45 @@ final class OyCachedTest {
             Matchers.equalTo(expected)
         );
     }
+
+    @Test
+    void checksIsDirectoryWithEmptyCache() throws IOException {
+        MatcherAssert.assertThat(
+            "The directory should not be found in origin, but it was",
+            new OyCached(
+                new Objectionary.Fake(), new MapOf<>()
+            ).isDirectory("xxx"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void checksIsDirectoryWithExistingInCache() throws IOException {
+        final String key = "abc";
+        final Input value = new InputOf("[] > abc");
+        final Map<String, Input> programs = new MapOf<>();
+        final Map<String, Boolean> dirs = new MapOf<>(key, true);
+        MatcherAssert.assertThat(
+            "The directory should be found in cache, but it was not",
+            new OyCached(
+                new Objectionary.Fake(nme -> value), programs, dirs
+            ).isDirectory(key),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void checksIsDirectoryWithNotExisingInCache() throws IOException {
+        final String key = "jeff";
+        final Input value = new InputOf("[] > jeff");
+        final Map<String, Input> programs = new MapOf<>();
+        final Map<String, Boolean> dirs = new MapOf<>(key, true);
+        MatcherAssert.assertThat(
+            "The directory should not be found in cache, but it was",
+            new OyCached(
+                new Objectionary.Fake(nme -> value), programs, dirs
+            ).isDirectory("key"),
+            Matchers.is(false)
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
@@ -73,4 +73,24 @@ final class OyIndexedTest {
             Matchers.is(true)
         );
     }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    void checksIsDirectoryForObject() throws IOException {
+        MatcherAssert.assertThat(
+            "OyIndexed must contain stdout object, but it doesn't",
+            new OyIndexed(new Objectionary.Fake()).isDirectory(OyIndexedTest.STDOUT_OBJECT),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    void checksIsDirectoryForDirectory() throws IOException {
+        MatcherAssert.assertThat(
+            "OyIndexed must not contain directory, but it does",
+            new OyIndexed(new Objectionary.Fake()).isDirectory("xxx"),
+            Matchers.is(false)
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -22,38 +22,64 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class OyRemoteTest {
 
     @Test
-    void buildsCorrectUrl() throws Exception {
+    void buildsCorrectUrlForProgram() throws Exception {
         MatcherAssert.assertThat(
-            "OyRemove.UrlOy generates correct URL",
+            "OyRemove.UrlOy generates correct URL for program",
             new OyRemote.UrlOy(
-                "https://raw/objectionary/home/%s/objects/%s.eo",
+                "https://github.com/objectionary/home/tree/%s/objects/%s.eo",
                 "abcde"
             ).value("org.eolang.app"),
             Matchers.is(
-                new URL("https://raw/objectionary/home/abcde/objects/org/eolang/app.eo")
+                new URL("https://github.com/objectionary/home/tree/abcde/objects/org/eolang/app.eo")
             )
         );
     }
 
     @Test
-    void throwsExceptionOnInvalidUrl() {
+    void buildsCorrectUrlForDirectory() throws Exception {
+        MatcherAssert.assertThat(
+            "OyRemove.UrlOy generates correct URL for directory",
+            new OyRemote.UrlOy(
+                "https://github.com/objectionary/home/tree/%s/objects/%s",
+                "abcde"
+            ).value("org.eolang.test"),
+            Matchers.is(
+                new URL("https://github.com/objectionary/home/tree/abcde/objects/org/eolang/test")
+            )
+        );
+    }
+
+    @Test
+    void throwsExceptionOnInvalidUrlForProgram() {
         Assertions.assertThrows(
             MalformedURLException.class,
             () -> new OyRemote.UrlOy(
-                "hts:raw.githubusercontent.com/objectionary/home/%s/objects/%s.eo",
-                "abcde"
+                "hts:github.com/objectionary/home/tree/%s/objects/%s.eo",
+                "xyz"
             ).value("org.eolang.app"),
             "Expected MalformedURLException when the URL format is invalid"
         );
     }
 
     @Test
+    void throwsExceptionOnInvalidUrlForDirectory() {
+        Assertions.assertThrows(
+            MalformedURLException.class,
+            () -> new OyRemote.UrlOy(
+                "hts:github.com/objectionary/home/tree/%s/objects/%s",
+                "xyz"
+            ).value("org.eolang.dir"),
+            "Expected MalformedURLException when the URL format is invalid"
+        );
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
-    void checksPresenceOfObject() throws IOException {
+    void checksPresenceOfProgram() throws IOException {
         final CommitHash hash = new ChRemote("master");
         final Objectionary objectionary = new OyRemote(hash);
         MatcherAssert.assertThat(
-            "OyRemote positively checks the presence of the object in Objectionary",
+            "OyRemote positively checks the presence of the program in Objectionary",
             objectionary.contains("org.eolang.io.stdout"),
             Matchers.is(true)
         );
@@ -61,11 +87,41 @@ final class OyRemoteTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
-    void checksPresenceOfObjectWithNarrowHash() throws IOException {
+    void checksPresenceOfDirectory() throws IOException {
+        final CommitHash hash = new ChRemote("master");
+        final Objectionary objectionary = new OyRemote(hash);
+        MatcherAssert.assertThat(
+            "OyRemote positively checks the presence of the directory in Objectionary",
+            objectionary.contains("org.eolang.math"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    void checksPresenceOfProgramWithNarrowHash() throws IOException {
         final String stdout = "org.eolang.io.stdout";
         MatcherAssert.assertThat(
             String.format(
-                "OyRemote with narrow hash should have contained object %s, but it didn't",
+                "OyRemote with narrow hash should have contained program %s, but it didn't",
+                stdout
+            ),
+            new OyRemote(
+                new ChNarrow(
+                    new ChRemote("master")
+                )
+            ).contains(stdout),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    void checksPresenceOfDirectoryWithNarrowHash() throws IOException {
+        final String stdout = "org.eolang.structs";
+        MatcherAssert.assertThat(
+            String.format(
+                "OyRemote with narrow hash should have contained directory %s, but it didn't",
                 stdout
             ),
             new OyRemote(


### PR DESCRIPTION
In this PR, I made it so that the `contains` method from `OyRemote` can accept not only programs, but also directories. I also added the `isDirectory` method, which accepts an object as input and determines whether it is a directory or not. Since `OyRemote` is used in `OyCached` and in `OyIndexed`, I have refined the logic for them as well. Tests have been written for all changes.
**Resolves**: #4505 