### PR TITLE
refactor(#5121): extract `Compiling` class from `MjCompile`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+
+/**
+ * Core compilation orchestration: runs Assembling, Linting, Resolving, and Placing in sequence.
+ *
+ * <p>
+ *     This class combines {@link Assembling}, {@link Linting}, {@link Resolving} and
+ *     {@link Placing} steps into a single sequential execution.
+ *     See their documentation for more details.
+ * </p>
+ *
+ * @since 0.61.0
+ */
+final class Compiling {
+
+    /**
+     * Assembling step.
+     */
+    private final Assembling assembling;
+
+    /**
+     * Linting step.
+     */
+    private final Linting linting;
+
+    /**
+     * Resolving step.
+     */
+    private final Resolving resolving;
+
+    /**
+     * Placing step.
+     */
+    private final Placing placing;
+
+    /**
+     * Constructor.
+     * @param asmbl Assembling step
+     * @param lnt Linting step
+     * @param rslv Resolving step
+     * @param plc Placing step
+     */
+    Compiling(
+        final Assembling asmbl,
+        final Linting lnt,
+        final Resolving rslv,
+        final Placing plc
+    ) {
+        this.assembling = asmbl;
+        this.linting = lnt;
+        this.resolving = rslv;
+        this.placing = plc;
+    }
+
+    /**
+     * Execute the full compilation pipeline.
+     * @throws IOException If any step fails
+     */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void exec() throws IOException {
+        final long begin = System.currentTimeMillis();
+        this.assembling.exec();
+        this.linting.exec();
+        this.resolving.exec();
+        this.placing.exec();
+        Logger.info(
+            this,
+            "Compilation process took %[ms]s",
+            System.currentTimeMillis() - begin
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -46,6 +46,7 @@ final class Compiling {
      * @param lnt Linting step
      * @param rslv Resolving step
      * @param plc Placing step
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     Compiling(
         final Assembling asmbl,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
@@ -39,28 +39,6 @@ public final class MjAssemble extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Assembling(
-            this.scopedTojos(),
-            new Parsing(
-                this.scopedTojos(),
-                this.targetDir.toPath(),
-                this.cache.toPath(),
-                this.cacheEnabled,
-                this.plugin.getVersion(),
-                this.sourcesDir.toPath()
-            ),
-            new Probing(this.scopedTojos(), this.objectionary(), !this.offline),
-            new Pulling(
-                this.scopedTojos(),
-                this.targetDir.toPath().resolve(Pulling.DIR),
-                this.hash,
-                this.objectionary(),
-                this.cache.toPath().resolve(Pulling.CACHE),
-                this.plugin.getVersion(),
-                this.overWrite,
-                this.cacheEnabled,
-                this.offline
-            )
-        ).exec();
+        this.assembling().exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -4,7 +4,7 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
+import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -28,27 +28,66 @@ import org.apache.maven.plugins.annotations.Mojo;
 )
 public final class MjCompile extends MjSafe {
 
-    /**
-     * Mojas to execute.
-     */
-    private static final Moja<?>[] MOJAS = {
-        new Moja<>(MjAssemble.class),
-        new Moja<>(MjLint.class),
-        new Moja<>(MjResolve.class),
-        new Moja<>(MjPlace.class),
-    };
-
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    public void exec() {
-        final long begin = System.currentTimeMillis();
-        for (final Moja<?> moja : MjCompile.MOJAS) {
-            moja.copy(this).execute();
-        }
-        Logger.info(
-            this,
-            "Compilation process took %[ms]s",
-            System.currentTimeMillis() - begin
-        );
+    public void exec() throws IOException {
+        new Compiling(
+            new Assembling(
+                this.scopedTojos(),
+                new Parsing(
+                    this.scopedTojos(),
+                    this.targetDir.toPath(),
+                    this.cache.toPath(),
+                    this.cacheEnabled,
+                    this.plugin.getVersion(),
+                    this.sourcesDir.toPath()
+                ),
+                new Probing(this.scopedTojos(), this.objectionary(), !this.offline),
+                new Pulling(
+                    this.scopedTojos(),
+                    this.targetDir.toPath().resolve(Pulling.DIR),
+                    this.hash,
+                    this.objectionary(),
+                    this.cache.toPath().resolve(Pulling.CACHE),
+                    this.plugin.getVersion(),
+                    this.overWrite,
+                    this.cacheEnabled,
+                    this.offline
+                )
+            ),
+            new Linting(
+                this.scopedTojos(),
+                this.compileTojos(),
+                this.targetDir.toPath(),
+                this.cache.toPath(),
+                this.cacheEnabled,
+                this.plugin.getVersion(),
+                this.skipSourceLints,
+                this.skipProgramLints,
+                this.skipExperimentalLints,
+                this.failOnWarning,
+                this.lintAsPackage,
+                this.sourcesDir.toPath(),
+                this.skipLinting
+            ),
+            new Resolving(
+                this.scopedTojos(),
+                this.targetDir.toPath().resolve(MjResolve.DIR),
+                new CentralMaven(this.system),
+                this.discoverSelf,
+                this.skipZeroVersions,
+                this.resolveJna,
+                this.ignoreRuntime,
+                this.runtime(),
+                this.ignoreVersionConflicts
+            ),
+            new Placing(
+                this.placedTojos,
+                this.targetDir.toPath().resolve(MjResolve.DIR),
+                this.classesDir.toPath(),
+                this.placeBinaries,
+                this.skipBinaries,
+                this.rewriteBinaries
+            )
+        ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -31,29 +31,7 @@ public final class MjCompile extends MjSafe {
     @Override
     public void exec() throws IOException {
         new Compiling(
-            new Assembling(
-                this.scopedTojos(),
-                new Parsing(
-                    this.scopedTojos(),
-                    this.targetDir.toPath(),
-                    this.cache.toPath(),
-                    this.cacheEnabled,
-                    this.plugin.getVersion(),
-                    this.sourcesDir.toPath()
-                ),
-                new Probing(this.scopedTojos(), this.objectionary(), !this.offline),
-                new Pulling(
-                    this.scopedTojos(),
-                    this.targetDir.toPath().resolve(Pulling.DIR),
-                    this.hash,
-                    this.objectionary(),
-                    this.cache.toPath().resolve(Pulling.CACHE),
-                    this.plugin.getVersion(),
-                    this.overWrite,
-                    this.cacheEnabled,
-                    this.offline
-                )
-            ),
+            this.assembling(),
             new Linting(
                 this.scopedTojos(),
                 this.compileTojos(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -9,7 +9,6 @@ import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.cactoos.Scalar;
 
 /**
  * Find all required runtime dependencies, download
@@ -50,20 +49,6 @@ public final class MjResolve extends MjSafe {
      */
     private BiConsumer<Dependency, Path> central;
 
-    /**
-     * Resolve default JNA dependency or not.
-     * @checkstyle MemberNameCheck (7 lines)
-     */
-    @SuppressWarnings("PMD.ImmutableField")
-    private boolean resolveJna = true;
-
-    /**
-     * Resolve dependencies in central or not.
-     * @checkstyle MemberNameCheck (7 lines)
-     */
-    @SuppressWarnings("PMD.ImmutableField")
-    private boolean resolveInCentral = true;
-
     @Override
     public void exec() {
         if (this.central == null) {
@@ -80,18 +65,5 @@ public final class MjResolve extends MjSafe {
             this.runtime(),
             this.ignoreVersionConflicts
         ).exec();
-    }
-
-    private Scalar<Dep> runtime() {
-        final Scalar<Dep> result;
-        final RtPom pom = new RtPom(this.project);
-        if (pom.isPresent()) {
-            result = pom;
-        } else if (this.resolveInCentral) {
-            result = new RtCentral();
-        } else {
-            result = new RtOffline();
-        }
-        return result;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -415,6 +415,22 @@ abstract class MjSafe extends AbstractMojo {
     );
 
     /**
+     * Resolve default JNA dependency or not.
+     * @checkstyle MemberNameCheck (7 lines)
+     * @checkstyle VisibilityModifierCheck (7 lines)
+     */
+    @SuppressWarnings("PMD.ImmutableField")
+    protected boolean resolveJna = true;
+
+    /**
+     * Resolve dependencies in central or not.
+     * @checkstyle MemberNameCheck (7 lines)
+     * @checkstyle VisibilityModifierCheck (7 lines)
+     */
+    @SuppressWarnings("PMD.ImmutableField")
+    protected boolean resolveInCentral = true;
+
+    /**
      * Objectionary.
      * @since 0.50
      * @checkstyle MemberNameCheck (5 lines)
@@ -535,6 +551,23 @@ abstract class MjSafe extends AbstractMojo {
 
     Objectionary objectionary() {
         return new Unchecked<>(this.objectionary).value();
+    }
+
+    /**
+     * Select the Maven EO runtime dependency source.
+     * @return Scalar supplying the runtime dependency
+     */
+    Scalar<Dep> runtime() {
+        final Scalar<Dep> result;
+        final RtPom pom = new RtPom(this.project);
+        if (pom.isPresent()) {
+            result = pom;
+        } else if (this.resolveInCentral) {
+            result = new RtCentral();
+        } else {
+            result = new RtOffline();
+        }
+        return result;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -419,7 +419,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean resolveJna = true;
 
     /**
@@ -427,7 +426,6 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean resolveInCentral = true;
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -569,6 +569,36 @@ abstract class MjSafe extends AbstractMojo {
     }
 
     /**
+     * Build the assembling step from this mojo's configuration.
+     * @return Configured Assembling instance
+     */
+    Assembling assembling() {
+        return new Assembling(
+            this.scopedTojos(),
+            new Parsing(
+                this.scopedTojos(),
+                this.targetDir.toPath(),
+                this.cache.toPath(),
+                this.cacheEnabled,
+                this.plugin.getVersion(),
+                this.sourcesDir.toPath()
+            ),
+            new Probing(this.scopedTojos(), this.objectionary(), !this.offline),
+            new Pulling(
+                this.scopedTojos(),
+                this.targetDir.toPath().resolve(Pulling.DIR),
+                this.hash,
+                this.objectionary(),
+                this.cache.toPath().resolve(Pulling.CACHE),
+                this.plugin.getVersion(),
+                this.overWrite,
+                this.cacheEnabled,
+                this.offline
+            )
+        );
+    }
+
+    /**
      * Get active proxy from Maven settings.
      * @return Proxy if any
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import org.cactoos.set.SetOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@link Compiling}.
+ * @since 0.61.0
+ */
+final class CompilingTest {
+
+    @Test
+    void runsWithoutExceptions(@TempDir final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new Compiling(
+                new Assembling(
+                    new TjsForeign(),
+                    new Parsing(
+                        new TjsForeign(),
+                        temp,
+                        temp,
+                        false,
+                        "0.0.0",
+                        temp
+                    ),
+                    new Probing(new TjsForeign(), new Objectionary.Fake(), false),
+                    new Pulling(
+                        new TjsForeign(),
+                        temp.resolve(Pulling.DIR),
+                        CommitHash.FAKE,
+                        new Objectionary.Fake(),
+                        temp.resolve(Pulling.CACHE),
+                        "0.0.0",
+                        false,
+                        false,
+                        true
+                    )
+                ),
+                new Linting(
+                    new TjsForeign(),
+                    new TjsForeign(),
+                    temp,
+                    temp,
+                    false,
+                    "0.0.0",
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    false,
+                    false,
+                    false,
+                    temp,
+                    true
+                ),
+                new Resolving(
+                    new TjsForeign(),
+                    temp.resolve("resolve"),
+                    (dep, path) -> { },
+                    false,
+                    false,
+                    false,
+                    true,
+                    () -> {
+                        throw new IllegalStateException("no runtime expected");
+                    },
+                    false
+                ),
+                new Placing(
+                    new TjsPlaced(temp.resolve("placed.json")),
+                    temp.resolve("nonexistent"),
+                    temp,
+                    new SetOf<>("**"),
+                    new SetOf<>(),
+                    false
+                )
+            ).exec(),
+            "Compiling must complete without exceptions for empty input"
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -18,69 +18,71 @@ import org.junit.jupiter.api.io.TempDir;
 final class CompilingTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void runsWithoutExceptions(@TempDir final Path temp) {
-        Assertions.assertDoesNotThrow(
-            () -> new Compiling(
-                new Assembling(
-                    new TjsForeign(),
-                    new Parsing(
-                        new TjsForeign(),
-                        temp,
-                        temp,
-                        false,
-                        "0.0.0",
-                        temp
-                    ),
-                    new Probing(new TjsForeign(), new Objectionary.Fake(), false),
-                    new Pulling(
-                        new TjsForeign(),
-                        temp.resolve(Pulling.DIR),
-                        CommitHash.FAKE,
-                        new Objectionary.Fake(),
-                        temp.resolve(Pulling.CACHE),
-                        "0.0.0",
-                        false,
-                        false,
-                        true
-                    )
-                ),
-                new Linting(
-                    new TjsForeign(),
+        final Compiling compiling = new Compiling(
+            new Assembling(
+                new TjsForeign(),
+                new Parsing(
                     new TjsForeign(),
                     temp,
                     temp,
                     false,
                     "0.0.0",
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    false,
-                    false,
-                    false,
-                    temp,
-                    true
+                    temp
                 ),
-                new Resolving(
+                new Probing(new TjsForeign(), new Objectionary.Fake(), false),
+                new Pulling(
                     new TjsForeign(),
-                    temp.resolve("resolve"),
-                    (dep, path) -> { },
+                    temp.resolve(Pulling.DIR),
+                    CommitHash.FAKE,
+                    new Objectionary.Fake(),
+                    temp.resolve(Pulling.CACHE),
+                    "0.0.0",
                     false,
                     false,
-                    false,
-                    true,
-                    () -> {
-                        throw new IllegalStateException("no runtime expected");
-                    },
-                    false
-                ),
-                new Placing(
-                    new TjsPlaced(temp.resolve("placed.json")),
-                    temp.resolve("nonexistent"),
-                    temp,
-                    new SetOf<>("**"),
-                    new SetOf<>(),
-                    false
+                    true
                 )
-            ).exec(),
+            ),
+            new Linting(
+                new TjsForeign(),
+                new TjsForeign(),
+                temp,
+                temp,
+                false,
+                "0.0.0",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                false,
+                false,
+                false,
+                temp,
+                true
+            ),
+            new Resolving(
+                new TjsForeign(),
+                temp.resolve("resolve"),
+                (dep, path) -> { },
+                false,
+                false,
+                false,
+                true,
+                () -> {
+                    throw new IllegalStateException("no runtime expected");
+                },
+                false
+            ),
+            new Placing(
+                new TjsPlaced(temp.resolve("placed.json")),
+                temp.resolve("nonexistent"),
+                temp,
+                new SetOf<>("**"),
+                new SetOf<>(),
+                false
+            )
+        );
+        Assertions.assertDoesNotThrow(
+            compiling::exec,
             "Compiling must complete without exceptions for empty input"
         );
     }


### PR DESCRIPTION
Introduces `Compiling` class to decouple core compilation orchestration from `MjCompile` Maven entry point, following the same pattern applied to other mojas.

Fixes #5121