### PR TITLE
fix(#371): exclude 'eo-maven-plugin' from the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 .idea/
-eo-maven-plugin/
+.settings/
+.project
 eo-parser/
 eo-runtime/
+eo-integration-tests/
 paper/
 target/
 .DS_Store
+.aidy
+.aider.*


### PR DESCRIPTION
I removed `eo-maven-plugin` from the ignore list in `gh-pages` branch. 

Related to #371 