### PR TITLE
chore(#5211): upgrade `lints` to `0.2.4` and remove stale suppressions

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.2.3</version>
+      <version>0.2.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -3,7 +3,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 +unlint mandatory-package
 
 # The object is a FALSE boolean state.

--- a/eo-runtime/src/main/eo/ms/e.eo
+++ b/eo-runtime/src/main/eo/ms/e.eo
@@ -2,7 +2,6 @@
 +home https://github.com/objectionary/eo
 +package ms
 +version 0.0.0
-+unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/eo-runtime/src/main/eo/ms/pi.eo
+++ b/eo-runtime/src/main/eo/ms/pi.eo
@@ -4,7 +4,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 
 # Returns an approximate PI number.
 3.14159265358979323846 > pi

--- a/eo-runtime/src/main/eo/sm/line-separator.eo
+++ b/eo-runtime/src/main/eo/sm/line-separator.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 
 # Returns the system-dependent line separator string.
 # On UNIX systems, it returns "\n";

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -3,7 +3,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 +unlint mandatory-package
 
 # The object is a TRUE boolean state.


### PR DESCRIPTION
Bumps `lints` to `0.2.4` and removes stale `+unlint unit-test-missing` suppressions from `eo-runtime` objects.

Fixes #5211