### PR TITLE
#5301: use Expect.Natural in EOresized instead of ad-hoc intValue narrowing

### DIFF
--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -382,6 +382,12 @@
       1
       m.resized -1 > [m]
 
+  # Tests that malloc throws an error when attempting to resize to a fractional size.
+  [] +> throws-on-changing-size-to-fractional
+    malloc.of > @
+      1
+      m.resized 1.5 > [m]
+
   # Tests that malloc.empty creates a memory block with zero size.
   [] +> tests-malloc-empty-is-empty
     malloc.empty > @

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOresized.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOresized.java
@@ -29,16 +29,8 @@ public final class EOmalloc$EOof$EOallocated$EOresized extends PhDefault impleme
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public Phi lambda() {
         final Phi rho = this.take(Phi.RHO);
-        final int id = Expect.at(rho, "id")
-            .that(phi -> new Dataized(phi).asNumber())
-            .otherwise("must be a number")
-            .that(Double::intValue)
-            .it();
-        final int size = Expect.at(this, "new-size")
-            .that(phi -> new Dataized(phi).asNumber())
-            .otherwise("must be a number")
-            .that(Double::intValue)
-            .it();
+        final int id = new Expect.Natural(Expect.at(rho, "id")).it();
+        final int size = new Expect.Natural(Expect.at(this, "new-size")).it();
         Heaps.INSTANCE.resize(id, size);
         return rho;
     }


### PR DESCRIPTION
Closes #5301.

`EOmalloc$EOof$EOallocated$EOresized.lambda()` built its own ad-hoc `Expect` chain for `id` and
`new-size` that narrows the `Double` to `int` with `Double::intValue` directly, unlike every other
malloc-related atom in this package (`EOmalloc$EOof$EOφ`, `EOmalloc$EOof$EOallocated$EOread`,
`EOmalloc$EOof$EOallocated$EOwrite`), which all use `Expect.Natural`. `Double.intValue()` truncates
fractional values silently and saturates out-of-range values instead of throwing, so
`<allocated>.resized 5.7` silently resized to `5` bytes instead of rejecting the non-integer size.

Replaced both ad-hoc chains with `new Expect.Natural(...)`, matching the sibling atoms.

Added a `throws-on-changing-size-to-fractional` test to `malloc.eo`, mirroring the existing
`throws-on-changing-size-to-negative` test, covering the fractional-size case that the ad-hoc
chain didn't validate.

Ran the full EO-generated malloc test suite locally (`EOmallocEOAtomTest`) — all 36 tests pass,
including the new one.
