### PR TITLE
feat(#5165): add `PhSticky` memoizing decorator

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -559,6 +559,10 @@
       <xsl:with-param name="indent" select="$indent"/>
       <xsl:with-param name="rho" select="$rho"/>
     </xsl:apply-templates>
+    <xsl:call-template name="sticky">
+      <xsl:with-param name="name" select="$name"/>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:call-template>
     <xsl:apply-templates select="." mode="located">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
@@ -595,10 +599,24 @@
       <xsl:with-param name="skip" select="1"/>
       <xsl:with-param name="rho" select="$rho"/>
     </xsl:apply-templates>
+    <xsl:call-template name="sticky">
+      <xsl:with-param name="name" select="$name"/>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:call-template>
     <xsl:apply-templates select="." mode="located">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
     </xsl:apply-templates>
+  </xsl:template>
+  <!-- Wrap a formed object into a memoizing PhSticky -->
+  <xsl:template name="sticky">
+    <xsl:param name="indent"/>
+    <xsl:param name="name"/>
+    <xsl:value-of select="eo:eol($indent)"/>
+    <xsl:value-of select="$name"/>
+    <xsl:text> = new PhSticky(</xsl:text>
+    <xsl:value-of select="$name"/>
+    <xsl:text>);</xsl:text>
   </xsl:template>
   <!-- Location of object -->
   <xsl:template match="*" mode="located">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -616,7 +616,9 @@
     <xsl:value-of select="$name"/>
     <xsl:text> = new PhSticky(</xsl:text>
     <xsl:value-of select="$name"/>
-    <xsl:text>);</xsl:text>
+    <xsl:text>, "</xsl:text>
+    <xsl:value-of select="@loc"/>
+    <xsl:text>");</xsl:text>
   </xsl:template>
   <!-- Location of object -->
   <xsl:template match="*" mode="located">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/fetching.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/fetching.yaml
@@ -18,6 +18,8 @@ asserts:
   - //java[contains(text(), 'Phi rb1 = new PhDispatch(Phi.Φ, "number");')]
   - //java[contains(text(), 'Phi rb11 = new PhDispatch(Phi.Φ, "bytes")')]
   - //java[contains(text(), 'Phi r = new PhDispatch(rb, "and");')]
+  - //java[contains(text(), 'rb1 = new PhSticky(rb1);')]
+  - //java[contains(text(), 'r = new PhSticky(r);')]
 input: |
   # Comment.
   [] > foo

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/fetching.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/fetching.yaml
@@ -18,8 +18,8 @@ asserts:
   - //java[contains(text(), 'Phi rb1 = new PhDispatch(Phi.Φ, "number");')]
   - //java[contains(text(), 'Phi rb11 = new PhDispatch(Phi.Φ, "bytes")')]
   - //java[contains(text(), 'Phi r = new PhDispatch(rb, "and");')]
-  - //java[contains(text(), 'rb1 = new PhSticky(rb1);')]
-  - //java[contains(text(), 'r = new PhSticky(r);')]
+  - //java[contains(text(), 'rb1 = new PhSticky(rb1, "')]
+  - //java[contains(text(), 'r = new PhSticky(r, "')]
 input: |
   # Comment.
   [] > foo

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * object. Keying by the full φ-expression and purity gating (so that
  * impure objects are never shared) come in later increments.</p>
  *
- * @since 0.60
+ * @since 0.74
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class PhSticky implements Phi {

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -11,17 +11,18 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * A decorator that memoizes the attributes it takes.
  *
- * <p>It wraps another object and, for a single predefined φ-expression,
- * remembers in a process-wide table the result of {@link #take(String)}
- * keyed on {@code (origin.forma()).name}. A second taking of that same
- * expression, anywhere in the program, yields the very same {@link Phi}
- * instead of building it again; every other expression is delegated and
- * rebuilt as usual.</p>
+ * <p>It wraps another object whose static φ-expression is baked in by the
+ * transpiler as {@code key}. For a single targeted expression it remembers,
+ * in a process-wide table, the result of {@link #take(String)} keyed on
+ * {@code key.name}. A second taking of that same expression, anywhere in the
+ * program, yields the very same {@link Phi} instead of building it again;
+ * every other expression is delegated and rebuilt as usual.</p>
  *
- * <p>The key comes from {@link Phi#forma()}, which is side-effect-free, so
- * computing it on every taking never activates nor dataizes the wrapped
- * object. Keying by the full φ-expression and purity gating (so that
- * impure objects are never shared) come in later increments.</p>
+ * <p>The key is a compile-time constant, so deciding whether to memoize
+ * costs a single string comparison and never activates, dataizes nor
+ * reflects upon the wrapped object. The transpiler bakes the object's
+ * locator as the key; full purity gating (so that impure objects are never
+ * shared) arrives with the {@code Impure} annotation in a later increment.</p>
  *
  * @since 0.74
  */
@@ -29,9 +30,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class PhSticky implements Phi {
 
     /**
-     * The single φ-expression whose taking is memoized.
+     * The single expression whose taking is memoized.
      */
-    private static final String KEY = "(Φ.memoized).alpha";
+    private static final String KEY = "Φ.nan.is-finite";
 
     /**
      * The table of memoized objects, shared across all stickies.
@@ -44,11 +45,18 @@ public final class PhSticky implements Phi {
     private final Phi origin;
 
     /**
+     * The static φ-expression of the wrapped object, baked by the transpiler.
+     */
+    private final String key;
+
+    /**
      * Ctor.
      * @param phi The object to wrap
+     * @param locator The static φ-expression of the object
      */
-    public PhSticky(final Phi phi) {
+    public PhSticky(final Phi phi, final String locator) {
         this.origin = phi;
+        this.key = locator;
     }
 
     @Override
@@ -63,7 +71,7 @@ public final class PhSticky implements Phi {
 
     @Override
     public Phi copy() {
-        return new PhSticky(this.origin.copy());
+        return new PhSticky(this.origin.copy(), this.key);
     }
 
     @Override
@@ -74,7 +82,7 @@ public final class PhSticky implements Phi {
     @Override
     public Phi take(final String name) {
         final Phi taken;
-        if (PhSticky.KEY.equals(String.format("(%s).%s", this.origin.forma(), name))) {
+        if (PhSticky.KEY.equals(String.join(".", this.key, name))) {
             taken = PhSticky.MEMORY.computeIfAbsent(PhSticky.KEY, ignore -> this.origin.take(name));
         } else {
             taken = this.origin.take(name);

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A decorator that memoizes the attributes it takes.
+ *
+ * <p>It wraps another object and, for a single predefined φ-expression,
+ * remembers in a process-wide table the result of {@link #take(String)}
+ * keyed on {@code (origin.forma()).name}. A second taking of that same
+ * expression, anywhere in the program, yields the very same {@link Phi}
+ * instead of building it again; every other expression is delegated and
+ * rebuilt as usual.</p>
+ *
+ * <p>The key comes from {@link Phi#forma()}, which is side-effect-free, so
+ * computing it on every taking never activates nor dataizes the wrapped
+ * object. Keying by the full φ-expression and purity gating (so that
+ * impure objects are never shared) come in later increments.</p>
+ *
+ * @since 0.60
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public final class PhSticky implements Phi {
+
+    /**
+     * The single φ-expression whose taking is memoized.
+     */
+    private static final String KEY = "(Φ.memoized).alpha";
+
+    /**
+     * The table of memoized objects, shared across all stickies.
+     */
+    private static final Map<String, Phi> MEMORY = new ConcurrentHashMap<>(1);
+
+    /**
+     * The wrapped object.
+     */
+    private final Phi origin;
+
+    /**
+     * Ctor.
+     * @param phi The object to wrap
+     */
+    public PhSticky(final Phi phi) {
+        this.origin = phi;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.origin.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.origin.hashCode();
+    }
+
+    @Override
+    public Phi copy() {
+        return new PhSticky(this.origin.copy());
+    }
+
+    @Override
+    public boolean hasRho() {
+        return this.origin.hasRho();
+    }
+
+    @Override
+    public Phi take(final String name) {
+        final Phi taken;
+        if (PhSticky.KEY.equals(String.format("(%s).%s", this.origin.forma(), name))) {
+            taken = PhSticky.MEMORY.computeIfAbsent(PhSticky.KEY, ignore -> this.origin.take(name));
+        } else {
+            taken = this.origin.take(name);
+        }
+        return taken;
+    }
+
+    @Override
+    public void put(final int pos, final Phi object) {
+        this.origin.put(pos, object);
+    }
+
+    @Override
+    public void put(final String name, final Phi object) {
+        this.origin.put(name, object);
+    }
+
+    @Override
+    public String locator() {
+        return this.origin.locator();
+    }
+
+    @Override
+    public String forma() {
+        return this.origin.forma();
+    }
+
+    @Override
+    public byte[] delta() {
+        return this.origin.delta();
+    }
+
+    @Override
+    public String φTerm() {
+        return this.origin.φTerm();
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -47,16 +47,16 @@ public final class PhSticky implements Phi {
     /**
      * The static φ-expression of the wrapped object, baked by the transpiler.
      */
-    private final String key;
+    private final String locator;
 
     /**
      * Ctor.
      * @param phi The object to wrap
-     * @param locator The static φ-expression of the object
+     * @param loc The static φ-expression of the object
      */
-    public PhSticky(final Phi phi, final String locator) {
+    public PhSticky(final Phi phi, final String loc) {
         this.origin = phi;
-        this.key = locator;
+        this.locator = loc;
     }
 
     @Override
@@ -71,7 +71,7 @@ public final class PhSticky implements Phi {
 
     @Override
     public Phi copy() {
-        return new PhSticky(this.origin.copy(), this.key);
+        return new PhSticky(this.origin.copy(), this.locator);
     }
 
     @Override
@@ -82,7 +82,7 @@ public final class PhSticky implements Phi {
     @Override
     public Phi take(final String name) {
         final Phi taken;
-        if (PhSticky.KEY.equals(String.join(".", this.key, name))) {
+        if (PhSticky.KEY.equals(String.join(".", this.locator, name))) {
             taken = PhSticky.MEMORY.computeIfAbsent(PhSticky.KEY, ignore -> this.origin.take(name));
         } else {
             taken = this.origin.take(name);

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -16,52 +16,58 @@ import org.junit.jupiter.api.Test;
 final class PhStickyTest {
 
     @Test
-    void memoizesThePredefinedExpression() {
+    void memoizesTheTargetedExpressionOfNan() {
         MatcherAssert.assertThat(
-            "PhSticky must serve the very same instance for its one predefined expression, but it didnt",
-            new PhSticky(new PhStickyTest.Formed("Φ.memoized")).take("alpha"),
+            "PhSticky must serve the very same is-finite of nan across the program, but it didnt",
+            Phi.Φ.take("nan").take("is-finite"),
             Matchers.sameInstance(
-                new PhSticky(new PhStickyTest.Formed("Φ.memoized")).take("alpha")
+                Phi.Φ.take("nan").take("is-finite")
             )
         );
     }
 
     @Test
-    void rebuildsEveryOtherExpression() {
+    void rebuildsExpressionWithAnotherKey() {
         MatcherAssert.assertThat(
-            "PhSticky must rebuild every expression other than its one predefined key, but it didnt",
-            new PhSticky(new PhStickyTest.Formed("Φ.elsewhere")).take("alpha"),
+            "PhSticky must rebuild an expression whose baked key is not the targeted one, but it didnt",
+            new PhSticky(new PhStickyTest.Formed(), "Φ.elsewhere").take("is-finite"),
             Matchers.not(
                 Matchers.sameInstance(
-                    new PhSticky(new PhStickyTest.Formed("Φ.elsewhere")).take("alpha")
+                    new PhSticky(new PhStickyTest.Formed(), "Φ.elsewhere").take("is-finite")
+                )
+            )
+        );
+    }
+
+    @Test
+    void rebuildsAnotherAttributeOfTheTargetedObject() {
+        MatcherAssert.assertThat(
+            "PhSticky must rebuild an attribute other than the targeted one, but it didnt",
+            new PhSticky(new PhStickyTest.Formed(), "Φ.nan").take("as-bytes"),
+            Matchers.not(
+                Matchers.sameInstance(
+                    new PhSticky(new PhStickyTest.Formed(), "Φ.nan").take("as-bytes")
                 )
             )
         );
     }
 
     /**
-     * An object reporting a chosen forma, with one freshly-built attribute.
+     * An object with a couple of freshly-built attributes.
      * @since 0.74
      */
     static final class Formed extends PhDefault {
 
         /**
-         * The forma this object reports.
-         */
-        private final String form;
-
-        /**
          * Ctor.
-         * @param forma The forma to report
          */
-        Formed(final String forma) {
-            super(new Attrs(new Attr("alpha", new AtComposite(Phi.Φ, rho -> new PhDefault()))));
-            this.form = forma;
-        }
-
-        @Override
-        public String forma() {
-            return this.form;
+        Formed() {
+            super(
+                new Attrs(
+                    new Attr("is-finite", new AtComposite(Phi.Φ, rho -> new PhDefault())),
+                    new Attr("as-bytes", new AtComposite(Phi.Φ, rho -> new PhDefault()))
+                )
+            );
         }
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link PhSticky}.
- * @since 0.60
+ * @since 0.74
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class PhStickyTest {
@@ -41,7 +41,7 @@ final class PhStickyTest {
 
     /**
      * An object reporting a chosen forma, with one freshly-built attribute.
-     * @since 0.60
+     * @since 0.74
      */
     static final class Formed extends PhDefault {
 

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PhSticky}.
+ * @since 0.60
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class PhStickyTest {
+
+    @Test
+    void memoizesThePredefinedExpression() {
+        MatcherAssert.assertThat(
+            "PhSticky must serve the very same instance for its one predefined expression, but it didnt",
+            new PhSticky(new PhStickyTest.Formed("Φ.memoized")).take("alpha"),
+            Matchers.sameInstance(
+                new PhSticky(new PhStickyTest.Formed("Φ.memoized")).take("alpha")
+            )
+        );
+    }
+
+    @Test
+    void rebuildsEveryOtherExpression() {
+        MatcherAssert.assertThat(
+            "PhSticky must rebuild every expression other than its one predefined key, but it didnt",
+            new PhSticky(new PhStickyTest.Formed("Φ.elsewhere")).take("alpha"),
+            Matchers.not(
+                Matchers.sameInstance(
+                    new PhSticky(new PhStickyTest.Formed("Φ.elsewhere")).take("alpha")
+                )
+            )
+        );
+    }
+
+    /**
+     * An object reporting a chosen forma, with one freshly-built attribute.
+     * @since 0.60
+     */
+    static final class Formed extends PhDefault {
+
+        /**
+         * The forma this object reports.
+         */
+        private final String form;
+
+        /**
+         * Ctor.
+         * @param forma The forma to report
+         */
+        Formed(final String forma) {
+            super(new Attrs(new Attr("alpha", new AtComposite(Phi.Φ, rho -> new PhDefault()))));
+            this.form = forma;
+        }
+
+        @Override
+        public String forma() {
+            return this.form;
+        }
+    }
+}


### PR DESCRIPTION
Part of #5165. First vertical slice toward memoization: the decorator and its transpilation seam.

`PhSticky` memoizes the result of `take` for a single targeted expression, keyed on a **compile-time constant** locator baked in by the transpiler (`key.name`). Deciding whether to memoize is one string comparison — it never activates, dataizes nor reflects upon the wrapped object (unlike `φTerm()`, which would). The first real target is `Φ.nan.is-finite`; a second taking of it anywhere yields the very same `Phi`. Every other expression is delegated and rebuilt as usual.

`to-java.xsl` wraps every formed object in `new PhSticky(origin, "<loc>")`, baking the object's `@loc` as the key and putting the seam in place.

Follow-ups in #5165: value-level keying via `φTerm()` (the baked locator is *source* identity, enough for context-free constants like `nan`) and purity gating via the `Impure` annotation (#5245), so impure objects are never shared.
