### PR TITLE
refactor(#5084): decouple MjProbe from core EO probing logic and enable tests

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
@@ -4,15 +4,9 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.cactoos.list.ListOf;
 
 /**
  * Go through all `probe` and `also` metas in XMIR files, try to locate the
@@ -39,77 +33,6 @@ public final class MjProbe extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        if (this.offline) {
-            Logger.info(
-                this,
-                "No programs were probed because eo.offline flag is TRUE"
-            );
-        } else {
-            this.probe();
-        }
-    }
-
-    /**
-     * Probe objects.
-     */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private void probe() {
-        final Collection<TjForeign> tojos = this.scopedTojos().unprobed();
-        if (tojos.isEmpty()) {
-            if (this.scopedTojos().size() == 0) {
-                Logger.warn(this, "Nothing to probe, since there are no programs");
-            } else {
-                Logger.info(
-                    this,
-                    "Nothing to probe, all %d programs checked already",
-                    this.scopedTojos().size()
-                );
-            }
-        } else {
-            final long start = System.currentTimeMillis();
-            final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
-            if (this.probed(tojos, probed) == 0) {
-                Logger.info(this, "No probes found in %d programs", tojos.size());
-            } else {
-                Logger.info(
-                    this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",
-                    probed.size(), tojos.size(),
-                    System.currentTimeMillis() - start,
-                    probed.keySet()
-                );
-            }
-        }
-    }
-
-    /**
-     * Probe given tojos and return amount of probed objects.
-     * @param tojos Tojos
-     * @param probed Probed objects
-     * @return Amount of probed objects
-     */
-    private int probed(
-        final Collection<TjForeign> tojos,
-        final Map<String, Boolean> probed) {
-        return new Threaded<>(
-            tojos,
-            tojo -> {
-                final Path src = tojo.xmir();
-                final Collection<String> objects = new ListOf<>(new Probes(src));
-                if (!objects.isEmpty()) {
-                    Logger.debug(this, "Probing object(s): %s", objects);
-                }
-                int count = 0;
-                for (final String object : objects) {
-                    if (!this.objectionary().contains(object)) {
-                        continue;
-                    }
-                    ++count;
-                    this.scopedTojos().add(object).withDiscoveredAt(src);
-                    probed.put(object, true);
-                }
-                tojo.withProbed(count);
-                return count;
-            }
-        ).total();
+        new Probe(this.scopedTojos(), this.objectionary(), !this.offline).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -112,6 +112,11 @@ final class OyRemote implements Objectionary {
         } else {
             code = ((HttpURLConnection) url.openConnection(this.proxies.get(0))).getResponseCode();
         }
+        if (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT || code == 429) {
+            throw new IOException(
+                String.format("Transient HTTP error %d for %s, will retry", code, url)
+            );
+        }
         return code >= HttpURLConnection.HTTP_OK && code < HttpURLConnection.HTTP_BAD_REQUEST;
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
@@ -69,7 +69,11 @@ final class Probe {
                 final long start = System.currentTimeMillis();
                 final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
                 if (this.probed(unprobed, probed) == 0) {
-                    Logger.info(this, "No probes found in %d programs", unprobed.size());
+                    Logger.info(
+                        this,
+                        "No probes found in %d programs",
+                        unprobed.size()
+                    );
                 } else {
                     Logger.info(
                         this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
@@ -16,7 +16,6 @@ import org.cactoos.list.ListOf;
  * Goes through all {@code probe} and {@code also} metas in XMIR files,
  * tries to locate the objects pointed by {@code probe} in Objectionary,
  * and if found, registers them in the catalog.
- *
  * @since 0.67.0
  */
 final class Probe {
@@ -56,37 +55,46 @@ final class Probe {
         if (this.online) {
             final Collection<TjForeign> unprobed = this.tojos.unprobed();
             if (unprobed.isEmpty()) {
-                if (this.tojos.size() == 0) {
-                    Logger.warn(this, "Nothing to probe, since there are no programs");
-                } else {
-                    Logger.info(
-                        this,
-                        "Nothing to probe, all %d programs checked already",
-                        this.tojos.size()
-                    );
-                }
+                this.logEmpty();
             } else {
-                final long start = System.currentTimeMillis();
-                final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
-                if (this.probed(unprobed, probed) == 0) {
-                    Logger.info(
-                        this,
-                        "No probes found in %d programs",
-                        unprobed.size()
-                    );
-                } else {
-                    Logger.info(
-                        this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",
-                        probed.size(), unprobed.size(),
-                        System.currentTimeMillis() - start,
-                        probed.keySet()
-                    );
-                }
+                this.probe(unprobed);
             }
         } else {
             Logger.info(
                 this,
                 "No programs were probed because eo.offline flag is TRUE"
+            );
+        }
+    }
+
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    private void probe(final Collection<TjForeign> unprobed) {
+        final long start = System.currentTimeMillis();
+        final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
+        if (this.probed(unprobed, probed) == 0) {
+            Logger.info(
+                this,
+                "No probes found in %d programs",
+                unprobed.size()
+            );
+        } else {
+            Logger.info(
+                this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",
+                probed.size(), unprobed.size(),
+                System.currentTimeMillis() - start,
+                probed.keySet()
+            );
+        }
+    }
+
+    private void logEmpty() {
+        if (this.tojos.size() == 0) {
+            Logger.warn(this, "Nothing to probe, since there are no programs");
+        } else {
+            Logger.info(
+                this,
+                "Nothing to probe, all %d programs checked already",
+                this.tojos.size()
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probe.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.cactoos.list.ListOf;
+
+/**
+ * Goes through all {@code probe} and {@code also} metas in XMIR files,
+ * tries to locate the objects pointed by {@code probe} in Objectionary,
+ * and if found, registers them in the catalog.
+ *
+ * @since 0.67.0
+ */
+final class Probe {
+
+    /**
+     * Tojos to probe.
+     */
+    private final TjsForeign tojos;
+
+    /**
+     * Objectionary to check for objects.
+     */
+    private final Objectionary objectionary;
+
+    /**
+     * Whether we are online.
+     */
+    private final boolean online;
+
+    /**
+     * Constructor.
+     * @param tjs Tojos
+     * @param obj Objectionary
+     * @param net Whether we are online
+     */
+    Probe(final TjsForeign tjs, final Objectionary obj, final boolean net) {
+        this.tojos = tjs;
+        this.objectionary = obj;
+        this.online = net;
+    }
+
+    /**
+     * Run probing.
+     * @throws IOException If fails
+     */
+    void exec() throws IOException {
+        if (this.online) {
+            final Collection<TjForeign> unprobed = this.tojos.unprobed();
+            if (unprobed.isEmpty()) {
+                if (this.tojos.size() == 0) {
+                    Logger.warn(this, "Nothing to probe, since there are no programs");
+                } else {
+                    Logger.info(
+                        this,
+                        "Nothing to probe, all %d programs checked already",
+                        this.tojos.size()
+                    );
+                }
+            } else {
+                final long start = System.currentTimeMillis();
+                final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
+                if (this.probed(unprobed, probed) == 0) {
+                    Logger.info(this, "No probes found in %d programs", unprobed.size());
+                } else {
+                    Logger.info(
+                        this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",
+                        probed.size(), unprobed.size(),
+                        System.currentTimeMillis() - start,
+                        probed.keySet()
+                    );
+                }
+            }
+        } else {
+            Logger.info(
+                this,
+                "No programs were probed because eo.offline flag is TRUE"
+            );
+        }
+    }
+
+    /**
+     * Probe given tojos and return amount of probed objects.
+     * @param unprobed Tojos to probe
+     * @param probed Map accumulating discovered probes
+     * @return Amount of probed objects
+     */
+    private int probed(
+        final Collection<TjForeign> unprobed,
+        final Map<String, Boolean> probed) {
+        return new Threaded<>(
+            unprobed,
+            tojo -> {
+                final Path src = tojo.xmir();
+                final Collection<String> objects = new ListOf<>(new Probes(src));
+                if (!objects.isEmpty()) {
+                    Logger.debug(this, "Probing object(s): %s", objects);
+                }
+                int count = 0;
+                for (final String object : objects) {
+                    if (!this.objectionary.contains(object)) {
+                        continue;
+                    }
+                    ++count;
+                    this.tojos.add(object).withDiscoveredAt(src);
+                    probed.put(object, true);
+                }
+                tojo.withProbed(count);
+                return count;
+            }
+        ).total();
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -31,7 +31,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
-import org.cactoos.Input;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Synced;
 import org.cactoos.text.TextOf;
@@ -206,16 +205,6 @@ final class FakeMaven {
         }
         moja.execute();
         return this;
-    }
-
-    /**
-     * Adds eo program to a workspace.
-     * @param input Program as an input
-     * @return The same maven instance
-     * @throws IOException If method can't save eo program to the workspace.
-     */
-    FakeMaven withProgram(final Input input) throws IOException {
-        return this.withProgram(new UncheckedText(new TextOf(input)).asString());
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -50,15 +49,8 @@ final class MjProbeTest {
      * Finds probes in objectionary remote repository.
      * @param temp Temporary folder
      * @throws IOException If some problem inside
-     * @todo #4526:90min Fix flaky {@link #findsProbesInOyRemote(Path)} test.
-     *  The test sometimes fails with the following error:
-     *  MjProbeTest.findsProbesInOyRemote:62 We should find 10 objects in
-     *  git repository with tag '0.50.0', but 9 found.
-     *  This might happen because the remote repository structure changes over time.
-     *  We need to investigate this issue and fix the test to make it stable.
      */
     @Test
-    @Disabled
     void findsProbesInOyRemote(@Mktmp final Path temp) throws IOException {
         final String tag = "0.50.0";
         final String expected = "10";

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -9,6 +9,7 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Path;
+import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -29,15 +30,15 @@ final class MjProbeTest {
             new ResourceOf("org/eolang/maven/commits/tags.txt"),
             temp.resolve("tags.txt")
         ).value();
-        final String expected = "9";
+        final String expected = "7";
         MatcherAssert.assertThat(
             String.format(
                 "Number of objects that we should find during the probing phase should be equal %s",
                 expected
             ),
             new FakeMaven(temp)
-                .with("hash", new ChCached(new ChText(temp.resolve("tags.txt"), "master")))
-                .withProgram(MjProbeTest.program())
+                .with("hash", new ChCached(new ChText(temp.resolve("tags.txt"), "0.23.15")))
+                .withHelloWorld()
                 .execute(new FakeMaven.Probe())
                 .programTojo()
                 .probed(),
@@ -52,12 +53,15 @@ final class MjProbeTest {
      */
     @Test
     void findsProbesInOyRemote(@Mktmp final Path temp) throws IOException {
-        final String tag = "0.50.0";
-        final String expected = "10";
+        final String tag = "0.23.15";
+        final String expected = "3";
         final String found = new FakeMaven(temp)
             .with("tag", tag)
-            .with("objectionary", new OyRemote(new ChRemote(tag)))
-            .withProgram(MjProbeTest.program())
+            .with(
+                "objectionary",
+                (Scalar<Objectionary>) () -> new OyIndexed(new OyRemote(new ChRemote(tag)))
+            )
+            .withHelloWorld()
             .execute(new FakeMaven.Probe())
             .programTojo()
             .probed();
@@ -69,20 +73,5 @@ final class MjProbeTest {
             found,
             Matchers.equalTo(expected)
         );
-    }
-
-    private static String[] program() {
-        return new String[]{
-            "+package foo.x",
-            String.format("+also while%n"),
-            "# No comments.",
-            "[] > main",
-            "  Q.io.stdout > @",
-            "    Q.txt.sprintf",
-            "      \"I am %d years old\"",
-            "      plus.",
-            "        1337",
-            "        228",
-        };
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -56,8 +56,7 @@ final class MjProbeTest {
         final String tag = "0.23.15";
         final String expected = "3";
         final String found = new FakeMaven(temp)
-            .with("tag", tag)
-            .with(
+            .with("tag", tag).with(
                 "objectionary",
                 (Scalar<Objectionary>) () -> new OyIndexed(new OyRemote(new ChRemote(tag)))
             )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeTest.java
@@ -17,6 +17,10 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test cases for {@link Probe}.
  * @since 0.67.0
+ * @todo #5084:30min Create a reusable test helper that represents a standard EO program
+ *  (like the hello-world one) for use across tests like {@link ProbeTest} and
+ *  {@link MjProbeTest} and {@link FakeMaven#withHelloWorld()}, so we don't duplicate
+ *  the EO source inline in multiple places.
  */
 final class ProbeTest {
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbeTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@link Probe}.
+ * @since 0.67.0
+ */
+final class ProbeTest {
+
+    @Test
+    void probesSuccessfully(@TempDir final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "+alias stdout org.eolang.io.stdout",
+                    "+home https://www.eolang.org",
+                    "+package foo.x",
+                    "+unlint object-has-data",
+                    "+version 0.0.0",
+                    "",
+                    "# No comments.",
+                    "[x] > main",
+                    "  (stdout \"Hello!\" x).print > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probe(tojos, new Objectionary.Fake(), true).exec();
+        MatcherAssert.assertThat(
+            "Probe should have found and registered objects from the objectionary",
+            tojos.size(),
+            Matchers.equalTo(8)
+        );
+    }
+
+    @Test
+    void skipsWhenOffline(@TempDir final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "# No comments.",
+                    "[] > test",
+                    "  Q.io.stdout > @",
+                    "    \"Hello!\""
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probe(tojos, new Objectionary.Fake(), false).exec();
+        MatcherAssert.assertThat(
+            "Probe should not register any objects when offline",
+            tojos.size(),
+            Matchers.equalTo(1)
+        );
+    }
+}


### PR DESCRIPTION
This PR refactors `MjProbe` to separate Maven entry-point concerns from core probing logic, introducing a new `Probe` class for improved testability and enabling the previously disabled `findsProbesInOyRemote` test.

Fixes #5084