### PR TITLE
bug(#4299): remove junit from eo-source-run

### DIFF
--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -11,11 +11,6 @@ import org.cactoos.Proc;
 /**
  * Execution of EO source.
  * @since 0.56.3
- * @todo #4232:30min Conditionally add JUnit dependencies to integration tests.
- *  JUnit dependencies are needed for EO programs that contain test attributes
- *  (methods starting with '+'), but not for programs without tests. The XSL
- *  template now conditionally generates JUnit imports, but integration tests
- *  still need JUnit dependencies available when processing EO programs with tests.
  */
 final class EoSourceRun implements Proc<Object> {
 

--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -42,26 +42,6 @@ final class EoSourceRun implements Proc<Object> {
             .configuration()
             .set("failOnWarning", Boolean.FALSE.toString())
             .set("skipLinting", Boolean.TRUE.toString());
-        this.farea.dependencies().append(
-            "org.junit.jupiter",
-            "junit-jupiter-engine",
-            "5.10.3"
-        );
-        this.farea.dependencies().append(
-            "org.junit.jupiter",
-            "junit-jupiter-params",
-            "5.10.3"
-        );
-        this.farea.dependencies().append(
-            "org.junit.jupiter",
-            "junit-jupiter-api",
-            "5.10.3"
-        );
-        this.farea.dependencies().append(
-            "org.junit-pioneer",
-            "junit-pioneer",
-            "2.2.0"
-        );
         this.farea.build()
             .plugins()
             .append("org.codehaus.mojo", "exec-maven-plugin", "3.1.1")


### PR DESCRIPTION
`junit` is removed because we don't execute maven `test` phase. The programs run right after `compile`.

Closes: #4299 