### PR TITLE
build(#5241): upgrade lints dependency from 0.2.6 to 0.2.7

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.2.6</version>
+      <version>0.2.7</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -246,21 +246,6 @@
                 -->
                 <lint>sparse-decoration</lint>
                 <!--
-                @todo #4935:30min. Enable `comment-not-capitalized` lint.
-                      The lint incorrectly flags comments starting with `@to-do` as not capitalized.
-                      We should enable it after the lints repo fixes the issue to
-                      ignore @to-do markers. See: https://github.com/objectionary/lints/issues/805
-                -->
-                <lint>comment-not-capitalized</lint>
-                <!--
-                @todo #5078:30min. Remove `idempotent-attribute-is-not-first` skip.
-                      The lint relies on the `xi🌵` positional marker that the legacy
-                      ANTLR parser emitted; the new spec-driven parser does not produce
-                      this marker, so the lint now fires on every formation. Drop this
-                      skip entry entirely once the lint is removed from the lints repo.
-                -->
-                <lint>idempotent-attribute-is-not-first</lint>
-                <!--
                 @todo #5221:30min Enable `compound-name` lint.
                       Several objects in eo-runtime use compound names that follow system
                       or platform naming conventions (e.g. neg-inf, groups-count, sin-family).

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -244,7 +244,7 @@
                       `+tests` meta, we have complains about sparse-decoration. Let's adjust and
                       enable it.
                 -->
-                <lint>sparse-decoration</lint>
+                <!-- <lint>sparse-decoration</lint> -->
                 <!--
                 @todo #5221:30min Enable `compound-name` lint.
                       Several objects in eo-runtime use compound names that follow system

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -120,87 +120,89 @@
 
   # Tests that the runtime handles deep nesting of objects.
   [] +> tests-nesting-blah-test
-    blah0 > @
-    [] > blah0
-      blah1 > @
-      [] > blah1
-        blah2 > @
-        [] > blah2
-          blah3 > @
-          [] > blah3
-            blah4 > @
-            [] > blah4
-              blah5 > @
-              [] > blah5
-                blah6 > @
-                [] > blah6
-                  blah7 > @
-                  [] > blah7
-                    blah8 > @
-                    [] > blah8
-                      blah9 > @
-                      [] > blah9
-                        blah10 > @
-                        [] > blah10
-                          blah11 > @
-                          [] > blah11
-                            blah12 > @
-                            [] > blah12
-                              blah13 > @
-                              [] > blah13
-                                blah14 > @
-                                [] > blah14
-                                  blah15 > @
-                                  [] > blah15
-                                    blah16 > @
-                                    [] > blah16
-                                      blah17 > @
-                                      [] > blah17
-                                        blah18 > @
-                                        [] > blah18
-                                          blah19 > @
-                                          [] > blah19
-                                            blah20 > @
-                                            [] > blah20
-                                              blah21 > @
-                                              [] > blah21
-                                                blah22 > @
-                                                [] > blah22
-                                                  blah23 > @
-                                                  [] > blah23
-                                                    blah24 > @
-                                                    [] > blah24
-                                                      blah25 > @
-                                                      [] > blah25
-                                                        blah26 > @
-                                                        [] > blah26
-                                                          blah27 > @
-                                                          [] > blah27
-                                                            blah28 > @
-                                                            [] > blah28
-                                                              blah29 > @
-                                                              [] > blah29
-                                                                blah30 > @
-                                                                [] > blah30
-                                                                  blah31 > @
-                                                                  [] > blah31
-                                                                    blah32 > @
-                                                                    [] > blah32
-                                                                      blah33 > @
-                                                                      [] > blah33
-                                                                        blah34 > @
-                                                                        [] > blah34
-                                                                          blah35 > @
-                                                                          [] > blah35
-                                                                            blah36 > @
-                                                                            [] > blah36
-                                                                              blah37 > @
-                                                                              [] > blah37
-                                                                                blah38 > @
-                                                                                [] > blah38
-                                                                                  blah39 > @
-                                                                                  [] > blah39
-                                                                                    true > @
+    eq. > @
+      blah0 0
+      39
+    [x] > blah0
+      blah1 (x.plus 1) > @
+      [x] > blah1
+        blah2 (x.plus 1) > @
+        [x] > blah2
+          blah3 (x.plus 1) > @
+          [x] > blah3
+            blah4 (x.plus 1) > @
+            [x] > blah4
+              blah5 (x.plus 1) > @
+              [x] > blah5
+                blah6 (x.plus 1) > @
+                [x] > blah6
+                  blah7 (x.plus 1) > @
+                  [x] > blah7
+                    blah8 (x.plus 1) > @
+                    [x] > blah8
+                      blah9 (x.plus 1) > @
+                      [x] > blah9
+                        blah10 (x.plus 1) > @
+                        [x] > blah10
+                          blah11 (x.plus 1) > @
+                          [x] > blah11
+                            blah12 (x.plus 1) > @
+                            [x] > blah12
+                              blah13 (x.plus 1) > @
+                              [x] > blah13
+                                blah14 (x.plus 1) > @
+                                [x] > blah14
+                                  blah15 (x.plus 1) > @
+                                  [x] > blah15
+                                    blah16 (x.plus 1) > @
+                                    [x] > blah16
+                                      blah17 (x.plus 1) > @
+                                      [x] > blah17
+                                        blah18 (x.plus 1) > @
+                                        [x] > blah18
+                                          blah19 (x.plus 1) > @
+                                          [x] > blah19
+                                            blah20 (x.plus 1) > @
+                                            [x] > blah20
+                                              blah21 (x.plus 1) > @
+                                              [x] > blah21
+                                                blah22 (x.plus 1) > @
+                                                [x] > blah22
+                                                  blah23 (x.plus 1) > @
+                                                  [x] > blah23
+                                                    blah24 (x.plus 1) > @
+                                                    [x] > blah24
+                                                      blah25 (x.plus 1) > @
+                                                      [x] > blah25
+                                                        blah26 (x.plus 1) > @
+                                                        [x] > blah26
+                                                          blah27 (x.plus 1) > @
+                                                          [x] > blah27
+                                                            blah28 (x.plus 1) > @
+                                                            [x] > blah28
+                                                              blah29 (x.plus 1) > @
+                                                              [x] > blah29
+                                                                blah30 (x.plus 1) > @
+                                                                [x] > blah30
+                                                                  blah31 (x.plus 1) > @
+                                                                  [x] > blah31
+                                                                    blah32 (x.plus 1) > @
+                                                                    [x] > blah32
+                                                                      blah33 (x.plus 1) > @
+                                                                      [x] > blah33
+                                                                        blah34 (x.plus 1) > @
+                                                                        [x] > blah34
+                                                                          blah35 (x.plus 1) > @
+                                                                          [x] > blah35
+                                                                            blah36 (x.plus 1) > @
+                                                                            [x] > blah36
+                                                                              blah37 (x.plus 1) > @
+                                                                              [x] > blah37
+                                                                                blah38 (x.plus 1) > @
+                                                                                [x] > blah38
+                                                                                  blah39 (x.plus 1) > @
+                                                                                  [x] > blah39
+                                                                                    x > @
 
   # Tests that the runtime compiles correctly with long duplicate names.
   [] +> tests-compiles-correctly-with-long-duplicate-names

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -71,13 +71,12 @@
           cached1.eq cached2
           1.eq cached1
     # Function that increments counter in memory for testing.
-    [] > func
-      malloc.for > @
-        0
-        [m]
-          seq > @
-            *
-              true
-              m.put (m.as-number.plus 1)
+    malloc.for > func
+      0
+      [m]
+        seq > @
+          *
+            true
+            m.put (m.as-number.plus 1)
     (dataized func).as-bytes > cached1
     func > cached2!

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -122,15 +122,11 @@
           *
             [] >>
               c3 > @
-            []
-              "true case" > @
+            "true case"
       "true case"
     # Condition that evaluates to false for testing purposes.
-    [] > c1
-      false > @
+    false > c1
     # Condition that compares unequal strings returning false.
-    [] > c2
-      "1".eq "2" > @
+    "1".eq "2" > c2
     # Condition that evaluates to true for testing purposes.
-    [] > c3
-      true > @
+    true > c3


### PR DESCRIPTION
Bumps `lints` from `0.2.6` to `0.2.7` and adjusts EO sources to pass the updated lint rules.

Fixes #5241