### PR TITLE
#5353: fix Comments.attach to not leak a dangling comment across a blank line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -10,16 +10,18 @@ import java.util.List;
  * Attach buffered comment lines to the next named object — §6.4.
  *
  * <p>A comment block accumulates in {@link Globals#pendingComments()}
- * as each {@link LnComment} arrives. The next named line — any
- * formation, application, method or reversed line whose suffix carries
- * a name — calls {@link #attach(Globals, Emit, Span, boolean)} to
- * either flush the block into {@code /object/comments/comment} (when
- * the line is named, sits at the same indent, and has no intervening
- * blank line — R-6.5.2) or report the block as dangling per
- * R-6.4.2.</p>
- *
- * <p>The buffer is always cleared after the call so a dangling block
- * is not re-reported by the EOF check.</p>
+ * as each {@link LnComment} arrives. Every subsequent line — named or
+ * not — calls {@link #attach(Globals, Emit, Span, boolean)}: a blank
+ * line separating the block from what follows is an immediate
+ * R-6.5.2 violation, reported as dangling per R-6.4.2 and cleared on
+ * the spot. Absent a blank, the block flushes into
+ * {@code /object/comments/comment} as soon as a named line at the
+ * same indent arrives; an unnamed or deeper/shallower-indent line in
+ * between is not itself a violation — the block stays pending so a
+ * later same-indent named line (e.g. the name-bearing tail of a
+ * vertical-continuation chain) can still claim it. Any block left
+ * pending at end of stream is reported dangling by the EOF check in
+ * {@link Eo}.</p>
  *
  * @since 0.1
  */
@@ -48,7 +50,13 @@ final class Comments {
             return;
         }
         final Span head = pending.get(0);
-        if (named && head.indent() == span.indent() && globals.pendingBlanks() == 0) {
+        if (globals.pendingBlanks() > 0) {
+            emit.error(
+                head.line(), head.indent(),
+                "comment must precede a named object"
+            );
+            globals.clearComments();
+        } else if (named && head.indent() == span.indent()) {
             emit.comment(pending, span.line());
             globals.clearComments();
         }

--- a/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
@@ -48,7 +48,8 @@ final class CommentsTest {
         globals.addComment(new Span("# orphan", 1));
         Comments.attach(globals, new Emit(), new Span("foo", 2), false);
         MatcherAssert.assertThat(
-            "an unnamed follower must leave the comment buffered for a later same-indent named line — no immediate error",
+            "an unnamed follower with no blank must leave the comment buffered for a"
+                .concat(" later same-indent named line — no immediate error"),
             globals.pendingComments(),
             Matchers.hasSize(1)
         );
@@ -60,22 +61,26 @@ final class CommentsTest {
         globals.addComment(new Span("# at-zero", 1));
         Comments.attach(globals, new Emit(), new Span("  [] > inner", 2), true);
         MatcherAssert.assertThat(
-            "a deeper-indent named line must not attach the buffered comment — it stays pending",
+            "a deeper-indent named line with no intervening blank must not attach the"
+                .concat(" buffered comment — it stays pending"),
             globals.pendingComments(),
             Matchers.hasSize(1)
         );
     }
 
     @Test
-    void defersAttachmentWhenBlankLineIntervenes() {
+    void reportsDanglingWhenBlankLineIntervenes() {
         final Globals globals = new Globals();
         globals.addComment(new Span("# split", 1));
         globals.blank();
-        Comments.attach(globals, new Emit(), new Span("[] > foo", 3), true);
+        final Emit emit = new Emit();
+        Comments.attach(globals, emit, new Span("[] > foo", 3), true);
         MatcherAssert.assertThat(
-            "a blank line between comment and named line breaks attachment per R-6.5.2 — buffer stays pending until EOF",
-            globals.pendingComments(),
-            Matchers.hasSize(1)
+            "a blank line between comment and named line breaks attachment per R-6.5.2 —"
+                .concat(" the comment must be reported as dangling and the buffer cleared"),
+            CommentsTest.render(emit).contains("comment must precede a named object")
+                && globals.pendingComments().isEmpty(),
+            Matchers.is(true)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -70,6 +70,19 @@ final class EoTest {
     }
 
     @Test
+    void doesNotLeakDanglingCommentToLaterUnrelatedObject() {
+        MatcherAssert.assertThat(
+            "a comment separated from its object by a blank line (dangling per R-6.5.2)"
+                .concat(" must be reported, not silently misattached to a later object"),
+            EoTest.render("# c", "", "[x] > foo", "[y] > bar"),
+            XhtmlMatchers.hasXPaths(
+                "/object/errors/error[contains(text(),'comment must precede a named object')]",
+                "/object[not(comments)]"
+            )
+        );
+    }
+
+    @Test
     void reportsOddIndentError() {
         MatcherAssert.assertThat(
             "a line whose indent is an odd number of spaces must surface the odd-indent error",


### PR DESCRIPTION
Closes #5353.

`Comments.attach` only cleared `globals.pendingComments()` on the flush branch (named, matching indent, no intervening blank). On any decline it fell through and returned without clearing — contradicting the class/method javadoc, which states the buffer is always cleared after the call (either flushed or reported dangling per R-6.4.2).

The three decline conditions aren't all equivalent, though. Two of them are legitimately "not yet, maybe later": an unnamed follower or an indent mismatch (with no intervening blank line) can still be reclaimed by a later same-indent named line — this is exactly how a vertical-continuation chain works (an anonymous `[]` immediately followed by nested lines, with the name only landing on the chain's tail several lines down, e.g. the existing `vmethod-after-formation.yaml` fixture). Reporting those as dangling immediately would be a false positive.

The third condition — a blank line separating the comment block from what follows — is an unconditional R-6.5.2 violation regardless of what comes after. That's the one the issue's concrete leak scenario hinges on: `# c` / blank / `[x] > foo` / `[y] > bar` — the blank-line decline used to silently leave the buffer pending, and it would then get flushed onto the next matching object (`bar`), which never should have received it.

Fix: check `globals.pendingBlanks() > 0` first — if a blank intervened, report dangling and clear immediately, regardless of the upcoming line's name/indent. Otherwise, keep the original flush-or-defer behavior unchanged (only clearing on a successful flush).

Added `EoTest.doesNotLeakDanglingCommentToLaterUnrelatedObject` reproducing the issue's exact scenario end-to-end, plus updated `CommentsTest` to cover the blank-line-dangling case directly and confirm the unnamed/indent-mismatch decline paths still correctly defer (unchanged behavior, verified against the existing `vmethod-after-formation.yaml` fixture, which continues to pass).

Verified the negative control: reverting to the original bundled condition reproduces the exact leak (comment `c` ends up attached to `bar` instead of being reported dangling).

Verification:
- `mvn -pl eo-parser test`: all 1449 tests green, including the existing `eo-syntax`/`eo-packs` fixture corpus.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
