### PR TITLE
fix(#5110): re-enable compilation with proxy test

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -27,19 +27,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
- * @todo #5102:60min Fix flaky proxy compilation test and re-enable it.
- *  The test {@code checksThatWeCanCompileTheProgramWithProxySet} fails with
- *  "BuildFailure build failed with exit code 0x0001" across multiple PRs,
- *  indicating a systemic issue unrelated to any specific change. Investigate
- *  why Farea.exec("package") exits with code 1 when routing through the local
- *  Jetty proxy, fix the root cause, remove @Disabled, and re-enable the test.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
@@ -66,7 +59,6 @@ final class ProxyIT {
         }
     }
 
-    @Disabled
     @Test
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -8,9 +8,15 @@ import com.jcabi.aspects.RetryOnFailure;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Input;
@@ -77,7 +83,18 @@ final class OyRemote implements Objectionary {
         if (this.proxies.isEmpty()) {
             remote = new InputOf(url);
         } else {
-            remote = () -> url.openConnection(this.proxies.get(0)).getInputStream();
+            remote = () -> {
+                try {
+                    return OyRemote.clientWith(this.proxies.get(0))
+                        .send(
+                            HttpRequest.newBuilder().uri(URI.create(url.toString())).GET().build(),
+                            HttpResponse.BodyHandlers.ofInputStream()
+                        ).body();
+                } catch (final InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(ex);
+                }
+            };
         }
         return new InputWithFallback(
             remote,
@@ -110,7 +127,16 @@ final class OyRemote implements Objectionary {
         if (this.proxies.isEmpty()) {
             code = ((HttpURLConnection) url.openConnection()).getResponseCode();
         } else {
-            code = ((HttpURLConnection) url.openConnection(this.proxies.get(0))).getResponseCode();
+            try {
+                code = OyRemote.clientWith(this.proxies.get(0))
+                    .send(
+                        HttpRequest.newBuilder().uri(URI.create(url.toString())).GET().build(),
+                        HttpResponse.BodyHandlers.discarding()
+                    ).statusCode();
+            } catch (final InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new IOException(ex);
+            }
         }
         if (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT || code == 429) {
             throw new IOException(
@@ -118,6 +144,13 @@ final class OyRemote implements Objectionary {
             );
         }
         return code >= HttpURLConnection.HTTP_OK && code < HttpURLConnection.HTTP_BAD_REQUEST;
+    }
+
+    private static HttpClient clientWith(final Proxy proxy) {
+        return HttpClient.newBuilder()
+            .proxy(ProxySelector.of((InetSocketAddress) proxy.address()))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -17,10 +17,8 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Input;
-import org.cactoos.io.InputOf;
 import org.cactoos.io.InputWithFallback;
 
 /**
@@ -41,9 +39,9 @@ final class OyRemote implements Objectionary {
     private final UrlOy directory;
 
     /**
-     * Proxies list to use for HTTP if needed.
+     * HTTP client, configured with proxy when provided.
      */
-    private final List<Proxy> proxies;
+    private final HttpClient http;
 
     /**
      * Constructor.
@@ -60,7 +58,7 @@ final class OyRemote implements Objectionary {
             "https://github.com/objectionary/home/tree/%s/objects/%s",
             hash
         );
-        this.proxies = List.of(proxies);
+        this.http = OyRemote.client(proxies);
     }
 
     @Override
@@ -79,25 +77,8 @@ final class OyRemote implements Objectionary {
             this, "The object '%s' will be pulled from %s...",
             name, url
         );
-        final Input remote;
-        if (this.proxies.isEmpty()) {
-            remote = new InputOf(url);
-        } else {
-            remote = () -> {
-                try {
-                    return OyRemote.clientWith(this.proxies.get(0))
-                        .send(
-                            HttpRequest.newBuilder().uri(URI.create(url.toString())).GET().build(),
-                            HttpResponse.BodyHandlers.ofInputStream()
-                        ).body();
-                } catch (final InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                    throw new IOException(ex);
-                }
-            };
-        }
         return new InputWithFallback(
-            remote,
+            () -> this.send(url, HttpResponse.BodyHandlers.ofInputStream()).body(),
             input -> {
                 throw new IOException(
                     String.format(
@@ -123,21 +104,7 @@ final class OyRemote implements Objectionary {
 
     @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
     private boolean exists(final URL url) throws IOException {
-        final int code;
-        if (this.proxies.isEmpty()) {
-            code = ((HttpURLConnection) url.openConnection()).getResponseCode();
-        } else {
-            try {
-                code = OyRemote.clientWith(this.proxies.get(0))
-                    .send(
-                        HttpRequest.newBuilder().uri(URI.create(url.toString())).GET().build(),
-                        HttpResponse.BodyHandlers.discarding()
-                    ).statusCode();
-            } catch (final InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new IOException(ex);
-            }
-        }
+        final int code = this.send(url, HttpResponse.BodyHandlers.discarding()).statusCode();
         if (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT || code == 429) {
             throw new IOException(
                 String.format("Transient HTTP error %d for %s, will retry", code, url)
@@ -146,11 +113,27 @@ final class OyRemote implements Objectionary {
         return code >= HttpURLConnection.HTTP_OK && code < HttpURLConnection.HTTP_BAD_REQUEST;
     }
 
-    private static HttpClient clientWith(final Proxy proxy) {
-        return HttpClient.newBuilder()
-            .proxy(ProxySelector.of((InetSocketAddress) proxy.address()))
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
+    private <T> HttpResponse<T> send(
+        final URL url, final HttpResponse.BodyHandler<T> handler
+    ) throws IOException {
+        try {
+            return this.http.send(
+                HttpRequest.newBuilder().uri(URI.create(url.toString())).GET().build(),
+                handler
+            );
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IOException(ex);
+        }
+    }
+
+    private static HttpClient client(final Proxy... proxies) {
+        final HttpClient.Builder builder = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL);
+        if (proxies.length > 0) {
+            builder.proxy(ProxySelector.of((InetSocketAddress) proxies[0].address()));
+        }
+        return builder.build();
     }
 
     /**


### PR DESCRIPTION
Re-enables `checksThatWeCanCompileTheProgramWithProxySet` test in `ProxyIT` after fixing the flaky proxy compilation issue.

Fixes #5110