### PR TITLE
Migrate remaining error producers to ⊥/fallback or panic

### DIFF
--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -75,11 +75,12 @@
 
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i16` object.
-  # An `org.eolang.error` is returned if `x` is equal to `0`.
-  [x] > div
+  # When `x` is zero, the caller-supplied `cant-divide` fallback is returned,
+  # or the bottom object (⊥) when none was provided, which terminates on use.
+  [x cant-divide] > div
     if. > @
       xval.eq zero
-      error
+      cant-divide
         sprintf
           "Can't divide %d by i16 zero"
           * as-i32.as-i64.as-number
@@ -230,8 +231,17 @@
       -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
       32767.as-i64.as-i32.as-i16
 
-  # Tests that i16 division by zero throws an error.
+  # Tests that i16 division by zero with no fallback yields the bottom object
+  # (⊥) that terminates when used.
   2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] +> throws-on-division-i16-by-i16-zero
+
+  # Tests that i16 division by zero with a provided fallback yields the fallback.
+  [] +> tests-i16-div-by-zero-returns-provided-fallback
+    eq. > @
+      "recovered"
+      2.as-i64.as-i32.as-i16.div
+        0.as-i64.as-i32.as-i16
+        "recovered" > [msg]
 
   # Tests that i16 division by one returns the original value.
   [] +> tests-i16-div-by-i16-one

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -28,11 +28,11 @@
   # The conversion is validated by converting `left` back up to `org.eolang.i32` and
   # comparing it against the original value, so the check is exact for both signs
   # instead of relying on the upper two bytes alone.
-  [] > as-i16
+  [cant-convert] > as-i16
     if. > @
       ^.eq left.as-i32
       left
-      error
+      cant-convert
         sprintf
           "Can't convert i32 number %d to i16 because it's out of i16 bounds"
           * as-i64.as-number
@@ -90,11 +90,12 @@
 
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i32` object.
-  # An `error` is returned if `x` is equal to 0.
-  [x] > div
+  # When `x` is zero, the caller-supplied `cant-divide` fallback is returned,
+  # or the bottom object (⊥) when none was provided, which terminates on use.
+  [x cant-divide] > div
     if. > @
       xval.eq zero
-      error
+      cant-divide
         sprintf
           "Can't divide %d by i32 zero"
           * as-i64.as-number
@@ -267,11 +268,28 @@
       -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
       2147483647.as-i64.as-i32
 
-  # Tests that i32 division by zero throws an error.
+  # Tests that i32 division by zero with no fallback yields the bottom object
+  # (⊥) that terminates when used.
   2.as-i64.as-i32.div 0.as-i64.as-i32 > [] +> throws-on-division-i32-by-i32-zero
 
-  # Tests that converting i32 to i16 throws error when out of bounds.
+  # Tests that i32 division by zero with a provided fallback yields the fallback.
+  [] +> tests-i32-div-by-zero-returns-provided-fallback
+    eq. > @
+      "recovered"
+      2.as-i64.as-i32.div
+        0.as-i64.as-i32
+        "recovered" > [msg]
+
+  # Tests that converting i32 to i16 out of bounds with no fallback yields the
+  # bottom object (⊥) that terminates when used.
   247483647.as-i64.as-i32.as-i16 > [] +> throws-on-converting-to-i16-if-out-of-bounds
+
+  # Tests that an out-of-bounds i32-to-i16 conversion with a fallback yields it.
+  [] +> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
+    eq. > @
+      "recovered"
+      247483647.as-i64.as-i32.as-i16
+        "recovered" > [msg]
 
   # Tests that i32 division by one returns the original value.
   [] +> tests-i32-div-by-i32-one

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -17,13 +17,14 @@
   as-i32.as-i16 > as-i16
 
   # Convert this `org.eolang.i64` to `org.eolang.i32`.
-  # The `org.eolang.error` is returned if the `org.eolang.i64` number is more than
-  # max `org.eolang.i32` value `2147483647`.
-  [] > as-i32
+  # When the number is out of i32 bounds, the caller-supplied `cant-convert`
+  # fallback is returned, or the bottom object (⊥) when none was provided,
+  # which terminates on use.
+  [cant-convert] > as-i32
     if. > @
       ^.eq left.as-i64
       left
