### PR TITLE
fix(#4840): remove 'semver' field from 'FpIfRleased' and improve logging

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FpDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FpDefault.java
@@ -18,10 +18,7 @@ import org.cactoos.io.InputOf;
  *    It can be created from source, or from global cache if cache exists, is cacheable, and
  *    is newer than source.
  * 3) the cache is updated if it is cacheable (it does not exist or if it is older than source)
- * 4) if the semver is "0.0.0" or "SNAPSHOT" ({@link FpIfReleased}) - the target is always
- *    regenerated and cache is not touched at all.
  * </p>
- *
  * <p>Excluding any type of errors there are 4 possible scenarios
  * of this {@link Footprint} work:
  * 1) do nothing and just return target file.
@@ -96,7 +93,7 @@ final class FpDefault extends FpEnvelope {
         final Path tail,
         final boolean global
     ) {
-        this(generated, semver, hash, new CachePath(base, semver, hash, tail), global);
+        this(generated, hash, new CachePath(base, semver, hash, tail), global);
     }
 
     /**
@@ -104,14 +101,12 @@ final class FpDefault extends FpEnvelope {
      * <p>Here {@link FpIfReleased} is on the first place because we don't want to work with any
      * type of cache (local or global) if we work with SNAPSHOT version of the plugin</p>
      * @param generated Footprint that generates content
-     * @param semver Cache version
      * @param hash Cache hash
      * @param cache Lazy cache path
      * @param global Is global cache enabled or not
      */
     private FpDefault(
         final Footprint generated,
-        final String semver,
         final Supplier<String> hash,
         final Supplier<Path> cache,
         final boolean global
@@ -119,7 +114,6 @@ final class FpDefault extends FpEnvelope {
         super(
             new FpExistedSource(
                 new FpIfReleased(
-                    semver,
                     hash,
                     new FpIfOlder(
                         new FpIgnore(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FpIfReleased.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FpIfReleased.java
@@ -9,10 +9,8 @@ import java.util.function.Supplier;
 
 /**
  * Footprint that behaves like one of the given footprints depending on
- * hash and semver of provided cache.
- * Similar to {@link FpFork} but the condition is based on versioning and hash.
- * If the version is not a released one (e.g. "0.0.0" or "SNAPSHOT")
- * or the hash is empty, the second footprint is used, otherwise the first one.
+ * hash of provided cache.
+ * Similar to {@link FpFork} but the condition is based on hash.
  * @since 0.41
  * @checkstyle ParameterNumberCheck (100 lines)
  */
@@ -20,29 +18,25 @@ final class FpIfReleased extends FpEnvelope {
 
     /**
      * Ctor.
-     * @param semver Cache version
      * @param hash Git hash
      * @param first First footprint to use if a version is released and a hash is present
      * @param second Second footprint to use if a version is not released or a hash is not present
      */
     FpIfReleased(
-        final String semver,
         final String hash,
         final Footprint first,
         final Footprint second
     ) {
-        this(semver, () -> hash, first, second);
+        this(() -> hash, first, second);
     }
 
     /**
      * Ctor.
-     * @param semver Cache version
      * @param hash Git hash
      * @param first First footprint to use if a version is released and a hash is present
      * @param second Second footprint to use if a version is not released or a hash is not present
      */
     FpIfReleased(
-        final String semver,
         final Supplier<String> hash,
         final Footprint first,
         final Footprint second
@@ -55,14 +49,14 @@ final class FpIfReleased extends FpEnvelope {
                     if (cacheable) {
                         Logger.debug(
                             FpIfReleased.class,
-                            "The version '%s' and hash '%s' are good, using cache for %[file]s",
-                            semver, hsh, target
+                            "The hash '%s' is good, using cache for %[file]s",
+                            hsh, target
                         );
                     } else {
                         Logger.debug(
                             FpIfReleased.class,
-                            "The version is '%s' but hash is absent, not using cache for %[file]s",
-                            semver, target
+                            "The hash is absent, not using cache for %[file]s",
+                            target
                         );
                     }
                     return cacheable;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -136,7 +136,6 @@ public final class MjPull extends MjSafe {
         );
         final Footprint both = new FpUpdateBoth(generated, che);
         return new FpIfReleased(
-            this.plugin.getVersion(),
             hsh,
             new FpFork(
                 (src, tgt) -> {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -180,9 +180,11 @@ public final class MjTranspile extends MjSafe {
                 final String res = transform.apply(xmir).toString();
                 Logger.debug(
                     this,
-                    "Transpiled %[file]s to %[file]s in %[ms]s (cache miss)",
+                    "Transpiled %[file]s (%s) to %[file]s (%s) in %[ms]s (cache miss)",
                     source,
+                    MjTranspile.info(source),
                     target,
+                    MjTranspile.info(target),
                     System.currentTimeMillis() - start
                 );
                 return res;
@@ -194,6 +196,22 @@ public final class MjTranspile extends MjSafe {
             this.cacheEnabled
         ).apply(source, target);
         return this.javaGenerated(rewrite.get(), target, hsh.get());
+    }
+
+    /**
+     * File info for logging.
+     * @param info Path to file
+     * @return Info string
+     * @throws IOException If fails
+     */
+    private static String info(final Path info) throws IOException {
+        final String res;
+        if (Files.exists(info)) {
+            res = Files.getLastModifiedTime(info).toString();
+        } else {
+            res = "Not exists yet";
+        }
+        return res;
     }
 
     /**
@@ -254,7 +272,6 @@ public final class MjTranspile extends MjSafe {
                     );
                     new JavaPlaced(
                         new FpIfReleased(
-                            this.plugin.getVersion(),
                             hsh,
                             new FpAppliedWithCache(
                                 java,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfReleasedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfReleasedTest.java
@@ -21,7 +21,6 @@ final class FpIfReleasedTest {
         Assertions.assertThrows(
             NullPointerException.class,
             () -> new FpIfReleased(
-                "1.2.3",
                 () -> null,
                 (source, target) -> source,
                 (source, target) -> target
@@ -34,7 +33,6 @@ final class FpIfReleasedTest {
     void choosesTheFirstFootprintBecauseCacheable(@TempDir final Path tmp) throws IOException {
         final Path src = tmp.resolve("first");
         final Path result = new FpIfReleased(
-            "1.2.3",
             () -> "somehash",
             (source, target) -> source,
             (source, target) -> target
@@ -50,7 +48,6 @@ final class FpIfReleasedTest {
     void choosesTheSecondFootprintBecauseHashIsEmpty(@TempDir final Path tmp) throws IOException {
         final Path tgt = tmp.resolve("right-empty-hash");
         final Path result = new FpIfReleased(
-            "1.2.3",
             () -> "",
             (source, target) -> source,
             (source, target) -> target


### PR DESCRIPTION
In this PR I slightly improved logging and what is the most important, removed unused 'semver' field from 'FpIfReleased' class.

Related to #4840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache logic simplified: caching decisions now rely solely on artifact hash rather than version semantics.
  * Public behaviors streamlined to remove version-based branching.
  * Transpilation logging enhanced to include file metadata (e.g., last-modified info) for clearer cache diagnostics.

* **Tests**
  * Unit tests updated to align with the revised cache and logging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->