### PR TITLE
feat(#4654): separated withouti from ss.list

### DIFF
--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -2,6 +2,7 @@
 +alias ss.list
 +alias ss.reduced
 +alias ss.reducedi
++alias ss.withouti
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
@@ -53,18 +54,6 @@
     eachi > @
       ^
       func item > [item index] >>
-
-  # Create a new list without the i-th element.
-  [i] > withouti
-    list > @
-      reducedi
-        ^
-        *
-        [accum item idx] >>
-          if. > @
-            i.eq idx
-            accum
-            accum.with item
 
   # Create a new list without the `element` which is `.eq` to given one.
   [element] > without
@@ -264,36 +253,6 @@
             ^.m.put (^.m.as-number.plus i) > [i] >>
       6
 
-  # Tests that removing an element by index works correctly.
-  [] +> tests-list-withouti
-    eq. > @
-      withouti.
-        list
-          * 1 2 3
-        1
-      * 1 3
-
-  # Tests that removing an element by index works in complex scenarios.
-  [] +> tests-list-withouti-complex-case
-    eq. > @
-      foo
-        * 1 "text" "f"
-      * "text" "f"
-    # Helper function that removes first element from given tuple.
-    [a] > foo
-      withouti. > @
-        list a
-        0
-
-  # Tests that removing an element by index works with nested arrays.
-  [] +> tests-list-withouti-nested-array
-    eq. > @
-      withouti.
-        list
-          * "smthg" 27 (* 3 2 1)
-        2
-      * "smthg" 27
-
   # Tests that removing all occurrences of a value works correctly.
   [] +> tests-list-without
     eq. > @
@@ -327,7 +286,7 @@
       eq.
         list3
         * 1 2 3
-    withouti. > list3
+    withouti > list3
       concat.
         list (* 0 1)
         list (* 2 3)

--- a/eo-runtime/src/main/eo/ss/withouti.eo
+++ b/eo-runtime/src/main/eo/ss/withouti.eo
@@ -1,0 +1,50 @@
++alias ss.list
++alias ss.reducedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Create a new list without the i-th element of `lst`.
+[lst i] > withouti
+  list > @
+    reducedi
+      lst
+      *
+      [accum item idx] >>
+        if. > @
+          i.eq idx
+          accum
+          accum.with item
+
+  # Tests that removing an element by index works correctly.
+  [] +> tests-list-withouti
+    eq. > @
+      withouti
+        list
+          * 1 2 3
+        1
+      * 1 3
+
+  # Tests that removing an element by index works in complex scenarios.
+  [] +> tests-list-withouti-complex-case
+    eq. > @
+      foo
+        * 1 "text" "f"
+      * "text" "f"
+    # Helper function that removes first element from given tuple.
+    [a] > foo
+      withouti > @
+        list a
+        0
+
+  # Tests that removing an element by index works with nested arrays.
+  [] +> tests-list-withouti-nested-array
+    eq. > @
+      withouti
+        list
+          * "smthg" 27 (* 3 2 1)
+        2
+      * "smthg" 27


### PR DESCRIPTION
In this PR, I extracted the `withouti` object from `ss.list` into its own file `ss/withouti.eo`, mirroring the pattern used by other already-extracted siblings (`reducedi`, `eachi`, `mappedi`, etc.) and matching the `ms.real` decomposition from #4751.

The new free-standing object takes the list as an explicit free attribute (`[lst i] > withouti`) instead of relying on `^`. The three `tests-list-withouti*` tests moved with it. The remaining call site inside `tests-concatenates-lists` (`list.eo`) was updated from method-call (`withouti.`) to free-function (`withouti`) syntax, and `+alias ss.withouti` was added to `list.eo`.

This is one of several extractions toward fully decomposing `ss.list`; future PRs can extract `without`, `concat`, `front`, `back`, `slice`, `shifted`, `eq`, etc. one at a time.

Verified locally: `mvn qulice:check -Pqulice` passes for all four modules, and the affected tests (`EOss.EOlistTest` 36/36, `EOss.EOwithoutiTest` 3/3) all pass.

Resolves: #4654