### PR TITLE
fix(#4718): add `transpileTests` option

### DIFF
--- a/eo-integration-tests/src/it/fibonacci/pom.xml
+++ b/eo-integration-tests/src/it/fibonacci/pom.xml
@@ -21,12 +21,6 @@
       <artifactId>eo-runtime</artifactId>
       <version>@project.version@</version>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <!-- version from parent POM -->
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
@@ -34,22 +28,6 @@
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <failIfNoTests>false</failIfNoTests>
-          <!--
-            @todo #4702:90min EO tests are distributed with the eo-runtime library.
-            Currently, when we add 'eo-runtime' as a dependency, the surefire plugin
-            tries to run its tests as well, which takes significant time.
-            And it's rathter unexpected behavior when we just need to run an EO app.
-            We should either don't include EO tests in the eo-runtime jar,
-            or state it clearly in the documentation that when you add eo-runtime
-            as a dependency, you also get its tests.
-          -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
@@ -65,9 +43,16 @@
           </execution>
         </executions>
         <configuration>
+          <transpileTests>false</transpileTests>
           <ignoreRuntime>true</ignoreRuntime>
           <failOnWarning>false</failOnWarning>
           <skipLinting>true</skipLinting>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
         </configuration>
       </plugin>
       <plugin>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -10,13 +10,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import org.cactoos.Proc;
+import org.cactoos.BiProc;
 
 /**
  * Placed Java generated code.
  * @since 0.56.7
  */
-final class JavaPlaced implements Proc<Xnav> {
+final class JavaPlaced implements BiProc<Xnav, Boolean> {
 
     /**
      * The footprint.
@@ -46,11 +46,11 @@ final class JavaPlaced implements Proc<Xnav> {
     }
 
     @Override
-    public void exec(final Xnav clazz) throws IOException {
+    public void exec(final Xnav clazz, final Boolean tests) throws IOException {
         if (clazz.element("java").text().isPresent()) {
             this.footprint.apply(Paths.get(""), this.target);
         }
-        if (JavaPlaced.testsPresent(clazz)) {
+        if (tests && JavaPlaced.testsPresent(clazz)) {
             this.placeJavaTests(clazz);
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -109,13 +109,13 @@ public final class MjTranspile extends MjSafe {
     private boolean addSourcesRoot = true;
 
     /**
-     * Add to test source root.
+     * Whether to transpile tests.
      *
      * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.addTestSourcesRoot")
-    @SuppressWarnings("PMD.LongVariable")
-    private boolean addTestSourcesRoot;
+    @Parameter(property = "eo.transpileTests")
+    @SuppressWarnings("PMD.ImmutableField")
+    private boolean transpileTests = true;
 
     @Override
     public void exec() throws IOException {
@@ -246,7 +246,7 @@ public final class MjTranspile extends MjSafe {
                         ),
                         tgt,
                         this.generatedDir.toPath()
-                    ).exec(clazz);
+                    ).exec(clazz, this.transpileTests);
                 }
             }
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -38,7 +38,7 @@ final class JavaPlacedTest {
             ),
             target,
             generated
-        ).exec(java);
+        ).exec(java, false);
         MatcherAssert.assertThat(
             "Generated Java code does not match with expected",
             new TextOf(target).asString(),
@@ -64,7 +64,9 @@ final class JavaPlacedTest {
                 new Directives().add("class").attr("java-name", "Foo").add("tests").set(expected)
             ).xml()
         ).element("class");
-        new JavaPlaced(new FpJavaGenerated(java, generated, utest), utest, generated).exec(java);
+        new JavaPlaced(
+            new FpJavaGenerated(java, generated, utest), utest, generated
+        ).exec(java, true);
         MatcherAssert.assertThat(
             "Generated tests does not match with expected",
             new TextOf(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileIT.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileIT.java
@@ -21,10 +21,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Integration tests for {@link MjTranspile}.
  *
  * @since 0.52
+ * @todo #4718:90min Make {@linkg MjTranspileIT} independent on the previous eo-maven-plugin.
+ *  The tests in {@link MjTranspileIT} depend on the eo-maven-plugin being installed
+ *  on the local maven repository instead of using the current one.
+ *  We should either move these tests to eo-integration-tests, or find a way to use
+ *  the current eo-maven-plugin build for testing.
+ *  Otherwise, these tests check the previous version of the plugin.
  */
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class, RandomProgramResolver.class})
 final class MjTranspileIT {
+
     @Test
     void transpilesWithPackage(@Mktmp final Path temp) throws Exception {
         new Farea(temp).together(


### PR DESCRIPTION
The new 'transpileTests' option prevents EO tests from being included with the `eo-runtime` library.

Fixes #4718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a build parameter to control transpiling of test sources (transpileTests, defaults to true).

* **Refactor**
  * Simplified test-runner configuration and replaced an inlined plugin block with a minimal surefire setup (no-fail if no tests).
  * Removed an explicit JUnit API test dependency from the integration test build.

* **Tests**
  * Updated tests to respect the new transpile-tests setting.
  * Added a TODO note in integration tests clarifying current setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->