### PR TITLE
fix: number.floor rounds toward -infinity (not toward zero)

### DIFF
--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -118,9 +118,17 @@
       is-finite.not
       $
       if.
-        trunc.gt $
-        trunc.minus 1
-        trunc
+        or.
+          gte 9223372036854775808.0
+          lte -9223372036854775808.0
+        $
+        if.
+          as-bytes.eq -0.as-bytes
+          $
+          if.
+            trunc.gt $
+            trunc.minus 1
+            trunc
     as-i64.as-number > trunc
 
   # Tests that less-than comparison returns true when first number is smaller.
@@ -390,6 +398,26 @@
     eq. > @
       -42.floor
       -42
+
+  # Tests that floor of NaN returns NaN.
+  [] +> tests-floor-of-nan
+    nan.floor.is-nan > @
+
+  # Tests that floor of positive infinity returns positive infinity.
+  [] +> tests-floor-of-positive-infinity
+    positive-infinity.floor.eq positive-infinity > @
+
+  # Tests that floor of negative infinity returns negative infinity.
+  [] +> tests-floor-of-negative-infinity
+    negative-infinity.floor.eq negative-infinity > @
+
+  # Tests that floor of a large positive number returns the number itself.
+  [] +> tests-floor-of-large-number
+    9223372036854775808.0.floor.eq 9223372036854775808.0 > @
+
+  # Tests that floor of negative zero preserves its sign.
+  [] +> tests-floor-of-negative-zero
+    -0.0.floor.as-bytes.eq -0.0.as-bytes > @
 
   # Tests that division result can be less than one.
   [] +> tests-div-less-than-one

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -112,8 +112,16 @@
   # The object rounds down the original `number` to the nearest
   # whole `number` that is less than or equal to it
   # and returns the result as `org.eolang.number`.
+  # For non-finite inputs (NaN, ±infinity) the input is returned unchanged.
   [] > floor
-    as-i64.as-number > @
+    if. > @
+      is-finite.not
+      $
+      if.
+        trunc.gt $
+        trunc.minus 1
+        trunc
+    as-i64.as-number > trunc
 
   # Tests that less-than comparison returns true when first number is smaller.
   [] +> tests-int-less-true
@@ -351,7 +359,7 @@
     eq. > @
       floor.
         13.div -5
-      -2
+      -3
 
   # Tests that floor of a positive fractional number truncates toward zero.
   [] +> tests-floor-positive-fraction
@@ -359,17 +367,29 @@
       3.7.floor
       3
 
-  # Tests that floor of a negative fractional number truncates toward zero.
+  # Tests that floor of a negative fractional number rounds toward -infinity.
   [] +> tests-floor-negative-fraction
     eq. > @
       -3.7.floor
-      -3
+      -4
+
+  # Tests that floor of a small negative fraction rounds toward -infinity, not zero.
+  [] +> tests-floor-small-negative-fraction
+    eq. > @
+      -0.1.floor
+      -1
 
   # Tests that floor of a whole number returns the same number.
   [] +> tests-floor-of-integer
     eq. > @
       42.floor
       42
+
+  # Tests that floor of a negative whole number returns the same number.
+  [] +> tests-floor-of-negative-integer
+    eq. > @
+      -42.floor
+      -42
 
   # Tests that division result can be less than one.
   [] +> tests-div-less-than-one


### PR DESCRIPTION
## Summary

Changes `number.floor` in `eo-runtime/src/main/eo/number.eo` from truncation-toward-zero to mathematical floor (round toward -∞), matching the existing doc comment ("less than or equal to it") and the behavior of `Math.floor` in Java / Python / JS / Ruby.

Fixes #5043.

## Why this matters

The issue (syncended) traces it to the doc/implementation mismatch:

> `number.floor` performs truncation toward zero, but its own documentation and its name imply mathematical floor (rounding toward -∞).

| Input                  | Expected | Before  |
|------------------------|----------|---------|
| `3.7.floor`            | `3`      | `3`     |
| `-3.7.floor`           | `-4`     | `-3` ← wrong |
| `-0.1.floor`           | `-1`     | `0`  ← wrong |
| `floor. 13.div -5`     | `-3`     | `-2` ← wrong |

PR #5042 (merged this morning) refactored the Java atom into an EO expression (`as-i64.as-number`) but preserved the truncation-toward-zero behavior — that PR's description explicitly notes "See also: #5043 (separate behavioral fix for `floor` rounding semantics)." This PR is that separate behavioral fix.

## Change

`eo-runtime/src/main/eo/number.eo` floor body from:

```eo
[] > floor
  as-i64.as-number > @
```

to:

```eo
[] > floor
  if. > @
    is-finite.not
    $
    if.
      trunc.gt $
      trunc.minus 1
      trunc
  as-i64.as-number > trunc
```

Non-finite inputs (NaN, +∞, -∞) short-circuit via `is-finite.not` and are returned unchanged — this preserves the behavior the existing `tests-positive-infinity-floor-is-equal-to-self` and `tests-negative-infinity-floor-is-equal-to-self` tests codify. `is-nan` is not a separate case because `is-finite` already returns false for NaN, and the `$`-return branch returns NaN unchanged.

For finite inputs: `trunc` is the integer part (toward zero). `trunc > $` is true only for negative non-integers (-3.7 → trunc=-3 > -3.7); in that one case subtract 1 to round toward -∞. For positive non-integers, zero, and integers, `trunc` is already the correct floor.

`is-finite` is safe to reuse here because its definition at `number.eo:23-28` (`is-nan.not and. not. or. eq positive-infinity eq negative-infinity`) does not recurse through floor. The issue explicitly warns against reusing `is-integer` because that one is defined as `is-finite and eq floor` and would recurse.

## Tests

Two existing tests codified the buggy truncation-toward-zero behavior — both needed updating:

- `tests-div-with-remainder`: `floor(13 / -5)` now expects `-3` (was `-2`)
- `tests-floor-negative-fraction`: `-3.7.floor` now expects `-4` (was `-3`); comment updated from "truncates toward zero" to "rounds toward -infinity"

Two new regression tests added next to the existing floor tests:

- `tests-floor-small-negative-fraction`: `-0.1.floor = -1` (guards the case where truncation would hit zero)
- `tests-floor-of-negative-integer`: `-42.floor = -42` (guards against over-eager subtraction in the integer case)

Existing `tests-floor-positive-fraction` (`3.7.floor = 3`) and `tests-floor-of-integer` (`42.floor = 42`) continue to pass unchanged.

## Testing

I was not able to complete a full local `mvn test -Dtest=EOnumberEOAtomTest` run in a reasonable window on my environment (~10+ min into the build without finishing). Trusting upstream CI to catch any EO syntax issues in the new `if.` nesting. Happy to iterate on the review.

## AI disclosure

This contribution was developed with AI assistance (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the `floor` function to correctly handle edge cases and improve mathematical accuracy. Non-finite numbers are now returned unchanged, while negative numbers and fractions are properly rounded toward negative infinity, ensuring correct behavior across all input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->