### PR TITLE
build(#5192): upgrade jcabi-xml to 0.37.1 to fix race condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
       <dependency>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-xml</artifactId>
-        <version>0.37.0</version>
+        <version>0.37.1</version>
       </dependency>
       <dependency>
         <groupId>com.jcabi</groupId>


### PR DESCRIPTION
Bumps `jcabi-xml` dependency from `0.37.0` to `0.37.1` to fix the intermittent `NullPointerException` in `MjCompile` caused by a race condition during concurrent `eo-runtime` compilation.

Fixes #5192