### PR TITLE
feat(#4850): implement thread-safe caching with ConcurrentCache class

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -15,14 +15,8 @@ import org.cactoos.func.UncheckedFunc;
 
 /**
  * Simple cache mechanism.
+ * This class isn't thread-safe, use {@link ConcurrentCache} for concurrent scenarios.
  * @since 0.60
- * @todo #4846:30min Make Cache thread-safe.
- *  The Cache class lacks thread-safety mechanisms. If multiple threads call the apply method
- *  concurrently with the same source file, there could be race conditions where both threads
- *  determine the cache is stale and attempt to write simultaneously, potentially leading to
- *  corrupted files or inconsistent state. Consider adding synchronization or using atomic file
- *  operations. See ChCachedTest.java:63-86 for an example of how concurrency is tested in similar
- *  caching classes in this codebase.
  * @todo #4846:30min Replace {@link FpDefault} with {@link Cache}.
  *  The FpDefault class currently implements caching logic that is similar to the Cache class.
  *  Refactor the codebase to use Cache instead of FpDefault for caching functionality to

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Concurrent cache wrapper for Cache.
+ * Wrap {@link Cache} to make it thread-safe.
+ * @since 0.60
+ */
+final class ConcurrentCache {
+
+    /**
+     * Original cache.
+     */
+    private final Cache original;
+
+    /**
+     * Locks for each cache entry.
+     */
+    private final ConcurrentMap<? super Path, Object> locks;
+
+    /**
+     * Ctor.
+     * @param original Original cache
+     */
+    ConcurrentCache(final Cache original) {
+        this(original, new ConcurrentHashMap<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param original Original cache
+     * @param locks Locks map
+     */
+    private ConcurrentCache(final Cache original, final ConcurrentMap<? super Path, Object> locks) {
+        this.original = original;
+        this.locks = locks;
+    }
+
+    /**
+     * Check cache and apply compilation if needed.
+     * @param source From file
+     * @param target To file
+     * @param tail Tail path in cache
+     */
+    void apply(final Path source, final Path target, final Path tail) {
+        final Object loc = this.locks.computeIfAbsent(tail.normalize(), k -> new Object());
+        synchronized (loc) {
+            this.original.apply(source, target, tail.normalize());
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ConcurrentCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ConcurrentCacheTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link ConcurrentCache}.
+ * @since 0.60
+ */
+@ExtendWith(MktmpResolver.class)
+final class ConcurrentCacheTest {
+
+    @Test
+    void triesToCompileProgramConcurrently(@Mktmp final Path temp) throws IOException {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final var cache = new ConcurrentCache(
+            new Cache(
+                temp.resolve("cache"),
+                p -> String.format("only once %d", counter.incrementAndGet())
+            )
+        );
+        final var source = temp.resolve("program.eo");
+        new Saved("[] > main\n  (stdout \"Hello, EO!\") > @\n", source).value();
+        final var target = temp.resolve("program.xmir");
+        new Threaded<>(
+            IntStream.range(0, 100).boxed().collect(Collectors.toList()), ignored -> {
+            cache.apply(source, target, source.getFileName());
+            return ignored;
+        }
+        ).total();
+        MatcherAssert.assertThat(
+            "Program must be compiled only once",
+            counter.get(),
+            Matchers.equalTo(1)
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `ConcurrentCache` class to ensure thread-safety for the `Cache` mechanism, resolving issue #4846.

Fixes #4850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Cache class documentation with thread-safety guidance and best practices.

* **New Features**
  * Added thread-safe caching mechanism for concurrent operations.

* **Tests**
  * Added test coverage for concurrent caching functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->