### PR TITLE
feat(#3461): Use Expect.Int for x in EObytes$EOright

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOright.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOright.java
@@ -30,7 +30,7 @@ public final class EObytes$EOright extends PhDefault implements Atom {
         return new Data.ToPhi(
             new Dataized(this.take(Phi.RHO))
                 .asBytes()
-                .shift(new Dataized(this.take("x")).asNumber().intValue())
+                .shift(new Expect.Int(Expect.at(this, "x")).it())
                 .take()
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOrightExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOrightExpectTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (10 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case verifying {@link Expect}-based error messages
+ * raised by {@link EObytes$EOright} when the {@code x} attribute
+ * is not an integer.
+ * @since 0.51
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class EObytesEOrightExpectTest {
+
+    @Test
+    void throwsCorrectErrorForNonNumericX() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            new EObytes$EOright(),
+                            Phi.RHO,
+                            new Data.ToPhi(new byte[]{0x01, 0x02})
+                        ),
+                        "x",
+                        new Data.ToPhi(true)
+                    )
+                ).take(),
+                "right with non-numeric x must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'x' attribute must be a number")
+        );
+    }
+
+    @Test
+    void throwsCorrectErrorForFractionalX() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            new EObytes$EOright(),
+                            Phi.RHO,
+                            new Data.ToPhi(new byte[]{0x01, 0x02})
+                        ),
+                        "x",
+                        new Data.ToPhi(1.5)
+                    )
+                ).take(),
+                "right with fractional x must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'x' attribute (1.5) must be an integer")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the inline `new Dataized(this.take(\"x\")).asNumber().intValue()` in `EObytes\$EOright` with `new Expect.Int(Expect.at(this, \"x\")).it()`.
- Adds `EObytesEOrightExpectTest` covering two cases: non-numeric `x` and fractional `x`.

## Behavior change
The previous code silently truncated fractional `x` values (`.intValue()`). With `Expect.Int`, callers passing a fractional shift now get a clear error message: `the 'x' attribute (1.5) must be an integer`. All existing EO-level tests for `bytes.right` use integer literals, so no callers are affected.

Refs #3461.

## Test plan
- [x] `mvn test -Dtest=EObytesEOrightExpectTest` — passes (2/2)
- [x] `mvn -P qulice install -DskipTests` — passes
- [ ] CI green on all 26 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)