### PR TITLE
fix(#5205): suppress mandatory-package lint in root-level eo-runtime objects

### DIFF
--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -6,6 +6,7 @@
 +unlint redundant-object
 +unlint decorated-formation
 +unlint formation-without-comment
++unlint mandatory-package
 
 # A boolean value, parameterized by its choice `if`.
 # `if` is a two-argument object that returns either its first argument

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -7,6 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # @todo #4707:60min Remove `+unlint not-empty-atom` from all `.eo` files in eo-runtime.
 #  After restoring the `/name` syntax for atom return types, the `λ` marker now carries

--- a/eo-runtime/src/main/eo/cti.eo
+++ b/eo-runtime/src/main/eo/cti.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # Compile Time Instruction (CTI).
 #

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # The object dataizes `target`, makes a new instance of `bytes` from given
 # data and behaves as the result

--- a/eo-runtime/src/main/eo/error.eo
+++ b/eo-runtime/src/main/eo/error.eo
@@ -6,6 +6,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint mandatory-package
 
 # This object must be used in order to terminate the program
 # with an error. To use it, make a copy with an encapsulated object as the error message.

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint mandatory-package
 
 # The object is a FALSE boolean state.
 # It is the `bool` whose choice returns its second argument, so `if` picks

--- a/eo-runtime/src/main/eo/go.eo
+++ b/eo-runtime/src/main/eo/go.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -7,6 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -7,6 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -7,6 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -5,6 +5,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may

--- a/eo-runtime/src/main/eo/nan.eo
+++ b/eo-runtime/src/main/eo/nan.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/eo-runtime/src/main/eo/negative-infinity.eo
+++ b/eo-runtime/src/main/eo/negative-infinity.eo
@@ -5,6 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name
 +unlint redundant-object
++unlint mandatory-package
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # The `nop` object is a no-operation: it ignores its argument and
 # always behaves as TRUE. It is useful for temporarily disabling a

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -6,6 +6,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/eo-runtime/src/main/eo/positive-infinity.eo
+++ b/eo-runtime/src/main/eo/positive-infinity.eo
@@ -5,6 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name
 +unlint redundant-object
++unlint mandatory-package
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # Sequential execution object that dataizes all provided steps in order
 # and returns the value of the final step. All steps are dataized for

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -5,6 +5,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The `string` object represents UTF-8 encoded text strings stored internally
 # as byte sequences. It provides Unicode-aware operations for text manipulation

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # The object allows choosing the right options according to case conditions.
 # Parameter `cases` is an array of two-dimensional arrays, which

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint mandatory-package
 
 # The object is a TRUE boolean state.
 # It is the `bool` whose choice returns its first argument, so `if` picks

--- a/eo-runtime/src/main/eo/try.eo
+++ b/eo-runtime/src/main/eo/try.eo
@@ -5,6 +5,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # Exception handling mechanism that catches errors during dataization.
 # When `try` is dataized, it attempts to dataize the `main` attribute first.

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -4,6 +4,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:


### PR DESCRIPTION
Suppresses `mandatory-package` lint for root-level `eo-runtime` objects via `+unlint mandatory-package`.

Fixes #5205