### PR TITLE
#5296: use overflow-safe long arithmetic in Heaps.fits bounds check

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -150,7 +150,9 @@ final class Heaps {
                     )
                 );
             }
-            return offset + length <= this.blocks.get(identifier).length;
+            return offset >= 0
+                && length >= 0
+                && (long) offset + length <= this.blocks.get(identifier).length;
         } finally {
             this.lock.unlock();
         }

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -99,6 +99,34 @@ final class HeapsTest {
     }
 
     @Test
+    void failsOnReadIfOffsetPlusLengthOverflows() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.read(
+                Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10),
+                Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1
+            ),
+            "Heaps must fail on out-of-bounds read when offset + length overflows int"
+        );
+    }
+
+    @Test
+    void failsCleanlyOnNegativeReadArguments() {
+        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10);
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.read(idx, -5, 3),
+            "Heaps must reject a negative offset with a clean ExFailure, not a raw JVM exception"
+        );
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.read(idx, 2, -3),
+            "Heaps must reject a negative length with a clean ExFailure, not a raw JVM exception"
+        );
+        Heaps.INSTANCE.free(idx);
+    }
+
+    @Test
     void readsByOffsetAndLength() {
         final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});


### PR DESCRIPTION
Closes #5296.

`Heaps.fits(int, int, int)` computed `offset + length <= this.blocks.get(identifier).length` using
plain `int` addition, which can overflow and wrap to a negative number for large `offset`/`length`
(e.g. `2_000_000_000 + 2_000_000_000` wraps to `-294_967_296`). A negative sum is `<=` any
allocated block length, so `fits` wrongly reported `true` for a read nowhere near actually fitting,
which then let `Heaps.read` re-derive the same overflowed sum and crash with a raw
`Arrays.copyOfRange` `IllegalArgumentException` instead of routing through the documented
`cant-read` fallback.

Widened the addition to `long` so the comparison can't overflow, matching the style of an
overflow-safe bound check.

Added `failsOnReadIfOffsetPlusLengthOverflows` to `HeapsTest`, mirroring the existing
`failsOnReadIfOutOfBounds` test, using `offset = length = Integer.MAX_VALUE - 1` (the same class
of value from the issue's reproduction) against a small allocated block.

Ran the full `HeapsTest` suite locally — all 21 tests pass. Verified the overflow directly:
`(Integer.MAX_VALUE - 1) + (Integer.MAX_VALUE - 1)` as `int` gives `-4` (wrongly "fits" a 10-byte
block); as `long` gives `4294967292` (correctly rejected).
