### PR TITLE
bug(#5059): use larger JNA class in XmirBench

### DIFF
--- a/eo-parser/src/test/java/benchmarks/XmirBench.java
+++ b/eo-parser/src/test/java/benchmarks/XmirBench.java
@@ -40,7 +40,7 @@ public class XmirBench {
     /**
      * Large XMIR document.
      */
-    private static final XML XMIR = new LargeXmir("noname", "com/sun/jna/Klass.class").xml();
+    private static final XML XMIR = new LargeXmir("noname", "com/sun/jna/Native.class").xml();
 
     /**
      * This main method allows to run the benchmark from IDE.


### PR DESCRIPTION
`XmirBench` was feeding itself `com/sun/jna/Klass.class` — only ~1.7KB of bytecode (63 lines of source). That's not representative of "large XMIR", contradicting the `LargeXmir` fixture name and the benchmark's intent.

Swap to `com/sun/jna/Native.class` (~51KB), the largest top-level class on the JNA jar that's already a test-scope dependency of `eo-parser`. No new deps; ~30× the previous payload; distinct from `XslBench` which keeps using the `LargeXmir` default `Pointer.class`.

Closes: #5059
