### PR TITLE
fix(#5232): insert floated vars before tests in vars-float-up

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
@@ -43,12 +43,14 @@
       <xsl:if test="not(@name) and @as">
         <xsl:attribute name="as" select="@as"/>
       </xsl:if>
-      <xsl:apply-templates select="node()|@* except @as"/>
+      <xsl:apply-templates select="@* except @as"/>
+      <xsl:apply-templates select="node()[not(self::o and eo:test-attr(.))]"/>
       <xsl:for-each select="o/descendant::o[@name]">
         <xsl:if test="ancestor::o[eo:abstract(.)][1]/generate-id() = generate-id($o)">
           <xsl:apply-templates select="." mode="full"/>
         </xsl:if>
       </xsl:for-each>
+      <xsl:apply-templates select="node()[self::o and eo:test-attr(.)]"/>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="o[@name and ancestor::o[1][not(eo:abstract(.))]]">

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/float-up-vars-before-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/float-up-vars-before-tests.yaml
@@ -6,7 +6,7 @@ sheets:
   - /org/eolang/parser/parse/vars-float-up.xsl
 asserts:
   - /object[not(errors)]
-  - //o[@name='main' and count(o)=3]
+  - //o[@name='main' and count(o)=5]
   - //o[@name='main']/o[contains(@name,'🌵')]
   - //o[@name='main']/o[@name='+tests-foo']/preceding-sibling::o[contains(@name,'🌵')]
   - //o[@name='main']/o[@name='+tests-foo' and not(following-sibling::o)]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/float-up-vars-before-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/float-up-vars-before-tests.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/vars-float-up.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='main' and count(o)=3]
+  - //o[@name='main']/o[contains(@name,'🌵')]
+  - //o[@name='main']/o[@name='+tests-foo']/preceding-sibling::o[contains(@name,'🌵')]
+  - //o[@name='main']/o[@name='+tests-foo' and not(following-sibling::o)]
+input: |
+  # Main.
+  [lst func] > main
+    filteredi > @
+      lst
+      func item > [item index] >>
+
+    # Foo.
+    [] +> tests-foo
+      true > @


### PR DESCRIPTION
Fixes `vars-float-up` to insert floated anonymous objects before `+tests-*` siblings rather than appending them at the tail of the parent's child list.

Fixes #5232