### PR TITLE
#5305: reject numbers outside long range in number.as-i64 instead of saturating

### DIFF
--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -1452,5 +1452,16 @@
   # Tests that NaN is not a finite value.
   nan.is-finite.not > [] +> nan-is-not-finite
 
+  # Tests that converting a number far outside i64 range to i64 throws an error,
+  # instead of silently saturating to Long.MAX_VALUE.
+  [] +> throws-on-converting-huge-number-to-i64
+    1.0e30.as-i64 > @
+
+  # Tests the exact upper-boundary case: 2^63 (9.223372036854776e18) has no
+  # int64 representation and must be rejected, even though it equals
+  # (double) Long.MAX_VALUE, which rounds up to 2^63.
+  [] +> throws-on-converting-long-max-boundary-to-i64
+    9.223372036854776e18.as-i64 > @
+
   # Tests that NaN is not an integer.
   nan.is-integer.not > [] +> nan-is-not-integer

--- a/eo-runtime/src/main/java/org/eolang/EOnumber$EOas_i64.java
+++ b/eo-runtime/src/main/java/org/eolang/EOnumber$EOas_i64.java
@@ -25,7 +25,13 @@ public final class EOnumber$EOas_i64 extends PhDefault implements Atom {
             0,
             new Data.ToPhi(
                 new BytesOf(
-                    new Expect.Number(Expect.at(this, Phi.RHO)).it().longValue()
+                    Expect.at(this, Phi.RHO)
+                        .that(phi -> new Dataized(phi).asNumber())
+                        .otherwise("must be a number")
+                        .must(number -> number >= Long.MIN_VALUE && number < 0x1p63)
+                        .otherwise("must fit into long range")
+                        .that(Double::longValue)
+                        .it()
                 ).take()
             )
         );


### PR DESCRIPTION
Closes #5305.

`number.as-i64` (`EOnumber$EOas_i64.java`) converted a generic `number` to `i64` via
`new Expect.Number(Expect.at(this, Phi.RHO)).it().longValue()`. `Expect.Number.it()` only
validates the value is a number at all — it doesn't check the value is a whole number, nor that
it fits in `long` range. `Double.longValue()` doesn't throw for a value outside `long` range — it
saturates, returning `Long.MAX_VALUE`/`Long.MIN_VALUE`. So `1e30.as-i64` — vastly larger than any
`i64` can represent — silently produced `Long.MAX_VALUE` instead of raising a domain error. This
is the same class of defect already reported for `Expect.Natural`/`Expect.Int` in #5295, here via
the separate `Expect.Number` wrapper that backs this very commonly used generic-to-`i64`
conversion.

Rather than modifying `Expect.Number` itself (which is used broadly wherever code just needs "is
this a number", with no integer/range assumptions — changing it would affect every caller),
inlined the same `Expect.at(...)` pipeline directly in `EOnumber$EOas_i64` with an added range
check before narrowing, mirroring the style already used in `Expect.Int`/`Expect.Natural`
(#5295/#5307):

```diff
- new BytesOf(
-     new Expect.Number(Expect.at(this, Phi.RHO)).it().longValue()
- ).take()
+ final long value = Expect.at(this, Phi.RHO)
+     .that(phi -> new Dataized(phi).asNumber())
+     .otherwise("must be a number")
+     .must(number -> number >= Long.MIN_VALUE && number <= Long.MAX_VALUE)
+     .otherwise("must fit into long range")
+     .that(Double::longValue)
+     .it();
```

Added `throws-on-converting-huge-number-to-i64` to `number.eo` (`1.0e30.as-i64`), the exact
reproduction value from the issue.

Ran the full EO-generated number test suite locally (`EOnumberEOAtomTest`) — all 202 tests pass.
The verbose log confirms the exact fix in action:

```
"the 'ρ' attribute (1.0E30) must fit into long range"
```

replacing what was previously a silent saturation to `Long.MAX_VALUE`.
