### PR TITLE
#4654 Move out `list.reducedi`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ss/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/list.eo
@@ -1,4 +1,5 @@
 +alias org.eolang.ss.list
++alias org.eolang.ss.reducedi
 +alias org.eolang.tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -45,34 +46,13 @@
       back
         origin.length.minus index
 
-  # Reduce with index from "start" using the function "func".
-  # Here "func" must be an abstract object with three free attributes.
-  # The first one for the accumulator, the second one
-  # for the element of the collection and the third one for the index.
-  [start func] > reducedi
-    if. > @
-      is-empty
-      start
-      rec-reducedi origin
-
-    [tup] > rec-reducedi
-      if. > @
-        tup.length.eq 1
-        func
-          start
-          tup.head
-          0
-        func
-          rec-reducedi tup.tail
-          tup.head
-          tup.tail.length
-
   # Reduce from "start" using the function "func".
   # Here "func" must be an abstract object with two free attributes.
   # The first one for the accumulator, the second one for the element
   # of the collection.
   [start func] > reduced
     reducedi > @
+      ^
       start
       func accum item > [accum item idx] >>
 
@@ -83,6 +63,7 @@
   [func] > mappedi
     list > @
       reducedi
+        ^
         *
         [accum item idx] >>
           accum.with > @
@@ -102,6 +83,7 @@
   # The result of `func` must be dataizable.
   [func] > eachi
     reducedi > @
+      ^
       true
       [acc item index] >>
         seq * > @
@@ -119,6 +101,7 @@
   [i] > withouti
     list > @
       reducedi
+        ^
         *
         [accum item idx] >>
           if. > @
@@ -156,7 +139,8 @@
 
   # Concatenates current list with given one.
   [passed] > concat
-    (list passed).reducedi > @
+    reducedi > @
+      list passed
       ^
       accum.with item > [accum item index]
 
@@ -258,6 +242,7 @@
       ^
       list
         reducedi
+          ^
           *
           [accum item idx] >>
             if. > @
@@ -274,6 +259,7 @@
       list *
       list
         reducedi
+          ^
           *
           [accum item idx] >>
             if. > @
@@ -362,57 +348,6 @@
         0
         "hello"
       * "hello" 1 2 3 4 5
-
-  # Tests that reducing a list with index access works correctly.
-  [] +> tests-reduce-list-with-index
-    eq. > @
-      6
-      reducedi.
-        list
-          * 1 1
-        0
-        [a x i] >>
-          plus. > @
-            x
-            a.plus
-              (* 2 2).at i
-
-  # Tests that reducing a long array of integers with index works correctly.
-  [] +> tests-list-reducedi-long-int-array
-    eq. > @
-      reducedi.
-        list
-          * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
-        0
-        x.plus a > [a x i]
-      1
-
-  # Tests that reducing an array of boolean values with index works correctly.
-  [] +> tests-list-reducedi-bools-array
-    not. > @
-      reducedi.
-        list
-          * true true false
-        true
-        x.and a > [a x i]
-
-  # Tests that reducing with nested functions and conditional logic works correctly.
-  [] +> tests-list-reducedi-nested-functions
-    eq. > @
-      reducedi.
-        list
-          * 10 500
-        0
-        [acc x i]
-          check x > @
-          [el] > check
-            if. > @
-              ^.x.lt 100
-              ^.acc.plus x
-              ^.acc.minus x
-      plus.
-        10
-        0.minus 500
 
   # Tests that reducing a list without index access works correctly.
   [] +> tests-list-reduce-without-index

--- a/eo-runtime/src/main/eo/org/eolang/ss/reducedi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/reducedi.eo
@@ -1,0 +1,81 @@
++alias org.eolang.ss.list
++alias org.eolang.ss.reducedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Reduce list with index from "start" using the function "func".
+# Here "func" must be an abstract object with three free attributes.
+# The first one for the accumulator, the second one
+# for the element of the collection and the third one for the index.
+[lst start func] > reducedi
+  if. > @
+    lst.is-empty
+    start
+    rec-reducedi lst
+
+  [tup] > rec-reducedi
+    if. > @
+      tup.length.eq 1
+      func
+        start
+        tup.head
+        0
+      func
+        rec-reducedi tup.tail
+        tup.head
+        tup.tail.length
+
+  # Tests that reducing a list with index access works correctly.
+  [] +> tests-reduce-list-with-index
+    eq. > @
+      6
+      reducedi
+        list
+          * 1 1
+        0
+        [a x i] >>
+          plus. > @
+            x
+            a.plus
+              (* 2 2).at i
+
+  # Tests that reducing a long array of integers with index works correctly.
+  [] +> tests-list-reducedi-long-int-array
+    eq. > @
+      reducedi
+        list
+          * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
+        0
+        x.plus a > [a x i]
+      1
+
+  # Tests that reducing an array of boolean values with index works correctly.
+  [] +> tests-list-reducedi-bools-array
+    not. > @
+      reducedi
+        list
+          * true true false
+        true
+        x.and a > [a x i]
+
+  # Tests that reducing with nested functions and conditional logic works correctly.
+  [] +> tests-list-reducedi-nested-functions
+    eq. > @
+      reducedi
+        list
+          * 10 500
+        0
+        [acc x i]
+          check x > @
+          [el] > check
+            if. > @
+              ^.x.lt 100
+              ^.acc.plus x
+              ^.acc.minus x
+      plus.
+        10
+        0.minus 500


### PR DESCRIPTION
#4654 

In this PR I've moved `reducedi` object out of `list`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reduce-with-index functionality to process lists with index-aware operations, supporting three-argument functions (accumulator, element, index).

* **Tests**
  * Added comprehensive test coverage for new functionality, including integer arrays, boolean lists, and nested function scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->