### PR TITLE
feat(#5134): extract timing logic into `Timed` step decorator

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
@@ -10,9 +10,9 @@ import java.io.IOException;
 /**
  * Assembles EO sources by running Parsing, Probing, and Pulling in a loop
  * until no new objects are discovered.
- * @since 0.67.0
+ * @since 0.61.0
  */
-final class Assembling {
+final class Assembling implements Step {
 
     /**
      * Tojos to check assembly status.
@@ -58,8 +58,9 @@ final class Assembling {
      * Run assembly cycles until stable.
      * @throws IOException If fails
      */
+    @Override
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    void exec() throws IOException {
+    public void exec() throws IOException {
         final long begin = System.currentTimeMillis();
         String before = this.tojos.status();
         int cycle = 0;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
@@ -22,17 +22,17 @@ final class Assembling implements Step {
     /**
      * Parse step.
      */
-    private final Parsing parse;
+    private final Step parse;
 
     /**
      * Probe step.
      */
-    private final Probing probe;
+    private final Step probe;
 
     /**
      * Pull step.
      */
-    private final Pulling pull;
+    private final Step pull;
 
     /**
      * Constructor.
@@ -44,9 +44,9 @@ final class Assembling implements Step {
      */
     Assembling(
         final TjsForeign tjs,
-        final Parsing prs,
-        final Probing prb,
-        final Pulling pll
+        final Step prs,
+        final Step prb,
+        final Step pll
     ) {
         this.tojos = tjs;
         this.parse = prs;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
@@ -54,10 +54,6 @@ final class Assembling implements Step {
         this.pull = pll;
     }
 
-    /**
-     * Run assembly cycles until stable.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         String before = this.tojos.status();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Assembling.java
@@ -59,13 +59,10 @@ final class Assembling implements Step {
      * @throws IOException If fails
      */
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() throws IOException {
-        final long begin = System.currentTimeMillis();
         String before = this.tojos.status();
         int cycle = 0;
         while (true) {
-            final long start = System.currentTimeMillis();
             this.parse.exec();
             this.probe.exec();
             this.pull.exec();
@@ -73,23 +70,22 @@ final class Assembling implements Step {
             ++cycle;
             if (after.equals(before)) {
                 Logger.info(
-                    this, "Last assemble cycle #%d (%s), took %[ms]s",
-                    cycle, after, System.currentTimeMillis() - start
+                    this, "Last assemble cycle #%d (%s)",
+                    cycle, after
                 );
                 break;
             } else {
                 Logger.info(
-                    this, "Assemble cycle #%d (%s -> %s), took %[ms]s",
-                    cycle, before, after, System.currentTimeMillis() - start
+                    this, "Assemble cycle #%d (%s -> %s)",
+                    cycle, before, after
                 );
             }
             before = after;
         }
         Logger.info(
             this,
-            "%d assemble cycle(s) produced some new object(s) in %[ms]s: %s",
+            "%d assemble cycle(s) produced some new object(s): %s",
             cycle,
-            System.currentTimeMillis() - begin,
             before
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -22,22 +22,22 @@ final class Compiling implements Step {
     /**
      * Assembling step.
      */
-    private final Assembling assembling;
+    private final Step assembling;
 
     /**
      * Linting step.
      */
-    private final Linting linting;
+    private final Step linting;
 
     /**
      * Resolving step.
      */
-    private final Resolving resolving;
+    private final Step resolving;
 
     /**
      * Placing step.
      */
-    private final Placing placing;
+    private final Step placing;
 
     /**
      * Constructor.
@@ -48,10 +48,10 @@ final class Compiling implements Step {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     Compiling(
-        final Assembling asmbl,
-        final Linting lnt,
-        final Resolving rslv,
-        final Placing plc
+        final Step asmbl,
+        final Step lnt,
+        final Step rslv,
+        final Step plc
     ) {
         this.assembling = asmbl;
         this.linting = lnt;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
 
 /**
@@ -18,7 +17,7 @@ import java.io.IOException;
  *
  * @since 0.61.0
  */
-final class Compiling {
+final class Compiling implements Step {
 
     /**
      * Assembling step.
@@ -64,17 +63,11 @@ final class Compiling {
      * Execute the full compilation pipeline.
      * @throws IOException If any step fails
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    void exec() throws IOException {
-        final long begin = System.currentTimeMillis();
+    @Override
+    public void exec() throws IOException {
         this.assembling.exec();
         this.linting.exec();
         this.resolving.exec();
         this.placing.exec();
-        Logger.info(
-            this,
-            "Compilation process took %[ms]s",
-            System.currentTimeMillis() - begin
-        );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -59,10 +59,6 @@ final class Compiling implements Step {
         this.placing = plc;
     }
 
-    /**
-     * Execute the full compilation pipeline.
-     * @throws IOException If any step fails
-     */
     @Override
     public void exec() throws IOException {
         this.assembling.exec();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -54,7 +54,7 @@ import org.xembly.Xembler;
  * @since 0.31.0
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
-final class Linting {
+final class Linting implements Step {
 
     /**
      * The directory where to lint to.
@@ -198,7 +198,8 @@ final class Linting {
      * Execute linting.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         if (this.skipLinting) {
             Logger.info(this, "Linting is skipped because eo:skipLinting is TRUE");
         } else {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -207,9 +207,7 @@ final class Linting implements Step {
         }
     }
 
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void linting() throws IOException {
-        final long start = System.currentTimeMillis();
         final Collection<TjForeign> programs = this.tojos.withXmir();
         final Map<Severity, Integer> counts = new ConcurrentHashMap<>();
         counts.putIfAbsent(Severity.CRITICAL, 0);
@@ -241,8 +239,8 @@ final class Linting implements Step {
         final String sum = Linting.summary(counts);
         Logger.info(
             this,
-            "Linted %d out of %d XMIR program(s) that needed this (out of %d total programs) in %[ms]s: %s",
-            passed, programs.size(), programs.size(), System.currentTimeMillis() - start, sum
+            "Linted %d out of %d XMIR program(s) that needed this (out of %d total programs): %s",
+            passed, programs.size(), programs.size(), sum
         );
         Logger.info(
             this,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -194,10 +194,6 @@ final class Linting implements Step {
         this.skipLinting = skip;
     }
 
-    /**
-     * Execute linting.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         if (this.skipLinting) {
@@ -207,6 +203,7 @@ final class Linting implements Step {
         }
     }
 
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void linting() throws IOException {
         final Collection<TjForeign> programs = this.tojos.withXmir();
         final Map<Severity, Integer> counts = new ConcurrentHashMap<>();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -30,6 +30,7 @@ public final class MjCompile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
+        new Timed(
         new Compiling(
             this.assembling(),
             new Linting(
@@ -66,6 +67,7 @@ public final class MjCompile extends MjSafe {
                 this.skipBinaries,
                 this.rewriteBinaries
             )
+        )
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -31,43 +31,49 @@ public final class MjCompile extends MjSafe {
     @Override
     public void exec() throws IOException {
         new Timed(
-        new Compiling(
-            this.assembling(),
-            new Linting(
-                this.scopedTojos(),
-                this.compileTojos(),
-                this.targetDir.toPath(),
-                this.cache.toPath(),
-                this.cacheEnabled,
-                this.plugin.getVersion(),
-                this.skipSourceLints,
-                this.skipProgramLints,
-                this.skipExperimentalLints,
-                this.failOnWarning,
-                this.lintAsPackage,
-                this.sourcesDir.toPath(),
-                this.skipLinting
-            ),
-            new Resolving(
-                this.scopedTojos(),
-                this.targetDir.toPath().resolve(MjResolve.DIR),
-                new CentralMaven(this.system),
-                this.discoverSelf,
-                this.skipZeroVersions,
-                this.resolveJna,
-                this.ignoreRuntime,
-                this.runtime(),
-                this.ignoreVersionConflicts
-            ),
-            new Placing(
-                this.placedTojos,
-                this.targetDir.toPath().resolve(MjResolve.DIR),
-                this.classesDir.toPath(),
-                this.placeBinaries,
-                this.skipBinaries,
-                this.rewriteBinaries
+            new Compiling(
+                new Timed(this.assembling()),
+                new Timed(
+                    new Linting(
+                        this.scopedTojos(),
+                        this.compileTojos(),
+                        this.targetDir.toPath(),
+                        this.cache.toPath(),
+                        this.cacheEnabled,
+                        this.plugin.getVersion(),
+                        this.skipSourceLints,
+                        this.skipProgramLints,
+                        this.skipExperimentalLints,
+                        this.failOnWarning,
+                        this.lintAsPackage,
+                        this.sourcesDir.toPath(),
+                        this.skipLinting
+                    )
+                ),
+                new Timed(
+                    new Resolving(
+                        this.scopedTojos(),
+                        this.targetDir.toPath().resolve(MjResolve.DIR),
+                        new CentralMaven(this.system),
+                        this.discoverSelf,
+                        this.skipZeroVersions,
+                        this.resolveJna,
+                        this.ignoreRuntime,
+                        this.runtime(),
+                        this.ignoreVersionConflicts
+                    )
+                ),
+                new Timed(
+                    new Placing(
+                        this.placedTojos,
+                        this.targetDir.toPath().resolve(MjResolve.DIR),
+                        this.classesDir.toPath(),
+                        this.placeBinaries,
+                        this.skipBinaries,
+                        this.rewriteBinaries
+                    )
+                )
             )
-        )
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -575,25 +575,31 @@ abstract class MjSafe extends AbstractMojo {
     Assembling assembling() {
         return new Assembling(
             this.scopedTojos(),
-            new Parsing(
-                this.scopedTojos(),
-                this.targetDir.toPath(),
-                this.cache.toPath(),
-                this.cacheEnabled,
-                this.plugin.getVersion(),
-                this.sourcesDir.toPath()
+            new Timed(
+                new Parsing(
+                    this.scopedTojos(),
+                    this.targetDir.toPath(),
+                    this.cache.toPath(),
+                    this.cacheEnabled,
+                    this.plugin.getVersion(),
+                    this.sourcesDir.toPath()
+                )
             ),
-            new Probing(this.scopedTojos(), this.objectionary(), !this.offline),
-            new Pulling(
-                this.scopedTojos(),
-                this.targetDir.toPath().resolve(Pulling.DIR),
-                this.hash,
-                this.objectionary(),
-                this.cache.toPath().resolve(Pulling.CACHE),
-                this.plugin.getVersion(),
-                this.overWrite,
-                this.cacheEnabled,
-                this.offline
+            new Timed(
+                new Probing(this.scopedTojos(), this.objectionary(), !this.offline)
+            ),
+            new Timed(
+                new Pulling(
+                    this.scopedTojos(),
+                    this.targetDir.toPath().resolve(Pulling.DIR),
+                    this.hash,
+                    this.objectionary(),
+                    this.cache.toPath().resolve(Pulling.CACHE),
+                    this.plugin.getVersion(),
+                    this.overWrite,
+                    this.cacheEnabled,
+                    this.offline
+                )
             )
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -54,16 +54,18 @@ public final class MjTranspile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Transpiling(
-            this.scopedTojos().withXmir(),
-            this.targetDir.toPath(),
-            this.generatedDir.toPath(),
-            this.cache.toPath(),
-            this.cacheEnabled,
-            this.plugin.getVersion(),
-            this.trackTransformationSteps,
-            this.transpileTests,
-            this.xslMeasures.toPath()
+        new Timed(
+            new Transpiling(
+                this.scopedTojos().withXmir(),
+                this.targetDir.toPath(),
+                this.generatedDir.toPath(),
+                this.cache.toPath(),
+                this.cacheEnabled,
+                this.plugin.getVersion(),
+                this.trackTransformationSteps,
+                this.transpileTests,
+                this.xslMeasures.toPath()
+            )
         ).exec();
         if (this.addSourcesRoot) {
             this.project.addCompileSourceRoot(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
@@ -22,10 +22,12 @@ public final class MjUnplace extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Unplacing(
-            this.placedTojos,
-            this.classesDir.toPath(),
-            this.keepBinaries
+        new Timed(
+            new Unplacing(
+                this.placedTojos,
+                this.classesDir.toPath(),
+                this.keepBinaries
+            )
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnspile.java
@@ -23,10 +23,12 @@ public final class MjUnspile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Unspiling(
-            this.generatedDir.toPath(),
-            this.classesDir.toPath(),
-            this.keepBinaries
+        new Timed(
+            new Unspiling(
+                this.generatedDir.toPath(),
+                this.classesDir.toPath(),
+                this.keepBinaries
+            )
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -116,9 +116,7 @@ final class Parsing implements Step {
      * Run parsing of all sources.
      */
     @Override
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() {
-        final long start = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.tojos.withSources();
         final int total = new Threaded<>(
             new Filtered<>(TjForeign::notParsed, sources),
@@ -139,8 +137,8 @@ final class Parsing implements Step {
             }
         } else {
             Logger.info(
-                this, "Parsed %d new .eo sources out of %d to XMIRs in %[ms]s",
-                total, sources.size(), System.currentTimeMillis() - start
+                this, "Parsed %d new .eo sources out of %d to XMIRs",
+                total, sources.size()
             );
         }
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -112,9 +112,6 @@ final class Parsing implements Step {
         this.sourcesDir = sources;
     }
 
-    /**
-     * Run parsing of all sources.
-     */
     @Override
     public void exec() {
         final Collection<TjForeign> sources = this.tojos.withSources();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Node;
  *
  * @since 0.1
  */
-final class Parsing {
+final class Parsing implements Step {
 
     /**
      * Zero version.
@@ -115,8 +115,9 @@ final class Parsing {
     /**
      * Run parsing of all sources.
      */
+    @Override
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    void exec() {
+    public void exec() {
         final long start = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.tojos.withSources();
         final int total = new Threaded<>(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -25,9 +25,9 @@ import org.cactoos.scalar.Unchecked;
  * </p>
  *
  * @see <a href="https://news.eolang.org/2022-10-19-placed-catalog.html">Place catalog</a>
- * @since 0.67.0
+ * @since 0.61.0
  */
-final class Placing {
+final class Placing implements Step {
 
     /**
      * Catalog of already-placed binaries.
@@ -89,7 +89,8 @@ final class Placing {
      * Execute placing.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         if (Files.exists(this.home)) {
             final Collection<String> deps = new DepDirs(this.home);
             final long copied = deps.stream()
@@ -141,7 +142,7 @@ final class Placing {
 
     /**
      * Dependency whose binaries are being placed.
-     * @since 0.67.0
+     * @since 0.61.0
      */
     private final class PlacedDependency implements Supplier<Long> {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -85,10 +85,6 @@ final class Placing implements Step {
         this.rewrite = rewritebinaries;
     }
 
-    /**
-     * Execute placing.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         if (Files.exists(this.home)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -68,9 +68,7 @@ final class Probing implements Step {
         }
     }
 
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void probe(final Collection<TjForeign> unprobed) {
-        final long start = System.currentTimeMillis();
         final Map<String, Boolean> probed = new ConcurrentHashMap<>(0);
         if (this.probed(unprobed, probed) == 0) {
             Logger.info(
@@ -80,9 +78,8 @@ final class Probing implements Step {
             );
         } else {
             Logger.info(
-                this, "Found %d probe(s) in %d program(s) in %[ms]s: %s",
+                this, "Found %d probe(s) in %d program(s): %s",
                 probed.size(), unprobed.size(),
-                System.currentTimeMillis() - start,
                 probed.keySet()
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -16,9 +16,9 @@ import org.cactoos.list.ListOf;
  * Goes through all {@code probe} and {@code also} metas in XMIR files,
  * tries to locate the objects pointed by {@code probe} in Objectionary,
  * and if found, registers them in the catalog.
- * @since 0.67.0
+ * @since 0.61.0
  */
-final class Probing {
+final class Probing implements Step {
 
     /**
      * Tojos to probe.
@@ -51,7 +51,8 @@ final class Probing {
      * Run probing.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         if (this.online) {
             final Collection<TjForeign> unprobed = this.tojos.unprobed();
             if (unprobed.isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -47,10 +47,6 @@ final class Probing implements Step {
         this.online = net;
     }
 
-    /**
-     * Run probing.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         if (this.online) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
@@ -21,9 +21,9 @@ import java.util.function.Supplier;
  *     are stored in the {@link #DIR} directory.
  * </p>
  *
- * @since 0.67.0
+ * @since 0.61.0
  */
-final class Pulling {
+final class Pulling implements Step {
 
     /**
      * The directory where to store pulled sources.
@@ -119,7 +119,8 @@ final class Pulling {
      * Pull all objects.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         if (this.offline) {
             Logger.info(
                 this,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
@@ -115,10 +115,6 @@ final class Pulling implements Step {
         this.offline = off;
     }
 
-    /**
-     * Pull all objects.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         if (this.offline) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
@@ -128,7 +128,6 @@ final class Pulling implements Step {
             );
             return;
         }
-        final long start = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.tojos.withoutSources();
         final Collection<String> names = new ArrayList<>(0);
         final String hsh = this.hash.value();
@@ -153,17 +152,12 @@ final class Pulling implements Step {
             names.add(object);
         }
         if (sources.isEmpty()) {
-            Logger.info(
-                this,
-                "No programs were pulled in %[ms]s",
-                System.currentTimeMillis() - start
-            );
+            Logger.info(this, "No programs were pulled");
         } else {
             Logger.info(
                 this,
-                "%d program(s) were pulled in %[ms]s: %s",
+                "%d program(s) were pulled: %s",
                 sources.size(),
-                System.currentTimeMillis() - start,
                 names
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -108,9 +108,6 @@ final class Resolving implements Step {
         this.noconflicts = noconf;
     }
 
-    /**
-     * Execute the resolve process.
-     */
     @Override
     public void exec() {
         final Collection<Dep> deps = this.deps();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -23,10 +23,10 @@ import org.cactoos.text.Joined;
 /**
  * Resolves all required runtime dependencies: downloads from Maven Central,
  * unpacks and places them into the target directory.
- * @since 0.63.0
+ * @since 0.61.0
  * @checkstyle ParameterNumberCheck (100 lines)
  */
-final class Resolving {
+final class Resolving implements Step {
 
     /**
      * Tojos.
@@ -111,7 +111,8 @@ final class Resolving {
     /**
      * Execute the resolve process.
      */
-    void exec() {
+    @Override
+    public void exec() {
         final Collection<Dep> deps = this.deps();
         if (deps.isEmpty()) {
             Logger.info(this, "No new dependencies unpacked");

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Step.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Step.java
@@ -10,6 +10,7 @@ import java.io.IOException;
  * A single pipeline step that can be executed.
  * @since 0.61.0
  */
+@FunctionalInterface
 interface Step {
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Step.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Step.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+
+/**
+ * A single pipeline step that can be executed.
+ * @since 0.61.0
+ */
+interface Step {
+
+    /**
+     * Execute the step.
+     * @throws IOException If fails
+     */
+    void exec() throws IOException;
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Timed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Timed.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+
+/**
+ * A {@link Step} decorator that measures and logs elapsed execution time.
+ * @since 0.61.0
+ */
+final class Timed implements Step {
+
+    /**
+     * The wrapped step.
+     */
+    private final Step origin;
+
+    /**
+     * Constructor.
+     * @param step Step to wrap
+     */
+    Timed(final Step step) {
+        this.origin = step;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    public void exec() throws IOException {
+        final long start = System.currentTimeMillis();
+        this.origin.exec();
+        Logger.info(
+            this,
+            "%s took %[ms]s",
+            this.origin.getClass().getSimpleName(),
+            System.currentTimeMillis() - start
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -224,16 +224,14 @@ final class Transpiling implements Step {
                     new CachePath(cdir, this.version, hsh.get()),
                     src -> {
                         rewrite.compareAndSet(false, true);
-                        final long start = System.currentTimeMillis();
                         final String res = transform.apply(xmir).toString();
                         Logger.debug(
                             this,
-                            "Transpiled %[file]s (%s) to %[file]s (%s) in %[ms]s (cache miss), version: %s, hash: %s, tail: %s, cache enabled: %b, cache dir: %[file]s",
+                            "Transpiled %[file]s (%s) to %[file]s (%s) (cache miss), version: %s, hash: %s, tail: %s, cache enabled: %b, cache dir: %[file]s",
                             source,
                             Transpiling.info(source),
                             target,
                             Transpiling.info(target),
-                            System.currentTimeMillis() - start,
                             this.version,
                             hsh.get(),
                             tail,
@@ -341,7 +339,6 @@ final class Transpiling implements Step {
         final Path target,
         final String hsh
     ) throws IOException {
-        final long begin = System.currentTimeMillis();
         final AtomicInteger saved = new AtomicInteger(0);
         if (Files.exists(target)) {
             final Xnav object = new Xnav(target).element("object");
@@ -375,8 +372,8 @@ final class Transpiling implements Step {
             }
             Logger.debug(
                 this,
-                "Generated %d Java files from %[file]s in %[ms]s",
-                saved.get(), target, System.currentTimeMillis() - begin
+                "Generated %d Java files from %[file]s",
+                saved.get(), target
             );
         }
         return saved.get();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -49,7 +49,7 @@ import org.eolang.parser.TrFull;
  * @since 0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-final class Transpiling {
+final class Transpiling implements Step {
 
     /**
      * The directory where to transpile to.
@@ -187,9 +187,8 @@ final class Transpiling {
      * Run transpilation of all sources.
      * @throws IOException If any issues with I/O
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    void exec() throws IOException {
-        final long begin = System.currentTimeMillis();
+    @Override
+    public void exec() throws IOException {
         final int saved = new Threaded<>(
             this.sources,
             this::transpiled
@@ -197,11 +196,6 @@ final class Transpiling {
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(), saved, this.generatedDir
-        );
-        Logger.info(
-            this,
-            "Transpilation took %[ms]s in total",
-            System.currentTimeMillis() - begin
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -183,11 +183,8 @@ final class Transpiling implements Step {
         this.xslMeasures = measures;
     }
 
-    /**
-     * Run transpilation of all sources.
-     * @throws IOException If any issues with I/O
-     */
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void exec() throws IOException {
         final int saved = new Threaded<>(
             this.sources,
@@ -333,7 +330,6 @@ final class Transpiling implements Step {
      * @return Amount of generated .java files
      * @throws IOException If fails to save files
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private int javaGenerated(
         final boolean rewrite,
         final Path target,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * @since 0.61.0
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
-final class Unplacing {
+final class Unplacing implements Step {
 
     /**
      * Catalog of placed binaries.
@@ -60,7 +60,8 @@ final class Unplacing {
      * Execute unplacing.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         if (this.placed.isEmpty()) {
             Logger.info(this, "The list of placed binaries is empty, nothing to unplace");
         } else {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
@@ -56,10 +56,6 @@ final class Unplacing implements Step {
         this.keep = keepbinaries;
     }
 
-    /**
-     * Execute unplacing.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         if (this.placed.isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unspiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unspiling.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  * so they are not included in the result JAR.
  * @since 0.61.0
  */
-final class Unspiling {
+final class Unspiling implements Step {
 
     /**
      * Pattern for matching paths ended with .class.
@@ -73,7 +73,8 @@ final class Unspiling {
      * Execute unspiling.
      * @throws IOException If fails
      */
-    void exec() throws IOException {
+    @Override
+    public void exec() throws IOException {
         final Walk walk = new Walk(this.classes);
         if (walk.isEmpty()) {
             Logger.warn(this, "No .class files in %[file]s, nothing to unspile", this.classes);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unspiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unspiling.java
@@ -69,10 +69,6 @@ final class Unspiling implements Step {
         this.keep = keep;
     }
 
-    /**
-     * Execute unspiling.
-     * @throws IOException If fails
-     */
     @Override
     public void exec() throws IOException {
         final Walk walk = new Walk(this.classes);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TimedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TimedTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link Timed}.
+ * @since 0.61.0
+ */
+final class TimedTest {
+
+    @Test
+    void executesWrappedStep() {
+        final AtomicBoolean executed = new AtomicBoolean(false);
+        Assertions.assertDoesNotThrow(
+            () -> new Timed(() -> executed.set(true)).exec(),
+            "Timed must delegate execution to the wrapped step"
+        );
+        Assertions.assertTrue(
+            executed.get(),
+            "The wrapped step must have been executed"
+        );
+    }
+
+    @Test
+    void propagatesException() {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new Timed(
+                () -> {
+                    throw new IOException("simulated failure");
+                }
+            ).exec(),
+            "Timed must propagate IOException thrown by the wrapped step"
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TimedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TimedTest.java
@@ -16,12 +16,9 @@ import org.junit.jupiter.api.Test;
 final class TimedTest {
 
     @Test
-    void executesWrappedStep() {
+    void executesWrappedStep() throws IOException {
         final AtomicBoolean executed = new AtomicBoolean(false);
-        Assertions.assertDoesNotThrow(
-            () -> new Timed(() -> executed.set(true)).exec(),
-            "Timed must delegate execution to the wrapped step"
-        );
+        new Timed(() -> executed.set(true)).exec();
         Assertions.assertTrue(
             executed.get(),
             "The wrapped step must have been executed"


### PR DESCRIPTION
Extracts timing logic into a `Timed` decorator and introduces a `Step` interface for all pipeline steps.

Fixes #5134