### PR TITLE
#5359: point fragile ?. chain link @pos at the dot, not the question mark

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -474,8 +474,12 @@ final class Tokens {
     List<MethodChain> readChain() {
         final List<MethodChain> chain = new ArrayList<>(0);
         while (!this.atEnd() && this.dispatchAhead()) {
-            final int dot = this.span.indent() + this.cursor;
-            final boolean fragile = this.consumeDispatch();
+            final boolean fragile = Tokens.fragileAhead(this.body, this.cursor);
+            int dot = this.span.indent() + this.cursor;
+            if (fragile) {
+                dot = dot + 1;
+            }
+            this.consumeDispatch();
             final Value name = this.readMethodName();
             chain.add(new MethodChain(name.raw(), dot, name.end(), fragile));
         }

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -193,6 +193,20 @@ final class LnApplicationTest {
     }
 
     @Test
+    void recordsDotColumnForFragileChainLinkPos() {
+        final Emit emit = new Emit();
+        new LnApplication(new Span("foo?.bar > x", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a fragile `?.` chain link's @pos must point at the `.`, not at the `?`,"
+                .concat(" matching the standalone-continuation path in LnMethod"),
+            LnApplicationTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/o[@base='.bar' and @pos='4']")
+        );
+    }
+
+    @Test
     void emitsTwoLevelChainAsThreeSiblings() {
         final Emit emit = new Emit();
         new LnApplication(new Span("foo.bar.baz > x", 1))


### PR DESCRIPTION
Closes #5359.

`Tokens.readChain()` captured the dispatch link's source column (`dot`) BEFORE calling `consumeDispatch()`. For a plain `.` this is correct — the cursor already sits on the dot. But for the fragile `?.` operator the cursor sits on the `?`, one column before the dot, so the emitted `MethodChain` recorded the `?` column instead of the `.` column, violating `MethodChain`'s own contract ("Column of the leading dot ... Per R-9.1.3, the dot column is the @pos value") and disagreeing with the sibling standalone-continuation path in `LnMethod` (`method.pos() - 1`, which correctly points at the `.` for both plain and fragile continuations).

For `foo?.bar > x` at indent 0, the `.` sits at column 4 (`f`0 `o`1 `o`2 `?`3 `.`4), but the emitted `<o base='.bar'>` carried `@pos='3'` (the `?`).

Fix: determine `fragile` via `Tokens.fragileAhead` before consuming, and add 1 to the recorded column when fragile, so it points at the `.` for both forms.

Added `LnApplicationTest.recordsDotColumnForFragileChainLinkPos` reproducing the issue's exact example. Verified it fails (`pos='3'` instead of `'4'`) against the original code, and passes with the fix.

Verification:
- `mvn -pl eo-parser test`: all tests green.
- `mvn verify -Pqulice` (JDK 21): 0 violations.
