### PR TITLE
Route plugin resolution off the decommissioned oss.sonatype.org host

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,29 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <pluginRepositories>
+    <!--
+    The parent POM (com.jcabi:parent) points plugin resolution at
+    oss.sonatype.org, a host Sonatype has decommissioned. Re-declaring
+    the same id on Central shadows the dead host, since Maven merges
+    repositories by id and lets the child win. Without this, a cold
+    cache (every fork pull request) stalls on dead-host timeouts and
+    the qulice job burns its whole budget before a single check runs.
+    @todo #5284:30min Drop this override once com.jcabi:parent no
+     longer declares the decommissioned oss.sonatype.org plugin
+     repository, so plugin resolution relies on the parent again.
+    -->
+    <pluginRepository>
+      <id>oss.sonatype.org</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
The `qulice` job cancels at its fifteen-minute cap on fork pull requests. #5281 hit it three times in a row while the same job finishes in about two and a half minutes on branches inside the repository. The job never reaches a check: it is still downloading the qulice, PMD and error-prone plugin tree when the timeout fires, every artifact arriving `Downloading from oss.sonatype.org` with roughly thirty seconds between them.

The parent POM `com.jcabi:parent` declares a plugin repository pointing at `oss.sonatype.org`, a host Sonatype has decommissioned. On a warm cache nothing downloads and the dead host stays invisible; a fork pull request cannot write that cache, so every run resolves the whole plugin tree cold and waits out a connection timeout on each artifact. This change re-declares the same id on Central, which Maven merges by id with the child winning, so plugin resolution leaves the dead host for good.

```xml
<pluginRepository>
  <id>oss.sonatype.org</id>
  <url>https://repo.maven.apache.org/maven2</url>
  <releases><enabled>true</enabled></releases>
  <snapshots><enabled>false</enabled></snapshots>
</pluginRepository>
```

The override carries a puzzle to remove it once the parent POM drops the decommissioned repository. This PR is its own proof: its qulice run resolves plugins through Central instead of the dead host.

Closes #5284
