### PR TITLE
#5357: reject trailing garbage after expression in Suffix.parse

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -49,8 +49,11 @@ final class LnTextBlock implements Line {
                 "text block closer must start with triple-quote"
             );
         }
+        final Tokens tokens = new Tokens(body, this.span);
+        tokens.seek(3);
+        tokens.readChain();
         final Suffix suffix = new Suffix(
-            body.substring(3), this.span, this.span.indent() + 3
+            tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
         final String joined = Emissions.unescapeBody(
             String.join(String.valueOf('\n'), globals.tbody()).trim()

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -229,7 +229,10 @@ final class Suffix {
         } else if (tail.charAt(idx) == '>') {
             result = Suffix.named(tail, idx + 1, span, home);
         } else {
-            result = new Suffix.Parsed(Form.NONE, "", "", false);
+            throw new ParseError(
+                span.line(), home + idx,
+                "trailing garbage after expression"
+            );
         }
         return result;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -85,6 +85,37 @@ final class LnTextBlockTest {
     }
 
     @Test
+    void acceptsChainAfterCloserWithoutSuffix() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("hi");
+        final Stack stack = new Stack();
+        new LnTextBlock(new Span("\"\"\".as-bytes", 3))
+            .into(stack, globals, new Emit());
+        MatcherAssert.assertThat(
+            "a `.method` chain right after the closer (deferred, not yet emitted) must not"
+                .concat(" be rejected as trailing garbage"),
+            stack.top().kind(),
+            Matchers.equalTo(Kind.TEXT_BLOCK)
+        );
+    }
+
+    @Test
+    void marksLevelNamedWhenSuffixFollowsChain() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("hi");
+        final Stack stack = new Stack();
+        new LnTextBlock(new Span("\"\"\".as-bytes > greeting", 3))
+            .into(stack, globals, new Emit());
+        MatcherAssert.assertThat(
+            "a `> name` suffix following a deferred chain must still be parsed",
+            stack.top().named(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void marksLevelNamedWhenSuffixPresent() {
         final Globals globals = new Globals();
         globals.openTextBlock(1, 0);

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -198,6 +198,16 @@ final class SuffixTest {
     }
 
     @Test
+    void rejectsTrailingGarbageThatIsNotASuffixMarker() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix("x", new Span("5x", 1), 1),
+            "trailing content after a head that is not `>`, `>>`, or `+>` must be rejected,"
+                .concat(" not silently dropped")
+        );
+    }
+
+    @Test
     void rejectsNamedSuffixWithoutName() {
         Assertions.assertThrows(
             ParseError.class,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/qq.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/qq.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:2] error: 'object inside formation must have a name'
+  [3:3] error: 'trailing garbage after expression'
     QQ.io.stdout > @
-    ^
+     ^
 input: |
   # No comments
   [] > foo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/version-with-inline-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/version-with-inline-application.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:2] error: 'object inside formation must have a name'
+  [3:8] error: 'trailing garbage after expression'
     stdout|1.2.3 42
-    ^
+          ^
 input: |
   # No comments
   [args] > app


### PR DESCRIPTION
Closes #5357.

`Suffix.parse` skips leading spaces on the line tail and, if the remaining text is not `+>`, `>>`, or `>`, falls into a final `else` that silently returned `Form.NONE` — no suffix, no error. Callers (`LnApplication`, `LnCompactTuple`, `LnReversed`, `LnMethod`, `LnOnlyPhi`) pass the entire un-consumed token tail into `Suffix` and never verify the stream is fully consumed afterward, so any non-whitespace trailing content that isn't a suffix marker was silently dropped instead of being rejected. This is only reachable for heads with a well-defined end (INT/FLOAT/HEX/BYTES/STAR/STRING/ROOT/GROUP) — identifier heads greedily consume to a NAME terminator so they never hit it.

For `5x`: head reads INTEGER `5`, tail is `x`, and the old code silently accepted the program as `5` while dropping `x`. `named()` already guards this exact condition via `endsClean` ("trailing garbage after name suffix") for the `> name` path; the `NONE` path had no equivalent guard.

Fix: the final `else` now throws a `ParseError` ("trailing garbage after expression") instead of returning `Form.NONE`.

This also fixed two existing typo-pack fixtures that were silently exercising the same bug: `qq.yaml` (`QQ.io.stdout > @` — the extra `Q` was silently dropped, masking the intended `> @` suffix and surfacing an unrelated "object inside formation must have a name" error) and `version-with-inline-application.yaml` (`stdout|1.2.3 42` — `|1.2.3 42` was silently dropped after `stdout`). Both now correctly report "trailing garbage after expression" at the exact column the garbage starts, instead of an unrelated downstream error with no diagnostic value for the actual typo.

Added `rejectsTrailingGarbageThatIsNotASuffixMarker` reproducing the issue's exact `5x` example. Verified it fails (nothing thrown) against the original code, and passes with the fix.

Verification:
- `mvn -pl eo-parser test`: all 874+ tests green, including the two updated typo-pack fixtures.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