-      error
+      cant-convert
         sprintf
           "Can't convert i64 number %d to i32 because it's out of i32 bounds"
           * as-number
@@ -107,8 +108,16 @@
       -234.as-i64
       -234.as-i64.as-i32.as-i64
 
-  # Tests that converting i64 to i32 throws error when out of bounds.
+  # Tests that converting i64 to i32 out of bounds with no fallback yields the
+  # bottom object (⊥) that terminates when used.
   3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
+
+  # Tests that an out-of-bounds i64-to-i32 conversion with a fallback yields it.
+  [] +> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+    eq. > @
+      "recovered"
+      3147483647.as-i64.as-i32
+        "recovered" > [msg]
 
   # Tests that i32 max value converts to i32 without error.
   [] +> tests-i64-i32-max-converts-without-error

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -76,8 +76,11 @@
 
   # Quotient of the division of `$` by `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
-  # An `org.eolang.error` is returned if `x` is equal to 0.
+  # When `x` is zero, the division returns the caller-supplied `cant-divide`
+  # fallback instead, or the bottom object (⊥) when none was provided, which
+  # terminates on use.
   [x] > div /i64
+    ? > cant-divide /{string}
 
   # Tests that i64 number has correct byte representation.
   [] +> tests-i64-has-valid-bytes
@@ -234,19 +237,17 @@
       1.as-i64.minus 1.as-i64
       0.as-i64
 
-  # Tests that i64 division by zero throws an error.
+  # Tests that i64 division by zero with no fallback yields the bottom object
+  # (⊥) that terminates when used.
   2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
 
-  # Tests that i64 division by zero throws a catchable org.eolang.error,
-  # not an uncatchable JVM exception.
-  [] +> tests-i64-div-by-zero-throws-catchable-error
-    try > @
-      seq
-        *
-          2.as-i64.div 0.as-i64
-          false
-      true > [e]
-      false
+  # Tests that i64 division by zero with a provided fallback yields the fallback.
+  [] +> tests-i64-div-by-zero-returns-provided-fallback
+    eq. > @
+      "recovered"
+      2.as-i64.div
+        0.as-i64
+        "recovered" > [msg]
 
   # Tests that i64 division by one returns the original value.
   [] +> tests-i64-div-by-i64-one

--- a/eo-runtime/src/main/eo/ms/mod.eo
+++ b/eo-runtime/src/main/eo/ms/mod.eo
@@ -9,9 +9,12 @@
 # Calculate MOD.
 # An operation that finds the remainder after dividing `x` by `y`.
 [x y] > mod
+  # Recovery for a zero divisor: the caller-supplied `cant-mod` fallback, or
+  # the bottom object (⊥) when none was provided, which terminates on use.
+  ? > cant-mod
   if. > @
     divisor.eq 0
-    error "Can't calculate mod by zero"
+    cant-mod "cannot calculate mod by zero"
     if.
       dividend.gt 0
       abs-mod
@@ -87,3 +90,17 @@
     eq. > @
       mod 133 1
       0
+
+  # Tests that mod by zero with no fallback yields the bottom object (⊥)
+  # that terminates when used.
+  [] +> throws-on-mod-by-zero
+    mod 5 0 > @
+
+  # Tests that mod by zero with a provided fallback yields the fallback.
+  [] +> tests-mod-by-zero-returns-provided-fallback
+    eq. > @
+      "recovered"
+      mod
+        5
+        0
+        "recovered" > [msg]

--- a/eo-runtime/src/main/eo/ms/mod.eo
+++ b/eo-runtime/src/main/eo/ms/mod.eo
@@ -7,11 +7,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Calculate MOD.
-# An operation that finds the remainder after dividing `x` by `y`.
-[x y] > mod
-  # Recovery for a zero divisor: the caller-supplied `cant-mod` fallback, or
-  # the bottom object (⊥) when none was provided, which terminates on use.
-  ? > cant-mod
+# An operation that finds the remainder after dividing `x` by `y`. When `y`
+# is zero, the result is the caller-supplied `cant-mod` fallback, or the
+# bottom object (⊥) when none was provided, which terminates on use.
+[x y cant-mod] > mod
   if. > @
     divisor.eq 0
     cant-mod "cannot calculate mod by zero"

