### PR TITLE
feat(objectionary#4751): separated `pow` from `real`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ms/exp.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/exp.eo
@@ -1,6 +1,7 @@
 +alias org.eolang.ms.real
 +alias org.eolang.ms.e
 +alias org.eolang.ms.abs
++alias org.eolang.ms.pow
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -10,7 +11,7 @@
 
 # Returns Euler's number raised to the power of a `num`.
 [num] > exp
-  (real e).pow num > @
+  pow e num > @
 
   # Tests that exponential function e^1 approximately equals e.
   [] +> tests-exp-check-n0
@@ -38,7 +39,7 @@
       abs
         real
           minus.
-            (real e).pow 5
+            pow e 5
             exp 5
       0.0000001
 
@@ -48,7 +49,7 @@
       abs
         real
           minus.
-            (real e).pow -10
+            pow e -10
             exp -10
       0.000000000001
 

--- a/eo-runtime/src/main/eo/org/eolang/ms/pow.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/pow.eo
@@ -1,0 +1,11 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ms
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# An operation that raises `num` to the power of `x`.
+[num x] > pow ?

--- a/eo-runtime/src/main/eo/org/eolang/ms/real.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ms/real.eo
@@ -1,6 +1,7 @@
 +alias org.eolang.ms.e
 +alias org.eolang.ms.pi
 +alias org.eolang.ms.abs
++alias org.eolang.ms.pow
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ms
@@ -15,12 +16,6 @@
 # todo #4751:15min Remove `real` object when all inner objects are moved to a separate files
 [num] > real
   num > @
-
-  # An operation that raises `^.num` (a number) to the power of `x` and returns the result as
-  # `org.eolang.number`.
-  # todo #4751:15min Move `pow` to a separate object with it's tests.
-  # It's atom, don't forget change `EOreal$EOpow`.
-  [x] > pow ?
 
   # Returns the positive square root of a `num` as `org.eolang.number`.
   # todo #4751:15min Move `sqrt` to a separate object with it's tests.
@@ -43,249 +38,250 @@
   # It's atom, don't forget change `EOreal$EOasin`.
   [] > asin ?
 
+  # todo #4751:15min Move tests for `pow` to `pow.eo`.
   # Tests that power operation works correctly for 2^4.
   [] +> tests-pow-test
     eq. +> @
-      (real 2).pow 4
+      pow 2 4
       16
 
   # Tests that any number raised to the power of zero equals 1.
   [] +> tests-pow-is-zero
     eq. +> @
-      (real 2).pow 0
+      pow 2 0
       1
 
   # Tests that large number raised to large negative power approaches zero.
   [] +> tests-pow-is-negative
     eq. +> @
-      (real 984782).pow -12341
+      pow 984782 -12341
       0
 
   # Tests that 3 raised to the power of 2 equals 9.
   [] +> tests-pow-of-two
     eq. +> @
-      (real 3).pow 2
+      pow 3 2
       9
 
   # Tests that zero raised to any positive power equals zero.
   [] +> tests-pow-of-zero
     eq. +> @
-      (real 0).pow 145
+      pow 0 145
       0
 
   # Tests that zero raised to negative power throws error.
   [] +> throws-on-negative-pow-of-zero
-    (real 0).pow -567 +> @
+    pow 0 -567 +> @
 
   # Tests that NaN raised to NaN power results in NaN.
   # Check pow works with NaNs.
   [] +> tests-nan-to-the-pow-of-nan-is-nan
     is-nan. +> @
-      (real nan).pow nan
+      pow nan nan
 
   # Tests that NaN raised to any power results in NaN.
   [] +> tests-nan-to-the-pow-of-any-is-nan
     is-nan. +> @
-      (real nan).pow 42
+      pow nan 42
 
   # Tests that any number raised to NaN power results in NaN.
   [] +> tests-any-to-the-pow-of-nan-is-nan
     is-nan. +> @
-      (real 52).pow nan
+      pow 52 nan
 
   # Tests that any integer raised to the power of zero equals 1.
   # Check if pow is zero.
   [] +> tests-any-int-to-the-pow-of-zero-is-one
     eq. +> @
-      (real 42).pow 0
+      pow 42 0
       1
 
   # Tests that any float raised to the power of zero equals 1.
   [] +> tests-any-float-to-the-pow-of-zero-is-one
     eq. +> @
-      (real 42.5).pow 0
+      pow 42.5 0
       1
 
   # Tests that zero raised to negative power equals positive infinity.
   # Check if pow is less than zero.
   [] +> tests-zero-to-the-negative-pow-is-positive-infinity
     eq. +> @
-      (real 0).pow -52
+      pow 0 -52
       positive-infinity
 
   # Tests that zero raised to negative infinity equals positive infinity.
   [] +> tests-zero-to-the-negative-infinity-pow-is-positive-infinity
     eq. +> @
-      (real 0).pow negative-infinity
+      pow 0 negative-infinity
       positive-infinity
 
   # Tests that positive integer raised to negative infinity equals zero.
   [] +> tests-positive-int-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real 42).pow negative-infinity
+      pow 42 negative-infinity
       0
 
   # Tests that positive float raised to negative infinity equals zero.
   [] +> tests-positive-float-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real 42.5).pow negative-infinity
+      pow 42.5 negative-infinity
       0
 
   # Tests that negative integer raised to negative infinity equals zero.
   [] +> tests-negative-int-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real -42).pow negative-infinity
