### PR TITLE
#5342: fix i32.times overflow — always take low 32 bits

### DIFF
--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -56,18 +56,11 @@
 
   # Multiplication of `$` and `x`.
   # Here `x` must be an `org.eolang.i32` object.
+  # Two's-complement wrap: the result is the low 32 bits of the true
+  # 64-bit product, whatever the high half looks like.
   [x] > times
-    if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 right
-      plus.
-        i32 left
-        i32 right
-    (as-i64.times x.as-i32.as-i64).as-bytes > bts
-    bts.slice 0 4 > left
-    bts.slice 4 4 > right
+    i32 right > @
+    (as-i64.times x.as-i32.as-i64).as-bytes.slice 4 4 > right
 
   # Sum of `$` and `x`.
   # Here `x` must be an `org.eolang.i32` object.
@@ -321,3 +314,20 @@
     eq. > @
       2147483647.as-i64.as-i32.times 2.as-i64.as-i32
       -2.as-i64.as-i32
+
+  # Tests that i32 multiplication wraps modulo 2^32 when the true
+  # product's high 4 bytes are neither all-zero nor all-FF. Here
+  # 65536 * 65536 = 2^32, whose i64 encoding is 00-00-00-01-00-00-00-00;
+  # the correct two's-complement wrap discards the high half and yields 0.
+  [] +> tests-i32-times-wraps-modulo-2-pow-32
+    eq. > @
+      65536.as-i64.as-i32.times 65536.as-i64.as-i32
+      0.as-i64.as-i32
+
+  # Tests that i32 multiplication of two mid-range positive values
+  # wraps to the low 32 bits: 100000 * 100000 = 10_000_000_000
+  # = 0x2_540B_E400 (as i64), which as i32 is 1_410_065_408.
+  [] +> tests-i32-times-wraps-large-positive-product
+    eq. > @
+      100000.as-i64.as-i32.times 100000.as-i64.as-i32
+      1410065408.as-i64.as-i32


### PR DESCRIPTION
## Summary

Closes #5342. The else branch of the if. guard in i32.times added the high 4 bytes of the 64-bit product into the result whenever those bytes weren't a sign-extension mask, polluting the wrapping-multiplication semantics.

Two's-complement wrap for i32*i32 is always `low 32 bits of the 64-bit product` — no branch on the high half is needed. The method now evaluates directly to `i32 (as-i64.times x.as-i32.as-i64).as-bytes.slice 4 4`.

## Why the existing test didn't catch it

`tests-i32-times-with-overflow` uses `MAX_INT * 2 = -2`, whose i64 encoding is `00-00-00-00-FF-FF-FF-FE` — the `left.eq 00-00-00-00` branch fires, so the buggy `i32 left plus i32 right` never runs.

## New tests

* `tests-i32-times-wraps-modulo-2-pow-32`: `65536 * 65536 = 2^32`, i64 = `00-00-00-01-00-00-00-00`. The high half is non-trivial; with the old code this returned `1` instead of the correct wrap `0`.
* `tests-i32-times-wraps-large-positive-product`: `100000 * 100000 = 10_000_000_000`, i64 = `00-00-00-02-54-0B-E4-00`. Old code returned `1_410_065_410` (adding the high `2`) instead of `1_410_065_408`.