### PR TITLE
test(#4702): check 'class' element in OnDefault class to ensure object name resolution

### DIFF
--- a/eo-maven-plugin/src/it/fibonacci/invoker.properties
+++ b/eo-maven-plugin/src/it/fibonacci/invoker.properties
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 invoker.mavenOpts = -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-invoker.goals = clean test
+invoker.goals = clean test -X

--- a/eo-maven-plugin/src/it/fibonacci/src/main/eo/org/eolang/examples/app.eo
+++ b/eo-maven-plugin/src/it/fibonacci/src/main/eo/org/eolang/examples/app.eo
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +package org.eolang.examples
 +alias org.eolang.examples.fibonacci
 +alias org.eolang.io.stdout

--- a/eo-maven-plugin/src/it/fibonacci/src/main/eo/org/eolang/examples/fibonacci.eo
+++ b/eo-maven-plugin/src/it/fibonacci/src/main/eo/org/eolang/examples/fibonacci.eo
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +package org.eolang.examples
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -245,7 +245,7 @@ final class MjParseTest {
             ),
             XhtmlMatchers.hasXPaths(
                 "//error[@severity='critical']",
-                "//error[text()=\"XMIR should have '/object/o/@name' attribute\"]"
+                "//error[text()=\"XMIR should have either '/object/o/@name' or '/object/class/@name' attribute\"]"
             )
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -80,6 +80,26 @@ final class MjTranspileTest {
     }
 
     @Test
+    void transpilesSimpleProgram(@Mktmp final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp)
+                .withProgram(
+                    String.join(
+                        "\n",
+                        "+architect yegor256@gmail.com",
+                        "+package org.eolang.examples",
+                        "",
+                        "# This is the main abstract object",
+                        "[] > x"
+                    )
+                ).with("trackTransformationSteps", true)
+                .execute(MjParse.class)
+                .execute(MjTranspile.class),
+            "We should be able to transpile a simple EO program without exceptions when tracking transformation steps"
+        );
+    }
+
+    @Test
     void throwsDetailedError(@Mktmp final Path temp) {
         final IllegalStateException exception = Assertions.assertThrows(
             IllegalStateException.class,
@@ -94,7 +114,9 @@ final class MjTranspileTest {
             "TranspileMojo should throw an exception with detailed message on invalid EO code",
             writer.toString(),
             Matchers.allOf(
-                Matchers.containsString("XMIR should have '/object/o/@name' attribute"),
+                Matchers.containsString(
+                    "XMIR should have either '/object/o/@name' or '/object/class/@name' attribute"
+                ),
                 Matchers.containsString("main.xmir' encountered some problems, broken syntax?")
             )
         );


### PR DESCRIPTION
One of the errors reported in the `fibonacci` integration test was:

```
XMIR should have '/object/o/@name' attribute
```

This exception was thrown by `OnDefault`. It tries to find an object name in XMIR. This exact error happened because during XMIR -> Java transformation we create several XMIR-like files that instead of `object` contain `class` element. Thus, in these cases we need to look for an object name in a `class` element instead of `object` element.

Related to #4702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sprintf and sscanf library aliases for use in programs

* **Documentation**
  * Updated package metadata, license header formatting, and architect information

* **Refactor**
  * Improved parser robustness with fallback object-name resolution and clearer error messaging

* **Tests**
  * Added a transpilation test and relaxed error-message assertions to accept alternate name attributes

* **Chores**
  * Test runs now enable Maven debug logging for more detailed output

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->