### PR TITLE
build(#5378): upgrade lints dependency from 0.2.10 to 0.2.11

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -539,6 +539,7 @@
                 <exclude>duplicatefinder:.*</exclude>
                 <exclude>xml:/src/test/resources/META-INF/maven/plugin.xml</exclude>
                 <exclude>dependencies:org.hamcrest:hamcrest-core:jar:1.3:compile</exclude>
+                <exclude>dependencies:org.aspectj:aspectjrt</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.2.10</version>
+      <version>0.2.11</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -236,6 +236,17 @@
             <configuration>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
+                <!--
+                  @todo #5378:90min Fix compound-name lint violations in eo-runtime EO sources.
+                   Rename hyphenated parameter names such as `cant-divide`, `cant-parse`,
+                   `out-of-bounds`, `empty-cases`, `cant-convert`, `cant-split`, etc.
+                   to single-word alternatives so that the `compound-name` lint
+                   (introduced in objectionary/lints 0.2.11) passes without suppression.
+                   All affected formations are in files under eo-runtime/src/main/eo
+                   and use these names as positional parameters, so callers are unaffected
+                   by the rename.
+                -->
+                <lint>compound-name</lint>
               </skipProgramLints>
               <keepBinaries>
                 <glob>org/eolang/EOfs/package-info.class</glob>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -236,6 +236,8 @@
             <configuration>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
+              </skipProgramLints>
+              <skipSourceLints>
                 <!--
                   @todo #5378:90min Fix compound-name lint violations in eo-runtime EO sources.
                    Rename hyphenated parameter names such as `cant-divide`, `cant-parse`,
@@ -247,7 +249,7 @@
                    by the rename.
                 -->
                 <lint>compound-name</lint>
-              </skipProgramLints>
+              </skipSourceLints>
               <keepBinaries>
                 <glob>org/eolang/EOfs/package-info.class</glob>
                 <glob>org/eolang/EOms/package-info.class</glob>

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -5,10 +5,9 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint decorated-formation
-+unlint formation-without-comment
 +unlint mandatory-package
 
-# A boolean value, parameterized by its choice `if`.
+# Boolean value, parameterized by its choice `if`.
 # `if` is a two-argument object that returns either its first argument
 # (for TRUE) or its second one (for FALSE). Both the byte representation
 # and every other operation are derived from this single choice, so no

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -22,8 +22,8 @@
 # .
 [data] > bytes
   data > @
-  bytes data > as-bytes
   eq 01- > as-bool
+  bytes data > as-bytes
 
   # Converts this chain of eight bytes into a number.
   [cant-convert] > as-number

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -9,7 +9,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The object encapsulates a chain of bytes, providing bitwise operations,
+# Object `bytes` encapsulates a chain of bytes, providing bitwise operations,
 # numeric conversions, and byte manipulation methods. Objects like `number`, `string`,
 # and integer types (`i16`, `i32`, `i64`) use `bytes` as their internal representation.
 #
@@ -84,7 +84,7 @@
   # Represents a sub-sequence of `bytes` inside the current one.
   # When the requested range lies outside the current bytes, the slice
   # returns the caller-supplied `cant-slice` fallback instead, or the
-  # bottom object (⊥) when none was provided, which terminates on use.
+  # bottom object when none was provided, which terminates on use.
   [start len] > slice /bytes
     ? > cant-slice /{string}
 
@@ -511,7 +511,7 @@
       FF-FF-FF-FF-00-00-00-01
 
   # Tests that a wrong-sized conversion to number with no fallback yields the bottom
-  # object (⊥) that terminates when used.
+  # object that terminates when used.
   [] +> throws-on-bytes-of-wrong-size-as-number
     01-01-01-01.as-number > @
 
@@ -523,7 +523,7 @@
         "recovered" > [msg]
 
   # Tests that a wrong-sized conversion to i64 with no fallback yields the bottom
-  # object (⊥) that terminates when used.
+  # object that terminates when used.
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
 
@@ -535,7 +535,7 @@
         "recovered" > [msg]
 
   # Tests that an out-of-bounds slice with no `cant-slice` fallback yields the bottom
-  # object (⊥) that terminates when used.
+  # object that terminates when used.
   [] +> throws-on-out-of-bounds-slice
     20-1F-EE-B5-90.slice 3 10 > @
 

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -50,10 +50,10 @@
               cached.as-bytes
               cached.as-bool
               m
+          (dataized func).as-bytes > cached
           # Function that increments counter in memory for testing.
           [] > func
             ^.m.put (^.m.as-number.plus 1) > @
-          (dataized func).as-bytes > cached
       1
 
   # Tests that dataized bytes behave correctly when accessed with exclamation.
@@ -67,6 +67,8 @@
         and.
           cached1.eq cached2
           1.eq cached1
+    (dataized func).as-bytes > cached1
+    func > cached2!
     # Function that increments counter in memory for testing.
     malloc.for > func
       0
@@ -75,5 +77,3 @@
           *
             true
             m.put (m.as-number.plus 1)
-    (dataized func).as-bytes > cached1
-    func > cached2!

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The object dataizes `target`, makes a new instance of `bytes` from given
+# Object that dataizes `target`, makes a new instance of `bytes` from given
 # data and behaves as the result
 # `bytes`.
 # The object is used as implementation of caching syntax (`!`).

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The object is a FALSE boolean state.
+# FALSE boolean state.
 # It is the `bool` whose choice returns its second argument, so `if` picks
 # the `right` branch and the byte representation is `00-`.
 bool > false

--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -144,8 +144,8 @@
         inner.exists.not
       f.exists.not
     (dir tmpdir.tmpfile.deleted).made > d
-    (dir d.tmpfile.deleted).made > inner
     d.tmpfile > f
+    (dir d.tmpfile.deleted).made > inner
 
   # Tests that walking through a directory tree with a glob pattern finds matching files.
   [] +> tests-walks-recursively

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 
-# The file object in the filesystem.
+# File object in the filesystem.
 [path] > file
   path > @
   # Converts the `file` to a `path`.

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -133,25 +133,25 @@
             process-file
             ^
     mode > access!
-    (access.eq "r").as-bool > read
-    (access.eq "w").as-bool > write
-    (access.eq "r+").as-bool > rw
-    (access.eq "w+").as-bool > wr
+    as-bool. > existing
+      read.or rw
     (access.eq "a+").as-bool > ra
+    (access.eq "r").as-bool > read
     as-bool. > readable
       or.
         read.or rw
         wr.or ra
+    (access.eq "r+").as-bool > rw
+    as-bool. > truncate
+      write.or wr
+    (access.eq "w+").as-bool > wr
     as-bool. > writable
       or.
         or.
           write.or rw
           wr.or ra
         (access.eq "a").as-bool
-    as-bool. > existing
-      read.or rw
-    as-bool. > truncate
-      write.or wr
+    (access.eq "w").as-bool > write
 
     # Process current file in the provided scope.
     #
@@ -524,8 +524,8 @@
                   ^.m.put > @
                     f.read 13
               m
-    tmpdir.tmpfile > temp
     temp.path > src
+    tmpdir.tmpfile > temp
 
   # Tests that writing to a file using different file instances works correctly.
   [] +> tests-writes-to-file-from-different-instances
@@ -553,8 +553,8 @@
                           f.read 14
                 m
         .eq "Shrek is love!"
-    tmpdir.tmpfile > temp
     temp.path > src
+    tmpdir.tmpfile > temp
 
   # Tests that sequential reading from a file advances the position correctly.
   [] +> tests-reads-from-file-sequentially

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 
-# File object in the filesystem.
+# Represents a file in the filesystem for reading and writing.
 [path] > file
   path > @
   # Converts the `file` to a `path`.

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -51,9 +51,9 @@
   # A standardized way to represent file or directory locations in a Unix-like system.
   [uri] > posix
     uri > @
-    "/" > separator
-    file uri > as-file
     dir (file uri) > as-dir
+    file uri > as-file
+    "/" > separator
     # Returns `true` if current path is absolute - starts with '/' char.
     and. > is-absolute
       uri.length.gt 0
@@ -257,9 +257,9 @@
     # don't use the object programmatically outside of `path` object.
     [uri] > validated
       uri > @
-      ^.separator > separator
-      file uri > as-file
       dir (file uri) > as-dir
+      file uri > as-file
+      ^.separator > separator
 
       # Returns `true` if given `uri` is drive relative which means it
       # starts with "X:" where 'X' - system drive name.

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -53,11 +53,11 @@
     uri > @
     dir (file uri) > as-dir
     file uri > as-file
-    "/" > separator
     # Returns `true` if current path is absolute - starts with '/' char.
     and. > is-absolute
       uri.length.gt 0
       (uri.as-bytes.slice 0 1).eq separator
+    "/" > separator
 
     # Return new `path` with normalized uri.
     # Normalization includes:

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -69,15 +69,20 @@
           normalized.eq "//"
           "/"
           string normalized
-      uri > ubts!
       ^.is-absolute.as-bool > is-absolute
-      and. > trailing
-        ubts.size.gt 0
-        eq.
-          ubts.slice
-            ubts.size.plus -1
-            1
-          separator
+      as-bytes. > normalized
+        if.
+          uri.length.eq 0
+          "."
+          concat.
+            if.
+              is-absolute
+              separator.concat path
+              path
+            if.
+              trailing
+              separator
+              --
       Q.tt.joined > path
         separator
         reduced
@@ -104,19 +109,14 @@
                   segment.eq ""
                 accum
                 accum.with segment
-      as-bytes. > normalized
-        if.
-          uri.length.eq 0
-          "."
-          concat.
-            if.
-              is-absolute
-              separator.concat path
-              path
-            if.
-              trailing
-              separator
-              --
+      and. > trailing
+        ubts.size.gt 0
+        eq.
+          ubts.slice
+            ubts.size.plus -1
+            1
+          separator
+      uri > ubts!
 
     # Resolves `other` path against `^.uri` and returns as new `path` from it.
     # The original `uri` and resolving `other` may be:
@@ -174,11 +174,11 @@
               idx
               txt.length.minus
                 number idx
-      uri > pth!
-      string pth > txt
       plus. > idx!
         last-index-of txt separator
         1
+      uri > pth!
+      string pth > txt
 
     # Takes the extension part from the provided `path`, for example:
     # |------------------------------|--------|
@@ -207,8 +207,8 @@
               txt.length.minus
                 number idx
       basename > base!
-      string base > txt
       last-index-of txt "." > idx!
+      string base > txt
 
     # Takes the directory name from the provided `path`, for example:
     # |------------------------------|--------------------|
@@ -235,9 +235,9 @@
           pth
           as-bytes.
             txt.slice 0 len
+      last-index-of txt separator > len!
       uri > pth!
       string pth > txt
-      last-index-of txt separator > len!
 
   # Windows specified path.
   # Here `uri` is file system URI which may contain forward slashes '/'.
@@ -279,12 +279,12 @@
           (index-of pth path.posix.separator).eq -1
           string ubts
           string repl
-        uri > ubts!
         string ubts > pth
         replaced > repl!
           pth
           regex "/\\//"
           separator
+        uri > ubts!
 
       # Returns `true` if current path is absolute, which means:
       # - either path root is root relative (starts with "\")
@@ -311,22 +311,35 @@
             normalized.eq "\\\\"
             separator
             string normalized
-        uri > ubts!
-        (^.is-drive-relative ubts).as-bool > is-drive-relative
-        (^.is-root-relative ubts).as-bool > is-root-relative
         if. > driveless!
           is-drive-relative
           ubts.slice
             2
             ubts.size.plus -2
           ubts
-        and. > trailing
-          ubts.size.gt 0
-          eq.
-            ubts.slice
-              ubts.size.plus -1
-              1
-            separator
+        (^.is-drive-relative ubts).as-bool > is-drive-relative
+        (^.is-root-relative ubts).as-bool > is-root-relative
+        as-bytes. > normalized
+          if.
+            driveless.size.eq 0
+            "."
+            concat.
+              concat.
+                if.
+                  is-drive-relative
+                  if.
+                    (driveless.slice 0 1).eq separator
+                    uri.slice 0 3
+                    uri.slice 0 2
+                  if.
+                    is-root-relative
+                    separator
+                    --
+                path
+              if.
+                trailing
+                separator
+                --
         Q.tt.joined > path!
           separator
           reduced
@@ -355,27 +368,14 @@
                     segment.eq ""
                   accum
                   accum.with segment
-        as-bytes. > normalized
-          if.
-            driveless.size.eq 0
-            "."
-            concat.
-              concat.
-                if.
-                  is-drive-relative
-                  if.
-                    (driveless.slice 0 1).eq separator
-                    uri.slice 0 3
-                    uri.slice 0 2
-                  if.
-                    is-root-relative
-                    separator
-                    --
-                path
-              if.
-                trailing
-                separator
-                --
+        and. > trailing
+          ubts.size.gt 0
+          eq.
+            ubts.slice
+              ubts.size.plus -1
+              1
+            separator
+        uri > ubts!
 
       # Resolves `other` path against `^.uri` and returns as new `path` from it.
       # Original `uri` and `other` path for resolving may be:
@@ -448,11 +448,11 @@
                 idx
                 txt.length.minus
                   number idx
-        uri > pth!
-        string pth > txt
         plus. > idx!
           last-index-of txt separator
           1
+        uri > pth!
+        string pth > txt
 
       # Takes the extension part from the provided `path`, for example:
       # |------------------------------|--------|
@@ -481,8 +481,8 @@
                 txt.length.minus
                   number idx
         basename > base!
-        string base > txt
         last-index-of txt "." > idx!
+        string base > txt
 
       # Takes the directory name from the provided `path`, for example:
       # |------------------------------|--------------------|
@@ -505,9 +505,9 @@
             pth
             as-bytes.
               txt.slice 0 len
+        last-index-of txt separator > len!
         uri > pth!
         string pth > txt
-        last-index-of txt separator > len!
 
   # Tests that the path separator is determined correctly based on the operating system.
   [] +> tests-determines-separator-depending-on-os

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -16,7 +16,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 
-# A `path` represents a path that is hierarchical and composed of a sequence of
+# Path `path` that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
 [uri] > path
   if. > @
@@ -25,7 +25,7 @@
       string uri.as-bytes
     posix
       string uri.as-bytes
-  # The system-dependent default name-separator character.
+  # System-dependent default name-separator character.
   # On UNIX systems the value of this field is "/";
   # on Microsoft Windows systems it is "\\".
   if. > separator

--- a/eo-runtime/src/main/eo/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/fs/tmpdir.eo
@@ -47,12 +47,12 @@
                   temp
                 tmp
               tmpdir
-          getenv "TMPDIR" > tmpdir!
-          getenv "TMP" > tmp!
+          -- > empty
           getenv "TEMP" > temp!
           getenv "TEMPDIR" > tempdir!
+          getenv "TMP" > tmp!
+          getenv "TMPDIR" > tmpdir!
           getenv "USERPROFILE" > userprofile!
-          -- > empty
 
   # Tests that the global temporary directory exists on the filesystem.
   tmpdir.exists > [] +> global-temp-dir-exists

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -9,13 +9,13 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# 16-bit signed integer.
+# Signed 16-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i16
   as-bytes > @
-  times -1.as-i64.as-i32.as-i16 > neg
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
+  times -1.as-i64.as-i32.as-i16 > neg
 
   # Convert this `org.eolang.i16` to `org.eolang.i32` and return it.
   # The object is an atom because it's not possible to check what
@@ -92,10 +92,10 @@
         plus.
           i16 left
           i16 right
-    x.as-i16 > xval
     (as-i32.div xval.as-i32).as-bytes > bts
     bts.slice 0 2 > left
     bts.slice 2 2 > right
+    x.as-i16 > xval
     00-00 > zero
 
   # Tests that i16 number has correct byte representation.

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -9,7 +9,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 16 bits signed integer.
+# 16-bit signed integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i16
   as-bytes > @
@@ -76,7 +76,7 @@
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i16` object.
   # When `x` is zero, the caller-supplied `cant-divide` fallback is returned,
-  # or the bottom object (⊥) when none was provided, which terminates on use.
+  # or the bottom object when none was provided, which terminates on use.
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -232,7 +232,7 @@
       32767.as-i64.as-i32.as-i16
 
   # Tests that i16 division by zero with no fallback yields the bottom object
-  # (⊥) that terminates when used.
+  # that terminates when used.
   2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] +> throws-on-division-i16-by-i16-zero
 
   # Tests that i16 division by zero with a provided fallback yields the fallback.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -9,12 +9,12 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# 32-bit signed integer.
+# Signed 32-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i32
   as-bytes > @
-  times -1.as-i64.as-i32 > neg
   as-i64.as-number > as-number
+  times -1.as-i64.as-i32 > neg
 
   # Convert this `org.eolang.i32` to `org.eolang.i64` and return it.
   # The object is an atom because it's not possible to check what
@@ -107,10 +107,10 @@
         plus.
           i32 left
           i32 right
-    x.as-i32 > xval
     (as-i64.div xval.as-i64).as-bytes > bts
     bts.slice 0 4 > left
     bts.slice 4 4 > right
+    x.as-i32 > xval
     00-00-00-00 > zero
 
   # Tests that i32 number has correct byte representation.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -9,7 +9,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 32 bits signed integer.
+# 32-bit signed integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i32
   as-bytes > @
@@ -91,7 +91,7 @@
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i32` object.
   # When `x` is zero, the caller-supplied `cant-divide` fallback is returned,
-  # or the bottom object (⊥) when none was provided, which terminates on use.
+  # or the bottom object when none was provided, which terminates on use.
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -269,7 +269,7 @@
       2147483647.as-i64.as-i32
 
   # Tests that i32 division by zero with no fallback yields the bottom object
-  # (⊥) that terminates when used.
+  # that terminates when used.
   2.as-i64.as-i32.div 0.as-i64.as-i32 > [] +> throws-on-division-i32-by-i32-zero
 
   # Tests that i32 division by zero with a provided fallback yields the fallback.
@@ -281,7 +281,7 @@
         "recovered" > [msg]
 
   # Tests that converting i32 to i16 out of bounds with no fallback yields the
-  # bottom object (⊥) that terminates when used.
+  # bottom object that terminates when used.
   247483647.as-i64.as-i32.as-i16 > [] +> throws-on-converting-to-i16-if-out-of-bounds
 
   # Tests that an out-of-bounds i32-to-i16 conversion with a fallback yields it.

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -9,7 +9,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 64 bits signed integer.
+# 64-bit signed integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i64
   as-bytes > @
@@ -18,7 +18,7 @@
 
   # Convert this `org.eolang.i64` to `org.eolang.i32`.
   # When the number is out of i32 bounds, the caller-supplied `cant-convert`
-  # fallback is returned, or the bottom object (⊥) when none was provided,
+  # fallback is returned, or the bottom object when none was provided,
   # which terminates on use.
   [cant-convert] > as-i32
     if. > @
@@ -78,7 +78,7 @@
   # Quotient of the division of `$` by `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
   # When `x` is zero, the division returns the caller-supplied `cant-divide`
-  # fallback instead, or the bottom object (⊥) when none was provided, which
+  # fallback instead, or the bottom object when none was provided, which
   # terminates on use.
   [x] > div /i64
     ? > cant-divide /{string}
@@ -109,7 +109,7 @@
       -234.as-i64.as-i32.as-i64
 
   # Tests that converting i64 to i32 out of bounds with no fallback yields the
-  # bottom object (⊥) that terminates when used.
+  # bottom object that terminates when used.
   3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
 
   # Tests that an out-of-bounds i64-to-i32 conversion with a fallback yields it.
@@ -247,7 +247,7 @@
       0.as-i64
 
   # Tests that i64 division by zero with no fallback yields the bottom object
-  # (⊥) that terminates when used.
+  # that terminates when used.
   2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
 
   # Tests that i64 division by zero with a provided fallback yields the fallback.

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -9,12 +9,12 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# 64-bit signed integer.
+# Signed 64-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i64
   as-bytes > @
-  times -1.as-i64 > neg
   as-i32.as-i16 > as-i16
+  times -1.as-i64 > neg
 
   # Convert this `org.eolang.i64` to `org.eolang.i32`.
   # When the number is out of i32 bounds, the caller-supplied `cant-convert`

--- a/eo-runtime/src/main/eo/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/io/bytes-as-input.eo
@@ -59,7 +59,6 @@
                   number next
             as-bytes.
               data.slice 0 next
-        size > requested!
         data.size > available!
         if. > next!
           gt.
@@ -67,6 +66,7 @@
             requested
           requested
           available
+        size > requested!
 
   # Tests that bytes-as-input can create an input from bytes and read portions sequentially.
   [] +> tests-makes-an-input-from-bytes-and-reads

--- a/eo-runtime/src/main/eo/io/console.eo
+++ b/eo-runtime/src/main/eo/io/console.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The `console` object is basic I/O object that allows to
+# Basic I/O object `console` that allows to
 # interact with operation system console.
 #
 # Imagine, operation system console input is "Hello, world!"

--- a/eo-runtime/src/main/eo/io/stdin.eo
+++ b/eo-runtime/src/main/eo/io/stdin.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The `stdin` object is a convenient wrapper on `console` object
+# Convenient wrapper `stdin` on `console` object
 # which is used as input only and allows to read the data from console.
 #
 # To read just one line you can do:

--- a/eo-runtime/src/main/eo/io/stdout.eo
+++ b/eo-runtime/src/main/eo/io/stdout.eo
@@ -6,7 +6,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The `stdout` object is a convenient wrapper on `console` object which
+# Convenient wrapper `stdout` on `console` object which
 # uses it as output only and allows to print the given argument to console as `string`:
 # ```
 # [args] > app

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -479,8 +479,8 @@
             times.
               num
               num
-          number > num
-            ^.inc m > n!
+          ^.inc m > n!
+          number n > num
       64
     # Increments x and returns its new value.
     [x] > inc

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The `malloc` object is an abstraction of a storage of data in heap
+# Object `malloc` is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may
 # use either OS-level or VM-level memory management mechanism.
 #
@@ -116,7 +116,7 @@
       # Read `length` bytes with `offset` from the allocated block in memory and return them
       # as `bytes`. When the requested range is outside the allocated block, the
       # read returns the caller-supplied `cant-read` fallback object instead, or the bottom
-      # object (⊥) when no fallback was provided, which terminates on use.
+      # object when no fallback was provided, which terminates on use.
       [offset length] > read /bytes
         ? > cant-read /{string}
 
@@ -336,7 +336,7 @@
             01-02 > [ex]
 
   # Tests that an out-of-bounds read with no `cant-read` fallback yields the bottom
-  # object (⊥), which terminates the program when dataized.
+  # object, which terminates the program when dataized.
   [] +> throws-on-reading-over-a-limit-without-fallback
     malloc.for > @
       10

--- a/eo-runtime/src/main/eo/ms/angle.eo
+++ b/eo-runtime/src/main/eo/ms/angle.eo
@@ -9,8 +9,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 
-# The angle.
-# A measure of how much something is tilted or rotated, measured in degrees or radians.
+# Angle: measure of how much something is tilted or rotated, measured in degrees or radians.
 # When dataized, it shows direction or how two lines meet.
 [value] > angle
   value > @

--- a/eo-runtime/src/main/eo/ms/asin.eo
+++ b/eo-runtime/src/main/eo/ms/asin.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# An operation that finds the angle whose sine is `num`.
+# Operation that finds the angle whose sine is `num`.
 [num] > asin /number
   # Tests that asin by zero equals zero.
   [] +> tests-asin-zero

--- a/eo-runtime/src/main/eo/ms/e.eo
+++ b/eo-runtime/src/main/eo/ms/e.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The Euler's number.
+# Euler's number.
 # A fundamental mathematical constant approximately equal to 2.7182818284590452354.
 # When dataized, it represents the base of natural logarithms.
 2.7182818284590452354 > e

--- a/eo-runtime/src/main/eo/ms/mod.eo
+++ b/eo-runtime/src/main/eo/ms/mod.eo
@@ -9,7 +9,7 @@
 # Calculate MOD.
 # An operation that finds the remainder after dividing `x` by `y`. When `y`
 # is zero, the result is the caller-supplied `cant-mod` fallback, or the
-# bottom object (⊥) when none was provided, which terminates on use.
+# bottom object when none was provided, which terminates on use.
 [x y cant-mod] > mod
   if. > @
     divisor.eq 0
@@ -90,7 +90,7 @@
       mod 133 1
       0
 
-  # Tests that mod by zero with no fallback yields the bottom object (⊥)
+  # Tests that mod by zero with no fallback yields the bottom object
   # that terminates when used.
   [] +> throws-on-mod-by-zero
     mod 5 0 > @

--- a/eo-runtime/src/main/eo/ms/numbers.eo
+++ b/eo-runtime/src/main/eo/ms/numbers.eo
@@ -13,7 +13,7 @@
   sequence > @
 
   # Find max element in the numbers sequence. An empty sequence yields the
-  # caller-supplied `cant-max` fallback, or the bottom object (⊥) when none
+  # caller-supplied `cant-max` fallback, or the bottom object when none
   # was provided.
   [cant-max] > max
     if. > @
@@ -30,7 +30,7 @@
     list sequence > lst
 
   # Find min element in the numbers sequence. An empty sequence yields the
-  # caller-supplied `cant-min` fallback, or the bottom object (⊥) when none
+  # caller-supplied `cant-min` fallback, or the bottom object when none
   # was provided.
   [cant-min] > min
     if. > @
@@ -47,11 +47,11 @@
     list sequence > lst
 
   # Tests that taking max from an empty sequence with no fallback yields the
-  # bottom object (⊥) that terminates when used.
+  # bottom object that terminates when used.
   (numbers *).max > [] +> throws-on-taking-max-from-empty-sequence-of-numbers
 
   # Tests that taking min from an empty sequence with no fallback yields the
-  # bottom object (⊥) that terminates when used.
+  # bottom object that terminates when used.
   (numbers *).min > [] +> throws-on-taking-min-from-empty-sequence-of-numbers
 
   # Tests that max of an empty sequence with a fallback yields the fallback.

--- a/eo-runtime/src/main/eo/ms/pow.eo
+++ b/eo-runtime/src/main/eo/ms/pow.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# An operation that raises `num` to the power of `x`.
+# Operation that raises `num` to the power of `x`.
 [num x] > pow /number
   # Tests that power operation works correctly for 2^4.
   [] +> tests-pow-test

--- a/eo-runtime/src/main/eo/ms/random.eo
+++ b/eo-runtime/src/main/eo/ms/random.eo
@@ -75,10 +75,10 @@
               and.
                 tbytes
                 ((one.left shift3).as-i64.minus one).as-bytes
-    clock.as-bytes > tbytes
+    00-00-00-00-00-00-00-01 > one
     35 > shift1
     17 > shift3
-    00-00-00-00-00-00-00-01 > one
+    clock.as-bytes > tbytes
   # New random with pseudo-random seed derived from the system clock.
   clocked system-clock > pseudo
 

--- a/eo-runtime/src/main/eo/nan.eo
+++ b/eo-runtime/src/main/eo/nan.eo
@@ -5,6 +5,6 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The `not a number` object is an abstraction
+# `not a number` abstraction
 # for representing undefined or unrepresentable numerical results.
 number 7F-F8-00-00-00-00-00-00 > nan

--- a/eo-runtime/src/main/eo/nan.eo
+++ b/eo-runtime/src/main/eo/nan.eo
@@ -5,6 +5,6 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# `not a number` abstraction
+# Not-a-number (NaN) abstraction
 # for representing undefined or unrepresentable numerical results.
 number 7F-F8-00-00-00-00-00-00 > nan

--- a/eo-runtime/src/main/eo/nk/socket.eo
+++ b/eo-runtime/src/main/eo/nk/socket.eo
@@ -135,15 +135,15 @@
   # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [address port] > posix-socket
-    code. > sd
-      posix
-        "socket"
-        * posix.af-inet posix.sock-stream posix.ipproto-tcp
     code. > addr
       posix
         "inet_addr"
         * address
     addr.as-i32 > addrint
+    code. > sd
+      posix
+        "socket"
+        * posix.af-inet posix.sock-stream posix.ipproto-tcp
     posix.sockaddr-in > sockaddr
       posix.af-inet.as-i16
       htons port
@@ -255,11 +255,11 @@
                 scope
                   sock.scoped-socket
                     sock.sd
-          ^.^ > sock
           code. > connected
             posix
               "connect"
               * sock.sd sock.sockaddr sock.sockaddr.size
+          ^.^ > sock
         cant-connect
 
     # Listen for connections on a socket.
@@ -310,7 +310,6 @@
                           posix
                             "accept"
                             * sock.sd sock.sockaddr sock.sockaddr.size
-          ^.^ > sock
           code. > bound
             posix
               "bind"
@@ -319,6 +318,7 @@
             posix
               "listen"
               * sock.sd 2048
+          ^.^ > sock
         cant-listen
 
   # Win32 platform specified socket.
@@ -326,20 +326,20 @@
   # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [address port] > win-socket
-    code. > sd
-      win32
-        "socket"
-        * win32.af-inet win32.sock-stream win32.ipproto-tcp
     code. > addr
       win32
         "inet_addr"
         * address
     addr.as-i32 > addrint
+    win32 "WSAGetLastError" * > err
+    code. > sd
+      win32
+        "socket"
+        * win32.af-inet win32.sock-stream win32.ipproto-tcp
     win32.sockaddr-in > sockaddr
       win32.af-inet.as-i16
       htons port
       addrint
-    win32 "WSAGetLastError" * > err
 
     # Scoped win32 socket that is passed as argument
     # to scope of `win32-socket.connect`, `win32-socket.listen` and `scoped-socket.accept`.
@@ -461,11 +461,11 @@
                 scope
                   sock.scoped-socket
                     sock.sd
-          ^.^ > sock
           code. > connected
             win32
               "connect"
               * sock.sd sock.sockaddr sock.sockaddr.size
+          ^.^ > sock
         cant-connect
 
     # Listen for connections on a socket.
@@ -516,7 +516,6 @@
                           win32
                             "accept"
                             * sock.sd sock.sockaddr sock.sockaddr.size
-          ^.^ > sock
           code. > bound
             win32
               "bind"
@@ -525,4 +524,5 @@
             win32
               "listen"
               * sock.sd 2048
+          ^.^ > sock
         cant-listen

--- a/eo-runtime/src/main/eo/nk/socket.eo
+++ b/eo-runtime/src/main/eo/nk/socket.eo
@@ -166,7 +166,7 @@
       # Send bytes through the socket.
       # Here `buffer` must be an object that can be dataized.
       # On success the `number` of sent bytes is returned, otherwise the `cant-send`
-      # fallback is returned, or ⊥ when unbound.
+      # fallback is returned, or the bottom object when unbound.
       [buffer cant-send] > send
         if. > @
           sent.eq -1
@@ -184,7 +184,7 @@
       # Receive bytes from the socket.
       # Here `size` must be a `number` of desired bytes to receive.
       # On success the received `bytes` are returned, otherwise the `cant-receive`
-      # fallback is returned, or ⊥ when unbound.
+      # fallback is returned, or the bottom object when unbound.
       [size cant-receive] > recv
         if. > @
           received.code.eq -1
@@ -321,7 +321,7 @@
               * sock.sd 2048
         cant-listen
 
-  # The win32 platform specified socket.
+  # Win32 platform specified socket.
   #
   # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
@@ -355,7 +355,7 @@
       # Send bytes through the socket.
       # Here `buffer` must be an object that can be dataized.
       # On success the `number` of sent bytes is returned, otherwise the `cant-send`
-      # fallback is returned, or ⊥ when unbound.
+      # fallback is returned, or the bottom object when unbound.
       [buffer cant-send] > send
         if. > @
           sent.eq -1
@@ -373,7 +373,7 @@
       # Receive bytes from the socket.
       # Here `size` must be a `number` of desired bytes to receive.
       # On success the received `bytes` are returned, otherwise the `cant-receive`
-      # fallback is returned, or ⊥ when unbound.
+      # fallback is returned, or the bottom object when unbound.
       [size cant-receive] > recv
         if. > @
           received.code.eq -1

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The `nop` object is a no-operation: it ignores its argument and
+# No-operation object `nop`: it ignores its argument and
 # always behaves as TRUE. It is useful for temporarily disabling a
 # test (or any other dataizable expression) without removing the
 # code, by wrapping the original body inside `nop`:

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -12,19 +12,19 @@
 # number that internally is a chain of eight bytes.
 [as-bytes] > number
   as-bytes > @
-  times -1 > neg
-  as-i64.as-i32 > as-i32
   as-i32.as-i16 > as-i16
-  as-bytes.eq 7F-F8-00-00-00-00-00-00 > is-nan
-  and. > is-integer
-    is-finite
-    eq floor
+  as-i64.as-i32 > as-i32
   and. > is-finite
     is-nan.not
     not.
       or.
         as-bytes.eq 7F-F0-00-00-00-00-00-00
         as-bytes.eq FF-F0-00-00-00-00-00-00
+  and. > is-integer
+    is-finite
+    eq floor
+  as-bytes.eq 7F-F8-00-00-00-00-00-00 > is-nan
+  times -1 > neg
 
   # Convert this `org.eolang.number` to `org.eolang.i64` object and return it.
   [] > as-i64 /i64
@@ -48,10 +48,10 @@
             bts.eq pzero
             bts.eq nzero
         bts.eq xbts
-    x > xbts!
     as-bytes > bts!
-    0.as-bytes > pzero
     -0.as-bytes > nzero
+    0.as-bytes > pzero
+    x > xbts!
 
   # Returns `true` if `$` < `x`.
   # Here `x` can be a `number` or any other object which

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -8,7 +8,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The `number` object is an abstraction of a 64-bit floating-point
+# Object `number` is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.
 [as-bytes] > number
   as-bytes > @
@@ -108,7 +108,7 @@
   # can be converted to 8 `bytes` via `as-bytes` object.
   [x] > div /number
 
-  # The object rounds down the original `number` to the nearest
+  # Rounds down the original `number` to the nearest
   # whole `number` that is less than or equal to it
   # and returns the result as `org.eolang.number`.
   # For non-finite values (`nan`, `+inf`, `-inf`) the input is returned

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -33,7 +33,7 @@
   # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.
   [tv-sec tv-usec] > timeval
 
-  # The posix `sockaddr_in` structure.
+  # Posix `sockaddr_in` structure.
   [sin-family sin-port sin-addr] > sockaddr-in
     00-00-00-00-00-00-00-00 > sin-zero
     plus. > size

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -18,12 +18,12 @@
   # Makes an actual syscall to operating system
   # Returns `org.eolang.sm.posix.return` object.
   [] > @ /return
+  2 > af-inet
+  -1 > inaddr-none
+  6 > ipproto-tcp
+  1 > sock-stream
   0 > stdin-fileno
   1 > stdout-fileno
-  2 > af-inet
-  1 > sock-stream
-  6 > ipproto-tcp
-  -1 > inaddr-none
   # Result of a POSIX syscall with return code and output.
   [code output] > return
     output > @

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -33,7 +33,7 @@
   # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.
   [tv-sec tv-usec] > timeval
 
-  # Posix `sockaddr_in` structure.
+  # Posix `sockaddr_in` structure for IPv4 socket addressing.
   [sin-family sin-port sin-addr] > sockaddr-in
     00-00-00-00-00-00-00-00 > sin-zero
     plus. > size

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint compound-name
 +unlint redundant-object
 
 # Makes a Unix syscall by `name` with POSIX interface.

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -38,7 +38,7 @@
   # Structure for "GetSystemTime" function call.
   [year month day day-of-week hour minute second milliseconds] > system-time
 
-  # Win32 `sockaddr_in` structure.
+  # Win32 `sockaddr_in` structure for IPv4 socket addressing.
   [sin-family sin-port sin-addr] > sockaddr-in
     00-00-00-00-00-00-00-00 > sin-zero
     plus. > size

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint compound-name
 +unlint many-void-attributes
 +unlint redundant-object
 

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -21,14 +21,14 @@
   # Makes an actual function call to operating system
   # Returns `org.eolang.sm.win32.return` object.
   [] > @ /return
+  2 > af-inet
+  -1 > inaddr-none
+  -1 > invalid-socket
+  6 > ipproto-tcp
+  1 > sock-stream
+  -1 > socket-error
   -10 > std-input-handle
   -11 > std-output-handle
-  2 > af-inet
-  1 > sock-stream
-  6 > ipproto-tcp
-  -1 > invalid-socket
-  -1 > socket-error
-  -1 > inaddr-none
   02-02 > winsock-version-2-2
   # Result of a Win32 function call with return code and output.
   [code output] > return

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -38,7 +38,7 @@
   # Structure for "GetSystemTime" function call.
   [year month day day-of-week hour minute second milliseconds] > system-time
 
-  # The win32 `sockaddr_in` structure.
+  # Win32 `sockaddr_in` structure.
   [sin-family sin-port sin-addr] > sockaddr-in
     00-00-00-00-00-00-00-00 > sin-zero
     plus. > size

--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -147,16 +147,6 @@
                 idx.lt e
               accum.with item
               accum
-    if. > s!
-      start.gte 0
-      if.
-        start.gte origin.length
-        origin.length
-        start
-      if.
-        origin.length.neg.lte start
-        start.plus origin.length
-        0
     if. > e!
       end.gte 0
       if.
@@ -166,6 +156,16 @@
       if.
         origin.length.neg.lte end
         end.plus origin.length
+        0
+    if. > s!
+      start.gte 0
+      if.
+        start.gte origin.length
+        origin.length
+        start
+      if.
+        origin.length.neg.lte start
+        start.plus origin.length
         0
 
   # Create a new list without the first `shift` elements.

--- a/eo-runtime/src/main/eo/ss/map.eo
+++ b/eo-runtime/src/main/eo/ss/map.eo
@@ -77,7 +77,7 @@
     # The `exists` attribute is either `true`, if object was found,
     # or `false` if was not.
     # The `get` attribute takes a fallback and returns either the found
-    # object, or that fallback — the bottom object (⊥) when unbound — if
+    # object, or that fallback (the bottom object when unbound) if
     # the object was not found.
     # @todo #3251:30min Find a way to link hash code and index of key.
     #  Right now map is implemented as `tuple` of objects where every
@@ -290,7 +290,7 @@
         map.entry "one" 1
 
   # Tests that get on a missing key with no fallback yields the bottom object
-  # (⊥) that terminates when used.
+  # that terminates when used.
   [] +> throws-on-map-get-missing-without-fallback
     (mp.found "absent").get > @
     map > mp

--- a/eo-runtime/src/main/eo/ss/map.eo
+++ b/eo-runtime/src/main/eo/ss/map.eo
@@ -39,9 +39,9 @@
           couple
             prev.entries.with
               [] >>
+                ^.hash > hash
                 tup.head.key > key
                 tup.head.value > value
-                ^.hash > hash
             prev.hashes.with hash
       hash-code-of tup.head.key > hash!
       (rec-rebuild tup.tail).@ > prev
@@ -55,22 +55,6 @@
 
   # Initialized hash map with rebuilt entries.
   [entries] > initialized
-    entries.length > size
-    # Returns `list` of all keys in hash map.
-    # Keys order is not guaranteed.
-    mapped > keys
-      list entries
-      entry.key > [entry]
-    # Returns `list` of all values in hash map.
-    # Values order is not guaranteed.
-    mapped > values
-      list entries
-      entry.value > [entry]
-
-    # Returns `true` if hash map has object by given `key`.
-    # Here `key` must be dataizable.
-    (found key).exists > [key] > has
-
     # Tries to find object in hash map by given `key`.
     # Here `key` must be dataizable.
     # The returned object has two attributes: `exists` and `get`.
@@ -121,6 +105,21 @@
               "Object by hash code %d from given key does not exists"
               * hash
 
+    # Returns `true` if hash map has object by given `key`.
+    # Here `key` must be dataizable.
+    (found key).exists > [key] > has
+    # Returns `list` of all keys in hash map.
+    # Keys order is not guaranteed.
+    mapped > keys
+      list entries
+      entry.key > [entry]
+    entries.length > size
+    # Returns `list` of all values in hash map.
+    # Values order is not guaranteed.
+    mapped > values
+      list entries
+      entry.value > [entry]
+
     # Returns the new `map` with added object
     # Replaces if there was one before.
     [key value] > with
@@ -131,9 +130,9 @@
               list entries
               (hash.eq entry.hash).not > [entry] >>
           [] >>
+            ^.hash > hash
             ^.key > key
             ^.value > value
-            ^.hash > hash
       hash-code-of key > hash!
 
     # Returns a new `map`, without element with the given `key`
@@ -199,12 +198,12 @@
   # Tests that finding an element by key in a map works correctly.
   [] +> tests-finds-element-by-key-in-map
     2.eq found.get > @
+    mp.found "two" > found
     map > mp
       *
         map.entry "one" 1
         map.entry "two" 2
         map.entry "three" 3
-    mp.found "two" > found
 
   # Tests that searching for non-existent key returns false exists flag.
   [] +> tests-does-not-find-element-by-key-in-hash-map

--- a/eo-runtime/src/main/eo/ss/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/ss/range-of-numbers.eo
@@ -9,7 +9,7 @@
 
 # Range of numbers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not, the bottom object
-# (⊥) is returned, which terminates on use.
+# is returned, which terminates on use.
 [start end] > range-of-numbers
   if. > @
     and.

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -127,7 +127,7 @@
     start > sbts!
     as-bytes.size > size
 
-    # The object checks if `index` + `csize` is not out of the string bounds.
+    # Checks if `index` + `csize` is not out of the string bounds.
     # If not - the new recursion cycle is started with `index` increased by `csize` and
     # `accum` increased by 1.
     [index csize accum result cause] > increase

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -29,7 +29,6 @@
       size.eq 0
       0
       reclen 0 0
-    as-bytes.size > size
     80- > p1
     E0- > p2
     F0- > p3
@@ -38,6 +37,7 @@
     C0- > r2
     p2 > r3
     p3 > r4
+    as-bytes.size > size
 
     # Object that checks if `index` + `csize` is out of the string bounds.
     # If not - the new recursion iteration is started with `index` increased by `csize` and
@@ -96,27 +96,6 @@
           ""
           string
             as-bytes.slice bstart blen
-    start > sbts!
-    len > lbts!
-    number sbts > nstart
-    number lbts > nlen
-    as-bytes.size > size
-    nstart.plus nlen > end
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    recidx > bstart!
-      0
-      0
-      nstart
-      sprintf
-        "Start index (%d) is out of string bounds"
-        * nstart
     minus. > blen
       recidx
         number bstart
@@ -126,6 +105,27 @@
           "Start index + length to slice (%d) is out of string bounds"
           * (nstart.plus nlen)
       bstart
+    recidx > bstart!
+      0
+      0
+      nstart
+      sprintf
+        "Start index (%d) is out of string bounds"
+        * nstart
+    nstart.plus nlen > end
+    len > lbts!
+    number lbts > nlen
+    number sbts > nstart
+    80- > p1
+    E0- > p2
+    F0- > p3
+    F8- > p4
+    00- > r1
+    C0- > r2
+    p2 > r3
+    p3 > r4
+    start > sbts!
+    as-bytes.size > size
 
     # The object checks if `index` + `csize` is not out of the string bounds.
     # If not - the new recursion cycle is started with `index` increased by `csize` and

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -7,7 +7,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The `string` object represents UTF-8 encoded text strings stored internally
+# Object `string` represents UTF-8 encoded text strings stored internally
 # as byte sequences. It provides Unicode-aware operations for text manipulation
 # including slicing, length calculation, and character-level access.
 # Unicode characters may occupy 1-4 bytes each, so byte length differs from
@@ -39,7 +39,7 @@
     p2 > r3
     p3 > r4
 
-    # The object checks if `index` + `csize` is out of the string bounds.
+    # Object that checks if `index` + `csize` is out of the string bounds.
     # If not - the new recursion iteration is started with `index` increased by `csize` and
     # `accum` increased by 1.
     [index csize len] > inclen
@@ -53,7 +53,7 @@
           index.plus csize
           len.plus 1
 
-    # The object recursively calculates the length of current string considering how many bytes
+    # Object that recursively calculates the length of current string considering how many bytes
     # the character on each iteration must consist of.
     [index accum] > reclen
       if. > @
@@ -143,7 +143,7 @@
           result
           cause
 
-    # The object recursively calculates `index` of bytes representation of the string
+    # Object that recursively calculates `index` of bytes representation of the string
     # where `accum` equals provided `result`.
     # The `cause` here is the description of the error which is thrown when `index` reaches the end
     # of the bytes but `accum` does not reach the `result`.

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -6,7 +6,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-# The object allows choosing the right options according to case conditions.
+# Object that allows choosing the right options according to case conditions.
 # Parameter `cases` is an array of two-dimensional arrays, which
 # consist of condition bool value and expected value, if this
 # condition is true. For example:

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -102,7 +102,7 @@
           false
           "false2"
 
-  # Tests that empty switch cases with no fallback yield the bottom object (⊥)
+  # Tests that empty switch cases with no fallback yield the bottom object
   # that terminates when used.
   [] +> throws-on-empty-switch
     switch * > @

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -41,8 +41,8 @@
         previous.match
       previous
       [] >>
-        tup.head.tail.head > match!
         tup.head.head > head
+        tup.head.tail.head > match!
     (rec-case tup.tail).@ > previous
 
   # Tests that switch returns the value from the first true condition case.

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The object is a TRUE boolean state.
+# TRUE boolean state.
 # It is the `bool` whose choice returns its first argument, so `if` picks
 # the `left` branch and the byte representation is `01-`.
 bool > true

--- a/eo-runtime/src/main/eo/tt/as-fixed.eo
+++ b/eo-runtime/src/main/eo/tt/as-fixed.eo
@@ -26,9 +26,9 @@
   # Writes the non-negative `a` as integer part, dot and `places` fraction digits.
   [a] > positive
     concat. (concat. (as-decimal ip) ".".as-bytes) (rec-pad (m.minus (ip.times scale)) places --) > @
-    pow10 places > scale
-    ((a.times scale).plus 0.5).floor > m
     (m.div scale).floor > ip
+    ((a.times scale).plus 0.5).floor > m
+    pow10 places > scale
 
   # Emits exactly `count` least-significant digits of `value`, zero-padded.
   [value count acc] > rec-pad

--- a/eo-runtime/src/main/eo/tt/as-number.eo
+++ b/eo-runtime/src/main/eo/tt/as-number.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Returns the original `text` as `number`.
-# If the text is not numeric - the `cant-parse` fallback is returned, or ⊥ when unbound.
+# If the text is not numeric - the `cant-parse` fallback is returned, or the bottom object when unbound.
 [text cant-parse] > as-number
   if. > @
     scanned.length.eq 0
@@ -25,7 +25,7 @@
       5
       as-number "5"
 
-  # Tests that as-number terminates with ⊥ on non-numeric text when no fallback is given.
+  # Tests that as-number terminates on non-numeric text when no fallback is given.
   [] +> throws-on-converting-text-to-number
     as-number "Hello" > @
 

--- a/eo-runtime/src/main/eo/tt/as-number.eo
+++ b/eo-runtime/src/main/eo/tt/as-number.eo
@@ -8,7 +8,8 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Returns the original `text` as `number`.
-# If the text is not numeric - the `cant-parse` fallback is returned, or the bottom object when unbound.
+# If the text is not numeric, the `cant-parse` fallback is returned,
+# or the bottom object when unbound.
 [text cant-parse] > as-number
   if. > @
     scanned.length.eq 0

--- a/eo-runtime/src/main/eo/tt/at.eo
+++ b/eo-runtime/src/main/eo/tt/at.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Retrieve symbol by given index as `text`.
-# If 0 > index >= ^.length - the `out-of-bounds` fallback is returned, or ⊥ when unbound.
+# If 0 > index >= ^.length - the `out-of-bounds` fallback is returned, or the bottom object when unbound.
 [text i out-of-bounds] > at
   if. > @
     or.
@@ -44,7 +44,7 @@
       "m"
       at "some" -2
 
-  # Tests that at terminates with ⊥ when the index is out of bounds and no fallback is given.
+  # Tests that at terminates when the index is out of bounds and no fallback is given.
   [] +> throws-on-text-at-index-more-than-length
     at "some" 10 > @
 

--- a/eo-runtime/src/main/eo/tt/at.eo
+++ b/eo-runtime/src/main/eo/tt/at.eo
@@ -8,7 +8,8 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Retrieve symbol by given index as `text`.
-# If 0 > index >= ^.length - the `out-of-bounds` fallback is returned, or the bottom object when unbound.
+# If 0 > index >= ^.length, the `out-of-bounds` fallback is returned,
+# or the bottom object when unbound.
 [text i out-of-bounds] > at
   if. > @
     or.

--- a/eo-runtime/src/main/eo/tt/at.eo
+++ b/eo-runtime/src/main/eo/tt/at.eo
@@ -19,12 +19,12 @@
         "Given index %d is out of text bounds"
         * index
     slice text index 1
-  text.length > len!
   i > idx!
   if. > index!
     0.gt idx
     (number len).plus idx
     idx
+  text.length > len!
 
   # Tests specific functionality at method returns first character at index 0.
   [] +> tests-returns-first-char

--- a/eo-runtime/src/main/eo/tt/contains.eo
+++ b/eo-runtime/src/main/eo/tt/contains.eo
@@ -15,11 +15,11 @@
         tlen.eq slen
         txt.eq sub
       rec-contains 0
-  text > txt!
+  (number tlen).minus slen > end!
+  sub.size > slen!
   substring > sub!
   txt.size > tlen!
-  sub.size > slen!
-  (number tlen).minus slen > end!
+  text > txt!
 
   # Recursively searches for substring presence in text from given index.
   [idx] > rec-contains

--- a/eo-runtime/src/main/eo/tt/ends-with.eo
+++ b/eo-runtime/src/main/eo/tt/ends-with.eo
@@ -16,10 +16,10 @@
         (number tlen).minus slen
         slen
       sub
-  text > txt!
+  sub.size > slen!
   substring > sub!
   txt.size > tlen!
-  sub.size > slen!
+  text > txt!
 
   # Tests specific functionality ends-with returns true when text ends with given substring.
   [] +> tests-ends-with-substring

--- a/eo-runtime/src/main/eo/tt/index-of.eo
+++ b/eo-runtime/src/main/eo/tt/index-of.eo
@@ -21,12 +21,12 @@
     length.
       string
         slice txt 0 found
-  text > txt!
-  substring > sub!
-  txt.size > tlen!
-  sub.size > slen!
   (number tlen).minus slen > end!
   rec-index-of 0 > found!
+  sub.size > slen!
+  substring > sub!
+  txt.size > tlen!
+  text > txt!
 
   # Recursively searches for substring from beginning to end of text.
   [idx] > rec-index-of

--- a/eo-runtime/src/main/eo/tt/joined.eo
+++ b/eo-runtime/src/main/eo/tt/joined.eo
@@ -9,11 +9,11 @@
 # as a delimiter.
 [text items] > joined
   string bts > @
-  text > delimiter!
   if. > bts!
     items.length.eq 0
     --
     with-delimiter items.head items.tail
+  text > delimiter!
 
   # Recursively concatenates tuple elements with delimiter between them.
   [acc tup] > with-delimiter

--- a/eo-runtime/src/main/eo/tt/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tt/last-index-of.eo
@@ -21,12 +21,12 @@
     length.
       string
         slice txt 0 found
-  text > txt!
-  substring > sub!
-  txt.size > tlen!
-  sub.size > slen!
   rec-index-of > found!
     (number tlen).minus slen
+  sub.size > slen!
+  substring > sub!
+  txt.size > tlen!
+  text > txt!
 
   # Recursively searches for substring from end to beginning of text.
   [idx] > rec-index-of

--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -32,11 +32,11 @@
               1
             byte
         as-ascii byte > code
-  as-ascii "Z" > maxcode
-  as-ascii "A" > mincode
   minus. > distance
     as-ascii "a"
     as-ascii "A"
+  as-ascii "Z" > maxcode
+  as-ascii "A" > mincode
 
   # Tests that low-cased converts uppercase text to lowercase.
   [] +> tests-converts-text-to-lower-case

--- a/eo-runtime/src/main/eo/tt/nsplit.eo
+++ b/eo-runtime/src/main/eo/tt/nsplit.eo
@@ -10,7 +10,7 @@
 
 # Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
-# If `limit` < 1, the `cant-split` fallback is returned, or ⊥ when unbound.
+# If `limit` < 1, the `cant-split` fallback is returned, or the bottom object when unbound.
 [text delimiter limit cant-split] > nsplit
   if. > @
     1.gt limit
@@ -93,14 +93,14 @@
           10
       * "a" "b" "c"
 
-  # Tests that nsplit terminates with ⊥ on limit 0 when no fallback is given.
+  # Tests that nsplit terminates on limit 0 when no fallback is given.
   [] +> throws-on-nsplit-with-limit-zero
     nsplit > @
       "text"
       "-"
       0
 
-  # Tests that nsplit terminates with ⊥ on a negative limit when no fallback is given.
+  # Tests that nsplit terminates on a negative limit when no fallback is given.
   [] +> throws-on-nsplit-with-negative-limit
     nsplit > @
       "text"

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -91,8 +91,8 @@
       #  here, in `matched`. Don't forget to remove this puzzle.
       [position start from to groups] > matched
         groups.length > count
-        $ > matched
         start.gte 0 > exists
+        $ > matched
         if. > next
           exists
           matched.

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -90,8 +90,8 @@
       #  idempotency is not fully implemented, and we cannot remove some edge case usages, like
       #  here, in `matched`. Don't forget to remove this puzzle.
       [position start from to groups] > matched
-        $ > matched
         groups.length > count
+        $ > matched
         start.gte 0 > exists
         if. > next
           exists

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -258,7 +258,7 @@
         "no-slash" > [msg]
 
   # Tests that an invalid pattern with no `cant-compile` fallback yields the bottom
-  # object (⊥) that terminates when used.
+  # object that terminates when used.
   [] +> throws-on-compiling-invalid-regex-without-fallback
     (regex "/[a-z/").compile > @
 

--- a/eo-runtime/src/main/eo/tt/repeated.eo
+++ b/eo-runtime/src/main/eo/tt/repeated.eo
@@ -17,8 +17,8 @@
         "Can't repeat text %d times"
         * amount
     string result
-  text > bts!
   times > amount!
+  text > bts!
   if. > result!
     0.eq amount
     --

--- a/eo-runtime/src/main/eo/tt/repeated.eo
+++ b/eo-runtime/src/main/eo/tt/repeated.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 # Returns `text` repeated `times` times.
-# If `times` < 0, the `cant-repeat` fallback is returned, or ⊥ when unbound.
+# If `times` < 0, the `cant-repeat` fallback is returned, or the bottom object when unbound.
 # If `times` == 0, empty text is returned.
 [text times cant-repeat] > repeated
   if. > @
@@ -33,7 +33,7 @@
         accum.concat bts
         (index.plus 1).as-number
 
-  # Tests that repeated terminates with ⊥ on a negative count when no fallback is given.
+  # Tests that repeated terminates on a negative count when no fallback is given.
   [] +> throws-on-text-repeating-less-than-zero-times
     repeated > @
       ""

--- a/eo-runtime/src/main/eo/tt/replaced.eo
+++ b/eo-runtime/src/main/eo/tt/replaced.eo
@@ -16,8 +16,8 @@
     reinit
     rec-replaced matched "" matched.start
   text > bts!
-  string bts > reinit
   (target.match reinit).next > matched
+  string bts > reinit
 
   # Recursively replaces matched blocks with replacement string in text.
   [block accum start] > rec-replaced

--- a/eo-runtime/src/main/eo/tt/split.eo
+++ b/eo-runtime/src/main/eo/tt/split.eo
@@ -13,8 +13,8 @@
     len.eq 0
     *
     rec-split * 0 0
-  delimiter > delim!
   text > bts!
+  delimiter > delim!
   bts.size > len!
 
   # Recursively splits text by delimiter into tuple of substrings.

--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The `sprintf` object allows you to format and output text depending
+# Object `sprintf` allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.
 #
 # When arguments are processed - they're dataized and converted to objects

--- a/eo-runtime/src/main/eo/tt/starts-with.eo
+++ b/eo-runtime/src/main/eo/tt/starts-with.eo
@@ -11,10 +11,10 @@
   and. > @
     (number slen).lte tlen
     (slice txt 0 slen).eq sub
-  text > txt!
+  sub.size > slen!
   substring > sub!
   txt.size > tlen!
-  sub.size > slen!
+  text > txt!
 
   # Tests specific functionality starts-with returns true when text begins with given substring.
   [] +> tests-starts-with-substring

--- a/eo-runtime/src/main/eo/tt/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed-left.eo
@@ -15,8 +15,8 @@
         idx
         (number len).minus idx
   text > bts!
-  bts.size > len!
   first-non-space-index 0 > idx!
+  bts.size > len!
 
   # Recursively finds index of the first non-space character from left.
   [index] > first-non-space-index

--- a/eo-runtime/src/main/eo/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/tt/up-cased.eo
@@ -32,11 +32,11 @@
               1
             byte
         as-ascii byte > code
-  as-ascii "z" > maxcode!
-  as-ascii "a" > mincode!
   minus. > distance
     number mincode
     as-ascii "A"
+  as-ascii "z" > maxcode!
+  as-ascii "a" > mincode!
 
   # Tests that up-cased converts lowercase text to uppercase.
   [] +> tests-converts-text-to-upper-case

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -125,7 +125,7 @@
       "with"
 
   # Tests that an out-of-bounds index with no fallback yields the bottom object
-  # (⊥) that terminates when used.
+  # that terminates when used.
   [] +> throws-on-wrong-tuple-at
     at. > @
       * 1 2 3 4

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -110,7 +110,6 @@
   [] +> tests-iterating-tuple-with-while-using-internal-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
-    arr.length.plus -1 > max
     malloc.for > data
       0
       [acc] >>
@@ -132,12 +131,12 @@
                           arr.at i
                       iter.put
                         iter.as-number.plus 1
+    arr.length.plus -1 > max
 
   # Tests that while loop can iterate over tuple elements using external iterator.
   [] +> tests-iterating-tuple-with-while-using-external-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
-    arr.length.plus -1 > max
     malloc.for > data
       0
       [acc] >>
@@ -154,12 +153,12 @@
                         arr.at iter
                     iter.put
                       iter.as-number.plus 1
+    arr.length.plus -1 > max
 
   # Tests that while loop can iterate over multiple tuple elements without explicit body.
   [] +> tests-iterating-tuple-with-while-without-body-multiple
     data.eq arr.length > @
     * 1 1 1 > arr
-    arr.length > max
     malloc.for > data
       0
       [acc] >>
@@ -184,12 +183,12 @@
                       false
                   true > [i]
                 acc
+    arr.length > max
 
   # Tests that while loop can iterate over single tuple element without explicit body.
   [] +> tests-iterating-tuple-with-while-without-body-single
     data.eq arr.length > @
     * 1 > arr
-    arr.length > max
     malloc.for > data
       0
       [acc] >>
@@ -214,3 +213,4 @@
                       false
                   true > [i]
                 acc
+    arr.length > max

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The `while` object is very similar to a loop with a pre-condition.
+# Loop `while` with a pre-condition.
 # Here's how you can use it:
 # ```
 # while > last


### PR DESCRIPTION
Upgrades `lints` dependency from `0.2.10` to `0.2.11` and suppresses the new `compound-name` lint in `eo-runtime` until hyphenated parameter names are renamed.

Fixes #5378