### PR TITLE
fix: add path and length delimiter to Sha directory hashing to prevent collisions

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -6,6 +6,8 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -55,22 +57,36 @@ final class Sha {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
         try (Stream<Path> walk = Files.walk(path)) {
             walk.filter(Files::isRegularFile)
-                .sorted(Comparator.comparing(Path::toString)).forEach(
-                    file -> {
-                        try (InputStream input = Files.newInputStream(file)) {
-                            final byte[] buffer = new byte[8192];
-                            int read = input.read(buffer);
-                            while (read != -1) {
-                                digest.update(buffer, 0, read);
-                                read = input.read(buffer);
-                            }
-                        } catch (final IOException ex) {
-                            throw new IllegalStateException(
-                                String.format("Failed to read '%s'", file), ex
-                            );
-                        }
-                    }
+    .sorted(Comparator.comparing(Path::toString)).forEach(
+        file -> {
+            try {
+                // 1. Hash the relative path so renames change the digest
+                final Path rel = path.relativize(file);
+                digest.update(
+                    rel.toString().getBytes(StandardCharsets.UTF_8)
                 );
+                // 2. NUL byte as unambiguous separator between path and content
+                digest.update((byte) 0);
+                // 3. Hash the file size so boundary shifts change the digest
+                final long size = Files.size(file);
+                digest.update(
+                    ByteBuffer.allocate(Long.BYTES).putLong(size).array()
+                );
+                try (InputStream input = Files.newInputStream(file)) {
+                    final byte[] buffer = new byte[8192];
+                    int read = input.read(buffer);
+                    while (read != -1) {
+                        digest.update(buffer, 0, read);
+                        read = input.read(buffer);
+                    }
+                }
+            } catch (final IOException ex) {
+                throw new IllegalStateException(
+                    String.format("Failed to read '%s'", file), ex
+                );
+            }
+        }
+    );
         }
         return Base64.getEncoder().encodeToString(digest.digest());
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -146,11 +147,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content",
             Files.readString(base.resolve(String.format("%s.sha256", tail)), encoding),
-            Matchers.equalTo(
-                Base64.getEncoder().encodeToString(
-                    MessageDigest.getInstance("SHA-256").digest(msg.getBytes(encoding))
-                )
-            )
+            Matchers.equalTo(CacheTest.hash(temp, source))
         );
     }
 
@@ -176,12 +173,7 @@ final class CacheTest {
                 cache.resolve(String.format("%s.sha256", tail)),
                 StandardCharsets.UTF_8
             ),
-            Matchers.equalTo(
-                Base64.getEncoder().encodeToString(
-                    MessageDigest.getInstance("SHA-256")
-                        .digest(content.getBytes(StandardCharsets.UTF_8))
-                )
-            )
+            Matchers.equalTo(CacheTest.hash(temp, source))
         );
     }
 
@@ -202,7 +194,7 @@ final class CacheTest {
                 cache.resolve(String.format("%s.sha256", tail)),
                 StandardCharsets.UTF_8
             ),
-            Matchers.equalTo(CacheTest.hash(content))
+            Matchers.equalTo(CacheTest.hash(temp, source))
         );
     }
 
