### PR TITLE
#5346: print integer-valued doubles above Long range exactly in StUnhex

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/StUnhex.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StUnhex.java
@@ -7,6 +7,7 @@ package org.eolang.parser;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StEnvelope;
 import com.yegor256.xsline.StSequence;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
@@ -96,8 +97,10 @@ final class StUnhex extends StEnvelope {
         if (num % 1 == 0) {
             if ("-0.0".equals(num.toString())) {
                 str = "-0";
-            } else {
+            } else if (Math.abs(num) < 0x1p63) {
                 str = Long.toString(num.longValue());
+            } else {
+                str = BigDecimal.valueOf(num).toBigInteger().toString();
             }
         } else {
             str = Double.toString(num);

--- a/eo-parser/src/test/java/org/eolang/parser/StUnhexTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StUnhexTest.java
@@ -122,6 +122,23 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
+    void convertsBigIntegerValuedDoubleFromHexToEo(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must exactly print a double above Long range, but it didn't",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.number'><o base='Φ.bytes'><o>43-E1-58-E4-60-91-3D-00</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath("//o[text()='10000000000000000000']")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
     void convertsFloatFromHexToEo(final Shift shift, final String type) {
         MatcherAssert.assertThat(
             String.format("StUnhex by %s must convert float", type),


### PR DESCRIPTION
Closes #5346.

`StUnhex.number()` printed any integer-valued double via `Long.toString(num.longValue())`. `Double.longValue()` clamps out-of-`long`-range doubles to `Long.MAX_VALUE`/`Long.MIN_VALUE` instead of the actual value. Every double above `2^53` is integer-valued, so any integer-valued double with magnitude `>= 2^63` (e.g. `1e19`) printed as the saturated `Long` extreme (`9223372036854775807`) rather than its real value (`10000000000000000000`). `StUnhex` is wired into the real XMIR→EO printing pipeline (`Xmir.java`), so number literals `>= 2^63` round-tripped to corrupted EO source.

Fix: guard on `Math.abs(num) < 0x1p63` (2^63) before using `longValue()`; for magnitudes at or above that, render via `BigDecimal.valueOf(num).toBigInteger()`, which stays exact for the full representable integer range of `double` (small integers keep the existing dash-free `Long` path unchanged).

Added `convertsBigIntegerValuedDoubleFromHexToEo`, unhexing the IEEE-754 bytes of `1e19` and asserting the exact printed digits `10000000000000000000`. Verified the test fails against the original code (assertion mismatch against the actual output of `9223372036854775807`, matching the issue's reported symptom exactly) and passes with the fix.

Verification:
- `mvn -pl eo-parser test -Dtest=StUnhexTest`: 8 tests, 0 failures, 0 errors.
- `mvn verify -Pqulice`: 0 violations.
