### PR TITLE
feat(#5098): decouple MjAssemble from EO assembling logic

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assemble.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+
+/**
+ * Assembles EO sources by running Parse, Probe, and Pull in a loop
+ * until no new objects are discovered.
+ *
+ * @since 0.67.0
+ */
+final class Assemble {
+
+    /**
+     * Tojos to check assembly status.
+     */
+    private final TjsForeign tojos;
+
+    /**
+     * Parse step.
+     */
+    private final Parse parse;
+
+    /**
+     * Probe step.
+     */
+    private final Probe probe;
+
+    /**
+     * Pull step.
+     */
+    private final Pull pull;
+
+    /**
+     * Constructor.
+     * @param tjs Foreign tojos
+     * @param prs Parse step
+     * @param prb Probe step
+     * @param pll Pull step
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    Assemble(
+        final TjsForeign tjs,
+        final Parse prs,
+        final Probe prb,
+        final Pull pll
+    ) {
+        this.tojos = tjs;
+        this.parse = prs;
+        this.probe = prb;
+        this.pull = pll;
+    }
+
+    /**
+     * Run assembly cycles until stable.
+     * @throws IOException If fails
+     */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void exec() throws IOException {
+        final long begin = System.currentTimeMillis();
+        String before = this.tojos.status();
+        int cycle = 0;
+        while (true) {
+            final long start = System.currentTimeMillis();
+            this.parse.exec();
+            this.probe.exec();
+            this.pull.exec();
+            final String after = this.tojos.status();
+            ++cycle;
+            if (after.equals(before)) {
+                Logger.info(
+                    this, "Last assemble cycle #%d (%s), took %[ms]s",
+                    cycle, after, System.currentTimeMillis() - start
+                );
+                break;
+            } else {
+                Logger.info(
+                    this, "Assemble cycle #%d (%s -> %s), took %[ms]s",
+                    cycle, before, after, System.currentTimeMillis() - start
+                );
+            }
+            before = after;
+        }
+        Logger.info(
+            this,
+            "%d assemble cycle(s) produced some new object(s) in %[ms]s: %s",
+            cycle,
+            System.currentTimeMillis() - begin,
+            before
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assemble.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 /**
  * Assembles EO sources by running Parse, Probe, and Pull in a loop
  * until no new objects are discovered.
- *
  * @since 0.67.0
  */
 final class Assemble {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
@@ -4,7 +4,7 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
+import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -37,48 +37,30 @@ public final class MjAssemble extends MjSafe {
      */
     static final String EO = "eo";
 
-    /**
-     * Mojas to execute.
-     */
-    private static final Moja<?>[] MOJAS = {
-        new Moja<>(MjParse.class),
-        new Moja<>(MjProbe.class),
-        new Moja<>(MjPull.class),
-    };
-
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    public void exec() {
-        final long begin = System.currentTimeMillis();
-        String before = this.scopedTojos().status();
-        int cycle = 0;
-        while (true) {
-            final long start = System.currentTimeMillis();
-            for (final Moja<?> moja : MjAssemble.MOJAS) {
-                moja.copy(this).execute();
-            }
-            final String after = this.scopedTojos().status();
-            ++cycle;
-            if (after.equals(before)) {
-                Logger.info(
-                    this, "Last assemble cycle #%d (%s), took %[ms]s",
-                    cycle, after, System.currentTimeMillis() - start
-                );
-                break;
-            } else {
-                Logger.info(
-                    this, "Assemble cycle #%d (%s -> %s), took %[ms]s",
-                    cycle, before, after, System.currentTimeMillis() - start
-                );
-            }
-            before = after;
-        }
-        Logger.info(
-            this,
-            "%d assemble cycle(s) produced some new object(s) in %[ms]s: %s",
-            cycle,
-            System.currentTimeMillis() - begin,
-            before
-        );
+    public void exec() throws IOException {
+        new Assemble(
+            this.scopedTojos(),
+            new Parse(
+                this.scopedTojos().withSources(),
+                this.targetDir.toPath(),
+                this.cache.toPath(),
+                this.cacheEnabled,
+                this.plugin.getVersion(),
+                this.sourcesDir.toPath()
+            ),
+            new Probe(this.scopedTojos(), this.objectionary(), !this.offline),
+            new Pull(
+                this.scopedTojos().withoutSources(),
+                this.targetDir.toPath().resolve(Pull.DIR),
+                this.hash,
+                this.objectionary(),
+                this.cache.toPath().resolve(Pull.CACHE),
+                this.plugin.getVersion(),
+                this.overWrite,
+                this.cacheEnabled,
+                this.offline
+            )
+        ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
@@ -42,7 +42,7 @@ public final class MjAssemble extends MjSafe {
         new Assemble(
             this.scopedTojos(),
             new Parse(
-                this.scopedTojos().withSources(),
+                this.scopedTojos(),
                 this.targetDir.toPath(),
                 this.cache.toPath(),
                 this.cacheEnabled,
@@ -51,7 +51,7 @@ public final class MjAssemble extends MjSafe {
             ),
             new Probe(this.scopedTojos(), this.objectionary(), !this.offline),
             new Pull(
-                this.scopedTojos().withoutSources(),
+                this.scopedTojos(),
                 this.targetDir.toPath().resolve(Pull.DIR),
                 this.hash,
                 this.objectionary(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -36,7 +36,7 @@ public final class MjParse extends MjSafe {
     @Override
     public void exec() {
         new Parse(
-            this.scopedTojos().withSources(),
+            this.scopedTojos(),
             this.targetDir.toPath(),
             this.cache.toPath(),
             this.cacheEnabled,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -27,7 +27,7 @@ public final class MjPull extends MjSafe {
     @Override
     public void exec() throws IOException {
         new Pull(
-            this.scopedTojos().withoutSources(),
+            this.scopedTojos(),
             this.targetDir.toPath().resolve(Pull.DIR),
             this.hash,
             this.objectionary(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -430,6 +430,12 @@ abstract class MjSafe extends AbstractMojo {
 
     /**
      * Cached tojos.
+     * @todo #5098:90min Extract tojos lifecycle out of MjSafe.
+     *  TjsForeign and TjsPlaced are created, scoped, and closed here,
+     *  mixing Maven plumbing with catalog state management. Move their
+     *  construction and closing into each Mojo (or a dedicated owner)
+     *  so MjSafe is not responsible for their lifecycle. Ensure that
+     *  close() is still guaranteed even when exec() throws.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     private final TjsForeign tojos = new TjsForeign(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parse.java
@@ -53,9 +53,9 @@ final class Parse {
     static final String CACHE = "parsed";
 
     /**
-     * EO sources to parse.
+     * Foreign tojos catalog.
      */
-    private final Collection<TjForeign> tojos;
+    private final TjsForeign tojos;
 
     /**
      * Target directory.
@@ -88,7 +88,7 @@ final class Parse {
 
     /**
      * Constructor.
-     * @param srcs EO sources to parse
+     * @param srcs Foreign tojos catalog
      * @param target Target directory
      * @param cache Base cache directory
      * @param enabled Whether caching is enabled
@@ -97,7 +97,7 @@ final class Parse {
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     Parse(
-        final Collection<TjForeign> srcs,
+        final TjsForeign srcs,
         final Path target,
         final Path cache,
         final boolean enabled,
@@ -118,12 +118,13 @@ final class Parse {
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void exec() {
         final long start = System.currentTimeMillis();
+        final Collection<TjForeign> sources = this.tojos.withSources();
         final int total = new Threaded<>(
-            new Filtered<>(TjForeign::notParsed, this.tojos),
+            new Filtered<>(TjForeign::notParsed, sources),
             this::parsed
         ).total();
         if (0 == total) {
-            if (this.tojos.isEmpty()) {
+            if (sources.isEmpty()) {
                 Logger.info(
                     this,
                     "No .eo sources registered, nothing to be parsed to XMIRs (maybe you forgot to execute the \"register\" goal?)"
@@ -132,13 +133,13 @@ final class Parse {
                 Logger.info(
                     this,
                     "No new .eo sources out of %d parsed to XMIRs",
-                    this.tojos.size()
+                    sources.size()
                 );
             }
         } else {
             Logger.info(
                 this, "Parsed %d new .eo sources out of %d to XMIRs in %[ms]s",
-                total, this.tojos.size(), System.currentTimeMillis() - start
+                total, sources.size(), System.currentTimeMillis() - start
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pull.java
@@ -36,9 +36,9 @@ final class Pull {
     static final String CACHE = "pulled";
 
     /**
-     * Tojos without sources to pull.
+     * Foreign tojos catalog.
      */
-    private final Collection<TjForeign> tojos;
+    private final TjsForeign tojos;
 
     /**
      * Base target directory (targetDir + DIR).
@@ -82,7 +82,7 @@ final class Pull {
 
     /**
      * Constructor.
-     * @param tjs Tojos without sources
+     * @param tjs Foreign tojos catalog
      * @param dir Base target directory
      * @param hsh Commit hash
      * @param obj Objectionary
@@ -94,7 +94,7 @@ final class Pull {
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     Pull(
-        final Collection<TjForeign> tjs,
+        final TjsForeign tjs,
         final Path dir,
         final CommitHash hsh,
         final Objectionary obj,
@@ -128,9 +128,10 @@ final class Pull {
             return;
         }
         final long start = System.currentTimeMillis();
+        final Collection<TjForeign> sources = this.tojos.withoutSources();
         final Collection<String> names = new ArrayList<>(0);
         final String hsh = this.hash.value();
-        for (final TjForeign tojo : this.tojos) {
+        for (final TjForeign tojo : sources) {
             final String object = tojo.identifier();
             if (this.objectionary.isDirectory(object)) {
                 continue;
@@ -150,7 +151,7 @@ final class Pull {
             }
             names.add(object);
         }
-        if (this.tojos.isEmpty()) {
+        if (sources.isEmpty()) {
             Logger.info(
                 this,
                 "No programs were pulled in %[ms]s",
@@ -160,7 +161,7 @@ final class Pull {
             Logger.info(
                 this,
                 "%d program(s) were pulled in %[ms]s: %s",
-                this.tojos.size(),
+                sources.size(),
                 System.currentTimeMillis() - start,
                 names
             );


### PR DESCRIPTION
This PR refactors `MjAssemble` to reduce coupling with Maven by introducing the `Assemble` class for core logic, enhancing testability.

Fixes #5098