### PR TITLE
fix(#4696): enable SnippetIT integration tests

### DIFF
--- a/eo-integration-tests/src/test/java/integration/SnippetIT.java
+++ b/eo-integration-tests/src/test/java/integration/SnippetIT.java
@@ -22,7 +22,6 @@ import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 


### PR DESCRIPTION
This PR enables the `SnippetIT` test by removing the `@Disabled` annotation, resolving puzzle `4679`.

Fixes #4696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled integration tests to improve coverage and reliability.
* **Documentation**
  * Removed an outdated TODO from test documentation for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->