### PR TITLE
feat(#5165): add `Taken` tuple object

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Taken.java
+++ b/eo-runtime/src/main/java/org/eolang/Taken.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+/**
+ * The outcome of taking an attribute from an object.
+ *
+ * <p>It pairs the object that was taken with a flag telling whether that
+ * object is pure, that is, whether the φ-expression that produced it always
+ * yields the same value. Caching decorators such as {@code PhSticky} memoize
+ * the object only when it is pure; an impure result (file access, the clock,
+ * shared memory) is never stored.</p>
+ *
+ * @since 0.60
+ */
+public final class Taken {
+
+    /**
+     * The object taken.
+     */
+    private final Phi object;
+
+    /**
+     * Whether the object may be memoized.
+     */
+    private final boolean clean;
+
+    /**
+     * Ctor.
+     * @param object The object taken
+     * @param clean Whether the object may be memoized
+     */
+    public Taken(final Phi object, final boolean clean) {
+        this.object = object;
+        this.clean = clean;
+    }
+
+    /**
+     * The object that was taken.
+     * @return The object
+     */
+    public Phi phi() {
+        return this.object;
+    }
+
+    /**
+     * Whether the taken object is pure and may be memoized.
+     * @return True if the object may be cached
+     */
+    public boolean pure() {
+        return this.clean;
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/TakenTest.java
+++ b/eo-runtime/src/test/java/org/eolang/TakenTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Taken}.
+ * @since 0.60
+ */
+final class TakenTest {
+
+    @Test
+    void keepsTheObjectItWasBuiltWith() {
+        final Phi object = new Data.ToPhi(42L);
+        MatcherAssert.assertThat(
+            "Taken must expose the very object it was given, but it does not",
+            new Taken(object, true).phi(),
+            Matchers.sameInstance(object)
+        );
+    }
+
+    @Test
+    void reportsTheImpureFlag() {
+        MatcherAssert.assertThat(
+            "Taken must report the purity flag it was given, but it does not",
+            new Taken(new Data.ToPhi(-7L), false).pure(),
+            Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
Part of #5165.

Adds `Taken`, the pair that `Phi.take(String)` will return: the taken object plus a `pure()` flag telling whether it may be memoized.

Unused for now — consumed when `Phi.take` adopts the new signature and `PhSticky` reads `pure()` to decide what to cache.
