### PR TITLE
#5341: fix i64.lt overflow by delegating to overflow-free gt instead of subtraction

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -36,10 +36,9 @@
   # Returns `org.eolang.true` if `$` < `x`.
   # Here `x` must be an `org.eolang.i64` object.
   [x] > lt
-    0.as-i64.gt > @
-      minus
-        i64 value
-    x > value!
+    gt. > @
+      i64 x.as-bytes
+      ^
 
   # Returns `org.eolang.true` if `$` <= `x`.
   # Here `x` must be an `org.eolang.i64` object.
@@ -156,6 +155,21 @@
       lt.
         10.as-i64
         -5.as-i64
+
+  # Tests that i64 less-than comparison is correct across the full range,
+  # where a subtraction-based implementation would wrap and invert the answer.
+  [] +> tests-i64-less-across-full-range
+    lt. > @
+      -9223372036854775808.as-i64
+      1.as-i64
+
+  # Tests that i64 less-than comparison doesn't wrap when the difference
+  # between the two operands exceeds the i64 range.
+  [] +> tests-i64-less-with-large-difference
+    not. > @
+      lt.
+        5000000000000000000.as-i64
+        -5000000000000000000.as-i64
 
   # Tests that i64 greater-than comparison returns true for larger values.
   [] +> tests-i64-greater-true


### PR DESCRIPTION
Closes #5341.

`i64.lt` was implemented as `0.as-i64.gt (minus (i64 value))`, computing the difference `$ - x` as an i64 and testing whether `0 > ($ - x)`. Since i64 subtraction wraps modulo 2^64 (native `Long` arithmetic), whenever the true mathematical difference falls outside `[Long.MIN_VALUE, Long.MAX_VALUE]` the wrapped result's sign flips and `lt` returns the inverted answer. `lte` is derived from `lt` and inherited the same defect. The sibling `gt` performs a direct, overflow-free `long > long` comparison, establishing exact ordering as the intended semantics — deriving `lt` from a wrapping subtraction contradicted that.

Fix: `lt` now delegates directly to the overflow-free `gt`, mirroring the suggested fix in the issue (`x.gt $`, i.e. `$ < x` iff `x > $`), with no intermediate difference ever formed:

```
[x] > lt
  gt. > @
    i64 x.as-bytes
    ^
```

Note on `i64 x.as-bytes`: `x` may arrive either as a live `i64` object or as the raw-bytes form `lte`/`gte` pass through their own const-cached `value` alias (`x > value!` dataizes+bytes-ifies `x` before forwarding it) — `.as-bytes` is valid on both shapes, and `i64 (...)` normalizes the result back into a proper `i64` before dispatching `.gt` on it. This is the same defensive normalization the original `lt` used (`i64 value`) before its subtraction; without it, `lte`'s indirect call into `lt` breaks even though direct external calls to `.lt` work fine.

Added two boundary tests to `i64.eo`, matching the verified traces from the issue:
- `tests-i64-less-across-full-range`: `Long.MIN_VALUE.lt(1)` must be `true` (the old subtraction-based version returned `false`, since `1 - Long.MIN_VALUE` overflows).
- `tests-i64-less-with-large-difference`: `5e18.lt(-5e18)` must be `false` (the old version returned `true`, since `5e18 - (-5e18) = 1e19` overflows `Long.MAX_VALUE`).

Verified both new tests fail against the original subtraction-based implementation with exactly the inverted answers described in the issue (`expected: <true> but was: <false>` for both), and pass with the fix. `i32.lt`/`i16.lt` delegate to `as-i64.lt`/`as-i32.lt` respectively, so they inherit the correct ordering transitively — no separate fix needed there.

Verification:
- `mvn -pl eo-runtime test -Dtest=EOi64Test`: 35 tests, 0 failures, 0 errors.
- `mvn verify -Pqulice`: 0 violations.
