### PR TITLE
refactor(#5081): decouple parsing logic from MjParse into Parse class

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
@@ -78,7 +78,7 @@ final class DpsDefault implements Dependencies {
             deps.add(DpsDefault.JNA);
         }
         for (final TjForeign tojo : list) {
-            if (MjParse.ZERO.equals(tojo.version()) && !this.discover) {
+            if (Parse.ZERO.equals(tojo.version()) && !this.discover) {
                 Logger.debug(
                     this,
                     "Program %s skipped due to its zero version",
@@ -93,7 +93,7 @@ final class DpsDefault implements Dependencies {
             }
             final Dep dep = opt.get();
             final String coords = dep.toString();
-            if (this.skip && MjParse.ZERO.equals(dep.get().getVersion())) {
+            if (this.skip && Parse.ZERO.equals(dep.get().getVersion())) {
                 Logger.debug(
                     this, "Zero-version dependency for %s skipped: %s",
                     tojo.description(), coords

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -4,23 +4,9 @@
  */
 package org.eolang.maven;
 
-import com.github.lombrozo.xnav.Filter;
-import com.github.lombrozo.xnav.Xnav;
-import com.jcabi.log.Logger;
-import com.jcabi.xml.XMLDocument;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.cactoos.iterable.Filtered;
-import org.cactoos.text.TextOf;
-import org.w3c.dom.Node;
 
 /**
  * Parse EO to XML.
@@ -34,7 +20,7 @@ import org.w3c.dom.Node;
  *    The goal scans all the EO sources registered in the foreign file catalog
  *    (see {@link MjRegister} and {@link MjPull}) and then parses those that were not parsed
  *    before (i.e. do not have XMIRs yet) to XMIR format.
- *    The resulting XMIR files are stored in the {@link #DIR} directory.
+ *    The resulting XMIR files are stored in the {@link Parse#DIR} directory.
  * </p>
  *
  * @since 0.1
@@ -47,170 +33,15 @@ import org.w3c.dom.Node;
 )
 public final class MjParse extends MjSafe {
 
-    /**
-     * Zero version.
-     */
-    static final String ZERO = "0.0.0";
-
-    /**
-     * The directory where to parse to.
-     */
-    static final String DIR = "1-parse";
-
-    /**
-     * Subdirectory for parsed cache.
-     */
-    static final String CACHE = "parsed";
-
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() {
-        final long start = System.currentTimeMillis();
-        final Collection<TjForeign> tojos = this.scopedTojos().withSources();
-        final int total = new Threaded<>(
-            new Filtered<>(TjForeign::notParsed, tojos),
-            this::parsed
-        ).total();
-        if (0 == total) {
-            if (tojos.isEmpty()) {
-                Logger.info(
-                    this,
-                    "No .eo sources registered, nothing to be parsed to XMIRs (maybe you forgot to execute the \"register\" goal?)"
-                );
-            } else {
-                Logger.info(
-                    this,
-                    "No new .eo sources out of %d parsed to XMIRs",
-                    tojos.size()
-                );
-            }
-        } else {
-            Logger.info(
-                this, "Parsed %d new .eo sources out of %d to XMIRs in %[ms]s",
-                total, tojos.size(), System.currentTimeMillis() - start
-            );
-        }
-    }
-
-    /**
-     * Parse EO file to XML.
-     *
-     * @param tojo The tojo
-     * @return Amount of parsed tojos
-     * @throws IOException If fails
-     */
-    private int parsed(final TjForeign tojo) throws Exception {
-        final Path source = tojo.source();
-        final String name = tojo.identifier();
-        final Path base = this.targetDir.toPath().resolve(MjParse.DIR);
-        final Path target = new Place(name).make(base, MjAssemble.XMIR);
-        final List<Node> refs = new ArrayList<>(1);
-        if (this.cacheEnabled) {
-            new ConcurrentCache(
-                new Cache(
-                    new CachePath(
-                        this.cache.toPath().resolve(MjParse.CACHE),
-                        this.plugin.getVersion(),
-                        new TojoHash(tojo).get()
-                    ),
-                    src -> {
-                        final Node node = this.parsed(src, name);
-                        refs.add(node);
-                        return new XMLDocument(node).toString();
-                    }
-                )
-            ).apply(source, target, base.relativize(target));
-        } else {
-            final Node node = this.parsed(source, name);
-            new Saved(new XMLDocument(node).toString(), target).value();
-            refs.add(node);
-        }
-        tojo.withXmir(target).withVersion(MjParse.version(target, refs));
-        final List<Xnav> errors = new Xnav(target)
-            .element("object")
-            .element("errors")
-            .elements(Filter.withName("error"))
-            .collect(Collectors.toList());
-        if (errors.isEmpty()) {
-            Logger.debug(this, "Parsed %[file]s to %[file]s", source, target);
-        } else {
-            for (final Xnav error : errors) {
-                Logger.error(
-                    this,
-                    "Failed to parse '%[file]s:%s': %s",
-                    source,
-                    error.attribute("line").text().orElse("0"),
-                    error.text().orElse("")
-                );
-            }
-        }
-        return 1;
-    }
-
-    /**
-     * Source parsed to {@link Node}.
-     * @param source Relative source path
-     * @param identifier Name of the EO object as tojo identifier
-     * @return Parsed EO object as {@link Node}
-     * @throws IOException If fails to parse
-     */
-    private Node parsed(final Path source, final String identifier) throws IOException {
-        final EoSource.Xmir xmir = new EoSource(identifier, source).parsed();
-        Logger.debug(
-            MjParse.class,
-            "Parsed program '%s' from %[file]s:\n %s",
-            identifier, this.sourcesDir.toPath().relativize(source.toAbsolutePath()), xmir
-        );
-        if (xmir.broken()) {
-            new Saved(
-                new TextOf(xmir.xml().toString()),
-                this.targetDir.toPath().resolve(
-                    String.format("broken-%x.xmir", System.nanoTime())
-                )
-            ).value();
-        }
-        return xmir.xml().inner();
-    }
-
-    /**
-     * Tojo version.
-     * The version can be extracted from:
-     * 1. Parsed {@link Node} if EO object was parsed for the first time
-     * 2. XML document that was already parsed before
-     * @param target Path to result XML document
-     * @param parsed List with either one parsed {@link Node} or empty
-     * @return Tojo version
-     * @throws FileNotFoundException If XML document file does not exist
-     */
-    private static String version(
-        final Path target,
-        final List<Node> parsed
-    ) throws FileNotFoundException {
-        final Node node;
-        if (parsed.isEmpty()) {
-            node = new XMLDocument(target).inner();
-        } else {
-            node = parsed.get(0);
-        }
-        return new Xnav(node)
-            .element("object")
-            .element("metas")
-            .elements(
-                Filter.all(
-                    Filter.withName("meta"),
-                    meta -> new Xnav(meta)
-                        .elements(
-                            Filter.all(
-                                Filter.withName("head"),
-                                head -> head.text().map("version"::equals).orElse(false)
-                            )
-                        )
-                        .findAny()
-                        .isPresent()
-                )
-            )
-            .findFirst()
-            .map(meta -> meta.element("tail").text().orElse(MjParse.ZERO))
-            .orElse(MjParse.ZERO);
+        new Parse(
+            this.scopedTojos().withSources(),
+            this.targetDir.toPath(),
+            this.cache.toPath(),
+            this.cacheEnabled,
+            this.plugin.getVersion(),
+            this.sourcesDir.toPath()
+        ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parse.java
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XMLDocument;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.cactoos.iterable.Filtered;
+import org.cactoos.text.TextOf;
+import org.w3c.dom.Node;
+
+/**
+ * Parse EO to XML.
+ *
+ * <p>
+ *     This class parses all found EO sources to XMIRs.
+ *     You can read more about XMIR format
+ *     <a href="https://www.eolang.org/XMIR.html">here</a>
+ * </p>
+ * <p>
+ *    The class scans all the EO sources registered in the foreign file catalog
+ *    and then parses those that were not parsed before (i.e. do not have XMIRs yet)
+ *    to XMIR format. The resulting XMIR files are stored in the {@link #DIR} directory.
+ * </p>
+ *
+ * @since 0.1
+ */
+final class Parse {
+
+    /**
+     * Zero version.
+     */
+    static final String ZERO = "0.0.0";
+
+    /**
+     * The directory where to parse to.
+     */
+    static final String DIR = "1-parse";
+
+    /**
+     * Subdirectory for parsed cache.
+     */
+    static final String CACHE = "parsed";
+
+    /**
+     * EO sources to parse.
+     */
+    private final Collection<TjForeign> tojos;
+
+    /**
+     * Target directory.
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private final Path targetDir;
+
+    /**
+     * Base cache directory.
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private final Path cacheDir;
+
+    /**
+     * Whether caching is enabled.
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private final boolean cacheEnabled;
+
+    /**
+     * Plugin version.
+     */
+    private final String version;
+
+    /**
+     * EO sources directory (used for logging).
+     * @checkstyle MemberNameCheck (5 lines)
+     */
+    private final Path sourcesDir;
+
+    /**
+     * Constructor.
+     * @param srcs EO sources to parse
+     * @param target Target directory
+     * @param cache Base cache directory
+     * @param enabled Whether caching is enabled
+     * @param ver Plugin version string
+     * @param sources EO sources directory
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    Parse(
+        final Collection<TjForeign> srcs,
+        final Path target,
+        final Path cache,
+        final boolean enabled,
+        final String ver,
+        final Path sources
+    ) {
+        this.tojos = srcs;
+        this.targetDir = target;
+        this.cacheDir = cache;
+        this.cacheEnabled = enabled;
+        this.version = ver;
+        this.sourcesDir = sources;
+    }
+
+    /**
+     * Run parsing of all sources.
+     */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void exec() {
+        final long start = System.currentTimeMillis();
+        final int total = new Threaded<>(
+            new Filtered<>(TjForeign::notParsed, this.tojos),
+            this::parsed
+        ).total();
+        if (0 == total) {
+            if (this.tojos.isEmpty()) {
+                Logger.info(
+                    this,
+                    "No .eo sources registered, nothing to be parsed to XMIRs (maybe you forgot to execute the \"register\" goal?)"
+                );
+            } else {
+                Logger.info(
+                    this,
+                    "No new .eo sources out of %d parsed to XMIRs",
+                    this.tojos.size()
+                );
+            }
+        } else {
+            Logger.info(
+                this, "Parsed %d new .eo sources out of %d to XMIRs in %[ms]s",
+                total, this.tojos.size(), System.currentTimeMillis() - start
+            );
+        }
+    }
+
+    /**
+     * Parse EO file to XML.
+     *
+     * @param tojo The tojo
+     * @return Amount of parsed tojos
+     * @throws Exception If fails
+     */
+    private int parsed(final TjForeign tojo) throws Exception {
+        final Path source = tojo.source();
+        final String name = tojo.identifier();
+        final Path base = this.targetDir.resolve(Parse.DIR);
+        final Path target = new Place(name).make(base, MjAssemble.XMIR);
+        final List<Node> refs = new ArrayList<>(1);
+        if (this.cacheEnabled) {
+            new ConcurrentCache(
+                new Cache(
+                    new CachePath(
+                        this.cacheDir.resolve(Parse.CACHE),
+                        this.version,
+                        new TojoHash(tojo).get()
+                    ),
+                    src -> {
+                        final Node node = this.parsed(src, name);
+                        refs.add(node);
+                        return new XMLDocument(node).toString();
+                    }
+                )
+            ).apply(source, target, base.relativize(target));
+        } else {
+            final Node node = this.parsed(source, name);
+            new Saved(new XMLDocument(node).toString(), target).value();
+            refs.add(node);
+        }
+        tojo.withXmir(target).withVersion(Parse.tojoVersion(target, refs));
+        final List<Xnav> errors = new Xnav(target)
+            .element("object")
+            .element("errors")
+            .elements(Filter.withName("error"))
+            .collect(Collectors.toList());
+        if (errors.isEmpty()) {
+            Logger.debug(this, "Parsed %[file]s to %[file]s", source, target);
+        } else {
+            for (final Xnav error : errors) {
+                Logger.error(
+                    this,
+                    "Failed to parse '%[file]s:%s': %s",
+                    source,
+                    error.attribute("line").text().orElse("0"),
+                    error.text().orElse("")
+                );
+            }
+        }
+        return 1;
+    }
+
+    /**
+     * Source parsed to {@link Node}.
+     * @param source Relative source path
+     * @param identifier Name of the EO object as tojo identifier
+     * @return Parsed EO object as {@link Node}
+     * @throws IOException If fails to parse
+     */
+    private Node parsed(final Path source, final String identifier) throws IOException {
+        final EoSource.Xmir xmir = new EoSource(identifier, source).parsed();
+        Logger.debug(
+            Parse.class,
+            "Parsed program '%s' from %[file]s:\n %s",
+            identifier, this.sourcesDir.relativize(source.toAbsolutePath()), xmir
+        );
+        if (xmir.broken()) {
+            new Saved(
+                new TextOf(xmir.xml().toString()),
+                this.targetDir.resolve(
+                    String.format("broken-%x.xmir", System.nanoTime())
+                )
+            ).value();
+        }
+        return xmir.xml().inner();
+    }
+
+    /**
+     * Tojo version.
+     * The version can be extracted from:
+     * 1. Parsed {@link Node} if EO object was parsed for the first time
+     * 2. XML document that was already parsed before
+     * @param target Path to result XML document
+     * @param parsed List with either one parsed {@link Node} or empty
+     * @return Tojo version
+     * @throws FileNotFoundException If XML document file does not exist
+     */
+    private static String tojoVersion(
+        final Path target,
+        final List<Node> parsed
+    ) throws FileNotFoundException {
+        final Node node;
+        if (parsed.isEmpty()) {
+            node = new XMLDocument(target).inner();
+        } else {
+            node = parsed.get(0);
+        }
+        return new Xnav(node)
+            .element("object")
+            .element("metas")
+            .elements(
+                Filter.all(
+                    Filter.withName("meta"),
+                    meta -> new Xnav(meta)
+                        .elements(
+                            Filter.all(
+                                Filter.withName("head"),
+                                head -> head.text().map("version"::equals).orElse(false)
+                            )
+                        )
+                        .findAny()
+                        .isPresent()
+                )
+            )
+            .findFirst()
+            .map(meta -> meta.element("tail").text().orElse(Parse.ZERO))
+            .orElse(Parse.ZERO);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -42,7 +42,7 @@ final class MjParseTest {
     void parsesSuccessfully(@Mktmp final Path temp) throws Exception {
         final String parsed = String.format(
             "target/%s/foo/x/main.%s",
-            MjParse.DIR,
+            Parse.DIR,
             MjAssemble.XMIR
         );
         MatcherAssert.assertThat(
@@ -89,10 +89,10 @@ final class MjParseTest {
             new TextOf(new ResourceOf("org/eolang/maven/main.xmir"))
         ).asString();
         final CommitHash hash = new ChCached(new ChNarrow(new ChRemote("0.40.5")));
-        final Path base = maven.targetPath().resolve(MjParse.DIR);
+        final Path base = maven.targetPath().resolve(Parse.DIR);
         final Path target = new Place("foo.x.main").make(base, MjAssemble.XMIR);
         new Cache(
-            cache.resolve(MjParse.CACHE)
+            cache.resolve(Parse.CACHE)
                 .resolve(FakeMaven.pluginVersion())
                 .resolve(hash.value()),
             src -> expected
@@ -100,7 +100,7 @@ final class MjParseTest {
         target.toFile().delete();
         final String actual = String.format(
             "target/%s/foo/x/main.%s",
-            MjParse.DIR,
+            Parse.DIR,
             MjAssemble.XMIR
         );
         MatcherAssert.assertThat(
@@ -130,7 +130,7 @@ final class MjParseTest {
                 .execute(new FakeMaven.Parse())
                 .result(),
             Matchers.hasKey(
-                String.format("target/%s/foo/x/main.%s", MjParse.DIR, MjAssemble.XMIR)
+                String.format("target/%s/foo/x/main.%s", Parse.DIR, MjAssemble.XMIR)
             )
         );
     }
@@ -164,7 +164,7 @@ final class MjParseTest {
             .execute(new FakeMaven.Parse())
             .result();
         final File parsed = result.get(
-            String.format("target/%s/foo/x/main.%s", MjParse.DIR, MjAssemble.XMIR)
+            String.format("target/%s/foo/x/main.%s", Parse.DIR, MjAssemble.XMIR)
         ).toFile();
         final long before = parsed.lastModified();
         maven.execute(MjParse.class);
@@ -198,7 +198,7 @@ final class MjParseTest {
                 Matchers.hasKey(
                     String.format(
                         "target/%s/foo/x/main%s.%s",
-                        MjParse.DIR,
+                        Parse.DIR,
                         FakeMaven.suffix(program),
                         MjAssemble.XMIR
                     )
@@ -219,7 +219,7 @@ final class MjParseTest {
                     )
                     .execute(new FakeMaven.Parse())
                     .result()
-                    .get(String.format("target/%s/main.%s", MjParse.DIR, MjAssemble.XMIR))
+                    .get(String.format("target/%s/main.%s", Parse.DIR, MjAssemble.XMIR))
             ),
             XhtmlMatchers.hasXPaths(
                 "/object/errors[count(error)=1]",
@@ -254,7 +254,7 @@ final class MjParseTest {
         final File parsed = maven
             .withHelloWorld()
             .execute(new FakeMaven.Parse())
-            .result().get(String.format("target/%s/foo/x/main.%s", MjParse.DIR, MjAssemble.XMIR))
+            .result().get(String.format("target/%s/foo/x/main.%s", Parse.DIR, MjAssemble.XMIR))
             .toFile();
         Files.setLastModifiedTime(
             parsed.toPath(), FileTime.fromMillis(System.currentTimeMillis() + 60_000L)


### PR DESCRIPTION
This PR refactors the `MjParse` class to decouple Maven-specific logic from core EO-to-XMIR parsing.

Fixes #5081