### PR TITLE
feat(objectionary#4654): separated `reduced` from `list`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/fs/path.eo
+++ b/eo-runtime/src/main/eo/org/eolang/fs/path.eo
@@ -2,6 +2,7 @@
 +alias org.eolang.fs.file
 +alias org.eolang.sm.os
 +alias org.eolang.ss.list
++alias org.eolang.ss.reduced
 +alias org.eolang.tt.regex
 +alias org.eolang.tt.index-of
 +alias org.eolang.tt.last-index-of
@@ -84,7 +85,7 @@
           separator
       QQ.tt.joined > path
         separator
-        reduced.
+        reduced
           list
             split
               uri
@@ -333,7 +334,7 @@
             separator
         QQ.tt.joined > path!
           separator
-          reduced.
+          reduced
             list
               split
                 driveless

--- a/eo-runtime/src/main/eo/org/eolang/ms/numbers.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/numbers.eo
@@ -1,4 +1,5 @@
 +alias org.eolang.ss.list
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -16,7 +17,7 @@
     if. > @
       lst.is-empty
       error "Can't get the max number from an empty sequence"
-      reduced.
+      reduced
         lst
         negative-infinity
         [max item]
@@ -31,7 +32,7 @@
     if. > @
       lst.is-empty
       error "Can't get the min number from an empty sequence"
-      reduced.
+      reduced
         lst
         positive-infinity
         [min item]

--- a/eo-runtime/src/main/eo/org/eolang/ss/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/list.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ss.list
 +alias org.eolang.ss.reducedi
++alias org.eolang.ss.reduced
 +alias org.eolang.ss.eachi
 +alias org.eolang.tt.sprintf
 +architect yegor256@gmail.com
@@ -47,16 +48,6 @@
       back
         origin.length.minus index
 
-  # Reduce from "start" using the function "func".
-  # Here "func" must be an abstract object with two free attributes.
-  # The first one for the accumulator, the second one for the element
-  # of the collection.
-  [start func] > reduced
-    reducedi > @
-      ^
-      start
-      func accum item > [accum item idx] >>
-
   # Map with index. Here "func" must be an abstract
   # object with two free attributes. The first
   # one for the element of the collection, the second one
@@ -101,6 +92,7 @@
   [element] > without
     list > @
       reduced
+        ^
         *
         [accum item] >>
           if. > @
@@ -336,30 +328,6 @@
         0
         "hello"
       * "hello" 1 2 3 4 5
-
-  # Tests that reducing a list without index access works correctly.
-  [] +> tests-list-reduce-without-index
-    eq. > @
-      reduced.
-        list
-          * 1 2 3 4
-        -1
-        a.times x > [a x]
-      -24
-
-  # Tests that reducing a list to create a formatted string works correctly.
-  [] +> tests-list-reduced-printing
-    eq. > @
-      reduced.
-        list
-          * 0 1
-        ""
-        [acc item]
-          acc.concat > @
-            sprintf
-              "%d"
-              * item
-      "01"
 
   # Tests that comparing complex nested lists works correctly.
   [] +> tests-complex-objects-list-comparison

--- a/eo-runtime/src/main/eo/org/eolang/ss/reduced.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/reduced.eo
@@ -1,0 +1,43 @@
++alias org.eolang.ss.list
++alias org.eolang.ss.reducedi
++alias org.eolang.tt.sprintf
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Reduce `lst` from "start" using the function "func".
+# Here "func" must be an abstract object with two free attributes.
+# The first one for the accumulator, the second one for the element
+# of the collection.
+[lst start func] > reduced
+  reducedi > @
+    lst
+    start
+    func accum item > [accum item idx] >>
+
+  # Tests that reducing a list without index access works correctly.
+  [] +> tests-list-reduce-without-index
+    eq. > @
+      reduced
+        list
+          * 1 2 3 4
+        -1
+        a.times x > [a x]
+      -24
+
+  # Tests that reducing a list to create a formatted string works correctly.
+  [] +> tests-list-reduced-printing
+    eq. > @
+      reduced
+        list
+          * 0 1
+        ""
+        [acc item]
+          acc.concat > @
+            sprintf
+              "%d"
+              * item
+      "01"

--- a/eo-runtime/src/main/eo/org/eolang/tt/chained.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/chained.eo
@@ -1,4 +1,5 @@
 +alias org.eolang.ss.list
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -13,7 +14,7 @@
     0.eq others.length
     text
     string
-      reduced.
+      reduced
         list others
         text.as-bytes
         accum.concat str.as-bytes > [accum str]

--- a/eo-runtime/src/main/eo/org/eolang/tt/contains-all.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/contains-all.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.tt.contains
 +alias org.eolang.ss.list
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -9,7 +10,7 @@
 
 # Checks if `text` contains all elements from `substrings`
 [text substrings] > contains-all
-  reduced. > @
+  reduced > @
     mapped.
       substrings
       contains text-bts x > [x] >>

--- a/eo-runtime/src/main/eo/org/eolang/tt/contains-any.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/contains-any.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.tt.contains
 +alias org.eolang.ss.list
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -9,7 +10,7 @@
 
 # Checks if `text` contains any element from `substrings`
 [text substrings] > contains-any
-  reduced. > @
+  reduced > @
     mapped.
       substrings
       contains text-bts x > [x] >>

--- a/eo-runtime/src/main/eo/org/eolang/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/low-cased.eo
@@ -1,6 +1,7 @@
 +alias org.eolang.tt.up-cased
 +alias org.eolang.ss.list
 +alias org.eolang.ss.bytes-as-array
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -11,7 +12,7 @@
 # Returns the `text` in lower case.
 [text] > low-cased
   string > @
-    reduced.
+    reduced
       list
         bytes-as-array
           text.as-bytes

--- a/eo-runtime/src/main/eo/org/eolang/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/up-cased.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ss.list
 +alias org.eolang.ss.bytes-as-array
++alias org.eolang.ss.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -10,7 +11,7 @@
 # Returns the `text` in upper case.
 [text] > up-cased
   string > @
-    reduced.
+    reduced
       list
         bytes-as-array
           text.as-bytes


### PR DESCRIPTION
In this PR, I separated `reduced` object from `list`.

**Resolves**: #4654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added list reduction operation enabling custom accumulation logic on list elements with a starting value.

* **Refactors**
  - Standardized syntax across list operations for improved consistency.
  - Enhanced module metadata with architect information, versioning, and licensing declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->