### PR TITLE
bug(#5066): stop benchmark.yml from re-triggering on its own PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,8 @@ name: benchmark
   push:
     branches:
       - master
+    paths-ignore:
+      - README.md
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
The `benchmark.yml` workflow runs on push to `master` and opens a PR that updates `README.md` (the benchmark block + the `[benchmark-gha]` URL). When that PR is merged, the push event re-triggers the workflow → another PR → infinite loop.

Fix: add `paths-ignore: [README.md]` to the `push` trigger, so a push that only modifies `README.md` (i.e. a merged benchmark PR) is skipped. Same approach as `objectionary/phino`'s `benchmark.yml`. Mixed commits (README + code) still trigger the job.

Closes: #5066