### PR TITLE
#5358: fix LnOnlyPhi split to use depth/string-aware marker scan

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -87,6 +87,46 @@ final class Eo implements Iterable<Directive> {
     }
 
     /**
+     * The index of the substring {@code "> ["} at paren depth 0 (i.e.,
+     * outside of any paren group and outside of strings), or -1 if
+     * none exists. Shared by the {@link Eo#onlyPhi} classifier and
+     * {@link LnOnlyPhi}, so both agree on where an only-phi formation
+     * splits.
+     * @param body Line body to scan
+     * @return Index of the top-level marker, or -1
+     */
+    static int topLevelGreaterBracketIndex(final String body) {
+        int depth = 0;
+        boolean instr = false;
+        int found = -1;
+        int idx = 0;
+        while (idx < body.length() - 2 && found < 0) {
+            final char glyph = body.charAt(idx);
+            if (instr) {
+                if (glyph == '\\' && idx + 1 < body.length()) {
+                    idx = idx + 2;
+                    continue;
+                }
+                if (glyph == '"') {
+                    instr = false;
+                }
+            } else if (glyph == '"') {
+                instr = true;
+            } else if (glyph == '(') {
+                depth = depth + 1;
+            } else if (glyph == ')') {
+                depth = depth - 1;
+            } else if (depth == 0 && glyph == '>'
+                && body.charAt(idx + 1) == ' '
+                && body.charAt(idx + 2) == '[') {
+                found = idx;
+            }
+            idx = idx + 1;
+        }
+        return found;
+    }
+
+    /**
      * Merge a BYTES continuation starting at index {@code start} —
      * concatenates the trailing-dash chunk with subsequent BYTES-only
      * lines at &gt;= the same indent until a chunk without trailing
@@ -493,44 +533,7 @@ final class Eo implements Iterable<Directive> {
      * @return True if the line shape is only-phi
      */
     private static boolean onlyPhi(final Span span) {
-        return Eo.topLevelGreaterBracket(span.body());
-    }
-
-    /**
-     * Whether the body contains the substring {@code "> ["} at paren
-     * depth 0 (i.e., outside of any paren group and outside of strings).
-     * @param body Line body to scan
-     * @return True if such a top-level marker exists
-     */
-    private static boolean topLevelGreaterBracket(final String body) {
-        int depth = 0;
-        boolean instr = false;
-        boolean found = false;
-        int idx = 0;
-        while (idx < body.length() - 2 && !found) {
-            final char glyph = body.charAt(idx);
-            if (instr) {
-                if (glyph == '\\' && idx + 1 < body.length()) {
-                    idx = idx + 2;
-                    continue;
-                }
-                if (glyph == '"') {
-                    instr = false;
-                }
-            } else if (glyph == '"') {
-                instr = true;
-            } else if (glyph == '(') {
-                depth = depth + 1;
-            } else if (glyph == ')') {
-                depth = depth - 1;
-            } else if (depth == 0 && glyph == '>'
-                && body.charAt(idx + 1) == ' '
-                && body.charAt(idx + 2) == '[') {
-                found = true;
-            }
-            idx = idx + 1;
-        }
-        return found;
+        return Eo.topLevelGreaterBracketIndex(span.body()) >= 0;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -66,7 +66,7 @@ final class LnOnlyPhi implements Line {
     public void into(final Stack stack, final Globals globals, final Emit emit) {
         Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
-        final int phi = body.indexOf("> [");
+        final int phi = Eo.topLevelGreaterBracketIndex(body);
         if (phi < 0) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -157,6 +157,23 @@ final class LnOnlyPhiTest {
     }
 
     @Test
+    void splitsAtTopLevelMarkerNotInsideLhsString() {
+        final Emit emit = new Emit();
+        new LnOnlyPhi(new Span("x.print \"> [\" > [a] > n", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `> [` inside the LHS string literal must not be mistaken for the split marker",
+            LnOnlyPhiTest.render(emit),
+            XhtmlMatchers.hasXPaths(
+                "/object/o[@name='n']/o[@name='a' and @base='∅']",
+                "/object/o[@name='n']/o[@base='x' and not(@name)]",
+                "/object/o[@name='n']/o[@name='φ' and @method='' and @base='.print']"
+            )
+        );
+    }
+
+    @Test
     void rejectsEmptyLhs() {
         Assertions.assertThrows(
             ParseError.class,


### PR DESCRIPTION
Closes #5358.

`Eo.onlyPhi` classifies a line as an only-phi formation via a depth/string-aware scan for the top-level `> [` marker (`Eo.topLevelGreaterBracket`, now `topLevelGreaterBracketIndex`) — it tracks paren depth and string-literal state (with backslash-escape handling) and only accepts the marker outside strings and at depth 0. But `LnOnlyPhi.into` located the actual split point with a naive `body.indexOf("> [")`, which matches the first literal occurrence anywhere, including inside a string literal or paren group in the LHS.

For `x.print "> [" > [a] > n` (a STRING harg is explicitly supported per the class's own javadoc), the classifier correctly finds the real marker at index 14 and routes to `LnOnlyPhi`, but `indexOf` matches the `> [` inside the string at index 9, so `lhs = body.substring(0, 9)` = `x.print "` — a truncated string literal. `Tokens` then throws a spurious "unterminated string literal" `ParseError`, rejecting a valid program.

Fix: extracted the classifier's scan into a package-private `Eo.topLevelGreaterBracketIndex(body)` returning the marker's index (or -1), used by both `Eo.onlyPhi` (`>= 0`) and `LnOnlyPhi.into` — so the two pieces of logic that must agree now share one implementation instead of drifting.

Added `splitsAtTopLevelMarkerNotInsideLhsString` asserting `x.print "> [" > [a] > n` parses into the expected shape (param `a`, φ chain `x.print`). Verified it throws the exact "unterminated string literal" `ParseError` against the original `indexOf`-based code, and passes with the fix.

Verification:
- `mvn -pl eo-parser test -Dtest=LnOnlyPhiTest,EoTest`: all green.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
