### PR TITLE
Use Expect.I64 for EOi64 arithmetic atoms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
@@ -26,17 +26,12 @@ public final class EOi64$EOdiv extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
+        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
+        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(
-            0,
-            new Data.ToPhi(
-                new BytesOf(
-                    new Dataized(this.take(Phi.RHO)).take(Long.class)
-                        / new Dataized(this.take("x").take("as-i64")).take(Long.class)
-                ).take()
-            )
-        );
+        num.put(0, new Data.ToPhi(new BytesOf(left / right).take()));
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
@@ -26,12 +26,17 @@ public final class EOi64$EOdiv extends PhDefault implements Atom {
     }
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
-        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
-        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(0, new Data.ToPhi(new BytesOf(left / right).take()));
+        num.put(
+            0,
+            new Data.ToPhi(
+                new BytesOf(
+                    new Expect.I64(Expect.at(this, Phi.RHO)).it()
+                        / new Expect.I64(Expect.at(this, "x")).it()
+                ).take()
+            )
+        );
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOgt.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOgt.java
@@ -26,10 +26,10 @@ public final class EOi64$EOgt extends PhDefault implements Atom {
     }
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
-        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
-        final Long right = new Expect.I64(Expect.at(this, "x")).it();
-        return new Data.ToPhi(left > right);
+        return new Data.ToPhi(
+            new Expect.I64(Expect.at(this, Phi.RHO)).it()
+            > new Expect.I64(Expect.at(this, "x")).it()
+        );
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOgt.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOgt.java
@@ -26,10 +26,10 @@ public final class EOi64$EOgt extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
-        return new Data.ToPhi(
-            new Dataized(this.take(Phi.RHO)).take(Long.class)
-                > new Dataized(this.take("x").take("as-i64")).take(Long.class)
-        );
+        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
+        final Long right = new Expect.I64(Expect.at(this, "x")).it();
+        return new Data.ToPhi(left > right);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOplus.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOplus.java
@@ -26,19 +26,12 @@ public final class EOi64$EOplus extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
+        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
+        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(
-            0,
-            new Data.ToPhi(
-                new BytesOf(
-                    Long.sum(
-                        new Dataized(this.take(Phi.RHO)).take(Long.class),
-                        new Dataized(this.take("x").take("as-i64")).take(Long.class)
-                    )
-                ).take()
-            )
-        );
+        num.put(0, new Data.ToPhi(new BytesOf(Long.sum(left, right)).take()));
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOplus.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOplus.java
@@ -26,12 +26,19 @@ public final class EOi64$EOplus extends PhDefault implements Atom {
     }
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
-        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
-        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(0, new Data.ToPhi(new BytesOf(Long.sum(left, right)).take()));
+        num.put(
+            0,
+            new Data.ToPhi(
+                new BytesOf(
+                    Long.sum(
+                        new Expect.I64(Expect.at(this, Phi.RHO)).it(),
+                        new Expect.I64(Expect.at(this, "x")).it()
+                    )
+                ).take()
+            )
+        );
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOtimes.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOtimes.java
@@ -26,17 +26,12 @@ public final class EOi64$EOtimes extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
+        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
+        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(
-            0,
-            new Data.ToPhi(
-                new BytesOf(
-                    new Dataized(this.take(Phi.RHO)).take(Long.class)
-                        * new Dataized(this.take("x").take("as-i64")).take(Long.class)
-                ).take()
-            )
-        );
+        num.put(0, new Data.ToPhi(new BytesOf(left * right).take()));
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOtimes.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOtimes.java
@@ -26,12 +26,17 @@ public final class EOi64$EOtimes extends PhDefault implements Atom {
     }
 
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
-        final Long left = new Expect.I64(Expect.at(this, Phi.RHO)).it();
-        final Long right = new Expect.I64(Expect.at(this, "x")).it();
         final Phi num = Phi.Φ.take("i64").copy();
