### PR TITLE
fix(#4873): remove verbose logging from fibonacci integration tests

### DIFF
--- a/eo-integration-tests/src/it/fibonacci/pom.xml
+++ b/eo-integration-tests/src/it/fibonacci/pom.xml
@@ -71,7 +71,6 @@
         <configuration>
           <mainClass>org.eolang.Main</mainClass>
           <arguments>
-            <argument>--verbose</argument>
             <argument>org.eolang.examples.app</argument>
             <argument>6</argument>
             <argument>8</argument>

--- a/eo-integration-tests/src/it/fibonacci/verify.groovy
+++ b/eo-integration-tests/src/it/fibonacci/verify.groovy
@@ -30,4 +30,6 @@ String log = new File(basedir, 'build.log').text
         'BUILD SUCCESS',
 ].each { expectedLog -> assert log.contains(expectedLog) || !online() }
 
+assert !log.contains(' ➜ org.eolang.PhDefault'):
+    'The log contains verbose logs, but shouldn\'t, remove the --verbose option'
 true


### PR DESCRIPTION
This PR removes the `--verbose` option from the `fibonacci` test to reduce excessive log output.

Fixes #4873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled verbose output for the Fibonacci integration test run.
  * Added a verification step that causes the integration test to fail if verbose build output appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->