### PR TITLE
#5091: remove resolved 4707 not-empty-atom puzzle from bytes.eo

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -9,13 +9,6 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# @todo #4707:60min Remove `+unlint not-empty-atom` from all `.eo` files in eo-runtime.
-#  After restoring the `/name` syntax for atom return types, the `λ` marker now carries
-#  a `base` attribute, which makes the `not-empty-atom` lint (objectionary/lints 0.0.60)
-#  treat λ as a regular inner object and flag every atom with parameters or return type.
-#  We need to fix the rule upstream in `objectionary/lints` so that λ with `base` is
-#  still recognised as the atom marker, bump the lints dependency, and then drop the
-#  `+unlint not-empty-atom` lines added across eo-runtime.
 # The object encapsulates a chain of bytes, providing bitwise operations,
 # numeric conversions, and byte manipulation methods. Objects like `number`, `string`,
 # and integer types (`i16`, `i32`, `i64`) use `bytes` as their internal representation.


### PR DESCRIPTION
Resolves the PDD puzzle `4707-ff431d75` (from #4707), tracked by #5091.

The `+unlint not-empty-atom` lines have already been removed from all `.eo` files in `eo-runtime`, and the `not-empty-atom` lint now passes without them (it is not in the `skipSourceLints` list), so the puzzle's prerequisites are complete. This change removes the now-resolved `@todo #4707` text from `eo-runtime/src/main/eo/bytes.eo`, which is the remaining deliverable for #5091.

Closes #5091
