### PR TITLE
Migrate string and tt text operations to ⊥/fallback, and unmask ⊥ causes

### DIFF
--- a/eo-runtime/src/main/eo/ss/map.eo
+++ b/eo-runtime/src/main/eo/ss/map.eo
@@ -76,8 +76,9 @@
     # The returned object has two attributes: `exists` and `get`.
     # The `exists` attribute is either `true`, if object was found,
     # or `false` if was not.
-    # The `get` attribute returns either found object, or `error` if
-    # the object wasn't found.
+    # The `get` attribute takes a fallback and returns either the found
+    # object, or that fallback — the bottom object (⊥) when unbound — if
+    # the object was not found.
     # @todo #3251:30min Find a way to link hash code and index of key.
     #  Right now map is implemented as `tuple` of objects where every
     #  element is composition of three entities: hash, key and value.
@@ -107,16 +108,18 @@
               tup.head.hash.eq hash
               [] >>
                 true > exists
-                tup.head.value > get
+                [cant-get] > get
+                  tup.head.value > @
               not-found
         (rec-key-search tup.tail).@ > prev
       # Result when key is not found in map.
       [] > not-found
         false > exists
-        error > get
-          sprintf
-            "Object by hash code %d from given key does not exists"
-            * hash
+        [cant-get] > get
+          cant-get > @
+            sprintf
+              "Object by hash code %d from given key does not exists"
+              * hash
 
     # Returns the new `map` with added object
     # Replaces if there was one before.
@@ -275,3 +278,21 @@
         map.entry "one" 1
         map.entry "two" 2
     .with "two" 3 > mp
+
+  # Tests that get on a missing key with a fallback yields the fallback.
+  [] +> tests-map-get-missing-returns-provided-fallback
+    eq. > @
+      "recovered"
+      (mp.found "absent").get
+        "recovered" > [msg]
+    map > mp
+      *
+        map.entry "one" 1
+
+  # Tests that get on a missing key with no fallback yields the bottom object
+  # (⊥) that terminates when used.
+  [] +> throws-on-map-get-missing-without-fallback
+    (mp.found "absent").get > @
+    map > mp
+      *
+        map.entry "one" 1

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -45,7 +45,7 @@
     [index csize len] > inclen
       if. > @
         (index.plus csize).gt size
-        error
+        T
           sprintf
             "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
             * csize index as-bytes
@@ -71,7 +71,7 @@
               if.
                 (byte.and p4).eq r4
                 inclen index 4 accum
-                error
+                T
                   sprintf
                     "Unknown byte format (%x), can't recognize character"
                     * byte

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -81,13 +81,13 @@
   [start len] > slice
     if. > @
       nstart.lt 0
-      error
+      T
         sprintf
           "Start index must be >= 0, but was %d"
           * nstart
       if.
         nlen.lt 0
-        error
+        T
           sprintf
             "Length to slice must be >= 0, but was %d"
             * nlen
@@ -133,7 +133,7 @@
     [index csize accum result cause] > increase
       if. > @
         (index.plus csize).gt size
-        error
+        T
           sprintf
             "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
             * csize index as-bytes
@@ -155,7 +155,7 @@
         index
         if.
           index.eq size
-          error cause
+          T cause
           if.
             (byte.and p1).eq r1
             increase index 1 accum result cause
@@ -168,7 +168,7 @@
                 if.
                   (byte.and p4).eq r4
                   increase index 4 accum result cause
-                  error
+                  T
                     sprintf
                       "Unknown byte format (%x), can't recognize character"
                       * byte

--- a/eo-runtime/src/main/eo/tt/as-number.eo
+++ b/eo-runtime/src/main/eo/tt/as-number.eo
@@ -8,10 +8,11 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Returns the original `text` as `number`.
-[text] > as-number
+# If the text is not numeric - the `cant-parse` fallback is returned, or ⊥ when unbound.
+[text cant-parse] > as-number
   if. > @
     scanned.length.eq 0
-    error
+    cant-parse
       sprintf
         "Can't convert text %s to number"
         * text
@@ -24,9 +25,17 @@
       5
       as-number "5"
 
-  # Tests that as-number throws error when text is not numeric.
+  # Tests that as-number terminates with ⊥ on non-numeric text when no fallback is given.
   [] +> throws-on-converting-text-to-number
     as-number "Hello" > @
+
+  # Tests that as-number on non-numeric text with a fallback yields the fallback.
+  [] +> tests-non-numeric-text-returns-provided-fallback
+    eq. > @
+      42
+      as-number
+        "Hello"
+        42 > [msg]
 
   # Tests that as-number converts floating point string to number.
   [] +> tests-converts-float-text-to-number

