### PR TITLE
#5335: check HTTP status in OyRemote.get() to avoid caching throttled responses

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.jcabi.aspects.RetryOnFailure;
 import com.jcabi.log.Logger;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -50,14 +51,29 @@ final class OyRemote implements Objectionary {
      * @checkstyle ConstructorsCodeFreeCheck (15 lines)
      */
     OyRemote(final CommitHash hash, final Proxy... proxies) {
-        this.program = new OyRemote.UrlOy(
-            "https://raw.githubusercontent.com/objectionary/home/%s/objects/%s.eo",
-            hash
+        this(
+            new OyRemote.UrlOy(
+                "https://raw.githubusercontent.com/objectionary/home/%s/objects/%s.eo",
+                hash
+            ),
+            new OyRemote.UrlOy(
+                "https://github.com/objectionary/home/tree/%s/objects/%s",
+                hash
+            ),
+            proxies
         );
-        this.directory = new OyRemote.UrlOy(
-            "https://github.com/objectionary/home/tree/%s/objects/%s",
-            hash
-        );
+    }
+
+    /**
+     * Ctor for testing.
+     * @param program Address template to program
+     * @param directory Address template to directory
+     * @param proxies Proxies to use
+     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
+     */
+    OyRemote(final UrlOy program, final UrlOy directory, final Proxy... proxies) {
+        this.program = program;
+        this.directory = directory;
         this.http = OyRemote.client(proxies);
     }
 
@@ -78,7 +94,7 @@ final class OyRemote implements Objectionary {
             name, url
         );
         return new InputWithFallback(
-            () -> this.send(url, HttpResponse.BodyHandlers.ofInputStream()).body(),
+            () -> this.fetch(url),
             input -> {
                 throw new IOException(
                     String.format(
@@ -111,6 +127,25 @@ final class OyRemote implements Objectionary {
             );
         }
         return code >= HttpURLConnection.HTTP_OK && code < HttpURLConnection.HTTP_BAD_REQUEST;
+    }
+
+    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
+    private InputStream fetch(final URL url) throws IOException {
+        final HttpResponse<InputStream> response = this.send(
+            url, HttpResponse.BodyHandlers.ofInputStream()
+        );
+        final int code = response.statusCode();
+        if (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT || code == 429) {
+            throw new IOException(
+                String.format("Transient HTTP error %d for %s, will retry", code, url)
+            );
+        }
+        if (code < HttpURLConnection.HTTP_OK || code >= HttpURLConnection.HTTP_BAD_REQUEST) {
+            throw new IOException(
+                String.format("HTTP error %d for %s", code, url)
+            );
+        }
+        return response.body();
     }
 
     private <T> HttpResponse<T> send(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -4,10 +4,13 @@
  */
 package org.eolang.maven;
 
+import com.sun.net.httpserver.HttpServer;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -108,6 +111,36 @@ final class OyRemoteTest {
             ).contains(stdout),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    void doesNotReturnThrottledResponseBodyAsSource() throws Exception {
+        final HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+            "/",
+            exchange -> {
+                final byte[] body = "429: Too Many Requests".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(429, body.length);
+                exchange.getResponseBody().write(body);
+                exchange.close();
+            }
+        );
+        server.start();
+        try {
+            final String tpl = String.format(
+                "http://127.0.0.1:%d/%%s/%%s.eo", server.getAddress().getPort()
+            );
+            Assertions.assertThrows(
+                IOException.class,
+                () -> new OyRemote(
+                    new OyRemote.UrlOy(tpl, "stub"),
+                    new OyRemote.UrlOy(tpl, "stub")
+                ).get("org.eolang.foo").stream(),
+                "Expected an IOException instead of the throttled HTTP body being returned as EO source"
+            );
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #5335.

`OyRemote.get()` (eo-maven-plugin) returned `this.send(url, ...).body()` without ever inspecting the HTTP status code. When `raw.githubusercontent.com` throttles a burst of object pulls with `429 Too Many Requests`, the error-page body was handed back as if it were the object's `.eo` source, then persisted into the pulled-object cache — so every later build reused the poisoned file and failed with a misleading parse error, long after GitHub had recovered.

`exists()` in the same class already guarded against this (429/408 detection + retry), but `get()` had neither the status check nor `@RetryOnFailure`.

Fix: extracted a `fetch(URL)` helper that checks the response status the same way `exists()` does — 429/408 throw and retry via `@RetryOnFailure`, any other non-2xx throws immediately — so a throttled or failed response is never returned or cached as source. `get()`'s supplier now calls `fetch(url)` instead of reading the body unconditionally.

Added `OyRemoteTest.doesNotReturnThrottledResponseBodyAsSource`, which stands up a local `HttpServer` that always answers `429` with the literal throttling body text, and asserts `get(...).stream()` throws `IOException` instead of returning that body. Verified the test fails without the fix (reverting only the `get()` lambda back to the unconditional `.body()` call reproduces `AssertionFailedError: ... nothing was thrown`), and passes with it.

Added a test-only constructor `OyRemote(UrlOy, UrlOy, Proxy...)` (mirroring the existing "Ctor for testing" pattern already used by `OyRemote.UrlOy`) so the test can point `OyRemote` at the local stub server instead of hitting the real Objectionary endpoints.

Verification:
- `mvn -pl eo-maven-plugin test -Dtest=OyRemoteTest`: 9 tests, 0 failures, 0 errors (includes the pre-existing live-network tests).
- `mvn verify -Pqulice`: 0 violations.
