### PR TITLE
feat(#4156): enable `duplicate-names-in-diff-context` lint in pom.xml

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.2.7</version>
+      <version>0.2.8</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -229,16 +229,6 @@
               <goal>unspile</goal>
             </goals>
             <configuration>
-              <skipSourceLints>
-                <!--
-                @todo #4148:30min. Enable `duplicate-names-in-diff-context` lint.
-                      For now its too pedantic.
-                      See this: https://github.com/objectionary/lints/issues/578.
-                      Also, we should fix the bug with false positives with lambda object
-                      names in the atoms, in order to enable this lint.
-                -->
-                <lint>duplicate-names-in-diff-context</lint>
-              </skipSourceLints>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
               </skipProgramLints>


### PR DESCRIPTION
Enables `duplicate-names-in-diff-context` lint and upgrades `lints` dependency to `0.2.8`.

Fixes #4156