### PR TITLE
test(#4236): enable tests-resolves-and-touches in file.eo

### DIFF
--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -285,22 +285,9 @@
     (tmpdir.as-path.resolved "foo").@.tmpfile > @
 
   # Tests that resolving nested paths and touching files works correctly.
-  # @todo #4096:30min Enable tests-resolves-and-touches unit test.
-  #  Now its disabled because of: "Can't #take("path"), the attribute is absent among other test 34
-  #  attrs. After we fix it, we should enable the test.
-  [] > tests-resolves-and-touches
-    seq > @
-      *
-        resolved.deleted.made
-        and.
-          f.exists
-          contains.
-            f.path
-            joined.
-              path.separator
-              * "foo" "bar"
-    (tmpdir.as-path.resolved "foo/bar").@ > resolved
-    resolved.tmpfile > f
+  [] +> tests-resolves-and-touches
+    resolved.made.tmpfile.exists > @
+    (tmpdir.as-path.resolved "foo/bar").as-dir > resolved
 
   # Tests that moving a file to a new location works correctly.
   [] +> tests-moves-a-file

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -1,6 +1,8 @@
 +alias fs.file
 +alias fs.path
 +alias fs.tmpdir
++alias tt.contains
++alias tt.joined
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -286,8 +288,14 @@
 
   # Tests that resolving nested paths and touching files works correctly.
   [] +> tests-resolves-and-touches
-    resolved.made.tmpfile.exists > @
-    (tmpdir.as-path.resolved "foo/bar").as-dir > resolved
+    and. > @
+      resolved.as-dir.made.tmpfile.exists
+      contains
+        resolved
+        joined
+          Q.fs.path.separator
+          * "foo" "bar"
+    tmpdir.as-path.resolved "foo/bar" > resolved
 
   # Tests that moving a file to a new location works correctly.
   [] +> tests-moves-a-file


### PR DESCRIPTION
Closes #4236.

The `tests-resolves-and-touches` unit test in `fs/file.eo` was enabled in #4127 (2025-05-04), then disabled again under #4096 (2025-06-04) because it had started failing on `Can't #take("path")` as the `fs` API evolved away from what the test assumed. The disabled body had three problems:

- `.@` was used to turn a resolved `path` into a directory, but `path.@` yields another path with no `tmpfile`/`made`. The `posix` path exposes `as-dir` (`dir (file uri)`) for exactly this conversion.
- `deleted.made` was called on a directory that does not exist yet; `dir.deleted` runs `walk "**"`, which fails on an absent dir. The established idiom (see `fs/dir.eo`) is `.as-dir.made`.
- The assertion called `contains.` as a method on a `path`, which is not valid.

The test now resolves `foo/bar` under `tmpdir`, makes the directory, touches a tmpfile, and asserts **both** that the file exists **and** that the resolved path contains the nested `foo/bar` segment — so the "resolves" half of the test is actually verified, not just the touch. The expected fragment is built from `Q.fs.path.separator` + `joined`, so it holds on both POSIX (`foo/bar`) and Windows (`foo\bar`). Puzzle removed.

Two subtleties that were the real cause of the historic `Can't #take("path")`:

- `f.path` is not accessible from outside a `file`: the `[path]` void attribute is consumed by `path > @`. The assertion checks the resolved `path` object directly instead.
- Inside `fs.file`, the bareword `path` resolves to the file's own void attribute and shadows the `fs.path` alias, so `path.separator` also throws. Fully-qualified `Q.fs.path.separator` is used.
