### PR TITLE
fix: remove incorrect-number-of-attributes lint skip

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -282,17 +282,6 @@
               </skipSourceLints>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
-                <!--
-                @todo #5078:30min. Remove `incorrect-number-of-attributes` skip.
-                      WPA miscounts calls of the form `list *` (compact-tuple
-                      head with no vertical children, which synthesises a
-                      `Φ.tuple.empty` argument) — it reports 0 args provided
-                      while 1 (the synthesised tuple) is the actual shape.
-                      Drop this skip once the WPA lint understands the
-                      compact-tuple-with-zero-children synthesis (R-3.9.2 in
-                      the spec).
-                -->
-                <lint>incorrect-number-of-attributes</lint>
               </skipProgramLints>
               <keepBinaries>
                 <glob>org/eolang/EOfs/package-info.class</glob>


### PR DESCRIPTION
## Summary
- Remove the obsolete `incorrect-number-of-attributes` program lint skip from `eo-runtime/pom.xml`.
- Remove the associated PDD puzzle text for `#5078`.

Closes #5155

## Tests
- XML parse of updated `eo-runtime/pom.xml`
- Verified `<lint>incorrect-number-of-attributes</lint>` is no longer present

Prepared with local automation assistance and reviewed before submission.