### PR TITLE
test(#4752): add sprintf edge-case tests for %d truncation and %f width

### DIFF
--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -116,3 +116,51 @@
       sprintf
         "%s %s %2$s is after %1$s"
         * "first" "second"
+
+  # Tests that sprintf truncates a positive float towards zero for %d.
+  [] +> truncates-positive-float-towards-zero-as-decimal
+    eq. > @
+      "42"
+      sprintf
+        "%d"
+        * 42.321
+
+  # Tests that sprintf truncates a negative float towards zero for %d.
+  [] +> truncates-negative-float-towards-zero-as-decimal
+    eq. > @
+      "-7"
+      sprintf
+        "%d"
+        * -7.89
+
+  # Tests that sprintf truncates rather than rounds a float for %d.
+  [] +> truncates-rather-than-rounds-float-as-decimal
+    eq. > @
+      "9"
+      sprintf
+        "%d"
+        * 9.99
+
+  # Tests that sprintf always pads a float to exactly six fraction digits.
+  [] +> formats-float-always-with-six-fraction-digits
+    eq. > @
+      "1.250000"
+      sprintf
+        "%f"
+        * 1.25
+
+  # Tests that sprintf carries the rounding of a float into the integer part.
+  [] +> rounds-float-carrying-into-integer-part
+    eq. > @
+      "1.000000"
+      sprintf
+        "%f"
+        * 0.9999999
+
+  # Tests that sprintf formats a zero float with six fraction digits.
+  [] +> formats-zero-float-with-six-fraction-digits
+    eq. > @
+      "0.000000"
+      sprintf
+        "%f"
+        * 0.0


### PR DESCRIPTION
Part of #4752. Tests-only change.

Adds edge-case tests to `tt/sprintf.eo` that pin down two behaviors that were
previously unspecified by tests:

**`%d` with a non-integer float — truncates towards zero (never rounds):**
- `42.321` → `42`
- `-7.89` → `-7`
- `9.99` → `9` (key case: confirms truncation, not rounding up to `10`)

**`%f` — always exactly six fraction digits:**
- `1.25` → `1.250000` (fixed width, zero-padded)
- `0.9999999` → `1.000000` (rounding carries into the integer part)
- `0.0` → `0.000000`