### PR TITLE
#5356: require a dot boundary in decorate.xsl string-prefix matching

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/decorate.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/decorate.xsl
@@ -52,7 +52,7 @@
   <xsl:template match="o[@base]">
     <xsl:apply-templates select="." mode="with-base"/>
   </xsl:template>
-  <xsl:template match="o[some $p in $metas/part[1] satisfies starts-with(@base, $p)]" mode="with-base">
+  <xsl:template match="o[some $p in $metas/part[1] satisfies (@base=$p or starts-with(@base, concat($p, '.')))]" mode="with-base">
     <xsl:variable name="meta" select="$metas[part[1]=current()/@base][1]"/>
     <xsl:choose>
       <xsl:when test="exists($meta)">
@@ -66,7 +66,7 @@
     </xsl:choose>
   </xsl:template>
   <xsl:template match="o" mode="not-equal">
-    <xsl:variable name="meta" select="$metas[starts-with(current()/@base, part[1])][1]"/>
+    <xsl:variable name="meta" select="$metas[starts-with(current()/@base, concat(part[1], '.'))][1]"/>
     <xsl:variable name="after" select="reverse(tokenize(substring-after(@base, concat($meta/part[1], '.')), '\.'))"/>
     <xsl:apply-templates select="." mode="method">
       <xsl:with-param name="meta" select="$meta"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/decorate-string-prefix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/decorate-string-prefix.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/decorate.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='main']/o[@name='φ' and @base='Φ.tt.text']/o[@base='Φ.string' and not(@name)]
+  - /object/o[@name='main']/o[@name='y' and @base='Φ.stringify']
+  - /object/o[@name='main']/o[@name='z' and @base='Φ.strings']
+input: |
+  +decorate string tt.text
+
+  # No comments.
+  [] > main
+    "Hello" > @
+    stringify > y
+    strings > z


### PR DESCRIPTION
Closes #5356.

`decorate.xsl`'s entry guard (`some $p in $metas/part[1] satisfies starts-with(@base, $p)`) and its `not-equal` meta re-selection (`$metas[starts-with(current()/@base, part[1])][1]`) both used a raw string `starts-with` with no `.`-boundary check. For a `+decorate string tt.text` meta (`part[1]='Φ.string'`), an unrelated object whose FQN merely *starts with* the same characters — `Φ.stringify`, `Φ.strings` — satisfied the prefix test even though it isn't the decorated object or a dotted sub-path of it. It then fell into `not-equal` mode, where `substring-after(@base, concat($meta/part[1], '.'))` produced an empty string (no `.` after the shared prefix), `tokenize('', '\.')` yielded an empty sequence, and the `method` template's `$index > count($methods)` branch (1 > 0) fired immediately — rebuilding the object with `base=$meta/part[1]` and decorating it. So `Φ.stringify`/`Φ.strings` got silently corrupted into the same decorated shape as a genuine `Φ.string` match.

Fix: require an exact match or a `.`-terminated prefix in both places — `(@base=$p or starts-with(@base, concat($p, '.')))` for the entry guard, `starts-with(current()/@base, concat(part[1], '.'))` for the not-equal re-selection.

Added `decorate-string-prefix.yaml` reproducing the exact scenario: `+decorate string tt.text` alongside `stringify > y` and `strings > z`. Verified both fail (corrupted into the decorated shape) against the original loose-prefix code, and pass unchanged with the fix.

Verification:
- `mvn -pl eo-parser test`: all tests green, including the new fixture and existing `decorate.yaml`/`decorate-fqn.yaml`.
- `mvn -pl eo-runtime compile`: the real build pipeline (which uses this sheet) still compiles cleanly.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
