### PR TITLE
#5351: enforce strict NAME token for +> test suffix

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -267,7 +267,7 @@ final class Suffix {
             );
         }
         final int start = idx;
-        while (idx < tail.length() && !Suffix.terminates(tail.charAt(idx))) {
+        while (idx < tail.length() && !Suffix.endsName(tail.charAt(idx))) {
             idx = idx + 1;
         }
         if (start == idx) {
@@ -276,8 +276,15 @@ final class Suffix {
                 "test attribute requires a name"
             );
         }
+        final String name = tail.substring(start, idx);
+        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
+            throw new ParseError(
+                span.line(), home + start,
+                "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
         Suffix.endsClean(tail, idx, span, home);
-        return new Suffix.Parsed(Form.TEST, tail.substring(start, idx), "", false);
+        return new Suffix.Parsed(Form.TEST, name, "", false);
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -218,6 +218,30 @@ final class SuffixTest {
     }
 
     @Test
+    void rejectsTrailingGarbageAfterPlusGreaterName() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " +> bar baz",
+                new Span("[] +> bar baz", 1), 2
+            ),
+            "`+> bar baz` must reject the extra token, not silently drop it"
+        );
+    }
+
+    @Test
+    void rejectsDotInPlusGreaterName() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " +> a.b",
+                new Span("[] +> a.b", 1), 2
+            ),
+            "`+> a.b` must be rejected — `.` is not a legal NAME character"
+        );
+    }
+
+    @Test
     void rejectsTrailingGarbageThatIsNotASuffixMarker() {
         Assertions.assertThrows(
             ParseError.class,


### PR DESCRIPTION
Closes #5351.

`Suffix.test` (the `+> name` parser) scanned the name with the loose `terminates` predicate (stops only at space/tab/`!`//`) instead of the stricter `endsName` used by the sibling `named` (`> name`) path, and never rejected the cactus-emoji codepoint that `named` rejects. R-6.3.5 requires a `+>` test name to be a NAME token, same as `> name`.

Concretely, `[] +> a.b` was accepted, producing an invalid `@name='+a.b'` attribute — `.` is not a legal NAME character but `terminates` doesn't treat it as a boundary, so the scan swallowed the whole `a.b` as one token.

(The issue also flagged a missing trailing-garbage check — `endsClean` — but that part was already fixed as a side effect of #5357's `Suffix.parse` fix, which is now merged on master. This PR covers the remaining `terminates`-vs-`endsName` gap and the missing cactus-emoji guard.)

Fix: scan with `endsName` instead of `terminates`, and reject the cactus emoji codepoint, mirroring `named`.

Added `rejectsDotInPlusGreaterName` (`[] +> a.b`) and `rejectsTrailingGarbageAfterPlusGreaterName` (`[] +> bar baz`, regression-guarding the already-fixed part). Verified `rejectsDotInPlusGreaterName` fails (nothing thrown) against the pre-fix `terminates`-based scan, and passes with the fix.

Verification:
- `mvn -pl eo-parser test`: all tests green.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
