### PR TITLE
bug(#4987): fixed `classedDir` in `MjSafe`

### DIFF
--- a/eo-integration-tests/src/test/java/integration/JarIT.java
+++ b/eo-integration-tests/src/test/java/integration/JarIT.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration test that runs simple EO program from packaged jar.
  * @since 0.54
+ * @todo #4987:30min Enable JarIt integration tests. The tests were disabled because of this ticket:
+ *  https://github.com/objectionary/eo/issues/4987?issue=objectionary%7Ceo%7C4538. When new release
+ *  is made, we should try to enable them. Don't forget to remove the puzzle.
  */
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "PMD.UnitTestShouldIncludeAssert"})
 @ExtendWith(MktmpResolver.class)
@@ -166,6 +169,7 @@ final class JarIT {
         );
     }
 
+    @Disabled
     @Test
     @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -79,7 +79,7 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (8 lines)
      */
     @Parameter(
-        defaultValue = "${project.build.directory}/classes/org/eolang",
+        defaultValue = "${project.build.directory}/classes",
         readonly = true,
         required = true
     )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
@@ -67,15 +67,15 @@ final class MjUnspileTest {
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void deletesInnerGeneratedClasses(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
-        new Saved("outer", maven.generatedPath().resolve("EOorg/EOnumber.java")).value();
+        new Saved("outer", maven.generatedPath().resolve("org/EOnumber.java")).value();
         final Path clazz = new Saved(
-            "clz", maven.classesPath().resolve("EOorg/EOnumber.class")
+            "clz", maven.classesPath().resolve("org/EOnumber.class")
         ).value();
         final Path inner = new Saved(
-            "inner", maven.classesPath().resolve("EOorg/EOnumber$1$2$3.class")
+            "inner", maven.classesPath().resolve("org/EOnumber$1$2$3.class")
         ).value();
         final Path located = new Saved(
-            "clss", maven.classesPath().resolve("EOorg/EOnumber$EOΦorgeolanginner.class")
+            "clss", maven.classesPath().resolve("org/EOnumber$EOΦorgeolanginner.class")
         ).value();
         MatcherAssert.assertThat(
             "UnspileMojo must delete inner auto generated classes",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -79,7 +79,7 @@ final class ObjectsIndexTest {
     void downloadsAndChecksFromRealSource() throws Exception {
         MatcherAssert.assertThat(
             "The index must contain the default value",
-            new ObjectsIndex().contains("org.eolang.io.stdout"),
+            new ObjectsIndex().contains("io.stdout"),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
@@ -93,6 +93,6 @@ final class OyIndexedTest {
      * Returns the stdout path.
      */
     private String stdout() {
-        return "org.eolang.io.stdout";
+        return "io.stdout";
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -78,7 +78,7 @@ final class OyRemoteTest {
     void checksPresenceOfProgram() throws IOException {
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the program in Objectionary",
-            new OyRemote(new ChRemote("master")).contains("org.eolang.io.stdout"),
+            new OyRemote(new ChRemote("master")).contains("io.stdout"),
             Matchers.is(true)
         );
     }
@@ -88,7 +88,7 @@ final class OyRemoteTest {
     void checksPresenceOfDirectory() throws IOException {
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the directory in Objectionary",
-            new OyRemote(new ChRemote("master")).contains("org.eolang.ms"),
+            new OyRemote(new ChRemote("master")).contains("ms"),
             Matchers.is(true)
         );
     }
@@ -96,7 +96,7 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfProgramWithNarrowHash() throws IOException {
-        final String stdout = "org.eolang.io.stdout";
+        final String stdout = "io.stdout";
         MatcherAssert.assertThat(
             String.format(
                 "OyRemote with narrow hash should have contained program %s, but it didn't",
@@ -114,7 +114,7 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfDirectoryWithNarrowHash() throws IOException {
-        final String stdout = "org.eolang.ss";
+        final String stdout = "ss";
         MatcherAssert.assertThat(
             String.format(
                 "OyRemote with narrow hash should have contained directory %s, but it didn't",

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -265,13 +265,162 @@
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
               </skipProgramLints>
+              <!--
+                @todo #4987:30min. Reduce keepBinaries back to package-info entries only.
+                  Due to incorrect default value of classesDir in MjSafe (fixed in #4987),
+                  MjUnplace and MjUnspile were not working properly, so all classes —
+                  hand-written, generated, and placed — were published to Maven Central by
+                  mistake (see #4538). As a result, when eo-runtime resolves itself as a
+                  dependency, all those extra classes get placed into target/classes and
+                  would be included in the JAR unless explicitly kept here. Once a release
+                  with the fix is published to Maven Central and this module stops resolving
+                  the bloated artifact, this list can be reduced back to the five
+                  package-info.class entries.
+              -->
               <keepBinaries>
-                <glob>EOorg/package-info.class</glob>
-                <glob>EOorg/EOeolang/package-info.class</glob>
-                <glob>EOorg/EOeolang/EOfs/package-info.class</glob>
-                <glob>EOorg/EOeolang/EOms/package-info.class</glob>
-                <glob>EOorg/EOeolang/EOsm/package-info.class</glob>
-                <glob>EOorg/EOeolang/EOtt/package-info.class</glob>
+                <glob>org/eolang/AtComposite.class</glob>
+                <glob>org/eolang/Atom.class</glob>
+                <glob>org/eolang/AtomSafe.class</glob>
+                <glob>org/eolang/AtOnce.class</glob>
+                <glob>org/eolang/AtRho.class</glob>
+                <glob>org/eolang/Attr.class</glob>
+                <glob>org/eolang/AtVoid.class</glob>
+                <glob>org/eolang/AtWithRho.class</glob>
+                <glob>org/eolang/Bytes.class</glob>
+                <glob>org/eolang/BytesOf.class</glob>
+                <glob>org/eolang/BytesRaw.class</glob>
+                <glob>org/eolang/Data.class</glob>
+                <glob>org/eolang/Dataized.class</glob>
+                <glob>org/eolang/EObytes$EOand.class</glob>
+                <glob>org/eolang/EObytes$EOconcat.class</glob>
+                <glob>org/eolang/EObytes$EOeq.class</glob>
+                <glob>org/eolang/EObytes$EOnot.class</glob>
+                <glob>org/eolang/EObytes$EOor.class</glob>
+                <glob>org/eolang/EObytes$EOright.class</glob>
+                <glob>org/eolang/EObytes$EOsize.class</glob>
+                <glob>org/eolang/EObytes$EOslice.class</glob>
+                <glob>org/eolang/EObytes$EOxor.class</glob>
+                <glob>org/eolang/EOerror.class</glob>
+                <glob>org/eolang/EOfs/EOdir$EOmade$EOmkdir.class</glob>
+                <glob>org/eolang/EOfs/EOdir$EOtmpfile$EOtouch.class</glob>
+                <glob>org/eolang/EOfs/EOdir$EOwalk.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOdeleted$EOdelete.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOexists.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOis_directory.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOmoved$EOmove.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOread$EOchunk.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOwrite$EOwritten_bytes.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOopen$EOprocess_file.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOsize.class</glob>
+                <glob>org/eolang/EOfs/EOfile$EOtouched$EOtouch.class</glob>
+                <glob>org/eolang/EOfs/Files.class</glob>
+                <glob>org/eolang/EOfs/package-info.class</glob>
+                <glob>org/eolang/EOi16$EOas_i32.class</glob>
+                <glob>org/eolang/EOi32$EOas_i64.class</glob>
+                <glob>org/eolang/EOi64$EOas_number.class</glob>
+                <glob>org/eolang/EOi64$EOdiv.class</glob>
+                <glob>org/eolang/EOi64$EOgt.class</glob>
+                <glob>org/eolang/EOi64$EOplus.class</glob>
+                <glob>org/eolang/EOi64$EOtimes.class</glob>
+                <glob>org/eolang/EOmalloc$EOof$EOφ.class</glob>
+                <glob>org/eolang/EOmalloc$EOof$EOallocated$EOread.class</glob>
+                <glob>org/eolang/EOmalloc$EOof$EOallocated$EOresized.class</glob>
+                <glob>org/eolang/EOmalloc$EOof$EOallocated$EOsize.class</glob>
+                <glob>org/eolang/EOmalloc$EOof$EOallocated$EOwrite.class</glob>
+                <glob>org/eolang/EOms/EOacos.class</glob>
+                <glob>org/eolang/EOms/EOangle$EOcos.class</glob>
+                <glob>org/eolang/EOms/EOangle$EOsin.class</glob>
+                <glob>org/eolang/EOms/EOasin.class</glob>
+                <glob>org/eolang/EOms/EOln.class</glob>
+                <glob>org/eolang/EOms/EOpow.class</glob>
+                <glob>org/eolang/EOms/EOsqrt.class</glob>
+                <glob>org/eolang/EOms/package-info.class</glob>
+                <glob>org/eolang/EOnumber$EOas_i64.class</glob>
+                <glob>org/eolang/EOnumber$EOdiv.class</glob>
+                <glob>org/eolang/EOnumber$EOfloor.class</glob>
+                <glob>org/eolang/EOnumber$EOgt.class</glob>
+                <glob>org/eolang/EOnumber$EOplus.class</glob>
+                <glob>org/eolang/EOnumber$EOtimes.class</glob>
+                <glob>org/eolang/EOsm/EOos$EOname.class</glob>
+                <glob>org/eolang/EOsm/EOposix$EOφ.class</glob>
+                <glob>org/eolang/EOsm/EOwin32$EOφ.class</glob>
+                <glob>org/eolang/EOsm/package-info.class</glob>
+                <glob>org/eolang/EOsm/Posix/AcceptSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/BindSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/CloseSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/ConnectSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/CStdLib.class</glob>
+                <glob>org/eolang/EOsm/Posix/ErrnoSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/GetenvSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/GetpidSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/GettimeofdaySyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/InetAddrSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/ListenSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/package-info.class</glob>
+                <glob>org/eolang/EOsm/Posix/ReadSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/RecvSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/SendSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/SocketSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/StrerrorSyscall.class</glob>
+                <glob>org/eolang/EOsm/Posix/WriteSyscall.class</glob>
+                <glob>org/eolang/EOsm/SockaddrIn.class</glob>
+                <glob>org/eolang/EOsm/Syscall.class</glob>
+                <glob>org/eolang/EOsm/TupleToArray.class</glob>
+                <glob>org/eolang/EOsm/Win32/AcceptFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/BaseTSD.class</glob>
+                <glob>org/eolang/EOsm/Win32/BindFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/ClosesocketFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/ConnectFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/GetCurrentProcessIdFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/GetEnvironmentVariableFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/GetSystemTimeFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/InetAddrFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/Kernel32.class</glob>
+                <glob>org/eolang/EOsm/Win32/ListenFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/package-info.class</glob>
+                <glob>org/eolang/EOsm/Win32/ReadFileFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/RecvFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/SendFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/SocketFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/WinBase.class</glob>
+                <glob>org/eolang/EOsm/Win32/Wincon.class</glob>
+                <glob>org/eolang/EOsm/Win32/WinDef.class</glob>
+                <glob>org/eolang/EOsm/Win32/WinNT.class</glob>
+                <glob>org/eolang/EOsm/Win32/Winsock.class</glob>
+                <glob>org/eolang/EOsm/Win32/WriteFileFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/WSACleanupFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/WSAGetLastErrorFuncCall.class</glob>
+                <glob>org/eolang/EOsm/Win32/WSAStartupFuncCall.class</glob>
+                <glob>org/eolang/EOtry.class</glob>
+                <glob>org/eolang/EOtt/EOregex$EOφ.class</glob>
+                <glob>org/eolang/EOtt/EOregex$EOpattern$EOmatch$EOmatched_from_index.class</glob>
+                <glob>org/eolang/EOtt/EOsprintf.class</glob>
+                <glob>org/eolang/EOtt/EOsscanf.class</glob>
+                <glob>org/eolang/EOtt/package-info.class</glob>
+                <glob>org/eolang/EOtt/SprintfArgs.class</glob>
+                <glob>org/eolang/ExAbstract.class</glob>
+                <glob>org/eolang/ExFailure.class</glob>
+                <glob>org/eolang/ExInterrupted.class</glob>
+                <glob>org/eolang/Expect.class</glob>
+                <glob>org/eolang/ExReadOnly.class</glob>
+                <glob>org/eolang/ExUnset.class</glob>
+                <glob>org/eolang/Heaps.class</glob>
+                <glob>org/eolang/JavaPath.class</glob>
+                <glob>org/eolang/Main.class</glob>
+                <glob>org/eolang/package-info.class</glob>
+                <glob>org/eolang/PhCached.class</glob>
+                <glob>org/eolang/PhCopy.class</glob>
+                <glob>org/eolang/PhDefault.class</glob>
+                <glob>org/eolang/Phi.class</glob>
+                <glob>org/eolang/PhLogged.class</glob>
+                <glob>org/eolang/PhMethod.class</glob>
+                <glob>org/eolang/PhOnce.class</glob>
+                <glob>org/eolang/PhPackage.class</glob>
+                <glob>org/eolang/PhSafe.class</glob>
+                <glob>org/eolang/PhVoid.class</glob>
+                <glob>org/eolang/PhWith.class</glob>
+                <glob>org/eolang/VerboseBytesAsString.class</glob>
+                <glob>org/eolang/XmirObject.class</glob>
               </keepBinaries>
             </configuration>
           </execution>


### PR DESCRIPTION
Closes: #4987 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test suite to reflect changes in internal package naming conventions and build artifact organization.

* **Chores**
  * Modified build configuration to adjust how compiled classes are retained during the build process.
  * Temporarily disabled a test pending resolution of a known issue; scheduled for re-enablement in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->