### PR TITLE
bug(#4496): reversed notation before star

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Eo.g4
@@ -229,12 +229,12 @@ vapplicationHead
     : applicable
     | hmethod
     | vmethod
-    | compactArray
+    | compactTuple
     ;
 
-// Compact arrays
-compactArray
-    : (hmethod | applicable) SPACE STAR INT?
+// Compact tuple
+compactTuple
+    : (hmethod | applicable | reversed) SPACE STAR INT?
     ;
 
 // Vertical application arguments

--- a/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
+++ b/eo-parser/src/main/java/org/eolang/parser/XeEoListener.java
@@ -534,12 +534,12 @@ final class XeEoListener implements EoListener, Iterable<Directive> {
     }
 
     @Override
-    public void enterCompactArray(final EoParser.CompactArrayContext ctx) {
+    public void enterCompactTuple(final EoParser.CompactTupleContext ctx) {
         // Nothing here
     }
 
     @Override
-    public void exitCompactArray(final EoParser.CompactArrayContext ctx) {
+    public void exitCompactTuple(final EoParser.CompactTupleContext ctx) {
         final int count;
         if (ctx.INT() != null) {
             final String num = ctx.INT().getText();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/validate-resolve-before-stars.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/validate-resolve-before-stars.yaml
@@ -12,6 +12,7 @@ asserts:
   - //o[@name='third' and count(o)=3]/o[position()=3 and @base='Φ.org.eolang.tuple' and @star and count(o)=1]
   - //o[@name='fourth' and count(o)=2]/o[@base='sprintf' and count(o)=1]/o[@base='Φ.org.eolang.tuple' and @star and count(o)=2]
   - //o[@name='fourth']/o[@base='Φ.org.eolang.tuple' and @star and count(o)=1]
+  - //o[@name='sixth' and @base='.joined' and o[@base='text']/o[@base='Φ.org.eolang.string'] and o[@base='Φ.org.eolang.tuple' and @star]]
   - /object[count(//o[@before-star])=0]
 input: |
   # No comments.
@@ -34,3 +35,7 @@ input: |
         x
         y
       z
+    joined. *1 > sixth
+      text ""
+      x
+      y


### PR DESCRIPTION
Closes: #4496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated parser to use tuple-based structures instead of array-based structures for improved handling of compact expressions.

* **Tests**
  * Added test coverage for tuple resolution and validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->