### PR TITLE
test(#4714): add unit tests for OnDefault class in eo-parser module

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/OnDefault.java
+++ b/eo-parser/src/main/java/org/eolang/parser/OnDefault.java
@@ -16,10 +16,6 @@ import java.util.Optional;
  * <p>If package is present - it'll be joined with object name by dot.
  * Otherwise, only object name without package is returned.</p>
  * @since 0.52
- * @todo #4702:30min Add tests for {@link OnDefault} class.
- *  For some reason this class is not covered by tests at all.
- *  We need to add unit tests that will cover all possible cases of
- *  object name resolution including cases with and without package meta.
  */
 public final class OnDefault implements ObjectName {
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/OnDefaultTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/OnDefaultTest.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link OnDefault}.
+ *
+ * @since 0.60
+ */
+final class OnDefaultTest {
+
+    @Test
+    void returnsObjectNameWhenOnlyONamePresent() {
+        MatcherAssert.assertThat(
+            "We should get object name 'hello'",
+            new OnDefault(new XMLDocument("<object><o name='hello'/></object>")).get(),
+            Matchers.equalTo("hello")
+        );
+    }
+
+    @Test
+    void joinsPackageWithObjectNameWhenPackageMetaPresent() {
+        MatcherAssert.assertThat(
+            "We should get 'org.example.world' when package meta is present",
+            new OnDefault(
+                new XMLDocument(
+                    String.join(
+                        "\n",
+                        "<object>",
+                        "    <o name='world'/>",
+                        "    <metas>",
+                        "      <meta>",
+                        "        <head>package</head>",
+                        "        <tail>org.example</tail>",
+                        "      </meta>",
+                        "    </metas>",
+                        "</object>"
+                    )
+                )
+            ).get(),
+            Matchers.equalTo("org.example.world")
+        );
+    }
+
+    @Test
+    void usesClassNameWhenONameMissing() {
+        MatcherAssert.assertThat(
+            "We should get class name 'Clazz' when o name is missing",
+            new OnDefault(
+                new XMLDocument(
+                    "<object><class name='Clazz'/></object>"
+                )
+            ).get(),
+            Matchers.equalTo("Clazz")
+        );
+    }
+
+    @Test
+    void throwsWhenNeitherONameNorClassNamePresent() {
+        MatcherAssert.assertThat(
+            "Expecting exception when neither o name nor class name present",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new OnDefault(new XMLDocument("<object></object>")).get(),
+                "We should throw IllegalStateException"
+            ).getMessage(),
+            Matchers.equalTo(
+                "XMIR should have either '/object/o/@name' or '/object/class/@name' attribute"
+            )
+        );
+    }
+
+    @Test
+    void ignoresNonPackageMetaAndReturnsObjectName() {
+        MatcherAssert.assertThat(
+            "We should get object name 'o' when non-package meta is present",
+            new OnDefault(
+                new XMLDocument(
+                    String.join(
+                        "\n",
+                        "<object>",
+                        "    <o name='o'/>",
+                        "    <metas>",
+                        "      <meta>",
+                        "        <head>author</head>",
+                        "        <tail>me</tail>",
+                        "      </meta>",
+                        "    </metas>",
+                        "</object>"
+                    )
+                )
+            ).get(),
+            Matchers.equalTo("o")
+        );
+    }
+
+    @Test
+    void doesNotUsePackageMetaWithoutTail() {
+        MatcherAssert.assertThat(
+            "We should get object name 'o' when package meta has no tail",
+            new OnDefault(
+                new XMLDocument(
+                    String.join(
+                        "\n",
+                        "<object>",
+                        "    <o name='x'/>",
+                        "    <metas>",
+                        "      <meta>",
+                        "        <head>package</head>",
+                        "      </meta>",
+                        "    </metas>",
+                        "</object>"
+                    )
+                )
+            ).get(),
+            Matchers.equalTo("x")
+        );
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for the `OnDefault` class in the `eo-parser` module.

Fixes #4714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for the OnDefault parser component, covering various parsing scenarios and edge cases.

* **Documentation**
  * Removed outdated code comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->