### PR TITLE
#5304: mix relative path into Cache.dirSha so a file rename changes the hash

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -146,7 +146,7 @@ final class Cache {
                 stream.filter(Files::isRegularFile)
                     .filter(this.filter::test)
                     .sorted(Comparator.comparing(Path::toString))
-                    .map(p -> new Sha(p).toString())
+                    .map(p -> String.format("%s\u0000%s", dir.relativize(p), new Sha(p)))
                     .map(s -> s.getBytes(StandardCharsets.UTF_8))
                     .forEach(digest::update);
             }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -226,8 +226,12 @@ final class CacheTest {
             source.getFileName()
         );
         final MessageDigest instance = MessageDigest.getInstance("SHA-256");
-        instance.update(CacheTest.hash(first).getBytes(StandardCharsets.UTF_8));
-        instance.update(CacheTest.hash(second).getBytes(StandardCharsets.UTF_8));
+        instance.update(
+            String.format("file1.txt\u0000%s", CacheTest.hash(first)).getBytes(StandardCharsets.UTF_8)
+        );
+        instance.update(
+            String.format("file2.txt\u0000%s", CacheTest.hash(second)).getBytes(StandardCharsets.UTF_8)
+        );
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for folder with several files",
             Files.readString(
@@ -235,6 +239,40 @@ final class CacheTest {
                 StandardCharsets.UTF_8
             ),
             Matchers.equalTo(Base64.getEncoder().encodeToString(instance.digest()))
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void generatesDifferentHashesForFoldersWithDifferentlyNamedIdenticalFiles(
+        @Mktmp final Path temp
+    ) throws IOException {
+        final Path cache = temp.resolve("cache");
+        Files.createDirectories(cache);
+        final String content = "same content";
+        final Path first = temp.resolve("dirA");
+        Files.createDirectories(first);
+        Files.writeString(first.resolve("original-name.eo"), content, StandardCharsets.UTF_8);
+        new Cache(cache, p -> "compiled-a").apply(
+            first, temp.resolve("out-a.txt"), first.getFileName()
+        );
+        final Path second = temp.resolve("dirB");
+        Files.createDirectories(second);
+        Files.writeString(
+            second.resolve("completely-different-name.eo"), content, StandardCharsets.UTF_8
+        );
+        new Cache(cache, p -> "compiled-b").apply(
+            second, temp.resolve("out-b.txt"), second.getFileName()
+        );
+        MatcherAssert.assertThat(
+            "Directories with identically-content but differently-named files "
+                + "must produce different hashes",
+            Files.readString(cache.resolve("dirA.sha256"), StandardCharsets.UTF_8),
+            Matchers.not(
+                Matchers.equalTo(
+                    Files.readString(cache.resolve("dirB.sha256"), StandardCharsets.UTF_8)
+                )
+            )
         );
     }
 


### PR DESCRIPTION
Closes #5304.

`Cache.dirSha` — the production directory-hashing path used by `Linting`, `Transpiling`, and
`Parsing` to decide whether cached compiled output can be reused — hashed each regular file's
*content* independently (`new Sha(p).toString()`), sorted by path only for iteration order, but
never fed the path itself into the digest. Two single-file directories whose one file has
identical content but a different name produced the exact same per-file content hash, so
`dirSha(dirA)` and `dirSha(dirB)` came out byte-for-byte identical — even though a file's name is
semantically significant in this toolchain (the compiled output for `original-name.eo` encodes
that name). Since `Cache.apply` treats a `sha` match as "reuse the cached content," a rename that
happens to collide this way could make the cache silently serve compiled output built for a
different file name.

This is the other half of the defect already fixed for `Sha.hash`'s own directory branch in
#5254/#5262 — that fix addressed the delimiter-injection half (concatenating raw file *contents*
with no boundary), while `Cache.dirSha`'s independent reimplementation sidestepped that half (each
per-file contribution is already a fixed-length Base64 SHA-256 string) but never addressed the
path-omission half at all.

Mixed each file's relative path into the digest alongside its content hash, joined by a NUL byte
(`rel_path + "\0" + Sha(file)`, matching the fix suggested in the issue) — a NUL is safe as a
separator since file paths can't contain one, unlike a printable delimiter such as a space.

## Test

Updated the existing `generatesCorrectHashForEntireFolderWithSeveralFiles` test to expect the new
per-entry format (`"file1.txt\0" + hash` instead of just `hash`).

Added `generatesDifferentHashesForFoldersWithDifferentlyNamedIdenticalFiles`, reproducing the
exact scenario from the issue: two directories, `dirA/original-name.eo` and
`dirB/completely-different-name.eo`, both containing the same content, asserting their cached
`.sha256` files are no longer identical.

Ran the full `CacheTest` suite locally — all 10 tests pass.
