### PR TITLE
#5344: tolerate null PhSafe exception messages

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -7,6 +7,7 @@ package org.eolang;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -207,15 +208,24 @@ public final class PhSafe implements Phi, Atom {
             throw new EOerror.ExError(ex, this.label(suffix));
         } catch (final ExAbstract ex) {
             throw new EOerror.ExError(
-                new Data.ToPhi(ex.getMessage()),
+                new Data.ToPhi(PhSafe.message(ex)),
                 this.label(suffix)
             );
         } catch (final Throwable ex) {
             throw new EOerror.ExError(
-                new Data.ToPhi(ex.getMessage()),
+                new Data.ToPhi(PhSafe.message(ex)),
                 PhSafe.trace(ex, this.label(suffix))
             );
         }
+    }
+
+    /**
+     * Exception message safe for EO dataization.
+     * @param exp The exception
+     * @return Message
+     */
+    private static String message(final Throwable exp) {
+        return Objects.toString(exp.getMessage(), exp.getClass().getName());
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -200,7 +200,7 @@ public final class PhSafe implements Phi, Atom {
      * @return Result
      * @checkstyle IllegalCatchCheck (20 lines)
      */
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -59,6 +59,44 @@ final class PhSafeTest {
     }
 
     @Test
+    void catchesRuntimeExceptionWithoutMessage() {
+        Assertions.assertThrows(
+            EOerror.ExError.class,
+            () -> new PhSafe(
+                new PhDefault() {
+                    @Override
+                    public byte[] delta() {
+                        throw new RuntimeException();
+                    }
+                }
+            ).delta(),
+            "catches an exception with a null message"
+        );
+    }
+
+    @Test
+    void catchesAbstractExceptionWithoutMessage() {
+        Assertions.assertThrows(
+            EOerror.ExError.class,
+            () -> new PhSafe(
+                new PhDefault() {
+                    @Override
+                    public byte[] delta() {
+                        throw new ExAbstract((String) null) {
+                            /**
+                             * Serialization identifier.
+                             */
+                            private static final long serialVersionUID =
+                                6895797670679429822L;
+                        };
+                    }
+                }
+            ).delta(),
+            "catches an abstract exception with a null message"
+        );
+    }
+
+    @Test
     void rendersMultiLayeredErrorMessageCorrectly() {
         MatcherAssert.assertThat(
             "rethrows correctly",

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -82,13 +82,7 @@ final class PhSafeTest {
                 new PhDefault() {
                     @Override
                     public byte[] delta() {
-                        throw new ExAbstract((String) null) {
-                            /**
-                             * Serialization identifier.
-                             */
-                            private static final long serialVersionUID =
-                                6895797670679429822L;
-                        };
+                        throw new ExFailure((String) null, (Throwable) null);
                     }
                 }
             ).delta(),

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -66,7 +66,7 @@ final class PhSafeTest {
                 new PhDefault() {
                     @Override
                     public byte[] delta() {
-                        throw new RuntimeException();
+                        throw new IllegalStateException();
                     }
                 }
             ).delta(),


### PR DESCRIPTION
Fixes #5344

### Summary
- Guard null exception messages before wrapping them as EO strings in `PhSafe`.
- Add coverage for null-message `RuntimeException` and `ExAbstract` paths.

### Verification
- `mvn -pl eo-maven-plugin -am -DskipTests install`
- `mvn -pl eo-runtime -Dtest=PhSafeTest test`
- `mvn -pl eo-runtime -Pqulice -DskipTests test`
- `git diff --check`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.