### PR TITLE
#5255: tighten i64.as-i32 range guard to actual i32 bounds

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -21,15 +21,13 @@
   # max `org.eolang.i32` value `2147483647`.
   [] > as-i32
     if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 (as-bytes.slice 4 4)
+      ^.eq left.as-i64
+      left
       error
         sprintf
           "Can't convert i64 number %d to i32 because it's out of i32 bounds"
           * as-number
-    (as-bytes.slice 0 4).as-bytes > left
+    i32 (as-bytes.slice 4 4) > left
 
   # Convert this `org.eolang.i64` to `org.eolang.number` object and return it.
   [] > as-number /number
@@ -108,6 +106,24 @@
 
   # Tests that converting i64 to i32 throws error when out of bounds.
   3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
+
+  # Tests that i32 max value converts to i32 without error.
+  [] +> tests-i64-i32-max-converts-without-error
+    eq. > @
+      2147483647.as-i64
+      2147483647.as-i64.as-i32.as-i64
+
+  # Tests that i32 min value converts to i32 without error.
+  [] +> tests-i64-i32-min-converts-without-error
+    eq. > @
+      -2147483648.as-i64
+      -2147483648.as-i64.as-i32.as-i64
+
+  # Tests that i32 max plus one throws when converted to i32.
+  2147483648.as-i64.as-i32 > [] +> throws-on-converting-i32-max-plus-one-to-i32
+
+  # Tests that i32 min minus one throws when converted to i32.
+  -2147483649.as-i64.as-i32 > [] +> throws-on-converting-i32-min-minus-one-to-i32
 
   # Tests that i64 less-than comparison returns true for smaller values.
   [] +> tests-i64-less-true


### PR DESCRIPTION
## What happens

`i64.as-i32` guards range only by checking whether the high 4 bytes of the
i64 equal `00-00-00-00` (positive) or `FF-FF-FF-FF` (negative). This guard
accepts any value whose magnitude fits in 32 bits, not 31. Values in
`[2^31, 2^32)` have high bytes `00-00-00-00` and values in `[-2^32, -2^31)`
have high bytes `FF-FF-FF-FF`, so they pass the guard, and
`i32 (as-bytes.slice 4 4)` reinterprets the low 4 bytes as a signed i32,
silently producing a wrong (sign-flipped) result instead of the documented
error.

Example: `3000000000.as-i64.as-i32` yields `-1294967296`;
`2147483648.as-i64.as-i32` (i32 max + 1) yields `-2147483648`;
`-2147483649.as-i64.as-i32` yields `2147483647`. `number.as-i32` is defined
as `as-i64.as-i32`, so `number` values in these ranges are silently
corrupted too.

The Javadoc directly above the object states: "The `org.eolang.error` is
returned if the `org.eolang.i64` number is more than max `org.eolang.i32`
value `2147483647`." The implementation does not honor that contract.

## What should happen

Out-of-i32-range i64 values (anything outside `-2147483648..2147483647`)
should return the `org.eolang.error` the else branch already produces.

## Fix

Replaced the magnitude-only guard with a round-trip check: convert the low
4 bytes to i32, sign-extend that back to i64 via `.as-i64`, and compare
against the original i64 value with `^.eq`. If they match, the conversion
is lossless and safe; if not, the value is out of i32 range and the
existing error path fires.

```diff
   [] > as-i32
     if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 (as-bytes.slice 4 4)
+      ^.eq left.as-i64
+      left
       error
         sprintf
           "Can't convert i64 number %d to i32 because it's out of i32 bounds"
           * as-number
-    (as-bytes.slice 0 4).as-bytes > left
+    i32 (as-bytes.slice 4 4) > left
```

## Test

Added four regression tests exercising the exact boundary the bug report
demonstrated:

- `tests-i64-i32-max-converts-without-error` — i32 max (`2147483647`)
  still converts without error
- `tests-i64-i32-min-converts-without-error` — i32 min (`-2147483648`)
  still converts without error
- `throws-on-converting-i32-max-plus-one-to-i32` — i32 max + 1
  (`2147483648`) now throws instead of silently wrapping
- `throws-on-converting-i32-min-minus-one-to-i32` — i32 min - 1
  (`-2147483649`) now throws instead of silently wrapping

The existing `throws-on-converting-to-i32-if-out-of-bounds` (using
`3147483647`) and the two round-trip tests (`234`, `-234`) still pass
unchanged.

## Verification

- `mvn test -pl eo-runtime` — `EOi64Test`: 32/32, `EOi32Test`: 30/30, full
  module green (only pre-existing environment-dependent skips: win32,
  socket, io)
- `mvn qulice:check -Pqulice -pl eo-runtime` — no violations attributed to
  `i64.eo`; the 100 pre-existing violations in the module are the same
  baseline seen on unrelated branches

Closes #5255
