### PR TITLE
fix(#4949): enable `object-has-data` lint in pom.xml

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -256,13 +256,6 @@
                 -->
                 <lint>comment-not-capitalized</lint>
                 <!--
-                @todo #4538:30min. Enable `object-has-data` lint.
-                      The lint incorrectly flags all objects with bytes inside because they
-                      don't have @base='Φ.org.eolang.bytes'. It was changed in
-                      https://github.com/objectionary/eo/issues/4538. Right now we have just Φ.bytes
-                -->
-                <lint>object-has-data</lint>
-                <!--
                 @todo #5078:30min. Remove `idempotent-attribute-is-not-first` skip.
                       The lint relies on the `xi🌵` positional marker that the legacy
                       ANTLR parser emitted; the new spec-driven parser does not produce


### PR DESCRIPTION
Enables the `object-has-data` lint in `eo-runtime/pom.xml` and removes the associated `@todo` puzzle.

Fixes #4949