### PR TITLE
Fix single-byte bytes string representation

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -134,17 +134,22 @@ final class BytesRaw implements Bytes {
 
     @Override
     public String asString() {
-        final StringBuilder out = new StringBuilder(3);
-        for (final byte bte : this.data) {
-            if (out.length() > 0) {
-                out.append('-');
-            }
-            out.append(String.format("%02X", bte));
-        }
+        final String result;
         if (this.data.length == 0) {
-            out.append("--");
+            result = "--";
+        } else if (this.data.length == 1) {
+            result = String.format("%02X-", this.data[0]);
+        } else {
+            final StringBuilder out = new StringBuilder(this.data.length * 3);
+            for (final byte bte : this.data) {
+                if (out.length() > 0) {
+                    out.append('-');
+                }
+                out.append(String.format("%02X", bte));
+            }
+            result = out.toString();
         }
-        return out.toString();
+        return result;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -461,7 +461,7 @@ public class PhDefault implements Phi, Cloneable {
     private String structural() {
         final List<String> list = new ArrayList<>(this.attrs.size());
         if (this.data != null) {
-            list.add(String.format("D> %s", new BytesOf(this.data).asString()));
+            list.add(String.format("D> %s", PhDefault.termBytes(this.data)));
         }
         for (final Map.Entry<String, Attribute> ent : this.attrs.entrySet().stream().filter(
             e -> !e.getKey().equals(Phi.RHO)
@@ -479,6 +479,29 @@ public class PhDefault implements Phi, Cloneable {
             term = String.format("[%s]", String.join(",", list));
         }
         return term;
+    }
+
+    /**
+     * Bytes representation for the φ-term D> slot.
+     * This is intentionally not {@link Bytes#asString()}.
+     * @param data Bytes
+     * @return Bytes as shown in φ-terms
+     */
+    private static String termBytes(final byte[] data) {
+        final String result;
+        if (data.length == 0) {
+            result = "--";
+        } else {
+            final StringBuilder out = new StringBuilder(data.length * 3);
+            for (final byte bte : data) {
+                if (out.length() > 0) {
+                    out.append('-');
+                }
+                out.append(String.format("%02X", bte));
+            }
+            result = out.toString();
+        }
+        return result;
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -94,6 +94,15 @@ final class BytesOfTest {
     }
 
     @Test
+    void convertsSingleByteToString() {
+        MatcherAssert.assertThat(
+            "Single byte should render with a trailing dash, but it didn't",
+            new BytesOf(new byte[]{(byte) 0xFF}).asString(),
+            Matchers.equalTo("FF-")
+        );
+    }
+
+    @Test
     void checksUnderflowForLong() {
         Assertions.assertThrows(
             ExFailure.class,

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -43,6 +43,15 @@ final class PhDefaultTest {
     }
 
     @Test
+    void printsSingleByteDataAsTerm() {
+        MatcherAssert.assertThat(
+            "Object with one data byte must render it without trailing dash in φ-term",
+            new PhDefault(new byte[] {(byte) 0x01}).φTerm(),
+            Matchers.equalTo("[D> 01]")
+        );
+    }
+
+    @Test
     void printsVoidAttributeAsTerm() {
         MatcherAssert.assertThat(
             "Object with unset void attribute must render it as question mark, but it didnt",


### PR DESCRIPTION
Fixes #5253.\n\nThis updates runtime byte formatting so single-byte values include the trailing dash, matching the parser-side representation and the BYTES grammar expectation.\n\nTested with:\n- mvn -pl eo-runtime -Dtest=BytesOfTest -DskipITs test