### PR TITLE
bug(#4495): introduced `input-as-bytes` object

### DIFF
--- a/eo-runtime/src/main/eo/io/input-as-bytes.eo
+++ b/eo-runtime/src/main/eo/io/input-as-bytes.eo
@@ -1,0 +1,37 @@
++alias io.copied
++alias io.malloc-as-output
++alias io.bytes-as-input
++alias io.dead-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package io
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Reads all bytes from the provided `input` and returns them as bytes.
+#
+# Example usage:
+# ```
+# input-as-bytes > bts
+#   bytes-as-input 01-02-03-04-05
+# ```
+# After dataization, `bts` equals `01-02-03-04-05`.
+[input] > input-as-bytes
+  malloc.of > @
+    0
+    [m] >>
+      seq * > @
+        copied input (malloc-as-output m)
+        m
+
+  # Tests that input-as-bytes reads all bytes from input and returns them.
+  [] +> tests-bytes-to-input-and-back
+    eq. > @
+      input-as-bytes (bytes-as-input bts)
+      bts
+    01-02-03-04-05-06-07-08 > bts
+
+  # Tests that input-as-bytes returns empty bytes from dead input.
+  [] +> tests-returns-empty-bytes-from-dead-input
+    (input-as-bytes dead-input).eq -- > @


### PR DESCRIPTION
Closes: #4495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added byte input conversion capability to the runtime library, enabling efficient conversion of input streams to byte sequences.
  * Supports round-trip conversion (input → bytes → input) with proper handling of empty input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->