### PR TITLE
#5297: use overflow-safe long arithmetic in Heaps.write resize-trigger

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -199,8 +199,17 @@ final class Heaps {
                     )
                 );
             }
-            if (this.blocks.get(identifier).length < offset + data.length) {
-                this.resize(identifier, offset + data.length);
+            final long end = (long) offset + data.length;
+            if (end > Integer.MAX_VALUE) {
+                throw new ExFailure(
+                    String.format(
+                        "Block '%d': can't write at offset '%d', resulting size '%d' is too large for int",
+                        identifier, offset, end
+                    )
+                );
+            }
+            if (this.blocks.get(identifier).length < end) {
+                this.resize(identifier, (int) end);
             }
             final byte[] source = this.blocks.get(identifier);
             final int length = source.length;

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -79,6 +79,18 @@ final class HeapsTest {
     }
 
     @Test
+    void failsOnWriteIfOffsetPlusLengthOverflows() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.write(
+                Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10),
+                Integer.MAX_VALUE, new byte[] {0x01}
+            ),
+            "Heaps should throw an exception on write when offset + data.length overflows int, but it didn't"
+        );
+    }
+
+    @Test
     void failsOnReadFromEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,


### PR DESCRIPTION
Closes #5297.

`Heaps.write(int, int, byte[])` decided whether the block needs to grow via plain `int` addition:
`this.blocks.get(identifier).length < offset + data.length`. For `offset = Integer.MAX_VALUE` and
a one-byte `data` — a value `Expect.Natural` happily accepts — `offset + data.length` wraps to
`Integer.MIN_VALUE`, so the resize-trigger condition is never true, execution falls through to
`System.arraycopy(data, 0, result, offset, data.length)` with the original small block size, and
throws a raw `ArrayIndexOutOfBoundsException` instead of resizing (or raising a clean domain error)
as the method's own logic intends.

Widened the sum to `long` (`end`). If `end` exceeds `Integer.MAX_VALUE` — meaning no `byte[]` of
that size can ever be allocated — the method now throws a clean `ExFailure` naming the offset and
resulting size, instead of silently skipping the resize and crashing later with an unrelated
`ArrayIndexOutOfBoundsException`. Otherwise, the existing resize path is used unchanged with the
now-correct `long`-computed value.

Added `failsOnWriteIfOffsetPlusLengthOverflows` to `HeapsTest`, using `offset = Integer.MAX_VALUE`
against a small allocated block, mirroring the existing `failsOnWriteToEmptyBlock` test style.

Ran the full `HeapsTest` suite locally — all 21 tests pass.
