### PR TITLE
fix: re-enable proxy integration test

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -60,6 +61,7 @@ final class ProxyIT {
     }
 
     @Test
+    @Disabled("registry still serves pre-spec EO sources")
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -61,7 +60,6 @@ final class ProxyIT {
     }
 
     @Test
-    @Disabled("registry still serves pre-spec EO sources")
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -27,26 +27,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
- * @todo #5078:60min Re-enable
- *  {@code checksThatWeCanCompileTheProgramWithProxySet} once the objectionary
- *  remote registry is re-published with the new parser's syntax. The test
- *  runs {@code mvn package} through a local proxy; the build pulls runtime
- *  sources from the registry, and those pulled {@code .eo} files
- *  ({@code tuple}/{@code seq}/{@code number}/...) still contain pre-spec
- *  syntax (fluent {@code .method} continuation after horizontal-completed
- *  lines, the {@code ?} name-suffix modifier, etc.) that the new spec-strict
- *  parser rejects, so {@code mvn package} fails before the proxy assertion
- *  ever runs. The local {@code eo-runtime/src/main/eo/} files are already
- *  rewritten and pass; only the registry needs the matching re-upload. To
- *  re-enable: publish the updated runtime to objectionary, then drop the
- *  {@link Disabled} annotation on the method.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
@@ -74,7 +60,6 @@ final class ProxyIT {
     }
 
     @Test
-    @Disabled("registry still serves pre-spec EO sources, see class javadoc")
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);


### PR DESCRIPTION
## Summary
- Re-enable `checksThatWeCanCompileTheProgramWithProxySet` by removing its `@Disabled` annotation.
- Remove the resolved PDD puzzle text for `#5078`.

Closes #5152

## Tests
- Verified `ProxyIT.java` no longer imports or uses `Disabled`
- Verified the `#5078` PDD text was removed from `ProxyIT.java`

Prepared with local automation assistance and reviewed before submission.