### PR TITLE
Migrate atoms from throw-based failures to the ⊥/fallback model

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+---
+exclude_paths:
+  - "eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOcompile.java"

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -161,16 +161,7 @@ final class Emissions {
         } else if (value.kind() == Value.Kind.TERM) {
             emit.object(name, "⊥", line, value.pos());
         } else if (value.kind() == Value.Kind.GROUP) {
-            final String inner = value.raw().substring(1, value.raw().length() - 1);
-            final int phi = Emissions.topLevelInlinePhi(inner);
-            if (phi >= 0) {
-                Emissions.inlinePhi(emit, name, inner, phi, value.pos() + 1, line);
-            } else {
-                final Span sub = new Span(
-                    " ".repeat(value.pos() + 1).concat(inner), line
-                );
-                Emissions.expression(emit, name, new Tokens(sub.body(), sub), line);
-            }
+            Emissions.group(emit, name, value, line);
         } else {
             emit.object(name, value.raw(), line, value.pos());
         }
@@ -292,6 +283,30 @@ final class Emissions {
             }
         }
         return out.toString();
+    }
+
+    /**
+     * Emit a parenthesised group value, either as an inline-phi formation or
+     * as a nested expression.
+     * @param emit Emitter
+     * @param name Name attribute (or {@code null})
+     * @param value The group value
+     * @param line Source line
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private static void group(
+        final Emit emit, final String name, final Value value, final int line
+    ) {
+        final String inner = value.raw().substring(1, value.raw().length() - 1);
+        final int phi = Emissions.topLevelInlinePhi(inner);
+        if (phi >= 0) {
+            Emissions.inlinePhi(emit, name, inner, phi, value.pos() + 1, line);
+        } else {
+            final Span sub = new Span(
+                " ".repeat(value.pos() + 1).concat(inner), line
+            );
+            Emissions.expression(emit, name, new Tokens(sub.body(), sub), line);
+        }
     }
 
     /**

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -77,7 +77,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="∅|\.(ρ|φ|[a-z][^\s.]*|α[0-9]*)|([Φξ])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*"/>
+      <xs:pattern value="⊥|∅|\.(ρ|φ|[a-z][^\s.]*|α[0-9]*)|([Φξ])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="locator">

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -24,85 +24,89 @@
   data > @
   bytes data > as-bytes
   eq 01- > as-bool
-  # Converts this chain of eight bytes into a number.
-  # Returns an error if the byte count is not exactly eight.
-  if. > as-number
-    eq nan.as-bytes
-    nan
-    if.
-      eq pinf.as-bytes
-      pinf
-      if.
-        eq ninf.as-bytes
-        ninf
-        if.
-          size.eq 8
-          number as-bytes
-          error
-            sprintf
-              "Can't convert non 8 length bytes to a number, bytes are %x"
-              * as-bytes
-  # Converts this chain of eight bytes into an i64 number.
-  # Returns an error if the byte count is not exactly eight.
-  if. > as-i64
-    size.eq 8
-    i64 as-bytes
-    error
-      sprintf
-        "Can't convert non 8 length bytes to i64, bytes are %x"
-        * as-bytes
-  # Converts this chain of four bytes into an i32 number.
-  # Returns an error if the byte count is not exactly four.
-  if. > as-i32
-    size.eq 4
-    i32 as-bytes
-    error
-      sprintf
-        "Can't convert non 4 length bytes to i32, bytes are %x"
-        * as-bytes
-  # Converts this chain of two bytes into an i16 number.
-  # Returns an error if the byte count is not exactly two.
-  if. > as-i16
-    size.eq 2
-    i16 as-bytes
-    error
-      sprintf
-        "Can't convert non 2 length bytes to i16, bytes are %x"
-        * as-bytes
 
-  # Returns `org.eolang.true` if current sequence of bytes equals another object.
+  # Converts this chain of eight bytes into a number.
+  [cant-convert] > as-number
+    if. > @
+      eq nan.as-bytes
+      nan
+      if.
+        eq pinf.as-bytes
+        pinf
+        if.
+          eq ninf.as-bytes
+          ninf
+          if.
+            size.eq 8
+            number as-bytes
+            cant-convert
+              sprintf
+                "Can't convert non 8 length bytes to a number, bytes are %x"
+                * as-bytes
+
+  # Converts this chain of eight bytes into an i64 number.
+  [cant-convert] > as-i64
+    if. > @
+      size.eq 8
+      i64 as-bytes
+      cant-convert
+        sprintf
+          "Can't convert non 8 length bytes to i64, bytes are %x"
+          * as-bytes
+
+  # Converts this chain of four bytes into an i32 number.
+  [cant-convert] > as-i32
+    if. > @
+      size.eq 4
+      i32 as-bytes
+      cant-convert
+        sprintf
+          "Can't convert non 4 length bytes to i32, bytes are %x"
+          * as-bytes
+
+  # Converts this chain of two bytes into an i16 number.
+  [cant-convert] > as-i16
+    if. > @
+      size.eq 2
+      i16 as-bytes
+      cant-convert
+        sprintf
+          "Can't convert non 2 length bytes to i16, bytes are %x"
+          * as-bytes
+
+  # Returns `true` if current sequence of bytes equals another object.
   # Before the actual comparison the object `b` is dataized.
   [b] > eq /bool
 
-  # Returns total amount of current bytes as `org.eolang.number`.
+  # Returns total amount of current bytes as `number`.
   [] > size /number
 
-  # Represents a sub-sequence of `org.eolang.bytes` inside the current one.
+  # Represents a sub-sequence of `bytes` inside the current one.
   # When the requested range lies outside the current bytes, the slice
   # returns the caller-supplied `cant-slice` fallback instead, or the
   # bottom object (⊥) when none was provided, which terminates on use.
   [start len] > slice /bytes
     ? > cant-slice /{string}
 
-  # Calculates the bitwise AND operation and returns result as `org.eolang.bytes`.
+  # Calculates the bitwise AND operation and returns result as `bytes`.
   [b] > and /bytes
 
-  # Calculates the bitwise OR operation and returns result as `org.eolang.bytes`.
+  # Calculates the bitwise OR operation and returns result as `bytes`.
   [b] > or /bytes
 
-  # Calculates the bitwise XOR operation and returns result as `org.eolang.bytes`.
+  # Calculates the bitwise XOR operation and returns result as `bytes`.
   [b] > xor /bytes
 
-  # Calculates the bitwise NOT operation and returns result as `org.eolang.bytes`.
+  # Calculates the bitwise NOT operation and returns result as `bytes`.
   [] > not /bytes
 
   # Calculates the bitwise left shift.
   right x.neg > [x] > left
 
-  # Calculates the bitwise right shift and returns result as `org.eolang.bytes`.
+  # Calculates the bitwise right shift and returns result as `bytes`.
   [x] > right /bytes
 
-  # Concatenation of two byte sequences and returns result as `org.eolang.bytes`.
+  # Concatenation of two byte sequences and returns result as `bytes`.
   [b] > concat /bytes
 
   # Tests that a slice of bytes can be extracted from a larger byte sequence.
@@ -499,13 +503,29 @@
       FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
       FF-FF-FF-FF-00-00-00-01
 
-  # Tests that conversion to number throws error for wrong-sized bytes.
+  # Tests that a wrong-sized conversion to number with no fallback yields the bottom
+  # object (⊥) that terminates when used.
   [] +> throws-on-bytes-of-wrong-size-as-number
     01-01-01-01.as-number > @
 
-  # Tests that conversion to i64 throws error for wrong-sized bytes.
+  # Tests that a wrong-sized conversion to number with a fallback yields the fallback.
+  [] +> tests-wrong-size-as-number-returns-provided-fallback
+    eq. > @
+      "recovered"
+      01-01-01-01.as-number
+        "recovered" > [msg]
+
+  # Tests that a wrong-sized conversion to i64 with no fallback yields the bottom
+  # object (⊥) that terminates when used.
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
+
+  # Tests that a wrong-sized conversion to i64 with a fallback yields the fallback.
+  [] +> tests-wrong-size-as-i64-returns-provided-fallback
+    eq. > @
+      "recovered"
+      01-01-01-01.as-i64
+        "recovered" > [msg]
 
   # Tests that an out-of-bounds slice with no `cant-slice` fallback yields the bottom
   # object (⊥) that terminates when used.

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -78,7 +78,11 @@
   [] > size /number
 
   # Represents a sub-sequence of `org.eolang.bytes` inside the current one.
+  # When the requested range lies outside the current bytes, the slice
+  # returns the caller-supplied `cant-slice` fallback instead, or the
+  # bottom object (⊥) when none was provided, which terminates on use.
   [start len] > slice /bytes
+    ? > cant-slice /{string}
 
   # Calculates the bitwise AND operation and returns result as `org.eolang.bytes`.
   [b] > and /bytes
@@ -503,9 +507,19 @@
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
 
-  # Tests that slicing out of bounds throws an error.
+  # Tests that an out-of-bounds slice with no `cant-slice` fallback yields the bottom
+  # object (⊥) that terminates when used.
   [] +> throws-on-out-of-bounds-slice
     20-1F-EE-B5-90.slice 3 10 > @
+
+  # Tests that an out-of-bounds slice with a `cant-slice` fallback yields the fallback.
+  [] +> tests-out-of-bounds-slice-returns-provided-fallback
+    eq. > @
+      "recovered"
+      20-1F-EE-B5-90.slice
+        3
+        10
+        "recovered" > [msg]
 
   # Tests that bytes can be correctly converted to i64 integer.
   [] +> tests-bytes-converts-to-i64

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -23,10 +23,10 @@
 # ```
 #
 # This object returns the value of the first true statement.
-[cases] > switch
+[cases empty-cases] > switch
   if. > @
     cases.length.eq 0
-    error "Switch cases are empty"
+    empty-cases "Switch cases are empty"
     if.
       true.eq found.match
       found.head
@@ -102,9 +102,18 @@
           false
           "false2"
 
-  # Tests that switch throws an error when given empty cases array.
+  # Tests that empty switch cases with no fallback yield the bottom object (⊥)
+  # that terminates when used.
   [] +> throws-on-empty-switch
     switch * > @
+
+  # Tests that empty switch cases with a provided fallback yield the fallback.
+  [] +> tests-empty-switch-returns-provided-fallback
+    eq. > @
+      "recovered"
+      switch
+        *
+        "recovered" > [msg]
 
   # Tests that switch works correctly with complex nested conditions and custom objects.
   [] +> tests-switch-complex-case

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -24,6 +24,12 @@
 # /s - Enables dotall mode.
 # /u - Enables Unicode-aware case folding.
 [expression] > regex
+  # Recovery object for an `expression` that cannot be compiled into a pattern
+  # (a missing slash or invalid syntax). When compilation fails the pattern is
+  # replaced by this fallback, or by the bottom object (⊥) when none was
+  # provided, which terminates on use.
+  ? > cant-compile
+
   # Compile regular expression into pattern.
   # ```
   # (regex "/[a-z]+/").compiled.matches "hello"
@@ -239,6 +245,27 @@
   # Tests that regex compilation throws error when missing closing slash.
   [] +> throws-on-missing-closing-slash-in-regex
     (regex "/pattern").compiled > @
+
+  # Tests that an invalid pattern body with a `cant-compile` fallback yields the fallback.
+  [] +> tests-invalid-regex-syntax-returns-provided-fallback
+    eq. > @
+      "recovered"
+      regex
+        "/[a-z/"
+        "recovered" > [msg]
+
+  # Tests that a missing slash with a `cant-compile` fallback yields the fallback.
+  [] +> tests-missing-slash-returns-provided-fallback
+    eq. > @
+      "no-slash"
+      regex
+        "(.)+"
+        "no-slash" > [msg]
+
+  # Tests that an invalid pattern with no `cant-compile` fallback yields the bottom
+  # object (⊥) that terminates when used.
+  [] +> throws-on-compiling-invalid-regex-without-fallback
+    regex "/[a-z/" > @
 
   # Tests that regex with capturing groups returns correct group count and content.
   [] +> tests-regex-contains-valid-groups-on-each-matched-block

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -24,11 +24,7 @@
 # /s - Enables dotall mode.
 # /u - Enables Unicode-aware case folding.
 [expression] > regex
-  # Recovery object for an `expression` that cannot be compiled into a pattern
-  # (a missing slash or invalid syntax). When compilation fails the pattern is
-  # replaced by this fallback, or by the bottom object (⊥) when none was
-  # provided, which terminates on use.
-  ? > cant-compile
+  compile > @
 
   # Compile regular expression into pattern.
   # ```
@@ -47,7 +43,8 @@
   # ptn2.matches "hello"                # doesn't recompile regex
   # ```
   # Returns `org.eolang.tt.regex.pattern` object.
-  [] > @ /Q.tt.regex.pattern
+  [] > compile /Q.tt.regex.pattern
+    ? > cant-compile /{string}
 
   # Regular expression compiled into pattern.
   # Here `serialized` is `bytes` which represents serialized structure in memory
@@ -250,22 +247,20 @@
   [] +> tests-invalid-regex-syntax-returns-provided-fallback
     eq. > @
       "recovered"
-      regex
-        "/[a-z/"
+      (regex "/[a-z/").compile
         "recovered" > [msg]
 
   # Tests that a missing slash with a `cant-compile` fallback yields the fallback.
   [] +> tests-missing-slash-returns-provided-fallback
     eq. > @
       "no-slash"
-      regex
-        "(.)+"
+      (regex "(.)+").compile
         "no-slash" > [msg]
 
   # Tests that an invalid pattern with no `cant-compile` fallback yields the bottom
   # object (⊥) that terminates when used.
   [] +> throws-on-compiling-invalid-regex-without-fallback
-    regex "/[a-z/" > @
+    (regex "/[a-z/").compile > @
 
   # Tests that regex with capturing groups returns correct group count and content.
   [] +> tests-regex-contains-valid-groups-on-each-matched-block

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -183,6 +183,14 @@
       tuple.empty.length
       0
 
+  # Tests that getting the head of an empty tuple terminates because it does not exist.
+  [] +> throws-on-getting-head-from-empty-tuple
+    tuple.empty.head > @
+
+  # Tests that getting the tail of an empty tuple terminates because it does not exist.
+  [] +> throws-on-getting-tail-from-empty-tuple
+    tuple.empty.tail > @
+
   # Tests that adding a number to an empty tuple creates a tuple with that element.
   [] +> tests-creates-empty-tuple-with-number
     eq. > @

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -12,17 +12,17 @@
   # Empty tuple.
   # A tuple with no elements. When dataized, it represents an immutable, empty collection.
   tuple > empty
-    error "Can't get tail from the empty tuple"
-    error "Can't get head from the empty tuple"
+    T "Can't get tail from the empty tuple"
+    T "Can't get head from the empty tuple"
     0
 
   # Take one element from the tuple, at the given position.
-  [i] > at
+  [i out-of-bounds] > at
     if. > @
       or.
         0.gt index
         length.lte index
-      error "Given index is out of tuple bounds"
+      out-of-bounds "Given index is out of tuple bounds"
       at-fast ^
     i > idx!
     if. > index!
@@ -124,11 +124,21 @@
       * 1 2 3
       "with"
 
-  # Tests that accessing a tuple with an out-of-bounds index throws an error.
+  # Tests that an out-of-bounds index with no fallback yields the bottom object
+  # (⊥) that terminates when used.
   [] +> throws-on-wrong-tuple-at
     at. > @
       * 1 2 3 4
       20
+
+  # Tests that an out-of-bounds index with a provided fallback yields the fallback.
+  [] +> tests-out-of-bounds-at-returns-provided-fallback
+    eq. > @
+      "recovered"
+      at.
+        * 1 2 3 4
+        20
+        "recovered" > [msg]
 
   # Tests that fluent chaining of with method works correctly for tuple construction.
   [] +> tests-tuple-fluent-with

--- a/eo-runtime/src/main/java/org/eolang/AtWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtWithRho.java
@@ -7,6 +7,8 @@ package org.eolang;
 
 /**
  * The attribute that tries to copy object and set \rho to it if it has not already set.
+ * The terminator ⊥ ({@link PhTerminator}) is excluded: it is not a real object and never
+ * takes a \rho, so no container leaks into it as it propagates.
  * This attribute is NOT thread safe!
  * @since 0.36.0
  * @todo #4673:30min The {@link AtWithRho#get()} is not thread safe. If multiple threads
@@ -50,7 +52,7 @@ final class AtWithRho implements Attribute {
     @Override
     public Phi get() {
         Phi ret = this.original.get();
-        if (!ret.hasRho()) {
+        if (!(ret instanceof PhTerminator) && !ret.hasRho()) {
             ret = ret.copy();
             ret.put(Phi.RHO, this.rho);
         }

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
@@ -21,19 +21,52 @@ import java.util.Arrays;
 public final class EObytes$EOslice extends PhDefault implements Atom {
 
     /**
+     * Name of the error-branch void that holds the caller's slice fallback.
+     */
+    private static final String FALLBACK = "cant-slice";
+
+    /**
      * Ctor.
      */
     public EObytes$EOslice() {
         super(new Attrs(
             new Attr("start", new AtVoid("start")),
-            new Attr("len", new AtVoid("len"))
+            new Attr("len", new AtVoid("len")),
+            new Attr(EObytes$EOslice.FALLBACK, new AtVoid(EObytes$EOslice.FALLBACK))
         ));
     }
 
     @Override
     public Phi lambda() {
         final byte[] bytes = new Dataized(this.take(Phi.RHO)).take();
-        final int start = Expect.at(this, "start")
+        final int start = this.natural("start");
+        final int len = this.natural("len");
+        final Phi result;
+        if (start + len <= bytes.length) {
+            result = new Data.ToPhi(Arrays.copyOfRange(bytes, start, start + len));
+        } else {
+            result = this.take(EObytes$EOslice.FALLBACK);
+            result.put(
+                0,
+                new Data.ToPhi(
+                    String.format(
+                        "cannot slice '%d' bytes from offset '%d' of bytes of size %d",
+                        len, start, bytes.length
+                    )
+                )
+            );
+        }
+        return result;
+    }
+
+    /**
+     * Read the given attribute as a non-negative integer, aborting when it is
+     * not one (a contract violation, not a recoverable failure).
+     * @param attr Attribute name
+     * @return The attribute as a non-negative int
+     */
+    private int natural(final String attr) {
+        return Expect.at(this, attr)
             .that(phi -> new Dataized(phi).asNumber())
             .otherwise("must be a number")
             .must(number -> number % 1 == 0)
@@ -42,23 +75,5 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
             .must(integer -> integer >= 0)
             .otherwise("must be a positive integer")
             .it();
-        return new Data.ToPhi(
-            Arrays.copyOfRange(
-                bytes,
-                start,
-                start + Expect.at(this, "len")
-                    .that(phi -> new Dataized(phi).asNumber())
-                    .otherwise("must be a number")
-                    .must(number -> number % 1 == 0)
-                    .that(Double::intValue)
-                    .otherwise("must be an integer")
-                    .must(integer -> integer >= 0)
-                    .otherwise("must be a positive integer")
-                    .must(integer -> start + integer <= bytes.length).otherwise(
-                        String.format("is out of bounds for bytes of size %d", bytes.length)
-                    )
-                    .it()
-            )
-        );
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOcompile.java
@@ -14,7 +14,10 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.eolang.AtVoid;
 import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
@@ -23,13 +26,30 @@ import org.eolang.Phi;
 import org.eolang.XmirObject;
 
 /**
- * Regex.@ object.
+ * Regex.compile object.
  * @since 0.39.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "regex.@")
+@XmirObject(oname = "regex.compile")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOregex$EOφ extends PhDefault implements Atom {
+public final class EOregex$EOcompile extends PhDefault implements Atom {
+
+    /**
+     * Name of the error-branch void that holds the caller's compile fallback.
+     */
+    private static final String FALLBACK = "cant-compile";
+
+    /**
+     * Ctor.
+     */
+    public EOregex$EOcompile() {
+        super(new Attrs(
+            new Attr(
+                EOregex$EOcompile.FALLBACK,
+                new AtVoid(EOregex$EOcompile.FALLBACK)
+            )
+        ));
+    }
 
     @Override
     public Phi lambda() {
@@ -55,7 +75,7 @@ public final class EOregex$EOφ extends PhDefault implements Atom {
      * @return The fallback object carrying the message
      */
     private Phi fallback(final String message) {
-        final Phi cant = this.take(Phi.RHO).take("cant-compile");
+        final Phi cant = this.take(EOregex$EOcompile.FALLBACK);
         cant.put(0, new Data.ToPhi(message));
         return cant;
     }

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOφ.java
@@ -33,35 +33,62 @@ public final class EOregex$EOφ extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {
-        final Phi regex = this.take(Phi.RHO);
-        final String expression = new Dataized(regex.take("expression")).asString();
-        if (!expression.startsWith("/")) {
-            throw new ExFailure("Wrong regex syntax: \"/\" is missing");
-        }
+        final String expression = new Dataized(this.take(Phi.RHO).take("expression")).asString();
         final int last = expression.lastIndexOf('/');
-        if (last == 0) {
-            throw new ExFailure("Wrong regex syntax: closing \"/\" is missing");
+        final Phi result;
+        if (expression.startsWith("/")) {
+            if (last == 0) {
+                result = this.fallback("regex is missing the closing slash");
+            } else {
+                result = this.compile(expression, last);
+            }
+        } else {
+            result = this.fallback("regex is missing the opening slash");
         }
+        return result;
+    }
+
+    /**
+     * The caller-supplied {@code cant-compile} recovery for an expression that
+     * cannot become a pattern, or the bottom object (⊥) when none was bound.
+     * @param message Why the expression could not be compiled
+     * @return The fallback object carrying the message
+     */
+    private Phi fallback(final String message) {
+        final Phi cant = this.take(Phi.RHO).take("cant-compile");
+        cant.put(0, new Data.ToPhi(message));
+        return cant;
+    }
+
+    /**
+     * Compile the expression into a serialized pattern, or fall back when its
+     * body is invalid. An invalid body is only discoverable by compiling, so
+     * the {@link PatternSyntaxException} is caught at that boundary and routed
+     * to the fallback; a serialization {@link IOException} on an in-memory
+     * stream is unpredictable and aborts as a system failure.
+     * @param expression The Perl-format expression, slashes included
+     * @param last Index of the closing slash in the expression
+     * @return The compiled pattern, or the {@code cant-compile} fallback
+     */
+    private Phi compile(final String expression, final int last) {
         final StringBuilder builder = new StringBuilder();
         if (!expression.endsWith("/")) {
             builder.append("(?").append(expression.substring(last + 1)).append(')');
         }
         builder.append(expression, 1, last);
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final Phi pattern = regex.take("pattern");
+        Phi result;
         try {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             final ObjectOutputStream ous = new ObjectOutputStream(baos);
             ous.writeObject(Pattern.compile(builder.toString()));
-            pattern.put(0, new Data.ToPhi(baos.toByteArray()));
             ous.close();
-            return pattern;
-        } catch (final PatternSyntaxException exception) {
-            throw new ExFailure(
-                "Regular expression syntax is invalid",
-                exception
-            );
+            result = this.take(Phi.RHO).take("pattern");
+            result.put(0, new Data.ToPhi(baos.toByteArray()));
+        } catch (final PatternSyntaxException ex) {
+            result = this.fallback("regex syntax is invalid");
         } catch (final IOException ex) {
-            throw new IllegalArgumentException(ex);
+            throw new ExFailure("cannot serialize the compiled regex pattern", ex);
         }
+        return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -19,14 +19,15 @@ package org.eolang;
  * propagates through copying and dispatch and surfaces the failure at
  * the outer dataization, not at the point it was produced.</p>
  *
- * <p>A ⊥ may carry a <em>cause</em>: it has a single slot, addressable at
- * position 0 or as the attribute {@code cause} (as in {@code T "why it
- * failed"}). Any other {@code put} — including the ρ-binding the runtime
- * performs as ⊥ propagates — is ignored, keeping ⊥ tolerant. The first
- * object put into the slot is remembered and used as the panic message
- * when the ⊥ is finally forced. The cause is write-once and never handed
- * back by {@link #take(String)}, so EO code can neither read it nor catch
- * it — it exists only to explain the termination at the very top.</p>
+ * <p>A ⊥ may carry a <em>cause</em>: it has a single slot, addressable only
+ * at position 0 (as in {@code T "why it failed"}). A {@code put} at any other
+ * position, or any {@code put} by name, aborts — ⊥ has no named attributes,
+ * and the ρ-binding the runtime would otherwise attempt is excluded upstream
+ * in {@link AtWithRho}. The first object put at position 0 is remembered and
+ * used as the panic message when the ⊥ is finally forced. The cause is
+ * write-once and never handed back by {@link #take(String)}, so EO code can
+ * neither read it nor catch it — it exists only to explain the termination
+ * at the very top.</p>
  *
  * @since 0.73.1
  */
@@ -55,16 +56,21 @@ public final class PhTerminator implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        if (pos == 0) {
-            this.remember(object);
+        if (pos != 0) {
+            throw new ExFailure(
+                "the ⊥ object only accepts a cause at position 0, not %d", pos
+            );
+        }
+        if (this.cause == null) {
+            this.cause = object;
         }
     }
 
     @Override
     public void put(final String name, final Phi object) {
-        if ("cause".equals(name)) {
-            this.remember(object);
-        }
+        throw new ExFailure(
+            "the ⊥ object does not accept attributes by name, but got '%s'", name
+        );
     }
 
     @Override
@@ -91,16 +97,5 @@ public final class PhTerminator implements Phi {
     @Override
     public String φTerm() {
         return "⊥";
-    }
-
-    /**
-     * Remember the first object put into this ⊥ as its cause, ignoring any
-     * later ones so the birth reason survives propagation.
-     * @param object The object being put
-     */
-    private void remember(final Phi object) {
-        if (this.cause == null) {
-            this.cause = object;
-        }
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -21,11 +21,12 @@ package org.eolang;
  *
  * <p>A ⊥ may carry a <em>cause</em>: it has a single slot, addressable at
  * position 0 or as the attribute {@code cause} (as in {@code T "why it
- * failed"}), and any other {@code put} aborts. The first object put there
- * is remembered and used as the panic message when the ⊥ is finally forced.
- * The cause is write-once and never handed back by {@link #take(String)},
- * so EO code can neither read it nor catch it — it exists only to explain
- * the termination at the very top.</p>
+ * failed"}). Any other {@code put} — including the ρ-binding the runtime
+ * performs as ⊥ propagates — is ignored, keeping ⊥ tolerant. The first
+ * object put into the slot is remembered and used as the panic message
+ * when the ⊥ is finally forced. The cause is write-once and never handed
+ * back by {@link #take(String)}, so EO code can neither read it nor catch
+ * it — it exists only to explain the termination at the very top.</p>
  *
  * @since 0.73.1
  */
@@ -54,22 +55,16 @@ public final class PhTerminator implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        if (pos != 0) {
-            throw new ExFailure(
-                "the ⊥ object only accepts a cause at position 0, not %d", pos
-            );
+        if (pos == 0) {
+            this.remember(object);
         }
-        this.remember(object);
     }
 
     @Override
     public void put(final String name, final Phi object) {
-        if (!"cause".equals(name)) {
-            throw new ExFailure(
-                "the ⊥ object only accepts a cause named 'cause', not '%s'", name
-            );
+        if ("cause".equals(name)) {
+            this.remember(object);
         }
-        this.remember(object);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -4,29 +4,38 @@
  */
 package org.eolang;
 
-import java.util.Objects;
-
 /**
  * The ⊥ ("bottom") object of φ-calculus — a terminated computation.
  *
  * <p>It is a value that can be carried around — returned, copied, and
- * have attributes bound into it — but it has no data and no behaviour.
+ * have an object put into it — but it has no data and no behaviour.
  * It detonates only when something tries to <em>force</em> it: reading
- * its data ({@link #delta()}) or dispatching an attribute on it
- * ({@link #take(String)}) aborts through an {@link ExFailure}. Because
+ * its data ({@link #delta()}) aborts through an {@link ExFailure}. Because
  * EO {@code try} only intercepts {@link EOerror.ExError}, that failure
  * cannot be caught, so forcing ⊥ terminates the program for good.</p>
  *
  * <p>The remaining operations are tolerant on purpose: {@link #copy()}
- * yields another ⊥, {@link #put(int, Phi)} is a no-op, and the
- * metadata accessors return sentinels. This lets ⊥ propagate through
- * copying and ρ-binding (the dispatch plumbing) and surface the failure
- * at the outer dataization or dispatch, not at the point it was
- * produced.</p>
+ * yields the same ⊥ and {@link #take(String)} yields ⊥ again, so it
+ * propagates through copying and dispatch and surfaces the failure at
+ * the outer dataization, not at the point it was produced.</p>
+ *
+ * <p>A ⊥ may carry a <em>cause</em>: it has a single slot, addressable at
+ * position 0 or as the attribute {@code cause} (as in {@code T "why it
+ * failed"}), and any other {@code put} aborts. The first object put there
+ * is remembered and used as the panic message when the ⊥ is finally forced.
+ * The cause is write-once and never handed back by {@link #take(String)},
+ * so EO code can neither read it nor catch it — it exists only to explain
+ * the termination at the very top.</p>
  *
  * @since 0.73.1
  */
 public final class PhTerminator implements Phi {
+
+    /**
+     * The reason this computation terminated, used only as the panic
+     * message when the ⊥ is forced, or {@code null} when none was given.
+     */
+    private Phi cause;
 
     @Override
     public Phi copy() {
@@ -45,12 +54,22 @@ public final class PhTerminator implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        Objects.requireNonNull(object);
+        if (pos != 0) {
+            throw new ExFailure(
+                "the ⊥ object only accepts a cause at position 0, not %d", pos
+            );
+        }
+        this.remember(object);
     }
 
     @Override
     public void put(final String name, final Phi object) {
-        Objects.requireNonNull(object);
+        if (!"cause".equals(name)) {
+            throw new ExFailure(
+                "the ⊥ object only accepts a cause named 'cause', not '%s'", name
+            );
+        }
+        this.remember(object);
     }
 
     @Override
@@ -65,11 +84,28 @@ public final class PhTerminator implements Phi {
 
     @Override
     public byte[] delta() {
-        throw new ExFailure("the ⊥ object is a terminated computation and cannot be used");
+        final String reason;
+        if (this.cause == null) {
+            reason = "the ⊥ object is a terminated computation and cannot be used";
+        } else {
+            reason = new Dataized(this.cause).asString();
+        }
+        throw new ExFailure(reason);
     }
 
     @Override
     public String φTerm() {
         return "⊥";
+    }
+
+    /**
+     * Remember the first object put into this ⊥ as its cause, ignoring any
+     * later ones so the birth reason survives propagation.
+     * @param object The object being put
+     */
+    private void remember(final Phi object) {
+        if (this.cause == null) {
+            this.cause = object;
+        }
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
@@ -48,11 +48,11 @@ final class EObytesEOsliceTest {
     @Test
     void throwsOnOutOfBoundsSlice() {
         MatcherAssert.assertThat(
-            "error message is correct for out of bounds slice",
+            "an out-of-bounds slice with no fallback must terminate with the reason",
             new UncheckedText(
                 new TextOf(
                     Assertions.assertThrows(
-                        EOerror.ExError.class,
+                        ExAbstract.class,
                         () -> new Dataized(
                             new PhApplication(
                                 new PhApplication(
@@ -67,11 +67,11 @@ final class EObytesEOsliceTest {
                                 new Data.ToPhi(10)
                             )
                         ).asString(),
-                        "doesnt throw on out of bounds slice"
+                        "doesnt terminate on out of bounds slice"
                     )
                 )
             ).asString(),
-            Matchers.containsString("is out of bounds for bytes of size 5")
+            Matchers.containsString("bytes of size 5")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
@@ -46,7 +46,7 @@ final class RegexAtomTest {
     @Test
     void throwsClearErrorOnMissingClosingSlash() {
         MatcherAssert.assertThat(
-            "regex without closing slash should throw a clear ExFailure that mentions \"/\" and is not an opaque IndexOutOfBoundsException",
+            "regex without closing slash must terminate with a clear reason about the missing slash, not an opaque IndexOutOfBoundsException",
             Assertions.assertThrows(
                 ExAbstract.class,
                 () -> new Dataized(
@@ -57,7 +57,7 @@ final class RegexAtomTest {
                 ).take()
             ).toString(),
             Matchers.allOf(
-                Matchers.containsString("/"),
+                Matchers.containsString("slash"),
                 Matchers.not(Matchers.containsString("out of bounds"))
             )
         );

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -105,20 +105,30 @@ final class PhTerminatorTest {
     }
 
     @Test
-    void rejectsPutAtOtherPositions() {
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> new PhTerminator().put(1, new Data.ToPhi("nope")),
-            "putting into the bottom object anywhere but the cause slot must abort"
+    void ignoresPutAtOtherPositions() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put(1, new Data.ToPhi("ignored"));
+        MatcherAssert.assertThat(
+            "putting at a position other than the cause slot must not become the cause",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(bottom).take()
+            ).getMessage(),
+            Matchers.not(Matchers.containsString("ignored"))
         );
     }
 
     @Test
-    void rejectsPutUnderOtherNames() {
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> new PhTerminator().put("other", new Data.ToPhi("nope")),
-            "putting into the bottom object under any name but cause must abort"
+    void ignoresPutUnderOtherNames() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put("ρ", new Data.ToPhi("ignored"));
+        MatcherAssert.assertThat(
+            "putting under a name other than cause must not become the cause",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(bottom).take()
+            ).getMessage(),
+            Matchers.not(Matchers.containsString("ignored"))
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -91,44 +91,20 @@ final class PhTerminatorTest {
     }
 
     @Test
-    void acceptsTheCauseByName() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put("cause", new Data.ToPhi("named reason"));
-        MatcherAssert.assertThat(
-            "putting a cause by its name must not be lost from the panic message",
-            Assertions.assertThrows(
-                ExFailure.class,
-                () -> new Dataized(bottom).take()
-            ).getMessage(),
-            Matchers.containsString("named reason")
+    void rejectsPutAtOtherPositions() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminator().put(1, new Data.ToPhi("nope")),
+            "putting into the bottom object anywhere but position 0 must abort"
         );
     }
 
     @Test
-    void ignoresPutAtOtherPositions() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put(1, new Data.ToPhi("ignored"));
-        MatcherAssert.assertThat(
-            "putting at a position other than the cause slot must not become the cause",
-            Assertions.assertThrows(
-                ExFailure.class,
-                () -> new Dataized(bottom).take()
-            ).getMessage(),
-            Matchers.not(Matchers.containsString("ignored"))
-        );
-    }
-
-    @Test
-    void ignoresPutUnderOtherNames() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put("ρ", new Data.ToPhi("ignored"));
-        MatcherAssert.assertThat(
-            "putting under a name other than cause must not become the cause",
-            Assertions.assertThrows(
-                ExFailure.class,
-                () -> new Dataized(bottom).take()
-            ).getMessage(),
-            Matchers.not(Matchers.containsString("ignored"))
+    void rejectsPutByName() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminator().put("cause", new Data.ToPhi("nope")),
+            "putting into the bottom object by name, even cause, must abort"
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -46,7 +46,79 @@ final class PhTerminatorTest {
     void toleratesBinding() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(0, new PhTerminator()),
-            "binding an attribute into the bottom object must be a no-op, not abort"
+            "putting an object into the bottom object must not abort"
+        );
+    }
+
+    @Test
+    void reportsTheGivenCauseOnPanic() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put(0, new Data.ToPhi("cannot proceed here"));
+        MatcherAssert.assertThat(
+            "forcing the bottom object must not hide the cause that was put into it",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(bottom).take()
+            ).getMessage(),
+            Matchers.containsString("cannot proceed here")
+        );
+    }
+
+    @Test
+    void keepsTheFirstCause() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put(0, new Data.ToPhi("the birth reason"));
+        bottom.put(0, new Data.ToPhi("a later reason"));
+        MatcherAssert.assertThat(
+            "a later object put into the bottom object must not overwrite its first cause",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(bottom).take()
+            ).getMessage(),
+            Matchers.containsString("the birth reason")
+        );
+    }
+
+    @Test
+    void hidesTheCauseFromTake() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put(0, new Data.ToPhi("secret cause"));
+        MatcherAssert.assertThat(
+            "taking an attribute must not hand back the cause, only another bottom",
+            bottom.take("cause"),
+            Matchers.instanceOf(PhTerminator.class)
+        );
+    }
+
+    @Test
+    void acceptsTheCauseByName() {
+        final PhTerminator bottom = new PhTerminator();
+        bottom.put("cause", new Data.ToPhi("named reason"));
+        MatcherAssert.assertThat(
+            "putting a cause by its name must not be lost from the panic message",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(bottom).take()
+            ).getMessage(),
+            Matchers.containsString("named reason")
+        );
+    }
+
+    @Test
+    void rejectsPutAtOtherPositions() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminator().put(1, new Data.ToPhi("nope")),
+            "putting into the bottom object anywhere but the cause slot must abort"
+        );
+    }
+
+    @Test
+    void rejectsPutUnderOtherNames() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new PhTerminator().put("other", new Data.ToPhi("nope")),
+            "putting into the bottom object under any name but cause must abort"
         );
     }
 }


### PR DESCRIPTION
Part of #5261. #5280 prototyped the termination-plus-fallback model on `malloc.of.allocated.read`: a predictable failure routes to a caller-supplied recovery object and yields the bottom object (⊥) when none was bound, so the failure surfaces only when the result is forced. This PR carries that model across the remaining atoms, one at a time. It is a draft so the approach can be reviewed on a concrete atom before the pattern spreads.

The first atom is `regex.@`. A `expression` that cannot become a pattern used to throw an uncatchable exception; now it hands back the `cant-compile` recovery declared on the user-facing `regex`, or ⊥ when none was provided. Because `regex.@` is internal machinery the caller never touches, the recovery void lives on `regex` and the atom reads it through `Phi.RHO`.

```java
if (expression.startsWith("/")) {
    if (last == 0) {
        result = this.fallback("regex is missing the closing slash");
    } else {
        result = this.compile(expression, last);
    }
} else {
    result = this.fallback("regex is missing the opening slash");
}
```

An invalid pattern body is discoverable only by compiling it, so the `PatternSyntaxException` is caught at that boundary and routed to the fallback rather than driving control flow; a serialization failure on the in-memory stream stays a system panic. Still to come: the filesystem atoms (`io.file-error` group) and `sscanf`/`sprintf`.

Closes #5285