--- a/eo-runtime/src/main/eo/ms/numbers.eo
+++ b/eo-runtime/src/main/eo/ms/numbers.eo
@@ -14,9 +14,10 @@
 
   # Find max element in the numbers sequence.
   [] > max
+    ? > cant-max
     if. > @
       lst.is-empty
-      error "Can't get the max number from an empty sequence"
+      cant-max "cannot get the max number from an empty sequence"
       reduced
         lst
         ninf
@@ -29,9 +30,10 @@
 
   # Find min element in the numbers sequence.
   [] > min
+    ? > cant-min
     if. > @
       lst.is-empty
-      error "Can't get the min number from an empty sequence"
+      cant-min "cannot get the min number from an empty sequence"
       reduced
         lst
         pinf
@@ -42,11 +44,27 @@
             min
     list sequence > lst
 
-  # Tests that taking max from empty sequence throws error.
+  # Tests that taking max from an empty sequence with no fallback yields the
+  # bottom object (⊥) that terminates when used.
   (numbers *).max > [] +> throws-on-taking-max-from-empty-sequence-of-numbers
 
-  # Tests that taking min from empty sequence throws error.
+  # Tests that taking min from an empty sequence with no fallback yields the
+  # bottom object (⊥) that terminates when used.
   (numbers *).min > [] +> throws-on-taking-min-from-empty-sequence-of-numbers
+
+  # Tests that max of an empty sequence with a fallback yields the fallback.
+  [] +> tests-max-of-empty-returns-provided-fallback
+    eq. > @
+      "recovered"
+      (numbers *).max
+        "recovered" > [msg]
+
+  # Tests that min of an empty sequence with a fallback yields the fallback.
+  [] +> tests-min-of-empty-returns-provided-fallback
+    eq. > @
+      "recovered"
+      (numbers *).min
+        "recovered" > [msg]
 
   # Tests that max of single-item array returns that item.
   [] +> tests-max-of-one-item-array

--- a/eo-runtime/src/main/eo/ms/numbers.eo
+++ b/eo-runtime/src/main/eo/ms/numbers.eo
@@ -12,9 +12,10 @@
 [sequence] > numbers
   sequence > @
 
-  # Find max element in the numbers sequence.
-  [] > max
-    ? > cant-max
+  # Find max element in the numbers sequence. An empty sequence yields the
+  # caller-supplied `cant-max` fallback, or the bottom object (⊥) when none
+  # was provided.
+  [cant-max] > max
     if. > @
       lst.is-empty
       cant-max "cannot get the max number from an empty sequence"
@@ -28,9 +29,10 @@
             max
     list sequence > lst
 
-  # Find min element in the numbers sequence.
-  [] > min
-    ? > cant-min
+  # Find min element in the numbers sequence. An empty sequence yields the
+  # caller-supplied `cant-min` fallback, or the bottom object (⊥) when none
+  # was provided.
+  [cant-min] > min
     if. > @
       lst.is-empty
       cant-min "cannot get the min number from an empty sequence"

--- a/eo-runtime/src/main/eo/ss/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/ss/range-of-numbers.eo
@@ -8,8 +8,8 @@
 +unlint redundant-object
 
 # Range of numbers from `start` to `end` (soft border) with step = 1.
-# Here `start` and `end` must be `int`s. If they're not - an error will
-# be returned.
+# Here `start` and `end` must be `int`s. If they're not, the bottom object
+# (⊥) is returned, which terminates on use.
 [start end] > range-of-numbers
   if. > @
     and.
@@ -27,7 +27,7 @@
           num > @
           ^.build (1.plus @) > next
       end
-    error "Some of the arguments are not integers"
+    T "Some of the arguments are not integers"
 
   # Tests that simple range of integers from one to ten works correctly.
   [] +> tests-simple-range-of-numbers-from-one-to-ten

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -99,11 +99,11 @@
             matched-from-index
               position.plus 1
               to
