### PR TITLE
fix(#5070): preserve leading sign in sscanf %d format

### DIFF
--- a/eo-runtime/src/main/eo/tt/sscanf.eo
+++ b/eo-runtime/src/main/eo/tt/sscanf.eo
@@ -34,6 +34,20 @@
       head.
         sscanf "%d" "33"
 
+  # Tests that sscanf preserves the minus sign for negative integers.
+  [] +> tests-sscanf-with-negative-int
+    eq. > @
+      -42
+      head.
+        sscanf "%d" "-42"
+
+  # Tests that sscanf accepts an optional leading plus sign for integers.
+  [] +> tests-sscanf-with-positive-signed-int
+    eq. > @
+      42
+      head.
+        sscanf "%d" "+42"
+
   # Tests that sscanf parses floating point number using %f format specifier.
   [] +> tests-sscanf-with-float
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
@@ -78,7 +78,7 @@ public final class EOsscanf extends PhDefault implements Atom {
                 if (literal) {
                     switch (sym) {
                         case 'd':
-                            regex.append("(\\d+)");
+                            regex.append("([+-]?\\d+)");
                             break;
                         case 'f':
                             regex.append("([+-]?\\d+(?:\\.\\d+)?)");

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
@@ -63,7 +63,7 @@ public final class EOsscanf extends PhDefault implements Atom {
     @SuppressWarnings("PMD.CognitiveComplexity")
     public Phi lambda() {
         final String format = new Dataized(this.take("format")).asString();
-        final StringBuilder regex = new StringBuilder(30);
+        final StringBuilder regex = new StringBuilder(64);
         boolean literal = false;
         for (int idx = 0; idx < format.length(); ++idx) {
             final char sym = format.charAt(idx);

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SscanfNegativeIntegerTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SscanfNegativeIntegerTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EOtt; // NOPMD
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhCopy;
+import org.eolang.PhWith;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@code tt.sscanf} with signed integer inputs.
+ *
+ * @since 0.57.4
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class SscanfNegativeIntegerTest {
+
+    @Test
+    void parsesNegativeIntegerWithDecimalFormat() {
+        MatcherAssert.assertThat(
+            "sscanf with \"%d\" should preserve the leading minus sign for negative integers",
+            new Dataized(SscanfNegativeIntegerTest.first("%d", "-42")).asNumber().longValue(),
+            Matchers.equalTo(-42L)
+        );
+    }
+
+    @Test
+    void parsesPositiveIntegerWithLeadingPlusSign() {
+        MatcherAssert.assertThat(
+            "sscanf with \"%d\" should accept an optional leading plus sign",
+            new Dataized(SscanfNegativeIntegerTest.first("%d", "+42")).asNumber().longValue(),
+            Matchers.equalTo(42L)
+        );
+    }
+
+    @Test
+    void parsesPlainPositiveIntegerWithDecimalFormat() {
+        MatcherAssert.assertThat(
+            "sscanf with \"%d\" should still parse plain unsigned integers",
+            new Dataized(SscanfNegativeIntegerTest.first("%d", "42")).asNumber().longValue(),
+            Matchers.equalTo(42L)
+        );
+    }
+
+    /**
+     * Build a {@code tt.sscanf} call and return the first parsed item.
+     * @param format Format string for {@code sscanf}
+     * @param read Input string for {@code sscanf}
+     * @return Phi at index 0 of the resulting tuple
+     */
+    private static Phi first(final String format, final String read) {
+        final Phi item = new PhWith(
+            new PhWith(
+                new PhCopy(Phi.Φ.take("tt.sscanf")),
+                "format", new Data.ToPhi(format)
+            ),
+            "read", new Data.ToPhi(read)
+        ).take("at").copy();
+        item.put(0, new Data.ToPhi(0L));
+        return item;
+    }
+}


### PR DESCRIPTION
@yegor256

This PR fixes #5070, where `tt.sscanf` with the `%d` format silently dropped a leading `-` (or `+`) sign and returned the unsigned value:

```
sscanf "%d" "-42"   # returned 42 instead of -42
sscanf "%d" "+42"   # returned 42 by accident, not by design
```

## Root cause

In `EOsscanf.java` the regex generated for `%d` was `(\d+)`, which has no sign prefix. When the input was `"-42"`, `Matcher.find()` matched the first run of digits (`"42"`), and `Long.parseLong("42")` produced `42L`. The minus was discarded silently. The `%f` branch already used `([+-]?\d+(?:\.\d+)?)`, so floats already handled signs correctly; only `%d` was inconsistent.

## Fix

- `eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java`: change the `%d` regex to `([+-]?\d+)`, mirroring the sign-prefix that `%f` already accepts. `Long.parseLong` already handles a leading `+`/`-`, so no other code changes are needed. The initial `StringBuilder` capacity was also bumped from 30 to 64 to keep PMD's `InsufficientStringBufferDeclaration` rule happy now that the longest specifier expansion is slightly longer.
- `eo-runtime/src/main/eo/tt/sscanf.eo`: add two object-level tests, `tests-sscanf-with-negative-int` and `tests-sscanf-with-positive-signed-int`, alongside the existing `tests-sscanf-with-int`.
- `eo-runtime/src/test/java/org/eolang/EOtt/SscanfNegativeIntegerTest.java`: a Java JUnit test that pins down the regression at the Phi level — it parses `"-42"`, `"+42"` and `"42"` and asserts the first tuple element. Both this Java test and the auto-generated `EOsscanfTest.tests_sscanf_with_negative_int` fail on `master` and pass on this branch.

## Verification

- `mvn -pl eo-runtime test` — 1256 tests pass locally.
- `mvn -pl eo-runtime -Pqulice verify -DskipTests` — clean.
- All 26 CI checks on this PR are green (mvn ubuntu/macos/windows on Java 23, integration, qulice, benchmark, ort, pr-size, sonar, codacy, snippets, etc.).
- The new tests both fail on `master` (the Java one with `Expected: <-42L> but: was <42L>`, the EO one with `expected: <true> but was: <false>`) and pass on this branch.

Closes #5070.