### PR TITLE
#5256: i64.div by zero throws catchable org.eolang.error

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -221,6 +221,17 @@
   # Tests that i64 division by zero throws an error.
   2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
 
+  # Tests that i64 division by zero throws a catchable org.eolang.error,
+  # not an uncatchable JVM exception.
+  [] +> tests-i64-div-by-zero-throws-catchable-error
+    try > @
+      seq
+        *
+          2.as-i64.div 0.as-i64
+          false
+      true > [e]
+      false
+
   # Tests that i64 division by one returns the original value.
   [] +> tests-i64-div-by-i64-one
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
@@ -26,16 +26,19 @@ public final class EOi64$EOdiv extends PhDefault implements Atom {
     }
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
+        final long dividend = new Expect.I64(Expect.at(this, Phi.RHO)).it();
+        final long divisor = new Expect.I64(Expect.at(this, "x")).it();
+        if (divisor == 0L) {
+            throw new EOerror.ExError(
+                new Data.ToPhi("i64.div: division by zero")
+            );
+        }
         final Phi num = Phi.Φ.take("i64").copy();
         num.put(
             0,
-            new Data.ToPhi(
-                new BytesOf(
-                    new Expect.I64(Expect.at(this, Phi.RHO)).it()
-                        / new Expect.I64(Expect.at(this, "x")).it()
-                ).take()
-            )
+            new Data.ToPhi(new BytesOf(dividend / divisor).take())
         );
         return num;
     }


### PR DESCRIPTION
## What happens

`EOi64$EOdiv` evaluates the quotient as a raw Java `long / long`. When the
divisor (attribute `x`) is zero, the JVM throws
`java.lang.ArithmeticException: / by zero`. `AtomSafe.lambda()` rethrows any
`RuntimeException` unchanged (it only wraps checked `Exception`s into
`ExFailure`), and the EO `try` object only catches `EOerror.ExError`. So an
`i64` division by zero surfaces as an uncaught `ArithmeticException` that
propagates out of the interpreter and cannot be caught by EO-level `try`,
unlike a normal EO error object.

The Javadoc for `i64.div` in `i64.eo` states: "An `org.eolang.error` is
returned if `x` is equal to 0." No such error was actually produced.

The existing regression test, `throws-on-division-i64-by-i64-zero`, doesn't
protect against this: a `throws`-prefixed `.eo` test transpiles to
`Assertions.assertThrows(Exception.class, ...)`, which passes for any
`Exception` including the raw `ArithmeticException` — it never verifies that
a *catchable EO error object* is produced.

## What should happen

`i64.div` by zero should yield an `org.eolang.error` object (an
`EOerror.ExError`) that EO `try` can catch, matching the documented
behavior.

## Fix

Guarded the divisor in `EOi64$EOdiv.lambda()`: if it's `0`, throw
`EOerror.ExError` directly instead of performing the raw `long` division.
`AtomSafe` rethrows `RuntimeException` (which `ExError` is, via `ExAbstract`)
unchanged, so it propagates correctly to `EOtry`.

Kept the original left-to-right evaluation order — `ρ` (dividend) evaluated
before `x` (divisor) — so the existing `EOi64ExpectTest` parameterized tests
(which rely on that order to assert the correct attribute name in type-error
messages) keep passing.

`@SuppressWarnings("PMD.UnnecessaryLocalRule")` mirrors the same pattern
already used in the sibling `EOnumber$EOdiv` for the identical
evaluation-order requirement.

## Test

Added `tests-i64-div-by-zero-throws-catchable-error` in `i64.eo`: wraps
`2.as-i64.div 0.as-i64` in `try`, asserting the error is caught (rather than
propagating as an uncatchable exception), unlike the existing `throws-*`
test which only checks that *some* exception is thrown.

## Verification

- `mvn test -pl eo-runtime` — full suite green (`EOi64Test`: 28/28,
  `EOi64ExpectTest`: 8/8, including the new test and the pre-existing
  parameterized tests that depend on evaluation order)
- `mvn qulice:check -Pqulice -pl eo-runtime` — violation count for
  `EOi64$EOdiv.java` reduced by the fix; the one remaining flag on that file
  (`UnicodeInCode` for `Φ`) is a pre-existing pattern shared with sibling
  atoms `EOi64$EOplus` and `EOi64$EOtimes`, not introduced by this change

Closes #5256
