### PR TITLE
refactor(#5049): Move system and central fields from MjSafe to MjResolve

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -9,9 +9,7 @@ import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.Scalar;
-import org.eclipse.aether.RepositorySystem;
 
 /**
  * Find all required runtime dependencies, download
@@ -44,12 +42,6 @@ public final class MjResolve extends MjSafe {
      * The directory where to resolve to.
      */
     static final String DIR = "4-resolve";
-
-    /**
-     * Maven Resolver repository system.
-     */
-    @Parameter
-    private RepositorySystem system;
 
     /**
      * The central.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -7,9 +7,9 @@ package org.eolang.maven;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.Scalar;
 import org.eclipse.aether.RepositorySystem;
 
@@ -46,17 +46,17 @@ public final class MjResolve extends MjSafe {
     static final String DIR = "4-resolve";
 
     /**
+     * Maven Resolver repository system.
+     */
+    @Parameter
+    private RepositorySystem system;
+
+    /**
      * The central.
      *
      * @checkstyle MemberNameCheck (5 lines)
      */
-    protected BiConsumer<Dependency, Path> central;
-
-    /**
-     * Maven Resolver repository system.
-     */
-    @Component
-    private RepositorySystem system;
+    private BiConsumer<Dependency, Path> central;
 
     /**
      * Resolve default JNA dependency or not.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -4,9 +4,14 @@
  */
 package org.eolang.maven;
 
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.Scalar;
+import org.eclipse.aether.RepositorySystem;
 
 /**
  * Find all required runtime dependencies, download
@@ -41,6 +46,19 @@ public final class MjResolve extends MjSafe {
     static final String DIR = "4-resolve";
 
     /**
+     * Maven Resolver repository system.
+     */
+    @Component
+    private RepositorySystem system;
+
+    /**
+     * The central.
+     *
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private BiConsumer<Dependency, Path> central;
+
+    /**
      * Resolve default JNA dependency or not.
      *
      * @checkstyle MemberNameCheck (7 lines)
@@ -57,6 +75,9 @@ public final class MjResolve extends MjSafe {
 
     @Override
     public void exec() {
+        if (this.central == null) {
+            this.central = new CentralMaven(this.system);
+        }
         new Resolve(
             this.scopedTojos(),
             this.targetDir.toPath().resolve(MjResolve.DIR),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -46,17 +46,17 @@ public final class MjResolve extends MjSafe {
     static final String DIR = "4-resolve";
 
     /**
-     * Maven Resolver repository system.
-     */
-    @Component
-    private RepositorySystem system;
-
-    /**
      * The central.
      *
      * @checkstyle MemberNameCheck (5 lines)
      */
-    private BiConsumer<Dependency, Path> central;
+    protected BiConsumer<Dependency, Path> central;
+
+    /**
+     * Maven Resolver repository system.
+     */
+    @Component
+    private RepositorySystem system;
 
     /**
      * Resolve default JNA dependency or not.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -452,7 +452,7 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle CyclomaticComplexityCheck (70 lines)
      */
     @Override
-    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.UnnecessaryLocalRule"})
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public final void execute() throws MojoFailureException {
         StaticLoggerBinder.getSingleton().setMavenLog(this.getLog());
         if (this.skip) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
@@ -32,6 +33,7 @@ import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
+import org.eclipse.aether.RepositorySystem;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -49,6 +51,16 @@ abstract class MjSafe extends AbstractMojo {
      */
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
+
+    /**
+     * Maven Resolver repository system.
+     * Do NOT move this field to a subclass: it is used in both
+     * {@link MjResolve} and {@link MjCompile} (indirectly), so it
+     * must be injected once here in the base class.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Component
+    protected RepositorySystem system;
 
     /**
      * Directory where classes are stored in target.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -22,12 +21,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiConsumer;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
@@ -36,7 +32,6 @@ import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
-import org.eclipse.aether.RepositorySystem;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -54,13 +49,6 @@ abstract class MjSafe extends AbstractMojo {
      */
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
-
-    /**
-     * Maven Resolver repository system.
-     * @checkstyle VisibilityModifierCheck (5 lines)
-     */
-    @Component
-    protected RepositorySystem system;
 
     /**
      * Directory where classes are stored in target.
@@ -415,14 +403,6 @@ abstract class MjSafe extends AbstractMojo {
     );
 
     /**
-     * The central.
-     *
-     * @checkstyle MemberNameCheck (7 lines)
-     * @checkstyle VisibilityModifierCheck (5 lines)
-     */
-    protected BiConsumer<Dependency, Path> central;
-
-    /**
      * The Git hash to pull objects from.
      * If not set, will be computed from {@code tag} field.
      * @checkstyle VisibilityModifierCheck (5 lines)
@@ -483,9 +463,6 @@ abstract class MjSafe extends AbstractMojo {
             }
         } else {
             try {
-                if (this.central == null) {
-                    this.central = new CentralMaven(this.system);
-                }
                 final long start = System.nanoTime();
                 this.execWithTimeout();
                 if (Logger.isDebugEnabled(this)) {


### PR DESCRIPTION
Moves `RepositorySystem system` and `BiConsumer<Dependency, Path> central` fields from `MjSafe` to `MjResolve`, since they are only used there. Lazy `CentralMaven` initialization moves accordingly to `MjResolve.exec()`.

Related to #5049