--- a/eo-runtime/src/main/eo/tt/at.eo
+++ b/eo-runtime/src/main/eo/tt/at.eo
@@ -8,13 +8,13 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Retrieve symbol by given index as `text`.
-# If 0 > index >= ^.length - the error will be returned.
-[text i] > at
+# If 0 > index >= ^.length - the `out-of-bounds` fallback is returned, or ⊥ when unbound.
+[text i out-of-bounds] > at
   if. > @
     or.
       0.gt index
       (number index).gte len
-    error
+    out-of-bounds
       sprintf
         "Given index %d is out of text bounds"
         * index
@@ -44,6 +44,15 @@
       "m"
       at "some" -2
 
-  # Tests specific functionality at method throws error when index exceeds text length.
+  # Tests that at terminates with ⊥ when the index is out of bounds and no fallback is given.
   [] +> throws-on-text-at-index-more-than-length
     at "some" 10 > @
+
+  # Tests that at with an out-of-bounds index and a fallback yields the fallback.
+  [] +> tests-text-at-out-of-bounds-returns-provided-fallback
+    eq. > @
+      "recovered"
+      at
+        "some"
+        10
+        "recovered" > [msg]

--- a/eo-runtime/src/main/eo/tt/nsplit.eo
+++ b/eo-runtime/src/main/eo/tt/nsplit.eo
@@ -10,11 +10,11 @@
 
 # Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
-# If `limit` < 1, an error is returned.
-[text delimiter limit] > nsplit
+# If `limit` < 1, the `cant-split` fallback is returned, or ⊥ when unbound.
+[text delimiter limit cant-split] > nsplit
   if. > @
     1.gt limit
-    error
+    cant-split
       sprintf
         "Invalid limit %d for nsplit, must be at least 1"
         * limit
@@ -93,19 +93,29 @@
           10
       * "a" "b" "c"
 
-  # Tests that nsplit throws error with limit 0.
+  # Tests that nsplit terminates with ⊥ on limit 0 when no fallback is given.
   [] +> throws-on-nsplit-with-limit-zero
     nsplit > @
       "text"
       "-"
       0
 
-  # Tests that nsplit throws error with negative limit.
+  # Tests that nsplit terminates with ⊥ on a negative limit when no fallback is given.
   [] +> throws-on-nsplit-with-negative-limit
     nsplit > @
       "text"
       "-"
       -1
+
+  # Tests that nsplit with an invalid limit and a fallback yields the fallback.
+  [] +> tests-nsplit-invalid-limit-returns-provided-fallback
+    eq. > @
+      "fallback"
+      nsplit
+        "text"
+        "-"
+        0
+        "fallback" > [msg]
 
   # Tests that nsplit handles empty strings between delimiters.
   [] +> tests-nsplit-with-empty-strings

--- a/eo-runtime/src/main/eo/tt/repeated.eo
+++ b/eo-runtime/src/main/eo/tt/repeated.eo
@@ -7,12 +7,12 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Returns `text` repeated `times` times.
-# If `times` < 0, an error is returned.
+# If `times` < 0, the `cant-repeat` fallback is returned, or ⊥ when unbound.
 # If `times` == 0, empty text is returned.
-[text times] > repeated
+[text times cant-repeat] > repeated
   if. > @
     0.gt amount
-    error
+    cant-repeat
       sprintf
         "Can't repeat text %d times"
         * amount
@@ -33,11 +33,20 @@
         accum.concat bts
         (index.plus 1).as-number
 
-  # Tests specific functionality repeated method throws error when times is negative.
+  # Tests that repeated terminates with ⊥ on a negative count when no fallback is given.
   [] +> throws-on-text-repeating-less-than-zero-times
     repeated > @
       ""
       -1
+
+  # Tests that repeated with a negative count and a fallback yields the fallback.
+  [] +> tests-text-repeated-negative-times-returns-provided-fallback
+    eq. > @
+      "recovered"
+      repeated
+        "x"
+        -1
+        "recovered" > [msg]
 
   # Tests specific functionality repeated method returns empty string when times is zero.
   [] +> tests-text-repeated-zero-times-is-empty

