### PR TITLE
Add logging for transpilation duration and clean up invoker properties

### DIFF
--- a/eo-integration-tests/src/it/fibonacci/invoker.properties
+++ b/eo-integration-tests/src/it/fibonacci/invoker.properties
@@ -1,5 +1,3 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
-
-invoker.mavenOpts = -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-invoker.goals = clean test -X
+invoker.goals = clean test

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -123,6 +123,7 @@ public final class MjTranspile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
+        final long begin = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.scopedTojos().withXmir();
         final int saved = new Threaded<>(
             sources,
@@ -147,6 +148,11 @@ public final class MjTranspile extends MjSafe {
                 gtests
             );
         }
+        Logger.info(
+            this,
+            "Transpilation took %[ms]s in total",
+            System.currentTimeMillis() - begin
+        );
     }
 
     /**


### PR DESCRIPTION
Add transpilation duration printing.

Related to #4838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transpilation now reports total execution time, providing visibility into build performance.

* **Chores**
  * Reduced Maven verbosity in test configuration for cleaner output during test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->