### PR TITLE
bug(#4218): optimize XSL performance

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/classes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/classes.xsl
@@ -20,7 +20,7 @@
       <xsl:value-of select="."/>
       <xsl:text>"</xsl:text>
     </xsl:for-each>
-    <xsl:variable name="content" select="replace(text()[1], '^\s*(.+?)\s*$', '$1')"/>
+    <xsl:variable name="content" select="normalize-space(string(text()[1]))"/>
     <xsl:if test="$content = '' and not($node/element())">
       <xsl:text>/</xsl:text>
     </xsl:if>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -606,14 +606,14 @@
       <xsl:text> = new PhSafe(</xsl:text>
       <xsl:value-of select="$name"/>
       <xsl:text>, "</xsl:text>
-      <xsl:value-of select="eo:escape-plus($object-name)"/>
+      <xsl:value-of select="$object-name"/>
       <xsl:text>", </xsl:text>
       <xsl:value-of select="@line"/>
       <xsl:text>, </xsl:text>
       <xsl:value-of select="@pos"/>
       <xsl:text>, </xsl:text>
       <xsl:text>"</xsl:text>
-      <xsl:value-of select="eo:escape-plus(@loc)"/>
+      <xsl:value-of select="@loc"/>
       <xsl:text>"</xsl:text>
       <xsl:text>, "</xsl:text>
       <xsl:value-of select="eo:escape-plus(@original-name)"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl
@@ -165,9 +165,8 @@
     <xsl:value-of select="xs:int($decimal)"/>
   </xsl:function>
   <!-- Escape `+` in test name syntax. -->
-  <xsl:function name="eo:escape-plus">
-    <xsl:param name="name"/>
-    <xsl:variable name="pos" select="string-length(tokenize($name, '\+')[1]) + 1"/>
-    <xsl:value-of select="concat(substring($name, 1, $pos - 1), substring($name, $pos + 1))"/>
+  <xsl:function name="eo:escape-plus" as="xs:string">
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="if (contains($name, '+')) then concat(substring-before($name, '+'), substring-after($name, '+')) else $name"/>
   </xsl:function>
 </xsl:stylesheet>


### PR DESCRIPTION
## Summary

- Replace regex-based `tokenize` in `eo:escape-plus` (`_funcs.xsl`) with `contains`/`substring-before`/`substring-after` — avoids regex compilation overhead on every call
- Remove two no-op `eo:escape-plus` calls in `to-java.xsl`'s `located` template: `eo:escape-plus($object-name)` (top-level object names cannot start with `+` per grammar) and `eo:escape-plus(@loc)` (the guard `not(contains(@loc, '+'))` already guarantees no `+`)
- Replace backtracking regex trim in `classes.xsl`'s `serialize` template with `normalize-space`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace normalization in serialized text content processing
  * Fixed escape sequence handling in code generation to prevent unintended character transformations
  * Enhanced type safety declarations in string processing utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->