### PR TITLE
#5257: throw ParseError on invalid unicode escape in string literal

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -129,9 +129,19 @@ final class Emissions {
             emit.close();
         } else if (value.kind() == Value.Kind.STRING) {
             emit.object(name, "Φ.string", line, value.pos());
+            final String unescaped;
+            try {
+                unescaped = Emissions.unescape(value.raw());
+            } catch (final NumberFormatException ex) {
+                final ParseError error = new ParseError(
+                    line, value.pos(), "invalid unicode escape in string literal"
+                );
+                error.initCause(ex);
+                throw error;
+            }
             Emissions.bytesCarrier(
                 emit, line, value.pos(),
-                new Hex(Emissions.unescape(value.raw())).asString()
+                new Hex(unescaped).asString()
             );
         } else if (value.kind() == Value.Kind.STAR) {
             emit.object(name, "Φ.tuple", line, value.pos());

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -437,6 +437,17 @@ final class LnApplicationTest {
     }
 
     @Test
+    void rejectsStringWithInvalidUnicodeEscape() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnApplication(new Span("\"\\uZZZZ\" > x", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a string with a non-hex \\u escape must be rejected instead of"
+                + " crashing with an uncaught NumberFormatException"
+        );
+    }
+
+    @Test
     void emitsRootIdentifierAsHead() {
         final Emit emit = new Emit();
         new LnApplication(new Span("Q > x", 1))

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -442,8 +442,7 @@ final class LnApplicationTest {
             ParseError.class,
             () -> new LnApplication(new Span("\"\\uZZZZ\" > x", 1))
                 .into(new Stack(), new Globals(), new Emit()),
-            "a string with a non-hex \\u escape must be rejected instead of"
-                + " crashing with an uncaught NumberFormatException"
+            "a string with a non-hex \\u escape must be rejected, not crash"
         );
     }
 


### PR DESCRIPTION
## What happens

`Emissions.appendUnicode` decodes a `\uXXXX` escape by calling
`Integer.parseInt(body.substring(cursor, cursor + 4), 16)` whenever there
are at least 4 characters after the `u` run, without validating that
those 4 characters are actually hex digits. `Tokens.readString` accepts
any backslash escape without checking the following characters, so a
literal such as `"\uZZZZ"` tokenizes cleanly and reaches `unescapeBody`
during emission, where `parseInt` throws an uncaught
`NumberFormatException`. `Emissions.openValue`'s `STRING` branch is called
from inside the walker's per-line dispatch, which only catches
`ParseError` — so the `NumberFormatException` propagates out and aborts
the entire parse instead of producing a positioned error, the same class
of defect already fixed for oversized `HEX` literals in #5287.

## What should happen

A malformed `\uXXXX` escape should raise a positioned `ParseError`
("invalid unicode escape in string literal") that the walker can catch
and report, not an uncaught `NumberFormatException` that kills the whole
parse.

## Fix

`Emissions.openValue`'s `STRING` branch now catches the
`NumberFormatException` from `Emissions.unescape` and rethrows it as a
`ParseError` carrying the value's line/position, preserving the original
cause via `initCause`:

```diff
 } else if (value.kind() == Value.Kind.STRING) {
     emit.object(name, "Φ.string", line, value.pos());
+    final String unescaped;
+    try {
+        unescaped = Emissions.unescape(value.raw());
+    } catch (final NumberFormatException ex) {
+        final ParseError error = new ParseError(
+            line, value.pos(), "invalid unicode escape in string literal"
+        );
+        error.initCause(ex);
+        throw error;
+    }
     Emissions.bytesCarrier(
         emit, line, value.pos(),
-        new Hex(Emissions.unescape(value.raw())).asString()
+        new Hex(unescaped).asString()
     );
```

Added `rejectsStringWithInvalidUnicodeEscape` to `LnApplicationTest`,
which reproduces the exact reported stack trace on unmodified master
(`NumberFormatException: For input string: "ZZZZ" under radix 16`) and
asserts a `ParseError` is thrown instead.

## Verification

`mvn -pl eo-parser test -Dtest=LnApplicationTest` — 23 tests pass,
including the new one. Confirmed the new test fails with the reported
`NumberFormatException` on unmodified master and passes with this fix.

Closes #5257
