### PR TITLE
Use Expect in i16/i32/i64 converter atoms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOi16$EOas_i32.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi16$EOas_i32.java
@@ -25,7 +25,7 @@ public final class EOi16$EOas_i32 extends PhDefault implements Atom {
             0,
             new ToPhi(
                 new BytesOf(
-                    new Dataized(this.take(Phi.RHO)).take(Short.class).intValue()
+                    new Expect.I16(Expect.at(this, Phi.RHO)).it().intValue()
                 ).take()
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/EOi32$EOas_i64.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi32$EOas_i64.java
@@ -26,7 +26,7 @@ public final class EOi32$EOas_i64 extends PhDefault implements Atom {
             0,
             new Data.ToPhi(
                 new BytesOf(
-                    new Dataized(this.take(Phi.RHO)).take(Integer.class).longValue()
+                    new Expect.I32(Expect.at(this, Phi.RHO)).it().longValue()
                 ).take()
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOas_number.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOas_number.java
@@ -21,7 +21,7 @@ public final class EOi64$EOas_number extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         return new Data.ToPhi(
-            new Dataized(this.take(Phi.RHO)).take(Long.class).doubleValue()
+            new Expect.I64(Expect.at(this, Phi.RHO)).it().doubleValue()
         );
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -268,6 +268,70 @@ public class Expect<T> {
     }
 
     /**
+     * Transform Expect to Short (i16).
+     * @since 0.51
+     */
+    public static final class I16 {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public I16(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
+        public Short it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).take(Short.class))
+                .otherwise("must be an i16")
+                .it();
+        }
+    }
+
+    /**
+     * Transform Expect to Integer (i32).
+     * @since 0.51
+     */
+    public static final class I32 {
+
+        /**
+         * Expect.
+         */
+        private final Expect<Phi> expect;
+
+        /**
+         * Ctor.
+         * @param expect Expect
+         */
+        public I32(final Expect<Phi> expect) {
+            this.expect = expect;
+        }
+
+        /**
+         * Return it.
+         * @return The token
+         * @checkstyle MethodNameCheck (5 lines)
+         */
+        public Integer it() {
+            return this.expect
+                .that(phi -> new Dataized(phi).take(Integer.class))
+                .otherwise("must be an i32")
+                .it();
+        }
+    }
+
+    /**
      * Transform Expect to Long (i64).
      * @since 0.51
      */

--- a/eo-runtime/src/test/java/org/eolang/EOiConvertersExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOiConvertersExpectTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (10 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test case verifying {@link Expect}-based error messages
+ * raised by the {@code EOi16/i32/i64} converter atoms.
+ * @since 0.51
+ * @checkstyle TypeNameCheck (4 lines)
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class EOiConvertersExpectTest {
+
+    @ParameterizedTest
+    @MethodSource("converters")
+    void throwsCorrectErrorForRhoAttr(final Class<?> cls, final String expected) {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        (Phi) cls.getDeclaredConstructor().newInstance(),
+                        Phi.RHO,
+                        new Data.ToPhi(true)
+                    )
+                ).take(),
+                "conversion with a non-integer rho must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    private static Stream<Arguments> converters() {
+        return Stream.of(
+            Arguments.of(EOi16$EOas_i32.class, "the 'ρ' attribute must be an i16"),
+            Arguments.of(EOi32$EOas_i64.class, "the 'ρ' attribute must be an i32"),
+            Arguments.of(EOi64$EOas_number.class, "the 'ρ' attribute must be an i64")
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to merged PR #5117. Migrates the three remaining numeric **converter** atoms in the `i16`/`i32`/`i64` family to use `Expect` for `ρ` validation, following the same pattern.

## Scope clarification

After #5117 landed, the only atoms left in the integer family that still bypass `Expect` are the converters — there are no `EOi32$EO{div,gt,plus,times}` etc. Java atoms; those operations are implemented in `i32.eo`/`i16.eo` and delegate to `i64` after `as-i64` conversion.

## Changes

- Add `Expect.I16` (returns `Short`, validates via `Dataized.take(Short.class)`) and `Expect.I32` (returns `Integer`, validates via `Dataized.take(Integer.class)`) inner classes to `Expect.java`, mirroring the existing `Expect.I64`.
- Migrate three converter atoms:
  - `EOi16$EOas_i32` → `Expect.I16`
  - `EOi32$EOas_i64` → `Expect.I32`
  - `EOi64$EOas_number` → `Expect.I64` (reuse)
- Add `EOiConvertersExpectTest` — parameterized via `@MethodSource` so each class is paired with its expected message (`the 'ρ' attribute must be an i16/i32/i64`).

## Diff size

5 files, **+123 / -3** lines — well under the `pr-size` 200-line gate.

## Verified locally

- `mvn -DskipTests -DskipITs -Pqulice verify` — BUILD SUCCESS, no PMD suppressions added (per #5117 review feedback).
- `mvn test -Dtest=EOiConvertersExpectTest,EOi64ExpectTest,EOi64Test,EOi32Test,EOi16Test,EOnumberTest,EOnumberEOAtomTest` — **139 tests, 0 failures**.

## Issue stays open

Remaining clusters for follow-up PRs: `EObytes$*` bitwise ops, `EOmalloc$*`. The `EOmalloc` cluster warrants a maintainer ping before starting — PR #3853 in that subtree was closed silently in April.

Ref: #3461