### PR TITLE
feat(#5179): invalidate SNAPSHOT cache on every build with Janitor

### DIFF
--- a/.github/workflows/simian.yml
+++ b/.github/workflows/simian.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - run: wget --quiet http://public.yegor256.com/simian.jar -O /tmp/simian.jar
+      - run: wget --quiet https://public.yegor256.com/simian.jar -O /tmp/simian.jar
       - run: java -jar /tmp/simian.jar -threshold=15 "-excludes=**/EOsocketTest.java" "-excludes=**/gen" "-excludes=**/it" "**/*.java"

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -126,7 +126,7 @@ final class Cache {
         if (Files.isDirectory(any)) {
             result = this.dirSha(any);
         } else if (Files.isRegularFile(any)) {
-            result = Cache.fileSha(any);
+            result = new Sha(any).toString();
         } else {
             throw new IllegalArgumentException(
                 String.format("Path '%s' is neither a regular file nor a directory", any)
@@ -147,7 +147,7 @@ final class Cache {
                 stream.filter(Files::isRegularFile)
                     .filter(this.filter::test)
                     .sorted(Comparator.comparing(Path::toString))
-                    .map(Cache::fileSha)
+                    .map(p -> new Sha(p).toString())
                     .map(s -> s.getBytes(StandardCharsets.UTF_8))
                     .forEach(digest::update);
             }
@@ -165,30 +165,5 @@ final class Cache {
         }
     }
 
-    /**
-     * Calculate SHA-256 hash of a file and return it as Base64 string.
-     * @param file File path
-     * @return Base64-encoded SHA-256 hash
-     */
-    private static String fileSha(final Path file) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            try (InputStream stream = Files.newInputStream(file)) {
-                final byte[] buffer = new byte[8192];
-                int read = stream.read(buffer);
-                while (read != -1) {
-                    digest.update(buffer, 0, read);
-                    read = stream.read(buffer);
-                }
-            }
-            return Base64.getEncoder().encodeToString(digest.digest());
-        } catch (final NoSuchAlgorithmException exception) {
-            throw new IllegalStateException("SHA-256 algorithm is not available", exception);
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("Failed to read file '%s' for hashing", file),
-                exception
-            );
-        }
-    }
+
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -164,6 +163,4 @@ final class Cache {
             );
         }
     }
