### PR TITLE
(#4884) Replaced synchronized with ReentrantLock in PhOnce

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -12,8 +12,8 @@ import java.util.function.Supplier;
 /**
  * An object wrapping another one.
  *
- * @since 0.1
  * @checkstyle DesignForExtensionCheck (100 lines)
+ * @since 0.1
  */
 public class PhOnce implements Phi {
 
@@ -42,14 +42,18 @@ public class PhOnce implements Phi {
         this.ref = new AtomicReference<>(null);
         this.lock = new ReentrantLock();
         this.object = () -> {
-            lock.lock();
-            try {
-                if (this.ref.get() == null) {
-                    this.ref.set(obj.get());
+            Phi cached = this.ref.get();
+            if (cached == null) {
+                this.lock.lock();
+                try {
+                    cached = this.ref.get();
+                    if (cached == null) {
+                        cached = obj.get();
+                        this.ref.set(cached);
+                    }
+                } finally {
+                    this.lock.unlock();
                 }
-                return this.ref.get();
-            } finally {
-                lock.unlock();
             }
         };
     }
@@ -67,7 +71,7 @@ public class PhOnce implements Phi {
     @Override
     public Phi copy() {
         return new PhOnce(
-            () -> this.object.get().copy()
+                () -> this.object.get().copy()
         );
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -55,6 +55,7 @@ public class PhOnce implements Phi {
                     this.lock.unlock();
                 }
             }
+            return cached;
         };
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -11,8 +11,8 @@ import java.util.function.Supplier;
 
 /**
  * An object wrapping another one.
- * @checkstyle DesignForExtensionCheck (100 lines)
  * @since 0.1
+ * @checkstyle DesignForExtensionCheck (100 lines)
  */
 public class PhOnce implements Phi {
 

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -6,17 +6,13 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
  * An object wrapping another one.
  *
  * @since 0.1
- * @todo #4884:30min Use ReentrantLock instead of synchronized block in the constructor.
- *  This will allow to avoid blocking the whole object while fetching the wrapped one.
- *  Moreover, using 'syznchronized' is forbidden by qulice.
- *  Don't forget to remove the suppression of PMD.AvoidSynchronizedStatement in
- *  the constructor after that.
  * @checkstyle DesignForExtensionCheck (100 lines)
  */
 public class PhOnce implements Phi {
@@ -32,19 +28,28 @@ public class PhOnce implements Phi {
     private final AtomicReference<Phi> ref;
 
     /**
+     * Reentrant lock for thread-safe initialization
+     */
+    private final ReentrantLock lock;
+
+
+    /**
      * Ctor.
      *
      * @param obj The object
      */
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public PhOnce(final Supplier<Phi> obj) {
         this.ref = new AtomicReference<>(null);
+        this.lock = new ReentrantLock();
         this.object = () -> {
-            synchronized (this.ref) {
+            lock.lock();
+            try {
                 if (this.ref.get() == null) {
                     this.ref.set(obj.get());
                 }
                 return this.ref.get();
+            } finally {
+                lock.unlock();
             }
         };
     }

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -11,7 +11,6 @@ import java.util.function.Supplier;
 
 /**
  * An object wrapping another one.
- *
  * @checkstyle DesignForExtensionCheck (100 lines)
  * @since 0.1
  */
@@ -28,14 +27,12 @@ public class PhOnce implements Phi {
     private final AtomicReference<Phi> ref;
 
     /**
-     * Reentrant lock for thread-safe initialization
+     * Reentrant lock for thread-safe initialization.
      */
     private final ReentrantLock lock;
 
-
     /**
      * Ctor.
-     *
      * @param obj The object
      */
     public PhOnce(final Supplier<Phi> obj) {
@@ -72,7 +69,7 @@ public class PhOnce implements Phi {
     @Override
     public Phi copy() {
         return new PhOnce(
-                () -> this.object.get().copy()
+            () -> this.object.get().copy()
         );
     }
 


### PR DESCRIPTION
### What does this PR do?
Replaces `synchronized` block with `ReentrantLock` in `PhOnce` constructor to avoid blocking the whole object during lazy initialization and to comply with qulice rules.

### Related issues
- Fixes #4884

### Changes
- Added `ReentrantLock` field
- Replaced `synchronized (this.ref)` with `lock.lock()` / `lock.unlock()` in try-finally block
- Removed corresponding `@todo` puzzle
- Preserved all existing functionality

### How to test
Run `mvn clean install -pl eo-runtime -am` to verify the module compiles. The change is internal and should not affect existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal synchronization and initialization to make concurrency handling more robust.
  * Strengthened atomic creation of internal resources for more reliable startup under concurrent use.
  * Preserves all public APIs and observable behavior.
  * No user-facing changes; improvements confined to internal implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->