### PR TITLE
fix(#5269): skip test source generation for discovered EO dependencies

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -33,6 +33,56 @@ final class TranspileIT {
     @Test
     @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
+    void generatesTestSourcesForUserWrittenTests(final @Mktmp Path temp) throws IOException {
+        new Farea(temp).together(
+            f -> {
+                f.properties()
+                    .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
+                    .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
+                f.files()
+                    .file("src/main/eo/simple.eo")
+                    .write(
+                        String.join(
+                            System.lineSeparator(),
+                            "# Simple.",
+                            "[] > simple",
+                            "  \"hello\" > @",
+                            "  [] +> tests-simple-works",
+                            "    true > @"
+                        ).getBytes(StandardCharsets.UTF_8)
+                    );
+                f.dependencies().append(
+                    "org.eolang",
+                    "eo-runtime",
+                    System.getProperty("eo.version", Manifests.read("EO-Version"))
+                );
+                new EoMavenPlugin(f)
+                    .appended()
+                    .execution("compile")
+                    .goals("register", "compile", "transpile")
+                    .configuration()
+                    .set("failOnWarning", Boolean.FALSE.toString())
+                    .set("skipLinting", Boolean.TRUE.toString());
+                f.exec("clean", "compile");
+            }
+        );
+        final List<String> names;
+        try (Stream<Path> walk = Files.walk(temp.resolve("target/generated-test-sources"))) {
+            names = walk
+                .filter(Files::isRegularFile)
+                .map(p -> p.getFileName().toString())
+                .collect(Collectors.toList());
+        }
+        MatcherAssert.assertThat(
+            "User-written test sources must be generated",
+            names,
+            Matchers.hasItem("EOsimpleTest.java")
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    @ExtendWith(MayBeSlow.class)
     void doesNotGenerateRuntimeTestSourcesForUserProject(final @Mktmp Path temp) throws IOException {
         new Farea(temp).together(
             f -> {

--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -27,107 +28,89 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.62
  */
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
-@ExtendWith(MktmpResolver.class)
+@ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
 final class TranspileIT {
 
     @Test
-    @ExtendWith(WeAreOnline.class)
-    @ExtendWith(MayBeSlow.class)
-    void generatesSourcesForUserWrittenObjects(final @Mktmp Path temp) throws IOException {
+    void generatesTestSourcesForUserWrittenTests(final @Mktmp Path temp) throws IOException {
         new Farea(temp).together(
             f -> {
-                f.properties()
-                    .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
-                    .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
-                f.files()
-                    .file("src/main/eo/simple.eo")
-                    .write(
-                        String.join(
-                            System.lineSeparator(),
-                            "# Simple.",
-                            "[] > simple",
-                            "  \"hello\" > @",
-                            "  [] +> tests-simple-works",
-                            "    true > @"
-                        ).getBytes(StandardCharsets.UTF_8)
-                    );
-                f.dependencies().append(
-                    "org.eolang",
-                    "eo-runtime",
-                    System.getProperty("eo.version", Manifests.read("EO-Version"))
+                TranspileIT.setup(f, TranspileIT.programWithTests());
+                MatcherAssert.assertThat(
+                    "User-written test sources must be generated",
+                    TranspileIT.generatedNames(temp),
+                    Matchers.hasItem("EOsimpleTest.java")
                 );
-                new EoMavenPlugin(f)
-                    .appended()
-                    .execution("compile")
-                    .goals("register", "compile", "transpile")
-                    .configuration()
-                    .set("failOnWarning", Boolean.FALSE.toString())
-                    .set("skipLinting", Boolean.TRUE.toString());
-                f.exec("clean", "compile");
             }
-        );
-        final List<String> names;
-        try (Stream<Path> walk = Files.walk(temp.resolve("target/generated-test-sources"))) {
-            names = walk
-                .filter(Files::isRegularFile)
-                .map(p -> p.getFileName().toString())
-                .collect(Collectors.toList());
-        }
-        MatcherAssert.assertThat(
-            "User-written test sources must be generated",
-            names,
-            Matchers.hasItem("EOsimpleTest.java")
         );
     }
 
     @Test
-    @ExtendWith(WeAreOnline.class)
-    @ExtendWith(MayBeSlow.class)
-    void doesNotGenerateRuntimeTestSourcesForUserProject(final @Mktmp Path temp) throws IOException {
+    void doesNotGenerateRuntimeTestSourcesForUserProject(
+        final @Mktmp Path temp
+    ) throws IOException {
         new Farea(temp).together(
             f -> {
-                f.properties()
-                    .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
-                    .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
-                f.files()
-                    .file("src/main/eo/simple.eo")
-                    .write(
-                        String.join(
-                            System.lineSeparator(),
-                            "# Simple.",
-                            "[] > simple",
-                            "  \"hello\" > @"
-                        ).getBytes(StandardCharsets.UTF_8)
-                    );
-                f.dependencies().append(
-                    "org.eolang",
-                    "eo-runtime",
-                    System.getProperty("eo.version", Manifests.read("EO-Version"))
+                TranspileIT.setup(f, TranspileIT.simpleProgram());
+                MatcherAssert.assertThat(
+                    "EO runtime test sources must not be generated in a user project",
+                    TranspileIT.generatedNames(temp),
+                    Matchers.not(Matchers.hasItem(Matchers.containsString("EOstringTest")))
                 );
-                new EoMavenPlugin(f)
-                    .appended()
-                    .execution("compile")
-                    .goals("register", "compile", "transpile")
-                    .configuration()
-                    .set("failOnWarning", Boolean.FALSE.toString())
-                    .set("skipLinting", Boolean.TRUE.toString());
-                f.exec("clean", "compile");
             }
         );
-        final Path generated = temp.resolve("target/generated-test-sources");
-        if (Files.exists(generated)) {
-            final List<String> names;
-            try (Stream<Path> walk = Files.walk(generated)) {
-                names = walk
-                    .filter(Files::isRegularFile)
+    }
+
+    private static void setup(final Farea farea, final byte[] program) throws IOException {
+        farea.properties()
+            .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
+            .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
+        farea.files().file("src/main/eo/simple.eo").write(program);
+        farea.dependencies().append(
+            "org.eolang", "eo-runtime",
+            System.getProperty("eo.version", Manifests.read("EO-Version"))
+        );
+        new EoMavenPlugin(farea).appended()
+            .execution("transpile-it")
+            .goals("register", "compile", "transpile")
+            .configuration()
+            .set("failOnWarning", Boolean.FALSE.toString())
+            .set("skipLinting", Boolean.TRUE.toString());
+        farea.exec("clean", "compile");
+    }
+
+    private static List<String> generatedNames(final Path temp) throws IOException {
+        final Path dir = temp.resolve("target/generated-test-sources");
+        final List<String> result;
+        if (Files.exists(dir)) {
+            try (Stream<Path> walk = Files.walk(dir)) {
+                result = walk.filter(Files::isRegularFile)
                     .map(p -> p.getFileName().toString())
                     .collect(Collectors.toList());
             }
-            MatcherAssert.assertThat(
-                "EO runtime test sources must not be generated in a user project, but these were found",
-                names,
-                Matchers.not(Matchers.hasItem(Matchers.containsString("EOstringTest")))
-            );
+        } else {
+            result = Collections.emptyList();
         }
+        return result;
+    }
+
+    private static byte[] simpleProgram() {
+        return String.join(
+            System.lineSeparator(),
+            "# Simple.",
+            "[] > simple",
+            "  \"hello\" > @"
+        ).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] programWithTests() {
+        return String.join(
+            System.lineSeparator(),
+            "# Simple.",
+            "[] > simple",
+            "  \"hello\" > @",
+            "  [] +> tests-simple-works",
+            "    true > @"
+        ).getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package integration;
+
+import com.jcabi.manifests.Manifests;
+import com.yegor256.MayBeSlow;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import com.yegor256.WeAreOnline;
+import com.yegor256.farea.Farea;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests for transpile behavior.
+ * @since 0.62
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@ExtendWith(MktmpResolver.class)
+final class TranspileIT {
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
+    @ExtendWith(MayBeSlow.class)
+    void doesNotGenerateRuntimeTestSourcesForUserProject(final @Mktmp Path temp) throws IOException {
+        new Farea(temp).together(
+            f -> {
+                f.properties()
+                    .set("project.build.sourceEncoding", StandardCharsets.UTF_8.name())
+                    .set("project.reporting.outputEncoding", StandardCharsets.UTF_8.name());
+                f.files()
+                    .file("src/main/eo/simple.eo")
+                    .write(
+                        String.join(
+                            System.lineSeparator(),
+                            "# Simple.",
+                            "[] > simple",
+                            "  \"hello\" > @"
+                        ).getBytes(StandardCharsets.UTF_8)
+                    );
+                f.dependencies().append(
+                    "org.eolang",
+                    "eo-runtime",
+                    System.getProperty("eo.version", Manifests.read("EO-Version"))
+                );
+                new EoMavenPlugin(f)
+                    .appended()
+                    .execution("compile")
+                    .goals("register", "compile", "transpile")
+                    .configuration()
+                    .set("failOnWarning", Boolean.FALSE.toString())
+                    .set("skipLinting", Boolean.TRUE.toString());
+                f.exec("clean", "compile");
+            }
+        );
+        final Path generated = temp.resolve("target/generated-test-sources");
+        if (Files.exists(generated)) {
+            final List<String> names;
+            try (Stream<Path> walk = Files.walk(generated)) {
+                names = walk
+                    .filter(Files::isRegularFile)
+                    .map(p -> p.getFileName().toString())
+                    .collect(Collectors.toList());
+            }
+            MatcherAssert.assertThat(
+                "EO runtime test sources must not be generated in a user project, but these were found",
+                names,
+                Matchers.not(Matchers.hasItem(Matchers.containsString("EOstringTest")))
+            );
+        }
+    }
+}

--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Integration tests for transpile behavior.
  * @since 0.62
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleNotContainsTestWord"})
 @ExtendWith(MktmpResolver.class)
 final class TranspileIT {
 
     @Test
     @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
-    void generatesTestSourcesForUserWrittenTests(final @Mktmp Path temp) throws IOException {
+    void generatesSourcesForUserWrittenObjects(final @Mktmp Path temp) throws IOException {
         new Farea(temp).together(
             f -> {
                 f.properties()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
@@ -157,6 +157,15 @@ final class TjForeign {
     }
 
     /**
+     * Checks if tojo was discovered as a dependency of another object,
+     * rather than registered directly as a user source.
+     * @return True if discovered, false otherwise
+     */
+    boolean discovered() {
+        return this.delegate.exists(TjsForeign.Attribute.DISCOVERED_AT.getKey());
+    }
+
+    /**
      * Set the jar.
      * @param coordinates The coordinates of jar
      * @return The tojo itself

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -243,7 +243,9 @@ final class Transpiling implements Step {
             rewrite.compareAndSet(false, true);
             new Saved(transform.apply(xmir).toString(), target).value();
         }
-        return this.javaGenerated(rewrite.get(), target, hsh.get());
+        return this.javaGenerated(
+            rewrite.get(), target, hsh.get(), this.transpileTests && !tojo.discovered()
+        );
     }
 
     /**
@@ -327,13 +329,16 @@ final class Transpiling implements Step {
      * @param rewrite Rewrite .java files even if they exist
      * @param target Full target path to XMIR after transpilation optimizations
      * @param hsh Tojo hash
+     * @param tests Whether to generate test sources for this tojo
      * @return Amount of generated .java files
      * @throws IOException If fails to save files
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     private int javaGenerated(
         final boolean rewrite,
         final Path target,
-        final String hsh
+        final String hsh,
+        final boolean tests
     ) throws IOException {
         final AtomicInteger saved = new AtomicInteger(0);
         if (Files.exists(target)) {
@@ -363,7 +368,7 @@ final class Transpiling implements Step {
                         ),
                         tgt,
                         this.generatedDir
-                    ).exec(clazz, this.transpileTests);
+                    ).exec(clazz, tests);
                 }
             }
             Logger.debug(


### PR DESCRIPTION
Fixes `Transpiling` to skip test source generation for discovered (pulled) EO objects, ensuring only user-written EO tests are compiled and executed.

Fixes #5269