@@ -218,16 +210,18 @@ final class CacheTest {
         final String first = "file1 content";
         final String second = "file2 content";
         final String result = String.format("%s%s", first, second);
-        Files.writeString(source.resolve("file1.txt"), first, StandardCharsets.UTF_8);
-        Files.writeString(source.resolve("file2.txt"), second, StandardCharsets.UTF_8);
+        final Path file1 = source.resolve("file1.txt");
+        final Path file2 = source.resolve("file2.txt");
+        Files.writeString(file1, first, StandardCharsets.UTF_8);
+        Files.writeString(file2, second, StandardCharsets.UTF_8);
         new Cache(cache, p -> result).apply(
             source,
             temp.resolve("out.txt"),
             source.getFileName()
         );
         final MessageDigest instance = MessageDigest.getInstance("SHA-256");
-        instance.update(CacheTest.hash(first).getBytes(StandardCharsets.UTF_8));
-        instance.update(CacheTest.hash(second).getBytes(StandardCharsets.UTF_8));
+        instance.update(CacheTest.hash(source, file1).getBytes(StandardCharsets.UTF_8));
+        instance.update(CacheTest.hash(source, file2).getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for folder with several files",
             Files.readString(
@@ -238,10 +232,24 @@ final class CacheTest {
         );
     }
 
-    private static String hash(final String content) throws NoSuchAlgorithmException {
-        return Base64.getEncoder().encodeToString(
-            MessageDigest.getInstance("SHA-256")
-                .digest(content.getBytes(StandardCharsets.UTF_8))
-        );
+    /**
+     * Compute the SHA-256 hash of a file, based on its path relative to
+     * {@code root}, its size, and its content.
+     * @param root The root directory used to relativize the file path.
+     * @param file The file to hash.
+     * @return Base64-encoded SHA-256 hash.
+     * @throws NoSuchAlgorithmException If SHA-256 is not available.
+     * @throws IOException If the file cannot be read.
+     */
+    private static String hash(final Path root, final Path file)
+        throws NoSuchAlgorithmException, IOException {
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final Path rel = root.relativize(file);
+        digest.update(rel.toString().getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        final long size = Files.size(file);
+        digest.update(ByteBuffer.allocate(Long.BYTES).putLong(size).array());
+        digest.update(Files.readAllBytes(file));
+        return Base64.getEncoder().encodeToString(digest.digest());
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -1,0 +1,69 @@
+package org.eolang.maven;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tests for {@link Sha}.
+ */
+final class ShaTest {
+
+    @Test
+    void doesNotCollideOnDifferentFileBoundaries(@TempDir final Path tmp)
+        throws Exception {
+        // Directory A: file1="ab", file2="c"  → concat = "abc"
+        final Path dirA = tmp.resolve("A");
+        Files.createDirectory(dirA);
+        Files.writeString(dirA.resolve("file1"), "ab");
+        Files.writeString(dirA.resolve("file2"), "c");
+
+        // Directory B: file1="a", file2="bc"  → concat = "abc"
+        final Path dirB = tmp.resolve("B");
+        Files.createDirectory(dirB);
+        Files.writeString(dirB.resolve("file1"), "a");
+        Files.writeString(dirB.resolve("file2"), "bc");
+
+        assertThat(
+            "directories with same content concatenation but different file boundaries must not collide",
+            new Sha(dirA).toString(),
+            not(equalTo(new Sha(dirB).toString()))
+        );
+    }
+
+    @Test
+    void doesNotCollideOnFileRename(@TempDir final Path tmp)
+        throws Exception {
+        // Same content, different file name
+        final Path dirA = tmp.resolve("A");
+        Files.createDirectory(dirA);
+        Files.writeString(dirA.resolve("foo.txt"), "hello");
+
+        final Path dirB = tmp.resolve("B");
+        Files.createDirectory(dirB);
+        Files.writeString(dirB.resolve("bar.txt"), "hello");
+
+        assertThat(
+            "directories differing only in file name must not collide",
+            new Sha(dirA).toString(),
+            not(equalTo(new Sha(dirB).toString()))
+        );
+    }
+
+    @Test
+    void sameDirectoryProducesSameHash(@TempDir final Path tmp)
+        throws Exception {
+        final Path dir = tmp.resolve("C");
+        Files.createDirectory(dir);
+        Files.writeString(dir.resolve("a.txt"), "consistent");
+        assertThat(
+            "same directory must always produce the same hash",
+            new Sha(dir).toString(),
+            equalTo(new Sha(dir).toString())
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -53,7 +53,7 @@ final class ShaTest {
     }
 
     @Test
-    void sameDirectoryProducesSameHash(@Mktmp final Path temp) throws Exception {
+    void providesSameHashForSameDirectory(@Mktmp final Path temp) throws Exception {
         final Path dir = temp.resolve("C");
         Files.createDirectories(dir);
         Files.writeString(dir.resolve("a.txt"), "consistent");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -1,69 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
 package org.eolang.maven;
 
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Tests for {@link Sha}.
+ * Test for {@link Sha}.
+ * @since 0.62
  */
+@ExtendWith(MktmpResolver.class)
 final class ShaTest {
 
     @Test
-    void doesNotCollideOnDifferentFileBoundaries(@TempDir final Path tmp)
-        throws Exception {
-        // Directory A: file1="ab", file2="c"  → concat = "abc"
-        final Path dirA = tmp.resolve("A");
-        Files.createDirectory(dirA);
-        Files.writeString(dirA.resolve("file1"), "ab");
-        Files.writeString(dirA.resolve("file2"), "c");
-
-        // Directory B: file1="a", file2="bc"  → concat = "abc"
-        final Path dirB = tmp.resolve("B");
-        Files.createDirectory(dirB);
-        Files.writeString(dirB.resolve("file1"), "a");
-        Files.writeString(dirB.resolve("file2"), "bc");
-
-        assertThat(
+    void doesNotCollideOnDifferentFileBoundaries(@Mktmp final Path temp) throws Exception {
+        final Path dira = temp.resolve("A");
+        Files.createDirectories(dira);
+        Files.writeString(dira.resolve("file1"), "ab");
+        Files.writeString(dira.resolve("file2"), "c");
+        final Path dirb = temp.resolve("B");
+        Files.createDirectories(dirb);
+        Files.writeString(dirb.resolve("file1"), "a");
+        Files.writeString(dirb.resolve("file2"), "bc");
+        MatcherAssert.assertThat(
             "directories with same content concatenation but different file boundaries must not collide",
-            new Sha(dirA).toString(),
-            not(equalTo(new Sha(dirB).toString()))
+            new Sha(dira).toString(),
+            Matchers.not(Matchers.equalTo(new Sha(dirb).toString()))
         );
     }
 
     @Test
-    void doesNotCollideOnFileRename(@TempDir final Path tmp)
-        throws Exception {
-        // Same content, different file name
-        final Path dirA = tmp.resolve("A");
-        Files.createDirectory(dirA);
-        Files.writeString(dirA.resolve("foo.txt"), "hello");
-
-        final Path dirB = tmp.resolve("B");
-        Files.createDirectory(dirB);
-        Files.writeString(dirB.resolve("bar.txt"), "hello");
-
-        assertThat(
+    void doesNotCollideOnFileRename(@Mktmp final Path temp) throws Exception {
+        final Path dira = temp.resolve("A");
+        Files.createDirectories(dira);
+        Files.writeString(dira.resolve("foo.txt"), "hello");
+        final Path dirb = temp.resolve("B");
+        Files.createDirectories(dirb);
+        Files.writeString(dirb.resolve("bar.txt"), "hello");
+        MatcherAssert.assertThat(
             "directories differing only in file name must not collide",
-            new Sha(dirA).toString(),
-            not(equalTo(new Sha(dirB).toString()))
+            new Sha(dira).toString(),
+            Matchers.not(Matchers.equalTo(new Sha(dirb).toString()))
         );
     }
 
     @Test
-    void sameDirectoryProducesSameHash(@TempDir final Path tmp)
-        throws Exception {
-        final Path dir = tmp.resolve("C");
-        Files.createDirectory(dir);
+    void sameDirectoryProducesSameHash(@Mktmp final Path temp) throws Exception {
+        final Path dir = temp.resolve("C");
+        Files.createDirectories(dir);
         Files.writeString(dir.resolve("a.txt"), "consistent");
-        assertThat(
+        MatcherAssert.assertThat(
             "same directory must always produce the same hash",
             new Sha(dir).toString(),
-            equalTo(new Sha(dir).toString())
+            Matchers.equalTo(new Sha(dir).toString())
         );
     }
 }


### PR DESCRIPTION

Without a per-file delimiter, two directory trees whose file contents concatenate to the same byte sequence produce identical SHA-256 hashes, breaking the contract the class advertises. For example:

  dir A: file1="ab", file2="c"  → concat "abc" → same hash
  dir B: file1="a",  file2="bc" → concat "abc" → same hash

Fix: before streaming each file's content into the digest, feed:
  1. the relative file path (UTF-8 bytes) — so renames change the hash
  2. a NUL byte separator — unambiguous boundary between path and content
  3. the 8-byte file size (big-endian long) — so boundary shifts change the hash

Adds ShaTest covering the collision case, file-rename case, and determinism, as required by the acceptance criteria in #5254.

Fixes #5254