### PR TITLE
feat(#5226): wire up-cased/low-cased to tt.as-ascii

### DIFF
--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -2,7 +2,6 @@
 +alias ss.list
 +alias ss.reduced
 +alias tt.as-ascii
-+alias tt.up-cased
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
@@ -28,13 +27,16 @@
             slice.
               as-bytes.
                 as-i64.
-                  code.plus (up-cased text).distance
+                  code.plus distance
               7
               1
             byte
         as-ascii byte > code
   as-ascii "Z" > maxcode
   as-ascii "A" > mincode
+  minus. > distance
+    as-ascii "a"
+    as-ascii "A"
 
   # Tests that low-cased converts uppercase text to lowercase.
   [] +> tests-converts-text-to-lower-case

--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -1,14 +1,13 @@
++alias tt.as-ascii
 +alias ss.bytes-as-array
 +alias ss.list
 +alias ss.reduced
-+alias tt.as-ascii
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 # Returns the `text` in lower case.
 [text] > low-cased
@@ -32,9 +31,9 @@
               1
             byte
         as-ascii byte > code
-  as-ascii "Z" > maxcode
-  as-ascii "A" > mincode
-  minus. > distance
+  as-ascii "Z" > maxcode!
+  as-ascii "A" > mincode!
+  minus. > distance!
     as-ascii "a"
     as-ascii "A"
 

--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -8,6 +8,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 
 # Returns the `text` in lower case.
 [text] > low-cased
@@ -31,9 +32,9 @@
               1
             byte
         as-ascii byte > code
-  as-ascii "Z" > maxcode!
-  as-ascii "A" > mincode!
-  minus. > distance!
+  as-ascii "Z" > maxcode
+  as-ascii "A" > mincode
+  minus. > distance
     as-ascii "a"
     as-ascii "A"
 

--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -1,6 +1,7 @@
 +alias ss.bytes-as-array
 +alias ss.list
 +alias ss.reduced
++alias tt.as-ascii
 +alias tt.up-cased
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -31,9 +32,9 @@
               7
               1
             byte
-        (up-cased text).ascii byte > code
-  (up-cased text).ascii "Z" > maxcode
-  (up-cased text).ascii "A" > mincode
+        as-ascii byte > code
+  as-ascii "Z" > maxcode
+  as-ascii "A" > mincode
 
   # Tests that low-cased converts uppercase text to lowercase.
   [] +> tests-converts-text-to-lower-case

--- a/eo-runtime/src/main/eo/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/tt/up-cased.eo
@@ -1,6 +1,7 @@
 +alias ss.bytes-as-array
 +alias ss.list
 +alias ss.reduced
++alias tt.as-ascii
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
@@ -30,20 +31,12 @@
               7
               1
             byte
-        ascii byte > code
-  ascii "z" > maxcode!
-  ascii "a" > mincode!
+        as-ascii byte > code
+  as-ascii "z" > maxcode!
+  as-ascii "a" > mincode!
   minus. > distance
     number mincode
-    ascii "A"
-
-  # Converts character to its ASCII numeric value as number.
-  [char] > ascii
-    as-number. > @
-      as-i64.
-        concat.
-          00-00-00-00-00-00-00
-          char.as-bytes
+    as-ascii "A"
 
   # Tests that up-cased converts lowercase text to uppercase.
   [] +> tests-converts-text-to-upper-case

--- a/eo-runtime/src/main/eo/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/tt/up-cased.eo
@@ -1,7 +1,7 @@
++alias tt.as-ascii
 +alias ss.bytes-as-array
 +alias ss.list
 +alias ss.reduced
-+alias tt.as-ascii
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt


### PR DESCRIPTION
Closes #5226.

`tt.as-ascii` was added in #4752 as a standalone object that reads a single character as its ASCII numeric value (0-255), but it had no production callers.

This PR wires it in:

- **`tt.up-cased`** — removes the private nested `[char] > ascii` helper and calls `tt.as-ascii` instead.
- **`tt.low-cased`** — replaces the `(up-cased text).ascii ...` expressions with direct `tt.as-ascii` calls, computes `distance` locally, and drops the `+alias tt.up-cased`, fully removing the dependency on `up-cased` internals.