### PR TITLE
#5215: strip full ASCII whitespace in trimmed*/-left/-right

### DIFF
--- a/eo-runtime/src/main/eo/tt/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed-left.eo
@@ -1,4 +1,8 @@
 # Returns `text` trimmed from left side.
+# Removes all leading ASCII whitespace bytes: `20-` (space), `09-`
+# (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
+# (form feed), and `0D-` (carriage return). Matches the strip-set
+# used by `String.strip()` in Java for the ASCII range.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -16,18 +20,31 @@
         idx
         (number len).minus idx
   text > bts!
-  first-non-space-index 0 > idx!
+  first-non-ws-index 0 > idx!
   bts.size > len!
 
-  [index] > first-non-space-index
+  [index] > first-non-ws-index
     if. > @
       len.eq index
       index
       if.
-        char.eq 20-
-        first-non-space-index (index.plus 1).as-number
+        is-ws char
+        first-non-ws-index (index.plus 1).as-number
         index
     bts.slice index 1 > char!
+
+  [c] > is-ws
+    or. > @
+      c.eq 20-
+      or.
+        c.eq 09-
+        or.
+          c.eq 0A-
+          or.
+            c.eq 0B-
+            or.
+              c.eq 0C-
+              c.eq 0D-
 
   [] +> tests-trimmed-left-empty-text
     eq. > @
@@ -48,3 +65,28 @@
     eq. > @
       trimmed-left "     "
       ""
+
+  [] +> tests-trimmed-left-strips-tab
+    eq. > @
+      trimmed-left "\tvalue"
+      "value"
+
+  [] +> tests-trimmed-left-strips-lf
+    eq. > @
+      trimmed-left "\nvalue"
+      "value"
+
+  [] +> tests-trimmed-left-strips-ff
+    eq. > @
+      trimmed-left "\fvalue"
+      "value"
+
+  [] +> tests-trimmed-left-strips-cr
+    eq. > @
+      trimmed-left "\rvalue"
+      "value"
+
+  [] +> tests-trimmed-left-strips-mixed-ws
+    eq. > @
+      trimmed-left " \t\n\f\rvalue"
+      "value"

--- a/eo-runtime/src/main/eo/tt/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed-right.eo
@@ -1,4 +1,8 @@
 # Returns `text` trimmed from right side.
+# Removes all trailing ASCII whitespace bytes: `20-` (space), `09-`
+# (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
+# (form feed), and `0D-` (carriage return). Matches the strip-set
+# used by `String.strip()` in Java for the ASCII range.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -14,20 +18,33 @@
     string
       bts.slice
         0
-        first-non-space-index
+        first-non-ws-index
           (number len).plus -1
   text > bts!
   bts.size > len!
 
-  [index] > first-non-space-index
+  [index] > first-non-ws-index
     if. > @
       -1.eq index
       0
       if.
-        char.eq 20-
-        first-non-space-index (index.plus -1).as-number
+        is-ws char
+        first-non-ws-index (index.plus -1).as-number
         index.plus 1
     bts.slice index 1 > char!
+
+  [c] > is-ws
+    or. > @
+      c.eq 20-
+      or.
+        c.eq 09-
+        or.
+          c.eq 0A-
+          or.
+            c.eq 0B-
+            or.
+              c.eq 0C-
+              c.eq 0D-
 
   [] +> tests-trimmed-right-empty-text
     eq. > @
@@ -48,3 +65,28 @@
     eq. > @
       trimmed-right "     "
       ""
+
+  [] +> tests-trimmed-right-strips-tab
+    eq. > @
+      trimmed-right "value\t"
+      "value"
+
+  [] +> tests-trimmed-right-strips-lf
+    eq. > @
+      trimmed-right "value\n"
+      "value"
+
+  [] +> tests-trimmed-right-strips-ff
+    eq. > @
+      trimmed-right "value\f"
+      "value"
+
+  [] +> tests-trimmed-right-strips-cr
+    eq. > @
+      trimmed-right "value\r"
+      "value"
+
+  [] +> tests-trimmed-right-strips-mixed-ws
+    eq. > @
+      trimmed-right "value \t\n\f\r"
+      "value"

--- a/eo-runtime/src/main/eo/tt/trimmed.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed.eo
@@ -1,4 +1,9 @@
 # Returns `text` trimmed from both sides.
+# Removes all leading and trailing ASCII whitespace bytes: `20-`
+# (space), `09-` (horizontal tab), `0A-` (line feed), `0B-` (vertical
+# tab), `0C-` (form feed), and `0D-` (carriage return). Delegates to
+# `tt.trimmed-left` and `tt.trimmed-right`, so the strip-set matches
+# `String.strip()` in Java for the ASCII range.
 
 +alias tt.trimmed-left
 +alias tt.trimmed-right
@@ -46,3 +51,18 @@
     eq. > @
       trimmed "        "
       ""
+
+  [] +> tests-trimmed-strips-mixed-ws-both-sides
+    eq. > @
+      trimmed " \t\n\f\rvalue \t\n\f\r"
+      "value"
+
+  [] +> tests-trimmed-preserves-inner-content
+    eq. > @
+      trimmed "no-whitespace"
+      "no-whitespace"
+
+  [] +> tests-trimmed-preserves-inner-whitespace
+    eq. > @
+      trimmed "\t hello world \n"
+      "hello world"


### PR DESCRIPTION
## Summary

Closes #5215. `trimmed-left` and `trimmed-right` compared each byte to `20-` (ASCII space) only, so tabs, line feeds, vertical tabs, form feeds, and carriage returns were never trimmed — `trimmed "\tfoo\t"` returned `"\tfoo\t"` unchanged. Widened the predicate to the six ASCII whitespace bytes covered by `String.strip()` in Java: `20-` (space), `09-` (HT), `0A-` (LF), `0B-` (VT), `0C-` (FF), `0D-` (CR).

## Change shape

Factored the check out of the inline `if.` into an inner `[c] > is-ws` object that returns `true` when `c` equals any of the six whitespace bytes (nested `or.` — same shape already used by `left.eq 00-…`/`FF-…` in `i16.eo`/`i32.eo`). The recursive index finder is renamed from `first-non-space-index` to `first-non-ws-index` so its identifier matches what it actually skips over. Both sides share the same helper structure; behaviour is only widened on the "yes, skip this byte" side of the branch.

`trimmed.eo` is untouched apart from doc and new tests — it delegates to the left/right pair, so the widening propagates automatically.

## New tests

Per-side (`tests-trimmed-left-strips-tab` / `-lf` / `-ff` / `-cr`, mirrored on `trimmed-right`) and mixed (`tests-trimmed-left-strips-mixed-ws` / `-right-…` / `-trimmed-strips-mixed-ws-both-sides`). `trimmed.eo` also gets `tests-trimmed-preserves-inner-content` (no-whitespace input round-trips) and `tests-trimmed-preserves-inner-whitespace` (leading `\t ` and trailing ` \n` are stripped but the space between `hello` and `world` survives), guarding against a future "trim everything" over-fix.

VT (`0B-`) is covered by the `c.eq 0B-` clause in `is-ws` and by any real-world use, but I skipped a dedicated `` test to avoid embedding a control byte in an EO source file — the `\v` escape isn't in the EO string grammar (see `string.eo:442` where the covered escapes are `\b\f\n\r\t\uXXXX`) and injecting a raw `0x0B` byte into source is a portability trap.

## Cross-refs

The `is-ws` idiom (nested `or.` over a fixed byte set) matches how `i16.eo:52-56` and `i32.eo:60-63` express the same "byte-in-set" check today, so no new pattern is introduced.
