### PR TITLE
feat(objectionary#4751): separated `abs` from `real`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ms/abs.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/abs.eo
@@ -1,0 +1,44 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ms
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Absolute value of `num` (i.e., with no sign).
+[num] > abs
+  if. > @
+    value.gte 0
+    value
+    value.neg
+  number num.as-bytes > value
+
+  # Tests that absolute value of positive integer is the integer itself.
+  [] +> tests-abs-int-positive
+    eq. +> @
+      abs 3
+      3
+
+  # Tests that absolute value of negative integer removes the sign.
+  [] +> tests-abs-int-negative
+    eq. +> @
+      abs -3
+      3
+
+  # Tests that absolute value of zero is zero.
+  [] +> tests-abs-zero
+    eq. +> @
+      abs 0
+      0
+
+  # Tests that absolute value of positive float is the float itself.
+  [] +> tests-abs-float-positive
+    eq. +> @
+      abs 13.5
+      13.5
+
+  # Tests that absolute value of negative float removes the sign.
+  [] +> tests-abs-float-negative
+    eq. +> @
+      abs -17.9
+      17.9

--- a/eo-runtime/src/main/eo/org/eolang/ms/exp.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/exp.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ms.real
 +alias org.eolang.ms.e
++alias org.eolang.ms.abs
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -14,7 +15,7 @@
   # Tests that exponential function e^1 approximately equals e.
   [] +> tests-exp-check-n0
     lt. +> @
-      abs.
+      abs
         real
           minus.
             e
@@ -24,7 +25,7 @@
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n1
     lt. +> @
-      abs.
+      abs
         real
           minus.
             1.div e
@@ -34,7 +35,7 @@
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n2
     lt. +> @
-      abs.
+      abs
         real
           minus.
             (real e).pow 5
@@ -44,7 +45,7 @@
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n3
     lt. +> @
-      abs.
+      abs
         real
           minus.
             (real e).pow -10

--- a/eo-runtime/src/main/eo/org/eolang/ms/mod.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/mod.eo
@@ -1,4 +1,5 @@
 +alias org.eolang.ms.real
++alias org.eolang.ms.abs
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -25,8 +26,8 @@
       divisor-abs.times
         floor.
           dividend-abs.div divisor-abs
-    (real dividend).abs > dividend-abs
-    (real divisor).abs > divisor-abs
+    abs dividend > dividend-abs
+    abs divisor > divisor-abs
 
   # Tests that modulo operation works correctly for 1 mod 2.
   [] +> tests-mod-n1-n2

--- a/eo-runtime/src/main/eo/org/eolang/ms/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/real.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ms.e
 +alias org.eolang.ms.pi
++alias org.eolang.ms.abs
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -14,15 +15,6 @@
 # todo #4751:15min Remove `real` object when all inner objects are moved to a separate files
 [num] > real
   num > @
-
-  # Absolute value of `num` (i.e., with no sign).
-  # todo #4751:10min Move `abs` to a separate object with it's tests.
-  [] > abs
-    if. > @
-      value.gte 0
-      value
-      value.neg
-    number num.as-bytes > value
 
   # An operation that raises `^.num` (a number) to the power of `x` and returns the result as
   # `org.eolang.number`.
@@ -50,36 +42,6 @@
   # todo #4751:15min Move `asin` to a separate object with it's tests.
   # It's atom, don't forget change `EOreal$EOasin`.
   [] > asin ?
-
-  # Tests that absolute value of positive integer is the integer itself.
-  [] +> tests-abs-int-positive
-    eq. +> @
-      (real 3).abs
-      3
-
-  # Tests that absolute value of negative integer removes the sign.
-  [] +> tests-abs-int-negative
-    eq. +> @
-      (real -3).abs
-      3
-
-  # Tests that absolute value of zero is zero.
-  [] +> tests-abs-zero
-    eq. +> @
-      (real 0).abs
-      0
-
-  # Tests that absolute value of positive float is the float itself.
-  [] +> tests-abs-float-positive
-    eq. +> @
-      (real 13.5).abs
-      13.5
-
-  # Tests that absolute value of negative float removes the sign.
-  [] +> tests-abs-float-negative
-    eq. +> @
-      (real -17.9).abs
-      17.9
 
   # Tests that power operation works correctly for 2^4.
   [] +> tests-pow-test
@@ -329,7 +291,7 @@
   # Tests that square root of zero equals zero.
   [] +> tests-sqrt-check-zero-input
     lt. +> @
-      abs.
+      abs
         real
           minus.
             0
@@ -346,7 +308,7 @@
   # Tests that square root calculation works correctly for float input.
   [] +> tests-sqrt-check-float-input
     lt. +> @
-      abs.
+      abs
         real
           minus.
             2
@@ -358,7 +320,7 @@
   # Tests that square root calculation works correctly for integer input.
   [] +> tests-sqrt-check-int-input
     lt. +> @
-      abs.
+      abs
         real
           minus.
             9
@@ -466,7 +428,7 @@
   # Tests mathematical operation functionality.
   [] +> tests-arccos-positive-calculated-test
     lt. +> @
-      abs.
+      abs
         real
           minus.
             acos.
@@ -477,7 +439,7 @@
   # Tests mathematical operation functionality.
   [] +> tests-arccos-negative-calculated-test
     lt. +> @
-      abs.
+      abs
         real
           minus.
             acos.


### PR DESCRIPTION
In this PR, I separated `abs` object from `real`.

**Resolves**: #4751.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new absolute value mathematical operation supporting both integers and floating-point numbers for enhanced numeric computations

* **Tests**
  * Added comprehensive test suite covering all key edge cases including positive integers, negative integers, zero values, positive floats, and negative floats

* **Refactor**
  * Reorganized mathematical operations module structure to improve overall code organization and system maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->