### PR TITLE
fix(#5071): clear error on missing closing slash in regex

### DIFF
--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -247,6 +247,10 @@
   [] +> throws-on-missing-first-slash-in-regex
     (regex "(.)+").compiled > @
 
+  # Tests that regex compilation throws error when missing closing slash.
+  [] +> throws-on-missing-closing-slash-in-regex
+    (regex "/pattern").compiled > @
+
   # Tests that regex with capturing groups returns correct group count and content.
   [] +> tests-regex-contains-valid-groups-on-each-matched-block
     and. > @

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOφ.java
@@ -38,6 +38,9 @@ public final class EOregex$EOφ extends PhDefault implements Atom {
             throw new ExFailure("Wrong regex syntax: \"/\" is missing");
         }
         final int last = expression.lastIndexOf('/');
+        if (last == 0) {
+            throw new ExFailure("Wrong regex syntax: closing \"/\" is missing");
+        }
         final StringBuilder builder = new StringBuilder();
         if (!expression.endsWith("/")) {
             builder.append("(?").append(expression.substring(last + 1)).append(')');

--- a/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
@@ -21,12 +21,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link EOregex$EOφ}.
+ * Tests for the regex atom.
  *
  * @since 0.57.4
- * @checkstyle TypeNameCheck (3 lines)
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "PMD.AvoidDollarSigns"})
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class RegexAtomTest {
 
     @Test
@@ -49,26 +48,23 @@ final class RegexAtomTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void throwsClearErrorOnMissingClosingSlash() {
-        final ExAbstract error = Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new Dataized(
-                new PhWith(
-                    new PhCopy(Phi.Φ.take("tt.regex")),
-                    "expression", new Data.ToPhi("/pattern")
-                ).take("compiled")
-            ).take(),
-            "regex without closing slash should throw a clear ExFailure, but did not"
-        );
         MatcherAssert.assertThat(
-            "Error should mention the missing closing slash, but it did not",
-            error.toString(),
-            Matchers.containsString("/")
-        );
-        MatcherAssert.assertThat(
-            "Error must not be an opaque IndexOutOfBoundsException",
-            error.toString(),
-            Matchers.not(Matchers.containsString("out of bounds"))
+            "regex without closing slash should throw a clear ExFailure that mentions \"/\" and is not an opaque IndexOutOfBoundsException",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhCopy(Phi.Φ.take("tt.regex")),
+                        "expression", new Data.ToPhi("/pattern")
+                    ).take("compiled")
+                ).take()
+            ).toString(),
+            Matchers.allOf(
+                Matchers.containsString("/"),
+                Matchers.not(Matchers.containsString("out of bounds"))
+            )
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EOtt; // NOPMD
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.ExAbstract;
+import org.eolang.PhCopy;
+import org.eolang.PhWith;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EOregex$EOφ}.
+ *
+ * @since 0.57.4
+ * @checkstyle TypeNameCheck (3 lines)
+ */
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "PMD.AvoidDollarSigns"})
+final class RegexAtomTest {
+
+    @Test
+    void compilesRegexWithSlashes() {
+        MatcherAssert.assertThat(
+            "regex \"/[a-z]+/\" should compile and match \"hello\"",
+            new Dataized(
+                new PhWith(
+                    new PhCopy(
+                        new PhWith(
+                            new PhCopy(Phi.Φ.take("tt.regex")),
+                            "expression", new Data.ToPhi("/[a-z]+/")
+                        ).take("compiled").take("matches")
+                    ),
+                    "txt", new Data.ToPhi("hello")
+                )
+            ).asBool(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void throwsClearErrorOnMissingClosingSlash() {
+        final ExAbstract error = Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new Dataized(
+                new PhWith(
+                    new PhCopy(Phi.Φ.take("tt.regex")),
+                    "expression", new Data.ToPhi("/pattern")
+                ).take("compiled")
+            ).take(),
+            "regex without closing slash should throw a clear ExFailure, but did not"
+        );
+        MatcherAssert.assertThat(
+            "Error should mention the missing closing slash, but it did not",
+            error.toString(),
+            Matchers.containsString("/")
+        );
+        MatcherAssert.assertThat(
+            "Error must not be an opaque IndexOutOfBoundsException",
+            error.toString(),
+            Matchers.not(Matchers.containsString("out of bounds"))
+        );
+    }
+}


### PR DESCRIPTION
@yegor256 this is ready for merge.

Fixes #5071.

## What was wrong
`EOregex$EOφ.lambda()` only validated the *opening* `/` in a regex expression. When the closing `/` was missing (e.g. `regex "/pattern"`), `lastIndexOf('/')` returned `0`, then `builder.append(expression, 1, 0)` threw an opaque `IndexOutOfBoundsException` (`Range [1, 0) out of bounds for length 8`), which was wrapped into an EO error and surfaced to users as a confusing message.

## Fix
Added a single guard right after the existing opening-slash check: when `last == 0`, throw `ExFailure("Wrong regex syntax: closing \"/\" is missing")`, mirroring the existing missing-opening-slash diagnostic. Three lines of production code.

## Tests
- `eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java` — new Java test class with two cases:
  - `compilesRegexWithSlashes` — sanity check that a well-formed `/[a-z]+/` still compiles and matches.
  - `throwsClearErrorOnMissingClosingSlash` — fails on master with `"out of bounds"`, passes after the fix and asserts the error message no longer contains `"out of bounds"`.
- `eo-runtime/src/main/eo/tt/regex.eo` — added an EO test `throws-on-missing-closing-slash-in-regex`, parallel to the existing `throws-on-missing-first-slash-in-regex`.

All 47 regex tests in `eo-runtime` pass locally; all 26 CI checks are green.

## Test plan
- [x] New Java tests added (`RegexAtomTest`) — fail on master, pass after fix.
- [x] New EO test added (`throws-on-missing-closing-slash-in-regex`).
- [x] Local `mvn test` and `mvn verify -Pqulice` succeed.
- [x] All 26 CI checks pass.