+      pow -42 negative-infinity
       0
 
   # Tests that negative float raised to negative infinity equals zero.
   [] +> tests-negative-float-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real -42.5).pow negative-infinity
+      pow -42.5 negative-infinity
       0
 
   # Tests that positive infinity raised to negative infinity equals zero.
   [] +> tests-positive-infinity-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real positive-infinity).pow negative-infinity
+      pow positive-infinity negative-infinity
       0
 
   # Tests that negative infinity raised to negative infinity equals zero.
   [] +> tests-negative-infinity-to-the-pow-of-negative-infinity-is-zero
     eq. +> @
-      (real negative-infinity).pow negative-infinity
+      pow negative-infinity negative-infinity
       0
 
   # Tests that positive infinity raised to finite negative power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-int-pow-is-zero
     eq. +> @
-      (real positive-infinity).pow -42
+      pow positive-infinity -42
       0
 
   # Tests that positive infinity raised to finite negative float power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-float-pow-is-zero
     eq. +> @
-      (real positive-infinity).pow -42.2
+      pow positive-infinity -42.2
       0.0
 
   # Tests that 2 raised to the power of -1 equals 0.5.
   [] +> tests-two-to-the-pow-of-minus-one
     eq. +> @
-      (real 2).pow -1
+      pow 2 -1
       0.5
 
   # Tests that 2 raised to the power of -2 equals 0.25.
   [] +> tests-two-to-the-pow-of-int-minus-two
     eq. +> @
-      (real 2).pow -2
+      pow 2 -2
       0.25
 
   # Tests mathematical operation functionality.
   [] +> tests-two-to-the-pow-of-minus-three
     eq. +> @
-      (real 2).pow -3
+      pow 2 -3
       0.125
 
   # Tests mathematical operation functionality.
   [] +> tests-four-to-the-pow-of-minus-three
     eq. +> @
-      (real 4).pow -3.0
+      pow 4 -3.0
       0.015625
 
   # Tests mathematical operation functionality.
   # Check if pow more than zero.
   [] +> tests-zero-to-the-pow-of-positive-int-is-zero
     eq. +> @
-      (real 0).pow 4
+      pow 0 4
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-zero-to-the-pow-of-positive-float-is-zero
     eq. +> @
-      (real 0).pow 4.2
+      pow 0 4.2
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-zero-to-the-pow-of-positive-infinity-is-zero
     eq. +> @
-      (real 0).pow positive-infinity
+      pow 0 positive-infinity
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-int-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. +> @
-      (real -10).pow positive-infinity
+      pow -10 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-float-to-the-pow-of-positive-infinity-is-infinity
     eq. +> @
-      (real -4.2).pow positive-infinity
+      pow -4.2 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. +> @
-      (real 42).pow positive-infinity
+      pow 42 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. +> @
-      (real 42.5).pow positive-infinity
+      pow 42.5 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
     eq. +> @
-      (real positive-infinity).pow 42
+      pow positive-infinity 42
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
     eq. +> @
-      (real positive-infinity).pow 10.8
+      pow positive-infinity 10.8
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. +> @
-      (real positive-infinity).pow positive-infinity
+      pow positive-infinity positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
     eq. +> @
-      (real negative-infinity).pow 9.9
+      pow negative-infinity 9.9
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
     eq. +> @
-      (real negative-infinity).pow 10
+      pow negative-infinity 10
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
     eq. +> @
-      (real negative-infinity).pow 9
+      pow negative-infinity 9
       negative-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-int-is-int
     eq. +> @
-      (real 2).pow 3
+      pow 2 3
       8
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-int-is-float
     eq. +> @
-      (real 3.5).pow 4
+      pow 3.5 4
       150.0625
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-float-is-float
     eq. +> @
-      (real 4).pow 5
+      pow 4 5
       1024
 
   # Tests that square root of zero equals zero.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOms/EOpow.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOms/EOpow.java
@@ -22,14 +22,15 @@ import org.eolang.XmirObject;
  * @since 0.40
  * @checkstyle TypeNameCheck (100 lines)
  */
-@XmirObject(oname = "real.pow")
+@XmirObject(oname = "pow")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOreal$EOpow extends PhDefault implements Atom {
+public final class EOpow extends PhDefault implements Atom {
     /**
      * Ctor.
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public EOreal$EOpow() {
+    public EOpow() {
+        this.add("num", new AtVoid("num"));
         this.add("x", new AtVoid("x"));
     }
 
@@ -37,7 +38,7 @@ public final class EOreal$EOpow extends PhDefault implements Atom {
     public Phi lambda() {
         return new ToPhi(
             Math.pow(
-                new Dataized(this.take(Phi.RHO)).asNumber(),
+                new Dataized(this.take("num")).asNumber(),
                 new Dataized(this.take("x")).asNumber()
             )
         );


### PR DESCRIPTION
In this PR, I separated `pow` object from `real`. But the tests are still in `real.eo` due to the PR size limit.

**Resolves**: #4751 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added org.eolang.ms.pow operation for computing base raised to exponent, with comprehensive handling of edge cases including zero, negative exponents, infinity, and NaN.

* **Tests**
  * Extensive test suite added covering integer powers, negative exponents, special values (infinity, NaN), and mixed numeric types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->