-          error "Matched block does not exist, can't get next"
+          T "Matched block does not exist, can't get next"
         if. > text
           exists
           group 0
-          error "Matched block does not exist, can't get text"
+          T "Matched block does not exist, can't get text"
 
         # Returns the string subsequence captured by the group
         # by `index` during the `match` operation.

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
@@ -19,10 +19,18 @@ package org.eolang;
 public final class EOi64$EOdiv extends PhDefault implements Atom {
 
     /**
+     * Name of the error-branch void that holds the caller's divide-by-zero fallback.
+     */
+    private static final String FALLBACK = "cant-divide";
+
+    /**
      * Ctor.
      */
     public EOi64$EOdiv() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(
+            new Attr("x", new AtVoid("x")),
+            new Attr(EOi64$EOdiv.FALLBACK, new AtVoid(EOi64$EOdiv.FALLBACK))
+        ));
     }
 
     @Override
@@ -30,16 +38,14 @@ public final class EOi64$EOdiv extends PhDefault implements Atom {
     public Phi lambda() {
         final long dividend = new Expect.I64(Expect.at(this, Phi.RHO)).it();
         final long divisor = new Expect.I64(Expect.at(this, "x")).it();
+        final Phi result;
         if (divisor == 0L) {
-            throw new EOerror.ExError(
-                new Data.ToPhi("i64.div: division by zero")
-            );
+            result = this.take(EOi64$EOdiv.FALLBACK);
+            result.put(0, new Data.ToPhi("i64 cannot be divided by zero"));
+        } else {
+            result = Phi.Φ.take("i64").copy();
+            result.put(0, new Data.ToPhi(new BytesOf(dividend / divisor).take()));
         }
-        final Phi num = Phi.Φ.take("i64").copy();
-        num.put(
-            0,
-            new Data.ToPhi(new BytesOf(dividend / divisor).take())
-        );
-        return num;
+        return result;
     }
 }


### PR DESCRIPTION
Closes #5322. Part of #5261, continuing #5285. The epic replaces the execution-interrupting `error` with the ⊥/fallback model; this PR removes the remaining tractable catchable `error` raises in the standard library so those objects no longer produce an `ExError`.

Predictable, recoverable failures now route to a caller-supplied fallback, or the bottom object ⊥ when none is bound:

```
2.as-i64.div 0.as-i64                 # ⊥ (terminates on use)
2.as-i64.div 0.as-i64 (recovery)      # the recovery
```

| Object | Failure | Fallback |
|---|---|---|
| `i64.div`, `i16.div`, `i32.div` | division by zero | `cant-divide` |
| `ms.mod` | modulo by zero | `cant-mod` |
| `ms.numbers` `max`/`min` | empty sequence | `cant-max` / `cant-min` |
| `i32.as-i16`, `i64.as-i32` | narrowing conversion out of range | `cant-convert` |

The atom (`i64.div`) declares its fallback as `? > cant-divide /{string}` with a forma-list; the plain objects use a bracket param (`[x cant-divide]`, `[cant-max]`), since the vertical-void form is for atoms.

Failures with no place for a caller fallback become ⊥ carrying the reason (surfaced only if forced, per #5285's write-once cause):

- `regex.matched` `next`/`text` — a non-existent block (nullary attributes, like an empty tuple's `head`).
- `ss.range-of-numbers` — non-integer arguments (a contract violation).

The i64 div-by-zero test that relied on `try`-catchability is replaced by a returns-fallback test, since ⊥ is uncatchable by design — the first `try` consumer this epic touches. Each migrated object gains a returns-fallback test where it has a fallback; the existing throws-on tests still hold because forcing ⊥ aborts.

Out of scope, for their own follow-ups: `string.slice` and `ss.map.get` (further fallbacks); `string`'s UTF-8 decoding internals; `nk/socket.eo` (entangled with the socket object's own `try` blocks); `fs/file` (the filesystem-over-syscalls track); and `go`'s error-based backtracking plus the other `try` consumers, which must be reworked before `error`/`try` can be deleted outright.

Full `eo-runtime` suite is green (1412 tests) and qulice-clean.

Closes #5322