### PR TITLE
#5303: use Expect.Natural for chunk size instead of raw intValue narrowing

### DIFF
--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -487,6 +487,15 @@
             m
     .eq "Hello, world" > @
 
+  # Tests that reading a negative size from a file throws a clean domain error
+  # instead of an uncaught NegativeArraySizeException.
+  [] +> throws-on-reading-negative-size-from-file
+    tmpdir
+    .tmpfile
+    .open > @
+      "r"
+      f.read -5 > [f]
+
   # Tests that attempting to read from a file opened in write-only mode throws an error.
   [] +> throws-on-reading-from-file-with-wrong-mode
     tmpdir

--- a/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOread$EOchunk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOfs/EOfile$EOopen$EOfile_stream$EOread$EOchunk.java
@@ -17,6 +17,7 @@ import org.eolang.Atom;
 import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Dataized;
+import org.eolang.Expect;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -54,7 +55,7 @@ public final class EOfile$EOopen$EOfile_stream$EOread$EOchunk
             return new ToPhi(
                 Files.INSTANCE.read(
                     path.toString(),
-                    new Dataized(this.take("size")).asNumber().intValue()
+                    new Expect.Natural(Expect.at(this, "size")).it()
                 )
             );
         } catch (final IOException ex) {


### PR DESCRIPTION
Closes #5303.

`EOfile$EOopen$EOfile_stream$EOread$EOchunk.lambda()` read its `size` attribute with a raw
`new Dataized(this.take("size")).asNumber().intValue()` and passed the result straight into
`Files.INSTANCE.read(String, int)` (`eo-runtime/src/main/java/org/eolang/EOfs/Files.java`), which
does `new byte[size]`. There was no check that `size` is non-negative (or even a whole number —
`Double.intValue()` truncates fractions silently too). A negative `size` — e.g.
`file-stream.read.chunk -5`, or any EO expression that computes a negative remaining-bytes count
by mistake — reached `new byte[size]` with a negative length and threw an uncaught
`NegativeArraySizeException`.

`file.open.file-stream.read.chunk` is a public atom directly reachable from ordinary EO code
(`file-stream.read` → `input-block.read` → `chunk`), so any program computing a bad `size` value
got a raw Java exception instead of the kind of clean domain error other atoms in this codebase
raise for bad size arguments (`Expect.Natural`'s "must be greater or equal to zero" — already used
by the malloc atoms for exactly this purpose).

Replaced the raw narrowing with `new Expect.Natural(Expect.at(this, "size")).it()`, matching the
established convention.

Added `throws-on-reading-negative-size-from-file` to `fs/file.eo`, mirroring the neighboring
`throws-on-reading-from-file-with-wrong-mode` test, opening a tmpfile for reading and calling
`f.read -5`.

Ran the full EO-generated file test suite locally (`EOfs.EOfileTest`) — all 34 tests pass. The
verbose log confirms the exact fix in action:

```
"the 'size' attribute (-5) must be greater or equal to zero"
```

replacing what was previously an uncaught `NegativeArraySizeException`.
