### PR TITLE
fix: remove empty-object lint skip

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -270,15 +270,6 @@
                       skip entry entirely once the lint is removed from the lints repo.
                 -->
                 <lint>idempotent-attribute-is-not-first</lint>
-                <!--
-                @todo #5078:30min. Remove `empty-object` skip.
-                      The lint flags formations whose `<o>` has no @base/@name
-                      and no children — the canonical empty anonymous formation.
-                      The new spec parser emits this shape verbatim for `[]`
-                      and similar; the lint disagrees. Drop this skip when the
-                      lint is updated or removed upstream.
-                -->
-                <lint>empty-object</lint>
               </skipSourceLints>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>


### PR DESCRIPTION
## Summary
- Remove the obsolete `empty-object` source lint skip from `eo-runtime/pom.xml`.
- Remove the associated PDD puzzle text for `#5078`.

Closes #5154

## Tests
- XML parse of updated `eo-runtime/pom.xml`
- Verified `<lint>empty-object</lint>` is no longer present

Prepared with local automation assistance and reviewed before submission.