### PR TITLE
#5306: reject numbers outside long range in sprintf %d conversion instead of saturating

### DIFF
--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -141,6 +141,13 @@
         "%d"
         * 9.99
 
+  # Tests that sprintf throws an error for %d when the number doesn't fit
+  # into long range, instead of silently saturating to Long.MAX_VALUE.
+  [] +> throws-on-formatting-huge-number-as-decimal
+    sprintf > @
+      "%d"
+      * 1.0e30
+
   # Tests that sprintf always pads a float to exactly six fraction digits.
   [] +> formats-float-always-with-six-fraction-digits
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
@@ -40,7 +40,7 @@ final class SprintfArgs {
 
     static {
         SprintfArgs.CONVERSION.put('s', Dataized::asString);
-        SprintfArgs.CONVERSION.put('d', element -> element.asNumber().longValue());
+        SprintfArgs.CONVERSION.put('d', element -> SprintfArgs.toLong(element.asNumber()));
         SprintfArgs.CONVERSION.put('f', Dataized::asNumber);
         SprintfArgs.CONVERSION.put('x', element -> SprintfArgs.bytesToHex(element.take()));
         SprintfArgs.CONVERSION.put('b', Dataized::asBool);
@@ -121,6 +121,25 @@ final class SprintfArgs {
             );
         }
         return SprintfArgs.CONVERSION.get(symbol).apply(element);
+    }
+
+    /**
+     * Convert a number to {@code long} for the {@code %d} conversion, rejecting
+     * a value outside {@code long} range instead of silently saturating to
+     * {@link Long#MAX_VALUE}/{@link Long#MIN_VALUE} as {@link Double#longValue()} does.
+     * @param number Number to convert
+     * @return The number as {@code long}
+     */
+    private static long toLong(final double number) {
+        if (number < Long.MIN_VALUE || number > Long.MAX_VALUE) {
+            throw new ExFailure(
+                String.format(
+                    "The number %s doesn't fit into long range for the '%%d' conversion",
+                    number
+                )
+            );
+        }
+        return (long) number;
     }
 
     /**


### PR DESCRIPTION
Closes #5306.

`sprintf`'s `%d` conversion (`SprintfArgs.CONVERSION.put('d', element -> element.asNumber().longValue())`)
narrowed the argument's `Double` value to `long` via `Double.longValue()`, which doesn't throw for
a value outside `long` range — it saturates, returning `Long.MAX_VALUE`/`Long.MIN_VALUE`. So
`sprintf("%d", *1e30)` silently printed `9223372036854775807` instead of raising a domain error
naming the offending value. This is the same `Double`-to-integral narrowing-without-validation
defect already fixed for `Expect.Natural`/`Expect.Int` (#5295/#5307) and `number.as-i64`
(#5305/#5315), here in the `%d` conversion path used by every `sprintf` call in this codebase.

Added a `SprintfArgs.toLong(double)` helper that checks the value against `Long.MIN_VALUE`/
`Long.MAX_VALUE` before narrowing, and wired it into the `'d'` entry of the `CONVERSION` map in
place of the raw `.longValue()` call.

Added `throws-on-formatting-huge-number-as-decimal` to `tt/sprintf.eo`, using `1.0e30` — the exact
reproduction value from the issue — mirroring the existing `truncates-*-as-decimal` tests for the
`%d` conversion.

Ran the full EO-generated sprintf test suite locally (`EOtt.EOsprintfTest`) — all 20 tests pass.
