### PR TITLE
#5330: validate regex start index

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -20,6 +20,8 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
+import org.eolang.Expect;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.XmirObject;
@@ -66,22 +68,28 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
     public Phi lambda() {
         final Phi match = this.take(Phi.RHO);
         final Matcher matcher;
+        final String text;
         try {
+            text = new Dataized(match.take("txt")).asString();
             matcher = ((Pattern) new ObjectInputStream(
                 new ByteArrayInputStream(
                     new Dataized(match.take(Phi.RHO).take("serialized")).take()
                 )
-            ).readObject()).matcher(
-                new Dataized(match.take("txt")).asString()
-            );
+            ).readObject()).matcher(text);
         } catch (final IOException | ClassNotFoundException ex) {
             throw new IllegalArgumentException(ex);
         }
-        final boolean found = matcher.find(
-            new Dataized(
-                this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
-            ).asNumber().intValue()
-        );
+        final int start = new Expect.Natural(
+            Expect.at(this, EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
+        ).it();
+        if (start > text.length()) {
+            throw new ExFailure(
+                "the 'start' attribute (%d) must be less than or equal to text length (%d)",
+                start,
+                text.length()
+            );
+        }
+        final boolean found = matcher.find(start);
         final Phi result = match.take("matched");
         if (found) {
             this.fill(result, matcher);

--- a/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/RegexAtomTest.java
@@ -9,6 +9,7 @@
  */
 package org.eolang.EOtt; // NOPMD
 
+import org.eolang.Bind;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
@@ -61,5 +62,113 @@ final class RegexAtomTest {
                 Matchers.not(Matchers.containsString("out of bounds"))
             )
         );
+    }
+
+    @Test
+    void rejectsStartIndexOutOfIntRange() {
+        MatcherAssert.assertThat(
+            String.format(
+                "matched-from-index must reject a %s index outside int range",
+                RegexAtomTest.start()
+            ),
+            RegexAtomTest.rejection(new Data.ToPhi(1.0e15)),
+            Matchers.allOf(
+                Matchers.containsString(RegexAtomTest.start()),
+                Matchers.containsString("must fit into int range")
+            )
+        );
+    }
+
+    @Test
+    void rejectsFractionalStartIndex() {
+        MatcherAssert.assertThat(
+            String.format(
+                "matched-from-index must reject a fractional %s index",
+                RegexAtomTest.start()
+            ),
+            RegexAtomTest.rejection(new Data.ToPhi(2.7)),
+            Matchers.allOf(
+                Matchers.containsString(RegexAtomTest.start()),
+                Matchers.containsString("must be an integer")
+            )
+        );
+    }
+
+    @Test
+    void rejectsNegativeStartIndex() {
+        MatcherAssert.assertThat(
+            String.format(
+                "matched-from-index must reject a negative %s index cleanly",
+                RegexAtomTest.start()
+            ),
+            RegexAtomTest.rejection(new Data.ToPhi(-1)),
+            Matchers.allOf(
+                Matchers.containsString(RegexAtomTest.start()),
+                Matchers.containsString("must be greater or equal to zero")
+            )
+        );
+    }
+
+    @Test
+    void rejectsStartIndexAfterTextEnd() {
+        MatcherAssert.assertThat(
+            String.format(
+                "matched-from-index must reject a %s index after text end cleanly",
+                RegexAtomTest.start()
+            ),
+            RegexAtomTest.rejection(new Data.ToPhi(6)),
+            Matchers.allOf(
+                Matchers.containsString(RegexAtomTest.start()),
+                Matchers.containsString("must be less than or equal to text length")
+            )
+        );
+    }
+
+    /**
+     * Dataize matched-from-index and return its rejection message.
+     * @param start Start index
+     * @return Rejection message
+     */
+    private static String rejection(final Phi start) {
+        return Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new Dataized(RegexAtomTest.matchedFromIndex(start).take("from")).take(),
+            "start index must be rejected before Matcher.find(int)"
+        ).toString();
+    }
+
+    /**
+     * Build an internal matched-from-index application.
+     * @param start Start index
+     * @return Application
+     */
+    private static Phi matchedFromIndex(final Phi start) {
+        return new PhApplication(
+            new PhApplication(
+                new PhApplication(
+                    Phi.Φ.take("tt.regex").copy(),
+                    "expression", new Data.ToPhi("/[a-z]+/")
+                ).take("compiled").take("match").copy(),
+                "txt", new Data.ToPhi("hello")
+            ).take("matched-from-index").copy(),
+            new Bind(RegexAtomTest.position(), new Data.ToPhi(1)),
+            new Bind(RegexAtomTest.start(), start)
+        );
+    }
+
+    /**
+     * Start attribute name.
+     * @return Start attribute name
+     */
+    private static String start() {
+        return "start";
+    }
+
+    /**
+     * Position attribute name.
+     * @return Position attribute name
+     */
+    private static String position() {
+        return "position";
     }
 }


### PR DESCRIPTION
Fixes #5330.

This patch validates the `start` attribute in `EOregex$EOpattern$EOmatch$EOmatched_from_index` before passing it to `Matcher.find(int)`.

Previously, the code used `Double.intValue()`, which could silently truncate fractional values and hide out-of-range values before `Matcher.find(int)` was called. Now the value is read through `Expect.Natural`, and the text length is checked explicitly.

Added regression coverage for:

- start value outside the `int` range
- fractional start value
- negative start value
- start value after the end of the input text

Verification:

- `mvn -pl eo-runtime -DskipITs -Dtest=RegexAtomTest test`
- `mvn -pl eo-runtime -DskipITs test`
- `mvn -pl eo-runtime -Pqulice -DskipTests -DskipITs verify`

Independent review:

- Codex review over the final diff passed with no security concerns or blocking logic errors.
