### PR TITLE
#5259: raise positioned ParseError for oversized HEX literals

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -116,11 +116,21 @@ final class Emissions {
                 new Hex(Double.parseDouble(value.raw())).asString()
             );
         } else if (value.kind() == Value.Kind.HEX) {
+            final long hex;
+            try {
+                hex = Long.parseLong(value.raw().substring(2), 16);
+            } catch (final NumberFormatException ex) {
+                final ParseError error = new ParseError(
+                    line, value.pos(),
+                    "hexadecimal literal is out of range"
+                );
+                error.initCause(ex);
+                throw error;
+            }
             emit.object(name, "Φ.number", line, value.pos());
             Emissions.bytesCarrier(
                 emit, line, value.pos(),
-                new Hex((double) Long.parseLong(value.raw().substring(2), 16))
-                    .asString()
+                new Hex((double) hex).asString()
             );
         } else if (value.kind() == Value.Kind.BYTES) {
             emit.object(name, "Φ.bytes", line, value.pos());

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -556,6 +556,17 @@ final class LnApplicationTest {
     }
 
     @Test
+    void rejectsOversizedHexHead() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnApplication(new Span("0x10000000000000000 > x", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a HEX literal wider than a signed 64-bit long must raise a positioned"
+                .concat(" ParseError instead of an uncaught NumberFormatException")
+        );
+    }
+
+    @Test
     void emitsBytesHead() {
         final Emit emit = new Emit();
         new LnApplication(new Span("CA-FE > x", 1))


### PR DESCRIPTION
## What happens

A HEX literal is emitted via `Long.parseLong(value.raw().substring(2), 16)`
in `Emissions.openValue`. The tokenizer (`Tokens.readHex`) reads an
unbounded run of hex digits with no length/range cap, so a literal like
`0x10000000000000000` (17 hex digits) tokenizes as a valid HEX value.
`Long.parseLong` then overflows and throws `NumberFormatException`. This
happens during emission, which the walker only guards against
`ParseError`, so the exception propagates and aborts the entire parse
instead of producing a positioned error for just that line.

Reproduced: `Long.parseLong("10000000000000000", 16)` throws
`NumberFormatException`.

## What should happen

An out-of-range HEX literal should produce a positioned `ParseError`
(e.g. "hexadecimal literal is out of range") that the walker catches and
reports, not an uncaught `NumberFormatException` aborting the parse.

## Fix

Wrapped the `Long.parseLong` call in a try/catch. On
`NumberFormatException`, raise a `ParseError` at `value.pos()` with the
line number, preserving the original exception as the cause via
`initCause` (required by PMD's `PreserveStackTrace` rule, confirmed by
`qulice`).

## Test

Added `rejectsOversizedHexHead` to `LnApplicationTest.java`, feeding
`0x10000000000000000 > x` through `LnApplication` and asserting a
`ParseError` is thrown instead of letting the `NumberFormatException`
escape. The existing `emitsHexHead` test (`0x1F > x`) continues to pass
unchanged, confirming normal HEX literals are unaffected.

## Verification

- `mvn test -pl eo-parser` — full module green, `LnApplicationTest`: 44/44
- `mvn qulice:check -Pqulice -pl eo-parser` — **BUILD SUCCESS**, 0
  violations (an intermediate attempt without `initCause` correctly
  triggered PMD's `PreserveStackTrace` rule, fixed by preserving the
  caught exception as the cause)

Closes #5259
