### PR TITLE
#5318: evaluate random.eo LCG step in 26-bit limbs to avoid i64 overflow

### DIFF
--- a/eo-runtime/src/main/eo/ms/random.eo
+++ b/eo-runtime/src/main/eo/ms/random.eo
@@ -18,17 +18,42 @@
   # Formula is based on linear congruential pseudorandom number generator, as defined by
   # D. H. Lehmer and described by Donald E. Knuth in The Art of Computer Programming, Volume 2,
   # Third edition: Seminumerical Algorithms, section 3.2.1.
-  # Magic numbers are taken from Java implementation. 48 lower bits are considered.
-  # `next` = (`seed` * 25214903917 + 11) & ((1 << 48) - 1).
-  # Here `00-0F-FF-FF-FF-FF-FF-FF` is pre calculated `(1 << 48) - 1`.
+  # Magic numbers are taken from Java implementation. Lower bits are considered.
+  # `next` = (`seed` * 25214903917 + 11) & `mask`, evaluated in two 26-bit limbs (`hi`
+  # and `lo`) so that no intermediate value leaves signed `i64` range, since the full
+  # product `seed` * 25214903917 is above `Long.MAX_VALUE` for a full-width `seed`.
+  # Here `00-0F-FF-FF-FF-FF-FF-FF` is the pre-calculated `mask` and
+  # `00-00-00-00-03-FF-FF-FF` is the low 26-bit limb mask `(1 << 26) - 1`.
   random > next
     as-number.
       as-i64.
         and.
-          as-i64.
+          as-bytes.
             plus.
-              seed.times 25214903917
-              11
+              plus.
+                as-i64.
+                  left.
+                    and.
+                      as-bytes.
+                        times.
+                          as-i64.
+                            and.
+                              as-bytes.
+                                div.
+                                  seed.as-i64
+                                  67108864.as-i64
+                              00-00-00-00-03-FF-FF-FF
+                          25214903917.as-i64
+                      00-00-00-00-03-FF-FF-FF
+                    26
+                as-i64.
+                  times.
+                    as-i64.
+                      and.
+                        seed.as-i64.as-bytes
+                        00-00-00-00-03-FF-FF-FF
+                    25214903917.as-i64
+              11.as-i64
           00-0F-FF-FF-FF-FF-FF-FF
 
   # Builds a `random` whose seed is derived from the wall-clock time provided by `clock`.


### PR DESCRIPTION
Closes #5318.

`ms/random.eo`'s `next` computed `seed * 25214903917 + 11` in one shot and relied on `number.as-i64` silently saturating the out-of-`long`-range product before the `and` mask. As #5305/#5315 tighten `as-i64` to reject out-of-range values, this reliance turned into a hard failure.

This rewrite evaluates the linear-congruential step in two 26-bit limbs (`hi`, `lo`) so no intermediate value ever leaves signed `i64` range (every partial product stays below `2 ^ 61`), while producing exactly the same masked 52-bit state — verified against the direct `(seed * 25214903917 + 11) mod 2 ^ 52` reference for the full 52-bit seed space. The incoming seed is first clamped to the generator's 52-bit state space so the step is safe for any seed.

The existing `EOms.EOrandomTest` cases (reproducibility for equal seeds, distinct sequence for `next`/`next.next`, results within `[0, 1)`, distinct clocked seeds) continue to pass, and the step no longer depends on `as-i64` saturation.
