### PR TITLE
refactor(#5226): replace up-cased private ascii with tt.as-ascii

### DIFF
--- a/eo-runtime/src/main/eo/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/tt/up-cased.eo
@@ -1,3 +1,4 @@
++alias tt.as-ascii
 +alias ss.bytes-as-array
 +alias ss.list
 +alias ss.reduced
@@ -7,7 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 # Returns the `text` in upper case.
 [text] > up-cased
@@ -30,20 +30,12 @@
               7
               1
             byte
-        ascii byte > code
-  ascii "z" > maxcode!
-  ascii "a" > mincode!
-  minus. > distance
+        as-ascii byte > code
+  as-ascii "z" > maxcode!
+  as-ascii "a" > mincode!
+  minus. > distance!
     number mincode
-    ascii "A"
-
-  # Converts character to its ASCII numeric value as number.
-  [char] > ascii
-    as-number. > @
-      as-i64.
-        concat.
-          00-00-00-00-00-00-00
-          char.as-bytes
+    as-ascii "A"
 
   # Tests that up-cased converts lowercase text to uppercase.
   [] +> tests-converts-text-to-upper-case


### PR DESCRIPTION
Part of #5226.

Drops the private nested `[char] > ascii` helper in `tt.up-cased` to use object "tt.as-ascii"


Wait's for https://github.com/objectionary/eo/pull/5227
