### PR TITLE
refactor(#4751): move misplaced pow tests out of real.eo

### DIFF
--- a/eo-runtime/src/main/eo/ms/pow.eo
+++ b/eo-runtime/src/main/eo/ms/pow.eo
@@ -193,3 +193,63 @@
     eq. > @
       pow 42 positive-infinity
       positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. > @
+      pow 42.5 positive-infinity
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
+    eq. > @
+      pow positive-infinity 42
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
+    eq. > @
+      pow positive-infinity 10.8
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. > @
+      pow positive-infinity positive-infinity
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
+    eq. > @
+      pow negative-infinity 9.9
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
+    eq. > @
+      pow negative-infinity 10
+      positive-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
+    eq. > @
+      pow negative-infinity 9
+      negative-infinity
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-int-to-the-pow-of-positive-int-is-int
+    eq. > @
+      pow 2 3
+      8
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-float-to-the-pow-of-positive-int-is-float
+    eq. > @
+      pow 3.5 4
+      150.0625
+
+  # Tests mathematical operation functionality.
+  [] +> tests-positive-int-to-the-pow-of-positive-float-is-float
+    eq. > @
+      pow 4 5
+      1024

--- a/eo-runtime/src/main/eo/ms/real.eo
+++ b/eo-runtime/src/main/eo/ms/real.eo
@@ -1,4 +1,3 @@
-+alias ms.pow
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
@@ -9,63 +8,3 @@
 # Returns a floating point number.
 [num] > real
   num > @
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
-      pow 42.5 positive-infinity
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
-    eq. > @
-      pow positive-infinity 42
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. > @
-      pow positive-infinity 10.8
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
-      pow positive-infinity positive-infinity
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. > @
-      pow negative-infinity 9.9
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
-    eq. > @
-      pow negative-infinity 10
-      positive-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
-    eq. > @
-      pow negative-infinity 9
-      negative-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-int-to-the-pow-of-positive-int-is-int
-    eq. > @
-      pow 2 3
-      8
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-float-to-the-pow-of-positive-int-is-float
-    eq. > @
-      pow 3.5 4
-      150.0625
-
-  # Tests mathematical operation functionality.
-  [] +> tests-positive-int-to-the-pow-of-positive-float-is-float
-    eq. > @
-      pow 4 5
-      1024


### PR DESCRIPTION
Part #4751.

`ms.real` was still acting as a utility class by holding `pow` tests inline. This moves those 10 tests into `ms/pow.eo`, leaving `real.eo` as a clean float wrapper (`real` is still used as an object by `acos`, `exp`, `sqrt`).