### PR TITLE
#5345: fix split/nsplit to support multi-character delimiters

### DIFF
--- a/eo-runtime/src/main/eo/tt/nsplit.eo
+++ b/eo-runtime/src/main/eo/tt/nsplit.eo
@@ -25,6 +25,7 @@
         1.eq limit
         * text
         rec-nsplit * 0 0 0
+  delimiter.size > delimiter-size!
 
   # Recursively splits text by delimiter up to limit number of times.
   [accum start current count] > rec-nsplit
@@ -37,21 +38,30 @@
             start
             current.minus start
       if.
-        and.
-          delimiter.eq
-            slice text current 1
-          (number count).lt
-            (number limit).minus 1
-        rec-nsplit
-          appended
-          (current.plus 1).as-number
-          (current.plus 1).as-number
-          (count.plus 1).as-number
+        or.
+          delimiter-size.eq 0
+          (current.plus delimiter-size).gt text.size
         rec-nsplit
           accum
           start
           (current.plus 1).as-number
           count
+        if.
+          and.
+            delimiter.eq
+              slice text current delimiter-size
+            (number count).lt
+              (number limit).minus 1
+          rec-nsplit
+            appended
+            (current.plus delimiter-size).as-number
+            (current.plus delimiter-size).as-number
+            (count.plus 1).as-number
+          rec-nsplit
+            accum
+            start
+            (current.plus 1).as-number
+            count
 
   # Tests that nsplit splits with limit 2 correctly.
   [] +> tests-nsplit-with-limit-two
@@ -126,3 +136,13 @@
           "-"
           3
       * "" "a" "b-c"
+
+  # Tests that nsplit correctly handles a multi-character delimiter.
+  [] +> tests-nsplit-with-multi-char-delimiter
+    eq. > @
+      list
+        nsplit
+          "a::b::c::d"
+          "::"
+          2
+      * "a" "b::c::d"

--- a/eo-runtime/src/main/eo/tt/split.eo
+++ b/eo-runtime/src/main/eo/tt/split.eo
@@ -15,6 +15,7 @@
     rec-split * 0 0
   text > bts!
   delimiter > delim!
+  delim.size > delim-size!
   bts.size > len!
 
   # Recursively splits text by delimiter into tuple of substrings.
@@ -28,16 +29,24 @@
             start
             current.minus start
       if.
-        delim.eq
-          slice bts current 1
-        rec-split
-          appended
-          (current.plus 1).as-number
-          (current.plus 1).as-number
+        or.
+          delim-size.eq 0
+          (current.plus delim-size).gt len
         rec-split
           accum
           start
           (current.plus 1).as-number
+        if.
+          delim.eq
+            slice bts current delim-size
+          rec-split
+            appended
+            (current.plus delim-size).as-number
+            (current.plus delim-size).as-number
+          rec-split
+            accum
+            start
+            (current.plus 1).as-number
 
   # Tests that split method divides text into parts using dash delimiter.
   [] +> tests-splits-text-by-dash
@@ -63,3 +72,10 @@
             " "
           1
       6
+
+  # Tests that split correctly handles a multi-character delimiter.
+  [] +> tests-splits-text-by-multi-char-delimiter
+    eq. > @
+      list
+        split "a::b::c" "::"
+      * "a" "b" "c"


### PR DESCRIPTION
Closes #5345.

Both `tt/split.eo` and `tt/nsplit.eo` decided where to cut by comparing the *whole* delimiter against a fixed **1-unit** slice: `delim.eq (slice bts current 1)`. `slice bts current 1` always returns exactly one unit, while `delim` for any delimiter of length >= 2 is two or more units, so byte-sequence equality between a 1-unit slice and a 2+-unit delimiter is always false — the delimiter branch is structurally unreachable for any multi-character delimiter, and the recursion only ever advances by 1 regardless. `split "a::b::c" "::"` returned the single-element tuple `["a::b::c"]` instead of `["a","b","c"]`; `nsplit` had the identical defect.

Fix (both files): slice exactly `delimiter.size` units instead of a hardcoded `1`, and advance `current`/`start` by the delimiter's length (not `1`) when it matches. Since slicing `delimiter.size` units past `current` could run past the end of `bts`/`text` for a delimiter near the tail, added an explicit bounds guard (`(current.plus delim-size).gt len`) before attempting the comparison — evaluated eagerly as a separate `if` rather than combined with `and.` into one condition, since EO's `and.` isn't short-circuiting and would otherwise still evaluate the (out-of-bounds) `slice` even when the guard fails. The guard also treats a zero-length delimiter as "never matches" (same as the original's de-facto behavior for an empty delimiter), avoiding a new degenerate infinite-recursion case that a naive `current + 0`-advance would introduce.

Added `tests-splits-text-by-multi-char-delimiter` (`split "a::b::c" "::"`) and `tests-nsplit-with-multi-char-delimiter` (`nsplit "a::b::c::d" "::" 2`), matching the exact scenario from the issue. Verified both new tests fail against the original single-unit-slice code (`expected: <true> but was: <false>`) and pass with the fix. All pre-existing single-character-delimiter tests continue to pass unchanged.

Verification:
- `mvn -pl eo-runtime test -Dtest=EOtt.EOsplitTest,EOtt.EOnsplitTest`: 13 tests total, 0 failures, 0 errors.
- `mvn verify -Pqulice`: 0 violations.
