### PR TITLE
Fix misleading exception message in BytesRaw.sshift()

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -86,7 +86,7 @@ final class BytesRaw implements Bytes {
     public Bytes sshift(final int bits) {
         if (bits < 0) {
             throw new UnsupportedOperationException(
-                "The \"right shift\" is NYI"
+                "The left sshift (negative bits) is not yet supported"
             );
         }
         final byte[] bytes = this.shift(bits).take();

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -148,11 +148,11 @@ final class BytesOfTest {
     }
 
     @Test
-    void doesNotSupportRightShift() {
+    void doesNotSupportNegativeBits() {
         Assertions.assertThrows(
             UnsupportedOperationException.class,
             () -> new BytesOf(Integer.MAX_VALUE).sshift(-1),
-            "Integer.MAX_VALUE << 1 should throw exception, but it didn't"
+            "sshift with negative bits should throw exception, but it didn't"
         );
     }
 }


### PR DESCRIPTION
Fixes #5036.

`BytesRaw.sshift()` threw `UnsupportedOperationException` with message `The "right shift" is NYI` when called with negative bits. Per the `Bytes` interface Javadoc, `sshift` is a signed **right** shift — positive bits shift right with sign extension, which is fully implemented. Negative bits represent the **left** direction, which is what is actually not supported. The message named the wrong direction.

**Changes:**
- Fixed error message in `BytesRaw.sshift()` to accurately say `"The left sshift (negative bits) is not yet supported"`
- Renamed test method `doesNotSupportRightShift` → `doesNotSupportNegativeBits` and updated its description to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for left shift operations with negative bit values to provide clearer feedback about unsupported functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->