### PR TITLE
refactor(#4989): decouple dependency resolution logic into separate class

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -4,22 +4,10 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.cactoos.iterable.Mapped;
-import org.cactoos.set.SetOf;
-import org.cactoos.text.Joined;
 
 /**
  * Find all required runtime dependencies, download
@@ -69,24 +57,19 @@ public final class MjResolve extends MjSafe {
     private boolean resolveInCentral = true;
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() throws IOException {
-        final Collection<Dep> deps = this.deps();
-        if (deps.isEmpty()) {
-            Logger.info(this, "No new dependencies unpacked");
-        } else {
-            final Path target = this.targetDir.toPath().resolve(MjResolve.DIR);
-            new Threaded<>(
-                deps,
-                dep -> this.resolved(dep, target)
-            ).total();
-            Logger.info(
-                this,
-                "New %d dependenc(ies) unpacked to %[file]s: %s",
-                deps.size(), target,
-                new Joined(", ", new Mapped<>(Dep::toString, deps))
-            );
-        }
+        new Resolve(
+            this.scopedTojos(),
+            this.targetDir.toPath().resolve(MjResolve.DIR),
+            this.central,
+            this.discoverSelf,
+            this.skipZeroVersions,
+            this.resolveJna,
+            this.ignoreRuntime,
+            this.project,
+            this.resolveInCentral,
+            this.ignoreVersionConflicts
+        ).exec();
     }
 
     /**
@@ -96,180 +79,6 @@ public final class MjResolve extends MjSafe {
      */
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static boolean isRuntime(final Dependency dep) {
-        return "org.eolang".equals(dep.getGroupId())
-            && "eo-runtime".equals(dep.getArtifactId());
-    }
-
-    /**
-     * Resolved dependency.
-     * @param dep Dependency
-     * @param target Target path
-     * @return Amount of resolved dependencies
-     * @throws IOException If fails to resolve
-     */
-    private int resolved(final Dep dep, final Path target) throws IOException {
-        final String classifier;
-        final Dependency dependency = dep.get();
-        if (dependency.getClassifier() == null
-            || dependency.getClassifier().isEmpty()) {
-            classifier = "-";
-        } else {
-            classifier = dependency.getClassifier();
-        }
-        final Path dest = this.cleanPlace(
-            target
-                .resolve(dependency.getGroupId())
-                .resolve(dependency.getArtifactId())
-                .resolve(classifier),
-            dependency.getVersion()
-        );
-        final int total;
-        if (Files.exists(dest)) {
-            Logger.debug(
-                this,
-                "Dependency %s already resolved and exists in %[file]s",
-                dep, dest
-            );
-            total = 0;
-        } else {
-            this.central.accept(dependency, dest);
-            final int files = new Walk(dest).size();
-            if (files == 0) {
-                Logger.warn(this, "No new files after unpacking of %s!", dep);
-            } else {
-                Logger.info(
-                    this, "Found %d new file(s) (%d MB) after unpacking of %s",
-                    files, MjResolve.folderSizeInMb(dest), dep
-                );
-            }
-            total = 1;
-        }
-        return total;
-    }
-
-    /**
-     * Returns directory where the files should be unpacked,
-     * making sure there are no old files around.
-     *
-     * <p>Say, on the first run of "resolve" binary files from some JAR
-     * get unpacked. Then, the user changes the version of the JAR
-     * in the "pom.xml" (or in some .eo file) and runs the build again.
-     * We don't want the old binary files to stay in the "5-resolve"
-     * directory, because they are outdated. We want them to be removed
-     * and only the new files from the right version of the JAR to be there.
-     * This method does exactly this: it removes old files and doesn't
-     * touches new ones.</p>
-     *
-     * @param dir The dir
-     * @param version Version of dependency
-     * @return Full path
-     * @throws IOException If fails
-     */
-    private Path cleanPlace(final Path dir, final String version) throws IOException {
-        final File[] subs = dir.toFile().listFiles();
-        if (subs != null) {
-            for (final File sub : subs) {
-                final String base = sub.getName();
-                Logger.info(this, "Base if %s", base);
-                if (base.equals(version)) {
-                    continue;
-                }
-                final Path bad = dir.resolve(base);
-                try (Stream<Path> walk = Files.walk(bad)) {
-                    walk
-                        .map(Path::toFile)
-                        .sorted(Comparator.reverseOrder())
-                        .forEach(File::delete);
-                }
-                Logger.info(
-                    this,
-                    "Directory %[file]s deleted because it contained wrong version files (not %s)",
-                    bad, version
-                );
-            }
-        }
-        return dir.resolve(version);
-    }
-
-    /**
-     * Find all deps for all Tojos.
-     *
-     * @return List of them
-     */
-    private Collection<Dep> deps() {
-        Dependencies deps = new DpsDefault(
-            this.scopedTojos(), this.discoverSelf, this.skipZeroVersions, this.resolveJna
-        );
-        if (this.ignoreRuntime) {
-            Logger.info(this, "Runtime dependency is ignored because eo:ignoreRuntime=TRUE");
-            deps = new DpsWithoutRuntime(deps);
-        } else {
-            final Optional<Dependency> runtime = this.runtimeDependencyFromPom();
-            if (runtime.isPresent()) {
-                deps = new DpsWithRuntime(deps, new Dep(runtime.get()));
-                Logger.info(
-                    this,
-                    "Runtime dependency added from pom with version: %s",
-                    runtime.get().getVersion()
-                );
-            } else {
-                if (this.resolveInCentral) {
-                    deps = new DpsWithRuntime(deps);
-                } else {
-                    deps = new DpsOfflineRuntime(deps);
-                }
-            }
-        }
-        if (!this.ignoreVersionConflicts) {
-            deps = new DpsUniquelyVersioned(deps);
-        }
-        return new SetOf<>(deps)
-            .stream()
-            .sorted()
-            .distinct()
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Runtime dependency from pom.xml.
-     *
-     * @return Dependency if found.
-     */
-    private Optional<Dependency> runtimeDependencyFromPom() {
-        final Optional<Dependency> res;
-        if (this.project == null) {
-            res = Optional.empty();
-        } else {
-            res = this.project
-                .getDependencies()
-                .stream()
-                .filter(MjResolve::isRuntime)
-                .findFirst();
-        }
-        return res;
-    }
-
-    /**
-     * Folder size in megabytes.
-     * @param path Folder
-     * @return Folder size
-     * @throws IOException if I/O fails
-     */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static long folderSizeInMb(final Path path) throws IOException {
-        try (Stream<Path> paths = Files.walk(path)) {
-            return paths.filter(Files::isRegularFile).mapToLong(
-                p -> {
-                    try {
-                        return Files.size(p);
-                    } catch (final IOException exception) {
-                        throw new IllegalStateException(
-                            String.format("Failed to calculate size in %s", p),
-                            exception
-                        );
-                    }
-                }
-            ).sum() / 1024L / 1024L;
-        }
+        return Resolve.isRuntime(dep);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -56,7 +55,7 @@ public final class MjResolve extends MjSafe {
     private boolean resolveInCentral = true;
 
     @Override
-    public void exec() throws IOException {
+    public void exec() {
         new Resolve(
             this.scopedTojos(),
             this.targetDir.toPath().resolve(MjResolve.DIR),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import java.io.IOException;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -70,15 +69,5 @@ public final class MjResolve extends MjSafe {
             this.resolveInCentral,
             this.ignoreVersionConflicts
         ).exec();
-    }
-
-    /**
-     * Checks if dependency is runtime.
-     * @param dep Dependency
-     * @return True if runtime.
-     */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static boolean isRuntime(final Dependency dep) {
-        return Resolve.isRuntime(dep);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
@@ -1,0 +1,311 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.set.SetOf;
+import org.cactoos.text.Joined;
+
+/**
+ * Resolves all required runtime dependencies: downloads from Maven Central,
+ * unpacks and places them into the target directory.
+ *
+ * @since 0.1
+ * @checkstyle ParameterNumberCheck (100 lines)
+ */
+final class Resolve {
+
+    /**
+     * Tojos.
+     */
+    private final TjsForeign tojos;
+
+    /**
+     * Target directory.
+     */
+    private final Path target;
+
+    /**
+     * Central dependency consumer.
+     */
+    private final BiConsumer<Dependency, Path> central;
+
+    /**
+     * Discover self too.
+     */
+    private final boolean discover;
+
+    /**
+     * Skip zero versions.
+     */
+    private final boolean skipzero;
+
+    /**
+     * Resolve default JNA dependency.
+     */
+    private final boolean jna;
+
+    /**
+     * Ignore runtime dependency.
+     */
+    private final boolean noruntime;
+
+    /**
+     * Maven project (may be null).
+     */
+    private final MavenProject project;
+
+    /**
+     * Resolve dependencies in central.
+     */
+    private final boolean incentral;
+
+    /**
+     * Ignore version conflicts.
+     */
+    private final boolean noconflicts;
+
+    /**
+     * Ctor.
+     * @param tjs Tojos
+     * @param tgt Target directory
+     * @param cntrl Central dependency consumer
+     * @param self Discover self
+     * @param zero Skip zero versions
+     * @param jnadep Resolve default JNA
+     * @param norun Ignore runtime
+     * @param proj Maven project
+     * @param central Resolve in central
+     * @param noconf Ignore version conflicts
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    Resolve(
+        final TjsForeign tjs,
+        final Path tgt,
+        final BiConsumer<Dependency, Path> cntrl,
+        final boolean self,
+        final boolean zero,
+        final boolean jnadep,
+        final boolean norun,
+        final MavenProject proj,
+        final boolean central,
+        final boolean noconf
+    ) {
+        this.tojos = tjs;
+        this.target = tgt;
+        this.central = cntrl;
+        this.discover = self;
+        this.skipzero = zero;
+        this.jna = jnadep;
+        this.noruntime = norun;
+        this.project = proj;
+        this.incentral = central;
+        this.noconflicts = noconf;
+    }
+
+    /**
+     * Execute the resolve process.
+     * @throws IOException If fails
+     */
+    void exec() throws IOException {
+        final Collection<Dep> deps = this.deps();
+        if (deps.isEmpty()) {
+            Logger.info(this, "No new dependencies unpacked");
+        } else {
+            new Threaded<>(
+                deps,
+                dep -> this.resolved(dep, this.target)
+            ).total();
+            Logger.info(
+                this,
+                "New %d dependenc(ies) unpacked to %[file]s: %s",
+                deps.size(), this.target,
+                new Joined(", ", new Mapped<>(Dep::toString, deps))
+            );
+        }
+    }
+
+    /**
+     * Resolve a single dependency.
+     * @param dep Dependency
+     * @param dest Destination directory
+     * @return Count resolved
+     * @throws IOException If fails
+     */
+    private int resolved(final Dep dep, final Path dest) throws IOException {
+        final String classifier;
+        final Dependency dependency = dep.get();
+        if (dependency.getClassifier() == null || dependency.getClassifier().isEmpty()) {
+            classifier = "-";
+        } else {
+            classifier = dependency.getClassifier();
+        }
+        final Path place = this.cleanPlace(
+            dest
+                .resolve(dependency.getGroupId())
+                .resolve(dependency.getArtifactId())
+                .resolve(classifier),
+            dependency.getVersion()
+        );
+        final int total;
+        if (Files.exists(place)) {
+            Logger.debug(
+                this,
+                "Dependency %s already resolved and exists in %[file]s",
+                dep, place
+            );
+            total = 0;
+        } else {
+            this.central.accept(dependency, place);
+            final int files = new Walk(place).size();
+            if (files == 0) {
+                Logger.warn(this, "No new files after unpacking of %s!", dep);
+            } else {
+                Logger.info(
+                    this, "Found %d new file(s) (%d MB) after unpacking of %s",
+                    files, Resolve.folderSizeInMb(place), dep
+                );
+            }
+            total = 1;
+        }
+        return total;
+    }
+
+    /**
+     * Returns directory where files should be unpacked, removing outdated versions.
+     * @param dir Directory
+     * @param version Version
+     * @return Full path
+     * @throws IOException If fails
+     */
+    private Path cleanPlace(final Path dir, final String version) throws IOException {
+        final File[] subs = dir.toFile().listFiles();
+        if (subs != null) {
+            for (final File sub : subs) {
+                final String base = sub.getName();
+                Logger.info(this, "Base if %s", base);
+                if (base.equals(version)) {
+                    continue;
+                }
+                final Path bad = dir.resolve(base);
+                try (Stream<Path> walk = Files.walk(bad)) {
+                    walk
+                        .map(Path::toFile)
+                        .sorted(Comparator.reverseOrder())
+                        .forEach(File::delete);
+                }
+                Logger.info(
+                    this,
+                    "Directory %[file]s deleted because it contained wrong version files (not %s)",
+                    bad, version
+                );
+            }
+        }
+        return dir.resolve(version);
+    }
+
+    /**
+     * Find all deps for all tojos.
+     * @return List of dependencies
+     */
+    private Collection<Dep> deps() {
+        Dependencies result = new DpsDefault(
+            this.tojos, this.discover, this.skipzero, this.jna
+        );
+        if (this.noruntime) {
+            Logger.info(this, "Runtime dependency is ignored because eo:ignoreRuntime=TRUE");
+            result = new DpsWithoutRuntime(result);
+        } else {
+            final Optional<Dependency> runtime = this.runtimeFromPom();
+            if (runtime.isPresent()) {
+                result = new DpsWithRuntime(result, new Dep(runtime.get()));
+                Logger.info(
+                    this,
+                    "Runtime dependency added from pom with version: %s",
+                    runtime.get().getVersion()
+                );
+            } else {
+                if (this.incentral) {
+                    result = new DpsWithRuntime(result);
+                } else {
+                    result = new DpsOfflineRuntime(result);
+                }
+            }
+        }
+        if (!this.noconflicts) {
+            result = new DpsUniquelyVersioned(result);
+        }
+        return new SetOf<>(result)
+            .stream()
+            .sorted()
+            .distinct()
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Runtime dependency from pom.xml.
+     * @return Dependency if found
+     */
+    private Optional<Dependency> runtimeFromPom() {
+        final Optional<Dependency> res;
+        if (this.project == null) {
+            res = Optional.empty();
+        } else {
+            res = this.project
+                .getDependencies()
+                .stream()
+                .filter(Resolve::isRuntime)
+                .findFirst();
+        }
+        return res;
+    }
+
+    /**
+     * Checks if dependency is the eo-runtime artifact.
+     * @param dep Dependency
+     * @return True if runtime
+     */
+    static boolean isRuntime(final Dependency dep) {
+        return "org.eolang".equals(dep.getGroupId())
+            && "eo-runtime".equals(dep.getArtifactId());
+    }
+
+    /**
+     * Folder size in megabytes.
+     * @param path Folder
+     * @return Size in MB
+     * @throws IOException If fails
+     */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    private static long folderSizeInMb(final Path path) throws IOException {
+        try (Stream<Path> paths = Files.walk(path)) {
+            return paths.filter(Files::isRegularFile).mapToLong(
+                p -> {
+                    try {
+                        return Files.size(p);
+                    } catch (final IOException exception) {
+                        throw new IllegalStateException(
+                            String.format("Failed to calculate size in %s", p),
+                            exception
+                        );
+                    }
+                }
+            ).sum() / 1024L / 1024L;
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
@@ -99,6 +99,7 @@ final class Resolve {
      * @param noconf Ignore version conflicts
      * @checkstyle ParameterNumberCheck (10 lines)
      */
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     Resolve(
         final TjsForeign tjs,
         final Path tgt,
@@ -125,9 +126,8 @@ final class Resolve {
 
     /**
      * Execute the resolve process.
-     * @throws IOException If fails
      */
-    void exec() throws IOException {
+    void exec() {
         final Collection<Dep> deps = this.deps();
         if (deps.isEmpty()) {
             Logger.info(this, "No new dependencies unpacked");
@@ -203,7 +203,6 @@ final class Resolve {
         if (subs != null) {
             for (final File sub : subs) {
                 final String base = sub.getName();
-                Logger.info(this, "Base if %s", base);
                 if (base.equals(version)) {
                     continue;
                 }
@@ -285,7 +284,7 @@ final class Resolve {
      * @param dep Dependency
      * @return True if runtime
      */
-    static boolean isRuntime(final Dependency dep) {
+    private static boolean isRuntime(final Dependency dep) {
         return "org.eolang".equals(dep.getGroupId())
             && "eo-runtime".equals(dep.getArtifactId());
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolve.java
@@ -25,7 +25,7 @@ import org.cactoos.text.Joined;
  * Resolves all required runtime dependencies: downloads from Maven Central,
  * unpacks and places them into the target directory.
  *
- * @since 0.1
+ * @since 0.63.0
  * @checkstyle ParameterNumberCheck (100 lines)
  */
 final class Resolve {
@@ -67,6 +67,11 @@ final class Resolve {
 
     /**
      * Maven project (may be null).
+     * @todo #4989:30min Remove MavenProject dependency from Resolve class.
+     *  Currently Resolve depends on MavenProject to find the eo-runtime version
+     *  declared in pom.xml. Extract that lookup into a plain {@code Optional<Dependency>}
+     *  parameter so Resolve has no Maven API dependency at all.
+     *  Don't forget to update MjResolve accordingly.
      */
     private final MavenProject project;
 


### PR DESCRIPTION
This PR refactors `MjResolve` into a thin Maven endpoint and a new `Resolve` class for core dependency logic, improving testability and reducing coupling.

Related to #4989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization: dependency resolution moved into a dedicated resolver with improved concurrency and clearer resolution logging.
  * No changes to user-facing behavior, workflows, outputs, or delivered runtime artifacts; dependency handling and resulting runtime content remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->