### PR TITLE
test(#5209): reproduce concurrent lint stylesheet compilation race

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ColdLint.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ColdLint.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Files;
+
+/**
+ * Child JVM entry point that runs a single cold linting pass.
+ *
+ * <p>The shared lint stylesheets compile once per JVM, so the race in #5209 has
+ * exactly one opportunity per process: the first parallel pass. This entry point
+ * lints many programs in one fresh JVM and propagates any failure as a non-zero
+ * exit code, letting {@link LintingTest} fork many of these to observe the race
+ * reliably.</p>
+ *
+ * @since 0.57.0
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public final class ColdLint {
+
+    /**
+     * Not for instantiation.
+     */
+    private ColdLint() {
+    }
+
+    /**
+     * Run one cold lint pass; a race surfaces as a thrown exception.
+     * @param args Ignored
+     * @throws Exception If linting fails (race reproduced)
+     */
+    public static void main(final String... args) throws Exception {
+        final FakeMaven maven = new FakeMaven(Files.createTempDirectory("coldlint"))
+            .with("cacheEnabled", false);
+        for (int idx = 0; idx < Runtime.getRuntime().availableProcessors() * 4; ++idx) {
+            maven.withProgram(
+                String.join(
+                    System.lineSeparator(),
+                    "+home https://www.eolang.org",
+                    String.format("+package foo.p%d", idx),
+                    "+version 0.0.0",
+                    "+unlint object-has-data",
+                    "",
+                    "# No comments.",
+                    "[x] > main",
+                    String.format("  (\"Hi %d\" x).length > @", idx)
+                ),
+                String.format("foo.p%d.main", idx),
+                String.format("foo/p%d/main.eo", idx)
+            );
+        }
+        maven.execute(new FakeMaven.Lint());
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -5,8 +5,12 @@
 package org.eolang.maven;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,6 +40,39 @@ final class LintingTest {
                 true
             ).exec(),
             "Linting must be fully skipped when skipLinting is TRUE"
+        );
+    }
+
+    @Disabled("Heavy #5209 reproduction; forks many JVMs and exceeds CI timeout, run manually")
+    @Test
+    void lintsManyProgramsConcurrentlyWithoutStylesheetRace() throws Exception {
+        final int forks = 24;
+        final String java = Paths.get(
+            System.getProperty("java.home"), "bin", "java"
+        ).toString();
+        final String classpath = System.getProperty("java.class.path");
+        final Collection<Process> children = new ArrayList<>(forks);
+        for (int fork = 0; fork < forks; ++fork) {
+            children.add(
+                new ProcessBuilder(java, "-cp", classpath, "org.eolang.maven.ColdLint")
+                    .redirectErrorStream(true)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .start()
+            );
+        }
+        int raced = 0;
+        for (final Process child : children) {
+            if (child.waitFor() != 0) {
+                raced += 1;
+            }
+        }
+        Assertions.assertEquals(
+            0,
+            raced,
+            String.format(
+                "Lint stylesheets must compile once before parallel linting, but %d of %d cold JVMs raced on first-time compilation (see #5209)",
+                raced, forks
+            )
         );
     }
 }


### PR DESCRIPTION
Relates to #5209.

Adds a disabled test that reproduces the intermittent lint-phase failure described in #5209.

**What it does:** `LintingTest#lintsManyProgramsConcurrentlyWithoutStylesheetRace` builds many programs and runs them through `Linting`'s parallel pass (`Threaded`, `availableProcessors() * 2` threads). That first parallel pass triggers concurrent first-time XSL compilation of the shared lint stylesheets (`Source.MONO`), which races inside Saxon / jcabi-xml and surfaces as `Cannot find a 1-argument function named ...lineno()` or DOM `HIERARCHY_REQUEST_ERR`.

**Why disabled:** the race only happens on a cold JVM (the stylesheets are compiled once and cached statically), so it reproduces intermittently and would make CI flaky. It is meant to be merged first as documentation of the bug, then enabled once the warm-up fix lands.

**Pairs with #5210:** that PR compiles every lint stylesheet once, single-threaded, before the parallel pass — after which this test can be enabled and passes deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)