### PR TITLE
ci(#4849): Move `trufflehog-oss` check to master branch only

### DIFF
--- a/.github/workflows/trufflehog-oss.yml
+++ b/.github/workflows/trufflehog-oss.yml
@@ -7,9 +7,6 @@ name: trufflehog-oss
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 jobs:
   trufflehog:
     timeout-minutes: 25


### PR DESCRIPTION
This PR modifies the `trufflehog-oss` workflow to run only on the `master` branch, improving PR efficiency.

Fixes #4849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow configuration to run security scanning exclusively on direct pushes to the main branch, streamlining the build process and reducing redundant checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->