### PR TITLE
feat(#5165): add `@Impure` and annotate impure atoms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOmade$EOmkdir.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOmade$EOmkdir.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -23,6 +24,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "dir.made.mkdir")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOdir$EOmade$EOmkdir extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOtmpfile$EOtouch.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOtmpfile$EOtouch.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -26,6 +27,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "dir.tmpfile.touch")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOdir$EOtmpfile$EOtouch extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOdir$EOwalk.java
@@ -22,6 +22,7 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -32,6 +33,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "dir.walk")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOdir$EOwalk extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOdeleted$EOdelete.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOdeleted$EOdelete.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -26,6 +27,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.deleted.delete")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOdeleted$EOdelete extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOexists.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOexists.java
@@ -14,6 +14,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -24,6 +25,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.exists")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOexists extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOis_directory.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOis_directory.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -23,6 +24,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.is-directory")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOis_directory extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOmoved$EOmove.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOmoved$EOmove.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -26,6 +27,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.moved.move")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOmoved$EOmove extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOread$EOchunk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOread$EOchunk.java
@@ -17,6 +17,7 @@ import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -27,6 +28,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.open.file-stream.read.chunk")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOopen$EOfile_stream$EOread$EOchunk
     extends PhDefault

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOwrite$EOwritten_bytes.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOwrite$EOwritten_bytes.java
@@ -18,6 +18,7 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -28,6 +29,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.open.file-stream.write.written-bytes")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOopen$EOfile_stream$EOwrite$EOwritten_bytes
     extends PhDefault

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOprocess_file.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOprocess_file.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -25,6 +26,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.open.process-file")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOopen$EOprocess_file extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOsize.java
@@ -13,6 +13,7 @@ import java.io.File;
 import org.eolang.Atom;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -23,6 +24,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.size")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOsize extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOtouched$EOtouch.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOtouched$EOtouch.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.eolang.Atom;
 import org.eolang.Dataized;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -24,6 +25,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "file.touched.touch")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOfile$EOtouched$EOtouch extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
@@ -15,6 +15,7 @@ package org.eolang;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "malloc.of.allocated.read")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOresized.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOresized.java
@@ -15,6 +15,7 @@ package org.eolang;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "malloc.of.allocated.resized")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOmalloc$EOof$EOallocated$EOresized extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOsize.java
@@ -15,6 +15,7 @@ package org.eolang;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "malloc.of.allocated.size")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOmalloc$EOof$EOallocated$EOsize extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOwrite.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOwrite.java
@@ -15,6 +15,7 @@ package org.eolang;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "malloc.of.allocated.write")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOmalloc$EOof$EOallocated$EOwrite extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOφ.java
@@ -15,6 +15,7 @@ package org.eolang;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "malloc.of.@")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOmalloc$EOof$EOφ extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOsm/EOos$EOname.java
+++ b/eo-runtime/src/main/java/org/eolang/EOsm/EOos$EOname.java
@@ -11,6 +11,7 @@ package org.eolang.EOsm; // NOPMD
 
 import org.eolang.Atom;
 import org.eolang.Data;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -21,6 +22,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (5 lines)
  */
 @XmirObject(oname = "os.name")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOos$EOname extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOsm/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOsm/EOposix$EOφ.java
@@ -30,6 +30,7 @@ import org.eolang.EOsm.Posix.SocketSyscall;
 import org.eolang.EOsm.Posix.StrerrorSyscall;
 import org.eolang.EOsm.Posix.WriteSyscall;
 import org.eolang.ExFailure;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -40,6 +41,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "posix.@")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOposix$EOφ extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/EOsm/EOwin32$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOsm/EOwin32$EOφ.java
@@ -31,6 +31,7 @@ import org.eolang.EOsm.Win32.WSAGetLastErrorFuncCall;
 import org.eolang.EOsm.Win32.WSAStartupFuncCall;
 import org.eolang.EOsm.Win32.WriteFileFuncCall;
 import org.eolang.ExFailure;
+import org.eolang.Impure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -41,6 +42,7 @@ import org.eolang.XmirObject;
  * @checkstyle TypeNameCheck (100 lines)
  */
 @XmirObject(oname = "win32.@")
+@Impure
 @SuppressWarnings("PMD.AvoidDollarSigns")
 public final class EOwin32$EOφ extends PhDefault implements Atom {
 

--- a/eo-runtime/src/main/java/org/eolang/Impure.java
+++ b/eo-runtime/src/main/java/org/eolang/Impure.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an atom whose result depends on the outside world.
+ *
+ * <p>An impure atom (file access, the operating system, the clock, randomness)
+ * yields a different object every time it is calculated. Its φ-expression is
+ * therefore not a reliable cache key, so caching decorators such as
+ * {@code PhSticky} must never memoize it.</p>
+ *
+ * @since 0.60
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Impure {
+}


### PR DESCRIPTION
Part of #5165.

1. Adds the `@Impure` marker annotation — it flags atoms whose result depends on the outside world or mutable state.
2. Annotates the 20 such atoms so the upcoming `PhSticky` caching decorator never memoizes them:
   - filesystem — all `EOfs/*` (`file.*`, `dir.*`);
   - OS — `EOsm`: `os.name`, `posix.φ`, `win32.φ`;
   - shared memory — `EOmalloc*` (`read`/`write`/`resized`/`size`/`of.φ`, all via `Heaps.INSTANCE`).

Pure atoms (arithmetic, math, regex/sprintf/sscanf, error/try) are left un-annotated so they remain cacheable.
