### PR TITLE
Support a vertical-argument body on only-phi formations

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -483,7 +483,7 @@ There are **four base forms** of name suffix (mutually exclusive on any one line
 | `> [params] > name` | Inline-phi formation with **explicit** name. |
 | `> [params] >>` | Inline-phi formation with **auto-generated** name (the right-hand side `>>` replaces `> name`). |
 
-R-3.10.1. Inline-phi mechanics: the LHS of the leftmost `> [` is the formation's body (assigned to `φ` of the inline-phi formation); the formation itself is named by the suffix on the right. The LHS must fit on the same line — it is horizontal by construction. The line is closed for deeper-indent children (§4.5).
+R-3.10.1. Inline-phi mechanics: the LHS of the leftmost `> [` is the formation's body (assigned to `φ` of the inline-phi formation); the formation itself is named by the suffix on the right. The LHS head must fit on the same line. When the LHS carries no horizontal args its `φ` is open and accepts a deeper-indent vertical-argument block; when the LHS is a happlication the line is closed for deeper-indent children (§4.5).
 
 Examples:
 
@@ -629,23 +629,48 @@ See §3.9. After its child block, the kind remains **`compact-tuple`** but its o
 
 ### 4.5 Inline-phi formation
 
-A line whose suffix is `> [params] > name` is an **`inline-phi-formation`**:
+A line whose suffix is `> [params] > name` is an **`inline-phi-formation`**: the LHS of `> [` is the formation's `φ`, and the bracket params are its voids. Whether the line accepts a deeper-indent body depends on the LHS:
 
-- LHS of `> [` is horizontal by construction.
-- The line is **closed for deeper-indent children** (the body is the LHS, not a vertical block).
-- The line may freely appear as a vertical arg of an enclosing expression — its closure rule applies only to *its own* depth.
+- **Bare φ (LHS has no horizontal args)** — the φ is `open`. Deeper-indent lines attach to it as **vertical application arguments**, exactly as they would under a plain `vapplication` head. So `foo > [x] > bar` with a body block is `[x] > bar` whose `φ` is `foo` applied to that block:
+
+  ```
+  foo > [x] > bar                     ← φ = foo, param = x, name = bar
+    x.plus 42                         ← first vertical arg of foo
+  ```
+
+  is identical in XMIR to:
+
+  ```
+  [x] > bar
+    foo > @
+      x.plus 42
+  ```
+
+- **φ with horizontal args (LHS is a happlication)** — the φ is already a complete application, so the line is **`horizontal-completed`** and accepts no body (R-6.1.1).
+
+- The line may freely appear as a vertical arg of an enclosing expression — the rules above apply only to *its own* depth.
+
+The formation binds only `φ`, so its arguments may not introduce a second named attribute: **an only-phi argument may not carry a name suffix** (`> name`, `>>`, `+> name`). The ban follows the argument down through nested applications and resets inside a nested formation argument, where naming resumes as usual (§6.2). This is the one place a vertical-application argument may not be named (contrast C.3).
+
+Legal — a nested formation argument names its own attributes:
 
 ```
-foo                                   ← vapplication head
-  a                                   ← arg 1
-  b > [x] > bar                       ← arg 2: inline-phi-formation with body=b, param=x, name=bar
+foo > [] >>
+  [y]                                 ← unnamed formation argument
+    z > w                             ← attribute of [y], named as usual
 ```
 
-Illegal:
+Illegal — a name suffix on an only-phi argument:
 
 ```
-io.stdout > [s] >> name
-  some-deeper-arg                     ← rejected: inline-phi line closed for deeper children
+foo > [] >>
+  bar > x                             ← rejected: only-phi argument cannot be named
+```
+
+```
+foo > [] >>
+  bar
+    baz > x                           ← rejected: still in argument position
 ```
 
 ### 4.6 Triple-quoted text block
@@ -711,8 +736,9 @@ R-5.2.2. When popping an entry at indent `K + 2` (so the new top is at indent `K
 **Step B — Same-indent line.** If the top entry now has indent = `N`:
 
 R-5.2.3. **MethodDispatch line dispatch.** If the line's kind is `MethodDispatch` (`.method` continuation):
-  - **(a) Extend:** If the top's openness ∈ {`open`, `vertical-completed`} AND the top's kind is **not** in the horizontally-completed set (Appendix A): extend the top's kind to `vmethod` (or to `vmethod-with-hargs` if the new line carries ≥1 hargs), update `named?` if the line carries a name suffix, leave openness `open` (or transition to `horizontal-completed` if the new kind is `vmethod-with-hargs`).
+  - **(a) Extend:** If the top's openness ∈ {`open`, `vertical-completed`} AND the top's kind is **not** in the horizontally-completed set (Appendix A) AND the top's kind is **not** `inline-phi-formation`: extend the top's kind to `vmethod` (or to `vmethod-with-hargs` if the new line carries ≥1 hargs), update `named?` if the line carries a name suffix, leave openness `open` (or transition to `horizontal-completed` if the new kind is `vmethod-with-hargs`).
   - **(b) Reject — horizontally-completed predecessor:** If the top's openness is `horizontal-completed` (equivalently, kind ∈ horizontally-completed set): error `method continuation not allowed after horizontal application` (§9.9).
+  - **(b′) Reject — only-phi predecessor:** If the top's kind is `inline-phi-formation` (whose bare-φ form is `open` but is not a method-chain host): error `method continuation not allowed after only-phi formation` (§9.9).
 
 R-5.2.4. **Non-MethodDispatch same-indent line.** If the line's kind is **not** MethodDispatch: the top entry is a *completed previous sibling*. Run close-time checks (§5.3) on it, then **replace** it with a new entry built from the new line. The new entry's `parent_kind` is read from the stack entry below.
 
@@ -744,7 +770,7 @@ R-5.3.5. **Test depth.** If the popped entry's name suffix is `+>`, the popped e
   - the popped entry's parent's own `parent_kind` must be `top-level` (otherwise the parent is itself nested, also illegal).
   
   Either failure yields error `test attribute legal only as direct child of top-level object` (R-6.3.3 / §9.9). The first failure case covers a stray `+>` at indent 0; the second covers `+>` at indent ≥ 4.
-R-5.3.6. **Inline-phi closure violation.** If `kind = inline-phi-formation` and the entry had any children pushed under it: error (caught at child-push time, R-5.2.6 + R-4.5).
+R-5.3.6. **Inline-phi argument rules.** An `inline-phi-formation` whose φ carries horizontal args is closed for deeper children (caught at child-push time via R-6.1.1). When its φ is bare, deeper children attach as φ's vertical arguments; because the formation binds only φ, such an argument may not be named — at close time an argument entry that carries a name suffix yields error `argument of an only-phi formation cannot carry a name suffix` (§9.9). The ban propagates down through nested applications and resets at a formation boundary (§4.5).
 
 ### 5.4 End-of-file (FSM action)
 
@@ -760,7 +786,7 @@ These rules state the contract in terms of cross-line behavior. Each rule is mec
 
 A horizontally-completed expression cannot be extended. Specifically:
 
-R-6.1.1. An expression whose outer kind is in the horizontally-completed set (defined once in Appendix A — currently `{happlication, reversed-with-hargs, vmethod-with-hargs, inline-phi-formation}`) admits:
+R-6.1.1. An expression whose outer kind is in the horizontally-completed set (defined once in Appendix A — currently `{happlication, reversed-with-hargs, vmethod-with-hargs}`) admits:
 - No deeper-indent children.
 - No same-indent `.method` continuation.
 
@@ -771,6 +797,8 @@ R-6.1.2. An expression whose outer kind is one of `head`, `hmethod` (0 hargs), `
 R-6.1.3. An expression whose openness is `vertical-completed` — i.e., `vapplication`, `vmethod`, `bare-reversed`, `bare-formation`, or `compact-tuple` whose child block has ended — is:
 - May not receive more deeper-indent children (the block is over).
 - May be wrapped by a same-indent `.method`, which transitions it back to `vmethod` (still `open`).
+
+R-6.1.4. An `inline-phi-formation` is governed by its openness rather than a fixed set membership. A φ with horizontal args starts `horizontal-completed` (R-6.1.1). A bare φ is `open` and admits deeper-indent children — its φ's vertical arguments (§4.5) — but, unlike the open kinds of R-6.1.2, it may **not** be wrapped by a same-indent `.method` (error `method continuation not allowed after only-phi formation`, §5.2.3(b′)); wrapping the formation would misattribute the method as a second attribute.
 
 Examples:
 
@@ -1096,7 +1124,7 @@ For each outer kind, this table fixes the order of `<o>` children inside its emi
 | `hmethod` (single line, 0 hargs) | Emits a **sequence of sibling `<o>`s** under the enclosing parent: (1) the receiver of the chain as the first sibling; (2) one `<o base='.<methodname>' method=''>` per `.method` segment, in source order. Because the whole chain lives on **one source line**, only the last `.method` segment can carry a name suffix (the line's `> name`); intermediate segments on the same line have no syntactic place for their own name. (The intermediate-names provision of R-6.2.3 applies only to `vmethod` chains, where each `.method` is on its own line.) See R-9.0.3 for the convention. |
 | `happlication`, `vapplication` | The outer `<o>` carries `@base = head reference` (or, for chained heads, the last link's `<o>` is the outer one — R-9.0.3.1). Arguments emit as direct children of that `<o>` in source order. |
 | `bare-formation` | (1) void params from the `[...]` head, in source order; (2) all body children — plain, master, and `+>` test attributes — in source order as they appear in the body. The parser does **not** reorder children by category; the category distinction in §1.3 is about role and naming requirements, not emission order. |
-| `inline-phi-formation` | (1) void params from `> [params]` in source order; (2) the LHS expression as a single child with `@name='φ'`. The line is closed for further children (R-6.1.1) — there are no plain, master, or test children for this kind. |
+| `inline-phi-formation` | (1) void params from `> [params]` in source order; (2) the LHS expression as a single child with `@name='φ'`. When the LHS has no horizontal args this `φ` `<o>` stays open, and deeper-indent lines emit inside it as its vertical arguments (`@as='αN'`, per `vapplication`); at close time the φ `<o>` and the formation `<o>` are both closed. When the LHS has horizontal args the φ is closed at emit time and the line accepts no children (R-6.1.1). The formation's other attribute slots stay empty — its only bound attribute is `φ` — so an argument may not carry a name suffix (R-5.3.6). |
 | Atom (formation + `/sig`) | (1) void params in source order; (2) `<o name='λ' atom='<sig>'/>` marker; (3) test attributes (`+>`) in source order |
 | `bare-reversed` (vertical) | (1) the receiver's `<o>` first; (2) each method-arg `<o>` in source order |
 | `reversed-with-hargs` | same as `bare-reversed` — receiver first, args in source order |
@@ -1165,6 +1193,8 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Tab in leading whitespace | `tab character in leading whitespace` |
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application` |
+| `.method` continuation on an only-phi formation | `method continuation not allowed after only-phi formation` |
+| Name suffix on an only-phi φ's argument | `argument of an only-phi formation cannot carry a name suffix` |
 | `.method` line at top level, deeper than parent, or with no same-indent sibling | `method continuation has no expression to attach to` |
 | Chained inline-phi suffix `expr > [a] > [b] > name` | `chained inline-phi suffixes are not allowed` |
 | Inline-phi without a name on the right (`expr > [params]` alone) | `inline-phi formation must carry a name on the right` |
@@ -1219,7 +1249,7 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 | `bare-reversed` | 1 line + body | yes (receiver+args) | yes (after) | `name.` vertical form |
 | `reversed-with-hargs` | 1 line | **no** | **no** | `name. arg1 arg2…` |
 | `compact-tuple` | 1 line + body | yes (tuple+direct args) | yes (after) | `head *N` |
-| `inline-phi-formation` | 1 line | **no** | **no** | `expr > [params] > name` |
+| `inline-phi-formation` | 1 line (+ body if bare φ) | yes if φ has 0 hargs (φ's vertical args); **no** if φ has hargs | **no** | `expr > [params] > name`; a bare φ opens for a vertical-argument block (§4.5), and its arguments may not be named (R-5.3.6) |
 | `vapplication` | multi-line | yes while in progress | yes after block closes | head + vertical block |
 | `vmethod` | multi-line | yes while in progress (only if last `.method` has 0 hargs) | yes (more `.method`s extend the chain; same-indent `.method` after block closes wraps it) | chain of `.method` continuations |
 | `vmethod-with-hargs` | multi-line | **no** | **no** | a `.method` continuation line that itself carries ≥1 horizontal args — closes the chain immediately |
@@ -1228,10 +1258,10 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 **Horizontally-completed kinds (the single source of truth)** — these never receive deeper children and cannot be wrapped by same-indent `.method`:
 
 ```
-{ happlication, reversed-with-hargs, vmethod-with-hargs, inline-phi-formation }
+{ happlication, reversed-with-hargs, vmethod-with-hargs }
 ```
 
-R-5.2.3 and R-6.1.1 reference this set; if the set changes, change it here, not in those rules.
+R-5.2.3 and R-6.1.1 reference this set; if the set changes, change it here, not in those rules. An `inline-phi-formation` is **not** a member: its openness depends on its φ (R-6.1.4) — a bare φ is `open` (but still not wrappable by `.method`, §5.2.3(b′)), a φ with hargs is `horizontal-completed`.
 
 ## Appendix B — Per-line shape decision table
 
@@ -1269,7 +1299,7 @@ Reproduced from §3.1 for convenience:
         *                             ← R-3.6: star tuple as head; becomes vapplication
           x.put 2                     ← R-3.6: happlication, horizontally-completed (R-6.1.1)
           loop                        ← R-3.6: bare head
-            x.lt 6 > [i] >>           ← R-3.10 inline-phi: outer = inline-phi-formation, closed for deeper children
+            x.lt 6 > [i] >>           ← R-3.10 inline-phi: outer = inline-phi-formation; φ `x.lt 6` has a harg, so closed for deeper children (§4.5)
             [i] >>                    ← R-3.4: formation
               true
 ```
@@ -1351,7 +1381,7 @@ Notable points:
 - **Horizontal reversed dispatch (`eq. (mod. y 4) 0`)** appears 4× in this snippet. R-3.8.2 and R-6.6.3 govern it.
 - **Receiver as paren group**: `(mod. y 4)` is the receiver of `.eq`. Per R-3.8.2, the first horizontal arg is always the receiver.
 - **`mod. y 4`**: receiver = `y` (just an identifier — receivers don't have to be paren groups), method arg = `4`. Same as `y.mod 4` in regular notation.
-- **`year!` on a vapp arg**: a vapplication's vertical args may each carry an independent name suffix. This is orthogonal to the all-or-nothing binding rule (R-6.6.2 governs `:label` bindings, not `> name` suffixes).
+- **`year!` on a vapp arg**: a vapplication's vertical args may each carry an independent name suffix. This is orthogonal to the all-or-nothing binding rule (R-6.6.2 governs `:label` bindings, not `> name` suffixes). The sole exception is an argument of an only-phi formation's φ, which may not be named (§4.5 / R-5.3.6), since that formation binds only `φ`.
 - **`:y` binding on `leap year:y`**: inside the paren group, `leap` is applied to `year` with binding `:y`. Single-arg application, all-or-nothing trivially satisfied.
 
 This snippet exercises hmethod chains, horizontal reversed dispatch, paren groups, vapplication, name suffixes with `!`, and `:label` bindings — every major construct except text blocks and compact tuples.

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -652,13 +652,16 @@ final class Eo implements Iterable<Directive> {
      * <p>Runs semantic checks on the popped level and balances the XML
      * cursor with an {@link Emit#close()} — every {@link Level} pushed
      * corresponds to one open {@code <o>} that must be closed when the
-     * level pops.</p>
+     * level pops. Two kinds open a second {@code <o>} and so emit an
+     * extra close: a compact tuple (its {@code Φ.tuple} wrapper) and an
+     * open only-phi formation (its φ application, left open for vertical
+     * arguments per §4.5).</p>
      *
-     * <p>For this slice the only semantic check is R-5.3.1 (naming
-     * requirement for plain children of formations and top-level
-     * objects). The atom-body, bare-reversed, compact-tuple, test-depth
-     * and only-phi-closure checks attach as their owning line shapes
-     * are implemented.</p>
+     * <p>Checks: R-5.3.1 (naming requirement for plain children of
+     * formations and top-level objects), the only-phi argument-naming
+     * ban (§4.5), bare-reversed receiver presence, and the compact-tuple
+     * count. Atom-body and test-depth checks attach as their owning line
+     * shapes are implemented.</p>
      *
      * @param level The level being closed
      * @param emit The directives sink
@@ -669,14 +672,7 @@ final class Eo implements Iterable<Directive> {
         } catch (final ParseError err) {
             emit.error(err.line(), err.pos(), err.getMessage());
         }
-        if (!level.named()
-            && (level.parent() == Kind.TOP_LEVEL
-                || level.parent() == Kind.BARE_FORMATION)) {
-            emit.error(
-                level.start(), level.indent(),
-                "object inside formation must have a name"
-            );
-        }
+        Eo.checkNaming(level, emit);
         if (level.kind() == Kind.BARE_REVERSED && !level.taken()) {
             emit.error(
                 level.start(), level.indent(),
@@ -686,7 +682,36 @@ final class Eo implements Iterable<Directive> {
         if (level.kind() == Kind.COMPACT_TUPLE) {
             Eo.closeCompactTuple(level, emit);
         }
+        if (level.kind() == Kind.ONLY_PHI_FORMATION
+            && level.openness() != Openness.HORIZONTAL_COMPLETED) {
+            emit.close();
+        }
         emit.close();
+    }
+
+    /**
+     * Report naming violations on the popped level: a plain child of a
+     * formation or top-level object that lacks a name (R-5.3.1), and an
+     * only-phi argument that carries one — the formation binds only φ,
+     * so its φ's arguments may not be named (§4.5).
+     * @param level The level being closed
+     * @param emit The directives sink
+     */
+    private static void checkNaming(final Level level, final Emit emit) {
+        if (!level.named()
+            && (level.parent() == Kind.TOP_LEVEL
+                || level.parent() == Kind.BARE_FORMATION)) {
+            emit.error(
+                level.start(), level.indent(),
+                "object inside formation must have a name"
+            );
+        }
+        if (level.argument() && level.named()) {
+            emit.error(
+                level.start(), level.indent(),
+                "argument of an only-phi formation cannot carry a name suffix"
+            );
+        }
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -14,12 +14,14 @@ package org.eolang.parser;
  * once the first deeper child appears). The same kind progresses through
  * {@link Openness} states; the kind name itself never regresses.</p>
  *
- * <p>The four kinds in the horizontally-completed set
+ * <p>The three kinds in the horizontally-completed set
  * ({@link #HAPPLICATION}, {@link #REVERSED_WITH_HARGS},
- * {@link #VMETHOD_WITH_HARGS}, {@link #ONLY_PHI_FORMATION}) never
- * receive deeper children and cannot be wrapped by a same-indent
- * {@code .method}. {@link #horizontallyCompleted()} is the single source
- * of truth for that set; R-5.2.3 and R-6.1.1 read it.</p>
+ * {@link #VMETHOD_WITH_HARGS}) never receive deeper children and cannot
+ * be wrapped by a same-indent {@code .method}.
+ * {@link #horizontallyCompleted()} is the single source of truth for
+ * that set; R-5.2.3 and R-6.1.1 read it. An {@link #ONLY_PHI_FORMATION}
+ * with a bare (zero-hargs) φ is instead {@link Openness#OPEN}: its φ
+ * accepts deeper-indent vertical arguments (§4.5).</p>
  *
  * <p>The {@link #TOP_LEVEL} sentinel is not a real expression kind — it is
  * the {@code parent_kind} for entries pushed at indent 0 (R-5.2.11), used
@@ -74,7 +76,9 @@ enum Kind {
     COMPACT_TUPLE,
 
     /**
-     * Only-phi formation {@code expr > [params] > name}. Horizontally completed.
+     * Only-phi formation {@code expr > [params] > name}. Horizontally
+     * completed when the φ (its {@code expr}) carries horizontal args;
+     * otherwise open, so its φ accepts deeper-indent vertical arguments.
      */
     ONLY_PHI_FORMATION,
 
@@ -118,7 +122,22 @@ enum Kind {
     boolean horizontallyCompleted() {
         return this == HAPPLICATION
             || this == REVERSED_WITH_HARGS
-            || this == VMETHOD_WITH_HARGS
-            || this == ONLY_PHI_FORMATION;
+            || this == VMETHOD_WITH_HARGS;
+    }
+
+    /**
+     * Whether this kind opens a formation — a fresh naming scope whose
+     * direct children are named attributes rather than positional
+     * arguments.
+     *
+     * <p>Read by {@link Stack} to stop the only-phi argument-position
+     * flag at a nested formation boundary: inside a formation, naming
+     * resumes as usual (§6.2), so the no-name-on-argument rule of §4.5
+     * must not leak past it.</p>
+     *
+     * @return True iff this kind is a formation
+     */
+    boolean formation() {
+        return this == BARE_FORMATION || this == ONLY_PHI_FORMATION;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -86,6 +86,15 @@ final class Level {
     private boolean plain;
 
     /**
+     * True when this entry sits in argument position under an only-phi
+     * formation's φ — set by {@link Stack} as it propagates the flag
+     * down through nested applications and resets it at a formation
+     * boundary. Read at close time to reject a name suffix on such an
+     * argument (§4.5).
+     */
+    private boolean argument;
+
+    /**
      * For {@link Kind#COMPACT_TUPLE}: the {@code N} count from {@code *N}.
      */
     private int count;
@@ -231,6 +240,34 @@ final class Level {
      */
     boolean taken() {
         return this.taken;
+    }
+
+    /**
+     * Whether this entry is an argument of an only-phi formation's φ.
+     * @return Argument-position flag
+     */
+    boolean argument() {
+        return this.argument;
+    }
+
+    /**
+     * Whether a child pushed under this entry sits in argument position
+     * of an only-phi formation's φ (§4.5): true for a direct child of
+     * the only-phi entry, and for a deeper child that stays in argument
+     * position — the flag propagates down through nested applications
+     * but resets at a formation boundary, where naming resumes.
+     * @return True if a child of this entry is an only-phi argument
+     */
+    boolean argumentative() {
+        return this.kind == Kind.ONLY_PHI_FORMATION
+            || this.argument && !this.kind.formation();
+    }
+
+    /**
+     * Flag this entry as an argument of an only-phi formation's φ.
+     */
+    void argues() {
+        this.argument = true;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -132,6 +132,12 @@ final class LnMethod implements Line {
                 "method continuation not allowed after horizontal application"
             );
         }
+        if (stack.top().kind() == Kind.ONLY_PHI_FORMATION) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "method continuation not allowed after only-phi formation"
+            );
+        }
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -27,9 +27,16 @@ import java.util.List;
  *   {@code >>}).</li>
  * </ul>
  *
- * <p>Outer kind: {@link Kind#ONLY_PHI_FORMATION}. Openness:
- * {@link Openness#HORIZONTAL_COMPLETED} — no deeper-indent children
- * permitted (R-6.1.1).</p>
+ * <p>Outer kind: {@link Kind#ONLY_PHI_FORMATION}. Openness depends on
+ * the φ (the LHS): with zero horizontal args the φ is
+ * {@link Openness#OPEN}, so deeper-indent lines attach to it as
+ * vertical application arguments (§4.5) — {@code foo > [x] > bar} with
+ * a body block is {@code [x] > bar} whose φ is {@code foo} applied to
+ * that block. With horizontal args the φ is already a full application
+ * and the line is {@link Openness#HORIZONTAL_COMPLETED} — no body is
+ * accepted. An only-phi argument may not carry a name suffix (the
+ * formation binds only φ); the {@link Stack} flags such arguments and
+ * the close-time check in {@link Eo} rejects a name on them.</p>
  *
  * <p>This iteration accepts identifier and root LHS heads with
  * optional chains and identifier / INT / STAR / STRING / FLOAT /
@@ -84,12 +91,19 @@ final class LnOnlyPhi implements Line {
         final List<String> params = LnOnlyPhi.parseParams(
             body.substring(bracket + 1, close), this.span, bracket + 1
         );
-        final String rhs = body.substring(close + 1);
         final Suffix suffix = new Suffix(
-            rhs, this.span, this.span.indent() + close + 1
+            body.substring(close + 1), this.span, this.span.indent() + close + 1
         );
+        final Span inner = new Span(
+            " ".repeat(this.span.indent()).concat(lhs), this.span.line()
+        );
+        final Tokens tokens = new Tokens(inner.body(), inner);
+        final Value head = tokens.readValue();
+        final List<MethodChain> chain = tokens.readChain();
+        final List<Value> args = tokens.readArgs();
+        final boolean open = args.isEmpty();
         Comments.attach(globals, emit, this.span, suffix.present() || suffix.test());
-        this.transition(stack, suffix);
+        this.transition(stack, suffix, open);
         globals.clearBlanks();
         globals.markEmitted();
         emit.object(
@@ -110,27 +124,29 @@ final class LnOnlyPhi implements Line {
             emit.voidParam(mapped, this.span.line(), column);
             column = column + param.length() + 1;
         }
-        this.emitLhs(emit, lhs);
+        this.emitLhs(emit, head, chain, args, open);
     }
 
     /**
-     * Parse and emit the LHS expression as a single child with
-     * {@code @name='φ'}. The LHS is an application expression — head +
-     * optional chain + optional hargs. Emission mirrors
-     * {@link LnApplication} but the topmost element carries
-     * {@code @name='φ'} and is closed by this method (the formation's
-     * {@code <o>} is what stays open for the {@link Stack.Closer}).
+     * Emit the pre-parsed LHS expression as a single child with
+     * {@code @name='φ'}. Emission mirrors {@link LnApplication}: the
+     * topmost element (head with no chain, or the chain's last link)
+     * carries {@code @name='φ'}. When {@code open} the φ {@code <o>} is
+     * left on the cursor so deeper-indent lines attach to it as
+     * vertical arguments, and the {@link Stack.Closer} closes both it
+     * and the formation; otherwise the φ is closed here (its horizontal
+     * args are complete) and only the formation stays open.
      * @param emit Emitter
-     * @param lhs The LHS substring
+     * @param head The pre-read head value
+     * @param chain The pre-read method chain (may be empty)
+     * @param args The pre-read horizontal args (may be empty)
+     * @param open Whether the φ stays open for vertical arguments
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
-    private void emitLhs(final Emit emit, final String lhs) {
-        final Span inner = new Span(
-            " ".repeat(this.span.indent()).concat(lhs), this.span.line()
-        );
-        final Tokens tokens = new Tokens(inner.body(), inner);
-        final Value head = tokens.readValue();
-        final List<MethodChain> chain = tokens.readChain();
-        final List<Value> args = tokens.readArgs();
+    private void emitLhs(
+        final Emit emit, final Value head, final List<MethodChain> chain,
+        final List<Value> args, final boolean open
+    ) {
         if (chain.isEmpty()) {
             Emissions.openValue(emit, "φ", head, this.span.line());
         } else {
@@ -149,19 +165,28 @@ final class LnOnlyPhi implements Line {
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, this.span.line());
         }
-        emit.close();
+        if (!open) {
+            emit.close();
+        }
     }
 
     /**
-     * Push or replace the stack level per Step B/C/D of §5.2.
+     * Push or replace the stack level per Step B/C/D of §5.2. A bare
+     * (zero-hargs) φ opens the level for vertical arguments; a φ that
+     * already carries horizontal args is horizontally completed.
      * @param stack The stack
      * @param suffix Right-hand-side suffix
+     * @param open Whether the φ has no horizontal args
      */
-    private void transition(final Stack stack, final Suffix suffix) {
+    private void transition(final Stack stack, final Suffix suffix, final boolean open) {
+        final Openness openness;
+        if (open) {
+            openness = Openness.OPEN;
+        } else {
+            openness = Openness.HORIZONTAL_COMPLETED;
+        }
         new Transition(stack, this.span).apply(
-            Kind.ONLY_PHI_FORMATION,
-            Openness.HORIZONTAL_COMPLETED,
-            suffix.present() || suffix.test()
+            Kind.ONLY_PHI_FORMATION, openness, suffix.present() || suffix.test()
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -166,6 +166,7 @@ final class Stack {
     ) {
         final Kind parent;
         final boolean patom;
+        final boolean argues;
         if (this.levels.isEmpty()) {
             if (indent != 0) {
                 throw new IllegalStateException(
@@ -176,6 +177,7 @@ final class Stack {
             }
             parent = Kind.TOP_LEVEL;
             patom = false;
+            argues = false;
         } else {
             final Level under = this.top();
             if (indent != under.indent() + Stack.STEP) {
@@ -188,12 +190,16 @@ final class Stack {
             }
             parent = under.kind();
             patom = under.atom();
+            argues = under.argumentative();
             under.observeVoid(kind, line, indent);
         }
         if (!this.levels.isEmpty()) {
             this.opener.beforeChild(this.top());
         }
         final Level fresh = new Level(indent, line, kind, openness, parent, patom);
+        if (argues) {
+            fresh.argues();
+        }
         this.levels.add(fresh);
         if (parent == Kind.BARE_REVERSED) {
             final Level host = this.levels.get(this.levels.size() - 2);
@@ -244,17 +250,23 @@ final class Stack {
         final int indent = old.indent();
         final Kind parent;
         final boolean patom;
+        final boolean argues;
         if (this.levels.isEmpty()) {
             parent = Kind.TOP_LEVEL;
             patom = false;
+            argues = false;
         } else {
             final Level under = this.top();
             parent = under.kind();
             patom = under.atom();
+            argues = under.argumentative();
             under.observeVoid(kind, line, indent);
             this.opener.beforeChild(under);
         }
         final Level fresh = new Level(indent, line, kind, openness, parent, patom);
+        if (argues) {
+            fresh.argues();
+        }
         this.levels.add(fresh);
         return fresh;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/KindTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/KindTest.java
@@ -22,8 +22,7 @@ final class KindTest {
         names = {
             "HAPPLICATION",
             "REVERSED_WITH_HARGS",
-            "VMETHOD_WITH_HARGS",
-            "ONLY_PHI_FORMATION"
+            "VMETHOD_WITH_HARGS"
         }
     )
     void marksHorizontallyCompletedKinds(final Kind kind) {
@@ -39,7 +38,8 @@ final class KindTest {
         value = Kind.class,
         names = {
             "TOP_LEVEL", "HEAD", "HMETHOD", "BARE_FORMATION", "BARE_REVERSED",
-            "COMPACT_TUPLE", "VAPPLICATION", "VMETHOD", "TEXT_BLOCK"
+            "COMPACT_TUPLE", "ONLY_PHI_FORMATION", "VAPPLICATION", "VMETHOD",
+            "TEXT_BLOCK"
         }
     )
     void leavesOtherKindsOutOfHorizontallyCompletedSet(final Kind kind) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -32,12 +32,24 @@ final class LnOnlyPhiTest {
     }
 
     @Test
-    void marksHorizontallyCompleted() {
+    void opensBarePhiForVerticalArgs() {
         final Stack stack = new Stack();
         new LnOnlyPhi(new Span("right > [x] > left", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "an only-phi line cannot accept deeper children — must be HORIZONTAL_COMPLETED",
+            "a bare-φ only-phi line must stay OPEN so its φ accepts vertical args",
+            stack.top().openness(),
+            Matchers.equalTo(Openness.OPEN)
+        );
+    }
+
+    @Test
+    void marksHorizontallyCompletedWhenPhiHasHargs() {
+        final Stack stack = new Stack();
+        new LnOnlyPhi(new Span("right arg > [x] > left", 1))
+            .into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "an only-phi whose φ carries horizontal args cannot accept a body — must be HORIZONTAL_COMPLETED",
             stack.top().openness(),
             Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-chained-phi-vertical-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-chained-phi-vertical-arg.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='∅' and @name='m']
+  - //o[@name='φ' and @base='ξ.ρ.b.put']/o[@as='α0' and @base='.lt']
+input: |
+  # No comments.
+  [b] > obj
+    b.put > [m] >>
+      lt.
+        3
+        1.1

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-nested-formation-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-nested-formation-arg.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.foo' and @name='φ']/o[@as='α0']/o[@base='∅' and @name='y']
+  - //o[@base='Φ.foo' and @name='φ']/o[@as='α0']/o[@base='Φ.z' and @name='w']
+input: |
+  # No comments.
+  [] > obj
+    foo > [] >>
+      [y]
+        z > w

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-vertical-args-auto-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-vertical-args-auto-named.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='∅' and @name='k']
+  - //o[@base='Φ.xyz' and @name='φ']/o[@as='α0' and @base='Φ.number']
+  - //o[@base='Φ.xyz' and @name='φ']/o[@as='α1' and @base='ξ.k.minus']
+input: |
+  # No comments.
+  [] > obj
+    xyz > [k] >>
+      33
+      k.minus 1

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-vertical-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-with-vertical-args.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='bar']/o[@base='∅' and @name='x']
+  - //o[@name='bar']/o[@base='Φ.foo' and @name='φ']/o[@base='ξ.x.plus' and @as='α0']
+input: |
+  # No comments.
+  [] > obj
+    foo > [x] > bar
+      x.plus 42

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-with-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-with-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  argument of an only-phi formation cannot carry a name suffix
+input: |
+  # Foo.
+  [] > obj
+    foo > [] >>
+      bar > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-with-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-with-name.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 5
+message: |-
+  argument of an only-phi formation cannot carry a name suffix
+input: |
+  # Foo.
+  [] > obj
+    foo > [] >>
+      bar
+        baz > x

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -48,14 +48,13 @@
       [b]
         malloc.for > @
           0.0
-          [m] >>
-            b.put > @
-              lt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1.0)
-                    m.as-number
-                1.1
+          b.put > [m] >>
+            lt.
+              seq
+                *
+                  m.put (m.as-number.plus 1.0)
+                  m.as-number
+              1.1
 
   # Tests that seq step processing and final value return with float greater than comparison.
   [] +> tests-seq-single-dataization-float-greater
@@ -64,14 +63,13 @@
       [b]
         malloc.for > @
           0.0
-          [m] >>
-            b.put > @
-              gt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1.0)
-                    m.as-number
-                0.9
+          b.put > [m] >>
+            gt.
+              seq
+                *
+                  m.put (m.as-number.plus 1.0)
+                  m.as-number
+              0.9
 
   # Tests that seq step processing and final value return with integer less than comparison.
   [] +> tests-seq-single-dataization-int-less
@@ -80,14 +78,13 @@
       [b]
         malloc.for > @
           0
-          [m] >>
-            b.put > @
-              lt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                2
+          b.put > [m] >>
+            lt.
+              seq
+                *
+                  m.put (m.as-number.plus 1)
+                  m.as-number
+              2
 
   # Tests that seq step processing and final value return with integer than or equal comparison.
   [] +> tests-seq-single-dataization-int-less-or-equal
@@ -96,14 +93,13 @@
       [b]
         malloc.for > @
           0
-          [m] >>
-            b.put > @
-              lte.
-                seq
-                  *
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                1
+          b.put > [m] >>
+            lte.
+              seq
+                *
+                  m.put (m.as-number.plus 1)
+                  m.as-number
+              1
 
   # This test should have acceptable time to pass.
   [] +> tests-very-long-seq
@@ -162,15 +158,14 @@
       [b]
         malloc.for > @
           0
-          [m] >>
-            b.put > @
-              eq.
-                seq
-                  *
-                    m.put 0
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                1
+          b.put > [m] >>
+            eq.
+              seq
+                *
+                  m.put 0
+                  m.put (m.as-number.plus 1)
+                  m.as-number
+              1
 
   # Tests that seq properly caches memory when processing array elements.
   [] +> tests-seq-single-dataization-int-equal-to-cache-problem-test
@@ -179,17 +174,16 @@
       [b]
         malloc.for > @
           0
-          [m] >>
-            b.put > @
-              eq.
-                seq
-                  *
-                    at.
-                      * 0 1
-                      m
-                    m.put (m.as-number.plus 1)
+          b.put > [m] >>
+            eq.
+              seq
+                *
+                  at.
+                    * 0 1
                     m
-                1
+                  m.put (m.as-number.plus 1)
+                  m
+              1
 
   # Tests that seq dataizes all steps except the last one and returns the last step's value.
   [] +> tests-seq-calculates-and-returns


### PR DESCRIPTION
Yegor asked (#5331) to be able to write `foo > [x] > bar` with the body hanging off it, instead of spelling out `[x] > bar` / `foo > @` / body by hand. This wires that up: when an only-phi line's φ carries no horizontal args, the φ stays open and deeper-indent lines attach to it as vertical arguments. The sugared and desugared forms produce identical XMIR.

```
foo > [x] > bar
  x.plus 42
```

A φ that already has horizontal args stays closed — there is nowhere to hang a body. And since the formation binds only φ, its arguments cannot be named; the ban follows the arguments down through nested applications but stops at a nested formation, where naming resumes as usual.

One incidental fix: `foo a > [x] > bar` with a body used to drop the body line silently, and now reports the same "closed for children" error as the bare case.

The parser spec is updated alongside the code (§3.10.1, §4.5, §5.2.3, §5.3.6, §6.1, §9.4, §9.9, Appendix A). Opened as a draft for review.

Closes #5331

## Validated end-to-end

Dogfooded in `eo-runtime`: the six `[m] >> / b.put > @` leaves in the `seq` tests now use `b.put > [m] >>`. The runtime transpiles, compiles, and runs green — `EOseqTest` stays 9/9.

Scope note: because an only-phi binds only `φ`, its arguments cannot be named. So the sugar fits leaf `φ` bodies whose arguments are unnamed (like these `seq` leaves), but not the `malloc.for`/`while` scope pattern, where the arguments are named `>>` formations and stay in the desugared form.