### PR TITLE
#5295: reject out-of-int-range numbers in Expect.Int and Expect.Natural

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Expect.java
+++ b/eo-runtime/src/main/java/org/eolang/Expect.java
@@ -262,6 +262,8 @@ public class Expect<T> {
                 .otherwise("must be a number")
                 .must(number -> number % 1 == 0)
                 .otherwise("must be an integer")
+                .must(number -> number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE)
+                .otherwise("must fit into int range")
                 .that(Double::intValue)
                 .it();
         }
@@ -394,6 +396,8 @@ public class Expect<T> {
                 .otherwise("must be a number")
                 .must(number -> number % 1 == 0)
                 .otherwise("must be an integer")
+                .must(number -> number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE)
+                .otherwise("must fit into int range")
                 .that(Double::intValue)
                 .must(integer -> integer >= 0)
                 .otherwise("must be greater or equal to zero")

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -273,4 +273,48 @@ final class ExpectTest {
             Matchers.equalTo("the 'ρ' attribute (-42) must be greater or equal to zero")
         );
     }
+
+    @Test
+    void failsInTransformingToIntegerForTooLarge() {
+        MatcherAssert.assertThat(
+            "inner class Integer throws error for a number outside int range, instead of saturating",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.Int(
+                    Expect.at(
+                        new PhApplication(
+                            new PhDefault(),
+                            Phi.RHO,
+                            new Data.ToPhi(1.0e15)
+                        ),
+                        Phi.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to Integer"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute (1.0E15) must fit into int range")
+        );
+    }
+
+    @Test
+    void failsInTransformingToNonNegativeIntegerForTooLarge() {
+        MatcherAssert.assertThat(
+            "inner class NonNegativeInteger throws error for a number outside int range, instead of saturating",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Expect.Natural(
+                    Expect.at(
+                        new PhApplication(
+                            new PhDefault(),
+                            Phi.RHO,
+                            new Data.ToPhi(1.0e15)
+                        ),
+                        Phi.RHO
+                    )
+                ).it(),
+                "fails with correct error message while transform Phi to NonNegativeInteger"
+            ).getMessage(),
+            Matchers.equalTo("the 'ρ' attribute (1.0E15) must fit into int range")
+        );
+    }
 }


### PR DESCRIPTION
Closes #5295.

`Expect.Int.it()` and `Expect.Natural.it()` narrow a `Double` to `Integer` via `Double::intValue`
without first checking the value fits in `int` range. `Double.intValue()` doesn't throw for a
value outside `int` range — it saturates, returning `Integer.MAX_VALUE`/`Integer.MIN_VALUE`. Since
the saturated value is still a "valid" integer (and, for `Natural`, still `>= 0`), no downstream
check catches it, e.g. `malloc.of 1000000000000000` silently allocates a `2147483647`-byte block
instead of raising a domain error for a size nowhere near what was requested.

Added a `must` step before the `Double::intValue` narrowing in both `Expect.Int` and
`Expect.Natural` that rejects any value outside `[Integer.MIN_VALUE, Integer.MAX_VALUE]` with a
`"must fit into int range"` message, matching the existing style of this validation pipeline
(`must be an integer`, `must be greater or equal to zero`).

Added two tests in `ExpectTest` (`failsInTransformingToIntegerForTooLarge`,
`failsInTransformingToNonNegativeIntegerForTooLarge`) mirroring the existing
`failsInTransformingTo...ForNotInteger`/`ForNegative` tests, using `1.0e15` as the out-of-range
value from the issue's reproduction.

Ran the full `Expect`-related test suite locally (`ExpectTest`, `EOmallocAllocatedExpectTest`,
`EOmallocWritePhiExpectTest`, `EOiConvertersExpectTest`, `EObytesEOrightExpectTest`,
`EOi64ExpectTest`) — all 36 tests pass.
