### PR TITLE
feat(#4983): enable WPA caching in MjLint

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -13,6 +13,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.cactoos.Func;
 import org.cactoos.func.UncheckedFunc;
@@ -35,6 +36,11 @@ final class Cache {
     private final Func<Path, String> compilation;
 
     /**
+     * Files filter for dir cache.
+     */
+    private final Predicate<Path> filter;
+
+    /**
      * Constructor.
      * @param path Cache path
      * @param compilation Compilation function
@@ -49,8 +55,23 @@ final class Cache {
      * @param compilation Compilation function
      */
     Cache(final Path base, final Func<Path, String> compilation) {
+        this(base, compilation, p -> true);
+    }
+
+    /**
+     * Constructor.
+     * @param base Base cache directory.
+     * @param compilation Compilation function.
+     * @param filter Filter for files.
+     */
+    public Cache(
+        final Path base,
+        final Func<Path, String> compilation,
+        final Predicate<Path> filter
+    ) {
         this.base = base;
         this.compilation = compilation;
+        this.filter = filter;
     }
 
     /**
@@ -61,7 +82,7 @@ final class Cache {
      */
     public void apply(final Path source, final Path target, final Path tail) {
         try {
-            final String sha = Cache.sha(source);
+            final String sha = this.sha(source);
             final Path hash = this.hash(tail);
             final Path cache = this.base.resolve(tail);
             if (
@@ -99,10 +120,10 @@ final class Cache {
      * @param any File or directory path
      * @return Base64-encoded SHA-256 hash of the file or directory contents
      */
-    private static String sha(final Path any) {
+    private String sha(final Path any) {
         final String result;
         if (Files.isDirectory(any)) {
-            result = Cache.dirSha(any);
+            result = this.dirSha(any);
         } else if (Files.isRegularFile(any)) {
             result = Cache.fileSha(any);
         } else {
@@ -118,11 +139,12 @@ final class Cache {
      * @param dir Directory path.
      * @return Base64-encoded SHA-256 hash of the directory contents.
      */
-    private static String dirSha(final Path dir) {
+    private String dirSha(final Path dir) {
         try {
             final MessageDigest digest = MessageDigest.getInstance("SHA-256");
             try (Stream<Path> stream = Files.walk(dir)) {
                 stream.filter(Files::isRegularFile)
+                    .filter(p-> this.filter.test(p))
                     .sorted(Comparator.comparing(Path::toString))
                     .map(Cache::fileSha)
                     .map(s -> s.getBytes(StandardCharsets.UTF_8))

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -64,7 +64,7 @@ final class Cache {
      * @param compilation Compilation function.
      * @param filter Filter for files.
      */
-    public Cache(
+    Cache(
         final Path base,
         final Func<Path, String> compilation,
         final Predicate<Path> filter
@@ -144,7 +144,7 @@ final class Cache {
             final MessageDigest digest = MessageDigest.getInstance("SHA-256");
             try (Stream<Path> stream = Files.walk(dir)) {
                 stream.filter(Files::isRegularFile)
-                    .filter(p-> this.filter.test(p))
+                    .filter(this.filter::test)
                     .sorted(Comparator.comparing(Path::toString))
                     .map(Cache::fileSha)
                     .map(s -> s.getBytes(StandardCharsets.UTF_8))

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -30,7 +30,6 @@ import org.eolang.parser.OnDefault;
 import org.eolang.parser.OnDetailed;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
-import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
@@ -208,8 +207,35 @@ public final class MjLint extends MjSafe {
         if (!this.skipProgramLints.isEmpty()) {
             Logger.info(this, "Unliting WPA lints: %[list]s", this.skipProgramLints);
         }
+        final List<Defect> defects;
+        if (this.cacheEnabled) {
+            final Path wpa = Path.of("wpa.xmir");
+            final Path target = this.targetDir.toPath().resolve(MjLint.DIR).resolve(wpa);
+            new Cache(
+                this.cache.toPath().resolve(MjLint.CACHE),
+                root -> {
+                    final Directives all = new Directives().add("defects");
+                    for (final Defect defect : this.wpa(pkg)) {
+                        MjLint.embedded(all, defect);
+                    }
+                    all.up();
+                    return new Xembler(all).xmlQuietly();
+                },
+                p -> p.getFileName().toString().endsWith(".xmir")
+                    && !p.getFileName().equals(wpa)
+            ).apply(this.sourcesDir.toPath(), target, wpa);
+            defects = MjLint.read(target);
+        } else {
+            defects = this.wpa(pkg);
+        }
+        for (final Defect defect : defects) {
+            counts.compute(defect.severity(), (sev, before) -> before + 1);
+        }
+        return pkg.size();
+    }
 
-        List<Defect> defects = new ArrayList<>(0);
+    private List<Defect> wpa(final Map<String, XML> pkg) {
+        final List<Defect> defects = new ArrayList<>(0);
         new Program(pkg)
             .without(this.skipProgramLints.toArray(new String[0]))
             .defects()
@@ -224,25 +250,13 @@ public final class MjLint extends MjSafe {
                             defect
                         )
                     ).applyQuietly(node);
-                    defects.add(defect);
                     if (MjLint.notSuppressed(new Xnav(node), defect)) {
-                        counts.compute(defect.severity(), (sev, before) -> before + 1);
+                        defects.add(defect);
                         MjLint.logOne(defect);
                     }
                 }
             );
-        if (this.cacheEnabled) {
-            final Directives all = new Directives().add("defects");
-            for (final Defect defect : defects) {
-                MjLint.embedded(all, defect);
-            }
-            all.up();
-            final String xml = new Xembler(all).xmlQuietly();
-            // where do we need to save all the defects?
-
-        }
-
-        return pkg.size();
+        return defects;
     }
 
     /**
@@ -421,6 +435,29 @@ public final class MjLint extends MjSafe {
             dirs.attr("line", defect.line());
         }
         return dirs.up();
+    }
+
+    private static List<Defect> read(final Path path) {
+        return new Xnav(path).path("/defects/error").map(
+            node -> {
+                return new Defect.Default(
+                    node.attribute("check").text().orElseThrow(),
+                    Severity.parsed(node.attribute("severity").text().orElseThrow()),
+                    "",
+                    0,
+                    ""
+                )
+                    ;
+            }
+        ).collect(Collectors.toList());
+//        dirs.add("error")
+//            .attr("check", defect.rule())
+//            .attr("severity", defect.severity().mnemo())
+//            .set(defect.text());
+//        if (defect.line() > 0) {
+//            dirs.attr("line", defect.line());
+//        }
+//        return dirs.up();
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -214,6 +214,7 @@ public final class MjLint extends MjSafe {
             new Cache(
                 this.cache.toPath().resolve(MjLint.CACHE),
                 root -> {
+                    Logger.info(this, "Linting a package");
                     final Directives all = new Directives().add("defects");
                     for (final Defect defect : this.wpa(pkg)) {
                         MjLint.embedded(all, defect);
@@ -226,6 +227,10 @@ public final class MjLint extends MjSafe {
             ).apply(this.sourcesDir.toPath(), target, wpa);
             defects = MjLint.read(target);
         } else {
+            Logger.info(
+                this,
+                "Linting a package without cache, this might be slow, consider enabling cache"
+            );
             defects = this.wpa(pkg);
         }
         for (final Defect defect : defects) {
@@ -437,27 +442,21 @@ public final class MjLint extends MjSafe {
         return dirs.up();
     }
 
+    /**
+     * Read defects from XMIR.
+     * @param path Path to XMIR
+     * @return Collection of defects
+     */
     private static List<Defect> read(final Path path) {
         return new Xnav(path).path("/defects/error").map(
-            node -> {
-                return new Defect.Default(
-                    node.attribute("check").text().orElseThrow(),
-                    Severity.parsed(node.attribute("severity").text().orElseThrow()),
-                    "",
-                    0,
-                    ""
-                )
-                    ;
-            }
+            node -> new Defect.Default(
+                node.attribute("check").text().orElseThrow(),
+                Severity.parsed(node.attribute("severity").text().orElseThrow()),
+                "",
+                0,
+                ""
+            )
         ).collect(Collectors.toList());
-//        dirs.add("error")
-//            .attr("check", defect.rule())
-//            .attr("severity", defect.severity().mnemo())
-//            .set(defect.text());
-//        if (defect.line() > 0) {
-//            dirs.attr("line", defect.line());
-//        }
-//        return dirs.up();
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -30,6 +30,7 @@ import org.eolang.parser.OnDefault;
 import org.eolang.parser.OnDetailed;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
@@ -207,6 +208,8 @@ public final class MjLint extends MjSafe {
         if (!this.skipProgramLints.isEmpty()) {
             Logger.info(this, "Unliting WPA lints: %[list]s", this.skipProgramLints);
         }
+
+        List<Defect> defects = new ArrayList<>(0);
         new Program(pkg)
             .without(this.skipProgramLints.toArray(new String[0]))
             .defects()
@@ -221,12 +224,24 @@ public final class MjLint extends MjSafe {
                             defect
                         )
                     ).applyQuietly(node);
+                    defects.add(defect);
                     if (MjLint.notSuppressed(new Xnav(node), defect)) {
                         counts.compute(defect.severity(), (sev, before) -> before + 1);
                         MjLint.logOne(defect);
                     }
                 }
             );
+        if (this.cacheEnabled) {
+            final Directives all = new Directives().add("defects");
+            for (final Defect defect : defects) {
+                MjLint.embedded(all, defect);
+            }
+            all.up();
+            final String xml = new Xembler(all).xmlQuietly();
+            // where do we need to save all the defects?
+
+        }
+
         return pkg.size();
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -26,10 +26,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Test cases for {@link MjLint}.
  *
  * @since 0.31.0
- * @todo #4940:90min Enable MjLintTests when WPA cache is ready.
- *  We need to enable the following test when we implement WPA cache.
- *  {@link MjLintTest#savesForWholeProgramAnalysisResultsToCache}
- *  For now, WPA results are not saved to cache.
  */
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 @ExtendWith(MktmpResolver.class)
@@ -118,47 +114,9 @@ final class MjLintTest {
     }
 
     @Test
-    @SuppressWarnings({
-        "PMD.UnitTestContainsTooManyAsserts",
-        "PMD.UnnecessaryLocalRule"
-    })
     void savesForWholeProgramAnalysisResultsToCache(@Mktmp final Path temp) throws IOException {
         final Path cache = temp.resolve("wpa-cache");
         final FakeMaven maven = new FakeMaven(temp)
-            .with("lintAsPackage", true)
-            .allTojosWithHash(() -> "abcdefq")
-            .with("cache", cache.toFile())
-           .withProgram(
-            "+home https://www.eolang.org",
-            "+package foo.x",
-            "+version 0.0.0",
-            "+unlint empty-object",
-            "+unlint unit-test-missing",
-            "+unlint mandatory-spdx",
-            "+unlint comment-too-short",
-            "+unlint object-has-data",
-            "",
-            "# No comments.",
-            "[x] > main",
-            "  (stdout \"Hello!\" x).print > @"
-        );
-        maven.execute(new FakeMaven.Lint());
-        MatcherAssert.assertThat(
-            "WPA results must be saved to cache",
-            cache.resolve(MjLint.CACHE)
-                .resolve("wpa.xmir").toFile(),
-            FileMatchers.anExistingFile()
-        );
-    }
-
-    @Test
-    @SuppressWarnings({
-        "PMD.UnitTestContainsTooManyAsserts",
-        "PMD.UnnecessaryLocalRule"
-    })
-    void getsWholeProgramAnalysisResultsFromCache(@Mktmp final Path temp) throws IOException {
-        final Path cache = temp.resolve("wpa-cache");
-        final FakeMaven maven = new FakeMaven(temp.resolve("src"))
             .with("lintAsPackage", true)
             .allTojosWithHash(() -> "abcdefq")
             .with("cache", cache.toFile())
@@ -176,7 +134,6 @@ final class MjLintTest {
                 "[x] > main",
                 "  (stdout \"Hello!\" x).print > @"
             );
-        maven.execute(new FakeMaven.Lint());
         maven.execute(new FakeMaven.Lint());
         MatcherAssert.assertThat(
             "WPA results must be saved to cache",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -118,30 +118,70 @@ final class MjLintTest {
     }
 
     @Test
-    @Disabled
     @SuppressWarnings({
         "PMD.UnitTestContainsTooManyAsserts",
         "PMD.UnnecessaryLocalRule"
     })
     void savesForWholeProgramAnalysisResultsToCache(@Mktmp final Path temp) throws IOException {
         final Path cache = temp.resolve("wpa-cache");
-        final String hash = "abcdefq";
         final FakeMaven maven = new FakeMaven(temp)
             .with("lintAsPackage", true)
-            .allTojosWithHash(() -> hash)
+            .allTojosWithHash(() -> "abcdefq")
             .with("cache", cache.toFile())
-            .withProgram(MjLintTest.probmlematic());
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> maven.execute(new FakeMaven.Lint()),
-            "We should get WPA error"
+           .withProgram(
+            "+home https://www.eolang.org",
+            "+package foo.x",
+            "+version 0.0.0",
+            "+unlint empty-object",
+            "+unlint unit-test-missing",
+            "+unlint mandatory-spdx",
+            "+unlint comment-too-short",
+            "+unlint object-has-data",
+            "",
+            "# No comments.",
+            "[x] > main",
+            "  (stdout \"Hello!\" x).print > @"
         );
+        maven.execute(new FakeMaven.Lint());
         MatcherAssert.assertThat(
             "WPA results must be saved to cache",
             cache.resolve(MjLint.CACHE)
-                .resolve(FakeMaven.pluginVersion())
-                .resolve(hash)
-                .resolve("foo/x/wpa.xmir").toFile(),
+                .resolve("wpa.xmir").toFile(),
+            FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    @SuppressWarnings({
+        "PMD.UnitTestContainsTooManyAsserts",
+        "PMD.UnnecessaryLocalRule"
+    })
+    void getsWholeProgramAnalysisResultsFromCache(@Mktmp final Path temp) throws IOException {
+        final Path cache = temp.resolve("wpa-cache");
+        final FakeMaven maven = new FakeMaven(temp.resolve("src"))
+            .with("lintAsPackage", true)
+            .allTojosWithHash(() -> "abcdefq")
+            .with("cache", cache.toFile())
+            .withProgram(
+                "+home https://www.eolang.org",
+                "+package foo.x",
+                "+version 0.0.0",
+                "+unlint empty-object",
+                "+unlint unit-test-missing",
+                "+unlint mandatory-spdx",
+                "+unlint comment-too-short",
+                "+unlint object-has-data",
+                "",
+                "# No comments.",
+                "[x] > main",
+                "  (stdout \"Hello!\" x).print > @"
+            );
+        maven.execute(new FakeMaven.Lint());
+        maven.execute(new FakeMaven.Lint());
+        MatcherAssert.assertThat(
+            "WPA results must be saved to cache",
+            cache.resolve(MjLint.CACHE)
+                .resolve("wpa.xmir").toFile(),
             FileMatchers.anExistingFile()
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -134,7 +134,7 @@ final class MjLintTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> maven.execute(new FakeMaven.Lint()),
-            "We should get WPA error, but we got it"
+            "We should get WPA error"
         );
         MatcherAssert.assertThat(
             "WPA results must be saved to cache",


### PR DESCRIPTION
This PR enables the WPA cache in `MjLintTest.java`.

Fixes #4983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced caching mechanism for linting analysis with improved defect collection and handling
  * Added performance notifications when caching is disabled during linting operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->