-        num.put(0, new Data.ToPhi(new BytesOf(left * right).take()));
+        num.put(
+            0,
+            new Data.ToPhi(
+                new BytesOf(
+                    new Expect.I64(Expect.at(this, Phi.RHO)).it()
+                        * new Expect.I64(Expect.at(this, "x")).it()
+                ).take()
+            )
+        );
         return num;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -268,6 +268,38 @@ public class Expect<T> {
     }
 
     /**
+     * Transform Expect to Long (i64).
+     * @since 0.51
+     */
+    public static final class I64 {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public I64(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
+        public Long it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).take(Long.class))
+                .otherwise("must be an i64")
+                .it();
+        }
+    }
+
+    /**
      * Transform Expect to Natural number.
      * Natural number is integer greater or equal to zero.
      * @since 0.51

--- a/eo-runtime/src/test/java/org/eolang/EOi64ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOi64ExpectTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (10 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test case verifying {@link Expect}-based error messages
+ * raised by the {@code EOi64$*} arithmetic atoms.
+ * @since 0.51
+ * @checkstyle TypeNameCheck (4 lines)
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class EOi64ExpectTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        classes = {
+            EOi64$EOdiv.class,
+            EOi64$EOgt.class,
+            EOi64$EOplus.class,
+            EOi64$EOtimes.class
+        }
+    )
+    void throwsCorrectErrorForXAttr(final Class<?> cls) {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            (Phi) cls.getDeclaredConstructor().newInstance(),
+                            Phi.RHO,
+                            new Data.ToPhi(42L)
+                        ),
+                        "x",
+                        new Data.ToPhi(true)
+                    )
+                ).take(),
+                "operation with TRUE fails with a proper message that explains what happened"
+            ).getMessage(),
+            Matchers.equalTo("the 'x' attribute must be an i64")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        classes = {
+            EOi64$EOdiv.class,
+            EOi64$EOgt.class,
+            EOi64$EOplus.class,
+            EOi64$EOtimes.class
+        }
+    )
+    void throwsCorrectErrorForRhoAttr(final Class<?> cls) {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        (Phi) cls.getDeclaredConstructor().newInstance(),
+                        Phi.RHO,
+                        new Data.ToPhi(true)
+                    )
+                ).take(),
+                "EOi64 must be an i64"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute must be an i64")
+        );
+    }
+}


### PR DESCRIPTION
Mirrors merged PR #3789 (which introduced `Expect.Number` for the four `EOnumber$EO{div,gt,plus,times}` atoms) for the corresponding four `EOi64$EO*` atoms.

## Changes

- Add `Expect.I64` inner class to `Expect.java`, mirroring the existing `Expect.Number`/`Int`/`Natural` pattern. Returns `Long`, validates via `Dataized.take(Long.class)` (which length-checks via `BytesRaw.whenFit`).
- Migrate `EOi64$EOdiv|gt|plus|times` to use `Expect.I64` for both `ρ` and `x`.
- Add `EOi64ExpectTest` with parameterized cases (mirrors `EOnumberTest.throwsCorrectErrorForXAttr` / `throwsCorrectErrorForRhoAttr`) asserting `the 'x'/'ρ' attribute must be an i64` on wrong-typed inputs.

## Note on coercion

The previous `take(\"as-i64\")` chain on `x` is removed. This matches:
- The EO-level contract documented in `i64.eo`: *Here `x` must be an `org.eolang.i64` object.*
- The precedent set by #3789, which similarly does **not** chain `take(\"as-number\")` on `x` for the `EOnumber` atoms.

Behavior change: passing a non-`i64` Phi (e.g. a `number` literal) directly to `i64.plus`/etc. previously coerced silently; now it raises an `Expect`-wrapped error. EO programs that follow the documented contract (`x.as-i64.plus y.as-i64`) are unaffected.

## Scope

Diff is **172 lines** (89 main + 83 test), under the `pr-size` 200-line gate. The issue stays **open** — remaining clusters (`EObytes$*` bitwise ops, `EOmalloc$*`, etc.) can land in follow-up PRs using the same pattern.

Verified locally:
- `mvn -DskipTests -DskipITs -Pqulice verify` — BUILD SUCCESS
- `mvn test -Dtest=EOi64ExpectTest,EOi64Test,EOnumberTest,EOnumberEOAtomTest` — 82 tests, 0 failures

Ref: #3461