### PR TITLE
#4945: enable ReadmeSnippetsIT

### DIFF
--- a/eo-integration-tests/src/test/java/integration/ReadmeSnippetsIT.java
+++ b/eo-integration-tests/src/test/java/integration/ReadmeSnippetsIT.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,15 +29,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * Integration test for EO snippets in `README.md`.
  * @since 0.56.3
- * @todo #4538:30min Enable ReadmeSnippetsIT. The test was disabled because we've moved
- *  EO objects from default org.eolang package to root package and most of the objects
- *  can't be downloaded from objectionary anymore. When new release is made, we need to enable
- *  the test.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class ReadmeSnippetsIT {
 
-    @Disabled
     @Tag("snippets")
     @ParameterizedTest
     @ExtendWith(MktmpResolver.class)


### PR DESCRIPTION
Closes #4945.

The `@todo #4538` puzzle said to re-enable `ReadmeSnippetsIT` once a new release
of `eo-runtime` is cut and the remote objectionary catalog catches up with the
root-package move. Several releases have shipped since (up to 0.61.3), so I
checked whether the test passes now instead of guessing.

Verification:
- Removed `@Disabled` locally and ran `mvn test -pl eo-integration-tests -Dtest=ReadmeSnippetsIT`
  against the real remote objectionary catalog (network-gated by `@WeAreOnline`).
- All 5 parameterized snippet cases pass: `tests="5" errors="0" skipped="0" failures="0"`.
- Ran `mvn checkstyle:check -pl eo-integration-tests`: clean.

Note: I separately checked the sibling puzzle in `JarIT` (#5047, same "wait for
next release" pattern) and that one is **not** yet fixable — it still fails,
but now on different missing atoms (`EObytes$EOxor`, `EOregex$EOφ`) than the
original `EOnumber$EOfloor` issue, so the remote hasn't caught up there yet.
Leaving that one alone; this PR only touches `ReadmeSnippetsIT`.
