### PR TITLE
#5366: fix i16.times overflow — always take low 16 bits

### DIFF
--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -41,18 +41,11 @@
 
   # Multiplication of `$` and `x`.
   # Here `x` must be an `org.eolang.i16` object.
+  # Two's-complement wrap: the result is the low 16 bits of the true
+  # 32-bit product, whatever the high half looks like.
   [x] > times
-    if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 right
-      plus.
-        i16 left
-        i16 right
-    (as-i32.times x.as-i16.as-i32).as-bytes > bts
-    bts.slice 0 2 > left
-    bts.slice 2 2 > right
+    i16 right > @
+    (as-i32.times x.as-i16.as-i32).as-bytes.slice 2 2 > right
 
   # Sum of `$` and `x`.
   # Here `x` must be an `org.eolang.i16` object.
@@ -273,3 +266,20 @@
     eq. > @
       32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
       -2.as-i64.as-i32.as-i16
+
+  # Tests that i16 multiplication wraps modulo 2^16 when the true
+  # product's high 2 bytes are neither all-zero nor all-FF. Here
+  # 256 * 256 = 2^16, whose i32 encoding is 00-01-00-00; the correct
+  # two's-complement wrap discards the high half and yields 0.
+  [] +> tests-i16-times-wraps-modulo-2-pow-16
+    eq. > @
+      256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
+      0.as-i64.as-i32.as-i16
+
+  # Tests that i16 multiplication of two mid-range positive values
+  # wraps to the low 16 bits: 300 * 300 = 90000 = 0x0001_5F90 as i32,
+  # which as i16 is 24464.
+  [] +> tests-i16-times-wraps-large-positive-product
+    eq. > @
+      300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
+      24464.as-i64.as-i32.as-i16


### PR DESCRIPTION
## Summary

Closes #5366. Direct sibling of #5342/#5364 (`i32.times`) on the same code shape: the else branch of the `if.` guard in `i16.times` folded the high 2 bytes of the 32-bit product into the result whenever those bytes weren't a sign-extension mask, polluting the wrapping-multiplication semantics.

Two's-complement wrap for `i16 * i16` is always **low 16 bits of the 32-bit product** — no branch on the high half is needed. The method now evaluates directly to `i16 (as-i32.times x.as-i16.as-i32).as-bytes.slice 2 2`.

## Why the existing test didn't catch it

`tests-i16-times-with-overflow` uses `32767 * 2 = 65534`, whose i32 encoding is `00-00-FF-FE` — the `left.eq 00-00` branch fires, so the buggy `i16 left plus i16 right` never runs.

## New tests

* `tests-i16-times-wraps-modulo-2-pow-16`: `256 * 256 = 2^16`, i32 = `00-01-00-00`. Old code returned `1` (folding the high `1`); correct wrap is `0`.
* `tests-i16-times-wraps-large-positive-product`: `300 * 300 = 90000`, i32 = `00-01-5F-90`. Old code returned `24465` (folding `1`); correct wrap is `24464` (`0x5F90`).
