### PR TITLE
feat(#4752): add reusable tt converters for sprintf

### DIFF
--- a/eo-runtime/src/main/eo/tt/as-char.eo
+++ b/eo-runtime/src/main/eo/tt/as-char.eo
@@ -1,0 +1,54 @@
++alias tt.as-ascii
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tt
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
+# The number is read as a 64-bit integer and its least-significant byte is taken.
+[code] > as-char
+  code.as-i64.as-bytes.slice 7 1 > @
+
+  # Tests that as-char writes the byte of an uppercase letter.
+  [] +> tests-writes-byte-of-uppercase-letter
+    eq. > @
+      "A"
+      string (as-char 65)
+
+  # Tests that as-char writes the byte of the last uppercase letter.
+  [] +> tests-writes-byte-of-last-uppercase-letter
+    eq. > @
+      "Z"
+      string (as-char 90)
+
+  # Tests that as-char writes the byte of a lowercase letter.
+  [] +> tests-writes-byte-of-lowercase-letter
+    eq. > @
+      "z"
+      string (as-char 122)
+
+  # Tests that as-char writes the byte of the zero digit.
+  [] +> tests-writes-byte-of-zero-digit
+    eq. > @
+      "0"
+      string (as-char 48)
+
+  # Tests that as-char writes the byte of the space character.
+  [] +> tests-writes-byte-of-space
+    eq. > @
+      " "
+      string (as-char 32)
+
+  # Tests that as-char writes the byte of the last printable character.
+  [] +> tests-writes-byte-of-last-printable
+    eq. > @
+      "~"
+      string (as-char 126)
+
+  # Tests that as-char round-trips through as-ascii.
+  [] +> tests-round-trips-through-as-ascii
+    eq. > @
+      "!"
+      string (as-char (as-ascii "!"))

--- a/eo-runtime/src/main/eo/tt/as-decimal.eo
+++ b/eo-runtime/src/main/eo/tt/as-decimal.eo
@@ -1,0 +1,65 @@
++alias tt.as-char
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tt
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Writes the number `n` as signed decimal digits, truncating its fraction
+# towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
+[n] > as-decimal
+  if. > @
+    n.lt 0
+    concat. "-".as-bytes (digits (n.times -1))
+    digits n
+
+  # Writes the non-negative `n` as decimal digits.
+  [n] > digits
+    if. > @
+      n.lt 10
+      as-char (n.floor.plus 48)
+      concat. (digits q) (as-char ((n.minus (q.times 10)).floor.plus 48))
+    (n.div 10).floor > q
+
+  # Tests that as-decimal writes a single digit.
+  [] +> tests-writes-single-digit
+    eq. > @
+      "7"
+      string (as-decimal 7)
+
+  # Tests that as-decimal writes zero.
+  [] +> tests-writes-zero
+    eq. > @
+      "0"
+      string (as-decimal 0)
+
+  # Tests that as-decimal writes a multi-digit number.
+  [] +> tests-writes-multi-digit-number
+    eq. > @
+      "31415"
+      string (as-decimal 31415)
+
+  # Tests that as-decimal writes a negative number with a leading minus.
+  [] +> tests-writes-negative-number
+    eq. > @
+      "-42"
+      string (as-decimal -42)
+
+  # Tests that as-decimal truncates a positive fraction towards zero.
+  [] +> tests-truncates-positive-fraction
+    eq. > @
+      "42"
+      string (as-decimal 42.987)
+
+  # Tests that as-decimal truncates a negative fraction towards zero.
+  [] +> tests-truncates-negative-fraction
+    eq. > @
+      "-7"
+      string (as-decimal -7.89)
+
+  # Tests that as-decimal writes a number whose middle digit is zero.
+  [] +> tests-writes-number-with-inner-zero
+    eq. > @
+      "105"
+      string (as-decimal 105)

--- a/eo-runtime/src/main/eo/tt/as-fixed.eo
+++ b/eo-runtime/src/main/eo/tt/as-fixed.eo
@@ -1,0 +1,83 @@
++alias tt.as-char
++alias tt.as-decimal
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tt
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Writes the number `n` as fixed-point decimal with exactly `places` fraction
+# digits, rounding to the nearest unit in the last place, so that `2.5` with
+# four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
+[n places] > as-fixed
+  if. > @
+    n.lt 0
+    concat. "-".as-bytes (positive (n.times -1))
+    positive n
+
+  # Ten raised to the power `p`, scaling the fraction part of the value.
+  [p] > pow10
+    if. > @
+      p.eq 0
+      1
+      (pow10 (p.minus 1).as-number).times 10
+
+  # Writes the non-negative `a` as integer part, dot and `places` fraction digits.
+  [a] > positive
+    concat. (concat. (as-decimal ip) ".".as-bytes) (rec-pad (m.minus (ip.times scale)) places --) > @
+    pow10 places > scale
+    ((a.times scale).plus 0.5).floor > m
+    (m.div scale).floor > ip
+
+  # Emits exactly `count` least-significant digits of `value`, zero-padded.
+  [value count acc] > rec-pad
+    if. > @
+      count.eq 0
+      acc
+      rec-pad
+        (value.div 10).floor
+        (count.minus 1).as-number
+        concat. (as-char ((value.minus ((value.div 10).floor.times 10)).floor.plus 48)) acc
+
+  # Tests that as-fixed pads an exact value with trailing zeros.
+  [] +> tests-pads-with-trailing-zeros
+    eq. > @
+      "1.250000"
+      string (as-fixed 1.25 6)
+
+  # Tests that as-fixed writes a negative value with a leading minus.
+  [] +> tests-writes-negative-value
+    eq. > @
+      "-2.500000"
+      string (as-fixed -2.5 6)
+
+  # Tests that as-fixed rounds to the nearest unit in the last place.
+  [] +> tests-rounds-to-last-place
+    eq. > @
+      "0.123457"
+      string (as-fixed 0.123456789 6)
+
+  # Tests that as-fixed carries the rounding into the integer part.
+  [] +> tests-carries-rounding-into-integer-part
+    eq. > @
+      "1.000000"
+      string (as-fixed 0.9999999 6)
+
+  # Tests that as-fixed writes zero with the requested fraction width.
+  [] +> tests-writes-zero
+    eq. > @
+      "0.000000"
+      string (as-fixed 0.0 6)
+
+  # Tests that as-fixed honours a custom number of places.
+  [] +> tests-honours-custom-places
+    eq. > @
+      "3.14"
+      string (as-fixed 3.14159 2)
+
+  # Tests that as-fixed writes a single fraction digit.
+  [] +> tests-writes-single-place
+    eq. > @
+      "2.5"
+      string (as-fixed 2.5 1)

--- a/eo-runtime/src/main/eo/tt/as-hex.eo
+++ b/eo-runtime/src/main/eo/tt/as-hex.eo
@@ -1,0 +1,64 @@
++alias tt.as-ascii
++alias tt.as-char
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tt
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Writes the bytes `bts` as uppercase hexadecimal pairs joined by a hyphen,
+# so that the two bytes `0x4A 0x65` become `4A-65`.
+[bts] > as-hex
+  rec-hex 0 -- > @
+
+  # Recursively appends the hex pair of each byte, separated by a hyphen.
+  [index acc] > rec-hex
+    if. > @
+      index.eq bts.size
+      acc
+      rec-hex
+        (index.plus 1).as-number
+        if.
+          index.eq 0
+          pair
+          concat. (concat. acc "-".as-bytes) pair
+    as-ascii (bts.slice index 1) > bval
+    concat. (hex-digit (bval.div 16).floor) (hex-digit (bval.minus ((bval.div 16).floor.times 16))) > pair
+
+  # Writes a single hexadecimal value `h` (0-15) as its uppercase ASCII byte.
+  [h] > hex-digit
+    if. > @
+      h.lt 10
+      as-char (h.plus 48)
+      as-char (h.plus 55)
+
+  # Tests that as-hex writes a single byte as one pair.
+  [] +> tests-writes-single-byte
+    eq. > @
+      "41"
+      string (as-hex "A".as-bytes)
+
+  # Tests that as-hex joins several bytes with hyphens.
+  [] +> tests-joins-bytes-with-hyphens
+    eq. > @
+      "4A-65-66-66"
+      string (as-hex "Jeff".as-bytes)
+
+  # Tests that as-hex writes the letter nibbles of a saturated byte.
+  [] +> tests-writes-letter-nibbles
+    eq. > @
+      "00-00-00-00-00-00-00-FF"
+      string (as-hex 255.as-i64.as-bytes)
+
+  # Tests that as-hex writes the eight bytes of a number.
+  [] +> tests-writes-number-bytes
+    eq. > @
+      "40-45-00-00-00-00-00-00"
+      string (as-hex 42.as-bytes)
+
+  # Tests that as-hex writes empty bytes as an empty string.
+  [] +> tests-writes-empty-bytes
+    eq. > @
+      ""
+      string (as-hex --)


### PR DESCRIPTION
Part of #4752. Prerequisite for #5271.

Adds four small, independently tested `tt` objects that render numbers and bytes as text:

- `as-char` — ASCII code (0-255) → single byte, the inverse of `as-ascii`
- `as-decimal` — number → signed decimal digits, truncating toward zero
- `as-hex` — bytes → uppercase hexadecimal pairs joined by a hyphen
- `as-fixed` — number → fixed-point decimal with a chosen number of fraction digits, rounded

### Why

Without these objects, `tt.sprintf` (#5271) carries a lot of internal methods — `dec`, `digits`, `one-digit`, `flt`, `positive`, `rec-pad`, `hex`, `rec-hex`, `hex-digit` — and becomes complicated to read. Extracting them into focused, reusable objects (mirroring the existing `as-ascii` and `is-digit`) keeps each concern small and lets `sprintf` compose them instead of inlining everything.

Once this is merged, #5271 is rebased to drop the inline formatters and use these objects directly.
