### PR TITLE
feat(#4717): print stackstrace if `--verbose` option is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ eo-runtime/measures.csv
 node_modules/
 target/
 xs3p.xsl_*
+build.log
+interpolated-pom.xml

--- a/eo-integration-tests/src/it/fibonacci/README.md
+++ b/eo-integration-tests/src/it/fibonacci/README.md
@@ -1,7 +1,13 @@
 <img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
 
 This is a simple example a program written entirely in EO.
-You can use the files from this directory as a template.
+To run this program only you might use the following command:
+
+```bash
+mvn invoker:run -Dinvoker.test=fibonacci
+```
+
+Additionally, you can use the files from this directory as a template.
 The only change you will have to do is setting
 the right versions the `pom.xml`. Use the latest version
 visible in this badge:

--- a/eo-integration-tests/src/it/fibonacci/pom.xml
+++ b/eo-integration-tests/src/it/fibonacci/pom.xml
@@ -92,6 +92,7 @@
         <configuration>
           <mainClass>org.eolang.Main</mainClass>
           <arguments>
+            <argument>--verbose</argument>
             <argument>org.eolang.examples.app</argument>
             <argument>6</argument>
             <argument>8</argument>

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -76,7 +76,7 @@ final class MainTest {
     void executesJvmFullRun() {
         MatcherAssert.assertThat(
             "Incorrect verbose output when dataizing \"false\" object",
-            MainTest.stderr("--verbose", "org.eolang.false"),
+            MainTest.stderr(Main.VERBOSE, "org.eolang.false"),
             Matchers.allOf(
                 Matchers.containsString("EOLANG"),
                 Matchers.containsString("false")
@@ -88,7 +88,7 @@ final class MainTest {
     void executesJvmFullRunWithDashedObject() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.stderr("--verbose", "as-bytes"),
+            MainTest.stderr(Main.VERBOSE, "as-bytes"),
             Matchers.containsString("Couldn't find object 'Φ.as-bytes'")
         );
     }
@@ -97,7 +97,7 @@ final class MainTest {
     void executesJvmFullRunWithAttributeCall() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.stderr("--verbose", "string$as-bytes"),
+            MainTest.stderr(Main.VERBOSE, "string$as-bytes"),
             Matchers.containsString("Couldn't find object 'Φ.string$as-bytes'")
         );
     }
@@ -106,7 +106,7 @@ final class MainTest {
     void executesJvmFullRunWithError() {
         MatcherAssert.assertThat(
             "Fails with the proper error message",
-            MainTest.stderr("--verbose", "org.eolang.io.stdout"),
+            MainTest.stderr(Main.VERBOSE, "org.eolang.io.stdout"),
             Matchers.containsString(
                 "Error in \"Φ.org.eolang.io.stdout.φ.Δ\" "
             )
@@ -174,6 +174,19 @@ final class MainTest {
                 )
             ).read(),
             Matchers.greaterThan(0)
+        );
+    }
+
+    @Test
+    void printsFullStacktraceIfVerboseIsEnabled() {
+        MatcherAssert.assertThat(
+            "Prints full stacktrace when verbose mode is enabled",
+            MainTest.stderr("--verbose", "org.eolang.examples.app"),
+            Matchers.allOf(
+                Matchers.containsString("at org.eolang.PhPackage.loadPhi"),
+                Matchers.containsString("at org.eolang.PhPackage.take"),
+                Matchers.containsString("at org.eolang.Main.run")
+            )
         );
     }
 


### PR DESCRIPTION
This PR refactors code a bit and makes the code to print stacktrase in case of error if `--verbose` option is enabled.
Without it it's almost imposible further ivestigation.

Related to #4717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --verbose flag to show full stack traces on errors.
  * Improved version and help option support in command-line interface.

* **Documentation**
  * Updated Fibonacci example with an explicit command to run the test.

* **Chores**
  * Added additional build-related files to .gitignore.
  * Enabled verbose execution for the integration test run.

* **Tests**
  * Added a test verifying full stack traces are produced when --verbose is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->