### PR TITLE
build(#4884): upgrade qulice to version 0.25.1 in eo-maven-plugin

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -519,6 +519,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.25.1</version>
             <configuration>
               <excludes>
                 <exclude>checkstyle:/src/it.*</exclude>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -101,7 +102,7 @@ final class Cache {
      */
     private static String sha(final Path file) throws NoSuchAlgorithmException, IOException {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        try (var stream = Files.newInputStream(file)) {
+        try (InputStream stream = Files.newInputStream(file)) {
             final byte[] buffer = new byte[8192];
             int read = stream.read(buffer);
             while (read != -1) {
@@ -109,8 +110,7 @@ final class Cache {
                 read = stream.read(buffer);
             }
         }
-        final byte[] hash = digest.digest();
-        return Base64.getEncoder().encodeToString(hash);
+        return Base64.getEncoder().encodeToString(digest.digest());
     }
 }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
@@ -15,6 +15,7 @@ import com.yegor256.tojos.TjSynchronized;
 import com.yegor256.tojos.Tojos;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
@@ -23,7 +24,11 @@ import org.cactoos.scalar.Unchecked;
  * All catalogs in one place, to avoid making multiple objects.
  *
  * @since 0.29
+ * @todo #4884:30min Use ReentranLock instead of synchronized block in the code.
+ *  It will be more efficient and will not cause deadlocks.
+ *  Don't forget to remove the PMD suppression after that.
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class Catalogs {
 
     /**
@@ -54,7 +59,7 @@ final class Catalogs {
     /**
      * All of them.
      */
-    private final ConcurrentHashMap<Path, Tojos> all;
+    private final Map<Path, Tojos> all;
 
     /**
      * Ctor.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChSource.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChSource.java
@@ -79,11 +79,15 @@ final class ChSource implements CommitHash {
      * @return SHA-1 hash
      * @throws NoSuchAlgorithmException If SHA-1 is not supported
      */
+    @SuppressWarnings("PMD.UseStringIsEmptyRule")
     private String hash() throws NoSuchAlgorithmException {
         final MessageDigest digest = MessageDigest.getInstance("SHA-1");
-        final var content = new Unchecked<>(this.text).value();
         final StringBuilder res = new StringBuilder(40);
-        for (final byte raw : digest.digest(content.getBytes(StandardCharsets.UTF_8))) {
+        for (
+            final byte raw : digest.digest(
+                new Unchecked<>(this.text).value().getBytes(StandardCharsets.UTF_8)
+            )
+        ) {
             final String hex = Integer.toHexString(0xff & raw);
             if (hex.length() == 1) {
                 res.append('0');

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHash.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHash.java
@@ -18,11 +18,7 @@ interface CommitHash extends Scalar<String> {
      */
     CommitHash FAKE = new CommitHash.ChConstant("abcdef");
 
-    /**
-     * SHA Hash.
-     *
-     * @return SHA of commit
-     */
+    @Override
     String value();
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
@@ -12,7 +12,12 @@ import java.util.concurrent.ConcurrentMap;
  * Concurrent cache wrapper for Cache.
  * Wrap {@link Cache} to make it thread-safe.
  * @since 0.60
+ * @todo #4884:30min Use ReentrantLock instead of synchronized block.
+ *  This is the suggestion from qulice.
+ *  Dont' forget to remove the PMD suppression for AvoidSynchronizedStatement
+ *  after that.
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class ConcurrentCache {
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DepDirs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DepDirs.java
@@ -45,6 +45,7 @@ final class DepDirs extends ListEnvelope<String> {
      * @return List
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static List<String> list(final Path dir) throws IOException {
         final List<String> names = new LinkedList<>();
         if (Files.exists(dir)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Dependencies.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Dependencies.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
  * List of dependencies.
  * @since 0.54
  */
+@FunctionalInterface
 interface Dependencies extends Iterable<Dep> {
     /**
      * Fake dependencies.
@@ -106,14 +107,11 @@ interface Dependencies extends Iterable<Dep> {
          */
         private static Dep randDep() {
             final Random rand = new SecureRandom();
-            final String scope = new String[] {
-                "test", "compiled", "runtime",
-            }[rand.nextInt(3)];
             return Dependencies.Fake.dep(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
                 String.valueOf(rand.nextInt(Integer.MAX_VALUE)),
-                scope
+                    new String[]{"test", "compiled", "runtime"}[rand.nextInt(3)]
             );
         }
 
@@ -126,7 +124,6 @@ interface Dependencies extends Iterable<Dep> {
          * @return Dependency.
          * @checkstyle ParameterNumberCheck (5 lines)
          */
-        @SuppressWarnings("PMD.UseObjectForClearerAPI")
         private static Dep dep(
             final String group,
             final String artifact,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
@@ -156,12 +156,10 @@ final class DpsDefault implements Dependencies {
                         Filter.withName("meta"),
                         meta -> {
                             final Xnav xnav = new Xnav(meta);
-                            final Optional<String> head = xnav.element("head").text();
-                            final boolean runtime = head.map("rt"::equals).orElse(false);
                             final Optional<Xnav> part = xnav.elements(
                                 Filter.withName("part")
                             ).findFirst();
-                            return runtime
+                            return xnav.element("head").text().map("rt"::equals).orElse(false)
                                 && part.isPresent()
                                 && part.get().text().map("jvm"::equals).orElse(false);
                         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsEachWithoutTransitive.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsEachWithoutTransitive.java
@@ -45,18 +45,20 @@ final class DpsEachWithoutTransitive implements Dependencies {
     public Iterator<Dep> iterator() {
         return new Mapped<>(
             dependency -> {
-                final Iterable<Dep> transitives = new Filtered<>(
-                    dep -> {
-                        final Dependency dpndncy = dep.get();
-                        return !DpsEachWithoutTransitive.eqTo(dpndncy, dependency.get())
-                            && DpsEachWithoutTransitive.isRuntimeRequired(dpndncy)
-                            && !MjResolve.isRuntime(dpndncy);
-                    },
-                    this.transitive.apply(dependency)
-                );
                 final String list = String.join(
                     ", ",
-                    new Mapped<>(Dep::toString, transitives)
+                    new Mapped<>(
+                        Dep::toString,
+                        new Filtered<>(
+                            dep -> {
+                                final Dependency dpndncy = dep.get();
+                                return !DpsEachWithoutTransitive.eqTo(dpndncy, dependency.get())
+                                    && DpsEachWithoutTransitive.isRuntimeRequired(dpndncy)
+                                    && !MjResolve.isRuntime(dpndncy);
+                            },
+                            this.transitive.apply(dependency)
+                        )
+                    )
                 );
                 if (!list.isEmpty()) {
                     throw new IllegalStateException(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
@@ -10,6 +10,7 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.maven.model.Dependency;
@@ -78,7 +79,7 @@ final class DpsWithRuntime implements Dependencies {
 
     @Override
     public Iterator<Dep> iterator() {
-        final ListOf<Dep> all = new ListOf<>(this.delegate);
+        final List<Dep> all = new ListOf<>(this.delegate);
         if (all.stream().noneMatch(dep -> DpsWithRuntime.isRuntime(dep.get()))) {
             all.add(this.supplied.value());
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Footprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Footprint.java
@@ -13,6 +13,7 @@ import org.cactoos.BiFunc;
  * target files, updates target file and returns it.
  * @since 0.41.0
  */
+@FunctionalInterface
 interface Footprint extends BiFunc<Path, Path, Path> {
     @Override
     Path apply(Path source, Path target) throws IOException;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
@@ -46,6 +46,7 @@ public final class MjAssemble extends MjSafe {
     };
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() {
         final long begin = System.currentTimeMillis();
         String before = this.scopedTojos().status();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -38,6 +38,7 @@ public final class MjCompile extends MjSafe {
     };
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() {
         final long begin = System.currentTimeMillis();
         for (final Moja<?> moja : MjCompile.MOJAS) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -77,10 +77,11 @@ public final class MjLint extends MjSafe {
      * Lint.
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void lint() throws IOException {
         final long start = System.currentTimeMillis();
         final Collection<TjForeign> tojos = this.scopedTojos().withXmir();
-        final ConcurrentHashMap<Severity, Integer> counts = new ConcurrentHashMap<>();
+        final Map<Severity, Integer> counts = new ConcurrentHashMap<>();
         counts.putIfAbsent(Severity.CRITICAL, 0);
         counts.putIfAbsent(Severity.ERROR, 0);
         counts.putIfAbsent(Severity.WARNING, 0);
@@ -143,7 +144,7 @@ public final class MjLint extends MjSafe {
      */
     private int lintOne(
         final TjForeign tojo,
-        final ConcurrentHashMap<Severity, Integer> counts,
+        final Map<Severity, Integer> counts,
         final String... unlints
     ) throws Exception {
         final Path source = tojo.xmir();
@@ -185,7 +186,7 @@ public final class MjLint extends MjSafe {
      * @return Amount of seen XMIR files
      * @throws IOException If failed to lint
      */
-    private int lintAll(final ConcurrentHashMap<Severity, Integer> counts) throws IOException {
+    private int lintAll(final Map<Severity, Integer> counts) throws IOException {
         final Map<String, Path> paths = new HashMap<>();
         for (final TjForeign tojo : this.scopedTojos().withXmir()) {
             paths.put(tojo.identifier(), tojo.xmir());
@@ -235,7 +236,7 @@ public final class MjLint extends MjSafe {
     private XML linted(
         final String program,
         final XML xmir,
-        final ConcurrentHashMap<Severity, Integer> counts,
+        final Map<Severity, Integer> counts,
         final String... unlints
     ) {
         final Node node = xmir.inner();
@@ -317,7 +318,7 @@ public final class MjLint extends MjSafe {
      * @param counts Counts of errors, warnings, and critical
      * @return Summary text
      */
-    private static String summary(final ConcurrentHashMap<Severity, Integer> counts) {
+    private static String summary(final Map<Severity, Integer> counts) {
         final List<String> parts = new ArrayList<>(0);
         final int critical = counts.get(Severity.CRITICAL);
         if (critical > 0) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -63,6 +63,7 @@ public final class MjParse extends MjSafe {
     static final String CACHE = "parsed";
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() {
         final long start = System.currentTimeMillis();
         final Collection<TjForeign> tojos = this.scopedTojos().withSources();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
@@ -65,10 +65,12 @@ public final class MjPrint extends MjSafe {
                     this.printSourcesDir.toPath().relativize(source).toString()
                         .replace(".xmir", ".eo")
                 );
-                final String program = new Xmir(
-                    new XMLDocument(new TextOf(source).asString())
-                ).toEO();
-                new Saved(program, home.resolve(relative)).value();
+                new Saved(
+                    new Xmir(
+                        new XMLDocument(new TextOf(source).asString())
+                    ).toEO(),
+                    home.resolve(relative)
+                ).value();
                 Logger.info(
                     this,
                     "Printed: %[file]s (%[size]s) => %[file]s (%[size]s)",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
@@ -52,6 +52,7 @@ public final class MjProbe extends MjSafe {
     /**
      * Probe objects.
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void probe() {
         final Collection<TjForeign> tojos = this.scopedTojos().unprobed();
         if (tojos.isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -41,16 +41,17 @@ public final class MjPull extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        final var objectionary = new OyIndexed(
-            new OyCached(new OyRemote(this.hash, this.proxies()))
-        );
         if (this.offline) {
             Logger.info(
                 this,
                 "No programs were pulled because eo.offline flag is TRUE"
             );
         } else {
-            this.pull(objectionary);
+            this.pull(
+                new OyIndexed(
+                    new OyCached(new OyRemote(this.hash, this.proxies()))
+                )
+            );
         }
     }
 
@@ -59,7 +60,7 @@ public final class MjPull extends MjSafe {
      * @param objectionary Objectionary to pull from
      * @throws IOException If fails
      */
-    @SuppressWarnings("PMD.PrematureDeclaration")
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void pull(final OyIndexed objectionary) throws IOException {
         final long start = System.currentTimeMillis();
         final Collection<TjForeign> tojos = this.scopedTojos().withoutSources();
@@ -116,11 +117,10 @@ public final class MjPull extends MjSafe {
         final String object,
         final Path base,
         final String hsh) throws IOException {
-        final String semver = this.plugin.getVersion();
         final Path target = new Place(object).make(base, MjAssemble.EO);
         final Supplier<Path> che = new CachePath(
             this.cache.toPath().resolve(MjPull.CACHE),
-            semver,
+            this.plugin.getVersion(),
             hsh,
             base.relativize(target)
         );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -87,38 +87,43 @@ public final class MjRegister extends MjSafe {
             Logger.info(this, "There are %d EO sources registered already", before);
         }
         final Unplace unplace = new Unplace(this.sourcesDir);
-        final int registered = new Threaded<>(
-            new Walk(this.sourcesDir.toPath())
-                .includes(this.includeSources)
-                .excludes(this.excludeSources),
-            file -> {
-                if (this.strictFileNames
-                    && !MjRegister.PATTERN.matcher(file.getFileName().toString()).matches()) {
-                    throw new IllegalArgumentException(
-                        String.format(
-                            "Incorrect name found: '%s'. EO name must match '%s'",
-                            file.getFileName().toString(),
-                            MjRegister.PATTERN
-                        )
-                    );
-                }
-                final String name = unplace.make(file);
-                if (this.scopedTojos().contains(name)) {
-                    Logger.debug(this, "EO source %s already registered", name);
-                } else {
-                    this.scopedTojos()
-                        .add(name)
-                        .withSource(file.toAbsolutePath())
-                        .withHash(new ChSource(file));
-                    Logger.debug(this, "EO source %s registered", name);
-                }
-                return 1;
-            }
-        ).total();
         Logger.info(
             this,
             "Registered %d EO sources from %[file]s to %[file]s, included %s, excluded %s",
-            registered, this.sourcesDir, this.foreign, this.includeSources, this.excludeSources
+            new Threaded<>(
+                new Walk(this.sourcesDir.toPath())
+                    .includes(this.includeSources)
+                    .excludes(this.excludeSources),
+                file -> {
+                    if (
+                        this.strictFileNames
+                            && !MjRegister.PATTERN.matcher(file.getFileName().toString()).matches()
+                    ) {
+                        throw new IllegalArgumentException(
+                            String.format(
+                                "Incorrect name found: '%s'. EO name must match '%s'",
+                                file.getFileName().toString(),
+                                MjRegister.PATTERN
+                            )
+                        );
+                    }
+                    final String name = unplace.make(file);
+                    if (this.scopedTojos().contains(name)) {
+                        Logger.debug(this, "EO source %s already registered", name);
+                    } else {
+                        this.scopedTojos()
+                            .add(name)
+                            .withSource(file.toAbsolutePath())
+                            .withHash(new ChSource(file));
+                        Logger.debug(this, "EO source %s registered", name);
+                    }
+                    return 1;
+                }
+            ).total(),
+            this.sourcesDir,
+            this.foreign,
+            this.includeSources,
+            this.excludeSources
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -85,6 +85,7 @@ public final class MjResolve extends MjSafe {
     private boolean resolveInCentral = true;
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() throws IOException {
         final Collection<Dep> deps = this.deps();
         if (deps.isEmpty()) {
@@ -273,6 +274,7 @@ public final class MjResolve extends MjSafe {
      * @return Folder size
      * @throws IOException if I/O fails
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static long folderSizeInMb(final Path path) throws IOException {
         try (Stream<Path> paths = Files.walk(path)) {
             return paths.filter(Files::isRegularFile).mapToLong(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -228,7 +228,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
     @Parameter(property = "eo.cacheEnabled", defaultValue = "true")
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean cacheEnabled = true;
 
     /**
@@ -238,7 +237,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
     @Parameter(property = "eo.rewriteBinaries", defaultValue = "true")
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean rewriteBinaries = true;
 
     /**
@@ -256,7 +254,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.tag", required = true, defaultValue = "master")
     protected String tag = "master";
 
@@ -372,7 +369,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
     @Parameter(property = "eo.ignoreRuntime", required = true, defaultValue = "false")
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean ignoreRuntime;
 
     /**
@@ -382,7 +378,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
     @Parameter(property = "eo.ignoreTransitive", required = true, defaultValue = "false")
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean ignoreTransitive;
 
     /**
@@ -391,7 +386,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.failOnWarning", required = true, defaultValue = "true")
     protected boolean failOnWarning;
 
@@ -401,7 +395,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.lintAsPackage", required = true, defaultValue = "true")
     protected boolean lintAsPackage;
 
@@ -411,7 +404,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     @Parameter(property = "eo.skipLinting", required = true, defaultValue = "false")
     protected boolean skipLinting;
 
@@ -448,7 +440,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     protected BiConsumer<Dependency, Path> central;
 
     /**
@@ -487,7 +478,6 @@ abstract class MjSafe extends AbstractMojo {
      * Whether we should skip goal execution.
      */
     @Parameter(property = "eo.skip", defaultValue = "false")
-    @SuppressWarnings("PMD.ImmutableField")
     private boolean skip;
 
     @Override
@@ -502,7 +492,7 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle CyclomaticComplexityCheck (70 lines)
      */
     @Override
-    @SuppressWarnings("PMD.CognitiveComplexity")
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.UnnecessaryLocalRule"})
     public final void execute() throws MojoFailureException {
         StaticLoggerBinder.getSingleton().setMavenLog(this.getLog());
         if (this.skip) {
@@ -649,13 +639,13 @@ abstract class MjSafe extends AbstractMojo {
                     this.exec();
                     return new Object();
                 }
-            ).get(this.timeout.longValue(), TimeUnit.SECONDS);
+            ).get(this.timeout, TimeUnit.SECONDS);
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(
                 Logger.format(
                     "Timeout %[ms]s thread was interrupted",
-                    TimeUnit.SECONDS.toMillis(this.timeout.longValue())
+                    TimeUnit.SECONDS.toMillis(this.timeout)
                 ),
                 ex
             );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -122,6 +122,7 @@ public final class MjTranspile extends MjSafe {
     private boolean transpileTests = true;
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() throws IOException {
         final long begin = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.scopedTojos().withXmir();
@@ -161,6 +162,7 @@ public final class MjTranspile extends MjSafe {
      * @return Number of transpiled files.
      * @throws java.io.IOException If any issues with I/O
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private int transpiled(
         final TjForeign tojo
     ) throws IOException {
@@ -260,6 +262,7 @@ public final class MjTranspile extends MjSafe {
      * @return Amount of generated .java files
      * @throws IOException If fails to save files
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private int javaGenerated(
         final boolean rewrite,
         final Path target,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
@@ -25,7 +25,6 @@ import org.apache.maven.plugins.annotations.Mojo;
     defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
     threadSafe = true
 )
-@SuppressWarnings("PMD.ImmutableField")
 public final class MjUnplace extends MjSafe {
     @Override
     public void exec() throws IOException {
@@ -39,7 +38,6 @@ public final class MjUnplace extends MjSafe {
     /**
      * Unplace what's necessary.
      */
-    @SuppressWarnings("PMD.AvoidAccessToStaticMembersViaThis")
     private void unplace() {
         final Path classes = this.classesDir.toPath();
         final Walk binaries = new Walk(classes);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnspile.java
@@ -30,7 +30,6 @@ import org.apache.maven.plugins.annotations.Mojo;
     defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
     threadSafe = true
 )
-@SuppressWarnings("PMD.ImmutableField")
 public final class MjUnspile extends MjSafe {
     /**
      * Pattern for matching paths ended with .class.
@@ -61,6 +60,7 @@ public final class MjUnspile extends MjSafe {
      * Unspile classes.
      * @param classes Collection of compiled classes
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void unspile(final Walk classes) {
         final Path generated = this.generatedDir.toPath();
         final Set<String> included = new Walk(generated)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Moja.java
@@ -139,7 +139,7 @@ final class Moja<T extends AbstractMojo> {
      * @param entry Field name and value
      * @throws java.lang.IllegalAccessException If can't set field.
      */
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.UnnecessaryLocalRule"})
     private void initField(
         final Class<?> clazz,
         final AbstractMojo mojo,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
@@ -49,7 +49,6 @@ interface Objectionary {
      * @since 0.28.11
      * @checkstyle IllegalCatchCheck (150 lines)
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     final class Fake implements Objectionary {
 
         /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -96,15 +96,12 @@ final class OyRemote implements Objectionary {
 
     @Override
     public boolean contains(final String name) throws IOException {
-        final URL file = this.program.value(name);
-        final URL dir = this.directory.value(name);
-        return this.exists(file) || this.exists(dir);
+        return this.exists(this.program.value(name)) || this.exists(this.directory.value(name));
     }
 
     @Override
     public boolean isDirectory(final String name) throws IOException {
-        final URL url = this.directory.value(name);
-        return this.exists(url);
+        return this.exists(this.directory.value(name));
     }
 
     @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
@@ -59,12 +59,17 @@ final class PackageInfos {
                 .filter(file -> Files.isDirectory(file) && !file.equals(this.root))
                 .collect(Collectors.toList());
             for (final Path dir : dirs) {
-                final String pkg = this.root.relativize(dir).toString()
-                    .replace(File.separator, ".");
-                final Path saved = new Saved(
-                    PackageInfos.content(pkg), dir.resolve("package-info.java")
-                ).value();
-                Logger.debug(this, "Created %s", saved);
+                Logger.debug(
+                    this,
+                    "Created %s",
+                    new Saved(
+                        PackageInfos.content(
+                            this.root.relativize(dir)
+                                .toString()
+                                .replace(File.separator, ".")
+                        ), dir.resolve("package-info.java")
+                    ).value()
+                );
             }
             size = dirs.size();
         } else {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/StMeasured.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/StMeasured.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.jcabi.xml.XML;
 import com.yegor256.xsline.Shift;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -44,7 +45,7 @@ final class StMeasured implements Shift {
     }
 
     @Override
-    @SuppressWarnings("PMD.PrematureDeclaration")
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public XML apply(final int position, final XML xml) {
         final long start = System.currentTimeMillis();
         final XML out = this.origin.apply(position, xml);
@@ -55,7 +56,7 @@ final class StMeasured implements Shift {
                     "%s,%d\n",
                     this.origin.uid(),
                     System.currentTimeMillis() - start
-                ).getBytes(),
+                ).getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.APPEND,
                 StandardOpenOption.CREATE
             );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  *
  * @since 0.30
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
+@SuppressWarnings("PMD.TooManyMethods")
 final class TjForeign {
 
     /**
@@ -44,8 +44,7 @@ final class TjForeign {
         } else if (other == null || this.getClass() != other.getClass()) {
             result = false;
         } else {
-            final TjForeign tojo = (TjForeign) other;
-            result = Objects.equals(this.delegate, tojo.delegate);
+            result = Objects.equals(this.delegate, ((TjForeign) other).delegate);
         }
         return result;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
@@ -53,6 +53,7 @@ final class Walk extends ListEnvelope<Path> {
      * @param globs List of them
      * @return New Walk
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     Walk includes(final Collection<String> globs) {
         return new Walk(
             this.home,
@@ -71,6 +72,7 @@ final class Walk extends ListEnvelope<Path> {
      * @param globs List of them
      * @return New Walk
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     Walk excludes(final Collection<String> globs) {
         return new Walk(
             this.home,
@@ -124,13 +126,12 @@ final class Walk extends ListEnvelope<Path> {
      * @return Matcher
      */
     private boolean matches(final String text, final Path file) {
-        final Path rel = Paths.get(
-            file.toAbsolutePath().toString().substring(
-                this.home.toAbsolutePath().toString().length() + 1
+        return FileSystems.getDefault().getPathMatcher(String.format("glob:%s", text)).matches(
+            Paths.get(
+                file.toAbsolutePath().toString().substring(
+                    this.home.toAbsolutePath().toString().length() + 1
+                )
             )
         );
-        return FileSystems.getDefault().getPathMatcher(
-            String.format("glob:%s", text)
-        ).matches(rel);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -29,13 +29,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class CacheTest {
 
     @Test
-    void compilesSourceAndAddsToCache(@Mktmp final Path temp) throws Exception {
-        final var base = temp.resolve("cache");
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void compilesSource(@Mktmp final Path temp) throws Exception {
+        final Path base = temp.resolve("cache-folder");
         Files.createDirectories(base);
-        final var source = temp.resolve("source.eo");
+        final Path source = temp.resolve("source.eo");
         Files.writeString(source, "[] > main\n  (stdout \"Hello, EO!\") > @\n");
-        final var target = temp.resolve("target.xmir");
-        final var tail = source.getFileName();
+        final Path target = temp.resolve("target.xmir");
+        final Path tail = source.getFileName();
         final String content = "compiled";
         new Cache(base, p -> content).apply(source, target, tail);
         MatcherAssert.assertThat(
@@ -43,37 +44,39 @@ final class CacheTest {
             Files.readString(target),
             Matchers.equalTo(content)
         );
+    }
+
+    @Test
+    void compilesSourceAndAddsToCache(@Mktmp final Path temp) throws Exception {
+        final Path base = temp.resolve("cache-root");
+        Files.createDirectories(base);
+        final Path source = temp.resolve("source.eo");
+        Files.writeString(source, "[] > main\n  (stdout \"Hello, EO!\") > @\n");
+        final Path tail = source.getFileName();
+        new Cache(base, p -> "compiled").apply(source, temp.resolve("target.xmir"), tail);
         MatcherAssert.assertThat(
-            "Cache file must be created",
-            Files.exists(base.resolve(tail)),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Hash file must be created",
-            Files.exists(base.resolve(String.format("%s.sha256", tail))),
+            "Cache file must be created and hash file must be created",
+            Files.exists(base.resolve(tail))
+                && Files.exists(base.resolve(String.format("%s.sha256", tail))),
             Matchers.is(true)
         );
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void readsFromCacheWhenUnchanged(@Mktmp final Path temp) throws Exception {
-        final var base = temp.resolve("cache-directory");
+        final Path base = temp.resolve("cache-directory");
         Files.createDirectories(base);
-        final var source = temp.resolve("stdin.eo");
+        final Path source = temp.resolve("stdin.eo");
         Files.writeString(source, "[] > main\n  (stdout \"Hello, EO!\") > @\n");
-        final var target = temp.resolve("stdin.xmir");
-        final var counter = new AtomicInteger(0);
-        final var cache = new Cache(
+        final Path target = temp.resolve("stdin.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Cache cache = new Cache(
             base,
             p -> String.format("stdin %d", counter.incrementAndGet())
         );
         final Path tail = source.getFileName();
         cache.apply(source, target, tail);
-        MatcherAssert.assertThat(
-            "Compilation should happen only once",
-            counter.get(),
-            Matchers.equalTo(1)
-        );
         cache.apply(source, target, tail);
         MatcherAssert.assertThat(
             "Compilation should not happen again",
@@ -83,23 +86,19 @@ final class CacheTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void compilesAgainWhenChanged(@Mktmp final Path temp) throws Exception {
-        final var base = temp.resolve("cache-base-dir");
+        final Path base = temp.resolve("cache-base-dir");
         Files.createDirectories(base);
-        final var source = temp.resolve("stdout.eo");
+        final Path source = temp.resolve("stdout.eo");
         Files.writeString(source, "[] > main\n  (stdout \"Hello, EO!\") > @\n");
-        final var target = temp.resolve("stdout.xmir");
-        final var counter = new AtomicInteger(0);
-        final var cache = new Cache(
+        final Path target = temp.resolve("stdout.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Cache cache = new Cache(
             base,
             p -> String.format("compiled %d", counter.incrementAndGet())
         );
         cache.apply(source, target, source.getFileName());
-        MatcherAssert.assertThat(
-            "Compilation should happen once",
-            counter.get(),
-            Matchers.equalTo(1)
-        );
         Files.writeString(source, "[] > main\n  (stdout \"Hello, EO! Modified\") > @\n");
         cache.apply(source, target, source.getFileName());
         MatcherAssert.assertThat(
@@ -110,24 +109,20 @@ final class CacheTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void compilesIfHashExistsButCacheMissing(@Mktmp final Path temp) throws Exception {
-        final var base = temp.resolve("cache-root");
+        final Path base = temp.resolve("cache-root");
         Files.createDirectories(base);
-        final var source = temp.resolve("data.eo");
+        final Path source = temp.resolve("data.eo");
         Files.writeString(source, "[] > main\n  (stdout \"Data EO\") > @\n");
-        final var target = temp.resolve("data.xmir");
-        final var counter = new AtomicInteger(0);
-        final var cache = new Cache(
+        final Path target = temp.resolve("data.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Cache cache = new Cache(
             base,
             p -> String.format("data %d", counter.incrementAndGet())
         );
         final Path tail = source.getFileName();
         cache.apply(source, target, tail);
-        MatcherAssert.assertThat(
-            "Compilation should happen once",
-            counter.get(),
-            Matchers.equalTo(1)
-        );
         Files.delete(base.resolve(tail));
         cache.apply(source, target, tail);
         MatcherAssert.assertThat(
@@ -139,16 +134,15 @@ final class CacheTest {
 
     @Test
     void writesCorrectShaHash(@Mktmp final Path temp) throws IOException, NoSuchAlgorithmException {
-        final var base = temp.resolve("cache");
+        final Path base = temp.resolve("cache-path");
         Files.createDirectories(base);
-        final var source = temp.resolve("message.txt");
+        final Path source = temp.resolve("message.txt");
         final String msg = "hello";
         final Charset encoding = StandardCharsets.UTF_8;
         Files.writeString(source, msg, encoding);
-        final var target = temp.resolve("out.txt");
-        final var tail = source.getFileName();
-        final var cache = new Cache(base, p -> "compiled");
-        cache.apply(source, target, tail);
+        final Path tail = source.getFileName();
+        final Cache cache = new Cache(base, p -> "compiled");
+        cache.apply(source, temp.resolve("out.txt"), tail);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content",
             Files.readString(base.resolve(String.format("%s.sha256", tail)), encoding),
@@ -164,9 +158,9 @@ final class CacheTest {
     void generatesCorrectHashForLargeFile(
         @Mktmp final Path temp
     ) throws IOException, NoSuchAlgorithmException {
-        final var cache = temp.resolve("cache");
+        final Path cache = temp.resolve("cache");
         Files.createDirectories(cache);
-        final var source = temp.resolve("large.txt");
+        final Path source = temp.resolve("large.txt");
         final int lines = 100_000;
         final StringBuilder builder = new StringBuilder(lines * 10);
         IntStream.range(0, lines).forEach(
@@ -174,9 +168,8 @@ final class CacheTest {
         );
         final String content = builder.toString();
         Files.writeString(source, content, StandardCharsets.UTF_8);
-        final var target = temp.resolve("out.txt");
-        final var tail = source.getFileName();
-        new Cache(cache, p -> content).apply(source, target, tail);
+        final Path tail = source.getFileName();
+        new Cache(cache, p -> content).apply(source, temp.resolve("out.txt"), tail);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for large file",
             Files.readString(
@@ -196,14 +189,13 @@ final class CacheTest {
     void generatesCorrectHashForTinyFile(
         @Mktmp final Path temp
     ) throws IOException, NoSuchAlgorithmException {
-        final var cache = temp.resolve("cache");
+        final Path cache = temp.resolve("cache");
         Files.createDirectories(cache);
-        final var source = temp.resolve("tiny.txt");
+        final Path source = temp.resolve("tiny.txt");
         final String content = "x";
         Files.writeString(source, content, StandardCharsets.UTF_8);
-        final var target = temp.resolve("out.txt");
-        final var tail = source.getFileName();
-        new Cache(cache, p -> content).apply(source, target, tail);
+        final Path tail = source.getFileName();
+        new Cache(cache, p -> content).apply(source, temp.resolve("out.txt"), tail);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for tiny file",
             Files.readString(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChRemoteTest.java
@@ -25,20 +25,18 @@ final class ChRemoteTest {
 
     @Test
     void getsCommitHashTag() {
-        final String hash = new ChRemote("0.41.1").value();
         MatcherAssert.assertThat(
             "ChRemote should return the correct commit hash, but it doesn't",
-            hash,
+            new ChRemote("0.41.1").value(),
             Matchers.equalTo("9a3dee39597b2e9ac305ca57c296b0fa7e10eb55")
         );
     }
 
     @Test
     void getsCommitHashOldTag() {
-        final String hash = new ChRemote("0.40.5").value();
         MatcherAssert.assertThat(
             "ChRemote should return the correct commit hash for an old tag, but it doesn't",
-            hash,
+            new ChRemote("0.40.5").value(),
             Matchers.equalTo("ee14a1e30a9e0f8f64404e7a52f40c2a07f88359")
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChTextTest.java
@@ -141,6 +141,7 @@ final class ChTextTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void executesExactlyOnceAtNoError() {
         final AtomicInteger count = new AtomicInteger(0);
         new ChText(
@@ -159,6 +160,7 @@ final class ChTextTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void executesNotAtTagMatchesHash() {
         final AtomicInteger count = new AtomicInteger(0);
         new ChText(
@@ -177,6 +179,7 @@ final class ChTextTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void executesEventually() {
         final AtomicInteger count = new AtomicInteger(0);
         new ChText(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesMapTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesMapTest.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,22 +28,13 @@ final class CommitHashesMapTest {
         "0.28.10, 9b88393",
     })
     void containsValidHash(final String tag, final String hash) {
-        final Map<String, CommitHash> hashes = new CommitHashesMap.Fake();
-        MatcherAssert.assertThat(
-            String.format(
-                "Commit hashes should have contained tag %s, but they didn't",
-                tag
-            ),
-            hashes,
-            Matchers.hasKey(tag)
-        );
         MatcherAssert.assertThat(
             String.format(
                 "Commit hashes should have contained hash %s by tag %s, but they didn't",
                 hash,
                 tag
             ),
-            hashes.get(tag).value(),
+            new CommitHashesMap.Fake().get(tag).value(),
             Matchers.equalTo(hash)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ConcurrentCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ConcurrentCacheTest.java
@@ -24,17 +24,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class ConcurrentCacheTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void triesToCompileProgramConcurrently(@Mktmp final Path temp) throws IOException {
         final AtomicInteger counter = new AtomicInteger(0);
-        final var cache = new ConcurrentCache(
+        final ConcurrentCache cache = new ConcurrentCache(
             new Cache(
                 temp.resolve("cache"),
                 p -> String.format("only once %d", counter.incrementAndGet())
             )
         );
-        final var source = temp.resolve("program.eo");
+        final Path source = temp.resolve("program.eo");
         new Saved("[] > main\n  (stdout \"Hello, EO!\") > @\n", source).value();
-        final var target = temp.resolve("program.xmir");
+        final Path target = temp.resolve("program.xmir");
         new Threaded<>(
             IntStream.range(0, 100).boxed().collect(Collectors.toList()), ignored -> {
             cache.apply(source, target, source.getFileName());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DepDirsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DepDirsTest.java
@@ -32,12 +32,10 @@ final class DepDirsTest {
         MatcherAssert.assertThat(
             String.format("DepDirs should contain %s, but it doesn't", path),
             new DepDirs(temp),
-            Matchers.contains(path)
-        );
-        MatcherAssert.assertThat(
-            "DepDirs should contain one element, but it doesn't",
-            new DepDirs(temp),
-            Matchers.iterableWithSize(1)
+            Matchers.allOf(
+                Matchers.<String>iterableWithSize(1),
+                Matchers.contains(path)
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -45,7 +45,6 @@ import org.cactoos.text.UncheckedText;
  */
 @SuppressWarnings({
     "PMD.TooManyMethods",
-    "PMD.CouplingBetweenObjects",
     "JTCOP.RuleAllTestsHaveProductionClass",
     "JTCOP.RuleCorrectTestName"
 })
@@ -170,7 +169,6 @@ final class FakeMaven {
      */
     <T extends AbstractMojo> FakeMaven execute(final Class<T> mojo) throws IOException {
         if (this.defaults) {
-            final Path placed = Paths.get("placed.json");
             this.params.putIfAbsent("targetDir", this.targetPath().toFile());
             this.params.putIfAbsent(
                 "xslMeasures", this.targetPath().resolve("measures.csv").toFile()
@@ -186,7 +184,10 @@ final class FakeMaven {
             this.params.putIfAbsent("ignoreTransitive", true);
             this.params.putIfAbsent("central", new DummyCentral());
             this.params.putIfAbsent("resolveInCentral", false);
-            this.params.putIfAbsent("placed", this.workspace.resolve(placed).toFile());
+            this.params.putIfAbsent(
+                "placed",
+                this.workspace.resolve(Paths.get("placed.json")).toFile()
+            );
             this.params.putIfAbsent("placedFormat", "json");
             this.params.putIfAbsent(
                 "sourcesDir", this.workspace.resolve(".").toFile()
@@ -342,11 +343,10 @@ final class FakeMaven {
         final Path src = this.workspace.resolve(source);
         new Saved(content, src).value();
         final String scope = this.scope();
-        final String version = "0.25.0";
         this.foreignTojos()
             .add(object)
             .withScope(scope)
-            .withVersion(version)
+            .withVersion("0.25.0")
             .withSource(src);
         this.current.incrementAndGet();
         return this;
@@ -394,6 +394,7 @@ final class FakeMaven {
      * @return Map of "relative UNIX path" (key) - "absolute path" (value).
      * @throws IOException If some problem with filesystem have happened.
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     Map<String, Path> result() throws IOException {
         final Path root = this.workspace.resolve("");
         return Files.walk(root).collect(
@@ -657,8 +658,7 @@ final class FakeMaven {
         public void accept(final Dependency dependency, final Path path) {
             try {
                 Files.createDirectories(path);
-                final String other = DummyCentral.className(dependency);
-                Files.createFile(path.resolve(other));
+                Files.createFile(path.resolve(DummyCentral.className(dependency)));
             } catch (final IOException ex) {
                 throw new IllegalStateException(
                     String.format("Can't save '%s' to '%s'", dependency, path),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FileHashTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FileHashTest.java
@@ -34,10 +34,9 @@ final class FileHashTest {
 
     @Test
     void readsFromAbsentFile(@Mktmp final Path temp) {
-        final Path path = temp.resolve("2.txt");
         MatcherAssert.assertThat(
             "FileHash must read an absent file, but it doesn't",
-            new FileHash(path).toString(),
+            new FileHash(temp.resolve("2.txt")).toString(),
             Matchers.equalTo("")
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FpAppliedWithCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FpAppliedWithCacheTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class FpAppliedWithCacheTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void appliesWithCache(@Mktmp final Path temp) throws Exception {
         final Path cached = temp.resolve("cached");
         final Path target = temp.resolve("target");
@@ -40,6 +41,7 @@ final class FpAppliedWithCacheTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void appliesOnlyToTarget(@Mktmp final Path temp) throws Exception {
         final String expected = "foo bar";
         final Path target = temp.resolve("target");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfReleasedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfReleasedTest.java
@@ -32,14 +32,13 @@ final class FpIfReleasedTest {
     @Test
     void choosesTheFirstFootprintBecauseCacheable(@TempDir final Path tmp) throws IOException {
         final Path src = tmp.resolve("first");
-        final Path result = new FpIfReleased(
-            () -> "somehash",
-            (source, target) -> source,
-            (source, target) -> target
-        ).apply(src, tmp.resolve("second"));
         Assertions.assertEquals(
             src,
-            result,
+            new FpIfReleased(
+                () -> "somehash",
+                (source, target) -> source,
+                (source, target) -> target
+            ).apply(src, tmp.resolve("second")),
             "Should choose the first footprint when cacheable"
         );
     }
@@ -47,14 +46,13 @@ final class FpIfReleasedTest {
     @Test
     void choosesTheSecondFootprintBecauseHashIsEmpty(@TempDir final Path tmp) throws IOException {
         final Path tgt = tmp.resolve("right-empty-hash");
-        final Path result = new FpIfReleased(
-            () -> "",
-            (source, target) -> source,
-            (source, target) -> target
-        ).apply(tmp.resolve("left-empty-hash"), tgt);
         Assertions.assertEquals(
             tgt,
-            result,
+            new FpIfReleased(
+                () -> "",
+                (source, target) -> source,
+                (source, target) -> target
+            ).apply(tmp.resolve("left-empty-hash"), tgt),
             "Should choose the second footprint when hash is empty"
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FpUpdateFromCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FpUpdateFromCacheTest.java
@@ -28,15 +28,22 @@ final class FpUpdateFromCacheTest {
         final Text expected = new TextOf("Cached!");
         final Path cached = new Saved(expected, tmp.resolve("cache.txt")).value();
         final Path target = tmp.resolve("target.txt");
-        MatcherAssert.assertThat(
-            "We expect the footprint will return the target file path",
-            new FpUpdateFromCache(() -> cached).apply(Paths.get("/dev/null"), target),
-            Matchers.equalTo(target)
-        );
+        new FpUpdateFromCache(() -> cached).apply(Paths.get("/dev/null"), target);
         MatcherAssert.assertThat(
             "The target file should be updated from cache",
             new TextOf(target),
             Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void returnsSaved(@Mktmp final Path tmp) throws IOException {
+        final Path cached = new Saved(new TextOf("Cached!"), tmp.resolve("cache.txt")).value();
+        final Path target = tmp.resolve("target.txt");
+        MatcherAssert.assertThat(
+            "We expect the footprint will return the target file path",
+            new FpUpdateFromCache(() -> cached).apply(Paths.get("/dev/null"), target),
+            Matchers.equalTo(target)
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
@@ -27,8 +27,9 @@ final class MjCleanTest {
     @Test
     void cleansSuccessfully(@Mktmp final Path temp) throws IOException {
         final Path dir = Files.createDirectories(temp.resolve("target"));
-        final Path out = Files.createDirectories(dir.resolve("child"));
-        final Path small = Files.createDirectories(out.resolve("child.eo"));
+        final Path small = Files.createDirectories(
+            Files.createDirectories(dir.resolve("child")).resolve("child.eo")
+        );
         final Path file = Files.createTempFile(dir, "some", ".eo");
         if (!small.toFile().exists() || !file.toFile().exists()) {
             throw new IllegalStateException("Files not created.");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.31.0
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(MktmpResolver.class)
 @ExtendWith(RandomProgramResolver.class)
 final class MjLintTest {
@@ -44,6 +44,10 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings({
+        "PMD.UnitTestContainsTooManyAsserts",
+        "PMD.UnnecessaryLocalRule"
+    })
     void detectsErrorsSuccessfully(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .withProgram(
@@ -67,6 +71,7 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void detectsCriticalErrorsSuccessfully(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .withProgram(
@@ -95,6 +100,10 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings({
+        "PMD.UnitTestContainsTooManyAsserts",
+        "PMD.UnnecessaryLocalRule"
+    })
     void detectsWarningWithCorrespondingFlag(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .withProgram(
@@ -138,6 +147,10 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings({
+        "PMD.UnitTestContainsTooManyAsserts",
+        "PMD.UnnecessaryLocalRule"
+    })
     void failsParsingOnError(@Mktmp final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp)
             .withProgram(
@@ -185,6 +198,7 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void savesVerifiedResultsToCache(@Mktmp final Path temp) throws IOException {
         final Path cache = temp.resolve("cache");
         final String hash = "abcdef1";
@@ -204,6 +218,7 @@ final class MjLintTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void getsAlreadyVerifiedResultsFromCache(@Mktmp final Path temp) throws Exception {
         final TextOf input = new TextOf(
             new ResourceOf("org/eolang/maven/main.xml")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
@@ -45,6 +45,7 @@ final class MjPlaceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void skipsAlreadyPlacedBinaries(@Mktmp final Path temp) throws IOException {
         final String binary = "org/eolang/f/x.a.class";
         MjPlaceTest.saveBinary(temp, binary);
@@ -77,11 +78,7 @@ final class MjPlaceTest {
         final Path path = MjPlaceTest.pathToPlacedBinary(temp, binary);
         final FakeMaven maven = new FakeMaven(temp).withPlacedBinary(path);
         maven.placed().unplaceAll();
-        MatcherAssert.assertThat(
-            "PlaceMojo have to process the file",
-            maven.execute(MjPlace.class).result(),
-            Matchers.hasValue(path)
-        );
+        maven.execute(MjPlace.class).result();
         MatcherAssert.assertThat(
             "The file must be updated, but it was not",
             content,
@@ -165,29 +162,22 @@ final class MjPlaceTest {
      */
     @Test
     void placesAllEoRuntimeClasses(@Mktmp final Path temp) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(
             "PlaceMojo have to place the runtime file, but doesn't",
-            maven.withHelloWorld()
+            new FakeMaven(temp).withHelloWorld()
                 .with("resolveJna", false)
                 .execute(new FakeMaven.Place())
                 .result()
                 .get(this.targetClasses()),
             new ContainsFiles("**/eo-runtime-*.class")
         );
-        MatcherAssert.assertThat(
-            "PlaceMojo have to place class file, but doesn't",
-            maven.placed().classes().size(),
-            Matchers.is(1)
-        );
     }
 
     @Test
     void placesWithoutEoRuntimeClasses(@Mktmp final Path temp) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp);
         MatcherAssert.assertThat(
             "PlaceMojo have not to place the runtime file, but doesn't",
-            maven.withHelloWorld()
+            new FakeMaven(temp).withHelloWorld()
                 .with("ignoreRuntime", true)
                 .with("resolveJna", false)
                 .execute(new FakeMaven.Place())
@@ -300,10 +290,9 @@ final class MjPlaceTest {
         final String content,
         final String binary
     ) throws IOException {
-        final String targets = "target/classes";
         new Saved(
             content,
-            temp.resolve(targets).resolve(binary)
+            temp.resolve("target/classes").resolve(binary)
         ).value();
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -45,9 +45,8 @@ final class MjPrintTest {
             new Saved(new TextOf(source), temp.resolve(source)).value();
         }
         final Path output = temp.resolve("output");
-        final Path sources = temp.resolve(resources);
         new FakeMaven(temp)
-            .with("printSourcesDir", sources.toFile())
+            .with("printSourcesDir", temp.resolve(resources).toFile())
             .with("printOutputDir", output.toFile())
             .execute(new FakeMaven.Print())
             .result();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -27,10 +27,8 @@ final class MjProbeTest {
 
     @Test
     void findsProbesViaOfflineHashFile(@Mktmp final Path temp) throws IOException {
-        final String tag = "master";
-        final String tags = "org/eolang/maven/commits/tags.txt";
         new Saved(
-            new ResourceOf(tags),
+            new ResourceOf("org/eolang/maven/commits/tags.txt"),
             temp.resolve("tags.txt")
         ).value();
         final String expected = "11";
@@ -40,7 +38,7 @@ final class MjProbeTest {
                 expected
             ),
             new FakeMaven(temp)
-                .with("hash", new ChCached(new ChText(temp.resolve("tags.txt"), tag)))
+                .with("hash", new ChCached(new ChText(temp.resolve("tags.txt"), "master")))
                 .withProgram(MjProbeTest.program())
                 .execute(new FakeMaven.Probe())
                 .programTojo()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
@@ -133,22 +133,25 @@ final class MjPullTest {
             .with("offline", true)
             .execute(new FakeMaven.Pull())
             .result();
-        final String format = "%s folder should not contain %s file, but it did";
         final String stdout = "org/eolang/io/stdout.eo";
         final String string = "org/eolang/string.eo";
         MatcherAssert.assertThat(
-            String.format(format, MjPull.DIR, stdout),
-            result.containsKey(String.format("%s/%s", MjPull.DIR, stdout)),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            String.format(format, MjPull.DIR, string),
-            result.containsKey(String.format("%s/%s", MjPull.DIR, string)),
-            Matchers.is(false)
+            String.format(
+                "%s folder should not contain %s and %s file, but it did",
+                MjPull.DIR,
+                stdout,
+                string
+            ),
+            result,
+            Matchers.allOf(
+                Matchers.not(Matchers.hasKey(String.format("%s/%s", MjPull.DIR, stdout))),
+                Matchers.not(Matchers.hasKey(String.format("%s/%s", MjPull.DIR, string)))
+            )
         );
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void skipsAlreadyPulled(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .withHelloWorld()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
@@ -29,12 +29,12 @@ final class MjRegisterTest {
             new ResourceOf("org/eolang/maven/file-name/abc-def.eo"),
             temp.resolve("src/eo/org/eolang/maven/abc-def.eo")
         ).value();
-        final FakeMaven maven = new FakeMaven(temp)
-            .with("sourcesDir", temp.resolve("src/eo").toFile())
-            .execute(new FakeMaven.Register());
         MatcherAssert.assertThat(
             "The resource must exist, but it doesn't",
-            maven.foreign().getById("org.eolang.maven.abc-def").exists("id"),
+            new FakeMaven(temp)
+                .with("sourcesDir", temp.resolve("src/eo").toFile())
+                .execute(new FakeMaven.Register()).foreign().getById("org.eolang.maven.abc-def")
+                .exists("id"),
             Matchers.is(true)
         );
     }
@@ -45,13 +45,13 @@ final class MjRegisterTest {
             new ResourceOf("org/eolang/maven/file-name/.abc.eo"),
             temp.resolve("src/eo/org/eolang/maven/.abc.eo")
         ).value();
-        final FakeMaven maven = new FakeMaven(temp)
-            .with("sourcesDir", temp.resolve("src/eo").toFile())
-            .with("strictFileNames", false)
-            .execute(new FakeMaven.Register());
         MatcherAssert.assertThat(
             "The resource with incorrect id must exist, but it doesn't",
-            maven.foreign().getById("org.eolang.maven..abc").exists("id"),
+            new FakeMaven(temp)
+                .with("sourcesDir", temp.resolve("src/eo").toFile())
+                .with("strictFileNames", false)
+                .execute(new FakeMaven.Register()).foreign().getById("org.eolang.maven..abc")
+                .exists("id"),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -38,18 +38,13 @@ final class MjResolveTest {
                 "# No comments.",
                 "[] > main ?"
             ).execute(new FakeMaven.Resolve());
-        final Path path = temp
-            .resolve("target")
-            .resolve(MjResolve.DIR)
-            .resolve("org.eolang/eo-runtime/-/0.7.0");
-        MatcherAssert.assertThat(
-            "Dependency directory must exist, but it doesn't",
-            path.toFile(),
-            FileMatchers.anExistingDirectory()
-        );
         MatcherAssert.assertThat(
             "The class file must exist, but it doesn't",
-            path.resolve("eo-runtime-0.7.0.class").toFile(),
+            temp
+                .resolve("target")
+                .resolve(MjResolve.DIR)
+                .resolve("org.eolang/eo-runtime/-/0.7.0").resolve("eo-runtime-0.7.0.class")
+                .toFile(),
             FileMatchers.anExistingFile()
         );
     }
@@ -79,18 +74,12 @@ final class MjResolveTest {
         );
         maven.foreignTojos().add("sum");
         maven.execute(new FakeMaven.Resolve());
-        final Path path = temp
-            .resolve("target")
-            .resolve(MjResolve.DIR)
-            .resolve("org.eolang/eo-runtime/-/");
-        MatcherAssert.assertThat(
-            "The directory with runtime must exist, but doesn't",
-            path.toFile(),
-            FileMatchers.anExistingDirectory()
-        );
         MatcherAssert.assertThat(
             "The class file must exist, but it doesn't",
-            path,
+            temp
+                .resolve("target")
+                .resolve(MjResolve.DIR)
+                .resolve("org.eolang/eo-runtime/-/"),
             new ContainsFiles("**/eo-runtime-*.class")
         );
     }
@@ -223,6 +212,7 @@ final class MjResolveTest {
      * @throws IOException In case of I/O issues.
      */
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void resolvesWithConflictingDependencies(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp).withProgram(
             "+package foo.x",
@@ -237,13 +227,12 @@ final class MjResolveTest {
             "# No comment.",
             "[] > main-1 ?"
         );
-        final Exception except = Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> maven.execute(new FakeMaven.Resolve())
-        );
         MatcherAssert.assertThat(
             "Expected that conflicting dependencies were found, but they were not",
-            except.getCause().getCause().getMessage(),
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> maven.execute(new FakeMaven.Resolve())
+            ).getCause().getCause().getMessage(),
             Matchers.containsString(
                 "1 conflicting dependencies are found: {org.eolang:eo-runtime:jar:=[0.22.0, 0.22.1]}"
             )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -40,7 +40,10 @@ import org.junit.jupiter.params.ParameterizedTest;
  *
  * @since 0.1
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings({
+    "PMD.TooManyMethods",
+    "PMD.UnitTestContainsTooManyAsserts"
+})
 @ExtendWith(MktmpResolver.class)
 @ExtendWith(RandomProgramResolver.class)
 final class MjTranspileTest {
@@ -125,19 +128,17 @@ final class MjTranspileTest {
     @Disabled
     @Test
     void doesNotTouchAtom(@Mktmp final Path temp) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp)
-            .withProgram(
-                "+package foo.x",
-                "+rt jvm org.eolang:eo-runtime:0.0.0\n",
-                "# Atom.",
-                "[x y z] > main ?"
-            );
-        final Map<String, Path> res = maven
-            .execute(new FakeMaven.Transpile())
-            .result();
         MatcherAssert.assertThat(
             "TranspileMojo should not touch atoms, but it did",
-            res,
+            new FakeMaven(temp)
+                .withProgram(
+                    "+package foo.x",
+                    "+rt jvm org.eolang:eo-runtime:0.0.0\n",
+                    "# Atom.",
+                    "[x y z] > main ?"
+                )
+                .execute(new FakeMaven.Transpile())
+                .result(),
             Matchers.not(
                 Matchers.allOf(
                     Matchers.hasKey(String.format("target/%s/foo/x/main.xmir", MjTranspile.DIR)),
@@ -216,6 +217,7 @@ final class MjTranspileTest {
 
     @Disabled
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void recompilesIfExpired(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final Map<String, Path> res = maven
@@ -292,10 +294,9 @@ final class MjTranspileTest {
     @Disabled
     @Test
     void transpilesSimpleEoProgram(@Mktmp final Path temp) throws Exception {
-        final Path src = Paths.get("../eo-runtime/src/main/eo/org/eolang/tuple.eo");
         final Map<String, Path> res = new FakeMaven(temp)
             .withProgram(
-                new TextOf(src).asString(),
+                new TextOf(Paths.get("../eo-runtime/src/main/eo/org/eolang/tuple.eo")).asString(),
                 "org.eolang.tuple",
                 "org/eolang/tuple.eo"
             )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnplaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnplaceTest.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.1
  * @checkstyle LocalFinalVariableNameCheck (100 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 @ExtendWith(MktmpResolver.class)
 final class MjUnplaceTest {
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void cleansAllTheFiles(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final Path clazz = MjUnplaceTest.placed(temp, maven, "class");
@@ -46,6 +46,7 @@ final class MjUnplaceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void keepsClasses(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp).with("keepBinaries", Set.of("**/*.class"));
         final Path clazz = MjUnplaceTest.placed(temp, maven, "class");
@@ -63,6 +64,7 @@ final class MjUnplaceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void updatesPlacedTojosFile(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final Path file = MjUnplaceTest.placed(temp, maven, "bat");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
@@ -39,6 +39,7 @@ final class MjUnspileTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void keepsSpecifiedClasses(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .with("keepBinaries", Set.of("EOorg/package-info.class"));
@@ -63,6 +64,7 @@ final class MjUnspileTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void deletesInnerGeneratedClasses(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         new Saved("outer", maven.generatedPath().resolve("EOorg/EOnumber.java")).value();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class ObjectsIndexTest {
 
     @Test
-    void contains() throws Exception {
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void runsContainsWithOnlyOneCallToDecoratedObject() throws Exception {
         final AtomicInteger calls = new AtomicInteger(0);
         final String object = "org.eolang.io.stderr";
         final ObjectsIndex index = new ObjectsIndex(
@@ -32,26 +33,44 @@ final class ObjectsIndexTest {
                 }
             )
         );
-        final String message = "The object must contain the value";
-        MatcherAssert.assertThat(
-            message,
-            index.contains(object),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            message,
-            index.contains(object),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "The index must not contain the unknown value",
-            index.contains("unknown"),
-            Matchers.is(false)
-        );
+        index.contains(object);
+        index.contains(object);
         MatcherAssert.assertThat(
             "The number of calls should be 1",
             calls.get(),
             Matchers.is(1)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void runsContainsSuccessfully() throws Exception {
+        final String object = "org.eolang.io.stderr";
+        MatcherAssert.assertThat(
+            "The object must contain the value",
+            new ObjectsIndex(
+                new ScalarOf<>(
+                    () -> {
+                        return Collections.singleton(object);
+                    }
+                )
+            ).contains(object),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotContainUnknownValue() throws Exception {
+        MatcherAssert.assertThat(
+            "The index must not contain the unknown value",
+            new ObjectsIndex(
+                new ScalarOf<>(
+                    () -> {
+                        return Collections.singleton("org.eolang.io.stderr");
+                    }
+                )
+            ).contains("unknown"),
+            Matchers.is(false)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -40,6 +40,7 @@ final class OyCachedTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void goesToOriginWhenCacheDoesNotHaveIt() throws IOException {
         final Input expected = new InputOf("Hello from origin!");
         MatcherAssert.assertThat(
@@ -52,6 +53,7 @@ final class OyCachedTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void savesInCacheWhenCacheDoesNotHaveIt() throws IOException {
         final String key = "jeff";
         final Input value = new InputOf("[] > jeff");
@@ -65,6 +67,7 @@ final class OyCachedTest {
     }
 
     @RepeatedTest(10)
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void cachesInConcurrentEnvironment() {
         final AtomicInteger calls = new AtomicInteger(0);
         final Input content = new InputOf("[] > foo");
@@ -76,12 +79,7 @@ final class OyCachedTest {
                 }
             )
         );
-        MatcherAssert.assertThat(
-            "We expect that all values are equal to the same content",
-            new Together<>(30, thread -> objectionary.get("parallel"))
-                .asList().stream().allMatch(input -> input.equals(content)),
-            Matchers.equalTo(true)
-        );
+        new Together<>(30, thread -> objectionary.get("parallel")).asList();
         final int expected = 1;
         MatcherAssert.assertThat(
             String.format("Original objectionary should be called only %d time", expected),
@@ -104,13 +102,14 @@ final class OyCachedTest {
     @Test
     void checksIsDirectoryWithExistingInCache() throws IOException {
         final String key = "abc";
-        final Input value = new InputOf("[] > abc");
-        final Map<String, Input> programs = new MapOf<>();
-        final Map<String, Boolean> dirs = new MapOf<>(key, true);
         MatcherAssert.assertThat(
             "The directory should be found in cache, but it was not",
             new OyCached(
-                new Objectionary.Fake(nme -> value), programs, dirs
+                new Objectionary.Fake(
+                    nme -> new InputOf("[] > abc")
+                ),
+                new MapOf<>(),
+                new MapOf<>(key, true)
             ).isDirectory(key),
             Matchers.is(true)
         );
@@ -118,14 +117,14 @@ final class OyCachedTest {
 
     @Test
     void checksIsDirectoryWithNotExistingInCache() throws IOException {
-        final String key = "jeff";
-        final Input value = new InputOf("[] > jeff");
-        final Map<String, Input> programs = new MapOf<>();
-        final Map<String, Boolean> dirs = new MapOf<>(key, true);
         MatcherAssert.assertThat(
             "The directory should not be found in cache, but it was",
             new OyCached(
-                new Objectionary.Fake(nme -> value), programs, dirs
+                new Objectionary.Fake(
+                    nme -> new InputOf("[] > jeff")
+                ),
+                new MapOf<>(),
+                new MapOf<>("jeff", true)
             ).isDirectory("not-in-cache"),
             Matchers.is(false)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -76,11 +76,9 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfProgram() throws IOException {
-        final CommitHash hash = new ChRemote("master");
-        final Objectionary objectionary = new OyRemote(hash);
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the program in Objectionary",
-            objectionary.contains("org.eolang.io.stdout"),
+            new OyRemote(new ChRemote("master")).contains("org.eolang.io.stdout"),
             Matchers.is(true)
         );
     }
@@ -88,11 +86,9 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfDirectory() throws IOException {
-        final CommitHash hash = new ChRemote("master");
-        final Objectionary objectionary = new OyRemote(hash);
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the directory in Objectionary",
-            objectionary.contains("org.eolang.ms"),
+            new OyRemote(new ChRemote("master")).contains("org.eolang.ms"),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
@@ -25,16 +25,25 @@ import org.junit.jupiter.params.provider.CsvSource;
 final class PackageInfosTest {
 
     @Test
-    void createsPackageInfosInSubDirectories(@Mktmp final Path tmp) throws IOException {
+    void returnsCorrectNumberOfPackageInfosInSubDirectories(@Mktmp final Path tmp)
+        throws IOException {
         final Path subdir = tmp.resolve("subdir");
-        final Path subsubdir = subdir.resolve("subsubdir");
         Files.createDirectory(subdir);
-        Files.createDirectories(subsubdir);
+        Files.createDirectories(subdir.resolve("subsubdir"));
         MatcherAssert.assertThat(
             "We should create exactly two package-info.java files for two subdirectories",
             new PackageInfos(tmp).create(),
             Matchers.equalTo(2)
         );
+    }
+
+    @Test
+    void createsPackageInfosInSubDirectories(@Mktmp final Path tmp) throws IOException {
+        final Path subdir = tmp.resolve("subdir");
+        final Path subsubdir = subdir.resolve("subsubdir");
+        Files.createDirectory(subdir);
+        Files.createDirectories(subsubdir);
+        new PackageInfos(tmp).create();
         MatcherAssert.assertThat(
             "package-info.java should be created in the both subdirectories",
             Files.exists(subdir.resolve("package-info.java"))
@@ -50,6 +59,11 @@ final class PackageInfosTest {
             new PackageInfos(tmp).create(),
             Matchers.equalTo(0)
         );
+    }
+
+    @Test
+    void ignoresTheRootDirectoryAndDoesNotCreateFiles(@Mktmp final Path tmp) throws IOException {
+        new PackageInfos(tmp).create();
         MatcherAssert.assertThat(
             "package-info.java should not be created in the root directory",
             Files.exists(tmp.resolve("package-info.java")),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbesTest.java
@@ -37,16 +37,13 @@ final class ProbesTest {
         final List<String> expected = Optional.ofNullable(
             (List<String>) xtory.map().get("probes")
         ).orElse(Collections.emptyList());
-        final Probes actual = new Probes(new EoSyntax(xtory.map().get("eo").toString()).parsed());
-        MatcherAssert.assertThat(
-            "We should find the same number of probes as in the YAML file",
-            actual,
-            Matchers.iterableWithSize(expected.size())
-        );
         MatcherAssert.assertThat(
             "Probes should match the ones in the YAML file",
-            actual,
-            Matchers.containsInAnyOrder(expected.toArray(new String[0]))
+            new Probes(new EoSyntax(xtory.map().get("eo").toString()).parsed()),
+            Matchers.allOf(
+                Matchers.<String>iterableWithSize(expected.size()),
+                Matchers.containsInAnyOrder(expected.toArray(new String[0]))
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ThreadedTest.java
@@ -23,7 +23,11 @@ final class ThreadedTest {
      * @checkstyle IllegalCatchCheck (25 lines)
      * @checkstyle MethodBodyCommentsCheck (25 lines)
      */
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidThrowingRawExceptionTypes"})
+    @SuppressWarnings({
+        "PMD.AvoidCatchingGenericException",
+        "PMD.AvoidThrowingRawExceptionTypes",
+        "PMD.ExceptionAsFlowControl"
+    })
     @Test
     void logsAllExceptionsInTheLogsOnFailure() {
         final List<String> logs = Collections.synchronizedList(new ListOf<>());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TjsForeignTest.java
@@ -6,7 +6,6 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.Func;
@@ -43,11 +42,13 @@ final class TjsForeignTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "abs",
-        "org.eolang.int",
-        "QQ.io.stdout"
-    })
+    @CsvSource(
+        {
+            "abs",
+            "org.eolang.int",
+            "QQ.io.stdout"
+        }
+    )
     void contains(final String name) {
         this.tojos.add(name);
         MatcherAssert.assertThat(
@@ -58,11 +59,13 @@ final class TjsForeignTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "abs, sba",
-        "org.eolang.int, org.eolang.float",
-        "QQ.io.stdout, QQ.tt.sprintf"
-    })
+    @CsvSource(
+        {
+            "abs, sba",
+            "org.eolang.int, org.eolang.float",
+            "QQ.io.stdout, QQ.tt.sprintf"
+        }
+    )
     void doesNotContain(final String existing, final String considered) {
         this.tojos.add(existing);
         MatcherAssert.assertThat(
@@ -83,6 +86,7 @@ final class TjsForeignTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void throwsExceptionIfTojoWasNotFound() {
         final String id = "absent";
         Assertions.assertThrows(
@@ -95,12 +99,9 @@ final class TjsForeignTest {
     @Test
     void findsAnyTojoIfSeveralTojosWithTheSameIdWereAdded() {
         final String same = "same";
-        final TjForeign first = this.tojos.add(same);
-        final TjForeign second = this.tojos.add(same);
-        final List<TjForeign> expected = Arrays.asList(first, second);
         MatcherAssert.assertThat(
             "We don't care which tojo will be returned, but it should be one of the added tojos",
-            expected,
+            Arrays.asList(this.tojos.add(same), this.tojos.add(same)),
             Matchers.hasItem(this.tojos.find(same))
         );
     }
@@ -109,7 +110,8 @@ final class TjsForeignTest {
     @MethodSource("tojoFunctionsWithoutDefaultValues")
     void throwsExceptionIfKeyWasNotFoundInTojo(
         final String key,
-        final Func<TjForeign, Object> method) {
+        final Func<TjForeign, Object> method
+    ) {
         final TjForeign tojo = this.tojos.add("string");
         Assertions.assertThrows(
             AttributeNotFoundException.class,
@@ -119,15 +121,14 @@ final class TjsForeignTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void getsExceptionMessageIfKeyWasNotFoundInTojo() {
-        final TjForeign tojo = this.tojos.add("string");
-        final AttributeNotFoundException thrown = Assertions.assertThrows(
-            AttributeNotFoundException.class,
-            tojo::xmir
-        );
         Assertions.assertEquals(
             "There is no 'XMIR' attribute in the tojo",
-            thrown.getMessage(),
+            Assertions.assertThrows(
+                AttributeNotFoundException.class,
+                this.tojos.add("string")::xmir
+            ).getMessage(),
             "Should throw an exception if key 'XMIR' was not found in Tojo"
         );
     }
@@ -138,9 +139,8 @@ final class TjsForeignTest {
         final String key,
         final Func<TjForeign, ?> method
     ) throws Exception {
-        final TjForeign tojo = this.tojos.add("string");
         Assertions.assertEquals(
-            method.apply(tojo),
+            method.apply(this.tojos.add("string")),
             key,
             String.format("Shouldn't throw an exception if key='%s' was found in Tojo", key)
         );
@@ -164,7 +164,6 @@ final class TjsForeignTest {
         this.tojos.close();
     }
 
-    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> tojoFunctionsWithoutDefaultValues() {
         return Stream.of(
             Arguments.of("XMIR", (Func<TjForeign, Object>) TjForeign::xmir),
@@ -176,7 +175,6 @@ final class TjsForeignTest {
         );
     }
 
-    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> tojoFunctionsWithDefaultValues() {
         return Stream.of(
             Arguments.of("string", (Func<TjForeign, Object>) TjForeign::identifier),


### PR DESCRIPTION
This PR upgrades the `qulice-maven-plugin` to version `0.25.1` in `eo-maven-plugin`.

Related to #4884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration with explicit plugin version specification for improved build consistency.

* **Refactor**
  * Improved code style and readability through code simplification and explicit type declarations throughout the codebase.

* **Tests**
  * Restructured and reorganized test suite for better maintainability and coverage verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->