### PR TITLE
#5343: use is-integer instead of x.div x for range-of-numbers integer guard

### DIFF
--- a/eo-runtime/src/main/eo/ss/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/ss/range-of-numbers.eo
@@ -13,12 +13,8 @@
 [start end] > range-of-numbers
   if. > @
     and.
-      or.
-        0.eq start
-        1.eq (start.div start)
-      or.
-        0.eq end
-        1.eq (end.div end)
+      start.is-integer
+      end.is-integer
     range
       [] >>
         build ^.start > @


### PR DESCRIPTION
Closes #5343.

`range-of-numbers` documents that `start`/`end` must be `int`s and that the bottom object (⊥) is returned otherwise, but the guard enforcing this was `or (0.eq x) (1.eq (x.div x))`. Since `number.div` is ordinary IEEE-754 floating-point division, `x/x == 1.0` for *any* finite nonzero `x` — integer or not. Combined with the `0.eq x` branch, the guard passed for every finite value and only rejected NaN/±infinity; it never actually detected non-integers. So `range-of-numbers 1.2 3` silently built the fractional-step list `[1.2, 2.2]` instead of returning ⊥.

Fix: replace the guard with the existing `number.is-integer` primitive (`and. is-finite (eq floor)`), which is exactly what the docstring's contract requires:

```
and.
  start.is-integer
  end.is-integer
```

`0` is still accepted since `0.is-integer` is `true`, so no existing behavior for integer inputs changes.

The existing `throws-on-range-of-numbers-with-non-number-start`/`-with-not-number-end`/`-of-not-numbers` tests already exercise exactly the fractional-input scenarios from the issue and continue to pass — now because `range-of-numbers` genuinely returns ⊥ on non-integer input, rather than (as the issue notes) passing only because `to-java.xsl` wraps `throws-on-*` tests in `assertThrows` around an unconditional `.asBool()` call, which throws on the previously-returned list regardless of whether real validation fired. That test-wrapping looseness is a separate, XSL-level concern outside the scope of this fix (and not specific to this object), so no new test was added on top of the existing three — a new test would be masked by the very same wrapping mechanism the issue describes and wouldn't add real signal.

Verification:
- `mvn -pl eo-runtime test -Dtest=EOss.EOrange_of_numbersTest`: 7 tests, 0 failures, 0 errors.
- `mvn verify -Pqulice`: 0 violations.
