### PR TITLE
feat(#4533): remove last $ usage from regex matched block

### DIFF
--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -55,7 +55,7 @@
 
     # Creates a `matcher` that will match the given input against the pattern.
     [txt] > match
-      (matched-from-index 1 0).matched > next
+      matched-from-index 1 0 > next
 
       # Get `position`-th block matched from `start` position.
       # Always returns a `org.eolang.tt.regex.pattern.match.matched` object: a
@@ -81,21 +81,14 @@
       # - `next`          - to get next matched block
       # - `text`          - to get matched subsequence as `string`
       # - `group {index}` - to get string subsequence captured by `index`-th group.
-      # @todo #4411:35min Replace all left usages of `$ > oname`.
-      #  We should remove all the usages like `$ > matched` from the syntax, and
-      #  from the runtime objects. Currently, it is not possible because syntax sugar for object
-      #  idempotency is not fully implemented, and we cannot remove some edge case usages, like
-      #  here, in `matched`. Don't forget to remove this puzzle.
       [position start from to groups] > matched
-        $ > matched
         groups.length > groups-count
         start.gte 0 > exists
         if. > next
           exists
-          matched.
-            matched-from-index
-              position.plus 1
-              to
+          ^.matched-from-index
+            position.plus 1
+            to
           error "Matched block does not exist, can't get next"
         if. > text
           exists


### PR DESCRIPTION
Closes #4533 (runtime part).

`regex.eo`'s `$ > matched` was the only remaining `$` (self/`ξ`) usage in the whole runtime library. Removed it by routing the `next` recursion through `^` (the block's ρ, which is `match`) and dropping the now-redundant `.matched` accessor — no Java atom or parser changes.

The idempotency sugar the original `@todo` waited on was dropped in the parser rewrite (`769675b1a`), so this approach uses no sugar at all.

Parser-level grammar removal of `$` is left as a follow-up.