### PR TITLE
#5193: replace unavailable pr_size_checker action with inline check

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -9,15 +9,17 @@ env:
 jobs:
   pr-size:
     runs-on: ubuntu-24.04
-    # @todo #5186:30min Re-enable pr-size check once maidsafe/pr_size_checker
-    #  action is available again. The action's GitHub repository was not found
-    #  during the CI run, causing the check to fail unconditionally.
-    #  Replace or restore the action and remove this guard.
     if: ${{ vars.RUN_WORKFLOW == 'true' }}
     steps:
-      - uses: actions/checkout@v6
-      - run: git fetch origin master --depth=1
-      - uses: maidsafe/pr_size_checker@v3
-        with:
-          target_branch: master
-          max_lines_changed: 200
+      - name: Check pull request size
+        env:
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+          MAX_LINES_CHANGED: 200
+        run: |
+          total=$((ADDITIONS + DELETIONS))
+          echo "Total lines changed: ${total}"
+          if [ "${total}" -gt "${MAX_LINES_CHANGED}" ]; then
+            echo "Pull request changes ${total} lines, exceeding the ${MAX_LINES_CHANGED}-line limit; consider breaking it down."
+            exit 1
+          fi


### PR DESCRIPTION
## What happens

`.github/workflows/pr-size.yml` runs `maidsafe/pr_size_checker@v3` to
enforce a 200-line PR size limit. That action's GitHub repository no
longer exists — `gh api repos/maidsafe/pr_size_checker` returns 404 — so
the step fails unconditionally with "action not found" whenever the
workflow runs.

## What should happen

The pull-request-size check should work again without depending on a
repository that no longer exists.

## Fix

Searched for a maintained replacement or a continuation of the deleted
action. The one same-named fork that turned up
(`joshuef/pr_size_checker`) is a single-owner, 0-star, unversioned
snapshot from 2021 with no release tags — not something to pin a
supply-chain dependency on, and inconsistent with this repo's own
discipline of pinning every action to an immutable tag.

Its actual logic, though, is trivial: sum `github.event.pull_request`'s
`additions` and `deletions` and compare against a threshold. That data is
already present in the PR webhook payload, so the fix replaces the
external action (and the now-unnecessary `checkout` + `git fetch` steps
that existed to support it) with an inline shell step that reproduces the
same check with zero external dependencies:

```yaml
- name: Check pull request size
  env:
    ADDITIONS: ${{ github.event.pull_request.additions }}
    DELETIONS: ${{ github.event.pull_request.deletions }}
    MAX_LINES_CHANGED: 200
  run: |
    total=$((ADDITIONS + DELETIONS))
    echo "Total lines changed: ${total}"
    if [ "${total}" -gt "${MAX_LINES_CHANGED}" ]; then
      echo "Pull request changes ${total} lines, exceeding the ${MAX_LINES_CHANGED}-line limit; consider breaking it down."
      exit 1
    fi
```

Removed the `@todo #5186` comment per the puzzle's "done" criteria. Left
the `if: vars.RUN_WORKFLOW == 'true'` gate untouched — the identical
pattern also gates `ort.yml`, confirming it's a deliberate repo-wide
opt-in switch unrelated to this bug.

## Verification

No `actionlint`/`shellcheck` available in this sandbox to run directly, so
verified manually:

- `ruby -ryaml -e "YAML.load_file(...)"` — YAML valid
- `bash -n` on the extracted shell script — syntax valid
- Ran the script directly against both scenarios: `ADDITIONS=50
  DELETIONS=30` (under the 200-line limit) exits 0; `ADDITIONS=150
  DELETIONS=100` (over the limit) prints the warning and exits 1

Closes #5193
