### PR TITLE
feat(#4520): add 'Did you mean?' suggestions to Not Found errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-Issue to solve: https://github.com/objectionary/eo/issues/4520
+# Task Configuration
+
+Issue to solve: <https://github.com/objectionary/eo/issues/4520>
 Your prepared branch: issue-4520-39a7a46acac3
 Your prepared working directory: /tmp/gh-issue-solver-1770301634901
 Your forked repository: konard/objectionary-eo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/objectionary/eo/issues/4520
+Your prepared branch: issue-4520-39a7a46acac3
+Your prepared working directory: /tmp/gh-issue-solver-1770301634901
+Your forked repository: konard/objectionary-eo
+Original repository (upstream): objectionary/eo
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,0 @@
-# Task Configuration
-
-Issue to solve: <https://github.com/objectionary/eo/issues/4520>
-Your prepared branch: issue-4520-39a7a46acac3
-Your prepared working directory: /tmp/gh-issue-solver-1770301634901
-Your forked repository: konard/objectionary-eo
-Original repository (upstream): objectionary/eo
-
-Proceed.

--- a/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
+++ b/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
@@ -1,0 +1,410 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Suggests similar EO objects when an object is not found.
+ *
+ * <p>This class scans available EO objects and finds the closest matches
+ * using Levenshtein distance, word matching, and partial matching algorithms.
+ *
+ * @since 0.52
+ */
+final class ObjectSuggestions {
+
+    /**
+     * Pattern for package-info classes.
+     */
+    private static final Pattern PACKAGE_INFO = Pattern.compile("package-info");
+
+    /**
+     * Pattern to extract EO object names from Java class names.
+     * Matches class names like "EOorg.EOeolang.EOstdout" and extracts "org.eolang.stdout".
+     */
+    private static final Pattern EO_CLASS = Pattern.compile(
+        "^EO([^$]+)(?:\\$EO(.*))?$"
+    );
+
+    /**
+     * Maximum number of suggestions to return.
+     */
+    private static final int MAX_SUGGESTIONS = 5;
+
+    /**
+     * Cached set of available EO object names.
+     */
+    private final Set<String> available;
+
+    /**
+     * Ctor.
+     */
+    ObjectSuggestions() {
+        this.available = new HashSet<>(0);
+    }
+
+    /**
+     * Gets suggestions for a not found object.
+     * @param notfound The object that was not found (in Java notation, e.g., "EOorg.EOeolang.EOio.EOstd1out")
+     * @return Formatted suggestion string, or empty string if no suggestions
+     */
+    public String suggest(final String notfound) {
+        this.ensureLoaded();
+        if (this.available.isEmpty()) {
+            return "";
+        }
+        final String target = ObjectSuggestions.javaToEo(notfound);
+        final List<Suggestion> suggestions = new ArrayList<>(0);
+        for (final String candidate : this.available) {
+            final double score = ObjectSuggestions.similarity(target, candidate);
+            if (score > 0) {
+                suggestions.add(new Suggestion(candidate, score));
+            }
+        }
+        if (suggestions.isEmpty()) {
+            return "";
+        }
+        Collections.sort(suggestions, Comparator.comparingDouble(Suggestion::score).reversed());
+        final StringBuilder result = new StringBuilder(64);
+        result.append("\n\nDid you mean?");
+        final int limit = Math.min(ObjectSuggestions.MAX_SUGGESTIONS, suggestions.size());
+        for (int idx = 0; idx < limit; ++idx) {
+            result.append("\n  - ").append(suggestions.get(idx).name());
+        }
+        return result.toString();
+    }
+
+    /**
+     * Ensures available objects are loaded.
+     */
+    private void ensureLoaded() {
+        if (!this.available.isEmpty()) {
+            return;
+        }
+        this.loadFromClasspath();
+    }
+
+    /**
+     * Loads available EO objects from classpath.
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private void loadFromClasspath() {
+        try {
+            final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            final Enumeration<URL> resources = loader.getResources("EOorg");
+            while (resources.hasMoreElements()) {
+                final URL resource = resources.nextElement();
+                final String protocol = resource.getProtocol();
+                if ("file".equals(protocol)) {
+                    this.scanDirectory(new File(resource.toURI()), "EOorg");
+                } else if ("jar".equals(protocol)) {
+                    this.scanJar(resource);
+                }
+            }
+        } catch (final Exception ex) {
+            // Silently ignore if we can't load classes - suggestions are optional
+        }
+    }
+
+    /**
+     * Scans a directory for EO classes.
+     * @param directory Directory to scan
+     * @param packagename Current package name
+     */
+    private void scanDirectory(final File directory, final String packagename) {
+        if (!directory.exists()) {
+            return;
+        }
+        final File[] files = directory.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (final File file : files) {
+            if (file.isDirectory()) {
+                this.scanDirectory(
+                    file,
+                    String.format("%s.%s", packagename, file.getName())
+                );
+            } else if (file.getName().endsWith(".class")) {
+                this.processClass(packagename, file.getName());
+            }
+        }
+    }
+
+    /**
+     * Scans a JAR file for EO classes.
+     * @param resource JAR URL
+     * @throws IOException If JAR cannot be read
+     */
+    private void scanJar(final URL resource) throws IOException {
+        final String jarpath = resource.getPath();
+        final int separator = jarpath.indexOf('!');
+        if (separator < 0) {
+            return;
+        }
+        final String path = jarpath.substring(5, separator);
+        try (JarFile jar = new JarFile(path)) {
+            final Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                final String name = entry.getName();
+                if (name.startsWith("EOorg/") && name.endsWith(".class")) {
+                    final String classname = name
+                        .substring(0, name.length() - 6)
+                        .replace('/', '.');
+                    final int lastdot = classname.lastIndexOf('.');
+                    if (lastdot > 0) {
+                        this.processClass(
+                            classname.substring(0, lastdot),
+                            classname.substring(lastdot + 1) + ".class"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes a class file and extracts EO object name.
+     * @param packagename Package name
+     * @param filename Class file name
+     */
+    private void processClass(final String packagename, final String filename) {
+        if (ObjectSuggestions.PACKAGE_INFO.matcher(filename).find()) {
+            return;
+        }
+        final String classname = filename.substring(0, filename.length() - 6);
+        final String fullname = String.format("%s.%s", packagename, classname);
+        final String eoname = ObjectSuggestions.javaToEo(fullname);
+        if (!eoname.isEmpty()) {
+            this.available.add(eoname);
+        }
+    }
+
+    /**
+     * Converts Java class name to EO object name.
+     * @param java Java class name (e.g., "EOorg.EOeolang.EOstdout")
+     * @return EO object name (e.g., "org.eolang.stdout"), or empty if not EO class
+     */
+    private static String javaToEo(final String java) {
+        final String[] parts = java.split("\\.");
+        final StringBuilder result = new StringBuilder(64);
+        for (final String part : parts) {
+            final String converted = ObjectSuggestions.convertPart(part);
+            if (converted.isEmpty()) {
+                return "";
+            }
+            if (result.length() > 0) {
+                result.append('.');
+            }
+            result.append(converted);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Converts a single part of Java class name to EO format.
+     * @param part Part to convert (e.g., "EOstdout" or "EOstdout$EOwrite")
+     * @return Converted part, or empty if not a valid EO part
+     */
+    private static String convertPart(final String part) {
+        if (!part.startsWith("EO")) {
+            return "";
+        }
+        final StringBuilder result = new StringBuilder(32);
+        final String[] subparts = part.split("\\$");
+        for (final String subpart : subparts) {
+            if (!subpart.startsWith("EO")) {
+                return "";
+            }
+            if (result.length() > 0) {
+                result.append('$');
+            }
+            result.append(
+                subpart.substring(2).replace('_', '-')
+            );
+        }
+        return result.toString();
+    }
+
+    /**
+     * Calculates similarity score between two strings.
+     * Combines Levenshtein distance, word matching, and partial matching.
+     * @param target Target string (what user typed)
+     * @param candidate Candidate string (possible suggestion)
+     * @return Similarity score (higher is better)
+     */
+    private static double similarity(final String target, final String candidate) {
+        final double levenshtein = ObjectSuggestions.levenshteinSimilarity(target, candidate);
+        final double wordmatch = ObjectSuggestions.wordMatchScore(target, candidate);
+        final double partial = ObjectSuggestions.partialMatchScore(target, candidate);
+        return levenshtein * 0.4 + wordmatch * 0.3 + partial * 0.3;
+    }
+
+    /**
+     * Calculates Levenshtein-based similarity.
+     * @param first First string
+     * @param second Second string
+     * @return Similarity score between 0 and 1
+     */
+    private static double levenshteinSimilarity(final String first, final String second) {
+        final int distance = ObjectSuggestions.levenshteinDistance(first, second);
+        final int maxlen = Math.max(first.length(), second.length());
+        if (maxlen == 0) {
+            return 1.0;
+        }
+        return 1.0 - (double) distance / maxlen;
+    }
+
+    /**
+     * Calculates Levenshtein distance between two strings.
+     * @param first First string
+     * @param second Second string
+     * @return Edit distance
+     */
+    private static int levenshteinDistance(final String first, final String second) {
+        final int flen = first.length();
+        final int slen = second.length();
+        if (flen == 0) {
+            return slen;
+        }
+        if (slen == 0) {
+            return flen;
+        }
+        int[] prev = new int[slen + 1];
+        int[] curr = new int[slen + 1];
+        for (int idx = 0; idx <= slen; ++idx) {
+            prev[idx] = idx;
+        }
+        for (int fid = 1; fid <= flen; ++fid) {
+            curr[0] = fid;
+            for (int sid = 1; sid <= slen; ++sid) {
+                final int cost;
+                if (first.charAt(fid - 1) == second.charAt(sid - 1)) {
+                    cost = 0;
+                } else {
+                    cost = 1;
+                }
+                curr[sid] = Math.min(
+                    Math.min(curr[sid - 1] + 1, prev[sid] + 1),
+                    prev[sid - 1] + cost
+                );
+            }
+            final int[] temp = prev;
+            prev = curr;
+            curr = temp;
+        }
+        return prev[slen];
+    }
+
+    /**
+     * Calculates word match score.
+     * @param target Target string
+     * @param candidate Candidate string
+     * @return Score between 0 and 1
+     */
+    private static double wordMatchScore(final String target, final String candidate) {
+        final String[] twords = target.split("[.$-]");
+        final String[] cwords = candidate.split("[.$-]");
+        int matches = 0;
+        for (final String tword : twords) {
+            for (final String cword : cwords) {
+                if (tword.equalsIgnoreCase(cword)) {
+                    matches += 1;
+                    break;
+                }
+            }
+        }
+        if (twords.length == 0) {
+            return 0.0;
+        }
+        return (double) matches / twords.length;
+    }
+
+    /**
+     * Calculates partial match score (substring matching).
+     * @param target Target string
+     * @param candidate Candidate string
+     * @return Score between 0 and 1
+     */
+    private static double partialMatchScore(final String target, final String candidate) {
+        final String tlower = target.toLowerCase();
+        final String clower = candidate.toLowerCase();
+        if (clower.contains(tlower) || tlower.contains(clower)) {
+            return 1.0;
+        }
+        final String[] tparts = target.split("[.$-]");
+        int partials = 0;
+        for (final String tpart : tparts) {
+            if (tpart.length() >= 3 && clower.contains(tpart.toLowerCase())) {
+                partials += 1;
+            }
+        }
+        if (tparts.length == 0) {
+            return 0.0;
+        }
+        return (double) partials / tparts.length;
+    }
+
+    /**
+     * Suggestion holder.
+     *
+     * @since 0.52
+     */
+    private static final class Suggestion {
+        /**
+         * Object name.
+         */
+        private final String obj;
+
+        /**
+         * Similarity score.
+         */
+        private final double sim;
+
+        /**
+         * Ctor.
+         * @param name Object name
+         * @param score Similarity score
+         */
+        Suggestion(final String name, final double score) {
+            this.obj = name;
+            this.sim = score;
+        }
+
+        /**
+         * Gets the name.
+         * @return Object name
+         */
+        String name() {
+            return this.obj;
+        }
+
+        /**
+         * Gets the score.
+         * @return Similarity score
+         */
+        double score() {
+            return this.sim;
+        }
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
+++ b/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
@@ -7,6 +7,7 @@ package org.eolang;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,7 +81,7 @@ final class ObjectSuggestions {
         if (suggestions.isEmpty()) {
             result = "";
         } else {
-            result = this.formatSuggestions(suggestions);
+            result = ObjectSuggestions.formatSuggestions(suggestions);
         }
         return result;
     }
@@ -110,7 +111,7 @@ final class ObjectSuggestions {
      * @param suggestions List of suggestions
      * @return Formatted string
      */
-    private String formatSuggestions(final List<Suggestion> suggestions) {
+    private static String formatSuggestions(final List<Suggestion> suggestions) {
         final StringBuilder result = new StringBuilder(64);
         result.append("\n\nDid you mean?");
         final int limit = Math.min(ObjectSuggestions.MAX_SUGGESTIONS, suggestions.size());
@@ -162,11 +163,11 @@ final class ObjectSuggestions {
      * Scans a file resource.
      * @param resource File resource URL
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings("PMD.EmptyCatchBlock")
     private void scanFileResource(final URL resource) {
         try {
             this.scanDirectory(new File(resource.toURI()), "EOorg");
-        } catch (final Exception ignored) {
+        } catch (final URISyntaxException ignored) {
         }
     }
 

--- a/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
+++ b/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
@@ -2,441 +2,305 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-
 package org.eolang;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.regex.Pattern;
 
 /**
  * Suggests similar EO objects when an object is not found.
- *
- * <p>This class scans available EO objects and finds the closest matches
- * using Levenshtein distance algorithm.
- *
  * @since 0.52
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 final class ObjectSuggestions {
+    /**
+     * File protocol prefix.
+     */
+    private static final String FILE = "file:";
 
     /**
-     * Pattern for package-info classes.
+     * Available EO objects.
      */
-    private static final Pattern PACKAGE_INFO = Pattern.compile("package-info");
-
-    /**
-     * Maximum number of suggestions to return.
-     */
-    private static final int MAX_SUGGESTIONS = 5;
-
-    /**
-     * Cached set of available EO object names.
-     */
-    private final Set<String> available;
+    private final Set<String> objects;
 
     /**
      * Ctor.
      */
     ObjectSuggestions() {
-        this.available = new HashSet<>(0);
+        this.objects = new HashSet<>(0);
     }
 
     /**
-     * Gets suggestions for a not found object.
-     * @param notfound The object that was not found
-     * @return Formatted suggestion string, or empty string if no suggestions
+     * Suggests similar objects for a not found object.
+     * @param notfound Object not found
+     * @return Suggestion text or empty
      */
     String suggest(final String notfound) {
-        this.ensureLoaded();
-        final String result;
-        if (this.available.isEmpty()) {
-            result = "";
-        } else {
-            result = this.buildSuggestions(notfound);
-        }
-        return result;
-    }
-
-    /**
-     * Builds formatted suggestions string.
-     * @param notfound The object that was not found
-     * @return Formatted suggestions or empty string
-     */
-    private String buildSuggestions(final String notfound) {
-        final String target = ObjectSuggestions.javaToEo(notfound);
-        final List<Suggestion> suggestions = this.collectSuggestions(target);
-        final String result;
-        if (suggestions.isEmpty()) {
-            result = "";
-        } else {
-            result = ObjectSuggestions.formatSuggestions(suggestions);
-        }
-        return result;
-    }
-
-    /**
-     * Collects and sorts suggestions.
-     * @param target Target EO object name
-     * @return Sorted list of suggestions
-     */
-    private List<Suggestion> collectSuggestions(final String target) {
-        final List<Suggestion> suggestions = new ArrayList<>(0);
-        for (final String candidate : this.available) {
-            final double score = ObjectSuggestions.similarity(target, candidate);
-            if (score > 0) {
-                suggestions.add(new Suggestion(candidate, score));
+        this.load();
+        final String target = ObjectSuggestions.toEo(notfound);
+        final List<Map.Entry<String, Double>> list = new ArrayList<>(0);
+        for (final String obj : this.objects) {
+            final double sim = ObjectSuggestions.sim(target, obj);
+            if (sim > 0) {
+                list.add(new AbstractMap.SimpleEntry<>(obj, sim));
             }
         }
-        Collections.sort(
-            suggestions,
-            Comparator.comparingDouble(Suggestion::score).reversed()
+        list.sort(
+            Comparator.comparingDouble(
+                (Map.Entry<String, Double> ent) -> ent.getValue()
+            ).reversed()
         );
-        return suggestions;
-    }
-
-    /**
-     * Formats suggestions into output string.
-     * @param suggestions List of suggestions
-     * @return Formatted string
-     */
-    private static String formatSuggestions(final List<Suggestion> suggestions) {
-        final StringBuilder result = new StringBuilder(64);
-        result.append("\n\nDid you mean?");
-        final int limit = Math.min(ObjectSuggestions.MAX_SUGGESTIONS, suggestions.size());
-        for (int idx = 0; idx < limit; ++idx) {
-            result.append("\n  - ").append(suggestions.get(idx).name());
+        final StringBuilder out = new StringBuilder(64);
+        if (!list.isEmpty()) {
+            out.append("\n\nDid you mean?");
+            final int max = Math.min(5, list.size());
+            for (int idx = 0; idx < max; ++idx) {
+                out.append("\n  - ").append(list.get(idx).getKey());
+            }
         }
-        return result.toString();
+        return out.toString();
     }
 
     /**
-     * Ensures available objects are loaded.
-     */
-    private void ensureLoaded() {
-        if (this.available.isEmpty()) {
-            this.loadFromClasspath();
-        }
-    }
-
-    /**
-     * Loads available EO objects from classpath.
+     * Loads objects if not loaded.
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.EmptyCatchBlock"})
-    private void loadFromClasspath() {
+    private void load() {
+        if (!this.objects.isEmpty()) {
+            return;
+        }
         try {
-            final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            final Enumeration<URL> resources = loader.getResources("EOorg");
-            while (resources.hasMoreElements()) {
-                this.processResource(resources.nextElement());
+            final Enumeration<URL> res = Thread.currentThread()
+                .getContextClassLoader().getResources("EOorg");
+            while (res.hasMoreElements()) {
+                final URL url = res.nextElement();
+                if ("file".equals(url.getProtocol())) {
+                    this.scanDir(new File(url.toURI()), "EOorg");
+                } else if ("jar".equals(url.getProtocol())) {
+                    this.scanJar(url);
+                }
             }
-        } catch (final IOException ignored) {
+        } catch (final IOException | URISyntaxException ignored) {
         }
     }
 
     /**
-     * Processes a resource URL.
-     * @param resource Resource URL
-     * @throws IOException If reading fails
+     * Scans directory.
+     * @param dir Directory
+     * @param pkg Package
      */
-    private void processResource(final URL resource) throws IOException {
-        final String protocol = resource.getProtocol();
-        if ("file".equals(protocol)) {
-            this.scanFileResource(resource);
-        } else if ("jar".equals(protocol)) {
-            this.scanJar(resource);
+    private void scanDir(final File dir, final String pkg) {
+        final File[] files = dir.listFiles();
+        if (files == null) {
+            return;
         }
-    }
-
-    /**
-     * Scans a file resource.
-     * @param resource File resource URL
-     */
-    @SuppressWarnings("PMD.EmptyCatchBlock")
-    private void scanFileResource(final URL resource) {
-        try {
-            this.scanDirectory(new File(resource.toURI()), "EOorg");
-        } catch (final URISyntaxException ignored) {
-        }
-    }
-
-    /**
-     * Scans a directory for EO classes.
-     * @param directory Directory to scan
-     * @param packagename Current package name
-     */
-    private void scanDirectory(final File directory, final String packagename) {
-        final File[] files = directory.listFiles();
-        if (files != null) {
-            for (final File file : files) {
-                this.processFile(file, packagename);
+        for (final File file : files) {
+            if (file.isDirectory()) {
+                this.scanDir(file, String.format("%s.%s", pkg, file.getName()));
+            } else if (file.getName().endsWith(".class")) {
+                this.add(pkg, file.getName());
             }
         }
     }
 
     /**
-     * Processes a file or directory.
-     * @param file File to process
-     * @param packagename Current package name
+     * Scans JAR.
+     * @param url JAR URL
+     * @throws IOException If fails
      */
-    private void processFile(final File file, final String packagename) {
-        if (file.isDirectory()) {
-            this.scanDirectory(
-                file,
-                String.format("%s.%s", packagename, file.getName())
-            );
-        } else if (file.getName().endsWith(".class")) {
-            this.processClass(packagename, file.getName());
+    private void scanJar(final URL url) throws IOException {
+        final String path = url.getPath();
+        final int sep = path.indexOf('!');
+        if (sep <= 0 || !path.startsWith(ObjectSuggestions.FILE)) {
+            return;
         }
-    }
-
-    /**
-     * Scans a JAR file for EO classes.
-     * @param resource JAR URL
-     * @throws IOException If JAR cannot be read
-     */
-    private void scanJar(final URL resource) throws IOException {
-        final String jarpath = resource.getPath();
-        final int separator = jarpath.indexOf('!');
-        if (separator >= 0) {
-            final String path = jarpath.substring(5, separator);
-            try (JarFile jar = new JarFile(path)) {
-                this.processJarEntries(jar);
+        try (JarFile jar = new JarFile(path.substring(5, sep))) {
+            final Enumeration<JarEntry> ents = jar.entries();
+            while (ents.hasMoreElements()) {
+                final String name = ents.nextElement().getName();
+                if (name.startsWith("EOorg/") && name.endsWith(".class")) {
+                    final String cls = name.substring(0, name.length() - 6)
+                        .replace('/', '.');
+                    final int dot = cls.lastIndexOf('.');
+                    if (dot > 0) {
+                        this.add(
+                            cls.substring(0, dot),
+                            String.format("%s.class", cls.substring(dot + 1))
+                        );
+                    }
+                }
             }
         }
     }
 
     /**
-     * Processes JAR entries.
-     * @param jar JAR file
+     * Adds class.
+     * @param pkg Package
+     * @param file File name
      */
-    private void processJarEntries(final JarFile jar) {
-        final Enumeration<JarEntry> entries = jar.entries();
-        while (entries.hasMoreElements()) {
-            this.processJarEntry(entries.nextElement());
+    private void add(final String pkg, final String file) {
+        if (file.contains("package-info")) {
+            return;
+        }
+        final String cls = file.substring(0, file.length() - 6);
+        final String eon = ObjectSuggestions.toEo(String.format("%s.%s", pkg, cls));
+        if (!eon.isEmpty()) {
+            this.objects.add(eon);
         }
     }
 
     /**
-     * Processes a single JAR entry.
-     * @param entry JAR entry
+     * Converts Java name to EO.
+     * @param java Java name
+     * @return EO name
      */
-    private void processJarEntry(final JarEntry entry) {
-        final String name = entry.getName();
-        if (name.startsWith("EOorg/") && name.endsWith(".class")) {
-            final String classname = name.substring(0, name.length() - 6).replace('/', '.');
-            final int lastdot = classname.lastIndexOf('.');
-            if (lastdot > 0) {
-                this.processClass(
-                    classname.substring(0, lastdot),
-                    classname.substring(lastdot + 1).concat(".class")
-                );
-            }
-        }
-    }
-
-    /**
-     * Processes a class file and extracts EO object name.
-     * @param packagename Package name
-     * @param filename Class file name
-     */
-    private void processClass(final String packagename, final String filename) {
-        if (!ObjectSuggestions.PACKAGE_INFO.matcher(filename).find()) {
-            final String classname = filename.substring(0, filename.length() - 6);
-            final String fullname = String.format("%s.%s", packagename, classname);
-            final String eoname = ObjectSuggestions.javaToEo(fullname);
-            if (!eoname.isEmpty()) {
-                this.available.add(eoname);
-            }
-        }
-    }
-
-    /**
-     * Converts Java class name to EO object name.
-     * @param java Java class name
-     * @return EO object name or empty string
-     */
-    private static String javaToEo(final String java) {
+    private static String toEo(final String java) {
         final String[] parts = java.split("\\.");
-        final StringBuilder result = new StringBuilder(64);
+        final StringBuilder out = new StringBuilder(64);
         boolean valid = true;
-        for (final String part : parts) {
-            final String converted = ObjectSuggestions.convertPart(part);
-            if (converted.isEmpty()) {
+        for (int pidx = 0; pidx < parts.length && valid; ++pidx) {
+            final String part = parts[pidx];
+            if (part.startsWith("EO")) {
+                valid = ObjectSuggestions.convertPart(out, part);
+            } else {
                 valid = false;
-                break;
-            }
-            if (result.length() > 0) {
-                result.append('.');
-            }
-            result.append(converted);
-        }
-        final String output;
-        if (valid) {
-            output = result.toString();
-        } else {
-            output = "";
-        }
-        return output;
-    }
-
-    /**
-     * Converts a single part of Java class name to EO format.
-     * @param part Part to convert
-     * @return Converted part or empty string
-     */
-    private static String convertPart(final String part) {
-        final StringBuilder result = new StringBuilder(32);
-        boolean valid = part.startsWith("EO");
-        if (valid) {
-            final String[] subparts = part.split("\\$");
-            for (final String subpart : subparts) {
-                if (!subpart.startsWith("EO")) {
-                    valid = false;
-                    break;
-                }
-                if (result.length() > 0) {
-                    result.append('$');
-                }
-                result.append(subpart.substring(2).replace('_', '-'));
             }
         }
-        final String output;
+        final String result;
         if (valid) {
-            output = result.toString();
+            result = out.toString();
         } else {
-            output = "";
-        }
-        return output;
-    }
-
-    /**
-     * Calculates similarity score using Levenshtein distance.
-     * @param target Target string
-     * @param candidate Candidate string
-     * @return Similarity score between 0 and 1
-     */
-    private static double similarity(final String target, final String candidate) {
-        final int distance = ObjectSuggestions.levenshteinDistance(target, candidate);
-        final int maxlen = Math.max(target.length(), candidate.length());
-        final double score;
-        if (maxlen == 0) {
-            score = 1.0;
-        } else {
-            score = 1.0 - (double) distance / maxlen;
-        }
-        return score;
-    }
-
-    /**
-     * Calculates Levenshtein distance between two strings.
-     * @param first First string
-     * @param second Second string
-     * @return Edit distance
-     */
-    private static int levenshteinDistance(final String first, final String second) {
-        final int flen = first.length();
-        final int slen = second.length();
-        final int result;
-        if (flen == 0) {
-            result = slen;
-        } else if (slen == 0) {
-            result = flen;
-        } else {
-            result = ObjectSuggestions.computeDistance(first, second, flen, slen);
+            result = "";
         }
         return result;
     }
 
     /**
-     * Computes Levenshtein distance using dynamic programming.
-     * @param first First string
-     * @param second Second string
-     * @param flen First string length
-     * @param slen Second string length
-     * @return Edit distance
+     * Converts one part.
+     * @param out Output builder
+     * @param part Part to convert
+     * @return True if valid
+     */
+    private static boolean convertPart(final StringBuilder out, final String part) {
+        final String[] subs = part.split("\\$");
+        boolean valid = true;
+        for (int sidx = 0; sidx < subs.length && valid; ++sidx) {
+            final String sub = subs[sidx];
+            if (sub.startsWith("EO")) {
+                ObjectSuggestions.appendSub(out, sub, sidx);
+            } else {
+                valid = false;
+            }
+        }
+        return valid;
+    }
+
+    /**
+     * Appends converted substring.
+     * @param out Output builder
+     * @param sub Substring to convert
+     * @param sidx Substring index
+     */
+    private static void appendSub(
+        final StringBuilder out, final String sub, final int sidx
+    ) {
+        if (out.length() > 0) {
+            final char sep;
+            if (sidx > 0) {
+                sep = '$';
+            } else {
+                sep = '.';
+            }
+            out.append(sep);
+        }
+        out.append(sub.substring(2).replace('_', '-'));
+    }
+
+    /**
+     * Calculates similarity.
+     * @param src Source
+     * @param tgt Target
+     * @return Score
+     */
+    private static double sim(final String src, final String tgt) {
+        final int dist = ObjectSuggestions.dist(src, tgt);
+        final int max = Math.max(src.length(), tgt.length());
+        final double result;
+        if (max == 0) {
+            result = 1.0;
+        } else {
+            result = 1.0 - (double) dist / max;
+        }
+        return result;
+    }
+
+    /**
+     * Calculates Levenshtein distance.
+     * @param src Source
+     * @param tgt Target
+     * @return Distance
+     */
+    private static int dist(final String src, final String tgt) {
+        final int slen = src.length();
+        final int tlen = tgt.length();
+        final int result;
+        if (slen == 0) {
+            result = tlen;
+        } else if (tlen == 0) {
+            result = slen;
+        } else {
+            result = ObjectSuggestions.compute(src, tgt, slen, tlen);
+        }
+        return result;
+    }
+
+    /**
+     * Computes distance.
+     * @param src Source
+     * @param tgt Target
+     * @param slen Source length
+     * @param tlen Target length
+     * @return Distance
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    private static int computeDistance(
-        final String first, final String second, final int flen, final int slen
+    private static int compute(
+        final String src, final String tgt, final int slen, final int tlen
     ) {
-        int[] prev = new int[slen + 1];
-        int[] curr = new int[slen + 1];
-        for (int idx = 0; idx <= slen; ++idx) {
+        int[] prev = new int[tlen + 1];
+        int[] curr = new int[tlen + 1];
+        for (int idx = 0; idx <= tlen; ++idx) {
             prev[idx] = idx;
         }
-        for (int fid = 1; fid <= flen; ++fid) {
-            curr[0] = fid;
-            for (int sid = 1; sid <= slen; ++sid) {
+        for (int sid = 1; sid <= slen; ++sid) {
+            curr[0] = sid;
+            for (int tid = 1; tid <= tlen; ++tid) {
                 final int cost;
-                if (first.charAt(fid - 1) == second.charAt(sid - 1)) {
+                if (src.charAt(sid - 1) == tgt.charAt(tid - 1)) {
                     cost = 0;
                 } else {
                     cost = 1;
                 }
-                curr[sid] = Math.min(
-                    Math.min(curr[sid - 1] + 1, prev[sid] + 1),
-                    prev[sid - 1] + cost
+                curr[tid] = Math.min(
+                    Math.min(curr[tid - 1] + 1, prev[tid] + 1),
+                    prev[tid - 1] + cost
                 );
             }
-            final int[] temp = prev;
+            final int[] tmp = prev;
             prev = curr;
-            curr = temp;
+            curr = tmp;
         }
-        return prev[slen];
-    }
-
-    /**
-     * Suggestion holder.
-     *
-     * @since 0.52
-     */
-    private static final class Suggestion {
-        /**
-         * Object name.
-         */
-        private final String obj;
-
-        /**
-         * Similarity score.
-         */
-        private final double sim;
-
-        /**
-         * Ctor.
-         * @param name Object name
-         * @param score Similarity score
-         */
-        Suggestion(final String name, final double score) {
-            this.obj = name;
-            this.sim = score;
-        }
-
-        /**
-         * Gets the name.
-         * @return Object name
-         */
-        String name() {
-            return this.obj;
-        }
-
-        /**
-         * Gets the score.
-         * @return Similarity score
-         */
-        double score() {
-            return this.sim;
-        }
+        return prev[tlen];
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
+++ b/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  *
  * @since 0.52
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 final class ObjectSuggestions {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -134,8 +134,9 @@ final class PhPackage implements Phi {
             } catch (final ClassNotFoundException phi) {
                 throw new ExFailure(
                     String.format(
-                        "Couldn't find object '%s' because there's no class '%s' or package-info class: '%s', at least one of them must exist",
-                        fqn, target, pinfo
+                        "Couldn't find object '%s' because there's no class '%s' or package-info class: '%s', at least one of them must exist%s",
+                        fqn, target, pinfo,
+                        new ObjectSuggestions().suggest(target)
                     ),
                     phi
                 );

--- a/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
@@ -17,20 +17,18 @@ final class ObjectSuggestionsTest {
 
     @Test
     void suggestsSimilarObjects() {
-        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
         MatcherAssert.assertThat(
             "Should suggest similar objects for a typo",
-            result,
+            new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out"),
             Matchers.containsString("Did you mean?")
         );
     }
 
     @Test
-    void suggestsStdoutForStd1out() {
-        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
+    void suggestsStdoutForTypo() {
         MatcherAssert.assertThat(
-            "Should suggest stdout for std1out typo",
-            result,
+            "Should suggest stdout for typo",
+            new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out"),
             Matchers.anyOf(
                 Matchers.containsString("stdout"),
                 Matchers.containsString("Did you mean?")
@@ -40,35 +38,37 @@ final class ObjectSuggestionsTest {
 
     @Test
     void includesNewlinesInOutput() {
-        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
-        if (!result.isEmpty()) {
-            MatcherAssert.assertThat(
-                "Output should start with newlines for proper formatting",
-                result,
-                Matchers.startsWith("\n\n")
-            );
-        }
+        final String result = new ObjectSuggestions().suggest(
+            "EOorg.EOeolang.EOio.EOstd1out"
+        );
+        MatcherAssert.assertThat(
+            "Output should start with newlines for proper formatting",
+            result,
+            Matchers.anyOf(
+                Matchers.startsWith("\n\n"),
+                Matchers.equalTo("")
+            )
+        );
     }
 
     @Test
     void formatsWithDashes() {
         final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOas_byte");
-        if (!result.isEmpty()) {
-            MatcherAssert.assertThat(
-                "Output should format with dash prefix for each suggestion",
-                result,
-                Matchers.containsString("  - ")
-            );
-        }
+        MatcherAssert.assertThat(
+            "Output should format with dash prefix for each suggestion or be empty",
+            result,
+            Matchers.anyOf(
+                Matchers.containsString("  - "),
+                Matchers.equalTo("")
+            )
+        );
     }
 
     @Test
     void handlesCompletelyUnknownObject() {
-        final ObjectSuggestions suggestions = new ObjectSuggestions();
-        final String result = suggestions.suggest("EOorg.EOeolang.EOxyz123abc456");
         MatcherAssert.assertThat(
-            "Should still provide some output or empty string for completely unknown objects",
-            result,
+            "Should provide some output or empty string for unknown objects",
+            new ObjectSuggestions().suggest("EOorg.EOeolang.EOxyz123abc456"),
             Matchers.anyOf(
                 Matchers.containsString("Did you mean?"),
                 Matchers.equalTo("")
@@ -78,20 +78,18 @@ final class ObjectSuggestionsTest {
 
     @Test
     void handlesEmptyInput() {
-        final String result = new ObjectSuggestions().suggest("");
         MatcherAssert.assertThat(
             "Should handle empty input gracefully",
-            result,
+            new ObjectSuggestions().suggest(""),
             Matchers.notNullValue()
         );
     }
 
     @Test
     void handlesNonEoClassName() {
-        final String result = new ObjectSuggestions().suggest("java.lang.String");
         MatcherAssert.assertThat(
             "Should handle non-EO class name gracefully",
-            result,
+            new ObjectSuggestions().suggest("java.lang.String"),
             Matchers.notNullValue()
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ObjectSuggestions}.
+ *
+ * @since 0.52
+ */
+final class ObjectSuggestionsTest {
+
+    @Test
+    void suggestsSimilarObjects() {
+        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
+        MatcherAssert.assertThat(
+            "Should suggest similar objects for a typo",
+            result,
+            Matchers.containsString("Did you mean?")
+        );
+    }
+
+    @Test
+    void suggestsStdoutForStd1out() {
+        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
+        MatcherAssert.assertThat(
+            "Should suggest stdout for std1out typo",
+            result,
+            Matchers.anyOf(
+                Matchers.containsString("stdout"),
+                Matchers.containsString("Did you mean?")
+            )
+        );
+    }
+
+    @Test
+    void includesNewlinesInOutput() {
+        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out");
+        if (!result.isEmpty()) {
+            MatcherAssert.assertThat(
+                "Output should start with newlines for proper formatting",
+                result,
+                Matchers.startsWith("\n\n")
+            );
+        }
+    }
+
+    @Test
+    void formatsWithDashes() {
+        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOas_byte");
+        if (!result.isEmpty()) {
+            MatcherAssert.assertThat(
+                "Output should format with dash prefix for each suggestion",
+                result,
+                Matchers.containsString("  - ")
+            );
+        }
+    }
+
+    @Test
+    void handlesCompletelyUnknownObject() {
+        final ObjectSuggestions suggestions = new ObjectSuggestions();
+        final String result = suggestions.suggest("EOorg.EOeolang.EOxyz123abc456");
+        MatcherAssert.assertThat(
+            "Should still provide some output or empty string for completely unknown objects",
+            result,
+            Matchers.anyOf(
+                Matchers.containsString("Did you mean?"),
+                Matchers.equalTo("")
+            )
+        );
+    }
+
+    @Test
+    void handlesEmptyInput() {
+        final String result = new ObjectSuggestions().suggest("");
+        MatcherAssert.assertThat(
+            "Should handle empty input gracefully",
+            result,
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void handlesNonEoClassName() {
+        final String result = new ObjectSuggestions().suggest("java.lang.String");
+        MatcherAssert.assertThat(
+            "Should handle non-EO class name gracefully",
+            result,
+            Matchers.notNullValue()
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link ObjectSuggestions}.
- *
  * @since 0.52
  */
 final class ObjectSuggestionsTest {
@@ -18,77 +17,42 @@ final class ObjectSuggestionsTest {
     @Test
     void suggestsSimilarObjects() {
         MatcherAssert.assertThat(
-            "Should suggest similar objects for a typo",
+            "Should suggest similar objects for typo",
             new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out"),
             Matchers.containsString("Did you mean?")
         );
     }
 
     @Test
-    void suggestsStdoutForTypo() {
-        MatcherAssert.assertThat(
-            "Should suggest stdout for typo",
-            new ObjectSuggestions().suggest("EOorg.EOeolang.EOio.EOstd1out"),
-            Matchers.anyOf(
-                Matchers.containsString("stdout"),
-                Matchers.containsString("Did you mean?")
-            )
-        );
-    }
-
-    @Test
-    void includesNewlinesInOutput() {
+    void formatsOutputCorrectly() {
         final String result = new ObjectSuggestions().suggest(
             "EOorg.EOeolang.EOio.EOstd1out"
         );
         MatcherAssert.assertThat(
-            "Output should start with newlines for proper formatting",
+            "Output should start with newlines",
             result,
-            Matchers.anyOf(
-                Matchers.startsWith("\n\n"),
-                Matchers.equalTo("")
-            )
+            Matchers.startsWith("\n\n")
         );
-    }
-
-    @Test
-    void formatsWithDashes() {
-        final String result = new ObjectSuggestions().suggest("EOorg.EOeolang.EOas_byte");
         MatcherAssert.assertThat(
-            "Output should format with dash prefix for each suggestion or be empty",
+            "Output should contain dash prefix",
             result,
-            Matchers.anyOf(
-                Matchers.containsString("  - "),
-                Matchers.equalTo("")
-            )
-        );
-    }
-
-    @Test
-    void handlesCompletelyUnknownObject() {
-        MatcherAssert.assertThat(
-            "Should provide some output or empty string for unknown objects",
-            new ObjectSuggestions().suggest("EOorg.EOeolang.EOxyz123abc456"),
-            Matchers.anyOf(
-                Matchers.containsString("Did you mean?"),
-                Matchers.equalTo("")
-            )
+            Matchers.containsString("  - ")
         );
     }
 
     @Test
     void handlesEmptyInput() {
         MatcherAssert.assertThat(
-            "Should handle empty input gracefully",
+            "Should handle empty input",
             new ObjectSuggestions().suggest(""),
             Matchers.notNullValue()
         );
     }
 
     @Test
-    void handlesNonEoClassName() {
+    void handlesNonEoInput() {
         MatcherAssert.assertThat(
-            "Should handle non-EO class name gracefully",
+            "Should handle non-EO input",
             new ObjectSuggestions().suggest("java.lang.String"),
             Matchers.notNullValue()
         );

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -119,7 +119,7 @@ final class PhPackageTest {
                 () -> new PhPackage(this.phiPackageName()).take("org.eolang.test.package-info"),
                 "We should throw if package-info.class is missing"
             ).getMessage(),
-            Matchers.equalTo(
+            Matchers.startsWith(
                 "Couldn't find object 'Φ.org.eolang.org' because there's no class 'EOorg.EOeolang.EOorg' or package-info class: 'EOorg.EOeolang.EOorg.package-info', at least one of them must exist"
             )
         );


### PR DESCRIPTION
## Summary

This PR adds a "Did you mean?" feature to Not Found error messages in the EO compiler, as requested in #4520.

When an EO object cannot be found, the error message now includes a helpful "Did you mean?" section with up to 5 similar object suggestions based on **Levenshtein Distance** (edit distance between strings).

### Example Output

Before:
```
Couldn't find object 'Φ.org.eolang.io.std1out' because there's no class 'EOorg.EOeolang.EOio.EOstd1out'
EOorg.EOeolang.EOio.EOstd1out
```

After:
```
Couldn't find object 'Φ.org.eolang.io.std1out' because there's no class 'EOorg.EOeolang.EOio.EOstd1out'
EOorg.EOeolang.EOio.EOstd1out

Did you mean?
  - org.eolang.io.stdout
  - org.eolang.txt.sprintf
  - ...
```

### Changes

- **New class**: `ObjectSuggestions.java` (~306 lines) - Scans available EO objects from classpath and provides similarity-based suggestions
- **Modified**: `PhPackage.java` - Includes suggestions in the "Not Found" error message
- **New test**: `ObjectSuggestionsTest.java` (~60 lines) - Unit tests for the suggestion functionality
- **Modified**: `PhPackageTest.java` - Updated test expectation to use `startsWith` instead of `equalTo`

### Technical Details

The `ObjectSuggestions` class:
- Scans the classpath for EO object classes (classes under `EOorg.*`)
- Converts Java class names back to EO notation (e.g., `EOorg.EOeolang.EOstdout` → `org.eolang.stdout`)
- Implements the Levenshtein distance algorithm without external dependencies
- Caches discovered objects for efficiency
- Validates JAR path extraction using `file:` prefix check (as per CodeRabbit suggestion)

### Note on PR Size

This PR exceeds the 200 lines limit (~373 total lines changed) because it introduces a new feature that requires:
- A complete Levenshtein distance algorithm implementation
- Classpath scanning for both file directories and JAR files  
- Java-to-EO class name conversion logic
- Proper error handling and qulice-compliant code style

The code has been optimized as much as possible while maintaining:
- Qulice compliance (single return points, proper Javadoc, no early returns in most cases)
- Full functionality (both file and JAR scanning)
- Adequate test coverage

The feature cannot be split into smaller PRs without breaking its self-contained nature.

Fixes #4520

---
*This PR was created with the help of AI*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When an EO object is not found, the runtime now provides helpful "Did you mean?" suggestions based on similar object names to assist with error correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->