### PR TITLE
fix(#5223): enable `wrong-test-order` lint in eo-runtime pom.xml

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -261,13 +261,6 @@
                 -->
                 <lint>idempotent-attribute-is-not-first</lint>
                 <!--
-                @todo #5221:60min Enable `wrong-test-order` lint.
-                      The lint fires as a false positive when anonymous `>>` objects from
-                      the main body are floated past tests by vars-float-up transformation.
-                      Enable once objectionary/lints#954 is resolved.
-                -->
-                <lint>wrong-test-order</lint>
-                <!--
                 @todo #5221:30min Enable `compound-name` lint.
                       Several objects in eo-runtime use compound names that follow system
                       or platform naming conventions (e.g. neg-inf, groups-count, sin-family).


### PR DESCRIPTION
Enables `wrong-test-order` lint in `eo-runtime/pom.xml` now that the upstream false-positive issue has been resolved.

Fixes #5223