### PR TITLE
#5348: reject unclosed inline-phi bracket with ParseError instead of crashing

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -496,6 +496,12 @@ final class Emissions {
     ) {
         final int bracket = phi + 2;
         final int close = inner.indexOf(']', bracket);
+        if (close < 0) {
+            throw new ParseError(
+                line, column + bracket,
+                "only-phi parameter list missing closing `]`"
+            );
+        }
         final String lhs = inner.substring(0, phi).stripTrailing();
         final String params = inner.substring(bracket + 1, close);
         emit.object(name, null, line, column);

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -518,6 +518,17 @@ final class LnApplicationTest {
     }
 
     @Test
+    void rejectsUnclosedInlinePhiBracketInGroupArg() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnApplication(new Span("x (a > [b)", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a `> [` inline-phi marker with no closing `]` inside a paren-group arg must be"
+                .concat(" rejected with a ParseError, not an unchecked exception")
+        );
+    }
+
+    @Test
     void emitsAsAttributeForLabelBinding() {
         final Emit emit = new Emit();
         new LnApplication(new Span("foo a:y b:z > x", 1))


### PR DESCRIPTION
Closes #5348.

`Emissions.inlinePhi` computed `close = inner.indexOf(']', bracket)` for an inline-phi formation's parameter list, then immediately used it in `inner.substring(bracket + 1, close)` without checking whether the closing `]` was actually found. When a parenthesized-group argument contains a top-level `> [` marker with no closing `]` (e.g. `x (a > [b)`), `close` is `-1`, and `substring` throws an unchecked `StringIndexOutOfBoundsException` — which is not a `ParseError`, so it escapes `Eo.dispatch`'s per-line recovery (which only catches `ParseError`) and aborts the entire parse instead of emitting a recoverable `<error>` directive.

`LnOnlyPhi.into` already guards the identical `> [ ... ]` construct with a `close < 0` check; `inlinePhi` was missing the equivalent guard for the same construct reached through a different path (a paren-group argument rather than a top-level line).

Fix: added the same guard, throwing `ParseError(line, column + bracket, "only-phi parameter list missing closing \`]\`")` before the `substring` call, mirroring `LnOnlyPhi`.

Added `LnApplicationTest.rejectsUnclosedInlinePhiBracketInGroupArg` reproducing the issue's exact `x (a > [b)` example. Verified it fails with the raw `StringIndexOutOfBoundsException` against the original code, and throws the intended `ParseError` with the fix.

Verification:
- `mvn -pl eo-parser test`: all tests green.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
