### PR TITLE
feat(objectionary#4654): separated `mappedi` from `list`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ss/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/list.eo
@@ -2,6 +2,7 @@
 +alias org.eolang.ss.reducedi
 +alias org.eolang.ss.reduced
 +alias org.eolang.ss.eachi
++alias org.eolang.ss.mappedi
 +alias org.eolang.tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -48,24 +49,12 @@
       back
         origin.length.minus index
 
-  # Map with index. Here "func" must be an abstract
-  # object with two free attributes. The first
-  # one for the element of the collection, the second one
-  # for the index.
-  [func] > mappedi
-    list > @
-      reducedi
-        ^
-        *
-        [accum item idx] >>
-          accum.with > @
-            func item idx
-
   # Map without index. Here "func" must be an abstract
   # object with one free attribute, for the element
   # of the collection.
   [func] > mapped
     mappedi > @
+      ^
       func item > [item idx] >>
 
   # For each collection element dataize the object
@@ -341,15 +330,6 @@
         * 0 1
         * 4 0
         * 7 3
-
-  # Tests that mapping with index access transforms elements correctly.
-  [] +> tests-list-mappedi-should-work
-    eq. > @
-      mappedi.
-        list
-          * 1 2 3 4
-        i.times x > [x i]
-      * 0 2 6 12
 
   # Tests that mapping without index transforms elements correctly.
   [] +> tests-simple-list-mapping

--- a/eo-runtime/src/main/eo/org/eolang/ss/mappedi.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/mappedi.eo
@@ -1,0 +1,30 @@
++alias org.eolang.ss.list
++alias org.eolang.ss.reducedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Map `lst` with index. Here "func" must be an abstract
+# object with two free attributes. The first
+# one for the element of the collection, the second one
+# for the index.
+[lst func] > mappedi
+  list > @
+    reducedi
+      lst
+      *
+      [accum item idx] >>
+        accum.with > @
+          func item idx
+
+  # Tests that mapping with index access transforms elements correctly.
+  [] +> tests-list-mappedi-should-work
+    eq. > @
+      mappedi
+        list
+          * 1 2 3 4
+        i.times x > [x i]
+      * 0 2 6 12


### PR DESCRIPTION
In this PR, I separated `mappedi` object from `list`.

**Resolves**: #4654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the `mappedi` functionality for mapping list elements with index information into a dedicated standalone module. This change improves code organization and maintains all existing capabilities.

* **Tests**
  * Tests for index-aware list mapping continue to validate correct behavior with indexed element transformations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->