### PR TITLE
fix: remove idempotent lint skip

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -263,14 +263,6 @@
                 -->
                 <lint>object-has-data</lint>
                 <!--
-                @todo #5078:30min. Remove `idempotent-attribute-is-not-first` skip.
-                      The lint relies on the `xi🌵` positional marker that the legacy
-                      ANTLR parser emitted; the new spec-driven parser does not produce
-                      this marker, so the lint now fires on every formation. Drop this
-                      skip entry entirely once the lint is removed from the lints repo.
-                -->
-                <lint>idempotent-attribute-is-not-first</lint>
-                <!--
                 @todo #5078:30min. Remove `empty-object` skip.
                       The lint flags formations whose `<o>` has no @base/@name
                       and no children — the canonical empty anonymous formation.


### PR DESCRIPTION
Summary:
- Remove the obsolete `idempotent-attribute-is-not-first` source lint skip from `eo-runtime/pom.xml`.
- Remove the associated PDD puzzle text for `#5078` while leaving the other open `#5078` lint-skip puzzles untouched.

Closes #5153

Validation:
- Desired-state check: `<lint>idempotent-attribute-is-not-first</lint>` is no longer present.
- XML parse: `[xml](Get-Content eo-runtime\pom.xml -Raw)`.
- Diff hygiene: `git diff --check` and `git diff --cached --check`.
- Secret scan: `gitleaks protect --staged --no-banner --redact --verbose`.

Not run:
- Maven tests, because `mvn` and `java` are not available on my local PATH.