### PR TITLE
feat(objectionary#4654): separated `mapped` from `list`

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/ss/list.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/list.eo
@@ -2,7 +2,6 @@
 +alias org.eolang.ss.reducedi
 +alias org.eolang.ss.reduced
 +alias org.eolang.ss.eachi
-+alias org.eolang.ss.mappedi
 +alias org.eolang.tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -48,14 +47,6 @@
         item
       back
         origin.length.minus index
-
-  # Map without index. Here "func" must be an abstract
-  # object with one free attribute, for the element
-  # of the collection.
-  [func] > mapped
-    mappedi > @
-      ^
-      func item > [item idx] >>
 
   # For each collection element dataize the object
   # Here "func" must be an abstract object with
@@ -330,15 +321,6 @@
         * 0 1
         * 4 0
         * 7 3
-
-  # Tests that mapping without index transforms elements correctly.
-  [] +> tests-simple-list-mapping
-    eq. > @
-      mapped.
-        list
-          * 1 2 3
-        x.times 2 > [x]
-      * 2 4 6
 
   # Tests that iterating over elements without index access works correctly.
   [] +> tests-iterates-with-each

--- a/eo-runtime/src/main/eo/org/eolang/ss/map.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/map.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ss.hash-code-of
 +alias org.eolang.ss.list
++alias org.eolang.ss.mapped
 +alias org.eolang.tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -65,12 +66,12 @@
     entries.length > size
     # Returns `list` of all keys in hash map.
     # Keys order is not guaranteed.
-    mapped. > keys
+    mapped > keys
       list entries
       entry.key > [entry]
     # Returns `list` of all values in hash map.
     # Values order is not guaranteed.
-    mapped. > values
+    mapped > values
       list entries
       entry.value > [entry]
 

--- a/eo-runtime/src/main/eo/org/eolang/ss/mapped.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/mapped.eo
@@ -1,0 +1,25 @@
++alias org.eolang.ss.list
++alias org.eolang.ss.mappedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Map `lst` without index. Here "func" must be an abstract
+# object with one free attribute, for the element
+# of the collection.
+[lst func] > mapped
+  mappedi > @
+    lst
+    func item > [item idx] >>
+
+  # Tests that mapping without index transforms elements correctly.
+  [] +> tests-simple-list-mapping
+    eq. > @
+      mapped
+        list
+          * 1 2 3
+        x.times 2 > [x]
+      * 2 4 6

--- a/eo-runtime/src/main/eo/org/eolang/ss/set.eo
+++ b/eo-runtime/src/main/eo/org/eolang/ss/set.eo
@@ -1,5 +1,6 @@
 +alias org.eolang.ss.list
 +alias org.eolang.ss.map
++alias org.eolang.ss.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.ss
@@ -13,11 +14,10 @@
 [lst] > set
   initialized > @
     map
-      list
-        lst
-      .mapped
+      mapped
+        list
+          lst
         map.entry item true > [item]
-      .origin
 
   # Initialized set with rebuilt unique sequence.
   [mp] > initialized

--- a/eo-runtime/src/main/eo/org/eolang/tt/contains-all.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/contains-all.eo
@@ -1,6 +1,7 @@
 +alias org.eolang.tt.contains
 +alias org.eolang.ss.list
 +alias org.eolang.ss.reduced
++alias org.eolang.ss.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -11,7 +12,7 @@
 # Checks if `text` contains all elements from `substrings`
 [text substrings] > contains-all
   reduced > @
-    mapped.
+    mapped
       substrings
       contains text-bts x > [x] >>
     true

--- a/eo-runtime/src/main/eo/org/eolang/tt/contains-any.eo
+++ b/eo-runtime/src/main/eo/org/eolang/tt/contains-any.eo
@@ -1,6 +1,7 @@
 +alias org.eolang.tt.contains
 +alias org.eolang.ss.list
 +alias org.eolang.ss.reduced
++alias org.eolang.ss.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.tt
@@ -11,7 +12,7 @@
 # Checks if `text` contains any element from `substrings`
 [text substrings] > contains-any
   reduced > @
-    mapped.
+    mapped
       substrings
       contains text-bts x > [x] >>
     false


### PR DESCRIPTION
In this PR, I separated `mapped` object from `list`.

**Resolves**: #4654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated mapping utility for processing list elements.

* **Refactor**
  * Reorganized collection processing APIs for improved modularity and consistency across utility libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->