### PR TITLE
test(#4756): add tests for ChSource to improve coverage and handle edge cases

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChSource.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChSource.java
@@ -40,18 +40,18 @@ final class ChSource implements CommitHash {
 
     /**
      * Constructor.
-     * @param src Source file
+     * @param input Source text
      */
-    private ChSource(final File src) {
-        this(new TextOf(src));
+    ChSource(final Text input) {
+        this(new ScalarOf<>(input::asString));
     }
 
     /**
      * Constructor.
-     * @param input Source text
+     * @param src Source file
      */
-    private ChSource(final Text input) {
-        this(new ScalarOf<>(input::asString));
+    private ChSource(final File src) {
+        this(new TextOf(src));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChSourceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChSourceTest.java
@@ -9,18 +9,19 @@ import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link ChSource}.
  *
  * @since 0.60
- * @todo #4526:30min Add more tests for {@link ChSource} class.
- *  Currently, there is only one test that checks the hash computation for a file.
- *  We need to add more tests to cover edge cases.
  */
 @ExtendWith(MktmpResolver.class)
 final class ChSourceTest {
@@ -36,6 +37,45 @@ final class ChSourceTest {
             "We should compute the correct hash (SHA-1) for the source file",
             new ChSource(file).value(),
             Matchers.equalTo("f97a8da03d184cab9a43e1288293391fb1ccc296")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "",
+            " ",
+            "    ",
+            "\n",
+            "\r\n",
+            "\t",
+            " \n\r\t "
+        }
+    )
+    void computesHashForDifferentTrickyValues(final String original) {
+        MatcherAssert.assertThat(
+            "We should compute correct hash for tricky values",
+            new ChSource(new TextOf(original)).value(),
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.not(Matchers.blankString()),
+                Matchers.hasLength(40)
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "hello, aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+        "world, 7c211433f02071597741e6ff5a8ea34789abbf43",
+        "eo-lang, 0af005396f4908b9a813149c18bb1220da6e1b3f",
+        "Maven Plugin, 85c363ac6898a8462b017caaf972ac0e79ef8b2c"
+    })
+    void computesHashForDifferentValues(final String original, final String expected) {
+        MatcherAssert.assertThat(
+            "We should compute correct hash for different values",
+            new ChSource(() -> original).value(),
+            Matchers.equalTo(expected)
         );
     }
 }


### PR DESCRIPTION
This PR enhances test coverage for the `ChSource` class in `ChSourceTest.java`, addressing puzzle #4526.

Fixes #4756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for hash computation with edge case validation, including whitespace-only strings and specific hash output scenarios.

* **Refactor**
  * Internal accessibility adjustments to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->