### PR TITLE
#5292: validate i32.as-i16 via lossless round trip instead of upper-byte check

### DIFF
--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -24,18 +24,19 @@
 
   # Convert this `org.eolang.i32` to `org.eolang.i16`.
   # The `org.eolang.error` is returned if the `org.eolang.i32` number is more than
-  # max `org.eolang.i16` value `32767`.
+  # max `org.eolang.i16` value `32767` or less than min `org.eolang.i16` value `-32768`.
+  # The conversion is validated by converting `left` back up to `org.eolang.i32` and
+  # comparing it against the original value, so the check is exact for both signs
+  # instead of relying on the upper two bytes alone.
   [] > as-i16
     if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 (as-bytes.slice 2 2)
+      ^.eq left.as-i32
+      left
       error
         sprintf
           "Can't convert i32 number %d to i16 because it's out of i16 bounds"
           * as-i64.as-number
-    (as-bytes.slice 0 2).as-bytes > left
+    i16 (as-bytes.slice 2 2) > left
 
   # Returns `org.eolang.true` if `$` < `x`.
   # Here `x` must be an `org.eolang.i32` object.
@@ -134,6 +135,16 @@
     eq. > @
       -123.as-i64.as-i32
       -123.as-i64.as-i32.as-i16.as-i32
+
+  # Tests that converting an i32 just above the i16 upper bound throws an error,
+  # even though its upper two bytes happen to be 00-00.
+  [] +> throws-on-converting-i16-max-plus-one-to-i16
+    32768.as-i64.as-i32.as-i16 > @
+
+  # Tests that converting an i32 just below the i16 lower bound throws an error,
+  # even though its upper two bytes happen to be FF-FF.
+  [] +> throws-on-converting-i16-min-minus-one-to-i16
+    -32769.as-i64.as-i32.as-i16 > @
 
   # Tests that i32 less-than comparison returns true for smaller values.
   [] +> tests-i32-less-true


### PR DESCRIPTION
Closes #5292.

`i32.eo`'s `as-i16` atom guarded the conversion by checking only the upper two bytes of the i32's
4-byte representation (`left.eq 00-00` / `left.eq FF-FF`). For i32 value `32768` (`0x00008000`),
the upper bytes are `00-00`, so the check passed, and the lower two bytes `80-00` were handed to
`i16` as-is, decoding to `-32768` — a value with the opposite sign of the original, instead of the
documented "out of i16 bounds" error. The same failure happened symmetrically for `-32769`
(`0xFFFF7FFF`, upper bytes `FF-FF`).

This is the same defect class already reported for `i64.as-i32` in #5255 (fixed in #5287 with a
round-trip validation approach). Applied the same fix here: build the candidate `i16` from the
lower two bytes first, then validate the conversion is lossless by widening it back up to `i32`
and comparing against the original value (`^.eq left.as-i32`), instead of inspecting the upper
bytes. This makes the check exact for both signs.

Added two tests to `i32.eo`, `throws-on-converting-i16-max-plus-one-to-i16` (`32768`) and
`throws-on-converting-i16-min-minus-one-to-i16` (`-32769`), covering exactly the boundary values
from the issue's reproduction that the old upper-byte check let slip through. The existing
`tests-i32-to-i16-and-back` / `tests-negative-i32-to-i16-and-back` round-trip tests, and the
existing `throws-on-converting-to-i16-if-out-of-bounds` test (a value far enough out of range that
the old check caught it too), still pass.

Ran the full EO-generated `i32`/`i16` test suites locally (`EOi32Test`, `EOi16Test`) — all 59
tests pass, including the two new boundary tests.
