### PR TITLE
#5302: reject digits beyond long capacity in sscanf %d conversion instead of raw NumberFormatException

### DIFF
--- a/eo-runtime/src/main/eo/tt/sscanf.eo
+++ b/eo-runtime/src/main/eo/tt/sscanf.eo
@@ -58,6 +58,11 @@
   [] +> throws-on-sscanf-with-wrong-format
     sscanf "%l" "error" > @
 
+  # Tests that sscanf throws error for %d when the digits don't fit
+  # into long range, instead of an uncaught NumberFormatException.
+  [] +> throws-on-sscanf-with-oversized-int
+    sscanf "%d" "99999999999999999999" > @
+
   # Tests that sscanf parses multiple values with different format specifiers.
   [] +> tests-sscanf-with-string-int-float
     eq. > @

--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
@@ -42,7 +42,7 @@ public final class EOsscanf extends PhDefault implements Atom {
 
     static {
         EOsscanf.CONVERSION.put('s', ToPhi::new);
-        EOsscanf.CONVERSION.put('d', str -> new Data.ToPhi(Long.parseLong(str)));
+        EOsscanf.CONVERSION.put('d', str -> new Data.ToPhi(EOsscanf.parsed(str)));
         EOsscanf.CONVERSION.put('f', str -> new Data.ToPhi(Double.parseDouble(str)));
     }
 
@@ -120,6 +120,26 @@ public final class EOsscanf extends PhDefault implements Atom {
             }
         }
         return new Data.ToPhi(output.toArray(new Phi[0]));
+    }
+
+    /**
+     * Parse a digits-only match as {@code long} for the {@code %d} conversion,
+     * rejecting a match with more digits than {@code long} can hold.
+     * @param str Matched digits
+     * @return The parsed value
+     */
+    private static long parsed(final String str) {
+        try {
+            return Long.parseLong(str);
+        } catch (final NumberFormatException ex) {
+            throw new ExFailure(
+                String.format(
+                    "The number %s doesn't fit into long range for the '%%d' conversion",
+                    str
+                ),
+                ex
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #5302.

`EOsscanf`'s `%d` conversion captured digits with the unbounded regex `([+-]?\d+)` and converted
the match directly via `Long.parseLong(str)`, with no guard. A numeric string longer than 19
digits — more than `Long.MAX_VALUE` can hold — matches the regex fine but threw an uncaught
`NumberFormatException` when handed to `Long.parseLong`, so
`sscanf "%d" "99999999999999999999"` crashed with a raw Java exception instead of a clean domain
error. This is the same defect class already fixed for `sprintf`'s oversized positional index
(#5299/#5317) and `sprintf`'s `%d` saturation (#5306/#5316).

Extracted a `parsed(String)` helper that wraps `Long.parseLong` in a try/catch, converting
`NumberFormatException` into an `ExFailure` naming the offending input ("The number ... doesn't
fit into long range for the '%d' conversion"), and wired it into the `'d'` entry of the
`CONVERSION` map.

Added `throws-on-sscanf-with-oversized-int` to `tt/sscanf.eo`, using the exact
`"99999999999999999999"` reproduction from the issue, mirroring the neighboring
`throws-on-sscanf-with-wrong-format` test.

Ran the full EO-generated sscanf test suite locally (`EOtt.EOsscanfTest`) — all 14 tests pass.