-
-
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Invalidates the local EO cache when the plugin JAR changes.
+ * Only applies to SNAPSHOT versions — released versions use version-keyed
+ * cache directories that never collide.
+ * @since 0.62.0
+ */
+final class Janitor {
+
+    /**
+     * Fingerprint file stored inside the cache root.
+     */
+    private static final String FINGERPRINT = ".snapshot-fingerprint";
+
+    /**
+     * Stage directories that share the versioned cache layout.
+     */
+    private static final String[] STAGES = {"parsed", "transpiled", "linted", "pulled"};
+
+    /**
+     * Base cache directory, e.g. ~/.eo/.
+     */
+    private final Path cache;
+
+    /**
+     * Current plugin version, e.g. "1.0-SNAPSHOT".
+     */
+    private final String version;
+
+    /**
+     * Ctor.
+     * @param cache Base cache directory
+     * @param version Plugin version
+     */
+    Janitor(final Path cache, final String version) {
+        this.cache = cache;
+        this.version = version;
+    }
+
+    /**
+     * Wipes all SNAPSHOT stage caches if the plugin JAR has changed.
+     */
+    void exec() {
+        if (!this.version.contains("SNAPSHOT")) {
+            return;
+        }
+        try {
+            final String current = new Sha(
+                MjSafe.class.getProtectionDomain().getCodeSource().getLocation().openStream()
+            ).toString();
+            final Path fingerprint = this.cache.resolve(Janitor.FINGERPRINT);
+            if (Files.exists(fingerprint)
+                && new String(Files.readAllBytes(fingerprint), StandardCharsets.UTF_8)
+                    .equals(current)) {
+                return;
+            }
+            Logger.info(
+                this,
+                "Plugin JAR changed, invalidating SNAPSHOT cache at %[file]s",
+                this.cache
+            );
+            for (final String stage : Janitor.STAGES) {
+                final Path dir = this.cache.resolve(stage).resolve(this.version);
+                if (Files.exists(dir)) {
+                    Janitor.wipe(dir);
+                }
+            }
+            new Saved(current, fingerprint).value();
+        } catch (final IOException ex) {
+            throw new IllegalStateException("Failed to clean SNAPSHOT cache", ex);
+        }
+    }
+
+    /**
+     * Recursively deletes a directory.
+     * @param dir Directory to delete
+     * @throws IOException If deletion fails
+     */
+    private static void wipe(final Path dir) throws IOException {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(
+                path -> {
+                    try {
+                        Files.delete(path);
+                    } catch (final IOException ex) {
+                        throw new IllegalStateException(
+                            String.format("Failed to delete %s", path), ex
+                        );
+                    }
+                }
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
@@ -6,14 +6,16 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.stream.Stream;
 
 /**
- * Invalidates the local EO cache when the plugin JAR changes.
+ * Invalidates the local EO cache when the plugin code changes.
  * Only applies to SNAPSHOT versions — released versions use version-keyed
  * cache directories that never collide.
  * @since 0.62.0
@@ -51,37 +53,60 @@ final class Janitor {
     }
 
     /**
-     * Wipes all SNAPSHOT stage caches if the plugin JAR has changed.
+     * Wipes all SNAPSHOT stage caches if the plugin code has changed since last build.
      */
     void exec() {
         if (!this.version.contains("SNAPSHOT")) {
             return;
         }
         try {
-            final String current = new Sha(
-                MjSafe.class.getProtectionDomain().getCodeSource().getLocation().openStream()
-            ).toString();
+            final String current = String.valueOf(Janitor.mtime());
             final Path fingerprint = this.cache.resolve(Janitor.FINGERPRINT);
             if (Files.exists(fingerprint)
                 && new String(Files.readAllBytes(fingerprint), StandardCharsets.UTF_8)
                     .equals(current)) {
                 return;
             }
-            Logger.info(
-                this,
-                "Plugin JAR changed, invalidating SNAPSHOT cache at %[file]s",
-                this.cache
-            );
             for (final String stage : Janitor.STAGES) {
                 final Path dir = this.cache.resolve(stage).resolve(this.version);
                 if (Files.exists(dir)) {
+                    Logger.info(
+                        this,
+                        "Plugin code changed, invalidating SNAPSHOT cache at %[file]s",
+                        dir
+                    );
                     Janitor.wipe(dir);
                 }
             }
             new Saved(current, fingerprint).value();
-        } catch (final IOException ex) {
+        } catch (final IOException | URISyntaxException ex) {
             throw new IllegalStateException("Failed to clean SNAPSHOT cache", ex);
         }
+    }
+
+    /**
+     * Returns the newest modification time across all files at the plugin code source location.
+     * Works for both a JAR file (production) and a classes directory (development).
+     * @return Newest last-modified timestamp in milliseconds
+     * @throws URISyntaxException If the code source location URI is malformed
+     * @throws IOException If reading the directory fails
+     */
+    private static long mtime() throws URISyntaxException, IOException {
+        final Path location = Paths.get(
+            Janitor.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+        );
+        final long result;
+        if (Files.isDirectory(location)) {
+            try (Stream<Path> stream = Files.walk(location)) {
+                result = stream.filter(Files::isRegularFile)
+                    .mapToLong(f -> f.toFile().lastModified())
+                    .max()
+                    .orElse(0L);
+            }
+        } else {
+            result = location.toFile().lastModified();
+        }
+        return result;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Janitor.java
@@ -7,7 +7,6 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,9 +14,10 @@ import java.util.Comparator;
 import java.util.stream.Stream;
 
 /**
- * Invalidates the local EO cache when the plugin code changes.
- * Only applies to SNAPSHOT versions — released versions use version-keyed
- * cache directories that never collide.
+ * Invalidates the local EO cache on every SNAPSHOT build.
+ * Released versions use version-keyed cache directories that never collide,
+ * so no invalidation is needed for them.
+ * @see <a href="https://github.com/objectionary/eo/issues/5179">issue #5179</a>
  * @since 0.62.0
  */
 final class Janitor {
@@ -53,41 +53,57 @@ final class Janitor {
     }
 
     /**
-     * Wipes all SNAPSHOT stage caches if the plugin code has changed since last build.
+     * Wipes all SNAPSHOT stage caches on every build.
+     * Does nothing for released versions.
      */
-    void exec() {
-        if (!this.version.contains("SNAPSHOT")) {
-            return;
-        }
-        try {
-            final String current = String.valueOf(Janitor.mtime());
-            final Path fingerprint = this.cache.resolve(Janitor.FINGERPRINT);
-            if (Files.exists(fingerprint)
-                && new String(Files.readAllBytes(fingerprint), StandardCharsets.UTF_8)
-                    .equals(current)) {
-                return;
+    void clean() {
+        if (this.version.contains("SNAPSHOT")) {
+            try {
+                this.invalidate();
+            } catch (final IOException | URISyntaxException ex) {
+                throw new IllegalStateException("Failed to clean SNAPSHOT cache", ex);
             }
-            for (final String stage : Janitor.STAGES) {
-                final Path dir = this.cache.resolve(stage).resolve(this.version);
-                if (Files.exists(dir)) {
-                    Logger.info(
-                        this,
-                        "Plugin code changed, invalidating SNAPSHOT cache at %[file]s",
-                        dir
-                    );
-                    Janitor.wipe(dir);
-                }
-            }
-            new Saved(current, fingerprint).value();
-        } catch (final IOException | URISyntaxException ex) {
-            throw new IllegalStateException("Failed to clean SNAPSHOT cache", ex);
         }
     }
 
     /**
-     * Returns the newest modification time across all files at the plugin code source location.
-     * Works for both a JAR file (production) and a classes directory (development).
-     * @return Newest last-modified timestamp in milliseconds
+     * Checks the fingerprint and wipes caches if it has changed.
+     * @throws IOException If an IO operation fails
+     * @throws URISyntaxException If the code source location URI is malformed
+     */
+    private void invalidate() throws IOException, URISyntaxException {
+        final String current = String.valueOf(Janitor.mtime());
+        final Path fingerprint = this.cache.resolve(Janitor.FINGERPRINT);
+        if (!Files.exists(fingerprint)
+            || !Files.readString(fingerprint).equals(current)) {
+            this.wipeCaches();
+            new Saved(current, fingerprint).value();
+        }
+    }
+
+    /**
+     * Deletes the versioned cache directory for each stage if it exists.
+     * @throws IOException If deletion fails
+     */
+    private void wipeCaches() throws IOException {
+        for (final String stage : Janitor.STAGES) {
+            final Path dir = this.cache.resolve(stage).resolve(this.version);
+            if (Files.exists(dir)) {
+                Logger.info(
+                    this,
+                    "Plugin code changed, invalidating SNAPSHOT cache at %[file]s",
+                    dir
+                );
+                Janitor.wipe(dir);
+            }
+        }
+    }
+
+    /**
+     * Returns the modification time of the plugin JAR or classes directory.
+     * Used as a build fingerprint: changes on every build, so comparing it
+     * to the stored value always detects a new build.
+     * @return Last-modified timestamp in milliseconds
      * @throws URISyntaxException If the code source location URI is malformed
      * @throws IOException If reading the directory fails
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -487,6 +487,7 @@ abstract class MjSafe extends AbstractMojo {
         } else {
             try {
                 final long start = System.nanoTime();
+                new Janitor(this.cache.toPath(), this.plugin.getVersion()).exec();
                 this.execWithTimeout();
                 if (Logger.isDebugEnabled(this)) {
                     Logger.debug(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -487,7 +487,7 @@ abstract class MjSafe extends AbstractMojo {
         } else {
             try {
                 final long start = System.nanoTime();
-                new Janitor(this.cache.toPath(), this.plugin.getVersion()).exec();
+                this.invalidate();
                 this.execWithTimeout();
                 if (Logger.isDebugEnabled(this)) {
                     Logger.debug(
@@ -620,6 +620,16 @@ abstract class MjSafe extends AbstractMojo {
                     new InetSocketAddress(p.getHost(), p.getPort())
                 )
             ).toArray(Proxy[]::new);
+    }
+
+    /**
+     * Invalidates the SNAPSHOT cache if the plugin descriptor is available.
+     * The descriptor is absent in some test scenarios that use minimal setup.
+     */
+    private void invalidate() {
+        if (this.plugin != null) {
+            new Janitor(this.cache.toPath(), this.plugin.getVersion()).clean();
+        }
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import org.cactoos.Scalar;
+
+/**
+ * SHA-256 hash of a stream or file.
+ * @since 0.62.0
+ */
+final class Sha {
+
+    /**
+     * Source of bytes to hash.
+     */
+    private final Scalar<InputStream> source;
+
+    /**
+     * Ctor.
+     * @param stream Input stream to hash
+     */
+    Sha(final InputStream stream) {
+        this(() -> stream);
+    }
+
+    /**
+     * Ctor.
+     * @param file File to hash
+     */
+    Sha(final Path file) {
+        this(() -> Files.newInputStream(file));
+    }
+
+    /**
+     * Primary ctor.
+     * @param source Source of bytes to hash
+     */
+    private Sha(final Scalar<InputStream> source) {
+        this.source = source;
+    }
+
+    /**
+     * Returns Base64-encoded SHA-256 hash of the bytes.
+     * @return Base64-encoded SHA-256 hash
+     */
+    @Override
+    public String toString() {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream stream = this.source.value()) {
+                final byte[] buffer = new byte[8192];
+                int read = stream.read(buffer);
+                while (read != -1) {
+                    digest.update(buffer, 0, read);
+                    read = stream.read(buffer);
+                }
+            }
+            return Base64.getEncoder().encodeToString(digest.digest());
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", ex);
+        } catch (final Exception ex) {
+            throw new IllegalStateException("Failed to compute SHA-256 hash", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -34,10 +34,6 @@ final class Sha {
         this.path = path;
     }
 
-    /**
-     * Returns Base64-encoded SHA-256 hash.
-     * @return Base64-encoded SHA-256 hash
-     */
     @Override
     public String toString() {
         try {
@@ -59,8 +55,7 @@ final class Sha {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
         try (Stream<Path> walk = Files.walk(path)) {
             walk.filter(Files::isRegularFile)
-                .sorted(Comparator.comparing(Path::toString))
-                .forEach(
+                .sorted(Comparator.comparing(Path::toString)).forEach(
                     file -> {
                         try (InputStream input = Files.newInputStream(file)) {
                             final byte[] buffer = new byte[8192];

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -4,70 +4,79 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import org.cactoos.Scalar;
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 /**
- * SHA-256 hash of a stream or file.
+ * SHA-256 hash of a file or directory.
+ * For a directory, walks all files sorted by path and hashes their combined contents.
  * @since 0.62.0
  */
 final class Sha {
 
     /**
-     * Source of bytes to hash.
+     * File or directory to hash.
      */
-    private final Scalar<InputStream> source;
+    private final Path path;
 
     /**
      * Ctor.
-     * @param stream Input stream to hash
+     * @param path File or directory to hash
      */
-    Sha(final InputStream stream) {
-        this(() -> stream);
+    Sha(final Path path) {
+        this.path = path;
     }
 
     /**
-     * Ctor.
-     * @param file File to hash
-     */
-    Sha(final Path file) {
-        this(() -> Files.newInputStream(file));
-    }
-
-    /**
-     * Primary ctor.
-     * @param source Source of bytes to hash
-     */
-    private Sha(final Scalar<InputStream> source) {
-        this.source = source;
-    }
-
-    /**
-     * Returns Base64-encoded SHA-256 hash of the bytes.
+     * Returns Base64-encoded SHA-256 hash.
      * @return Base64-encoded SHA-256 hash
      */
     @Override
     public String toString() {
         try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            try (InputStream stream = this.source.value()) {
-                final byte[] buffer = new byte[8192];
-                int read = stream.read(buffer);
-                while (read != -1) {
-                    digest.update(buffer, 0, read);
-                    read = stream.read(buffer);
-                }
-            }
-            return Base64.getEncoder().encodeToString(digest.digest());
-        } catch (final NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("SHA-256 algorithm is not available", ex);
-        } catch (final Exception ex) {
+            return Sha.hash(this.path);
+        } catch (final IOException | NoSuchAlgorithmException ex) {
             throw new IllegalStateException("Failed to compute SHA-256 hash", ex);
         }
+    }
+
+    /**
+     * Hashes all regular files reachable from the given path, sorted by path name.
+     * Works for both a single file and a directory.
+     * @param path File or directory
+     * @return Base64-encoded SHA-256 hash
+     * @throws IOException If reading fails
+     * @throws NoSuchAlgorithmException If SHA-256 is unavailable
+     */
+    private static String hash(final Path path) throws IOException, NoSuchAlgorithmException {
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.filter(Files::isRegularFile)
+                .sorted(Comparator.comparing(Path::toString))
+                .forEach(
+                    file -> {
+                        try (InputStream input = Files.newInputStream(file)) {
+                            final byte[] buffer = new byte[8192];
+                            int read = input.read(buffer);
+                            while (read != -1) {
+                                digest.update(buffer, 0, read);
+                                read = input.read(buffer);
+                            }
+                        } catch (final IOException ex) {
+                            throw new IllegalStateException(
+                                String.format("Failed to read '%s'", file), ex
+                            );
+                        }
+                    }
+                );
+        }
+        return Base64.getEncoder().encodeToString(digest.digest());
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JanitorTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JanitorTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link Janitor}.
+ * @since 0.62.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class JanitorTest {
+
+    @Test
+    void doesNothingForReleasedVersion(@Mktmp final Path temp) {
+        new Janitor(temp, "1.0").exec();
+        MatcherAssert.assertThat(
+            "Fingerprint must not be created for released versions",
+            Files.exists(temp.resolve(".snapshot-fingerprint")),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void wipesStageDirsAndWritesFingerprintOnFirstRun(@Mktmp final Path temp) throws Exception {
+        final String version = "1.0-SNAPSHOT";
+        Files.createDirectories(temp.resolve("transpiled").resolve(version));
+        Files.createFile(
+            temp.resolve("transpiled").resolve(version).resolve("stale.xmir")
+        );
+        new Janitor(temp, version).exec();
+        MatcherAssert.assertThat(
+            "Stale SNAPSHOT cache must be wiped on first run",
+            Files.exists(temp.resolve("transpiled").resolve(version).resolve("stale.xmir")),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            "Fingerprint file must be written after wipe",
+            Files.exists(temp.resolve(".snapshot-fingerprint")),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNothingWhenFingerprintMatches(@Mktmp final Path temp) throws Exception {
+        final String version = "1.0-SNAPSHOT";
+        new Janitor(temp, version).exec();
+        Files.createDirectories(temp.resolve("transpiled").resolve(version));
+        final Path kept = temp.resolve("transpiled").resolve(version).resolve("valid.xmir");
+        Files.createFile(kept);
+        new Janitor(temp, version).exec();
+        MatcherAssert.assertThat(
+            "Cache must not be wiped when fingerprint matches",
+            Files.exists(kept),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void wipesStageDirsWhenFingerprintDiffers(@Mktmp final Path temp) throws Exception {
+        final String version = "1.0-SNAPSHOT";
+        Files.write(
+            temp.resolve(".snapshot-fingerprint"),
+            "outdated-hash".getBytes(StandardCharsets.UTF_8)
+        );
+        Files.createDirectories(temp.resolve("transpiled").resolve(version));
+        Files.createFile(
+            temp.resolve("transpiled").resolve(version).resolve("stale.xmir")
+        );
+        new Janitor(temp, version).exec();
+        MatcherAssert.assertThat(
+            "Stale cache must be wiped when fingerprint differs",
+            Files.exists(temp.resolve("transpiled").resolve(version).resolve("stale.xmir")),
+            Matchers.is(false)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JanitorTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JanitorTest.java
@@ -23,7 +23,7 @@ final class JanitorTest {
 
     @Test
     void doesNothingForReleasedVersion(@Mktmp final Path temp) {
-        new Janitor(temp, "1.0").exec();
+        new Janitor(temp, "1.0").clean();
         MatcherAssert.assertThat(
             "Fingerprint must not be created for released versions",
             Files.exists(temp.resolve(".snapshot-fingerprint")),
@@ -32,18 +32,22 @@ final class JanitorTest {
     }
 
     @Test
-    void wipesStageDirsAndWritesFingerprintOnFirstRun(@Mktmp final Path temp) throws Exception {
+    void wipesStageDirsOnFirstRun(@Mktmp final Path temp) throws Exception {
         final String version = "1.0-SNAPSHOT";
-        Files.createDirectories(temp.resolve("transpiled").resolve(version));
-        Files.createFile(
-            temp.resolve("transpiled").resolve(version).resolve("stale.xmir")
-        );
-        new Janitor(temp, version).exec();
+        new Saved("", JanitorTest.staleFile(temp, version)).value();
+        new Janitor(temp, version).clean();
         MatcherAssert.assertThat(
             "Stale SNAPSHOT cache must be wiped on first run",
-            Files.exists(temp.resolve("transpiled").resolve(version).resolve("stale.xmir")),
+            Files.exists(JanitorTest.staleFile(temp, version)),
             Matchers.is(false)
         );
+    }
+
+    @Test
+    void writesFingerprintOnFirstRun(@Mktmp final Path temp) throws Exception {
+        final String version = "1.0-SNAPSHOT";
+        new Saved("", JanitorTest.staleFile(temp, version)).value();
+        new Janitor(temp, version).clean();
         MatcherAssert.assertThat(
             "Fingerprint file must be written after wipe",
             Files.exists(temp.resolve(".snapshot-fingerprint")),
@@ -54,11 +58,10 @@ final class JanitorTest {
     @Test
     void doesNothingWhenFingerprintMatches(@Mktmp final Path temp) throws Exception {
         final String version = "1.0-SNAPSHOT";
-        new Janitor(temp, version).exec();
-        Files.createDirectories(temp.resolve("transpiled").resolve(version));
+        new Janitor(temp, version).clean();
         final Path kept = temp.resolve("transpiled").resolve(version).resolve("valid.xmir");
-        Files.createFile(kept);
-        new Janitor(temp, version).exec();
+        new Saved("", kept).value();
+        new Janitor(temp, version).clean();
         MatcherAssert.assertThat(
             "Cache must not be wiped when fingerprint matches",
             Files.exists(kept),
@@ -73,15 +76,22 @@ final class JanitorTest {
             temp.resolve(".snapshot-fingerprint"),
             "outdated-hash".getBytes(StandardCharsets.UTF_8)
         );
-        Files.createDirectories(temp.resolve("transpiled").resolve(version));
-        Files.createFile(
-            temp.resolve("transpiled").resolve(version).resolve("stale.xmir")
-        );
-        new Janitor(temp, version).exec();
+        new Saved("", JanitorTest.staleFile(temp, version)).value();
+        new Janitor(temp, version).clean();
         MatcherAssert.assertThat(
             "Stale cache must be wiped when fingerprint differs",
-            Files.exists(temp.resolve("transpiled").resolve(version).resolve("stale.xmir")),
+            Files.exists(JanitorTest.staleFile(temp, version)),
             Matchers.is(false)
         );
+    }
+
+    /**
+     * Builds the path to the stale transpiled file used in cache-wipe tests.
+     * @param temp Temporary directory
+     * @param version Plugin version
+     * @return Path to the stale file inside the transpiled stage cache
+     */
+    private static Path staleFile(final Path temp, final String version) {
+        return temp.resolve("transpiled").resolve(version).resolve("stale.xmir");
     }
 }


### PR DESCRIPTION
Invalidates the local SNAPSHOT cache on every build to prevent stale generated files from referencing removed classes.

Fixes #5179