### PR TITLE
#4318: improve error message for atoms containing inner objects

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoParserErrors.java
@@ -127,7 +127,8 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
      * @return The detailed message
      */
     private static String mismatch(final Parser parser, final String msg) {
-        final String rule = parser.getRuleInvocationStack().get(0);
+        final List<String> stack = parser.getRuleInvocationStack();
+        final String rule = stack.get(0);
         final String[] names = parser.getRuleNames();
         final String detailed;
         if (names[EoParser.RULE_program].equals(rule)) {
@@ -136,6 +137,10 @@ final class EoParserErrors extends BaseErrorListener implements Iterable<Parsing
         } else if (names[EoParser.RULE_object].equals(rule)) {
             detailed =
                 "We expected a object here but encountered something unexpected";
+        } else if (stack.contains(names[EoParser.RULE_atom])
+            && stack.contains(names[EoParser.RULE_tests])) {
+            detailed =
+                "Atom cannot contain inner objects, only test objects are allowed in its body";
         } else {
             detailed = msg;
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -3,11 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 5
-# @todo #4264:45min Improve error message for atoms containing inners.
-#  For now we fail to report it properly. Current message contains:
-#  [5:-1] error: 'mismatched input 'UNTAB' expecting {'Q', 'QQ', '*', '$', '[', '(', '@', '^', '~', BYTES, STRING, INT, FLOAT, HEX, NAME, TEXT}'.
-#  We should improve, and verify it using `message` key in this YAML story. Also, check this issue:
-#  https://github.com/objectionary/eo/issues/4106.
+message: "Atom cannot contain inner objects"
 input: |
   # No comments.
   [] > test /bytes


### PR DESCRIPTION
Closes #4318.

Replace the cryptic ANTLR `mismatched input 'UNTAB' expecting {...}` error with a clear message when an atom (object with `/return-type`) is followed by inner objects.

## Detection

When `InputMismatchException` fires inside `EoParserErrors.mismatch()`, check the rule invocation stack. If both `atom` and `tests` rules are present, the parser entered the test-body of an atom and stumbled on a non-test inner object. In that case, emit:

```
Atom cannot contain inner objects, only test objects are allowed in its body
```

The check requires `tests` in the stack so it does not affect other in-atom errors (e.g. `broken-head.yaml` has stack `[atom, masterBody, object, program]` — no `tests`, falls through to the default branch).

## Fixture

`not-empty-atoms.yaml` updated: dropped the `@todo #4264` block, added `message:` key so `EoSyntaxTest.checksTypoPacks` verifies the new text via `containsString`.

## Verification

- `mvn test` (eo-parser): 1008/1008 passing
- `mvn -Pqulice qulice:check`: clean
