### PR TITLE
Use Expect.Natural in malloc allocated.{size,read} atoms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
@@ -32,9 +32,9 @@ public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements
     public Phi lambda() {
         return new Data.ToPhi(
             Heaps.INSTANCE.read(
-                new Dataized(this.take(Phi.RHO).take("id")).asNumber().intValue(),
-                new Dataized(this.take("offset")).asNumber().intValue(),
-                new Dataized(this.take("length")).asNumber().intValue()
+                new Expect.Natural(Expect.at(this.take(Phi.RHO), "id")).it(),
+                new Expect.Natural(Expect.at(this, "offset")).it(),
+                new Expect.Natural(Expect.at(this, "length")).it()
             )
         );
     }

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOsize.java
@@ -22,7 +22,7 @@ public final class EOmalloc$EOof$EOallocated$EOsize extends PhDefault implements
     public Phi lambda() {
         return new Data.ToPhi(
             Heaps.INSTANCE.size(
-                new Dataized(this.take(Phi.RHO).take("id")).asNumber().intValue()
+                new Expect.Natural(Expect.at(this.take(Phi.RHO), "id")).it()
             )
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (10 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case verifying {@link Expect}-based error messages
+ * raised by {@link EOmalloc$EOof$EOallocated$EOsize} and
+ * {@link EOmalloc$EOof$EOallocated$EOread} when their integer
+ * attributes are invalid.
+ * @since 0.51
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class EOmallocAllocatedExpectTest {
+
+    @Test
+    void throwsCorrectErrorForNegativeIdInSize() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new EOmalloc$EOof$EOallocated$EOsize(),
+                        Phi.RHO,
+                        new PhWith(
+                            new EOmallocAllocatedExpectTest.Dummy(),
+                            "id",
+                            new Data.ToPhi(-42)
+                        )
+                    )
+                ).take(),
+                "size with negative id must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'id' attribute (-42) must be greater or equal to zero")
+        );
+    }
+
+    @Test
+    void throwsCorrectErrorForNonNumericIdInRead() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new EOmalloc$EOof$EOallocated$EOread(),
+                        Phi.RHO,
+                        new PhWith(
+                            new EOmallocAllocatedExpectTest.Dummy(),
+                            "id",
+                            new Data.ToPhi(true)
+                        )
+                    )
+                ).take(),
+                "read with non-numeric id must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'id' attribute must be a number")
+        );
+    }
+
+    @Test
+    void throwsCorrectErrorForFractionalOffsetInRead() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            new PhWith(
+                                new EOmalloc$EOof$EOallocated$EOread(),
+                                Phi.RHO,
+                                new PhWith(
+                                    new EOmallocAllocatedExpectTest.Dummy(),
+                                    "id",
+                                    new Data.ToPhi(0)
+                                )
+                            ),
+                            "offset",
+                            new Data.ToPhi(1.5)
+                        ),
+                        "length",
+                        new Data.ToPhi(0)
+                    )
+                ).take(),
+                "read with fractional offset must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'offset' attribute (1.5) must be an integer")
+        );
+    }
+
+    @Test
+    void throwsCorrectErrorForNegativeLengthInRead() {
+        MatcherAssert.assertThat(
+            "the message in the error is correct",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhWith(
+                        new PhWith(
+                            new PhWith(
+                                new EOmalloc$EOof$EOallocated$EOread(),
+                                Phi.RHO,
+                                new PhWith(
+                                    new EOmallocAllocatedExpectTest.Dummy(),
+                                    "id",
+                                    new Data.ToPhi(0)
+                                )
+                            ),
+                            "offset",
+                            new Data.ToPhi(0)
+                        ),
+                        "length",
+                        new Data.ToPhi(-1)
+                    )
+                ).take(),
+                "read with negative length must fail with a proper message"
+            ).getMessage(),
+            Matchers.equalTo("the 'length' attribute (-1) must be greater or equal to zero")
+        );
+    }
+
+    /**
+     * Minimal Phi with a single {@code id} attribute used as a stand-in
+     * for the {@code allocated} parent in tests.
+     * @since 0.51
+     */
+    private static final class Dummy extends PhDefault {
+
+        Dummy() {
+            super(new Attrs(new AttrEntry("id", new AtVoid("id"))));
+        }
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
@@ -78,23 +78,9 @@ final class EOmallocAllocatedExpectTest {
             Assertions.assertThrows(
                 ExAbstract.class,
                 () -> new Dataized(
-                    new PhWith(
-                        new PhWith(
-                            new PhWith(
-                                new EOmalloc$EOof$EOallocated$EOread(),
-                                Phi.RHO,
-                                new PhWith(
-                                    new EOmallocAllocatedExpectTest.Dummy(),
-                                    "id",
-                                    new Data.ToPhi(0)
-                                )
-                            ),
-                            "offset",
-                            new Data.ToPhi(1.5)
-                        ),
-                        "length",
-                        new Data.ToPhi(0)
-                    )
+                    new EOmallocAllocatedExpectTest.Read(
+                        new Data.ToPhi(1.5), new Data.ToPhi(0)
+                    ).it()
                 ).take(),
                 "read with fractional offset must fail with a proper message"
             ).getMessage(),
@@ -109,23 +95,9 @@ final class EOmallocAllocatedExpectTest {
             Assertions.assertThrows(
                 ExAbstract.class,
                 () -> new Dataized(
-                    new PhWith(
-                        new PhWith(
-                            new PhWith(
-                                new EOmalloc$EOof$EOallocated$EOread(),
-                                Phi.RHO,
-                                new PhWith(
-                                    new EOmallocAllocatedExpectTest.Dummy(),
-                                    "id",
-                                    new Data.ToPhi(0)
-                                )
-                            ),
-                            "offset",
-                            new Data.ToPhi(0)
-                        ),
-                        "length",
-                        new Data.ToPhi(-1)
-                    )
+                    new EOmallocAllocatedExpectTest.Read(
+                        new Data.ToPhi(0), new Data.ToPhi(-1)
+                    ).it()
                 ).take(),
                 "read with negative length must fail with a proper message"
             ).getMessage(),
@@ -142,6 +114,54 @@ final class EOmallocAllocatedExpectTest {
 
         Dummy() {
             super(new Attrs(new AttrEntry("id", new AtVoid("id"))));
+        }
+    }
+
+    /**
+     * A {@code malloc.of.allocated.read} Phi with a valid id and the
+     * given {@code offset} and {@code length}.
+     * @since 0.51
+     */
+    private static final class Read {
+
+        /**
+         * Offset attribute value.
+         */
+        private final Phi offset;
+
+        /**
+         * Length attribute value.
+         */
+        private final Phi length;
+
+        Read(final Phi offset, final Phi length) {
+            this.offset = offset;
+            this.length = length;
+        }
+
+        /**
+         * Return it.
+         * @return The configured read Phi
+         * @checkstyle MethodNameCheck (5 lines)
+         */
+        Phi it() {
+            return new PhWith(
+                new PhWith(
+                    new PhWith(
+                        new EOmalloc$EOof$EOallocated$EOread(),
+                        Phi.RHO,
+                        new PhWith(
+                            new EOmallocAllocatedExpectTest.Dummy(),
+                            "id",
+                            new Data.ToPhi(0)
+                        )
+                    ),
+                    "offset",
+                    this.offset
+                ),
+                "length",
+                this.length
+            );
         }
     }
 }


### PR DESCRIPTION
Closes part of #3461 (continuing after #5117, #5131, #5138).

Replaces the silent `Dataized(...).asNumber().intValue()` truncation of integer attributes in two `malloc.of.allocated.*` atoms with `Expect.Natural`, which validates that the value is a number, an integer, and non-negative — producing a clear error message instead of a misleading default or NaN cast.

## Changed atoms

- `EOmalloc$EOof$EOallocated$EOsize` — validates `ρ.id`
- `EOmalloc$EOof$EOallocated$EOread` — validates `ρ.id`, `offset`, `length`

## Behavior change

Previously, passing a bogus `id`/`offset`/`length` (e.g. `1.5`, `-1`, `TRUE`) would either silently truncate via `intValue()` or throw a generic error from deeper in `Heaps`. Now the error is raised up front by `Expect.Natural` with a descriptive subject (`the 'offset' attribute (1.5) must be an integer`). No `.eo` callers pass fractional/negative/non-numeric values to these attributes, so no callers are affected.

## Tests

New `EOmallocAllocatedExpectTest` covers all three failure modes of `Expect.Natural` (non-number, fractional, negative) across both atoms. Reuses a small `Dummy` Phi as the `ρ` stand-in — same pattern as `EOmallocTest.Dummy`.

## Scope note

A wider EOmalloc-cluster rewrite was attempted in #3853 (asmirnov-backend, Jan 2025) and closed silently after ~14 months of inactivity. This PR is deliberately narrow: 2 atoms, 1 test file, ~150 lines diff. The other malloc atoms (`write`, `resized`, `φ`) are intentionally out of scope.