### PR TITLE
feat(#4752): add tt.as-ascii object

### DIFF
--- a/eo-runtime/src/main/eo/tt/as-ascii.eo
+++ b/eo-runtime/src/main/eo/tt/as-ascii.eo
@@ -1,0 +1,69 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tt
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Reads the single character `char` as its ASCII numeric value (0-255).
+# The byte of `char` is left-padded with a zero byte into a 16-bit word,
+# read as an integer and then expressed as a number.
+[char] > as-ascii
+  word.as-i16.as-number > @
+  concat. > word
+    00-
+    char.as-bytes
+
+  # Tests that as-ascii reads the code of an uppercase letter.
+  [] +> tests-reads-code-of-uppercase-letter
+    eq. > @
+      65
+      as-ascii "A"
+
+  # Tests that as-ascii reads the code of the last uppercase letter.
+  [] +> tests-reads-code-of-last-uppercase-letter
+    eq. > @
+      90
+      as-ascii "Z"
+
+  # Tests that as-ascii reads the code of a lowercase letter.
+  [] +> tests-reads-code-of-lowercase-letter
+    eq. > @
+      97
+      as-ascii "a"
+
+  # Tests that as-ascii reads the code of the last lowercase letter.
+  [] +> tests-reads-code-of-last-lowercase-letter
+    eq. > @
+      122
+      as-ascii "z"
+
+  # Tests that as-ascii reads the code of the zero digit.
+  [] +> tests-reads-code-of-zero-digit
+    eq. > @
+      48
+      as-ascii "0"
+
+  # Tests that as-ascii reads the code of the nine digit.
+  [] +> tests-reads-code-of-nine-digit
+    eq. > @
+      57
+      as-ascii "9"
+
+  # Tests that as-ascii reads the code of the space character.
+  [] +> tests-reads-code-of-space
+    eq. > @
+      32
+      as-ascii " "
+
+  # Tests that as-ascii reads the code of a punctuation character.
+  [] +> tests-reads-code-of-punctuation
+    eq. > @
+      33
+      as-ascii "!"
+
+  # Tests that as-ascii reads the code of the last printable character.
+  [] +> tests-reads-code-of-last-printable
+    eq. > @
+      126
+      as-ascii "~"


### PR DESCRIPTION
Part of #4752.

Adds a pure-EO `tt.as-ascii` object that reads a single character as its
ASCII numeric value (0-255), by widening the character's byte to the eight
bytes `i64` expects and reading it back as a number.

It is a small helper needed by the pure-EO `sprintf` reimplementation.