### PR TITLE
#5299: reject oversized positional index in sprintf instead of raw NumberFormatException

### DIFF
--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -101,6 +101,13 @@
         "Hello, %s! Bye, %1$s!"
         * "Jeff"
 
+  # Tests that sprintf throws a bounds error for a positional index too large
+  # to fit into long, instead of an uncaught NumberFormatException.
+  [] +> throws-on-sprintf-with-oversized-positional-index
+    sprintf > @
+      "%99999999999999999999$s"
+      * "Jeff"
+
   # Tests that sprintf handles mixed numbered and sequential parameters.
   [] +> formats-numbered-substitution-with-multiple-args
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
@@ -85,7 +85,18 @@ final class SprintfArgs {
             }
             final long arg;
             if (positional != null) {
-                arg = Long.parseLong(positional.substring(0, positional.length() - 1)) - 1L;
+                final String digits = positional.substring(0, positional.length() - 1);
+                try {
+                    arg = Long.parseLong(digits) - 1L;
+                } catch (final NumberFormatException ex) {
+                    throw new ExFailure(
+                        String.format(
+                            "The argument index %s is out of bounds (total arguments: %d)",
+                            digits, this.length
+                        ),
+                        ex
+                    );
+                }
             } else {
                 arg = auto;
                 auto += 1L;


### PR DESCRIPTION
Closes #5299.

`SprintfArgs.formatted()` parses positional argument specifiers (`%N$s`) with the regex
`%(\d+\$)?([a-zA-Z%])`, which places no upper bound on how many digits the positional index can
have, then calls `Long.parseLong(...)` on the captured digits with no try/catch. Since the format
string is arbitrary, fully user-controlled EO input, a positional index with more than 19 digits
(too large for `long`) reached `Long.parseLong` uncaught and crashed with a raw
`NumberFormatException` — e.g. `sprintf "%99999999999999999999$s" ...` — instead of the same
`ExFailure`-based "argument index ... is out of bounds" domain error this method already raises
for indices that parse fine but are simply too large for the argument list.

Wrapped the `Long.parseLong` call in a try/catch, converting `NumberFormatException` into the same
"out of bounds" `ExFailure` message (naming the offending digit string instead of a parsed index,
since parsing failed).

Added `throws-on-sprintf-with-oversized-positional-index` to `tt/sprintf.eo`, using the exact
`%99999999999999999999$s` reproduction from the issue.

Ran the full EO-generated sprintf test suite locally (`EOtt.EOsprintfTest`) — all 20 tests pass.
