### PR TITLE
fix(#4904): synchronized replaced with lock in Files

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOfs/Files.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/Files.java
@@ -59,14 +59,19 @@ final class Files {
      */
     @SuppressWarnings("java:S2095")
     void open(final String name) throws IOException {
-        final Path path = Paths.get(name);
-        this.streams.putIfAbsent(
-            name,
-            new Object[]{
-                java.nio.file.Files.newInputStream(path),
-                java.nio.file.Files.newOutputStream(path, StandardOpenOption.APPEND),
-            }
-        );
+        this.lock.lock();
+        try {
+            final Path path = Paths.get(name);
+            this.streams.putIfAbsent(
+                name,
+                new Object[]{
+                    java.nio.file.Files.newInputStream(path),
+                    java.nio.file.Files.newOutputStream(path, StandardOpenOption.APPEND),
+                }
+            );
+        } finally {
+            this.lock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR solves #4904  

## Changes
* `synchronized` statements replaced with `lock` in Files.java;
* Fixed text in write;
* Added lock in open.

## Test 

Run the following commands to verify:
```
# Compile and run tests
mvn clean install -pl eo-runtime -am
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal synchronization for file handling by replacing intrinsic synchronization with explicit locking to strengthen thread-safety.
  * Ensures locks are always released on error to improve reliability of concurrent operations.
  * Updated an error message for write failures for clearer diagnostics.
  * No changes to public interfaces or external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->