### PR TITLE
refactor(#4884): upgrade qulice to version 0.25.1 in `eo-runtime`

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -385,6 +385,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.25.1</version>
             <configuration>
               <excludes>
                 <exclude>dependencies:org.eolang:eo-maven-plugin</exclude>

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOslice.java
@@ -38,6 +38,7 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final int start = Expect.at(this, "start")
             .that(phi -> new Dataized(phi).asNumber())

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOerror.java
@@ -140,8 +140,10 @@ public final class EOerror extends PhDefault implements Atom {
          * @param message New one
          * @return New list of them
          */
-        private static Collection<String> concat(final Collection<String> before,
-            final String message) {
+        private static Collection<String> concat(
+            final Collection<String> before,
+            final String message
+        ) {
             final Collection<String> list = new ArrayList<>(before.size() + 1);
             list.addAll(before);
             list.add(message);
@@ -161,11 +163,10 @@ public final class EOerror extends PhDefault implements Atom {
                 result = "null Phi";
             } else {
                 try {
-                    final byte[] raw = new Dataized(enclosure).take();
                     result = String.format(
                         "%s(Δ = %s)",
                         enclosure,
-                        new VerboseBytesAsString(raw).get()
+                        new VerboseBytesAsString(new Dataized(enclosure).take()).get()
                     );
                 } catch (final Exception first) {
                     try {

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfs/EOdir$EOwalk.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfs/EOdir$EOwalk.java
@@ -42,17 +42,19 @@ public final class EOdir$EOwalk extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final Path path = Paths.get(
             new Dataized(
                 this.take(Phi.RHO).take("file").take("path")
             ).asString()
         ).toAbsolutePath();
-        final String glob = new Dataized(
-            this.take("glob")
-        ).asString();
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(
-            String.format("glob:%s", glob)
+            String.format(
+                "glob:%s", new Dataized(
+                    this.take("glob")
+                ).asString()
+            )
         );
         try (Stream<Path> paths = Files.walk(path)) {
             return new Data.ToPhi(

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfs/Files.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfs/Files.java
@@ -23,7 +23,12 @@ import org.eolang.ExFailure;
 /**
  * File streams.
  * @since 0.40
+ * @todo #4884:30min Use ReentrantLock instead of 'synchronized' in Files.
+ *  We should use ReentrantLock instead of 'synchronized' to avoid potential
+ *  deadlocks when multiple AtOnce attributes are used together.
+ *  Moreover, 'synchronized' keyword is forbidden by qulice.
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class Files {
     /**
      * Files instance.
@@ -33,6 +38,7 @@ final class Files {
     /**
      * File input streams for reading.
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     private final ConcurrentHashMap<String, Object[]> streams;
 
     /**
@@ -52,7 +58,7 @@ final class Files {
         final Path path = Paths.get(name);
         this.streams.putIfAbsent(
             name,
-            new Object[] {
+            new Object[]{
                 java.nio.file.Files.newInputStream(path),
                 java.nio.file.Files.newOutputStream(path, StandardOpenOption.APPEND),
             }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOresized.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmalloc$EOof$EOallocated$EOresized.java
@@ -34,6 +34,7 @@ public final class EOmalloc$EOof$EOallocated$EOresized extends PhDefault impleme
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final Phi rho = this.take(Phi.RHO);
         final int id = Expect.at(rho, "id")

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOms/EOpow.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOms/EOpow.java
@@ -23,7 +23,6 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "pow")
-@SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOpow extends PhDefault implements Atom {
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOdiv.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOdiv.java
@@ -35,6 +35,7 @@ public final class EOnumber$EOdiv extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final Double left = new Expect.Number(Expect.at(this, Phi.RHO)).it();
         final Double right = new Expect.Number(Expect.at(this, "x")).it();

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOgt.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOgt.java
@@ -35,6 +35,7 @@ public final class EOnumber$EOgt extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final Double left = new Expect.Number(Expect.at(this, Phi.RHO)).it();
         final Double right = new Expect.Number(Expect.at(this, "x")).it();

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOplus.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOplus.java
@@ -36,8 +36,11 @@ public final class EOnumber$EOplus extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        final Double left = new Expect.Number(Expect.at(this, Phi.RHO)).it();
-        final Double right = new Expect.Number(Expect.at(this, "x")).it();
-        return new Data.ToPhi(Double.sum(left, right));
+        return new Data.ToPhi(
+            Double.sum(
+                new Expect.Number(Expect.at(this, Phi.RHO)).it(),
+                new Expect.Number(Expect.at(this, "x")).it()
+            )
+        );
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOtimes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOnumber$EOtimes.java
@@ -36,8 +36,9 @@ public final class EOnumber$EOtimes extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        final Double left = new Expect.Number(Expect.at(this, Phi.RHO)).it();
-        final Double right = new Expect.Number(Expect.at(this, "x")).it();
-        return new Data.ToPhi(left * right);
+        return new Data.ToPhi(
+            new Expect.Number(Expect.at(this, Phi.RHO)).it()
+                * new Expect.Number(Expect.at(this, "x")).it()
+        );
     }
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Posix/ReadSyscall.java
@@ -36,7 +36,7 @@ public final class ReadSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
         final Phi result = this.posix.take("return").copy();
-        final byte[] buf = new byte[(int) size];
+        final byte[] buf = new byte[size];
         final int count = CStdLib.INSTANCE.read(
             new Dataized(params[0]).asNumber().intValue(), buf, size
         );

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Posix/RecvSyscall.java
@@ -36,7 +36,7 @@ public final class RecvSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
         final int size = new Dataized(params[1]).asNumber().intValue();
-        final byte[] buf = new byte[(int) size];
+        final byte[] buf = new byte[size];
         final int received = CStdLib.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),
             buf,

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/SockaddrIn.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/SockaddrIn.java
@@ -18,7 +18,7 @@ import java.util.List;
  * @checkstyle VisibilityModifierCheck (50 lines)
  * @checkstyle ParameterNumberCheck (50 lines)
  */
-@SuppressWarnings({"PMD.OnlyOneConstructorShouldDoInitialization", "PMD.DataClass"})
+@SuppressWarnings("PMD.OnlyOneConstructorShouldDoInitialization")
 public final class SockaddrIn extends Structure {
     /**
      * Address family (e.g., AF_INET).
@@ -55,7 +55,7 @@ public final class SockaddrIn extends Structure {
      * @param addr Address
      */
     public SockaddrIn(final short family, final short port, final int addr) {
-        this(family, port, addr, new byte[] {0, 0, 0, 0, 0, 0, 0, 0});
+        this(family, port, addr, new byte[]{0, 0, 0, 0, 0, 0, 0, 0});
     }
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Syscall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Syscall.java
@@ -15,6 +15,7 @@ import org.eolang.Phi;
  *
  * @since 0.40
  */
+@FunctionalInterface
 public interface Syscall {
     /**
      * Makes native method call.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/InetAddrFuncCall.java
@@ -42,11 +42,12 @@ public final class InetAddrFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
         try {
-            final byte[] bytes = InetAddress.getByName(
-                new Dataized(params[0]).asString()
-            ).getAddress();
             final ByteBuffer buffer = ByteBuffer.allocate(4);
-            buffer.put(bytes);
+            buffer.put(
+                InetAddress.getByName(
+                    new Dataized(params[0]).asString()
+                ).getAddress()
+            );
             result.put(0, new Data.ToPhi(Integer.reverseBytes(buffer.getInt(0))));
         } catch (final UnknownHostException exception) {
             Kernel32.INSTANCE.SetLastError(Winsock.WSAEINVAL);

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/ReadFileFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/ReadFileFuncCall.java
@@ -38,7 +38,7 @@ public final class ReadFileFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
-        final byte[] buf = new byte[(int) size];
+        final byte[] buf = new byte[size];
         final IntByReference read = new IntByReference();
         final Phi result = this.win.take("return").copy();
         result.put(

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/RecvFuncCall.java
@@ -38,7 +38,7 @@ public final class RecvFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
         final int size = new Dataized(params[1]).asNumber().intValue();
-        final byte[] buf = new byte[(int) size];
+        final byte[] buf = new byte[size];
         final int received = Winsock.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),
             buf,

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinBase.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinBase.java
@@ -19,7 +19,7 @@ import com.sun.jna.Structure;
  * @since 0.40.0
  * @checkstyle InterfaceIsTypeCheck (500 lines)
  */
-@SuppressWarnings({"PMD.ConstantsInInterface", "PMD.LongVariable"})
+@SuppressWarnings({"PMD.ConstantsInInterface", "PMD.LongVariable", "PMD.DataClass"})
 public interface WinBase extends WinDef, BaseTSD {
     /**
      * Constant value representing an invalid {@link WinNT.HANDLE}.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinDef.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinDef.java
@@ -21,6 +21,7 @@ public interface WinDef {
      * @since 0.40
      * @checkstyle AbbreviationAsWordInNameCheck (30 lines)
      */
+    @SuppressWarnings("PMD.OverrideBothEqualsAndHashCodeOnComparable")
     final class WORD extends IntegerType implements Comparable<WORD> {
 
         /**
@@ -47,6 +48,7 @@ public interface WinDef {
      * @since 0.40
      * @checkstyle AbbreviationAsWordInNameCheck (30 lines)
      */
+    @SuppressWarnings("PMD.OverrideBothEqualsAndHashCodeOnComparable")
     final class DWORD extends IntegerType implements Comparable<DWORD> {
         /**
          * Constant size.

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinNT.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOsm/Win32/WinNT.java
@@ -20,7 +20,7 @@ import com.sun.jna.PointerType;
  * @since 0.40
  * @checkstyle InterfaceIsTypeCheck (500 lines)
  */
-@SuppressWarnings("PMD.LongVariable")
+@SuppressWarnings({"PMD.LongVariable", "PMD.ConstantsInInterface"})
 public interface WinNT extends WinDef, WinBase, BaseTSD {
     /**
      * This flag specifies the file's attributes. FILE_ATTRIBUTE_NORMAL indicates that the file

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -11,7 +11,6 @@ package EOorg.EOeolang.EOtt; // NOPMD
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -61,22 +60,24 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
     @Override
     public Phi lambda() {
         final Phi match = this.take(Phi.RHO);
-        final InputStream stream = new ByteArrayInputStream(
-            new Dataized(match.take(Phi.RHO).take("serialized")).take()
-        );
         final Matcher matcher;
         try {
-            matcher = ((Pattern) new ObjectInputStream(stream).readObject()).matcher(
+            matcher = ((Pattern) new ObjectInputStream(
+                new ByteArrayInputStream(
+                    new Dataized(match.take(Phi.RHO).take("serialized")).take()
+                )
+            ).readObject()).matcher(
                 new Dataized(match.take("txt")).asString()
             );
         } catch (final IOException | ClassNotFoundException ex) {
             throw new IllegalArgumentException(ex);
         }
         final Phi start = this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.START);
-        final Double from = new Dataized(
-            this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
-        ).asNumber();
-        final boolean found = matcher.find(from.intValue());
+        final boolean found = matcher.find(
+            new Dataized(
+                this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
+            ).asNumber().intValue()
+        );
         final Phi result;
         if (found) {
             result = match.take("matched");
@@ -94,7 +95,7 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
                     groups[idx] = new Data.ToPhi(matcher.group(idx));
                 }
             } else {
-                groups = new Phi[] {new Data.ToPhi(matcher.group())};
+                groups = new Phi[]{new Data.ToPhi(matcher.group())};
             }
             result.put("groups", new Data.ToPhi(groups));
         } else {

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOregex$EOφ.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOregex$EOφ.java
@@ -47,8 +47,7 @@ public final class EOregex$EOφ extends PhDefault implements Atom {
         final Phi pattern = regex.take("pattern");
         try {
             final ObjectOutputStream ous = new ObjectOutputStream(baos);
-            final Pattern compiled = Pattern.compile(builder.toString());
-            ous.writeObject(compiled);
+            ous.writeObject(Pattern.compile(builder.toString()));
             pattern.put(0, new Data.ToPhi(baos.toByteArray()));
             ous.close();
             return pattern;

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOsprintf.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOsprintf.java
@@ -25,7 +25,6 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "sprintf")
-@SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOsprintf extends PhDefault implements Atom {
 
     /**

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOsscanf.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOtt/EOsscanf.java
@@ -31,7 +31,6 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "sscanf")
-@SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOsscanf extends PhDefault implements Atom {
     /**
      * Character conversion.
@@ -64,7 +63,7 @@ public final class EOsscanf extends PhDefault implements Atom {
     @SuppressWarnings("PMD.CognitiveComplexity")
     public Phi lambda() {
         final String format = new Dataized(this.take("format")).asString();
-        final StringBuilder regex = new StringBuilder();
+        final StringBuilder regex = new StringBuilder(30);
         boolean literal = false;
         for (int idx = 0; idx < format.length(); ++idx) {
             final char sym = format.charAt(idx);

--- a/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/Heaps.java
@@ -18,7 +18,12 @@ import org.eolang.Phi;
  * Dynamic memory.
  *
  * @since 0.19
+ * @todo #4884:30min Use ReentrantLock instead of 'synchronized' in Heaps.
+ *  We should use ReentrantLock instead of 'synchronized' to avoid potential
+ *  deadlocks when multiple AtOnce attributes are used together.
+ *  Moreover, 'synchronized' keyword is forbidden by qulice.
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class Heaps {
 
     /**
@@ -29,6 +34,7 @@ final class Heaps {
     /**
      * All.
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     private final ConcurrentHashMap<Integer, byte[]> blocks;
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -12,7 +12,12 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>It's highly recommended to use it with {@link AtComposite}.</p>
  *
  * @since 0.1
+ * @todo #4884:30min Use ReentrantLock instead of 'synchronized' in AtOnce.
+ *  We should use ReentrantLock instead of 'synchronized' to avoid potential
+ *  deadlocks when multiple AtOnce attributes are used together.
+ *  Moreover, 'synchronized' keyword is forbidden by qulice.
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 public final class AtOnce implements Attr {
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/Atom.java
+++ b/eo-runtime/src/main/java/org/eolang/Atom.java
@@ -13,6 +13,7 @@ package org.eolang;
  *
  * @since 0.36.0
  */
+@FunctionalInterface
 public interface Atom {
     /**
      * Executes λ function and calculates object.

--- a/eo-runtime/src/main/java/org/eolang/AtomSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtomSafe.java
@@ -9,7 +9,7 @@ package org.eolang;
  *
  * @since 0.36.0
  */
-@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
 public final class AtomSafe implements Atom {
     /**
      * Original atom.

--- a/eo-runtime/src/main/java/org/eolang/BytesOf.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesOf.java
@@ -99,7 +99,6 @@ public final class BytesOf implements Bytes {
     }
 
     @Override
-    @SuppressWarnings("PMD.CognitiveComplexity")
     public Bytes shift(final int bits) {
         return this.bytes.shift(bits);
     }

--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -135,7 +135,7 @@ final class BytesRaw implements Bytes {
 
     @Override
     public String asString() {
-        final StringBuilder out = new StringBuilder(0);
+        final StringBuilder out = new StringBuilder(3);
         for (final byte bte : this.data) {
             if (out.length() > 0) {
                 out.append('-');
@@ -192,7 +192,7 @@ final class BytesRaw implements Bytes {
             } else {
                 byte dst = (byte) (bytes[source] << mod);
                 if (source + 1 < bytes.length) {
-                    dst |= (byte) (bytes[source + 1] >>> (Byte.SIZE - mod) & (carry & 0xFF));
+                    dst |= (byte) (bytes[source + 1] >>> (Byte.SIZE - mod) & carry & 0xFF);
                 }
                 bytes[index] = dst;
             }
@@ -216,7 +216,7 @@ final class BytesRaw implements Bytes {
             } else {
                 byte dst = (byte) ((0xff & bytes[source]) >>> mod);
                 if (source - 1 >= 0) {
-                    dst |= (byte) (bytes[source - 1] << (Byte.SIZE - mod) & (carry & 0xFF));
+                    dst |= (byte) (bytes[source - 1] << (Byte.SIZE - mod) & carry & 0xFF);
                 }
                 bytes[index] = dst;
             }
@@ -258,8 +258,10 @@ final class BytesRaw implements Bytes {
      * @param type The type to fit into
      * @return The same buffer
      */
-    private static ByteBuffer whenFit(final ByteBuffer buf, final byte[] bytes,
-        final Class<?> type) {
+    private static ByteBuffer whenFit(
+        final ByteBuffer buf, final byte[] bytes,
+        final Class<?> type
+    ) {
         final int expected;
         try {
             expected = type.getField("BYTES").getInt(null);

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
  * @since 0.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
+@FunctionalInterface
 public interface Data {
     /**
      * Take the data.

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -75,7 +75,7 @@ public final class Dataized {
      *
      * @return The data
      */
-    @SuppressWarnings("PMD.PreserveStackTrace")
+    @SuppressWarnings({"PMD.UnnecessaryLocalRule", "PMD.PreserveStackTrace"})
     public byte[] take() {
         try {
             return this.phi.delta();

--- a/eo-runtime/src/main/java/org/eolang/JavaPath.java
+++ b/eo-runtime/src/main/java/org/eolang/JavaPath.java
@@ -45,7 +45,7 @@ final class JavaPath {
 
     @Override
     public String toString() {
-        return DOTS.matcher(JavaPath.PHI.matcher(this.object).replaceAll(""))
+        return JavaPath.DOTS.matcher(JavaPath.PHI.matcher(this.object).replaceAll(""))
             .replaceAll("$1EO$2")
             .replace("$", "$EO")
             .replace("-", "_");

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -198,6 +198,7 @@ public final class Main {
      * Run this opts.
      * @param opts The opts left
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static void run(final List<String> opts) {
         final String obj = opts.get(0);
         if (obj.isEmpty()) {
@@ -231,6 +232,7 @@ public final class Main {
      * @return Version string
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static String ver() throws IOException {
         try (
             BufferedReader input =

--- a/eo-runtime/src/main/java/org/eolang/PhCached.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCached.java
@@ -13,6 +13,10 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>It's highly recommended to use it with {@link PhComposite}.</p>
  *
  * @since 0.1
+ * @todo #4884:30min Replace 'synchronized' with ReentrantLock.
+ *  We need to replace 'synchronized' with ReentrantLock to avoid potential
+ *  deadlocks when multiple threads are trying to access the cache simultaneously.
+ *  Moreover, 'synchronized' keyword is forbidden by qulice.
  */
 public final class PhCached implements Phi {
 
@@ -46,6 +50,7 @@ public final class PhCached implements Phi {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Phi take(final String name) {
         synchronized (this.cached) {
             if (this.cached.get() == null) {

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
+@SuppressWarnings("PMD.TooManyMethods")
 public class PhDefault implements Phi, Cloneable {
     /**
      * Logger.

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -12,7 +12,7 @@ package org.eolang;
  * <p>This class is thread-safe.</p>
  * @since 0.24
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.SystemPrintln"})
+@SuppressWarnings("PMD.SystemPrintln")
 public final class PhLogged implements Phi {
 
     /**
@@ -45,6 +45,7 @@ public final class PhLogged implements Phi {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi take(final String name) {
         System.out.printf("%d.take(\"%s\")...\n", this.hashCode(), name);
         final Phi ret = this.origin.take(name);
@@ -87,6 +88,7 @@ public final class PhLogged implements Phi {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public byte[] delta() {
         System.out.printf("%d.delta()...\n", this.hashCode());
         final byte[] data = this.origin.delta();

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -12,9 +12,13 @@ import java.util.function.Supplier;
  * An object wrapping another one.
  *
  * @since 0.1
+ * @todo #4884:30min Use ReentrantLock instead of synchronized block in the constructor.
+ *  This will allow to avoid blocking the whole object while fetching the wrapped one.
+ *  Moreover, using 'syznchronized' is forbidden by qulice.
+ *  Don't forget to remove the suppression of PMD.AvoidSynchronizedStatement in
+ *  the constructor after that.
  * @checkstyle DesignForExtensionCheck (100 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public class PhOnce implements Phi {
 
     /**
@@ -32,6 +36,7 @@ public class PhOnce implements Phi {
      *
      * @param obj The object
      */
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public PhOnce(final Supplier<Phi> obj) {
         this.ref = new AtomicReference<>(null);
         this.object = () -> {

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -14,14 +14,12 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.22
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class PhPackage implements Phi {
     /**
      * Global package.
      * @checkstyle VisibilityModifierCheck (3 lines)
      * @checkstyle StaticVariableNameCheck (3 lines)
      */
-    @SuppressWarnings("PMD.FieldNamingConventions")
     public static final String GLOBAL = "Φ";
 
     /**
@@ -139,10 +137,8 @@ final class PhPackage implements Phi {
                     ),
                     phi
                 );
-            } catch (final NoSuchMethodException
-                | InvocationTargetException
-                | InstantiationException
-                | IllegalAccessException ex
+            } catch (final NoSuchMethodException | InvocationTargetException
+                | InstantiationException | IllegalAccessException ex
             ) {
                 throw new ExFailure(
                     String.format(

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -90,8 +90,10 @@ public final class PhSafe implements Phi, Atom {
      * @param oname Original name
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    public PhSafe(final Phi phi, final String prg, final int lne,
-        final int pos, final String loc, final String oname) {
+    public PhSafe(
+        final Phi phi, final String prg, final int lne,
+        final int pos, final String loc, final String oname
+    ) {
         this.origin = phi;
         this.program = prg;
         this.line = lne;
@@ -182,6 +184,7 @@ public final class PhSafe implements Phi, Atom {
      * @param <T> Type of result
      * @return Result
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private <T> T through(final Supplier<T> action) {
         return this.through(action, "");
     }
@@ -199,7 +202,7 @@ public final class PhSafe implements Phi, Atom {
      * @return Result
      * @checkstyle IllegalCatchCheck (20 lines)
      */
-    @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.PreserveStackTrace"})
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();

--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -49,11 +49,10 @@ public final class VerboseBytesAsString implements Supplier<String> {
                 );
                 break;
             case 8:
-                final Bytes bytes = new BytesOf(this.data);
                 result = String.format(
                     "[0x%s] = %s, or \"%s\")",
                     this.toHex(),
-                    bytes.asNumber(),
+                    new BytesOf(this.data).asNumber(),
                     this.escaped()
                 );
                 break;

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOsliceTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EObytesEOsliceTest.java
@@ -50,6 +50,7 @@ final class EObytesEOsliceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void takesWrongSlice() {
         MatcherAssert.assertThat(
             "error message is correct",

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOerrorTest.java
@@ -52,6 +52,7 @@ final class EOerrorTest {
 
     @ParameterizedTest
     @MethodSource("getTestSources")
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void getsReadableError(final byte[] cnst, final String text) {
         MatcherAssert.assertThat(
             "Bytes must be translated to string correctly",
@@ -95,7 +96,6 @@ final class EOerrorTest {
          * Ctor.
          * @param data The data inside error.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         MyError(final Object data) {
             this.add(
                 "φ",

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOfs/FilesTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOfs/FilesTest.java
@@ -66,8 +66,10 @@ final class FilesTest {
     @Test
     void readsFromFile(@Mktmp final Path dir) throws IOException {
         final String file = dir.resolve("bar.txt").toFile().getAbsolutePath();
-        try (BufferedWriter writer =
-            java.nio.file.Files.newBufferedWriter(Paths.get(file))) {
+        try (
+            BufferedWriter writer =
+                java.nio.file.Files.newBufferedWriter(Paths.get(file))
+        ) {
             writer.write("Hello, world");
         }
         Files.INSTANCE.open(file);
@@ -82,8 +84,10 @@ final class FilesTest {
     @Test
     void writesToFile(@Mktmp final Path dir) throws IOException {
         final String file = dir.resolve("foo.txt").toFile().getAbsolutePath();
-        try (BufferedWriter writer =
-            java.nio.file.Files.newBufferedWriter(Paths.get(file))) {
+        try (
+            BufferedWriter writer =
+                java.nio.file.Files.newBufferedWriter(Paths.get(file))
+        ) {
             writer.write("Hello, world");
         }
         Files.INSTANCE.open(file);

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOio/InputOutputTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOio/InputOutputTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  * @since 0.40
  * @checkstyle TypeNameCheck (100 lines)
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "PMD.TooManyMethods"})
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(MktmpResolver.class)
 final class InputOutputTest {
@@ -109,7 +109,9 @@ final class InputOutputTest {
      * @throws IOException If fails to create temporary file
      */
     private static byte[] redirectedStdin(
-        final Path temp, final String content, final Supplier<byte[]> action
+        final Path temp,
+        final String content,
+        final Supplier<byte[]> action
     ) throws IOException {
         final byte[] res;
         if (InputOutputTest.isWindows()) {
@@ -146,14 +148,17 @@ final class InputOutputTest {
      * @return Read content
      * @throws IOException If fails to create temporary file
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static byte[] posixStdin(
-        final Path temp, final String content, final Supplier<byte[]> action
+        final Path temp,
+        final String content,
+        final Supplier<byte[]> action
     ) throws IOException {
         final File file = Files.createTempFile(
             temp, String.valueOf(action.hashCode()), null
         ).toFile();
         file.deleteOnExit();
-        Files.write(file.toPath(), content.getBytes());
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
         final int descriptor = CStdLib.INSTANCE.open(file.getAbsolutePath(), CStdLib.O_RDONLY);
         assert descriptor >= 0;
         final int origin = CStdLib.INSTANCE.dup(CStdLib.INSTANCE.STDIN_FILENO);
@@ -195,8 +200,11 @@ final class InputOutputTest {
      * @param action Action to run
      * @throws IOException If fails to create temporary file
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static byte[] windowsStdin(
-        final Path temp, final String content, final Supplier<byte[]> action
+        final Path temp,
+        final String content,
+        final Supplier<byte[]> action
     ) throws IOException {
         final File file = Files.createTempFile(
             temp, String.valueOf(action.hashCode()), null
@@ -228,6 +236,7 @@ final class InputOutputTest {
      * @return Stdout as file
      * @throws IOException If fails to create temporary file
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static File windowsStdout(final Path temp, final Runnable action) throws IOException {
         final File file = Files.createTempFile(
             temp, String.valueOf(action.hashCode()), null
@@ -268,58 +277,71 @@ final class InputOutputTest {
     final class ConsoleTest {
         @Test
         void dataizesConsoleWriteAsTrue() {
-            final Phi phi = new PhWith(
-                Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.WRITE).copy(),
-                "buffer",
-                new Data.ToPhi("dataizes as true")
-            );
             Assertions.assertTrue(
-                new Dataized(phi).asBool(),
+                new Dataized(
+                    new PhWith(
+                        Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.WRITE).copy(),
+                        "buffer",
+                        new Data.ToPhi("dataizes as true")
+                    )
+                ).asBool(),
                 "The `console.write` should have returned TRUE, but it didn't"
             );
         }
 
         @Test
+        @SuppressWarnings("PMD.UnnecessaryLocalRule")
         void writesToConsole(@Mktmp final Path temp) throws IOException {
             final String msg = "writes to console";
-            final File file = InputOutputTest.redirectedStdout(
-                temp,
-                () -> new Dataized(
-                    new PhWith(
-                        Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.WRITE).copy(),
-                        "buffer",
-                        new Data.ToPhi(msg)
-                    )
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'console.write' should have written to console, but it didn't",
-                Files.readString(Paths.get(file.getAbsolutePath()), StandardCharsets.UTF_8),
+                Files.readString(
+                    Paths.get(
+                        InputOutputTest.redirectedStdout(
+                            temp,
+                            () -> new Dataized(
+                                new PhWith(
+                                    Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.WRITE)
+                                        .copy(),
+                                    "buffer",
+                                    new Data.ToPhi(msg)
+                                )
+                            ).take()
+                        ).getAbsolutePath()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.containsString(msg)
             );
         }
 
         @Test
         void writesToConsoleSequentially(@Mktmp final Path temp) throws IOException {
-            final File file = InputOutputTest.redirectedStdout(
-                temp,
-                () -> {
-                    final Phi first = new PhWith(
-                        Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.WRITE).copy(),
-                        0, new Data.ToPhi("Hey")
-                    );
-                    final Phi second = new PhWith(
-                        new PhCopy(
-                            new PhMethod(first, InputOutputTest.WRITE)
-                        ),
-                        0, new Data.ToPhi("There")
-                    );
-                    new Dataized(second).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The 'console.write' should have return output block ready to write again, but it didn't",
-                Files.readString(Paths.get(file.getAbsolutePath()), StandardCharsets.UTF_8),
+                Files.readString(
+                    Paths.get(
+                        InputOutputTest.redirectedStdout(
+                            temp,
+                            () -> {
+                                new Dataized(
+                                    new PhWith(
+                                        new PhCopy(
+                                            new PhMethod(
+                                                new PhWith(
+                                                    Phi.Φ.take(InputOutputTest.CONSOLE).take(
+                                                        InputOutputTest.WRITE
+                                                    ).copy(),
+                                                    0, new Data.ToPhi("Hey")
+                                                ), InputOutputTest.WRITE
+                                            )
+                                        ),
+                                        0, new Data.ToPhi("There")
+                                    )
+                                ).take();
+                            }
+                        ).getAbsolutePath()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.allOf(
                     Matchers.containsString("Hey"),
                     Matchers.containsString("There")
@@ -330,20 +352,22 @@ final class InputOutputTest {
         @Test
         void readsFromConsole(@Mktmp final Path temp) throws IOException {
             final String content = "read from console";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    new PhWith(
-                        Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.READ).copy(),
-                        0,
-                        new Data.ToPhi(content.length())
-                    )
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'console.read' object should have read all bytes from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            new PhWith(
+                                Phi.Φ.take(InputOutputTest.CONSOLE).take(InputOutputTest.READ)
+                                    .copy(),
+                                0,
+                                new Data.ToPhi(content.length())
+                            )
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -351,30 +375,34 @@ final class InputOutputTest {
         @Test
         void readsSequentiallyFromInputBlockViaConsole(@Mktmp final Path temp)
             throws IOException {
-            final String content = "read sequentially from console";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> {
-                    final Phi console = Phi.Φ.take(InputOutputTest.CONSOLE);
-                    final Phi first = new PhWith(
-                        new PhCopy(
-                            new PhMethod(console, InputOutputTest.READ)
-                        ),
-                        0, new Data.ToPhi(18)
-                    );
-                    final Phi second = new PhWith(
-                        new PhCopy(
-                            new PhMethod(first, InputOutputTest.READ)
-                        ),
-                        0, new Data.ToPhi(18)
-                    );
-                    return new Dataized(second).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The `console.read` object should have return input block ready to `read` again, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        "read sequentially from console",
+                        () -> {
+                            return new Dataized(
+                                new PhWith(
+                                    new PhCopy(
+                                        new PhMethod(
+                                            new PhWith(
+                                                new PhCopy(
+                                                    new PhMethod(
+                                                        Phi.Φ.take(InputOutputTest.CONSOLE),
+                                                        InputOutputTest.READ
+                                                    )
+                                                ),
+                                                0, new Data.ToPhi(18)
+                                            ), InputOutputTest.READ
+                                        )
+                                    ),
+                                    0, new Data.ToPhi(18)
+                                )
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo("from console")
             );
         }
@@ -390,16 +418,17 @@ final class InputOutputTest {
         @Test
         void dataizesOneLineOnOneLineInputViaStdin(@Mktmp final Path temp) throws IOException {
             final String content = "this is a test input1";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin.next-line' object should have returned one line from one line input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -409,16 +438,17 @@ final class InputOutputTest {
             @Mktmp final Path temp
         ) throws IOException {
             final String content = "this is a test input2";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin.next-line' object should have returned one line from one line with separator input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -427,27 +457,27 @@ final class InputOutputTest {
         void dataizesSecondLineOnThreeLineWithSeparatorInputViaStdin(
             @Mktmp final Path temp
         ) throws IOException {
-            final String content = String.join(
-                System.lineSeparator(),
-                "first",
-                "second",
-                "third"
-            );
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> {
-                    new Dataized(
-                        Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
-                    ).take();
-                    return new Dataized(
-                        Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The 'stdin.next-line' object should have returned second line from three lines input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        String.join(
+                            System.lineSeparator(),
+                            "first",
+                            "second",
+                            "third"
+                        ),
+                        () -> {
+                            new Dataized(
+                                Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
+                            ).take();
+                            return new Dataized(
+                                Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo("second")
             );
         }
@@ -455,16 +485,17 @@ final class InputOutputTest {
         @Test
         void dataizesEmptyInputViaStdin(@Mktmp final Path temp) throws IOException {
             final String content = "";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin.next-line' object should have returned empty line from empty input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN).take(InputOutputTest.NEXT_LINE)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -472,16 +503,17 @@ final class InputOutputTest {
         @Test
         void dataizesStdinOneLine(@Mktmp final Path temp) throws IOException {
             final String content = "this is a test input3";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin' object should have been dataized to one line from one line input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -489,16 +521,17 @@ final class InputOutputTest {
         @Test
         void dataizesStdinEmptyLine(@Mktmp final Path temp) throws IOException {
             final String content = "";
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin' object should have been dataized to one line from one line input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -511,16 +544,17 @@ final class InputOutputTest {
                 "second",
                 "third"
             );
-            final byte[] result = InputOutputTest.redirectedStdin(
-                temp,
-                content,
-                () -> new Dataized(
-                    Phi.Φ.take(InputOutputTest.STDIN)
-                ).take()
-            );
             MatcherAssert.assertThat(
                 "The 'stdin' object should have been dataized to one line from one line input",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.redirectedStdin(
+                        temp,
+                        content,
+                        () -> new Dataized(
+                            Phi.Φ.take(InputOutputTest.STDIN)
+                        ).take()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -537,32 +571,32 @@ final class InputOutputTest {
         @DisabledOnOs(OS.WINDOWS)
         void readsFromStdinViaPosixReadSyscall(@Mktmp final Path temp) throws IOException {
             final String content = "read from posix stdin";
-            final byte[] result = InputOutputTest.posixStdin(
-                temp,
-                content,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(CStdLib.STDIN_FILENO),
-                            new Data.ToPhi(content.length()),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.POSIX).copy(),
-                                "name",
-                                new Data.ToPhi(InputOutputTest.READ)
-                            ),
-                            "args",
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The posix 'read' syscall should have read all bytes from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.posixStdin(
+                        temp,
+                        content,
+                        () -> {
+                            return new Dataized(
+                                new PhWith(
+                                    new PhWith(
+                                        Phi.Φ.take(InputOutputTest.POSIX).copy(),
+                                        "name",
+                                        new Data.ToPhi(InputOutputTest.READ)
+                                    ),
+                                    "args",
+                                    new Data.ToPhi(
+                                        new Phi[]{
+                                            new Data.ToPhi(CStdLib.STDIN_FILENO),
+                                            new Data.ToPhi(content.length()),
+                                        }
+                                    )
+                                ).take(InputOutputTest.OUTPUT)
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -572,32 +606,32 @@ final class InputOutputTest {
         void readsOnlyAvailableFromStdinViaPosixReadSyscall(@Mktmp final Path temp)
             throws IOException {
             final String content = "read available from posix stdin";
-            final byte[] result = InputOutputTest.posixStdin(
-                temp,
-                content,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(CStdLib.STDIN_FILENO),
-                            new Data.ToPhi(content.length() * 2),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.POSIX).copy(),
-                                0,
-                                new Data.ToPhi(InputOutputTest.READ)
-                            ),
-                            1,
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The posix 'read' syscall should have read only available bytes from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.posixStdin(
+                        temp,
+                        content,
+                        () -> {
+                            return new Dataized(
+                                new PhWith(
+                                    new PhWith(
+                                        Phi.Φ.take(InputOutputTest.POSIX).copy(),
+                                        0,
+                                        new Data.ToPhi(InputOutputTest.READ)
+                                    ),
+                                    1,
+                                    new Data.ToPhi(
+                                        new Phi[]{
+                                            new Data.ToPhi(CStdLib.STDIN_FILENO),
+                                            new Data.ToPhi(content.length() * 2),
+                                        }
+                                    )
+                                ).take(InputOutputTest.OUTPUT)
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -605,32 +639,30 @@ final class InputOutputTest {
         @Test
         @DisabledOnOs(OS.WINDOWS)
         void readsFromEmptyStdinViaPosixReadSyscall(@Mktmp final Path temp) throws IOException {
-            final byte[] result = InputOutputTest.posixStdin(
-                temp,
-                "",
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(CStdLib.STDIN_FILENO),
-                            new Data.ToPhi(10),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.POSIX).copy(),
-                                0,
-                                new Data.ToPhi(InputOutputTest.READ)
-                            ),
-                            1,
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The posix 'read' syscall should have read empty string from standard input, but it didn't",
-                result.length,
+                InputOutputTest.posixStdin(
+                    temp,
+                    "",
+                    () -> {
+                        return new Dataized(
+                            new PhWith(
+                                new PhWith(
+                                    Phi.Φ.take(InputOutputTest.POSIX).copy(),
+                                    0,
+                                    new Data.ToPhi(InputOutputTest.READ)
+                                ),
+                                1,
+                                new Data.ToPhi(
+                                    new Phi[]{
+                                        new Data.ToPhi(CStdLib.STDIN_FILENO),
+                                        new Data.ToPhi(10),
+                                    }
+                                )
+                            ).take(InputOutputTest.OUTPUT)
+                        ).take();
+                    }
+                ).length,
                 Matchers.equalTo(0)
             );
         }
@@ -639,32 +671,32 @@ final class InputOutputTest {
         @DisabledOnOs(OS.WINDOWS)
         void readsFromStdinByPortionsViaPosixReadSyscall(@Mktmp final Path temp)
             throws IOException {
-            final byte[] result = InputOutputTest.posixStdin(
-                temp,
-                "helloworld",
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(CStdLib.STDIN_FILENO),
-                            new Data.ToPhi(5),
-                        }
-                    );
-                    final Phi read = new PhWith(
-                        new PhWith(
-                            Phi.Φ.take(InputOutputTest.POSIX).copy(),
-                            0,
-                            new Data.ToPhi(InputOutputTest.READ)
-                        ),
-                        1,
-                        args
-                    );
-                    read.take(InputOutputTest.OUTPUT);
-                    return new Dataized(read.take(InputOutputTest.OUTPUT)).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The posix 'read' syscall should have read empty string from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.posixStdin(
+                        temp,
+                        "helloworld",
+                        () -> {
+                            final Phi read = new PhWith(
+                                new PhWith(
+                                    Phi.Φ.take(InputOutputTest.POSIX).copy(),
+                                    0,
+                                    new Data.ToPhi(InputOutputTest.READ)
+                                ),
+                                1,
+                                new Data.ToPhi(
+                                    new Phi[]{
+                                        new Data.ToPhi(CStdLib.STDIN_FILENO),
+                                        new Data.ToPhi(5),
+                                    }
+                                )
+                            );
+                            read.take(InputOutputTest.OUTPUT);
+                            return new Dataized(read.take(InputOutputTest.OUTPUT)).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo("world")
             );
         }
@@ -681,32 +713,32 @@ final class InputOutputTest {
         @DisabledOnOs({OS.MAC, OS.LINUX})
         void readsFromStdinViaWindowsFileReadSyscall(@Mktmp final Path temp) throws IOException {
             final String content = "read from windows stdin";
-            final byte[] result = InputOutputTest.windowsStdin(
-                temp,
-                content,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
-                            new Data.ToPhi(content.length()),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.WIN).copy(),
-                                "name",
-                                new Data.ToPhi(InputOutputTest.READ_FILE)
-                            ),
-                            "args",
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The windows 'read' syscall should have read all bytes from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.windowsStdin(
+                        temp,
+                        content,
+                        () -> {
+                            return new Dataized(
+                                new PhWith(
+                                    new PhWith(
+                                        Phi.Φ.take(InputOutputTest.WIN).copy(),
+                                        "name",
+                                        new Data.ToPhi(InputOutputTest.READ_FILE)
+                                    ),
+                                    "args",
+                                    new Data.ToPhi(
+                                        new Phi[]{
+                                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
+                                            new Data.ToPhi(content.length()),
+                                        }
+                                    )
+                                ).take(InputOutputTest.OUTPUT)
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -716,32 +748,32 @@ final class InputOutputTest {
         void readsOnlyAvailableFromStdinViaWindowsFileReadSyscall(@Mktmp final Path temp)
             throws IOException {
             final String content = "read available from windows stdin";
-            final byte[] result = InputOutputTest.windowsStdin(
-                temp,
-                content,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
-                            new Data.ToPhi(content.length() * 2),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.WIN).copy(),
-                                0,
-                                new Data.ToPhi(InputOutputTest.READ_FILE)
-                            ),
-                            1,
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The windows 'read' syscall should have read only available bytes from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.windowsStdin(
+                        temp,
+                        content,
+                        () -> {
+                            return new Dataized(
+                                new PhWith(
+                                    new PhWith(
+                                        Phi.Φ.take(InputOutputTest.WIN).copy(),
+                                        0,
+                                        new Data.ToPhi(InputOutputTest.READ_FILE)
+                                    ),
+                                    1,
+                                    new Data.ToPhi(
+                                        new Phi[]{
+                                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
+                                            new Data.ToPhi(content.length() * 2),
+                                        }
+                                    )
+                                ).take(InputOutputTest.OUTPUT)
+                            ).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(content)
             );
         }
@@ -750,32 +782,30 @@ final class InputOutputTest {
         @DisabledOnOs({OS.MAC, OS.LINUX})
         void readsFromEmptyStdinViaWindowsFileReadSyscall(@Mktmp final Path temp)
             throws IOException {
-            final byte[] result = InputOutputTest.windowsStdin(
-                temp,
-                "",
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
-                            new Data.ToPhi(10),
-                        }
-                    );
-                    return new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.WIN).copy(),
-                                0,
-                                new Data.ToPhi(InputOutputTest.READ_FILE)
-                            ),
-                            1,
-                            args
-                        ).take(InputOutputTest.OUTPUT)
-                    ).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The windows 'read' syscall should have read empty string from standard input, but it didn't",
-                result.length,
+                InputOutputTest.windowsStdin(
+                    temp,
+                    "",
+                    () -> {
+                        return new Dataized(
+                            new PhWith(
+                                new PhWith(
+                                    Phi.Φ.take(InputOutputTest.WIN).copy(),
+                                    0,
+                                    new Data.ToPhi(InputOutputTest.READ_FILE)
+                                ),
+                                1,
+                                new Data.ToPhi(
+                                    new Phi[]{
+                                        new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
+                                        new Data.ToPhi(10),
+                                    }
+                                )
+                            ).take(InputOutputTest.OUTPUT)
+                        ).take();
+                    }
+                ).length,
                 Matchers.equalTo(0)
             );
         }
@@ -784,32 +814,32 @@ final class InputOutputTest {
         @DisabledOnOs({OS.MAC, OS.LINUX})
         void readsFromStdinByPortionsViaWindowsFileReadSyscall(@Mktmp final Path temp)
             throws IOException {
-            final byte[] result = InputOutputTest.windowsStdin(
-                temp,
-                "helloworld",
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
-                            new Data.ToPhi(5),
-                        }
-                    );
-                    final Phi read = new PhWith(
-                        new PhWith(
-                            Phi.Φ.take(InputOutputTest.WIN).copy(),
-                            0,
-                            new Data.ToPhi(InputOutputTest.READ_FILE)
-                        ),
-                        1,
-                        args
-                    );
-                    read.take(InputOutputTest.OUTPUT);
-                    return new Dataized(read.take(InputOutputTest.OUTPUT)).take();
-                }
-            );
             MatcherAssert.assertThat(
                 "The windows 'read' syscall should have read empty string from standard input, but it didn't",
-                new String(result, StandardCharsets.UTF_8),
+                new String(
+                    InputOutputTest.windowsStdin(
+                        temp,
+                        "helloworld",
+                        () -> {
+                            final Phi read = new PhWith(
+                                new PhWith(
+                                    Phi.Φ.take(InputOutputTest.WIN).copy(),
+                                    0,
+                                    new Data.ToPhi(InputOutputTest.READ_FILE)
+                                ),
+                                1,
+                                new Data.ToPhi(
+                                    new Phi[]{
+                                        new Data.ToPhi(Kernel32.STD_INPUT_HANDLE),
+                                        new Data.ToPhi(5),
+                                    }
+                                )
+                            );
+                            read.take(InputOutputTest.OUTPUT);
+                            return new Dataized(read.take(InputOutputTest.OUTPUT)).take();
+                        }
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo("world")
             );
         }
@@ -824,34 +854,37 @@ final class InputOutputTest {
     final class PosixWriteSyscallTest {
         @Test
         @DisabledOnOs(OS.WINDOWS)
+        @SuppressWarnings("PMD.UnnecessaryLocalRule")
         void writesToStdoutViaPosixWriteSyscall(@Mktmp final Path temp) throws IOException {
             final String msg = "writes to posix stdout";
-            final File file = InputOutputTest.posixStdout(
-                temp,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[] {
-                            new Data.ToPhi(CStdLib.STDOUT_FILENO),
-                            new Data.ToPhi(msg),
-                            new Data.ToPhi(msg.length()),
-                        }
-                    );
-                    new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take(InputOutputTest.POSIX).copy(),
-                                0,
-                                new Data.ToPhi(InputOutputTest.WRITE)
-                            ),
-                            1,
-                            args
-                        ).take("code")
-                    ).asNumber();
-                }
-            );
             MatcherAssert.assertThat(
                 "The posix 'write' syscall should have written to standard output, but it didn't",
-                Files.readString(Paths.get(file.getAbsolutePath()), StandardCharsets.UTF_8),
+                Files.readString(
+                    Paths.get(
+                        InputOutputTest.posixStdout(
+                            temp,
+                            () -> {
+                                new Dataized(
+                                    new PhWith(
+                                        new PhWith(
+                                            Phi.Φ.take(InputOutputTest.POSIX).copy(),
+                                            0,
+                                            new Data.ToPhi(InputOutputTest.WRITE)
+                                        ),
+                                        1,
+                                        new Data.ToPhi(
+                                            new Phi[]{
+                                                new Data.ToPhi(CStdLib.STDOUT_FILENO),
+                                                new Data.ToPhi(msg),
+                                                new Data.ToPhi(msg.length()),
+                                            }
+                                        )
+                                    ).take("code")
+                                ).asNumber();
+                            }
+                        ).getAbsolutePath()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.containsString(msg)
             );
         }
@@ -860,13 +893,6 @@ final class InputOutputTest {
         @DisabledOnOs(OS.WINDOWS)
         void invokesPosixWriteSyscallCorrectly() {
             final String msg = "invokes posix write";
-            final Phi args = new Data.ToPhi(
-                new Phi[] {
-                    new Data.ToPhi(1L),
-                    new Data.ToPhi(msg),
-                    new Data.ToPhi(msg.length()),
-                }
-            );
             MatcherAssert.assertThat(
                 "The \"write\" system call was expected to work correctly",
                 new Dataized(
@@ -877,7 +903,13 @@ final class InputOutputTest {
                             new Data.ToPhi(InputOutputTest.WRITE)
                         ),
                         1,
-                        args
+                        new Data.ToPhi(
+                            new Phi[]{
+                                new Data.ToPhi(1L),
+                                new Data.ToPhi(msg),
+                                new Data.ToPhi(msg.length()),
+                            }
+                        )
                     ).take("code")
                 ).asNumber().intValue(),
                 Matchers.equalTo(msg.length())
@@ -894,35 +926,38 @@ final class InputOutputTest {
     final class WindowsFileWriteSyscallTest {
         @Test
         @DisabledOnOs({OS.MAC, OS.LINUX})
+        @SuppressWarnings("PMD.UnnecessaryLocalRule")
         void writesToStdoutViaWindowsWriteFileFunction(@Mktmp final Path temp)
             throws IOException {
             final String msg = "writes to windows stdout";
-            final File file = InputOutputTest.windowsStdout(
-                temp,
-                () -> {
-                    final Phi args = new Data.ToPhi(
-                        new Phi[]{
-                            new Data.ToPhi(Kernel32.STD_OUTPUT_HANDLE),
-                            new Data.ToPhi(msg),
-                            new Data.ToPhi(msg.length()),
-                        }
-                    );
-                    new Dataized(
-                        new PhWith(
-                            new PhWith(
-                                Phi.Φ.take("org.eolang.sm.win32").copy(),
-                                0,
-                                new Data.ToPhi("WriteFile")
-                            ),
-                            1,
-                            args
-                        ).take("code")
-                    );
-                }
-            );
             MatcherAssert.assertThat(
                 "The win32 'WriteFile' call should have written to standard output, but it didn't",
-                Files.readString(Paths.get(file.getAbsolutePath()), StandardCharsets.UTF_8),
+                Files.readString(
+                    Paths.get(
+                        InputOutputTest.windowsStdout(
+                            temp,
+                            () -> {
+                                new Dataized(
+                                    new PhWith(
+                                        new PhWith(
+                                            Phi.Φ.take("org.eolang.sm.win32").copy(),
+                                            0,
+                                            new Data.ToPhi("WriteFile")
+                                        ),
+                                        1,
+                                        new Data.ToPhi(
+                                            new Phi[]{
+                                                new Data.ToPhi(Kernel32.STD_OUTPUT_HANDLE),
+                                                new Data.ToPhi(msg),
+                                                new Data.ToPhi(msg.length()),
+                                            }
+                                        )
+                                    ).take("code")
+                                );
+                            }
+                        ).getAbsolutePath()
+                    ), StandardCharsets.UTF_8
+                ),
                 Matchers.equalTo(msg)
             );
         }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOmallocTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOmallocTest {
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void freesMemory() {
         final Dummy dummy = new Dummy();
         new Dataized(
@@ -45,6 +46,7 @@ final class EOmallocTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void freesMemoryIfErrorIsOccurred() {
         final ErrorDummy dummy = new ErrorDummy();
         Assertions.assertThrows(
@@ -81,7 +83,7 @@ final class EOmallocTest {
      * Dummy.
      * @since 0.37.0
      */
-    private static class Dummy extends PhDefault {
+    private static final class Dummy extends PhDefault {
         /**
          * Id.
          */
@@ -112,7 +114,7 @@ final class EOmallocTest {
      * Dummy that throws an exception.
      * @since 0.36.0
      */
-    private static class ErrorDummy extends PhDefault {
+    private static final class ErrorDummy extends PhDefault {
         /**
          * Id.
          */

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOnumberTest.java
@@ -64,6 +64,7 @@ final class EOnumberTest {
         EOnumber$EOplus.class,
         EOnumber$EOtimes.class
     })
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void throwsCorrectErrorForXAttr(final Class<?> cls) {
         MatcherAssert.assertThat(
             "the message in the error is correct",
@@ -95,6 +96,7 @@ final class EOnumberTest {
         EOnumber$EOas_i64.class,
         EOnumber$EOfloor.class
     })
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void throwsCorrectErrorForRhoAttr(final Class<?> cls) {
         MatcherAssert.assertThat(
             "the message in the error is correct",

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EOtryTest.java
@@ -111,7 +111,7 @@ final class EOtryTest {
      * Body object with counter.
      * @since 0.36.0
      */
-    private static class MainWithCounter extends PhDefault {
+    private static final class MainWithCounter extends PhDefault {
         /**
          * Counter.
          */
@@ -120,7 +120,6 @@ final class EOtryTest {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         MainWithCounter() {
             super();
             this.add(
@@ -140,12 +139,11 @@ final class EOtryTest {
      * Main.
      * @since 0.1.0
      */
-    private static class Main extends PhDefault {
+    private static final class Main extends PhDefault {
 
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Main() {
             this.add(
                 "φ",
@@ -163,11 +161,10 @@ final class EOtryTest {
      * Broken.
      * @since 0.1.0
      */
-    private static class Broken extends PhDefault {
+    private static final class Broken extends PhDefault {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Broken() {
             this.add(
                 "φ",
@@ -185,7 +182,7 @@ final class EOtryTest {
      * Catcher.
      * @since 0.1.0
      */
-    private static class Catcher extends PhDefault {
+    private static final class Catcher extends PhDefault {
         /**
          * Ctor.
          */

--- a/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/HeapsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 final class HeapsTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void allocatesMemory() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10);
         Assertions.assertDoesNotThrow(
@@ -39,6 +40,7 @@ final class HeapsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void failsOnDoubleAllocation() {
         final Phi phi = new HeapsTest.PhFake();
         final int idx = Heaps.INSTANCE.malloc(phi, 10);
@@ -114,6 +116,7 @@ final class HeapsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void failsOnWriteMoreThanAllocated() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 2);
         final byte[] bytes = {1, 2, 3, 4, 5};
@@ -126,6 +129,7 @@ final class HeapsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void failsToWriteMoreThanAllocatedWithOffset() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 3);
         final byte[] bytes = {1, 2, 3};
@@ -151,6 +155,7 @@ final class HeapsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void freesSuccessfully() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         Heaps.INSTANCE.free(idx);
@@ -191,6 +196,7 @@ final class HeapsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void throwsOnChangingSizeToNegative() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         Assertions.assertThrows(
@@ -213,8 +219,7 @@ final class HeapsTest {
     @Test
     void increasesSizeSuccessfully() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        final byte[] bytes = {1, 2, 3, 4, 5};
-        Heaps.INSTANCE.write(idx, 0, bytes);
+        Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
         Heaps.INSTANCE.resize(idx, 7);
         MatcherAssert.assertThat(
             "Heaps should successfully increase size of allocated block, but it didn't",
@@ -227,8 +232,7 @@ final class HeapsTest {
     @Test
     void decreasesSizeSuccessfully() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        final byte[] bytes = {1, 2, 3, 4, 5};
-        Heaps.INSTANCE.write(idx, 0, bytes);
+        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
         Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should successfully decrease size of allocated block, but it didn't",
@@ -241,8 +245,7 @@ final class HeapsTest {
     @Test
     void returnsValidSizeAfterDecreasing() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        final byte[] bytes = {1, 2, 3, 4, 5};
-        Heaps.INSTANCE.write(idx, 0, bytes);
+        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
         Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should return valid size after decreasing, but it didn't",

--- a/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtCompositeTest.java
@@ -25,6 +25,7 @@ final class AtCompositeTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void executesExpression() {
         final AtomicInteger count = new AtomicInteger();
         new AtComposite(
@@ -52,12 +53,12 @@ final class AtCompositeTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void changesArgumentOnCopying() {
         final Phi first = new PhDefault();
-        final Phi second = new PhDefault();
         final Attr attr = new AtComposite(first, phi -> phi);
         final Phi res = attr.get();
-        final Phi copy = attr.copy(second).get();
+        final Phi copy = attr.copy(new PhDefault()).get();
         MatcherAssert.assertThat(
             "AtComposite must change expression argument on copying",
             res,

--- a/eo-runtime/src/test/java/org/eolang/AtOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtOnceTest.java
@@ -25,6 +25,7 @@ final class AtOnceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void cachesAttribute() {
         final AtomicInteger count = new AtomicInteger();
         final Attr attr = new AtOnce(
@@ -46,6 +47,7 @@ final class AtOnceTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void resetsCacheOnCopy() {
         final AtomicInteger count = new AtomicInteger();
         final Attr attr = new AtOnce(

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -14,16 +14,20 @@ import org.junit.jupiter.api.Test;
  */
 final class AtWithRhoTest {
     @Test
-    void copiesAndSetsRhoIfNotSet() {
-        final Phi obj = new PhDefault();
-        final Attr attr = new AtComposite(obj, phi -> phi);
+    void copiesAndSetsRhoIfNotSetMustSetRho() {
         final Phi rho = new PhDefault();
-        final Phi phi = new AtWithRho(attr, rho).get();
         MatcherAssert.assertThat(
             "AtWithRho must set RHO if it is not set before",
-            phi.take(Phi.RHO),
+            new AtWithRho(new AtComposite(new PhDefault(), phi -> phi), rho).get().take(Phi.RHO),
             Matchers.is(rho)
         );
+    }
+
+    @Test
+    void copiesAndSetsRhoIfNotSetMustCopyOriginal() {
+        final Phi obj = new PhDefault();
+        final Phi phi = new AtWithRho(new AtComposite(obj, p -> p), new PhDefault()).get();
+        phi.take(Phi.RHO);
         MatcherAssert.assertThat(
             "AtWithRho must copy original object if RHO is not set",
             phi,
@@ -45,17 +49,23 @@ final class AtWithRhoTest {
     }
 
     @Test
-    void doesNotCopyAndSetRhoIfAlreadySet() {
+    void doesNotCopyAndSetRhoIfAlreadySetMustNotResetRho() {
         final Phi obj = new PhDefault();
         final Phi rho = new PhDefault();
         obj.put(Phi.RHO, rho);
-        final Phi reset = new PhDefault();
-        final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), reset).get();
         MatcherAssert.assertThat(
             "AtWithRho must not reset RHO if it is already set",
-            res.take(Phi.RHO),
+            new AtWithRho(new AtComposite(obj, phi -> phi), new PhDefault()).get().take(Phi.RHO),
             Matchers.is(rho)
         );
+    }
+
+    @Test
+    void doesNotCopyAndSetRhoIfAlreadySetMustCopyOriginalIfRhoIsSet() {
+        final Phi obj = new PhDefault();
+        obj.put(Phi.RHO, new PhDefault());
+        final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), new PhDefault()).get();
+        res.take(Phi.RHO);
         MatcherAssert.assertThat(
             "AtWithRho must not copy original object if RHO is already set",
             res,
@@ -64,16 +74,23 @@ final class AtWithRhoTest {
     }
 
     @Test
-    void copiesWithNewRho() {
-        final Phi obj = new PhDefault();
-        final Phi rho = new PhDefault();
+    void copiesWithNewRhoMustSetNewPhoOnCopy() {
         final Phi self = new PhDefault();
-        final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), rho).copy(self).get();
         MatcherAssert.assertThat(
             "AtWithRho must set new RHO on copy() operation",
-            res.take(Phi.RHO),
+            new AtWithRho(new AtComposite(new PhDefault(), phi -> phi), new PhDefault()).copy(self)
+                .get().take(Phi.RHO),
             Matchers.is(self)
         );
+    }
+
+    @Test
+    void copiesWithNewRhoMustCallCopyOnOriginal() {
+        final Phi obj = new PhDefault();
+        final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), new PhDefault()).copy(
+            new PhDefault()
+        ).get();
+        res.take(Phi.RHO);
         MatcherAssert.assertThat(
             "AtWithRho must call copy() on original object",
             res,

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -22,20 +22,18 @@ final class BytesOfTest {
     @Test
     void negatesSeveralTimes() {
         final String text = "abc";
-        final Bytes bytes = new BytesOf(text);
         MatcherAssert.assertThat(
             "Double negation should return the original value, but it didn't",
-            bytes.not().not(),
+            new BytesOf(text).not().not(),
             Matchers.equalTo(new BytesOf(text))
         );
     }
 
     @Test
     void negatesOnce() {
-        final Bytes bytes = new BytesOf(-128L);
         MatcherAssert.assertThat(
             "Negation should give the correct value, but it didn't",
-            bytes.not(),
+            new BytesOf(-128L).not(),
             Matchers.equalTo(new BytesOf(127L))
         );
     }
@@ -80,30 +78,27 @@ final class BytesOfTest {
 
     @Test
     void checksXor() {
-        final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
             "'Xor' operation should give correct value, but it didn't",
-            bytes.xor(new BytesOf(-512L)),
+            new BytesOf(512L).xor(new BytesOf(-512L)),
             Matchers.equalTo(new BytesOf(-1024L))
         );
     }
 
     @Test
     void checksAsNumberLong() {
-        final Bytes bytes = new BytesOf(512L);
         MatcherAssert.assertThat(
             "Bytes as long number must be equals to correct number, but it didn't",
-            bytes.asNumber(Long.class),
+            new BytesOf(512L).asNumber(Long.class),
             Matchers.equalTo(512L)
         );
     }
 
     @Test
     void checksUnderflowForLong() {
-        final Bytes bytes = new BytesOf("A");
         Assertions.assertThrows(
             ExFailure.class,
-            bytes::asNumber,
+            new BytesOf("A")::asNumber,
             "Converting non-numeric bytes to number should throw, but it didn't"
         );
     }
@@ -119,13 +114,12 @@ final class BytesOfTest {
         "0x000000FF,   8, 0x00000000"
     })
     void checksShift(final long num, final int bits, final long expected) {
-        final Bytes bytes = new BytesOf(num);
         MatcherAssert.assertThat(
             String.format(
                 "%d >> %d should result in %d, but it didn't",
                 num, bits, expected
             ),
-            bytes.shift(bits).asNumber(Long.class),
+            new BytesOf(num).shift(bits).asNumber(Long.class),
             Matchers.equalTo(expected)
         );
     }
@@ -143,24 +137,21 @@ final class BytesOfTest {
         "0xFFFFFC00,   3, 0xFFFFFF80"
     })
     void checksShifts(final long num, final int bits, final long expected) {
-        final Bytes bytes = new BytesOf((int) num);
-        final int actual = bytes.sshift(bits).asNumber(Integer.class);
         MatcherAssert.assertThat(
             String.format(
                 "%d >> %d (arithmetic shift) should result in %d, but it didn't",
                 num, bits, expected
             ),
-            actual,
+            new BytesOf((int) num).sshift(bits).asNumber(Integer.class),
             Matchers.equalTo((int) expected)
         );
     }
 
     @Test
     void doesNotSupportRightShift() {
-        final Bytes bytes = new BytesOf(Integer.MAX_VALUE);
         Assertions.assertThrows(
             UnsupportedOperationException.class,
-            () -> bytes.sshift(-1),
+            () -> new BytesOf(Integer.MAX_VALUE).sshift(-1),
             "Integer.MAX_VALUE << 1 should throw exception, but it didn't"
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -4,9 +4,13 @@
  */
 package org.eolang;
 
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for {@link Data}.
@@ -27,27 +31,33 @@ final class DataTest {
         );
     }
 
-    @Test
-    void comparesTwoDatas() {
+    @ParameterizedTest
+    @MethodSource("toPhiData")
+    void comparesTwoDatas(final Object value, final String message) {
         MatcherAssert.assertThat(
-            "Data.ToPhi instances with the same long value should differ, but they didn't",
-            new Data.ToPhi(1L),
-            Matchers.not(Matchers.equalTo(new Data.ToPhi(1L)))
+            message,
+            new Data.ToPhi(value),
+            Matchers.not(Matchers.equalTo(new Data.ToPhi(value)))
         );
-        MatcherAssert.assertThat(
-            "Data.ToPhi instances with the same string value should differ, but they didn't",
-            new Data.ToPhi("Welcome"),
-            Matchers.not(Matchers.equalTo(new Data.ToPhi("Welcome")))
-        );
-        MatcherAssert.assertThat(
-            "Data.ToPhi instances with the same double value should differ, but they didn't",
-            new Data.ToPhi(2.18d),
-            Matchers.not(Matchers.equalTo(new Data.ToPhi(2.18d)))
-        );
-        MatcherAssert.assertThat(
-            "Data.ToPhi instances with the same byte array value should differ, but they didn't",
-            new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f}),
-            Matchers.not(Matchers.equalTo(new Data.ToPhi(new byte[] {(byte) 0x00, (byte) 0x1f})))
+    }
+
+    private static Stream<Arguments> toPhiData() {
+        return Stream.of(
+            Arguments.of(
+                1L, "Data.ToPhi instances with the same long value should differ, but they didn't"
+            ),
+            Arguments.of(
+                "Welcome",
+                "Data.ToPhi instances with the same string value should differ, but they didn't"
+            ),
+            Arguments.of(
+                2.18d,
+                "Data.ToPhi instances with the same double value should differ, but they didn't"
+            ),
+            Arguments.of(
+                new byte[]{(byte) 0x00, (byte) 0x1f},
+                "Data.ToPhi instances with the same byte array value should differ, but they didn't"
+            )
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.SAME_THREAD)
 final class DataizedTest {
     @Test
+    @SuppressWarnings({"PMD.UnitTestContainsTooManyAsserts", "PMD.UnnecessaryLocalRule"})
     void logsAllLocationsWithPhSafe() {
         final Logger log = Logger.getLogger("logsWithPhSafe");
         final Level before = log.getLevel();
@@ -81,6 +82,7 @@ final class DataizedTest {
     }
 
     @Test
+    @SuppressWarnings({"PMD.UnitTestContainsTooManyAsserts", "PMD.UnnecessaryLocalRule"})
     void doesNotLogGoToTokenJump() {
         final Logger log = Logger.getLogger("logsWithPhSafe");
         final Level before = log.getLevel();
@@ -122,7 +124,7 @@ final class DataizedTest {
      *
      * @since 0.1.0
      */
-    private static class Hnd extends Handler {
+    private static final class Hnd extends Handler {
         /**
          * Logs.
          */

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -32,6 +32,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceWithOneError() {
         MatcherAssert.assertThat(
             "Throw error in first 'must'. Error message is correct",
@@ -48,6 +49,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceWithTwoErrors() {
         MatcherAssert.assertThat(
             "Throw error in first 'must'. Not add error about second 'must'",
@@ -66,6 +68,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceWithOneOkAndOneError() {
         MatcherAssert.assertThat(
             "Throw error in second 'must'. First 'must' passes check",
@@ -84,6 +87,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceWithExFailureInThat() {
         MatcherAssert.assertThat(
             "Take error message from 'otherwise', not from original error",
@@ -104,6 +108,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceWithExFailureInThatForParsing() {
         MatcherAssert.assertThat(
             "Take error message from 'otherwise', not from original error",
@@ -128,6 +133,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsWithCorrectTraceForMustAndThat() {
         MatcherAssert.assertThat(
             "Take error message from must",
@@ -146,6 +152,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToNumberForNotNumber() {
         MatcherAssert.assertThat(
             "inner class Number working throws error if attr is not a number",
@@ -168,6 +175,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToIntegerForNotNumber() {
         MatcherAssert.assertThat(
             "inner class Integer throws error for not a number",
@@ -190,6 +198,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToIntegerForNotInteger() {
         MatcherAssert.assertThat(
             "inner class Integer throws error for not an integer number",
@@ -212,6 +221,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToNonNegativeIntegerForNotNumber() {
         MatcherAssert.assertThat(
             "inner class NonNegativeInteger throws error for not a number",
@@ -234,6 +244,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToNonNegativeIntegerForNotInteger() {
         MatcherAssert.assertThat(
             "inner class NonNegativeInteger throws error for not an integer number",
@@ -256,6 +267,7 @@ final class ExpectTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsInTransformingToNonNegativeIntegerForNegative() {
         MatcherAssert.assertThat(
             "inner class NonNegativeInteger throws error for a negative integer",

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -124,42 +124,40 @@ final class MainTest {
 
     @Test
     void readsStreamCorrectly() throws IOException {
-        final BufferedReader reader = new BufferedReader(
-            Channels.newReader(
-                Channels.newChannel(
-                    new ByteArrayInputStream(
-                        ">> ··\uD835\uDD38('text' for EOorgEOio.EOstdoutν2) ➜ ΦSFN".getBytes(
-                            StandardCharsets.UTF_8
-                        )
-                    )
-                ),
-                StandardCharsets.UTF_8.name()
-            )
-        );
         MatcherAssert.assertThat(
             "Reading stream should produce a non-empty line, but it didn't",
-            reader.readLine().length(),
+            new BufferedReader(
+                Channels.newReader(
+                    Channels.newChannel(
+                        new ByteArrayInputStream(
+                            ">> ··\uD835\uDD38('text' for EOorgEOio.EOstdoutν2) ➜ ΦSFN".getBytes(
+                                StandardCharsets.UTF_8
+                            )
+                        )
+                    ),
+                    StandardCharsets.UTF_8.name()
+                )
+            ).readLine().length(),
             Matchers.greaterThan(0)
         );
     }
 
     @Test
     void readsSimpleStreamCorrectly() throws IOException {
-        final BufferedReader reader = new BufferedReader(
-            Channels.newReader(
-                Channels.newChannel(
-                    new ByteArrayInputStream(
-                        "abc".getBytes(
-                            StandardCharsets.UTF_8
-                        )
-                    )
-                ),
-                StandardCharsets.UTF_8.name()
-            )
-        );
         MatcherAssert.assertThat(
             "Reading stream should produce a line longer then 1 character, but it didn't",
-            reader.readLine().length(),
+            new BufferedReader(
+                Channels.newReader(
+                    Channels.newChannel(
+                        new ByteArrayInputStream(
+                            "abc".getBytes(
+                                StandardCharsets.UTF_8
+                            )
+                        )
+                    ),
+                    StandardCharsets.UTF_8.name()
+                )
+            ).readLine().length(),
             Matchers.greaterThan(1)
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PhDefault}.
  * @since 0.1
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
+@SuppressWarnings("PMD.TooManyMethods")
 final class PhDefaultTest {
 
     @Test
@@ -78,6 +78,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void copiesKid() {
         final Phi phi = new PhDefaultTest.Int();
         final Phi first = phi.take(this.plus());
@@ -104,16 +105,21 @@ final class PhDefaultTest {
     }
 
     @Test
-    void hasKidWithSetRhoAfterCopying() {
-        final Phi phi = new PhDefaultTest.Int().copy();
-        final Phi plus = phi.take(this.plus());
+    void hasKidWithSetRhoAfterCopyingShouldGetAfttribute() {
         Assertions.assertDoesNotThrow(
-            () -> plus.take(Phi.RHO),
+            () -> new PhDefaultTest.Int().copy().take(this.plus()).take(Phi.RHO),
             String.format(
                 "Child object should get %s attribute after copying main object",
                 Phi.RHO
             )
         );
+    }
+
+    @Test
+    void hasKidWithSetRhoAfterCopying() {
+        final Phi phi = new PhDefaultTest.Int().copy();
+        final Phi plus = phi.take(this.plus());
+        plus.take(Phi.RHO);
         MatcherAssert.assertThat(
             String.format(
                 "%s attribute of copied child object should be equal to copied main object",
@@ -125,6 +131,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void hasDifferentKidsAfterDoubleCopying() {
         final Phi phi = new PhDefaultTest.Int();
         final Phi first = phi.copy();
@@ -139,7 +146,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void changesKidRhoAfterSelfCopying() {
+    void changesKidRhoAfterSelfCopyingKidShouldReferToOriginal() {
         final Phi phi = new PhDefaultTest.Int();
         final Phi copy = phi.copy();
         MatcherAssert.assertThat(
@@ -149,6 +156,13 @@ final class PhDefaultTest {
             phi.take(this.plus()).take(Phi.RHO),
             Matchers.not(Matchers.equalTo(copy.take(this.plus()).take(Phi.RHO)))
         );
+    }
+
+    @Test
+    void changesKidRhoAfterSelfCopyingKidShouldReferToCopied() {
+        final Phi phi = new PhDefaultTest.Int();
+        final Phi copy = phi.copy();
+        phi.take(this.plus()).take(Phi.RHO);
         MatcherAssert.assertThat(
             String.format(
                 "%s attribute of copied object kid should refer to copied object",
@@ -160,6 +174,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void doesNotChangeRhoAfterDirectKidCopying() {
         final Phi phi = new PhDefaultTest.Int();
         final Phi first = phi.take(this.plus());
@@ -235,13 +250,17 @@ final class PhDefaultTest {
     }
 
     @Test
-    void hasAccessToDependentOnContextAttribute() {
-        final Phi phi = new PhSafe(new PhDefaultTest.Int().copy());
+    void hasAccessToDependentOnContextAttributeThrows() {
         Assertions.assertThrows(
             ExAbstract.class,
-            () -> phi.take(Phi.PHI),
+            () -> new PhSafe(new PhDefaultTest.Int().copy()).take(Phi.PHI),
             "Phi should not be accessible without setting void attribute, but it did"
         );
+    }
+
+    @Test
+    void hasAccessToDependentOnContextAttributeDoesNotThrow() {
+        final Phi phi = new PhSafe(new PhDefaultTest.Int().copy());
         phi.put(this.getVoid(), new Data.ToPhi(10L));
         Assertions.assertDoesNotThrow(
             () -> phi.take(Phi.PHI),
@@ -263,10 +282,9 @@ final class PhDefaultTest {
 
     @Test
     void makesObjectIdentity() {
-        final Phi phi = new PhDefaultTest.Int();
         MatcherAssert.assertThat(
             "Object should have a hashCode greater then 0, but it didn't",
-            phi.hashCode(),
+            new PhDefaultTest.Int().hashCode(),
             Matchers.greaterThan(0)
         );
     }
@@ -309,6 +327,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void setsVoidAttributeOnlyOnce() {
         final Phi num = new Data.ToPhi(42L);
         final Phi phi = new PhDefaultTest.Foo();
@@ -322,33 +341,30 @@ final class PhDefaultTest {
 
     @Test
     void printsEndlessRecursionObject() {
-        final Phi phi = new PhDefaultTest.EndlessRecursion();
         PhDefaultTest.EndlessRecursion.count = 2;
         MatcherAssert.assertThat(
             "Dataization should discover the infinite recursion, but it didn't",
-            new Dataized(phi).asNumber(),
+            new Dataized(new PhDefaultTest.EndlessRecursion()).asNumber(),
             Matchers.equalTo(0.0)
         );
     }
 
     @Test
     void hesPhiRecursively() {
-        final Phi phi = new PhDefaultTest.RecursivePhi();
         PhDefaultTest.RecursivePhi.count = 3;
         MatcherAssert.assertThat(
             "Dataization should discover the infinite recursion, but it didn't",
-            new Dataized(phi).asNumber(),
+            new Dataized(new PhDefaultTest.RecursivePhi()).asNumber(),
             Matchers.equalTo(0.0)
         );
     }
 
     @Test
     void cachesPhiViaNewRecursively() {
-        final Phi phi = new PhDefaultTest.RecursivePhiViaNew();
         PhDefaultTest.RecursivePhiViaNew.count = 3;
         MatcherAssert.assertThat(
             "Does not cache phi via new recursively",
-            new Dataized(phi).asNumber(),
+            new Dataized(new PhDefaultTest.RecursivePhiViaNew()).asNumber(),
             Matchers.equalTo(0.0)
         );
     }
@@ -464,6 +480,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void failsCorrectlyWhenTooManyAttributesPut() {
         MatcherAssert.assertThat(
             "the message explains what's going on",
@@ -486,7 +503,7 @@ final class PhDefaultTest {
     }
 
     @Test
-    void verifiesThreadLocalNestingWithExceptions() {
+    void verifiesThreadLocalNestingWithExceptionsThrows() {
         final Phi phi = this.phiWithContextAttribute(
             "context-verifiesThreadLocalNestingWithExceptions"
         );
@@ -494,6 +511,13 @@ final class PhDefaultTest {
             ExUnset.class,
             () -> phi.take("non-existent-attribute"),
             "Should throw exception for non-existent attribute"
+        );
+    }
+
+    @Test
+    void verifiesThreadLocalNestingWithExceptionsDoesNotThrow() {
+        final Phi phi = this.phiWithContextAttribute(
+            "context-verifiesThreadLocalNestingWithExceptions"
         );
         Assertions.assertDoesNotThrow(
             () -> phi.take("context-verifiesThreadLocalNestingWithExceptions"),
@@ -513,6 +537,7 @@ final class PhDefaultTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void verifiesThreadLocalInMultipleThreads() {
         final int threads = 10;
         final int cnt = 100;
@@ -596,11 +621,10 @@ final class PhDefaultTest {
      * Rnd.
      * @since 0.1.0
      */
-    private static class Rnd extends PhDefault {
+    private static final class Rnd extends PhDefault {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Rnd() {
             this.add(
                 "φ",
@@ -616,7 +640,7 @@ final class PhDefaultTest {
      * Int.
      * @since 0.36.0
      */
-    private static class Int extends PhDefault {
+    private static final class Int extends PhDefault {
         /**
          * Ctor.
          */
@@ -655,7 +679,7 @@ final class PhDefaultTest {
      * Foo.
      * @since 0.1.0
      */
-    public static class Foo extends PhDefault {
+    public static final class Foo extends PhDefault {
         /**
          * Ctor.
          */
@@ -671,7 +695,7 @@ final class PhDefaultTest {
      * Dummy.
      * @since 0.1.0
      */
-    public static class WithVoidPhi extends PhDefault {
+    public static final class WithVoidPhi extends PhDefault {
         /**
          * Ctor.
          */
@@ -685,7 +709,7 @@ final class PhDefaultTest {
      * Counter.
      * @since 0.1.0
      */
-    public static class Counter extends PhDefault {
+    public static final class Counter extends PhDefault {
         /**
          * Count.
          */
@@ -694,7 +718,6 @@ final class PhDefaultTest {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Counter() {
             this.add(
                 Phi.PHI,
@@ -716,7 +739,7 @@ final class PhDefaultTest {
      * Kid.
      * @since 0.1.0
      */
-    public static class Kid extends PhDefault {
+    public static final class Kid extends PhDefault {
         /**
          * Ctor.
          */
@@ -731,7 +754,7 @@ final class PhDefaultTest {
      * Endless Recursion.
      * @since 0.1.0
      */
-    public static class EndlessRecursion extends PhDefault {
+    public static final class EndlessRecursion extends PhDefault {
         /**
          * Count.
          */
@@ -740,7 +763,7 @@ final class PhDefaultTest {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        @SuppressWarnings("PMD.AssignmentToNonFinalStatic")
         EndlessRecursion() {
             this.add(
                 Phi.PHI,
@@ -765,7 +788,7 @@ final class PhDefaultTest {
      * Recursive Phi.
      * @since 0.1.0
      */
-    public static class RecursivePhi extends PhDefault {
+    public static final class RecursivePhi extends PhDefault {
         /**
          * Count.
          */
@@ -774,7 +797,7 @@ final class PhDefaultTest {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        @SuppressWarnings("PMD.AssignmentToNonFinalStatic")
         RecursivePhi() {
             this.add(
                 "φ",
@@ -799,16 +822,17 @@ final class PhDefaultTest {
      * RecursivePhiViaNew.
      * @since 0.1.0
      */
-    public static class RecursivePhiViaNew extends PhDefault {
+    public static final class RecursivePhiViaNew extends PhDefault {
         /**
          * Count.
          */
+        @SuppressWarnings("PMD.UnusedPrivateField")
         private static int count;
 
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        @SuppressWarnings("PMD.AssignmentToNonFinalStatic")
         RecursivePhiViaNew() {
             this.add(
                 "φ",

--- a/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhMethodTest.java
@@ -25,6 +25,7 @@ final class PhMethodTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void calculatesPhiJustOnce() {
         final Dummy dummy = new Dummy();
         final Phi phi = new PhMethod(dummy, "φ");
@@ -40,6 +41,7 @@ final class PhMethodTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void calculatesLocalJustOnce() {
         final Dummy dummy = new Dummy();
         final Phi phi = new PhMethod(dummy, "foo");
@@ -57,8 +59,7 @@ final class PhMethodTest {
     @Test
     void calculatesPhiOnce() {
         final Dummy dummy = new Dummy();
-        final Phi phi = new PhMethod(dummy, "neg");
-        new Dataized(phi).take();
+        new Dataized(new PhMethod(dummy, "neg")).take();
         MatcherAssert.assertThat(
             "Neg should be calculated only once, but it wasn't",
             dummy.count,
@@ -84,7 +85,7 @@ final class PhMethodTest {
      * Dummy default.
      * @since 0.1.0
      */
-    public static class Dummy extends PhDefault {
+    public static final class Dummy extends PhDefault {
         /**
          * Count.
          */
@@ -93,7 +94,6 @@ final class PhMethodTest {
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Dummy() {
             this.add(
                 "φ",

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -52,13 +52,12 @@ final class PhPackageTest {
     @Test
     void setsRhoToPackage() {
         final Phi org = Phi.Φ.take("org");
-        final Phi eolang = org.take("eolang");
         MatcherAssert.assertThat(
             String.format(
                 "The %s attribute must be set to package object on dispatch",
                 Phi.RHO
             ),
-            eolang.take(Phi.RHO),
+            org.take("eolang").take(Phi.RHO),
             Matchers.equalTo(org)
         );
     }
@@ -66,13 +65,12 @@ final class PhPackageTest {
     @Test
     void setsRhoToObject() {
         final Phi eolang = Phi.Φ.take("org.eolang");
-        final Phi seq = eolang.take("seq");
         MatcherAssert.assertThat(
             String.format(
                 "The %s attribute must be set to object inside package on dispatch",
                 Phi.RHO
             ),
-            seq.take(Phi.RHO),
+            eolang.take("seq").take(Phi.RHO),
             Matchers.equalTo(eolang)
         );
     }
@@ -89,14 +87,12 @@ final class PhPackageTest {
     @ParameterizedTest
     @MethodSource("attributes")
     void retrievesAttribute(final String attribute, final Class<?> expected) {
-        final Phi parent = new PhPackage(this.phiPackageName());
-        final Phi actual = parent.take(attribute);
         MatcherAssert.assertThat(
             String.format(
                 "Attribute '%s' should be instance of %s, but it wasn't",
                 attribute, expected.getSimpleName()
             ),
-            actual,
+            new PhPackage(this.phiPackageName()).take(attribute),
             Matchers.instanceOf(expected)
         );
     }
@@ -111,6 +107,7 @@ final class PhPackageTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void throwsExceptionIfCantFindPackageInfo() {
         MatcherAssert.assertThat(
             "Exception message must mention missing package-info.class",

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -28,6 +28,7 @@ final class PhSafeTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void catchesRuntimeException() {
         MatcherAssert.assertThat(
             "rethrows correctly",
@@ -52,6 +53,7 @@ final class PhSafeTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void rendersMultiLayeredErrorMessageCorrectly() {
         MatcherAssert.assertThat(
             "rethrows correctly",
@@ -73,6 +75,7 @@ final class PhSafeTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void showsFileNameAndLineNumber() {
         MatcherAssert.assertThat(
             "shows file name and line number",

--- a/eo-runtime/src/test/java/org/eolang/PhWithTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhWithTest.java
@@ -43,12 +43,11 @@ final class PhWithTest {
 
     @Test
     void passesToSubObject() {
-        final Phi dummy = new PhWithTest.Dummy();
         MatcherAssert.assertThat(
             "PhWith should pass attribute to sub-object and calculate correctly, but it didn't",
             new Dataized(
                 new PhWith(
-                    new PhCopy(new PhMethod(dummy, "plus")),
+                    new PhCopy(new PhMethod(new PhWithTest.Dummy(), "plus")),
                     0, new Data.ToPhi(1L)
                 )
             ).asNumber(),
@@ -58,6 +57,7 @@ final class PhWithTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"hello", "bye", "", "привет"})
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void runsInThreads(final String data) {
         final String attr = "foo";
         final Phi ref = new PhWith(new DummyWithAtFree(attr), 0, new Data.ToPhi(data));
@@ -93,7 +93,7 @@ final class PhWithTest {
      * Dummy Phi with free attribute.
      * @since 0.1.0
      */
-    private static class DummyWithAtFree extends PhDefault {
+    private static final class DummyWithAtFree extends PhDefault {
 
         /**
          * Ctor.
@@ -109,12 +109,11 @@ final class PhWithTest {
      * Dummy Phi.
      * @since 0.1.0
      */
-    public static class Dummy extends PhDefault {
+    public static final class Dummy extends PhDefault {
 
         /**
          * Ctor.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Dummy() {
             this.add("φ", new AtComposite(this, self -> new Data.ToPhi(1L)));
         }


### PR DESCRIPTION
This PR upgrades the `qulice` version to `0.25.1` in `eo-runtime`.

Related to #4884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a build plugin to a specific version for reproducible builds.
  * Added/adjusted static-analysis suppressions and TODO notes around synchronization.

* **Refactor**
  * Inlined and simplified local variables and expressions for clarity.
  * Minor formatting and annotation adjustments across the codebase.

* **Tests**
  * Refactored tests (more inline constructions, parameterized cases) and added suppressions to reduce false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->