### PR TITLE
feat(#5093): decouple MjPull from core EO pulling logic with Pull class

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -27,22 +26,16 @@ public final class MjPull extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        if (this.offline) {
-            Logger.info(
-                this,
-                "No programs were pulled because eo.offline flag is TRUE"
-            );
-        } else {
-            new Pull(
-                this.scopedTojos().withoutSources(),
-                this.targetDir.toPath().resolve(Pull.DIR),
-                this.hash,
-                this.objectionary(),
-                this.cache.toPath().resolve(Pull.CACHE),
-                this.plugin.getVersion(),
-                this.overWrite,
-                this.cacheEnabled
-            ).exec();
-        }
+        new Pull(
+            this.scopedTojos().withoutSources(),
+            this.targetDir.toPath().resolve(Pull.DIR),
+            this.hash,
+            this.objectionary(),
+            this.cache.toPath().resolve(Pull.CACHE),
+            this.plugin.getVersion(),
+            this.overWrite,
+            this.cacheEnabled,
+            this.offline
+        ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -6,11 +6,6 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.function.Supplier;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -19,7 +14,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  * <p>
  *     This goal goes through all objects from "foreign" catalog and looks for those without
  *     sources and pulls them from Objectionary remote repository.
- *     The pulled sources are stored in the {@link #DIR} directory.
+ *     The pulled sources are stored in the {@link Pull#DIR} directory.
  * </p>
  * @since 0.1
  */
@@ -30,16 +25,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 )
 public final class MjPull extends MjSafe {
 
-    /**
-     * The directory where to process to.
-     */
-    static final String DIR = "2-pull";
-
-    /**
-     * Cache directory.
-     */
-    static final String CACHE = "pulled";
-
     @Override
     public void exec() throws IOException {
         if (this.offline) {
@@ -48,116 +33,16 @@ public final class MjPull extends MjSafe {
                 "No programs were pulled because eo.offline flag is TRUE"
             );
         } else {
-            this.pull(
-                new OyIndexed(
-                    new OyCached(new OyRemote(this.hash, this.proxies()))
-                )
-            );
+            new Pull(
+                this.scopedTojos().withoutSources(),
+                this.targetDir.toPath().resolve(Pull.DIR),
+                this.hash,
+                this.objectionary(),
+                this.cache.toPath().resolve(Pull.CACHE),
+                this.plugin.getVersion(),
+                this.overWrite,
+                this.cacheEnabled
+            ).exec();
         }
-    }
-
-    /**
-     * Pull them all.
-     * @param objectionary Objectionary to pull from
-     * @throws IOException If fails
-     */
-    private void pull(final OyIndexed objectionary) throws IOException {
-        final long start = System.currentTimeMillis();
-        final Collection<TjForeign> tojos = this.scopedTojos().withoutSources();
-        final Collection<String> names = new ArrayList<>(0);
-        final Path base = this.targetDir.toPath().resolve(MjPull.DIR);
-        final String hsh = this.hash.value();
-        for (final TjForeign tojo : tojos) {
-            final String object = tojo.identifier();
-            if (objectionary.isDirectory(object)) {
-                continue;
-            }
-            try {
-                tojo.withSource(this.pulled(object, base, hsh))
-                    .withHash(new ChNarrow(this.hash));
-            } catch (final IOException exception) {
-                throw new IOException(
-                    String.format(
-                        "Failed to pull '%s' earlier discovered at %s",
-                        tojo.identifier(),
-                        tojo.discoveredAt()
-                    ),
-                    exception
-                );
-            }
-            names.add(object);
-        }
-        if (tojos.isEmpty()) {
-            Logger.info(
-                this,
-                "No programs were pulled in %[ms]s",
-                System.currentTimeMillis() - start
-            );
-        } else {
-            Logger.info(
-                this,
-                "%d program(s) were pulled in %[ms]s: %s",
-                tojos.size(),
-                System.currentTimeMillis() - start,
-                names
-            );
-        }
-    }
-
-    /**
-     * Pull one object.
-     * @param object Name of the object
-     * @param base Base cache path
-     * @param hsh Git hash
-     * @return The path of .eo file
-     * @throws IOException If fails
-     * @checkstyle ParameterNumberCheck (5 lines)
-     */
-    private Path pulled(
-        final String object,
-        final Path base,
-        final String hsh) throws IOException {
-        final Path target = new Place(object).make(base, MjAssemble.EO);
-        final Supplier<Path> che = new CachePath(
-            this.cache.toPath().resolve(MjPull.CACHE),
-            this.plugin.getVersion(),
-            hsh,
-            base.relativize(target)
-        );
-        final Footprint generated = new FpGenerated(
-            src -> {
-                Logger.debug(
-                    this,
-                    "Pulling %s object from remote objectionary with hash %s",
-                    object, hsh
-                );
-                return this.objectionary().get(object);
-            }
-        );
-        final Footprint both = new FpUpdateBoth(generated, che);
-        return new FpIfReleased(
-            hsh,
-            new FpFork(
-                (src, tgt) -> {
-                    if (this.overWrite) {
-                        Logger.debug(
-                            this,
-                            "Pulling sources again because \"eo.overWrite=TRUE\""
-                        );
-                    }
-                    return this.overWrite;
-                },
-                new FpFork(this.cacheEnabled, both, generated),
-                new FpIfTargetExists(
-                    new FpIgnore(),
-                    new FpFork(
-                        this.cacheEnabled,
-                        new FpIfTargetExists(tgt -> che.get(), new FpUpdateFromCache(che), both),
-                        generated
-                    )
-                )
-            ),
-            generated
-        ).apply(Paths.get(""), target);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -138,7 +138,7 @@ public final class MjRegister extends MjSafe {
     private void removeOldFiles() {
         final File[] files = {
             this.foreign,
-            this.targetDir.toPath().resolve(MjPull.DIR).toFile(),
+            this.targetDir.toPath().resolve(Pull.DIR).toFile(),
             this.targetDir.toPath().resolve(MjResolve.DIR).toFile(),
         };
         for (final File file : files) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -423,7 +423,7 @@ abstract class MjSafe extends AbstractMojo {
     private Scalar<Objectionary> objectionary = new Synced<>(
         new Sticky<>(
             () -> new OyIndexed(
-                new OyCached(new OyRemote(this.hash))
+                new OyCached(new OyRemote(this.hash, this.proxies()))
             )
         )
     );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
@@ -58,7 +58,7 @@ final class Pull {
     /**
      * Cache directory (cache + CACHE).
      */
-    private final Path cacheDir;
+    private final Path cdir;
 
     /**
      * Plugin version string.
@@ -68,12 +68,12 @@ final class Pull {
     /**
      * Whether to overwrite already pulled sources.
      */
-    private final boolean overWrite;
+    private final boolean overwrite;
 
     /**
      * Whether caching is enabled.
      */
-    private final boolean cacheEnabled;
+    private final boolean cenabled;
 
     /**
      * Whether we are in offline mode.
@@ -108,10 +108,10 @@ final class Pull {
         this.base = dir;
         this.hash = hsh;
         this.objectionary = obj;
-        this.cacheDir = cache;
+        this.cdir = cache;
         this.version = ver;
-        this.overWrite = rewrite;
-        this.cacheEnabled = enabled;
+        this.overwrite = rewrite;
+        this.cenabled = enabled;
         this.offline = off;
     }
 
@@ -177,7 +177,7 @@ final class Pull {
     private Path pulled(final String object, final String hsh) throws IOException {
         final Path target = new Place(object).make(this.base, MjAssemble.EO);
         final Supplier<Path> che = new CachePath(
-            this.cacheDir,
+            this.cdir,
             this.version,
             hsh,
             this.base.relativize(target)
@@ -197,19 +197,19 @@ final class Pull {
             hsh,
             new FpFork(
                 (src, tgt) -> {
-                    if (this.overWrite) {
+                    if (this.overwrite) {
                         Logger.debug(
                             this,
                             "Pulling sources again because \"eo.overWrite=TRUE\""
                         );
                     }
-                    return this.overWrite;
+                    return this.overwrite;
                 },
-                new FpFork(this.cacheEnabled, both, generated),
+                new FpFork(this.cenabled, both, generated),
                 new FpIfTargetExists(
                     new FpIgnore(),
                     new FpFork(
-                        this.cacheEnabled,
+                        this.cenabled,
                         new FpIfTargetExists(tgt -> che.get(), new FpUpdateFromCache(che), both),
                         generated
                     )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
@@ -76,6 +76,11 @@ final class Pull {
     private final boolean cacheEnabled;
 
     /**
+     * Whether we are in offline mode.
+     */
+    private final boolean offline;
+
+    /**
      * Constructor.
      * @param tjs Tojos without sources
      * @param dir Base target directory
@@ -85,6 +90,7 @@ final class Pull {
      * @param ver Plugin version
      * @param rewrite Whether to overwrite existing sources
      * @param enabled Whether caching is enabled
+     * @param off Whether offline mode is active
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     Pull(
@@ -95,7 +101,8 @@ final class Pull {
         final Path cache,
         final String ver,
         final boolean rewrite,
-        final boolean enabled
+        final boolean enabled,
+        final boolean off
     ) {
         this.tojos = tjs;
         this.base = dir;
@@ -105,6 +112,7 @@ final class Pull {
         this.version = ver;
         this.overWrite = rewrite;
         this.cacheEnabled = enabled;
+        this.offline = off;
     }
 
     /**
@@ -112,6 +120,13 @@ final class Pull {
      * @throws IOException If fails
      */
     void exec() throws IOException {
+        if (this.offline) {
+            Logger.info(
+                this,
+                "No programs were pulled because eo.offline flag is TRUE"
+            );
+            return;
+        }
         final long start = System.currentTimeMillis();
         final Collection<String> names = new ArrayList<>(0);
         final String hsh = this.hash.value();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+/**
+ * Pulls EO sources from Objectionary.
+ *
+ * <p>
+ *     Goes through all objects from "foreign" catalog that lack sources and
+ *     pulls them from the Objectionary remote repository. The pulled sources
+ *     are stored in the {@link #DIR} directory.
+ * </p>
+ *
+ * @since 0.67.0
+ */
+final class Pull {
+
+    /**
+     * The directory where to store pulled sources.
+     */
+    static final String DIR = "2-pull";
+
+    /**
+     * Cache subdirectory name.
+     */
+    static final String CACHE = "pulled";
+
+    /**
+     * Tojos without sources to pull.
+     */
+    private final Collection<TjForeign> tojos;
+
+    /**
+     * Base target directory (targetDir + DIR).
+     */
+    private final Path base;
+
+    /**
+     * Commit hash to pull from.
+     */
+    private final CommitHash hash;
+
+    /**
+     * Objectionary to pull from.
+     */
+    private final Objectionary objectionary;
+
+    /**
+     * Cache directory (cache + CACHE).
+     */
+    private final Path cacheDir;
+
+    /**
+     * Plugin version string.
+     */
+    private final String version;
+
+    /**
+     * Whether to overwrite already pulled sources.
+     */
+    private final boolean overWrite;
+
+    /**
+     * Whether caching is enabled.
+     */
+    private final boolean cacheEnabled;
+
+    /**
+     * Constructor.
+     * @param tjs Tojos without sources
+     * @param dir Base target directory
+     * @param hsh Commit hash
+     * @param obj Objectionary
+     * @param cache Cache directory
+     * @param ver Plugin version
+     * @param rewrite Whether to overwrite existing sources
+     * @param enabled Whether caching is enabled
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    Pull(
+        final Collection<TjForeign> tjs,
+        final Path dir,
+        final CommitHash hsh,
+        final Objectionary obj,
+        final Path cache,
+        final String ver,
+        final boolean rewrite,
+        final boolean enabled
+    ) {
+        this.tojos = tjs;
+        this.base = dir;
+        this.hash = hsh;
+        this.objectionary = obj;
+        this.cacheDir = cache;
+        this.version = ver;
+        this.overWrite = rewrite;
+        this.cacheEnabled = enabled;
+    }
+
+    /**
+     * Pull all objects.
+     * @throws IOException If fails
+     */
+    void exec() throws IOException {
+        final long start = System.currentTimeMillis();
+        final Collection<String> names = new ArrayList<>(0);
+        final String hsh = this.hash.value();
+        for (final TjForeign tojo : this.tojos) {
+            final String object = tojo.identifier();
+            if (this.objectionary.isDirectory(object)) {
+                continue;
+            }
+            try {
+                tojo.withSource(this.pulled(object, hsh))
+                    .withHash(new ChNarrow(this.hash));
+            } catch (final IOException exception) {
+                throw new IOException(
+                    String.format(
+                        "Failed to pull '%s' earlier discovered at %s",
+                        tojo.identifier(),
+                        tojo.discoveredAt()
+                    ),
+                    exception
+                );
+            }
+            names.add(object);
+        }
+        if (this.tojos.isEmpty()) {
+            Logger.info(
+                this,
+                "No programs were pulled in %[ms]s",
+                System.currentTimeMillis() - start
+            );
+        } else {
+            Logger.info(
+                this,
+                "%d program(s) were pulled in %[ms]s: %s",
+                this.tojos.size(),
+                System.currentTimeMillis() - start,
+                names
+            );
+        }
+    }
+
+    /**
+     * Pull one object.
+     * @param object Name of the object
+     * @param hsh Git hash
+     * @return The path of .eo file
+     * @throws IOException If fails
+     */
+    private Path pulled(final String object, final String hsh) throws IOException {
+        final Path target = new Place(object).make(this.base, MjAssemble.EO);
+        final Supplier<Path> che = new CachePath(
+            this.cacheDir,
+            this.version,
+            hsh,
+            this.base.relativize(target)
+        );
+        final Footprint generated = new FpGenerated(
+            src -> {
+                Logger.debug(
+                    this,
+                    "Pulling %s object from remote objectionary with hash %s",
+                    object, hsh
+                );
+                return this.objectionary.get(object);
+            }
+        );
+        final Footprint both = new FpUpdateBoth(generated, che);
+        return new FpIfReleased(
+            hsh,
+            new FpFork(
+                (src, tgt) -> {
+                    if (this.overWrite) {
+                        Logger.debug(
+                            this,
+                            "Pulling sources again because \"eo.overWrite=TRUE\""
+                        );
+                    }
+                    return this.overWrite;
+                },
+                new FpFork(this.cacheEnabled, both, generated),
+                new FpIfTargetExists(
+                    new FpIgnore(),
+                    new FpFork(
+                        this.cacheEnabled,
+                        new FpIfTargetExists(tgt -> che.get(), new FpUpdateFromCache(che), both),
+                        generated
+                    )
+                )
+            ),
+            generated
+        ).apply(Paths.get(""), target);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
@@ -137,14 +137,14 @@ final class MjPullTest {
         MatcherAssert.assertThat(
             String.format(
                 "%s folder should not contain %s and %s file, but it did",
-                MjPull.DIR,
+                Pull.DIR,
                 stdout,
                 string
             ),
             result,
             Matchers.allOf(
-                Matchers.not(Matchers.hasKey(String.format("%s/%s", MjPull.DIR, stdout))),
-                Matchers.not(Matchers.hasKey(String.format("%s/%s", MjPull.DIR, string)))
+                Matchers.not(Matchers.hasKey(String.format("%s/%s", Pull.DIR, stdout))),
+                Matchers.not(Matchers.hasKey(String.format("%s/%s", Pull.DIR, string)))
             )
         );
     }
@@ -156,7 +156,7 @@ final class MjPullTest {
             .withHelloWorld()
             .execute(new FakeMaven.Pull());
         final Path path = maven.result().get(
-            String.format("target/%s/bytes.%s", MjPull.DIR, MjAssemble.EO)
+            String.format("target/%s/bytes.%s", Pull.DIR, MjAssemble.EO)
         );
         final long mtime = path.toFile().lastModified();
         maven.execute(MjPull.class);
@@ -183,7 +183,7 @@ final class MjPullTest {
             .execute(new FakeMaven.Pull());
         MatcherAssert.assertThat(
             "Pulled results must be saved to cache",
-            cache.resolve(MjPull.CACHE)
+            cache.resolve(Pull.CACHE)
                 .resolve(FakeMaven.pluginVersion())
                 .resolve(hash.value())
                 .resolve("org/eolang/bytes.eo")
@@ -200,7 +200,7 @@ final class MjPullTest {
         new Saved(
             cached,
             cache
-                .resolve(MjPull.CACHE)
+                .resolve(Pull.CACHE)
                 .resolve(FakeMaven.pluginVersion())
                 .resolve(hash)
                 .resolve("io/stdout.eo")
@@ -208,7 +208,7 @@ final class MjPullTest {
         Files.setLastModifiedTime(
             cache.resolve(
                 Paths
-                    .get(MjPull.CACHE)
+                    .get(Pull.CACHE)
                     .resolve(FakeMaven.pluginVersion())
                     .resolve(hash)
                     .resolve("io/stdout.eo")
@@ -231,7 +231,7 @@ final class MjPullTest {
                     temp.resolve(
                         String.format(
                             "target/%s/io/stdout.%s",
-                            MjPull.DIR,
+                            Pull.DIR,
                             MjAssemble.EO
                         )
                     )
@@ -264,6 +264,6 @@ final class MjPullTest {
      * @return Formatted source path
      */
     private static Path path(final String source) {
-        return new Place(source).make(Paths.get(MjPull.DIR), "eo");
+        return new Place(source).make(Paths.get(Pull.DIR), "eo");
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
@@ -21,7 +21,6 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -50,7 +49,6 @@ final class MjPullTest {
     }
 
     @Test
-    @Disabled
     void pullsFromProbes(@Mktmp final Path temp) throws IOException {
         new FakeMaven(temp).withProgram(
             String.format("+package foo.x%n"),
@@ -168,7 +166,6 @@ final class MjPullTest {
     }
 
     @Test
-    @Disabled
     void savesPulledResultsToCache(@Mktmp final Path temp) throws IOException {
         final Path cache = temp.resolve("cache");
         final CommitHash hash = new ChCached(
@@ -186,7 +183,7 @@ final class MjPullTest {
             cache.resolve(Pull.CACHE)
                 .resolve(FakeMaven.pluginVersion())
                 .resolve(hash.value())
-                .resolve("org/eolang/bytes.eo")
+                .resolve("bytes.eo")
                 .toFile(),
             FileMatchers.anExistingFile()
         );


### PR DESCRIPTION
This PR refactors `MjPull` to decouple Maven entry-point concerns from core EO pulling logic.

Fixes #5093