### PR TITLE
fix(#4708): resolve ArrayIndexOutOfBoundsException in debug mode for EoSyntax

### DIFF
--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -109,7 +109,12 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <!-- version from parent POM -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>1.2.22</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -203,7 +203,7 @@ public final class EoSyntax implements Syntax {
             );
         } else {
             Logger.debug(
-                this, "The %s program of %d EO lines compiled with %d error(s)",
+                this, "The program of %d EO lines compiled with %d error(s)",
                 lines.size(), errors
             );
         }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.log4j.Level;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Mapped;
@@ -31,10 +32,14 @@ import org.eolang.xax.Xtory;
 import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -48,7 +53,25 @@ import org.xml.sax.SAXParseException;
  * @since 0.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
+@Execution(ExecutionMode.SAME_THREAD)
 final class EoSyntaxTest {
+
+    /**
+     * Log level before test.
+     */
+    private Level before;
+
+    @BeforeEach
+    void setUp() {
+        final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(EoSyntax.class);
+        this.before = logger.getLevel();
+    }
+
+    @AfterEach
+    void tearDown() {
+        final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(EoSyntax.class);
+        logger.setLevel(this.before);
+    }
 
     @Test
     void parsesSimpleCode() throws Exception {
@@ -68,6 +91,23 @@ final class EoSyntaxTest {
                 "/object/metas/meta[head='meta2']",
                 "/object/o[@name='fibo']"
             )
+        );
+    }
+
+    @Test
+    void parsesSimpleCodeWithDebugMode() {
+        final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(EoSyntax.class);
+        logger.setLevel(Level.DEBUG);
+        final EoSyntax syntax = new EoSyntax(
+            String.join(
+                "\n",
+                "# No comments.",
+                "[] > x-н, 1\n"
+            )
+        );
+        Assertions.assertDoesNotThrow(
+            syntax::parsed,
+            "EO syntax should not fail in debug mode when program has errors"
         );
     }
 


### PR DESCRIPTION
This PR fixes an `ArrayIndexOutOfBoundsException` in `EoSyntax` when debug mode is enabled.

Fixes #4708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test exercising parser behavior in debug/logging mode and lifecycle setup to preserve logger state.

* **Chores**
  * Updated test logging dependencies and scopes.
  * Simplified error message formatting for clearer, less verbose logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->