### PR TITLE
fix(#5224): rename `positive-infinity`/`negative-infinity` to `pinf`/`ninf` and `line-separator` to `eol`

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -238,20 +238,6 @@
                       names in the atoms, in order to enable this lint.
                 -->
                 <lint>duplicate-names-in-diff-context</lint>
-                <!--
-                @todo #4096:30min. Enable `sparse-decoration` lint.
-                      After we merged EO tests together with their source objects, and removed
-                      `+tests` meta, we have complains about sparse-decoration. Let's adjust and
-                      enable it.
-                -->
-                <!-- <lint>sparse-decoration</lint> -->
-                <!--
-                @todo #5221:30min Enable `compound-name` lint.
-                      Several objects in eo-runtime use compound names that follow system
-                      or platform naming conventions (e.g. neg-inf, groups-count, sin-family).
-                      Either rename the objects or adjust the lint rule, then enable it.
-                -->
-                <lint>compound-name</lint>
               </skipSourceLints>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -30,11 +30,11 @@
     eq nan.as-bytes
     nan
     if.
-      eq positive-infinity.as-bytes
-      positive-infinity
+      eq pinf.as-bytes
+      pinf
       if.
-        eq negative-infinity.as-bytes
-        negative-infinity
+        eq ninf.as-bytes
+        ninf
         if.
           size.eq 8
           number as-bytes

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -1,9 +1,9 @@
-+alias fs.file
-+alias fs.path
-+alias fs.tmpdir
 +alias tt.contains
++alias fs.file
 +alias tt.joined
++alias fs.path
 +alias tt.sprintf
++alias fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs

--- a/eo-runtime/src/main/eo/io/stdin.eo
+++ b/eo-runtime/src/main/eo/io/stdin.eo
@@ -1,5 +1,5 @@
 +alias io.console
-+alias sm.line-separator
++alias sm.eol
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
@@ -29,7 +29,7 @@
   # If there's no line to consume, it returns an empty string.
   [] > all-lines
     rec-read next-line -- true > @
-    line-separator > separator!
+    eol > separator!
 
     # Recursive reading from console by one line.
     #

--- a/eo-runtime/src/main/eo/ms/acos.eo
+++ b/eo-runtime/src/main/eo/ms/acos.eo
@@ -67,12 +67,12 @@
     is-nan. > @
       acos nan
 
-  # Tests that arccosine of positive-infinity is NaN.
+  # Tests that arccosine of pinf is NaN.
   [] +> tests-arccos-positive-infinity
     is-nan. > @
-      acos positive-infinity
+      acos pinf
 
-  # Tests that arccosine of negative-infinity is NaN.
+  # Tests that arccosine of ninf is NaN.
   [] +> tests-arccos-negative-infinity
     is-nan. > @
-      acos negative-infinity
+      acos ninf

--- a/eo-runtime/src/main/eo/ms/asin.eo
+++ b/eo-runtime/src/main/eo/ms/asin.eo
@@ -71,9 +71,9 @@
   # Tests that asin of +inf equals NaN.
   [] +> tests-asin-positive-infinity
     is-nan. > @
-      asin positive-infinity
+      asin pinf
 
   # Tests that asin of -inf equals NaN.
   [] +> tests-asin-negative-infinity
     is-nan. > @
-      asin negative-infinity
+      asin ninf

--- a/eo-runtime/src/main/eo/ms/exp.eo
+++ b/eo-runtime/src/main/eo/ms/exp.eo
@@ -61,11 +61,11 @@
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-infinity-n1
     eq. > @
-      exp positive-infinity
-      positive-infinity
+      exp pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-infinity-n2
     eq. > @
-      exp negative-infinity
+      exp ninf
       0

--- a/eo-runtime/src/main/eo/ms/ln.eo
+++ b/eo-runtime/src/main/eo/ms/ln.eo
@@ -20,7 +20,7 @@
   [] +> tests-ln-of-zero-is-negative-infinity
     eq. > @
       ln 0
-      negative-infinity
+      ninf
 
   # Tests that natural logarithm of 1 equals zero.
   [] +> tests-ln-of-one-is-zero
@@ -57,13 +57,13 @@
   # Tests that natural logarithm of positive infinity equals positive infinity.
   [] +> tests-ln-positive-infinity
     eq. > @
-      ln positive-infinity
-      positive-infinity
+      ln pinf
+      pinf
 
   # Tests that natural logarithm of negative infinity returns NaN.
   [] +> tests-ln-negative-infinity
     is-nan. > @
-      ln negative-infinity
+      ln ninf
 
   # Tests that natural logarithm of NaN returns NaN.
   [] +> tests-ln-nan

--- a/eo-runtime/src/main/eo/ms/numbers.eo
+++ b/eo-runtime/src/main/eo/ms/numbers.eo
@@ -19,7 +19,7 @@
       error "Can't get the max number from an empty sequence"
       reduced
         lst
-        negative-infinity
+        ninf
         [max item]
           if. > @
             item.as-number.gt max
@@ -34,7 +34,7 @@
       error "Can't get the min number from an empty sequence"
       reduced
         lst
-        positive-infinity
+        pinf
         [min item]
           if. > @
             min.gt item.as-number

--- a/eo-runtime/src/main/eo/ms/pow.eo
+++ b/eo-runtime/src/main/eo/ms/pow.eo
@@ -77,60 +77,60 @@
   [] +> tests-zero-to-the-negative-pow-is-positive-infinity
     eq. > @
       pow 0 -52
-      positive-infinity
+      pinf
 
   # Tests that zero raised to negative infinity equals positive infinity.
   [] +> tests-zero-to-the-negative-infinity-pow-is-positive-infinity
     eq. > @
-      pow 0 negative-infinity
-      positive-infinity
+      pow 0 ninf
+      pinf
 
   # Tests that positive integer raised to negative infinity equals zero.
   [] +> tests-positive-int-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow 42 negative-infinity
+      pow 42 ninf
       0
 
   # Tests that positive float raised to negative infinity equals zero.
   [] +> tests-positive-float-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow 42.5 negative-infinity
+      pow 42.5 ninf
       0
 
   # Tests that negative integer raised to negative infinity equals zero.
   [] +> tests-negative-int-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow -42 negative-infinity
+      pow -42 ninf
       0
 
   # Tests that negative float raised to negative infinity equals zero.
   [] +> tests-negative-float-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow -42.5 negative-infinity
+      pow -42.5 ninf
       0
 
   # Tests that positive infinity raised to negative infinity equals zero.
   [] +> tests-positive-infinity-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow positive-infinity negative-infinity
+      pow pinf ninf
       0
 
   # Tests that negative infinity raised to negative infinity equals zero.
   [] +> tests-negative-infinity-to-the-pow-of-negative-infinity-is-zero
     eq. > @
-      pow negative-infinity negative-infinity
+      pow ninf ninf
       0
 
   # Tests that positive infinity raised to finite negative power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-int-pow-is-zero
     eq. > @
-      pow positive-infinity -42
+      pow pinf -42
       0
 
   # Tests that positive infinity raised to finite negative float power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-float-pow-is-zero
     eq. > @
-      pow positive-infinity -42.2
+      pow pinf -42.2
       0.0
 
   # Tests that 2 raised to the power of -1 equals 0.5.
@@ -173,68 +173,68 @@
   # Tests mathematical operation functionality.
   [] +> tests-zero-to-the-pow-of-positive-infinity-is-zero
     eq. > @
-      pow 0 positive-infinity
+      pow 0 pinf
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-int-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. > @
-      pow -10 positive-infinity
-      positive-infinity
+      pow -10 pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-float-to-the-pow-of-positive-infinity-is-infinity
     eq. > @
-      pow -4.2 positive-infinity
-      positive-infinity
+      pow -4.2 pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. > @
-      pow 42 positive-infinity
-      positive-infinity
+      pow 42 pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. > @
-      pow 42.5 positive-infinity
-      positive-infinity
+      pow 42.5 pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
     eq. > @
-      pow positive-infinity 42
-      positive-infinity
+      pow pinf 42
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
     eq. > @
-      pow positive-infinity 10.8
-      positive-infinity
+      pow pinf 10.8
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
     eq. > @
-      pow positive-infinity positive-infinity
-      positive-infinity
+      pow pinf pinf
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
     eq. > @
-      pow negative-infinity 9.9
-      positive-infinity
+      pow ninf 9.9
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
     eq. > @
-      pow negative-infinity 10
-      positive-infinity
+      pow ninf 10
+      pinf
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
     eq. > @
-      pow negative-infinity 9
-      negative-infinity
+      pow ninf 9
+      ninf
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-int-is-int

--- a/eo-runtime/src/main/eo/ms/real.eo
+++ b/eo-runtime/src/main/eo/ms/real.eo
@@ -8,3 +8,21 @@
 # Returns a floating point number.
 [num] > real
   num > @
+
+  # Tests that real of an integer returns the integer itself.
+  [] +> tests-real-of-int
+    eq. > @
+      real 5
+      5
+
+  # Tests that real of a float returns the float itself.
+  [] +> tests-real-of-float
+    eq. > @
+      real 5.5
+      5.5
+
+  # Tests that real of a negative float returns the negative float itself.
+  [] +> tests-real-of-negative-float
+    eq. > @
+      real -5.5
+      -5.5

--- a/eo-runtime/src/main/eo/ms/sqrt.eo
+++ b/eo-runtime/src/main/eo/ms/sqrt.eo
@@ -74,10 +74,10 @@
   # Tests that square root of positive infinity equals positive infinity.
   [] +> tests-sqrt-check-infinity-n1
     eq. > @
-      sqrt positive-infinity
-      positive-infinity
+      sqrt pinf
+      pinf
 
   # Tests that square root of negative infinity returns NaN.
   [] +> tests-sqrt-check-infinity-n2
     is-nan. > @
-      sqrt negative-infinity
+      sqrt ninf

--- a/eo-runtime/src/main/eo/ninf.eo
+++ b/eo-runtime/src/main/eo/ninf.eo
@@ -8,4 +8,4 @@
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.
 # When dataized, it signifies an unbounded lower limit or an unreachable minimum value.
-number FF-F0-00-00-00-00-00-00 > negative-infinity
+number FF-F0-00-00-00-00-00-00 > ninf

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -235,11 +235,11 @@
             and.
               and.
                 (0.eq nan).eq false
-                (0.eq positive-infinity).eq false
-              (0.eq negative-infinity).eq false
+                (0.eq pinf).eq false
+              (0.eq ninf).eq false
             (42.eq nan).eq false
-          (42.eq positive-infinity).eq false
-        (42.eq negative-infinity).eq false
+          (42.eq pinf).eq false
+        (42.eq ninf).eq false
       true
 
   # Tests that one zero value equals another zero value.
@@ -450,109 +450,109 @@
 
   # Tests that a number created with infinite bytes is not finite.
   [] +> tests-number-with-infinite-bytes-is-not-finite
-    (number positive-infinity.as-bytes).is-finite.not > @
+    (number pinf.as-bytes).is-finite.not > @
 
   # Equal to.
   # Tests that positive infinity equals one divided by zero.
   [] +> tests-positive-infinity-is-equal-to-one-div-zero
     eq. > @
-      positive-infinity
+      pinf
       1.0.div 0.0
 
   # Tests that positive infinity equals positive infinity.
   [] +> tests-positive-infinity-eq-positive-infinity
     eq. > @
-      positive-infinity
-      positive-infinity
+      pinf
+      pinf
 
   # Tests that positive infinity is not equal to negative infinity.
   [] +> tests-positive-infinity-not-eq-negative-infinity
     not. > @
       eq.
-        positive-infinity
-        negative-infinity
+        pinf
+        ninf
 
   # Tests that positive infinity is not equal to NaN.
   [] +> tests-positive-infinity-not-eq-nan
     not. > @
       eq.
-        positive-infinity
+        pinf
         nan
 
   # Tests that positive infinity is not equal to an integer.
   [] +> tests-positive-infinity-not-eq-int
     not. > @
       eq.
-        positive-infinity
+        pinf
         42
 
   # Tests that positive infinity is not equal to a float.
   [] +> tests-positive-infinity-not-eq-float
     not. > @
       eq.
-        positive-infinity
+        pinf
         42.5
 
   # Less than.
   # Tests that positive infinity is not less than positive infinity.
   [] +> tests-positive-infinity-lt-positive-infinity
     eq. > @
-      positive-infinity.lt positive-infinity
+      pinf.lt pinf
       false
 
   # Tests that positive infinity is not less than negative infinity.
   [] +> tests-positive-infinity-not-lt-negative-infinity
     eq. > @
-      positive-infinity.lt negative-infinity
+      pinf.lt ninf
       false
 
   # Tests that positive infinity is not less than NaN.
   [] +> tests-positive-infinity-not-lt-nan
     eq. > @
-      positive-infinity.lt nan
+      pinf.lt nan
       false
 
   # Tests that positive infinity is not less than an integer.
   [] +> tests-positive-infinity-not-lt-int
     eq. > @
-      positive-infinity.lt 42
+      pinf.lt 42
       false
 
   # Tests that positive infinity is not less than a float.
   [] +> tests-positive-infinity-not-lt-float
     eq. > @
-      positive-infinity.lt 42.5
+      pinf.lt 42.5
       false
 
   # Less or equal than.
   # Tests that positive infinity is less than or equal to positive infinity.
   [] +> tests-positive-infinity-lte-positive-infinity
     eq. > @
-      positive-infinity.lte positive-infinity
+      pinf.lte pinf
       true
 
   # Tests that positive infinity is not less than or equal to negative infinity.
   [] +> tests-positive-infinity-not-lte-negative-infinity
     eq. > @
-      positive-infinity.lte negative-infinity
+      pinf.lte ninf
       false
 
   # Tests that positive infinity is not less than or equal to NaN.
   [] +> tests-positive-infinity-not-lte-nan
     eq. > @
-      positive-infinity.lte nan
+      pinf.lte nan
       false
 
   # Tests that positive infinity is not less than or equal to an integer.
   [] +> tests-positive-infinity-not-lte-int
     eq. > @
-      positive-infinity.lte 42
+      pinf.lte 42
       false
 
   # Tests that positive infinity is not less than or equal to a float.
   [] +> tests-positive-infinity-not-lte-float
     eq. > @
-      positive-infinity.lte 42.5
+      pinf.lte 42.5
       false
 
   # Greater than.
@@ -560,63 +560,63 @@
   [] +> tests-positive-infinity-gt-positive-infinity
     not. > @
       gt.
-        positive-infinity
-        positive-infinity
+        pinf
+        pinf
 
   # Tests that positive infinity is greater than negative infinity.
   [] +> tests-positive-infinity-gt-negative-infinity
     gt. > @
-      positive-infinity
-      negative-infinity
+      pinf
+      ninf
 
   # Tests that positive infinity is not greater than NaN.
   [] +> tests-positive-infinity-not-gt-nan
     not. > @
       gt.
-        positive-infinity
+        pinf
         nan
 
   # Tests that positive infinity is greater than an integer.
   [] +> tests-positive-infinity-gt-int
     gt. > @
-      positive-infinity
+      pinf
       42
 
   # Tests that positive infinity is greater than a float.
   [] +> tests-positive-infinity-gt-float
     gt. > @
-      positive-infinity
+      pinf
       42.5
 
   # Greater or equal than.
   # Tests that positive infinity is greater than or equal to positive infinity.
   [] +> tests-positive-infinity-gte-positive-infinity
     eq. > @
-      positive-infinity.gte positive-infinity
+      pinf.gte pinf
       true
 
   # Tests that positive infinity is greater than or equal to negative infinity.
   [] +> tests-positive-infinity-gte-negative-infinity
     eq. > @
-      positive-infinity.gte negative-infinity
+      pinf.gte ninf
       true
 
   # Tests that positive infinity is not greater than or equal to NaN.
   [] +> tests-positive-infinity-not-gte-nan
     eq. > @
-      positive-infinity.gte nan
+      pinf.gte nan
       false
 
   # Tests that positive infinity is greater than or equal to an integer.
   [] +> tests-positive-infinity-gte-int
     eq. > @
-      positive-infinity.gte 42
+      pinf.gte 42
       true
 
   # Tests that positive infinity is greater than or equal to a float.
   [] +> tests-positive-infinity-gte-float
     eq. > @
-      positive-infinity.gte 42.5
+      pinf.gte 42.5
       true
 
   # Tests that float comparison with NaN and infinities returns false under high load.
@@ -634,359 +634,357 @@
                         and.
                           and.
                             (0.0.eq nan).eq false
-                            (0.0.eq positive-infinity).eq false
+                            (0.0.eq pinf).eq false
                           (0.0.eq ninf).eq false
                         (42.5.eq nan).eq false
-                      (42.5.eq positive-infinity).eq false
+                      (42.5.eq pinf).eq false
                     (42.5.eq ninf).eq false
                   (0.0.eq nan).eq false
-                (0.0.eq positive-infinity).eq false
+                (0.0.eq pinf).eq false
               (0.0.eq ninf).eq false
             (42.5.eq nan).eq false
-          (42.5.eq positive-infinity).eq false
+          (42.5.eq pinf).eq false
         (42.5.eq ninf).eq false
       true
-    negative-infinity > ninf
 
   # Times.
   # Tests that positive infinity times float zero returns NaN.
   [] +> tests-positive-infinity-times-float-zero
     eq. > @
       as-bytes.
-        positive-infinity.times 0.0
+        pinf.times 0.0
       nan.as-bytes
 
   # Tests that positive infinity times negative float zero returns NaN.
   [] +> tests-positive-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
-        positive-infinity.times -0.0
+        pinf.times -0.0
       nan.as-bytes
 
   # Tests that positive infinity times integer zero returns NaN.
   [] +> tests-positive-infinity-times-int-zero
     eq. > @
       as-bytes.
-        positive-infinity.times 0
+        pinf.times 0
       nan.as-bytes
 
   # Tests that positive infinity times NaN returns NaN.
   [] +> tests-positive-infinity-times-nan
     eq. > @
       as-bytes.
-        positive-infinity.times nan
+        pinf.times nan
       nan.as-bytes
 
   # Tests that positive infinity times negative infinity returns negative infinity.
   [] +> tests-positive-infinity-times-negative-infinity
     eq. > @
-      positive-infinity.times ninf
+      pinf.times ninf
       ninf
-    negative-infinity > ninf
 
   # Tests that positive infinity times positive infinity returns positive infinity.
   [] +> tests-positive-infinity-times-positive-infinity
     eq. > @
-      positive-infinity.times positive-infinity
-      positive-infinity
+      pinf.times pinf
+      pinf
 
   # Tests that positive infinity times a positive float returns positive infinity.
   [] +> tests-positive-infinity-times-positive-float
     eq. > @
-      positive-infinity.times 42.5
-      positive-infinity
+      pinf.times 42.5
+      pinf
 
   # Tests that positive infinity times a positive integer returns positive infinity.
   [] +> tests-positive-infinity-times-positive-int
     eq. > @
-      positive-infinity.times 42
-      positive-infinity
+      pinf.times 42
+      pinf
 
   # Tests that positive infinity times a negative float returns negative infinity.
   [] +> tests-positive-infinity-times-negative-float
     eq. > @
-      positive-infinity.times -42.5
-      negative-infinity
+      pinf.times -42.5
+      ninf
 
   # Tests that positive infinity times a negative integer returns negative infinity.
   [] +> tests-positive-infinity-times-negative-int
     eq. > @
-      positive-infinity.times -42
-      negative-infinity
+      pinf.times -42
+      ninf
 
   # Plus
   # Tests that positive infinity plus NaN returns NaN.
   [] +> tests-positive-infinity-plus-nan
     eq. > @
       as-bytes.
-        positive-infinity.plus nan
+        pinf.plus nan
       nan.as-bytes
 
   # Tests that positive infinity plus negative infinity returns NaN.
   [] +> tests-positive-infinity-plus-negative-infinity
     eq. > @
       as-bytes.
-        positive-infinity.plus negative-infinity
+        pinf.plus ninf
       nan.as-bytes
 
   # Tests that positive infinity plus positive infinity returns positive infinity.
   [] +> tests-positive-infinity-plus-positive-infinity
     eq. > @
-      positive-infinity.plus positive-infinity
-      positive-infinity
+      pinf.plus pinf
+      pinf
 
   # Tests that positive infinity plus a positive float returns positive infinity.
   [] +> tests-positive-infinity-plus-positive-float
     eq. > @
-      positive-infinity.plus 42.5
-      positive-infinity
+      pinf.plus 42.5
+      pinf
 
   # Negation
   # Tests that negation of positive infinity returns negative infinity.
   [] +> tests-positive-infinity-neg-is-negative-infinity
     eq. > @
-      positive-infinity.neg
-      negative-infinity
+      pinf.neg
+      ninf
 
   # Minus
   # Tests that positive infinity minus NaN returns NaN.
   [] +> tests-positive-infinity-minus-nan
     eq. > @
       as-bytes.
-        positive-infinity.minus nan
+        pinf.minus nan
       nan.as-bytes
 
   # Tests that positive infinity minus positive infinity returns NaN.
   [] +> tests-positive-infinity-minus-positive-infinity
     eq. > @
       as-bytes.
-        positive-infinity.minus positive-infinity
+        pinf.minus pinf
       nan.as-bytes
 
   # Tests that positive infinity minus negative infinity returns positive infinity.
   [] +> tests-positive-infinity-minus-negative-infinity
     eq. > @
-      positive-infinity.minus negative-infinity
-      positive-infinity
+      pinf.minus ninf
+      pinf
 
   # Tests that positive infinity minus a positive float returns positive infinity.
   [] +> tests-positive-infinity-minus-positive-float
     eq. > @
-      positive-infinity.minus 42.5
-      positive-infinity
+      pinf.minus 42.5
+      pinf
 
   # Tests that positive infinity minus a positive integer returns positive infinity.
   [] +> tests-positive-infinity-minus-positive-int
     eq. > @
-      positive-infinity.minus 42
-      positive-infinity
+      pinf.minus 42
+      pinf
 
   # Tests that positive infinity minus a negative float returns positive infinity.
   [] +> tests-positive-infinity-minus-negative-float
     eq. > @
-      positive-infinity.minus -42.5
-      positive-infinity
+      pinf.minus -42.5
+      pinf
 
   # Tests that positive infinity minus a negative integer returns positive infinity.
   [] +> tests-positive-infinity-minus-negative-int
     eq. > @
-      positive-infinity.minus -42
-      positive-infinity
+      pinf.minus -42
+      pinf
 
   # Division
   # Tests that positive infinity divided by float zero returns positive infinity.
   [] +> tests-positive-infinity-div-float-zero
     eq. > @
-      positive-infinity.div 0.0
-      positive-infinity
+      pinf.div 0.0
+      pinf
 
   # Tests that positive infinity divided by negative float zero returns negative infinity.
   [] +> tests-positive-infinity-div-neg-float-zero
     eq. > @
-      positive-infinity.div -0.0
-      negative-infinity
+      pinf.div -0.0
+      ninf
 
   # Tests that positive infinity divided by integer zero returns positive infinity.
   [] +> tests-positive-infinity-div-int-zero
     eq. > @
-      positive-infinity.div 0
-      positive-infinity
+      pinf.div 0
+      pinf
 
   # Tests that positive infinity divided by negative integer zero returns negative infinity.
   [] +> tests-positive-infinity-div-neg-int-zero
     eq. > @
-      positive-infinity.div -0
-      negative-infinity
+      pinf.div -0
+      ninf
 
   # Tests that positive infinity divided by NaN returns NaN.
   [] +> tests-positive-infinity-div-nan
     eq. > @
       as-bytes.
-        positive-infinity.div nan
+        pinf.div nan
       nan.as-bytes
 
   # Tests that positive infinity divided by negative infinity returns NaN.
   [] +> tests-positive-infinity-div-negative-infinity
     eq. > @
       as-bytes.
-        positive-infinity.div negative-infinity
+        pinf.div ninf
       nan.as-bytes
 
   # Tests that positive infinity divided by positive infinity returns NaN.
   [] +> tests-positive-infinity-div-positive-infinity
     eq. > @
       as-bytes.
-        positive-infinity.div positive-infinity
+        pinf.div pinf
       nan.as-bytes
 
   # Tests that positive infinity divided by a positive float returns positive infinity.
   [] +> tests-positive-infinity-div-positive-float
     eq. > @
-      positive-infinity.div 42.5
-      positive-infinity
+      pinf.div 42.5
+      pinf
 
   # Tests that positive infinity divided by a positive integer returns positive infinity.
   [] +> tests-positive-infinity-div-positive-int
     eq. > @
-      positive-infinity.div 42
-      positive-infinity
+      pinf.div 42
+      pinf
 
   # Tests that positive infinity divided by a negative float returns negative infinity.
   [] +> tests-positive-infinity-div-negative-float
     eq. > @
-      positive-infinity.div -42.5
-      negative-infinity
+      pinf.div -42.5
+      ninf
 
   # Tests that positive infinity divided by a negative integer returns negative infinity.
   [] +> tests-positive-infinity-div-negative-int
     eq. > @
-      positive-infinity.div -42
-      negative-infinity
+      pinf.div -42
+      ninf
 
   # Bytes.
   # Tests that positive infinity as bytes equals one divided by zero as bytes.
   [] +> tests-positive-infinity-as-bytes-is-valid
     eq. > @
-      positive-infinity.as-bytes
+      pinf.as-bytes
       (1.0.div 0.0).as-bytes
 
   # Tests that positive infinity floor equals itself.
   [] +> tests-positive-infinity-floor-is-equal-to-self
-    positive-infinity.floor.eq positive-infinity > @
+    pinf.floor.eq pinf > @
 
   # Tests that positive infinity is not NaN.
   [] +> tests-positive-infinity-is-not-nan
-    positive-infinity.is-nan.not > @
+    pinf.is-nan.not > @
 
   # Tests that positive infinity is not finite.
   [] +> tests-positive-infinity-is-not-finite
-    positive-infinity.is-finite.not > @
+    pinf.is-finite.not > @
 
   # Tests that positive infinity is not an integer.
   [] +> tests-positive-infinity-is-not-integer
-    positive-infinity.is-integer.not > @
+    pinf.is-integer.not > @
 
   # Equal to.
   # Tests that negative infinity equals negative one divided by zero.
   [] +> tests-negative-infinity-is-equal-to-one-div-zero
     eq. > @
-      negative-infinity
+      ninf
       -1.0.div 0.0
 
   # Tests that negative infinity equals negative infinity.
   [] +> tests-negative-infinity-eq-negative-infinity
     eq. > @
-      negative-infinity
-      negative-infinity
+      ninf
+      ninf
 
   # Tests that negative infinity is not equal to positive infinity.
   [] +> tests-negative-infinity-not-eq-positive-infinity
     not. > @
       eq.
-        negative-infinity
-        positive-infinity
+        ninf
+        pinf
 
   # Tests that negative infinity is not equal to NaN.
   [] +> tests-negative-infinity-not-eq-nan
     not. > @
       eq.
-        negative-infinity
+        ninf
         nan
 
   # Tests that negative infinity is not equal to an integer.
   [] +> tests-negative-infinity-not-eq-int
     not. > @
       eq.
-        negative-infinity
+        ninf
         42
 
   # Tests that negative infinity is not equal to a float.
   [] +> tests-negative-infinity-not-eq-float
     not. > @
       eq.
-        negative-infinity
+        ninf
         42.5
 
   # Less than.
   # Tests that negative infinity is not less than negative infinity.
   [] +> tests-negative-infinity-lt-negative-infinity
     eq. > @
-      negative-infinity.lt negative-infinity
+      ninf.lt ninf
       false
 
   # Tests that negative infinity is less than positive infinity.
   [] +> tests-negative-infinity-lt-positive-infinity
     eq. > @
-      negative-infinity.lt positive-infinity
+      ninf.lt pinf
       true
 
   # Tests that negative infinity is not less than NaN.
   [] +> tests-negative-infinity-not-lt-nan
     eq. > @
-      negative-infinity.lt nan
+      ninf.lt nan
       false
 
   # Tests that negative infinity is less than an integer.
   [] +> tests-negative-infinity-lt-int
     lt. > @
-      negative-infinity
+      ninf
       42
 
   # Tests that negative infinity is less than a float.
   [] +> tests-negative-infinity-lt-float
     lt. > @
-      negative-infinity
+      ninf
       42.5
 
   # Less or equal than.
   # Tests that negative infinity is less than or equal to negative infinity.
   [] +> tests-negative-infinity-lte-negative-infinity
     eq. > @
-      negative-infinity.lte negative-infinity
+      ninf.lte ninf
       true
 
   # Tests that negative infinity is less than or equal to positive infinity.
   [] +> tests-negative-infinity-lte-positive-infinity
     eq. > @
-      negative-infinity.lte positive-infinity
+      ninf.lte pinf
       true
 
   # Tests that negative infinity is not less than or equal to NaN.
   [] +> tests-negative-infinity-not-lte-nan
     eq. > @
-      negative-infinity.lte nan
+      ninf.lte nan
       false
 
   # Tests that negative infinity is less than or equal to an integer.
   [] +> tests-negative-infinity-lte-int
     eq. > @
-      negative-infinity.lte 42
+      ninf.lte 42
       true
 
   # Tests that negative infinity is less than or equal to a float.
   [] +> tests-negative-infinity-lte-float
     eq. > @
-      negative-infinity.lte 42.5
+      ninf.lte 42.5
       true
 
   # Greater than.
@@ -994,62 +992,62 @@
   [] +> tests-negative-infinity-gt-negative-infinity
     not. > @
       gt.
-        negative-infinity
-        negative-infinity
+        ninf
+        ninf
 
   # Tests that negative infinity is not greater than positive infinity.
   [] +> tests-negative-infinity-not-gt-positive-infinity
     eq. > @
-      negative-infinity.gt positive-infinity
+      ninf.gt pinf
       false
 
   # Tests that negative infinity is not greater than NaN.
   [] +> tests-negative-infinity-not-gt-nan
     eq. > @
-      negative-infinity.gt nan
+      ninf.gt nan
       false
 
   # Tests that negative infinity is not greater than an integer.
   [] +> tests-negative-infinity-not-gt-int
     eq. > @
-      negative-infinity.gt 42
+      ninf.gt 42
       false
 
   # Tests that negative infinity is not greater than a float.
   [] +> tests-negative-infinity-not-gt-float
     eq. > @
-      negative-infinity.gt 42.5
+      ninf.gt 42.5
       false
 
   # Greater or equal than.
   # Tests that negative infinity is greater than or equal to negative infinity.
   [] +> tests-negative-infinity-gte-negative-infinity
     eq. > @
-      negative-infinity.gte negative-infinity
+      ninf.gte ninf
       true
 
   # Tests that negative infinity is not greater than or equal to positive infinity.
   [] +> tests-negative-infinity-not-gte-positive-infinity
     eq. > @
-      negative-infinity.gte positive-infinity
+      ninf.gte pinf
       false
 
   # Tests that negative infinity is not greater than or equal to NaN.
   [] +> tests-negative-infinity-not-gte-nan
     eq. > @
-      negative-infinity.gte nan
+      ninf.gte nan
       false
 
   # Tests that negative infinity is not greater than or equal to an integer.
   [] +> tests-negative-infinity-not-gte-int
     eq. > @
-      negative-infinity.gte 42
+      ninf.gte 42
       false
 
   # Tests that negative infinity is not greater than or equal to a float.
   [] +> tests-negative-infinity-not-gte-float
     eq. > @
-      negative-infinity.gte 42.5
+      ninf.gte 42.5
       false
 
   # Times.
@@ -1057,255 +1055,255 @@
   [] +> tests-negative-infinity-times-float-zero
     eq. > @
       as-bytes.
-        negative-infinity.times 0.0
+        ninf.times 0.0
       nan.as-bytes
 
   # Tests that negative infinity times negative float zero returns NaN.
   [] +> tests-negative-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
-        negative-infinity.times -0.0
+        ninf.times -0.0
       nan.as-bytes
 
   # Tests that negative infinity times integer zero returns NaN.
   [] +> tests-negative-infinity-times-int-zero
     eq. > @
       as-bytes.
-        negative-infinity.times 0
+        ninf.times 0
       nan.as-bytes
 
   # Tests that negative infinity times NaN returns NaN.
   [] +> tests-negative-infinity-times-nan
     eq. > @
       as-bytes.
-        negative-infinity.times nan
+        ninf.times nan
       nan.as-bytes
 
   # Tests that negative infinity times positive infinity returns negative infinity.
   [] +> tests-negative-infinity-times-positive-infinity
     eq. > @
-      negative-infinity.times positive-infinity
-      negative-infinity
+      ninf.times pinf
+      ninf
 
   # Tests that negative infinity times negative infinity returns positive infinity.
   [] +> tests-negative-infinity-times-negative-infinity
     eq. > @
-      negative-infinity.times negative-infinity
-      positive-infinity
+      ninf.times ninf
+      pinf
 
   # Tests that negative infinity times a positive float returns negative infinity.
   [] +> tests-negative-infinity-times-positive-float
     eq. > @
-      negative-infinity.times 42.5
-      negative-infinity
+      ninf.times 42.5
+      ninf
 
   # Tests that negative infinity times a positive integer returns negative infinity.
   [] +> tests-negative-infinity-times-positive-int
     eq. > @
-      negative-infinity.times 42
-      negative-infinity
+      ninf.times 42
+      ninf
 
   # Tests that negative infinity times a negative float returns positive infinity.
   [] +> tests-negative-infinity-times-negative-float
     eq. > @
-      negative-infinity.times -42.5
-      positive-infinity
+      ninf.times -42.5
+      pinf
 
   # Tests that negative infinity times a negative integer returns positive infinity.
   [] +> tests-negative-infinity-times-negative-int
     eq. > @
-      negative-infinity.times -42
-      positive-infinity
+      ninf.times -42
+      pinf
 
   # Plus.
   # Tests that negative infinity plus NaN returns NaN.
   [] +> tests-negative-infinity-plus-nan
     eq. > @
       as-bytes.
-        negative-infinity.plus nan
+        ninf.plus nan
       nan.as-bytes
 
   # Tests that negative infinity plus positive infinity returns NaN.
   [] +> tests-negative-infinity-plus-positive-infinity
     eq. > @
       as-bytes.
-        negative-infinity.plus positive-infinity
+        ninf.plus pinf
       nan.as-bytes
 
   # Tests that negative infinity plus negative infinity returns negative infinity.
   [] +> tests-negative-infinity-plus-negative-infinity
     eq. > @
-      negative-infinity
-      negative-infinity.plus negative-infinity
+      ninf
+      ninf.plus ninf
 
   # Tests that negative infinity plus a positive float returns negative infinity.
   [] +> tests-negative-infinity-plus-positive-float
     eq. > @
-      negative-infinity.plus 42.5
-      negative-infinity
+      ninf.plus 42.5
+      ninf
 
   # Tests that negative infinity plus a positive integer returns negative infinity.
   [] +> tests-negative-infinity-plus-positive-int
     eq. > @
-      negative-infinity.plus 42
-      negative-infinity
+      ninf.plus 42
+      ninf
 
   # Tests that negative infinity plus a negative float returns negative infinity.
   [] +> tests-negative-infinity-plus-negative-float
     eq. > @
-      negative-infinity.plus -42.5
-      negative-infinity
+      ninf.plus -42.5
+      ninf
 
   # Tests that negative infinity plus a negative integer returns negative infinity.
   [] +> tests-negative-infinity-plus-negative-int
     eq. > @
-      negative-infinity.plus -42
-      negative-infinity
+      ninf.plus -42
+      ninf
 
   # Negation.
   # Tests that negation of negative infinity returns positive infinity.
   [] +> tests-negative-infinity-neg-is-positive-infinity
     eq. > @
-      negative-infinity.neg
-      positive-infinity
+      ninf.neg
+      pinf
 
   # Minus.
   # Tests that negative infinity minus NaN returns NaN.
   [] +> tests-negative-infinity-minus-nan
     eq. > @
       as-bytes.
-        negative-infinity.minus nan
+        ninf.minus nan
       nan.as-bytes
 
   # Tests that negative infinity minus negative infinity returns NaN.
   [] +> tests-negative-infinity-minus-negative-infinity
     eq. > @
       as-bytes.
-        negative-infinity.minus negative-infinity
+        ninf.minus ninf
       nan.as-bytes
 
   # Tests that negative infinity minus positive infinity returns negative infinity.
   [] +> tests-negative-infinity-minus-positive-infinity
     eq. > @
-      negative-infinity.minus positive-infinity
-      negative-infinity
+      ninf.minus pinf
+      ninf
 
   # Tests that negative infinity minus a positive float returns negative infinity.
   [] +> tests-negative-infinity-minus-positive-float
     eq. > @
-      negative-infinity.minus 42.5
-      negative-infinity
+      ninf.minus 42.5
+      ninf
 
   # Tests that negative infinity minus a positive integer returns negative infinity.
   [] +> tests-negative-infinity-minus-positive-int
     eq. > @
-      negative-infinity.minus 42
-      negative-infinity
+      ninf.minus 42
+      ninf
 
   # Tests that negative infinity minus a negative float returns negative infinity.
   [] +> tests-negative-infinity-minus-negative-float
     eq. > @
-      negative-infinity.minus -42.5
-      negative-infinity
+      ninf.minus -42.5
+      ninf
 
   # Tests that negative infinity minus a negative integer returns negative infinity.
   [] +> tests-negative-infinity-minus-negative-int
     eq. > @
-      negative-infinity.minus -42
-      negative-infinity
+      ninf.minus -42
+      ninf
 
   # Division.
   # Tests that negative infinity divided by float zero returns negative infinity.
   [] +> tests-negative-infinity-div-float-zero
     eq. > @
-      negative-infinity.div 0.0
-      negative-infinity
+      ninf.div 0.0
+      ninf
 
   # Tests that negative infinity divided by negative float zero returns positive infinity.
   [] +> tests-negative-infinity-div-neg-float-zero
     eq. > @
-      negative-infinity.div -0.0
-      positive-infinity
+      ninf.div -0.0
+      pinf
 
   # Tests that negative infinity divided by integer zero returns negative infinity.
   [] +> tests-negative-infinity-div-int-zero
     eq. > @
-      negative-infinity.div 0
-      negative-infinity
+      ninf.div 0
+      ninf
 
   # Tests that negative infinity divided by negative integer zero returns positive infinity.
   [] +> tests-negative-infinity-div-neg-int-zero
     eq. > @
-      negative-infinity.div -0
-      positive-infinity
+      ninf.div -0
+      pinf
 
   # Tests that negative infinity divided by NaN returns NaN.
   [] +> tests-negative-infinity-div-nan
     eq. > @
       as-bytes.
-        negative-infinity.div nan
+        ninf.div nan
       nan.as-bytes
 
   # Tests that negative infinity divided by positive infinity returns NaN.
   [] +> tests-negative-infinity-div-positive-infinity
     eq. > @
       as-bytes.
-        negative-infinity.div positive-infinity
+        ninf.div pinf
       nan.as-bytes
 
   # Tests that negative infinity divided by negative infinity returns NaN.
   [] +> tests-negative-infinity-div-negative-infinity
     eq. > @
       as-bytes.
-        negative-infinity.div negative-infinity
+        ninf.div ninf
       nan.as-bytes
 
   # Tests that negative infinity divided by a positive float returns negative infinity.
   [] +> tests-negative-infinity-div-positive-float
     eq. > @
-      negative-infinity.div 42.5
-      negative-infinity
+      ninf.div 42.5
+      ninf
 
   # Tests that negative infinity divided by a positive integer returns negative infinity.
   [] +> tests-negative-infinity-div-positive-int
     eq. > @
-      negative-infinity.div 42
-      negative-infinity
+      ninf.div 42
+      ninf
 
   # Tests that negative infinity divided by a negative float returns positive infinity.
   [] +> tests-negative-infinity-div-negative-float
     eq. > @
-      negative-infinity.div -42.5
-      positive-infinity
+      ninf.div -42.5
+      pinf
 
   # Tests that negative infinity divided by a negative integer returns positive infinity.
   [] +> tests-negative-infinity-div-negative-int
     eq. > @
-      negative-infinity.div -42
-      positive-infinity
+      ninf.div -42
+      pinf
 
   # Bytes.
   # Tests that negative infinity as bytes equals negative one divided by zero as bytes.
   [] +> tests-negative-infinity-as-bytes-is-valid
     eq. > @
-      negative-infinity.as-bytes
+      ninf.as-bytes
       (-1.0.div 0.0).as-bytes
 
   # Tests that negative infinity floor equals itself.
   [] +> tests-negative-infinity-floor-is-equal-to-self
-    negative-infinity.floor.eq negative-infinity > @
+    ninf.floor.eq ninf > @
 
   # Tests that negative infinity is not NaN.
   [] +> tests-negative-infinity-is-not-nan
-    negative-infinity.is-nan.not > @
+    ninf.is-nan.not > @
 
   # Tests that negative infinity is not finite.
   [] +> tests-negative-infinity-is-not-finite
-    negative-infinity.is-finite.not > @
+    ninf.is-finite.not > @
 
   # Tests that negative infinity is not an integer.
   [] +> tests-negative-infinity-is-not-integer
-    negative-infinity.is-integer.not > @
+    ninf.is-integer.not > @
 
   # Tests that NaN is not equal to a number.
   [] +> tests-nan-not-eq-number

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -635,18 +635,18 @@
                           and.
                             (0.0.eq nan).eq false
                             (0.0.eq positive-infinity).eq false
-                          (0.0.eq neg-inf).eq false
+                          (0.0.eq ninf).eq false
                         (42.5.eq nan).eq false
                       (42.5.eq positive-infinity).eq false
-                    (42.5.eq neg-inf).eq false
+                    (42.5.eq ninf).eq false
                   (0.0.eq nan).eq false
                 (0.0.eq positive-infinity).eq false
-              (0.0.eq neg-inf).eq false
+              (0.0.eq ninf).eq false
             (42.5.eq nan).eq false
           (42.5.eq positive-infinity).eq false
-        (42.5.eq neg-inf).eq false
+        (42.5.eq ninf).eq false
       true
-    negative-infinity > neg-inf
+    negative-infinity > ninf
 
   # Times.
   # Tests that positive infinity times float zero returns NaN.
@@ -680,9 +680,9 @@
   # Tests that positive infinity times negative infinity returns negative infinity.
   [] +> tests-positive-infinity-times-negative-infinity
     eq. > @
-      positive-infinity.times neg-inf
-      neg-inf
-    negative-infinity > neg-inf
+      positive-infinity.times ninf
+      ninf
+    negative-infinity > ninf
 
   # Tests that positive infinity times positive infinity returns positive infinity.
   [] +> tests-positive-infinity-times-positive-infinity

--- a/eo-runtime/src/main/eo/pinf.eo
+++ b/eo-runtime/src/main/eo/pinf.eo
@@ -8,4 +8,4 @@
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.
 # When dataized, it signifies an unbounded upper limit or an unreachable maximum value.
-number 7F-F0-00-00-00-00-00-00 > positive-infinity
+number 7F-F0-00-00-00-00-00-00 > pinf

--- a/eo-runtime/src/main/eo/sm/eol.eo
+++ b/eo-runtime/src/main/eo/sm/eol.eo
@@ -9,7 +9,7 @@
 # Returns the system-dependent line separator string.
 # On UNIX systems, it returns "\n";
 # on Microsoft Windows systems it returns "\r\n".
-string > line-separator
+string > eol
   as-bytes.
     if.
       os.is-windows

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -7,6 +7,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint compound-name
 +unlint redundant-object
 
 # Makes a Unix syscall by `name` with POSIX interface.

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -7,6 +7,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint compound-name
 +unlint many-void-attributes
 +unlint redundant-object
 

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -242,14 +242,14 @@
   # Tests that string comparison with positive infinity returns false.
   [] +> tests-compares-string-with-positive-infinity
     eq. > @
-      positive-infinity.eq "друг"
+      pinf.eq "друг"
       false
 
   # Tests that string comparison with negative infinity returns false.
   [] +> tests-compares-string-with-negative-infinity
     not. > @
       eq.
-        negative-infinity
+        ninf
         "друг"
 
   # Tests that single-line text block equals regular string.

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -76,7 +76,7 @@
       # - `groups`        - tuple of identified matched groups
       #
       # The block provides the next API to work with matched string subsequence:
-      # - `groups-count`  - to get amount of matched groups
+      # - `count`         - to get amount of matched groups
       # - `exists`        - to check if matched block is not empty
       # - `next`          - to get next matched block
       # - `text`          - to get matched subsequence as `string`
@@ -88,7 +88,7 @@
       #  here, in `matched`. Don't forget to remove this puzzle.
       [position start from to groups] > matched
         $ > matched
-        groups.length > groups-count
+        groups.length > count
         start.gte 0 > exists
         if. > next
           exists
@@ -154,7 +154,7 @@
 
   # Tests that accessing groups count on non-matched block throws error.
   [] +> throws-on-getting-groups-count-on-not-matched-block
-    ((regex "/[a-z]+/").match "123").next.groups-count > @
+    ((regex "/[a-z]+/").match "123").next.count > @
 
   # Tests that accessing groups on non-matched block throws error.
   [] +> throws-on-getting-groups-on-not-matched-block
@@ -245,12 +245,12 @@
     and. > @
       and.
         and.
-          first.groups-count.eq 3
+          first.count.eq 3
           (first.group 1).eq "hello"
         (first.group 2).eq "1"
       and.
         and.
-          second.groups-count.eq 3
+          second.count.eq 3
           (second.group 1).eq "world"
         (second.group 2).eq "2"
     ((regex "/([a-z]+)([1-9]{1})/").compiled.match "!hello1!world2").next > first

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -144,9 +144,9 @@ public interface Data {
                 if (Double.isNaN(value)) {
                     phi = Phi.Φ.take("nan");
                 } else if (value == Double.POSITIVE_INFINITY) {
-                    phi = Phi.Φ.take("positive-infinity");
+                    phi = Phi.Φ.take("pinf");
                 } else if (value == Double.NEGATIVE_INFINITY) {
-                    phi = Phi.Φ.take("negative-infinity");
+                    phi = Phi.Φ.take("ninf");
                 } else {
                     phi = Phi.Φ.take("number").copy();
                     final Phi bts = Phi.Φ.take("bytes").copy();


### PR DESCRIPTION
Enables `compound-name` lint by renaming `positive-infinity` and `negative-infinity` to `pinf` and `ninf`, and `line-separator` to `eol` across `eo-runtime` sources.

Fixes #5224