### PR TITLE
feat(#5202): add [LINT] prefix to lint warning and error log messages

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -456,9 +456,9 @@ final class Linting implements Step {
      */
     private static void logOne(final String severity, final String message) {
         if (Severity.WARNING.mnemo().equals(severity)) {
-            Logger.warn(Linting.class, message);
+            Logger.warn(Linting.class, "[LINT] %s", message);
         } else {
-            Logger.error(Linting.class, message);
+            Logger.error(Linting.class, "[LINT] %s", message);
         }
     }
 


### PR DESCRIPTION
Prefixes lint violation log messages with `[LINT]` to make them visually distinct and greppable in Maven build output.

Fixes #5202