### PR TITLE
Add `nop` object to disable EO tests

### DIFF
--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -1,0 +1,29 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# The `nop` object is a no-operation: it ignores its argument and
+# always behaves as TRUE. It is useful for temporarily disabling a
+# test (or any other dataizable expression) without removing the
+# code, by wrapping the original body inside `nop`:
+#
+# ```
+# [] +> works-just-fine
+#   nop > @
+#     "doesn't work for now"
+# ```
+#
+# The wrapped expression is not evaluated, and the surrounding test
+# passes trivially.
+[x] > nop
+  true > @
+
+  # Tests that nop ignores its argument and behaves as TRUE.
+  [] +> tests-nop-is-true
+    nop "anything" > @
+
+  # Tests that nop returns TRUE regardless of the argument type.
+  [] +> tests-nop-with-number-is-true
+    nop 42 > @


### PR DESCRIPTION
## Summary
- Re-introduces `nop` as `[x] > nop` with `true > @`, per the design agreed in #4228 (Yegor + Maxon, 2026-05-05).
- Tests opt out by wrapping their body: `nop > @` makes the surrounding `+>` test pass trivially without evaluating the wrapped expression.
- Two inline tests cover the always-TRUE semantics for string and number arguments.

Fixes #4228

## Test plan
- [x] `EOnopTest` passes (2/0/0)
- [x] qulice-runtime build is green (`mvn clean install -Pqulice -pl eo-runtime -am -DskipTests`)