### PR TITLE
perf(#4838): measure transpilation time

### DIFF
--- a/eo-integration-tests/src/it/fibonacci/invoker.properties
+++ b/eo-integration-tests/src/it/fibonacci/invoker.properties
@@ -1,3 +1,3 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
-invoker.goals = clean test
+invoker.goals = clean test -X

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -176,7 +176,16 @@ public final class MjTranspile extends MjSafe {
         new FpDefault(
             src -> {
                 rewrite.compareAndSet(false, true);
-                return transform.apply(xmir).toString();
+                final long start = System.currentTimeMillis();
+                final String res = transform.apply(xmir).toString();
+                Logger.debug(
+                    this,
+                    "Transpiled %[file]s to %[file]s in %[ms]s (cache miss)",
+                    source,
+                    target,
+                    System.currentTimeMillis() - start
+                );
+                return res;
             },
             this.cache.toPath().resolve(MjTranspile.CACHE),
             this.plugin.getVersion(),
@@ -227,6 +236,7 @@ public final class MjTranspile extends MjSafe {
         final Path target,
         final String hsh
     ) throws IOException {
+        final long begin = System.currentTimeMillis();
         final AtomicInteger saved = new AtomicInteger(0);
         if (Files.exists(target)) {
             final Xnav object = new Xnav(target).element("object");
@@ -259,6 +269,11 @@ public final class MjTranspile extends MjSafe {
                     ).exec(clazz, this.transpileTests);
                 }
             }
+            Logger.debug(
+                this,
+                "Generated %d Java files from %[file]s in %[ms]s",
+                saved.get(), target, System.currentTimeMillis() - begin
+            );
         }
         return saved.get();
     }


### PR DESCRIPTION
This PR enhances logging in the `MjTranspile` class to measure and report transpilation times.

Related to #4838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution timing and diagnostic logging for transpilation and Java file generation processes.

* **Chores**
  * Updated test execution configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->