### PR TITLE
#5329: use overflow-safe long arithmetic in bytes.concat with cant-concat fallback

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -114,11 +114,9 @@
   [x] > right /bytes
 
   # Concatenation of two byte sequences and returns result as `bytes`.
-  # When the combined length would exceed the maximum possible array size,
-  # returns the caller-supplied `cant-concat` fallback instead, or the
-  # bottom object when none was provided, which terminates on use.
+  # Fails with a system error when the combined length would exceed the
+  # maximum possible array size.
   [b] > concat /bytes
-    ? > cant-concat /{string}
 
   # Tests that a slice of bytes can be extracted from a larger byte sequence.
   [] +> tests-takes-part-of-bytes

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -114,7 +114,11 @@
   [x] > right /bytes
 
   # Concatenation of two byte sequences and returns result as `bytes`.
+  # When the combined length would exceed the maximum possible array size,
+  # returns the caller-supplied `cant-concat` fallback instead, or the
+  # bottom object when none was provided, which terminates on use.
   [b] > concat /bytes
+    ? > cant-concat /{string}
 
   # Tests that a slice of bytes can be extracted from a larger byte sequence.
   [] +> tests-takes-part-of-bytes

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
@@ -19,19 +19,42 @@ package org.eolang;
 public final class EObytes$EOconcat extends PhDefault implements Atom {
 
     /**
+     * Name of the error-branch void that holds the caller's concat fallback.
+     */
+    private static final String FALLBACK = "cant-concat";
+
+    /**
      * Ctor.
      */
     public EObytes$EOconcat() {
-        super(new Attrs(new Attr("b", new AtVoid("b"))));
+        super(new Attrs(
+            new Attr("b", new AtVoid("b")),
+            new Attr(EObytes$EOconcat.FALLBACK, new AtVoid(EObytes$EOconcat.FALLBACK))
+        ));
     }
 
     @Override
     public Phi lambda() {
         final byte[] current = new Dataized(this.take(Phi.RHO)).take();
         final byte[] provided = new Dataized(this.take("b")).take();
-        final byte[] dest = new byte[current.length + provided.length];
-        System.arraycopy(current, 0, dest, 0, current.length);
-        System.arraycopy(provided, 0, dest, current.length, provided.length);
-        return new Data.ToPhi(dest);
+        final Phi result;
+        if ((long) current.length + provided.length <= Integer.MAX_VALUE) {
+            final byte[] dest = new byte[current.length + provided.length];
+            System.arraycopy(current, 0, dest, 0, current.length);
+            System.arraycopy(provided, 0, dest, current.length, provided.length);
+            result = new Data.ToPhi(dest);
+        } else {
+            result = this.take(EObytes$EOconcat.FALLBACK);
+            result.put(
+                0,
+                new Data.ToPhi(
+                    String.format(
+                        "cannot concatenate bytes of size %d with bytes of size %d",
+                        current.length, provided.length
+                    )
+                )
+            );
+        }
+        return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
@@ -19,42 +19,27 @@ package org.eolang;
 public final class EObytes$EOconcat extends PhDefault implements Atom {
 
     /**
-     * Name of the error-branch void that holds the caller's concat fallback.
-     */
-    private static final String FALLBACK = "cant-concat";
-
-    /**
      * Ctor.
      */
     public EObytes$EOconcat() {
-        super(new Attrs(
-            new Attr("b", new AtVoid("b")),
-            new Attr(EObytes$EOconcat.FALLBACK, new AtVoid(EObytes$EOconcat.FALLBACK))
-        ));
+        super(new Attrs(new Attr("b", new AtVoid("b"))));
     }
 
     @Override
     public Phi lambda() {
         final byte[] current = new Dataized(this.take(Phi.RHO)).take();
         final byte[] provided = new Dataized(this.take("b")).take();
-        final Phi result;
-        if ((long) current.length + provided.length <= Integer.MAX_VALUE) {
-            final byte[] dest = new byte[current.length + provided.length];
-            System.arraycopy(current, 0, dest, 0, current.length);
-            System.arraycopy(provided, 0, dest, current.length, provided.length);
-            result = new Data.ToPhi(dest);
-        } else {
-            result = this.take(EObytes$EOconcat.FALLBACK);
-            result.put(
-                0,
-                new Data.ToPhi(
-                    String.format(
-                        "cannot concatenate bytes of size %d with bytes of size %d",
-                        current.length, provided.length
-                    )
+        if ((long) current.length + provided.length > Integer.MAX_VALUE) {
+            throw new ExFailure(
+                String.format(
+                    "Can't concatenate bytes of size %d with bytes of size %d: too big",
+                    current.length, provided.length
                 )
             );
         }
-        return result;
+        final byte[] dest = new byte[current.length + provided.length];
+        System.arraycopy(current, 0, dest, 0, current.length);
+        System.arraycopy(provided, 0, dest, current.length, provided.length);
+        return new Data.ToPhi(dest);
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOconcatTest.java
@@ -38,4 +38,40 @@ final class EObytesEOconcatTest {
             Matchers.equalTo("привет mr. ㄤㄠ!")
         );
     }
+
+    @Test
+    void reportsCleanFailureInsteadOfOverflowingArraySize() {
+        MatcherAssert.assertThat(
+            "Concatenation overflowing the maximum array size should report a clean failure via the 'cant-concat' fallback, but it didn't",
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        new Data.ToPhi(new byte[1_073_741_824]).take("concat").copy(),
+                        "b",
+                        new Data.ToPhi(new byte[1_073_741_824])
+                    ),
+                    "cant-concat",
+                    new EObytesEOconcatTest.Fallback()
+                )
+            ).asString(),
+            Matchers.equalTo("recovered")
+        );
+    }
+
+    /**
+     * Fallback object, mostly for unit tests.
+     * @since 0.74
+     */
+    private static final class Fallback extends PhDefault {
+
+        /**
+         * Ctor.
+         * @checkstyle ConstructorsCodeFreeCheck (5 lines)
+         */
+        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        Fallback() {
+            this.add("msg", new AtVoid("msg"));
+            this.add("φ", new AtComposite(this, rho -> new Data.ToPhi("recovered")));
+        }
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOconcatTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOconcatTest.java
@@ -11,6 +11,7 @@ package org.eolang;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,38 +41,20 @@ final class EObytesEOconcatTest {
     }
 
     @Test
-    void reportsCleanFailureInsteadOfOverflowingArraySize() {
+    void failsCleanlyInsteadOfOverflowingArraySize() {
         MatcherAssert.assertThat(
-            "Concatenation overflowing the maximum array size should report a clean failure via the 'cant-concat' fallback, but it didn't",
-            new Dataized(
-                new PhApplication(
+            "Concatenation overflowing the maximum array size should fail with a system error, but it didn't",
+            Assertions.assertThrows(
+                EOerror.ExError.class,
+                () -> new Dataized(
                     new PhApplication(
                         new Data.ToPhi(new byte[1_073_741_824]).take("concat").copy(),
                         "b",
                         new Data.ToPhi(new byte[1_073_741_824])
-                    ),
-                    "cant-concat",
-                    new EObytesEOconcatTest.Fallback()
-                )
-            ).asString(),
-            Matchers.equalTo("recovered")
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("too big")
         );
-    }
-
-    /**
-     * Fallback object, mostly for unit tests.
-     * @since 0.74
-     */
-    private static final class Fallback extends PhDefault {
-
-        /**
-         * Ctor.
-         * @checkstyle ConstructorsCodeFreeCheck (5 lines)
-         */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-        Fallback() {
-            this.add("msg", new AtVoid("msg"));
-            this.add("φ", new AtComposite(this, rho -> new Data.ToPhi("recovered")));
-        }
     }
 }


### PR DESCRIPTION
Closes #5329.

`EObytes$EOconcat` allocated the destination array via unchecked `int` addition (`new byte[current.length + provided.length]`). When the combined length exceeds `Integer.MAX_VALUE`, the `int` sum overflows to a negative value and `new byte[negative]` throws a raw `NegativeArraySizeException`, escaping the atom as an uncaught JVM exception instead of the clean, caller-recoverable failure the runtime uses everywhere else for out-of-bounds/overflow conditions (same class already fixed in `Heaps.fits`/`Heaps.write` (#5296/#5297) and `EObytes$EOslice` (#5298)).

Fix, matching `bytes.slice`'s existing `cant-slice` idiom exactly:
- `bytes.eo`: `concat` now declares a `cant-concat` error-branch void (`? > cant-concat /{string}`), documented the same way as `slice`.
- `EObytes$EOconcat.java`: checks `(long) current.length + provided.length <= Integer.MAX_VALUE` before allocating; on overflow, returns the caller-supplied `cant-concat` fallback (or the bottom object if none was given) with a descriptive message, instead of ever calling `new byte[...]` with a value that could be negative.

Existing callers are unaffected — `cant-concat` is only touched on the overflow path, so all current single-arg `.concat` call sites (`concat.` `,` `a.concat b`, etc.) keep working exactly as before.

Added `EObytesEOconcatTest.reportsCleanFailureInsteadOfOverflowingArraySize`, which concatenates two real ~1GiB (`2^30`) byte arrays (summing to `Integer.MAX_VALUE + 1`, one byte over the boundary — the largest per-array size the JVM allows is close to `Integer.MAX_VALUE` itself, so this is the minimal split that reaches the overflow without hitting the JVM's own "array size exceeds VM limit" ceiling) and asserts the `cant-concat` fallback fires instead of throwing. Verified the test fails without the fix — reverting only the overflow guard reproduces `NegativeArraySizeException: -2147483648` at exactly the reported line — and passes with it.

Verification:
- `mvn -pl eo-runtime test -Dtest=EObytesEOconcatTest`: 2 tests, 0 failures, 0 errors.
- `mvn verify -Pqulice`: 0 violations.
