### PR TITLE
#4884 Replace synchronized with ReentrantLock in PhOnce and PhCached

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhCached.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCached.java
@@ -6,6 +6,7 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Cached Phi.
@@ -13,10 +14,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>It's highly recommended to use it with {@link PhComposite}.</p>
  *
  * @since 0.1
- * @todo #4884:30min Replace 'synchronized' with ReentrantLock.
- *  We need to replace 'synchronized' with ReentrantLock to avoid potential
- *  deadlocks when multiple threads are trying to access the cache simultaneously.
- *  Moreover, 'synchronized' keyword is forbidden by qulice.
  */
 public final class PhCached implements Phi {
 
@@ -31,12 +28,18 @@ public final class PhCached implements Phi {
     private final AtomicReference<Phi> cached;
 
     /**
+     * Lock for thread-safe cache initialization.
+     */
+    private final ReentrantLock lock;
+
+    /**
      * Ctor.
      * @param attr Origin attribute
      */
     public PhCached(final Phi attr) {
         this.origin = attr;
         this.cached = new AtomicReference<>();
+        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -50,11 +53,15 @@ public final class PhCached implements Phi {
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Phi take(final String name) {
-        synchronized (this.cached) {
-            if (this.cached.get() == null) {
-                this.cached.set(this.origin.take(name));
+        if (this.cached.get() == null) {
+            this.lock.lock();
+            try {
+                if (this.cached.get() == null) {
+                    this.cached.set(this.origin.take(name));
+                }
+            } finally {
+                this.lock.unlock();
             }
         }
         return this.cached.get();

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -6,17 +6,13 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
  * An object wrapping another one.
  *
  * @since 0.1
- * @todo #4884:30min Use ReentrantLock instead of synchronized block in the constructor.
- *  This will allow to avoid blocking the whole object while fetching the wrapped one.
- *  Moreover, using 'syznchronized' is forbidden by qulice.
- *  Don't forget to remove the suppression of PMD.AvoidSynchronizedStatement in
- *  the constructor after that.
  * @checkstyle DesignForExtensionCheck (100 lines)
  */
 public class PhOnce implements Phi {
@@ -32,20 +28,30 @@ public class PhOnce implements Phi {
     private final AtomicReference<Phi> ref;
 
     /**
+     * Lock for thread-safe initialization.
+     */
+    private final ReentrantLock lock;
+
+    /**
      * Ctor.
      *
      * @param obj The object
      */
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public PhOnce(final Supplier<Phi> obj) {
         this.ref = new AtomicReference<>(null);
+        this.lock = new ReentrantLock();
         this.object = () -> {
-            synchronized (this.ref) {
-                if (this.ref.get() == null) {
-                    this.ref.set(obj.get());
+            if (this.ref.get() == null) {
+                this.lock.lock();
+                try {
+                    if (this.ref.get() == null) {
+                        this.ref.set(obj.get());
+                    }
+                } finally {
+                    this.lock.unlock();
                 }
-                return this.ref.get();
             }
+            return this.ref.get();
         };
     }
 


### PR DESCRIPTION
## Summary

- Replace `synchronized` blocks with `ReentrantLock` in `PhOnce` and `PhCached`
- Use double-checked locking pattern: first check without lock (fast path), then lock + re-check on initialization
- Remove `@SuppressWarnings("PMD.AvoidSynchronizedStatement")` suppressions — no longer needed
- Fixes qulice compliance: `synchronized` keyword is forbidden by the linter

## Test plan

- [ ] Existing unit tests for `PhOnce` and `PhCached` pass
- [ ] No regressions in `eo-runtime` test suite (`mvn test -pl eo-runtime`)

Closes #4884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal concurrency handling in cache initialization and object reference management through enhanced locking patterns for better thread-safety and performance under concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->