### PR TITLE
bug(#3538): throw error on `bytes.slice` with out of bounds

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -504,6 +504,10 @@
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
 
+  # Tests that slicing out of bounds throws an error.
+  [] +> throws-on-out-of-bounds-slice
+    20-1F-EE-B5-90.slice 3 10 > @
+
   # Tests that bytes can be correctly converted to i64 integer.
   [] +> tests-bytes-converts-to-i64
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
@@ -30,8 +30,8 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
     }
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
+        final byte[] bytes = new Dataized(this.take(Phi.RHO)).take();
         final int start = Expect.at(this, "start")
             .that(phi -> new Dataized(phi).asNumber())
             .otherwise("must be a number")
@@ -49,12 +49,11 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
             .otherwise("must be an integer")
             .must(integer -> integer >= 0)
             .otherwise("must be a positive integer")
-            .it();
-        return new Data.ToPhi(
-            Arrays.copyOfRange(
-                new Dataized(this.take(Phi.RHO)).take(),
-                start, start + length
+            .must(integer -> start + integer <= bytes.length)
+            .otherwise(
+                String.format("is out of bounds for bytes of size %d", bytes.length)
             )
-        );
+            .it();
+        return new Data.ToPhi(Arrays.copyOfRange(bytes, start, start + length));
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
@@ -48,6 +48,37 @@ final class EObytesEOsliceTest {
 
     @Test
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    void throwsOnOutOfBoundsSlice() {
+        MatcherAssert.assertThat(
+            "error message is correct for out of bounds slice",
+            new UncheckedText(
+                new TextOf(
+                    Assertions.assertThrows(
+                        EOerror.ExError.class,
+                        () -> new Dataized(
+                            new PhWith(
+                                new PhWith(
+                                    new Data.ToPhi("hello")
+                                        .take("as-bytes")
+                                        .take("slice")
+                                        .copy(),
+                                    "start",
+                                    new Data.ToPhi(3)
+                                ),
+                                "len",
+                                new Data.ToPhi(10)
+                            )
+                        ).asString(),
+                        "doesnt throw on out of bounds slice"
+                    )
+                )
+            ).asString(),
+            Matchers.containsString("is out of bounds for bytes of size 5")
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void takesWrongSlice() {
         MatcherAssert.assertThat(
             "error message is correct",


### PR DESCRIPTION
Closes: #3538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced byte slicing validation to detect and report out-of-bounds operations with descriptive error messages indicating when slice boundaries exceed available bytes.

* **Tests**
  * Added test coverage for out-of-bounds byte slice scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->