### PR TITLE
test(#4717): add Fibonacci integration tests to JarIT class

### DIFF
--- a/eo-integration-tests/src/test/java/integration/JarIT.java
+++ b/eo-integration-tests/src/test/java/integration/JarIT.java
@@ -44,13 +44,116 @@ final class JarIT {
                     "    \"Hello, world!\""
                 );
                 MatcherAssert.assertThat(
-                    "simple program must be successfully executed from jar",
+                    "simple program must be successfully executed",
                     new Jaxec(
                         "java", "-cp", classpath,
                         "-Dfile.encoding=UTF-8", "-Xss64M", "-Xms64M",
                         "org.eolang.Main", "simple"
                     ).withHome(temp.resolve("target")).exec().stdout(),
                     Matchers.containsString("Hello, world!")
+                );
+            }
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    @ExtendWith(MayBeSlow.class)
+    void runsProgramWithPackageFromJar(final @Mktmp Path temp) throws IOException {
+        new Farea(temp).together(
+            f -> {
+                final String classpath = JarIT.compile(
+                    f,
+                    "+package org.eolang.examples",
+                    "",
+                    "# Program with a package.",
+                    "[args] > packaged",
+                    "  QQ.io.stdout > @",
+                    "    \"Hello, world from a program with a package!\""
+                );
+                MatcherAssert.assertThat(
+                    "'packaged' program must be successfully executed",
+                    new Jaxec(
+                        "java", "-cp", classpath,
+                        "-Dfile.encoding=UTF-8", "-Xss64M", "-Xms64M",
+                        "org.eolang.Main", "org.eolang.examples.packaged"
+                    ).withHome(temp.resolve("target")).exec().stdout(),
+                    Matchers.containsString("Hello, world from a program with a package!")
+                );
+            }
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    @ExtendWith(MayBeSlow.class)
+    void runsProgramWithTwoObjects(final @Mktmp Path temp) throws IOException {
+        new Farea(temp).together(
+            f -> {
+                final String classpath = JarIT.compile(
+                    f,
+                    new ElegantObject(
+                        "app",
+                        new String[]{
+                            "+package org.eolang.examples",
+                            "+alias org.eolang.examples.fibonacci",
+                            "+alias org.eolang.io.stdout",
+                            "+alias org.eolang.tt.sprintf",
+                            "+alias org.eolang.tt.sscanf",
+                            "+architect yegor256@gmail.com",
+                            "",
+                            "# Application.",
+                            "[args] > app",
+                            "  number > n",
+                            "    at. > nn!",
+                            "      QQ.tt.sscanf",
+                            "        \"%d\"",
+                            "        args.at 0",
+                            "      0",
+                            "  at. > e!",
+                            "    QQ.tt.sscanf",
+                            "      \"%d\"",
+                            "      args.at 1",
+                            "    0",
+                            "  fibonacci n > f!",
+                            "  and. > @",
+                            "    stdout",
+                            "      sprintf",
+                            "        \"%dth Fibonacci number is %d\\n\"",
+                            "        * n f",
+                            "    e.eq f",
+                        }
+                    ),
+                    new ElegantObject(
+                        "fibonacci",
+                        new String[]{
+                            "+package org.eolang.examples",
+                            "+architect yegor256@gmail.com",
+                            "",
+                            "# This is the main abstract object that",
+                            "# represents n-th Fibonacci number",
+                            "[n] > fibonacci",
+                            "  if. > @",
+                            "    lt.",
+                            "      n",
+                            "      2",
+                            "    n",
+                            "    plus.",
+                            "      ^.fibonacci",
+                            "        n.minus 1",
+                            "      ^.fibonacci",
+                            "        n.minus 2",
+                        }
+                    )
+                );
+                MatcherAssert.assertThat(
+                    "'fibonacci' program must be successfully executed",
+                    new Jaxec(
+                        "java", "-cp", classpath,
+                        "-Dfile.encoding=UTF-8", "-Xss64M", "-Xms64M",
+                        "org.eolang.Main", "org.eolang.examples.app", "6", "8"
+                    ).withHome(temp.resolve("target")).exec().stdout(),
+                    Matchers.containsString("6th Fibonacci number is 8")
                 );
             }
         );
@@ -95,12 +198,25 @@ final class JarIT {
      * @throws IOException If fails to compile
      */
     private static String compile(final Farea farea, final String... program) throws IOException {
+        return JarIT.compile(farea, new ElegantObject(program));
+    }
+
+    /**
+     * Compile EO program to XMIR and package it into a JAR.
+     * @param farea Farea to use for compilation
+     * @param objects The EO programs to compile
+     * @return Classpath for the compiled program, with eo-runtime jar
+     * @throws IOException If fails to compile
+     */
+    private static String compile(
+        final Farea farea, final ElegantObject... objects
+    ) throws IOException {
         farea.properties()
             .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
             .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
-        farea.files()
-            .file("src/main/eo/simple.eo")
-            .write(String.join("\n", program).getBytes(StandardCharsets.UTF_8));
+        for (final ElegantObject object : objects) {
+            object.write(farea);
+        }
         farea.dependencies()
             .append(
                 "org.eolang",
@@ -137,5 +253,50 @@ final class JarIT {
             "test-0.0.0.jar",
             runtime
         );
+    }
+
+    /**
+     * An EO object represented as a file name and its content.
+     * @since 0.60
+     */
+    private static final class ElegantObject {
+        /**
+         * File name.
+         */
+        private final String file;
+
+        /**
+         * File content.
+         */
+        private final String content;
+
+        /**
+         * Ctor.
+         * @param content File content
+         */
+        private ElegantObject(final String... content) {
+            this("simple", content);
+        }
+
+        /**
+         * Ctor.
+         * @param file File name
+         * @param content File content
+         */
+        private ElegantObject(final String file, final String... content) {
+            this.file = file;
+            this.content = String.join("\n", content);
+        }
+
+        /**
+         * Write the EO object to Farea.
+         * @param farea Farea
+         * @throws IOException If fails to write
+         */
+        void write(final Farea farea) throws IOException {
+            farea.files()
+                .file(String.format("src/main/eo/%s.eo", this.file))
+                .write(this.content.getBytes(StandardCharsets.UTF_8));
+        }
     }
 }


### PR DESCRIPTION
This PR implements the `Fibonacci` integration test in `JarIT.java`.

This is the part of the fix https://github.com/objectionary/eo/pull/4726 (I created a separate PR to fit into 200 lines of code.)

Related to #4717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for packaging multiple objects together into a single JAR file
  * Enhanced JAR compilation with package path support

* **Tests**
  * Added test coverage for compiled JAR execution with packages
  * Added test coverage for multi-object JAR compilation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->