### PR TITLE
fix(#4949): enabled object-has-data lint

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -256,13 +256,6 @@
                 -->
                 <lint>comment-not-capitalized</lint>
                 <!--
-                @todo #4538:30min. Enable `object-has-data` lint.
-                      The lint incorrectly flags all objects with bytes inside because they
-                      don't have @base='Φ.org.eolang.bytes'. It was changed in
-                      https://github.com/objectionary/eo/issues/4538. Right now we have just Φ.bytes
-                -->
-                <lint>object-has-data</lint>
-                <!--
                 @todo #5078:30min. Remove `idempotent-attribute-is-not-first` skip.
                       The lint relies on the `xi🌵` positional marker that the legacy
                       ANTLR parser emitted; the new spec-driven parser does not produce


### PR DESCRIPTION
## Summary
This PR solves #4949 

## Changes
* enabled `object-has-data` lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused build-time lint suppression from the build configuration, reducing suppressed lint rules.

* **Refactor**
  * Simplified how package-name formatting is produced internally, producing shorter, more consistent forma strings.

* **Tests**
  * Updated tests to expect the new, simplified package naming in generated forma outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->