### PR TITLE
#5360: fix LnMeta double-space error column offset

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -65,7 +65,7 @@ final class LnMeta implements Line {
             parts = new ArrayList<>(0);
         } else {
             head = body.substring(1, space);
-            parts = LnMeta.split(body.substring(space + 1), this.span);
+            parts = LnMeta.split(body.substring(space + 1), space + 1, this.span);
         }
         globals.markMeta();
         globals.clearBlanks();
@@ -77,16 +77,17 @@ final class LnMeta implements Line {
      * R-3.2.4 and promoting any bare {@code Q} to {@code Φ} per
      * R-3.2.3 / R-9.3.
      * @param tail Substring after the {@code +name} prefix
+     * @param base Offset of {@code tail} within the line's body
      * @param span Source span (for error reporting)
      * @return Parts in source order
      */
-    private static List<String> split(final String tail, final Span span) {
+    private static List<String> split(final String tail, final int base, final Span span) {
         final List<String> out = new ArrayList<>(2);
         int idx = 0;
         while (idx < tail.length()) {
             if (tail.charAt(idx) == ' ') {
                 throw new ParseError(
-                    span.line(), span.indent() + idx,
+                    span.line(), span.indent() + base + idx,
                     "meta parts must be separated by exactly one space"
                 );
             }

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -104,11 +104,15 @@ final class LnMetaTest {
 
     @Test
     void rejectsDoubleSpaceBetweenParts() {
-        Assertions.assertThrows(
-            ParseError.class,
-            () -> new LnMeta(new Span("+rt jvm  extra", 1))
-                .into(new Stack(), new Globals(), new Emit()),
-            "double space between parts must be rejected per R-3.2.4"
+        MatcherAssert.assertThat(
+            "the reported column must point at the extra space, not before the parts tail",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("+rt jvm  extra", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "double space between parts must be rejected per R-3.2.4"
+            ).pos(),
+            Matchers.equalTo(8)
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:5] error: 'meta parts must be separated by exactly one space'
+  [1:11] error: 'meta parts must be separated by exactly one space'
   +meta with  spaces
-       ^
+             ^
 input: |
   +meta with  spaces
 


### PR DESCRIPTION
Closes #5360.

In `LnMeta.into`, `tail = body.substring(space + 1)` is a substring of `body` starting `space + 1` characters in. That offset was dropped when `split(tail, span)` reported the column of a rejected double space: it used `span.indent() + idx`, where `idx` indexes into `tail`, not into the full line body. Everywhere else in the parser a body-relative index becomes a column via `span.indent() + <body index>` (e.g. `Tokens` uses `span.indent() + this.cursor`), so this undercounted the column by exactly `space + 1`.

For `+rt jvm  extra` (indent 0): `space = 3`, `tail = "jvm  extra"`, the extra space sits at `tail` index 4. The old code reported column 4 (pointing inside "jvm"); the correct column is `0 + 4 (space+1) + 4 = 8`, the actual second space.

Fix: thread the tail's base offset (`space + 1`) through `split` and use `span.indent() + base + idx`.

Extended `rejectsDoubleSpaceBetweenParts` to assert the reported `ParseError.pos()` is the real column (8), not the old (wrong) value (4) — confirmed the assertion fails against the original code with `expected: <8> but: was <4>`, and passes with the fix.

Verification:
- `mvn -pl eo-parser test -Dtest=LnMetaTest`: 9 tests, 0 failures.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
