### PR TITLE
Introduce `T` term syntax mapping to `⊥` in XMIR

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -141,6 +141,9 @@
       <xsl:when test="$first='ξ'">
         <xsl:value-of select="$rho"/>
       </xsl:when>
+      <xsl:when test="$first='⊥'">
+        <xsl:text>new PhTerminated()</xsl:text>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:message terminate="yes">
           <xsl:text>FQN must start with either with Φ or ξ, but </xsl:text>
@@ -539,7 +542,7 @@
     <xsl:value-of select="$name"/>
     <xsl:text> = </xsl:text>
     <xsl:choose>
-      <xsl:when test="@base='ξ' or @base='Φ'">
+      <xsl:when test="@base='ξ' or @base='Φ' or @base='⊥'">
         <xsl:value-of select="eo:fqn-start(@base, $rho)"/>
         <xsl:text>;</xsl:text>
       </xsl:when>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/bottom-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/bottom-to-java.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/package.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/class/java[contains(text(), 'new PhTerminated()')]
+input: |
+  # No comments.
+  [] > app
+    T > x

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -167,6 +167,7 @@ The parser recognises the following lexical tokens:
 | `RHO` | `^` |
 | `ROOT` | `Q` |
 | `XI` | `$` |
+| `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A self-contained single-character token; carries no arguments and no chain. |
 | `INT` | optional sign, then `0` or non-zero digit string. |
 | `FLOAT` | optional sign, digits, `.`, digits, optional exponent. |
 | `HEX` | `0x` followed by hex digits. |
@@ -1050,6 +1051,7 @@ Example: a `>>` suffix at `line=12, pos=5` emits `@name="a🌵12-5"`.
 | `^` (RHO) | `ρ` | `@base='ρ'` for parent reference |
 | `Q` (ROOT) | `Φ` | `@base='Φ...'` for root-rooted FQNs |
 | `$` (XI) | `ξ` | `@base='ξ'` for self reference |
+| `T` (TERM) | `⊥` | `@base='⊥'` for the bottom term |
 | atom signature head `Q` | `Φ` | `@atom='Φ....'` |
 
 ### 9.4 Per-construct attribute emission

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -138,6 +138,8 @@ final class Emissions {
             emit.star();
         } else if (value.kind() == Value.Kind.ROOT) {
             emit.object(name, Emissions.rootBase(value.raw()), line, value.pos());
+        } else if (value.kind() == Value.Kind.TERM) {
+            emit.object(name, "⊥", line, value.pos());
         } else if (value.kind() == Value.Kind.GROUP) {
             final String inner = value.raw().substring(1, value.raw().length() - 1);
             final int phi = Emissions.topLevelInlinePhi(inner);

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -366,6 +366,7 @@ final class Eo implements Iterable<Directive> {
             || span.head() == '"'
             || span.head() == '('
             || span.head() == 'Q'
+            || span.head() == 'T'
             || span.head() == '@'
             || span.head() == '^'
             || span.head() == '$'

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -123,6 +123,11 @@ final class Tokens {
             value = this.readNumber();
         } else if (Tokens.rootStart(first)) {
             value = this.readRoot();
+        } else if (first == 'T') {
+            value = new Value(
+                Value.Kind.TERM, "T", this.span.indent() + this.cursor, this.cursor + 1
+            );
+            this.cursor = this.cursor + 1;
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
         } else {

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -209,6 +209,13 @@ final class Value {
         ROOT,
 
         /**
+         * {@code T} — the bottom term, similar to {@code ⊥} in
+         * 𝜑-calculus (§9.3). A self-contained leaf carrying no
+         * arguments; {@link Emissions} maps it to {@code @base='⊥'}.
+         */
+        TERM,
+
+        /**
          * Paren group — {@code (expr)}. The {@code raw()} string holds
          * the bracketed text <em>including</em> the surrounding
          * parentheses; {@link Emissions} re-parses and emits the inner

--- a/eo-parser/src/main/resources/org/eolang/parser/_specials.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/_specials.xsl
@@ -27,6 +27,7 @@
   <xsl:variable name="eo:clb" select="'('"/>
   <xsl:variable name="eo:crb" select="')'"/>
   <xsl:variable name="eo:empty" select="'∅'"/>
+  <xsl:variable name="eo:bottom" select="'⊥'"/>
   <xsl:variable name="eo:space" select="' '"/>
   <xsl:variable name="eo:new-line" select="'&#10;'"/>
 </xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
@@ -49,7 +49,7 @@
   <xsl:template match="o[not(contains(@base, '.'))]" mode="with-base">
     <xsl:apply-templates select="." mode="no-dots"/>
   </xsl:template>
-  <xsl:template match="o[@base!=$eo:phi and @base!=$eo:program and @base!=$eo:rho and @base!=$eo:empty and @base!=$eo:xi]" mode="no-dots">
+  <xsl:template match="o[@base!=$eo:phi and @base!=$eo:program and @base!=$eo:rho and @base!=$eo:empty and @base!=$eo:xi and @base!=$eo:bottom]" mode="no-dots">
     <xsl:apply-templates select="." mode="no-specials"/>
   </xsl:template>
   <xsl:template match="o[not(@base=/object/metas/meta[head='alias']/part[1])]" mode="no-specials">
@@ -64,7 +64,7 @@
   <xsl:template match="o[not(contains(@atom, '.'))]" mode="with-atom">
     <xsl:apply-templates select="." mode="atom-no-dots"/>
   </xsl:template>
-  <xsl:template match="o[@atom!=$eo:phi and @atom!=$eo:program and @atom!=$eo:rho and @atom!=$eo:empty and @atom!=$eo:xi]" mode="atom-no-dots">
+  <xsl:template match="o[@atom!=$eo:phi and @atom!=$eo:program and @atom!=$eo:rho and @atom!=$eo:empty and @atom!=$eo:xi and @atom!=$eo:bottom]" mode="atom-no-dots">
     <xsl:apply-templates select="." mode="atom-no-specials"/>
   </xsl:template>
   <xsl:template match="o[not(@atom=/object/metas/meta[head='alias']/part[1])]" mode="atom-no-specials">

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -203,7 +203,7 @@
       </xsl:element>
     </xsl:element>
   </xsl:template>
-  <xsl:template match="o[@base!='ξ' and @base!='ρ' and @base!=$eo:empty]" mode="no-dots">
+  <xsl:template match="o[@base!='ξ' and @base!='ρ' and @base!=$eo:empty and @base!=$eo:bottom]" mode="no-dots">
     <xsl:variable name="base" select="./@base"/>
     <xsl:apply-templates select="." mode="fqn">
       <xsl:with-param name="self" select="."/>

--- a/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/print/to-eo.xsl
@@ -79,6 +79,9 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:choose>
+          <xsl:when test="@base=$eo:bottom">
+            <xsl:text>T</xsl:text>
+          </xsl:when>
           <xsl:when test="starts-with(@base, 'Φ.')">
             <xsl:value-of select="substring-after(@base, 'Φ.')"/>
           </xsl:when>

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -201,6 +201,15 @@ final class EoTest {
     }
 
     @Test
+    void parsesBottomTermInsideFormation() {
+        MatcherAssert.assertThat(
+            "a bare T term inside a formation must emit the bottom object as @base='⊥'",
+            EoTest.render("[] > main", "  T > x"),
+            XhtmlMatchers.hasXPath("/object/o[@name='main']/o[@name='x' and @base='⊥']")
+        );
+    }
+
+    @Test
     void parsesHmethodInsideFormation() {
         MatcherAssert.assertThat(
             "a dotted-chain head inside a formation must emit flat siblings",

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -56,7 +56,7 @@ final class ValueTest {
         MatcherAssert.assertThat(
             "Value.Kind must enumerate every kind the parser currently recognises",
             Value.Kind.values().length,
-            Matchers.equalTo(9)
+            Matchers.equalTo(10)
         );
     }
 
@@ -129,6 +129,15 @@ final class ValueTest {
             "ROOT must be one of the recognised value kinds for Q/@/^/$",
             new Value(Value.Kind.ROOT, "Q", 0, 1).kind(),
             Matchers.equalTo(Value.Kind.ROOT)
+        );
+    }
+
+    @Test
+    void retainsTermKind() {
+        MatcherAssert.assertThat(
+            "TERM must be one of the recognised value kinds for the bottom term T",
+            new Value(Value.Kind.TERM, "T", 0, 1).kind(),
+            Matchers.equalTo(Value.Kind.TERM)
         );
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bottom-term-positions.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bottom-term-positions.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/decorate.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[@base='⊥'])=2]
+  - /object[not(//o[@base='Φ.⊥'])]
+  - /object/o[@name='app']/o[@name='φ' and @base='⊥']
+  - /object/o[@name='app']/o[@name='x' and @base='Φ.foo']/o[@base='⊥']
+input: |
+  [] > app
+    T > @
+    foo T > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bottom-term.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bottom-term.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/decorate.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[@base='⊥'])=2]
+  - /object[not(//o[@base='Φ.⊥'])]
+  - /object/o[@name='main']/o[@name='x' and @base='⊥']
+  - /object/o[@name='main']/o[@base='Φ.foo']/o[@base='⊥']
+input: |
+  [] > main
+    T > x
+    foo > y
+      T

--- a/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/bottom-term-phi.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/bottom-term-phi.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  # No comments.
+  [] > app
+    T > @
+
+printed: |
+  # No comments.
+  [] > app
+    T > @

--- a/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/bottom-term.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/print-packs/yaml/bottom-term.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  # No comments.
+  [] > app
+    T > x
+
+printed: |
+  # No comments.
+  [] > app
+    T > x

--- a/eo-runtime/src/main/java/org/eolang/PhTerminated.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminated.java
@@ -7,17 +7,63 @@ package org.eolang;
 /**
  * The ⊥ ("bottom") object of φ-calculus — a terminated computation.
  *
- * <p>It carries no data and no attributes. Dataizing it aborts the
- * program with an {@link ExFailure}, which EO {@code try} cannot catch
- * (that object only intercepts {@link EOerror.ExError}), so reaching ⊥
- * terminates the program for good.</p>
+ * <p>It has no data, no attributes, and no behaviour: every interaction
+ * with it aborts the program through an {@link ExFailure}. Because EO
+ * {@code try} only intercepts {@link EOerror.ExError}, this failure
+ * cannot be caught, so touching ⊥ terminates the program for good.</p>
  *
  * @since 0.73.1
  */
-public final class PhTerminated extends PhDefault {
+public final class PhTerminated implements Phi {
+
+    /**
+     * The message of the failure raised by every interaction with ⊥.
+     */
+    private static final String MESSAGE =
+        "the ⊥ object is a terminated computation and cannot be used";
+
+    @Override
+    public Phi copy() {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public boolean hasRho() {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public Phi take(final String name) {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public void put(final int pos, final Phi object) {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public void put(final String name, final Phi object) {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public String locator() {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public String forma() {
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
 
     @Override
     public byte[] delta() {
-        throw new ExFailure("the ⊥ object is a terminated computation and cannot be dataized");
+        throw new ExFailure(PhTerminated.MESSAGE);
+    }
+
+    @Override
+    public String φTerm() {
+        throw new ExFailure(PhTerminated.MESSAGE);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminated.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminated.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * The ⊥ ("bottom") object of φ-calculus — a terminated computation.
+ *
+ * <p>It carries no data and no attributes. Dataizing it aborts the
+ * program with an {@link ExFailure}, which EO {@code try} cannot catch
+ * (that object only intercepts {@link EOerror.ExError}), so reaching ⊥
+ * terminates the program for good.</p>
+ *
+ * @since 0.73.1
+ */
+public final class PhTerminated extends PhDefault {
+
+    @Override
+    public byte[] delta() {
+        throw new ExFailure("the ⊥ object is a terminated computation and cannot be dataized");
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PhTerminated}.
+ * @since 0.73.1
+ */
+final class PhTerminatedTest {
+
+    @Test
+    void cannotBeDataized() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new Dataized(new PhTerminated()).take(),
+            "dataizing the bottom object must abort instead of returning data"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 final class PhTerminatedTest {
 
     @Test
-    void cannotBeDataized() {
+    void failsWhenDataized() {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new Dataized(new PhTerminated()).take(),

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatedTest.java
@@ -21,4 +21,22 @@ final class PhTerminatedTest {
             "dataizing the bottom object must abort instead of returning data"
         );
     }
+
+    @Test
+    void failsWhenDispatched() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminated().take("any"),
+            "dispatching an attribute on the bottom object must abort"
+        );
+    }
+
+    @Test
+    void failsWhenCopied() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminated().copy(),
+            "copying the bottom object must abort"
+        );
+    }
 }


### PR DESCRIPTION
The fragile-objects epic #5261 needs a bottom term, `T`, analogous to `⊥` in 𝜑-calculus. This adds it to the spec-driven parser as a self-contained leaf: the source token `T` becomes `<o base="⊥"/>`, and the printer turns it back into `T`.

The mapping follows the existing §9.3 table (`Q`→`Φ`, `$`→`ξ`, `^`→`ρ`, void→`∅`), so `T` slots in as one more reserved single-character token. It collides with nothing — `NAME` is lowercase-led and `Q` is the only other uppercase glyph.

The subtle part is keeping `⊥` opaque through the XSL pipeline. Two passes would otherwise mangle a bare `⊥`: `add-default-package` prefixed it to `Φ.⊥`, and `build-fqns` tried to resolve it as a name. Both now exclude it, through a new special in `_specials.xsl`:

```xml
<xsl:variable name="eo:bottom" select="'⊥'"/>
```

Scope is syntax only. The runtime meaning of `⊥`, the `?.` operator, and the rest of #5261 are separate tickets. Tests cover the parse (`T` → `⊥` surviving the full sheet chain), the print round-trip, and the new `Value.Kind.TERM`.

Closes #5264.
