### PR TITLE
refactor(#5224): rename compound `groups-count` to `count` in regex

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -263,7 +263,7 @@
                 <!--
                 @todo #5221:30min Enable `compound-name` lint.
                       Several objects in eo-runtime use compound names that follow system
-                      or platform naming conventions (e.g. neg-inf, groups-count, sin-family).
+                      or platform naming conventions (e.g. neg-inf, sin-family).
                       Either rename the objects or adjust the lint rule, then enable it.
                 -->
                 <lint>compound-name</lint>

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -76,7 +76,7 @@
       # - `groups`        - tuple of identified matched groups
       #
       # The block provides the next API to work with matched string subsequence:
-      # - `groups-count`  - to get amount of matched groups
+      # - `count`         - to get amount of matched groups
       # - `exists`        - to check if matched block is not empty
       # - `next`          - to get next matched block
       # - `text`          - to get matched subsequence as `string`
@@ -88,7 +88,7 @@
       #  here, in `matched`. Don't forget to remove this puzzle.
       [position start from to groups] > matched
         $ > matched
-        groups.length > groups-count
+        groups.length > count
         start.gte 0 > exists
         if. > next
           exists
@@ -153,8 +153,8 @@
     ((regex "/[a-z]+/").match "123").next.to > @
 
   # Tests that accessing groups count on non-matched block throws error.
-  [] +> throws-on-getting-groups-count-on-not-matched-block
-    ((regex "/[a-z]+/").match "123").next.groups-count > @
+  [] +> throws-on-getting-count-on-not-matched-block
+    ((regex "/[a-z]+/").match "123").next.count > @
 
   # Tests that accessing groups on non-matched block throws error.
   [] +> throws-on-getting-groups-on-not-matched-block
@@ -245,12 +245,12 @@
     and. > @
       and.
         and.
-          first.groups-count.eq 3
+          first.count.eq 3
           (first.group 1).eq "hello"
         (first.group 2).eq "1"
       and.
         and.
-          second.groups-count.eq 3
+          second.count.eq 3
           (second.group 1).eq "world"
         (second.group 2).eq "2"
     ((regex "/([a-z]+)([1-9]{1})/").compiled.match "!hello1!world2").next > first


### PR DESCRIPTION
Partial step toward #5224 (enable the `compound-name` lint in `eo-runtime`).

The `compound-name` lint flags every non-formation object name that is compound (contains `-`, `_` or an uppercase letter). Fully enabling it requires renaming ~17 distinct objects — including math constants (`negative-infinity`/`positive-infinity`, ~500 usages) and POSIX/Win32 constants (`af-inet`, `sock-stream`, `ipproto-tcp`, …) that deliberately mirror C names. That is far more than 100 lines and carries a rename-vs-adjust-lint design decision, so it is left for follow-up work.

This PR takes one small, self-contained, low-risk slice: the internal `matched` block attribute `groups-count` (used only in `eo-runtime/src/main/eo/tt/regex.eo`) is renamed to `count`, and `groups-count` is dropped from the puzzle's example list. The lint stays skipped until the remaining violations are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)