### PR TITLE
fixed #5260: return self from floor for values >= 2^52

### DIFF
--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -118,7 +118,11 @@
   # the original, so we subtract `1` in that single case.
   [] > floor
     if. > @
-      ^.is-finite.not
+      or.
+        ^.is-finite.not
+        or.
+          ^.gte 4503599627370496
+          ^.lte -4503599627370496
       ^
       if.
         trunc.gt ^
@@ -393,6 +397,18 @@
     eq. > @
       -5.floor
       -5
+
+  # Tests that floor of a very large positive number >= 2^52 returns itself.
+  [] +> tests-floor-of-large-positive-integer
+    eq. > @
+      100000000000000000000.floor
+      100000000000000000000
+
+  # Tests that floor of a very large negative number <= -2^52 returns itself.
+  [] +> tests-floor-of-large-negative-integer
+    eq. > @
+      -100000000000000000000.floor
+      -100000000000000000000
 
   # Tests that floor of zero returns zero.
   [] +> tests-floor-of-zero


### PR DESCRIPTION
## Description

This PR fixes a bug in `number.floor` where finite numbers of magnitude $\ge 2^{63}$ were incorrectly returning saturated values (about $\pm 9.22 \times 10^{18}$) due to narrowing conversion to `i64`.

### Problem
`number.floor` was computing `trunc = ^.as-i64.as-number`. The conversion `as-i64` is backed by `Double.longValue()`. For finite doubles whose magnitude is $\ge 2^{63}$, `Double.longValue()` saturates to `Long.MAX_VALUE` or `Long.MIN_VALUE` per Java Language Specification narrowing rules, causing `floor` of values like `1e20` or `-1e20` to return the saturated boundary value.

### Solution
Since double-precision floating point numbers have 52 mantissa bits, any double value with a magnitude $\ge 2^{52}$ cannot represent a fractional part and is already an exact mathematical integer. 

We update the `floor` implementation to check if the magnitude is $\ge 2^{52}$ (specifically $\ge 4503599627370496$ or $\le -4503599627370496$), and if so, return the number itself unchanged. This bypasses the narrowing conversion path entirely for values where the result is guaranteed to be equal to the input.

## Related Issues
Closes #5260