### PR TITLE
refactor(#5120): extract HelloWorld EO fixture into shared test resource

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -258,17 +258,7 @@ final class FakeMaven {
      * @throws IOException If method can't save eo program to the workspace.
      */
     FakeMaven withHelloWorld() throws IOException {
-        return this.withProgram(
-            "+alias stdout org.eolang.io.stdout",
-            "+home https://www.eolang.org",
-            "+package foo.x",
-            "+unlint object-has-data",
-            "+version 0.0.0",
-            "",
-            "# No comments.",
-            "[x] > main",
-            "  (stdout \"Hello!\" x).print > @"
-        );
+        return this.withProgram(new HelloWorld().asString());
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/HelloWorld.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/HelloWorld.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+
+/**
+ * A standard "hello world" EO program used as a shared test fixture.
+ * @since 0.61.0
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class HelloWorld {
+
+    /**
+     * Path to the EO resource file.
+     */
+    private final String resource;
+
+    HelloWorld() {
+        this.resource = "org/eolang/maven/hello-world.eo";
+    }
+
+    String asString() {
+        return new UncheckedText(
+            new TextOf(new ResourceOf(this.resource))
+        ).asString();
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -17,10 +17,6 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test cases for {@link Probing}.
  * @since 0.67.0
- * @todo #5084:30min Create a reusable test helper that represents a standard EO program
- *  (like the hello-world one) for use across tests like {@link ProbingTest} and
- *  {@link MjProbeTest} and {@link FakeMaven#withHelloWorld()}, so we don't duplicate
- *  the EO source inline in multiple places.
  */
 final class ProbingTest {
 
@@ -30,18 +26,7 @@ final class ProbingTest {
         Files.write(
             xmir,
             new EoSyntax(
-                String.join(
-                    System.lineSeparator(),
-                    "+alias stdout org.eolang.io.stdout",
-                    "+home https://www.eolang.org",
-                    "+package foo.x",
-                    "+unlint object-has-data",
-                    "+version 0.0.0",
-                    "",
-                    "# No comments.",
-                    "[x] > main",
-                    "  (stdout \"Hello!\" x).print > @"
-                )
+                new HelloWorld().asString()
             ).parsed().toString().getBytes(StandardCharsets.UTF_8)
         );
         final TjsForeign tojos = new TjsForeign();

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
@@ -1,0 +1,11 @@
++alias stdout org.eolang.io.stdout
++home https://www.eolang.org
++package foo.x
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint object-has-data
++version 0.0.0
+
+# No comments.
+[x] > main
+  (stdout "Hello!" x).print > @


### PR DESCRIPTION
Introduces a reusable `HelloWorld` test fixture backed by a shared `hello-world.eo` resource, eliminating duplicated EO source across `FakeMaven`, `ProbingTest`, and related tests.

Fixes #5120