### PR TITLE
Fix stream leak on repeated file open

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOfs/Files.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/Files.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -47,7 +48,15 @@ final class Files {
      * Ctor.
      */
     private Files() {
-        this.streams = new ConcurrentHashMap<>(0);
+        this(new ConcurrentHashMap<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param streams File streams
+     */
+    Files(final Map<String, Object[]> streams) {
+        this.streams = new ConcurrentHashMap<>(streams);
         this.lock = new ReentrantLock();
     }
 
@@ -60,8 +69,11 @@ final class Files {
     void open(final String name) throws IOException {
         this.lock.lock();
         try {
+            if (this.streams.containsKey(name)) {
+                return;
+            }
             final Path path = Paths.get(name);
-            this.streams.putIfAbsent(
+            this.streams.put(
                 name,
                 new Object[]{
                     java.nio.file.Files.newInputStream(path),

--- a/eo-runtime/src/test/java/org/eolang/EOfs/FilesTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOfs/FilesTest.java
@@ -12,10 +12,14 @@ package org.eolang.EOfs; // NOPMD
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import org.eolang.ExFailure;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -80,6 +84,34 @@ final class FilesTest {
             Matchers.equalTo("Hello, world".getBytes(StandardCharsets.UTF_8))
         );
         Files.INSTANCE.close(file);
+    }
+
+    @Test
+    void reusesExistingStreams(@Mktmp final Path dir) throws IOException {
+        final String file = dir.resolve("absent.txt").toFile().getAbsolutePath();
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final Map<String, Object[]> streams = new HashMap<>(0);
+        streams.put(
+            file,
+            new Object[]{
+                new ByteArrayInputStream("Hello".getBytes(StandardCharsets.UTF_8)),
+                output,
+            }
+        );
+        final Files files = new Files(streams);
+        files.open(file);
+        files.write(file, "!".getBytes(StandardCharsets.UTF_8));
+        MatcherAssert.assertThat(
+            "The existing streams should be reused",
+            new Object[]{files.read(file, 5), output.toByteArray()},
+            Matchers.equalTo(
+                new Object[]{
+                    "Hello".getBytes(StandardCharsets.UTF_8),
+                    "!".getBytes(StandardCharsets.UTF_8),
+                }
+            )
+        );
+        files.close(file);
     }
 
     @Test


### PR DESCRIPTION
Fixes #5258.

## Summary
- skip opening new streams when a file path is already registered
- reuse the existing stream entry instead of creating unreachable handles
- add a focused regression test for the already-open path

This intentionally keeps the existing one-entry-per-path semantics and does not introduce ref-counting or independent streams per open.

## Tests
- mvn -pl eo-runtime -Dtest=FilesTest -DskipITs test
- mvn -pl eo-runtime -Pqulice -DskipTests verify *(failed in EO transpile on unrelated foreign objects such as `ss.mapped` / `io.bytes-as-input`; no remaining qulice violation was reported for the changed files after fixing import order)*