--- a/eo-runtime/src/main/java/org/eolang/AtWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtWithRho.java
@@ -7,8 +7,8 @@ package org.eolang;
 
 /**
  * The attribute that tries to copy object and set \rho to it if it has not already set.
- * The terminator ⊥ ({@link PhTerminator}) is excluded: it is not a real object and never
- * takes a \rho, so no container leaks into it as it propagates.
+ * The terminator ⊥ ({@link PhTerminator}) silently ignores this \rho itself, so no container
+ * leaks into it and its cause is not masked as it propagates.
  * This attribute is NOT thread safe!
  * @since 0.36.0
  * @todo #4673:30min The {@link AtWithRho#get()} is not thread safe. If multiple threads
@@ -52,7 +52,7 @@ final class AtWithRho implements Attribute {
     @Override
     public Phi get() {
         Phi ret = this.original.get();
-        if (!(ret instanceof PhTerminator) && !ret.hasRho()) {
+        if (!ret.hasRho()) {
             ret = ret.copy();
             ret.put(Phi.RHO, this.rho);
         }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -21,10 +21,12 @@ package org.eolang;
  *
  * <p>A ⊥ may carry a <em>cause</em>: it has a single slot, addressable only
  * at position 0 (as in {@code T "why it failed"}). A {@code put} at any other
- * position, or any {@code put} by name, aborts — ⊥ has no named attributes,
- * and the ρ-binding the runtime would otherwise attempt is excluded upstream
- * in {@link AtWithRho}. The first object put at position 0 is remembered and
- * used as the panic message when the ⊥ is finally forced. The cause is
+ * position, or any {@code put} by name other than ρ, aborts — ⊥ has no named
+ * attributes. The ρ-binding the runtime attempts on every take (via
+ * {@link AtWithRho}) is silently ignored, since a ⊥ has no ρ; this keeps its
+ * cause from being masked by a ρ-rejection while it propagates. The first
+ * object put at position 0 is remembered and used as the panic message when
+ * the ⊥ is finally forced. The cause is
  * write-once and never handed back by {@link #take(String)}, so EO code can
  * neither read it nor catch it — it exists only to explain the termination
  * at the very top.</p>
@@ -68,9 +70,11 @@ public final class PhTerminator implements Phi {
 
     @Override
     public void put(final String name, final Phi object) {
-        throw new ExFailure(
-            "the ⊥ object does not accept attributes by name, but got '%s'", name
-        );
+        if (!Phi.RHO.equals(name)) {
+            throw new ExFailure(
+                "the ⊥ object does not accept attributes by name, but got '%s'", name
+            );
+        }
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -6,6 +6,7 @@ package org.eolang;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -105,6 +106,28 @@ final class AtWithRhoTest {
             "AtWithRho must call copy() on original object",
             res,
             Matchers.not(Matchers.is(obj))
+        );
+    }
+
+    @Test
+    void keepsCauseVisibleWhenBindingRhoOntoWrappedBottom() {
+        MatcherAssert.assertThat(
+            "AtWithRho must not mask the cause of a wrapped bottom object when it binds ρ",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(
+                    new AtWithRho(
+                        new AtComposite(
+                            new PhDefault(),
+                            phi -> new PhApplication(
+                                new PhTerminator(), 0, new Data.ToPhi("the deep reason")
+                            )
+                        ),
+                        new PhDefault()
+                    ).get()
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("the deep reason")
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -107,4 +107,12 @@ final class PhTerminatorTest {
             "putting into the bottom object by name, even cause, must abort"
         );
     }
+
+    @Test
+    void toleratesRhoBinding() {
+        Assertions.assertDoesNotThrow(
+            () -> new PhTerminator().put(Phi.RHO, new PhDefault()),
+            "binding ρ onto the bottom object must not abort"
+        );
+    }
 }


### PR DESCRIPTION
This clears the string and `tt` (text) families of the catchable `error` object, moving each failure onto the ⊥/fallback model the rest of the fragile-objects work (#5261) is converging on.

`map.get` now takes a fallback and returns it when the key is absent — a get-or-default. Left unbound the fallback is ⊥, so a missing key still terminates on use:

```
[cant-get] > get
  cant-get > @
    sprintf
      "Object by hash code %d from given key does not exists"
      * hash
```

The same fallback shape is given to the text operations whose failure is a clean top-level branch: `tt.at` gains an `out-of-bounds` fallback (mirroring `tuple.at`), and `tt.as-number`, `tt.nsplit` and `tt.repeated` gain `cant-parse` / `cant-split` / `cant-repeat`. Each is a get-or-default: pass a fallback and it is returned on failure, omit it and the operation terminates with ⊥.

`string.slice` and `string.length` instead terminate with ⊥ on every out-of-bounds or malformed-byte failure. Their failure is detected deep inside the recursive UTF-8 byte-walk whose result feeds later arithmetic, so a caller fallback cannot cleanly become the output — the same structural situation as `tuple.head`/`tuple.tail`, which already use ⊥. This clears `string.eo` of `error` entirely.

Verifying the slice change surfaced a pre-existing bug. A ⊥ carrying a cause (`T "why"`) is transpiled wrapped in `PhSafe`/`PhApplication`, so `AtWithRho`'s `instanceof PhTerminator` guard missed it, bound ρ onto it, and the strict put-by-name rule turned that into a panic that masked the real cause — `tuple.empty.head` reported *"does not accept attributes by name, but got 'ρ'"* instead of *"Can't get head from the empty tuple"*. The first commit fixes it at the source: ⊥ now silently ignores a ρ-binding (still rejecting any other name), and the now-redundant guard in `AtWithRho` is gone.

Still deferred: `string`/`tt` share nothing with the harder tail — `nk/socket` (built on its own `try`), `go` (error+try backtracking), and the `fs` family (its own syscall track).

Closes #5324.
