### PR TITLE
#5360: report the correct LnMeta error column

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -65,7 +65,9 @@ final class LnMeta implements Line {
             parts = new ArrayList<>(0);
         } else {
             head = body.substring(1, space);
-            parts = LnMeta.split(body.substring(space + 1), this.span);
+            parts = LnMeta.split(
+                body.substring(space + 1), this.span, space + 1
+            );
         }
         globals.markMeta();
         globals.clearBlanks();
@@ -78,15 +80,18 @@ final class LnMeta implements Line {
      * R-3.2.3 / R-9.3.
      * @param tail Substring after the {@code +name} prefix
      * @param span Source span (for error reporting)
+     * @param base Body-relative offset where the tail starts
      * @return Parts in source order
      */
-    private static List<String> split(final String tail, final Span span) {
+    private static List<String> split(
+        final String tail, final Span span, final int base
+    ) {
         final List<String> out = new ArrayList<>(2);
         int idx = 0;
         while (idx < tail.length()) {
             if (tail.charAt(idx) == ' ') {
                 throw new ParseError(
-                    span.line(), span.indent() + idx,
+                    span.line(), span.indent() + base + idx,
                     "meta parts must be separated by exactly one space"
                 );
             }

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -103,12 +103,16 @@ final class LnMetaTest {
     }
 
     @Test
-    void rejectsDoubleSpaceBetweenParts() {
-        Assertions.assertThrows(
-            ParseError.class,
-            () -> new LnMeta(new Span("+rt jvm  extra", 1))
-                .into(new Stack(), new Globals(), new Emit()),
-            "double space between parts must be rejected per R-3.2.4"
+    void reportsDoubleSpacePosition() {
+        MatcherAssert.assertThat(
+            "double space error must point at the second space",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("+foo a  b", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "double space between parts must be rejected per R-3.2.4"
+            ).pos(),
+            Matchers.equalTo(7)
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:5] error: 'meta parts must be separated by exactly one space'
+  [1:11] error: 'meta parts must be separated by exactly one space'
   +meta with  spaces
-       ^
+             ^
 input: |
   +meta with  spaces
 


### PR DESCRIPTION
Fixes #5360.

## Summary

- pass the body-relative start offset of the metadata tail into `LnMeta.split`
- include that offset when constructing the double-space `ParseError`
- assert the corrected column in both the focused unit test and the parser typo fixture

For `+foo a  b`, the reported position is now column `7`, which points at the second space instead of a character in the metadata name.

## Tests

- `mvn -pl eo-parser -Dtest=LnMetaTest,EoSyntaxTest test` on JDK 21: 883 tests passed
- `mvn -pl eo-parser -Pqulice -DskipTests verify` on JDK 21: passed
- full reactor on the original base: `eo-parser` passed all 1,437 tests; the later unrelated `eo-maven-plugin` module hit the `org.eolang:lints`/`tojos` compatibility failure that upstream has since fixed in `9444089`. The PR's macOS and Windows JDK 23 merge checks are passing.
