### PR TITLE
#5090: enable SnippetIT.runsAllSnippets

### DIFF
--- a/eo-integration-tests/src/test/java/integration/SnippetIT.java
+++ b/eo-integration-tests/src/test/java/integration/SnippetIT.java
@@ -22,7 +22,6 @@ import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -34,17 +33,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 @ExtendWith(MktmpResolver.class)
 final class SnippetIT {
 
-    @Disabled
     @ParameterizedTest
     @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
     @ClasspathSource(value = "snippets", glob = "**.yaml")
     @SuppressWarnings("unchecked")
-    // @todo #4707:30min Re-enable SnippetIT.runsAllSnippets after the public
-    //  objectionary registry (https://github.com/objectionary/home) migrates
-    //  atom return types from the legacy `?` syntax to the new `/name` form.
-    //  This PR drops the `?` branch from the EO grammar; until the registry
-    //  catches up, MjPull fetches `.eo` files that fail to parse here.
     void runsAllSnippets(final String yml, final @Mktmp Path temp) throws IOException {
         final Xtory xtory = new XtSticky(new XtYaml(yml));
         Assumptions.assumeFalse(xtory.map().containsKey("skip"));


### PR DESCRIPTION
Closes #5090.

The `@todo #4707` puzzle said to re-enable `SnippetIT.runsAllSnippets` once the
public objectionary registry (`objectionary/home`) migrates atom return types
from the legacy `?` syntax to the new `/name` form. Checked whether the
registry has caught up instead of guessing.

Verification:
- Removed `@Disabled` locally and ran `mvn test -pl eo-integration-tests -Dtest=SnippetIT`
  against the real remote registry (network-gated by `@WeAreOnline`).
- All 4 snippet cases (`auto-phi`, `decorated`, `simple`, `fibo`) pass:
  `tests="4" errors="0" skipped="0" failures="0"`.
- Ran `mvn checkstyle:check -pl eo-integration-tests`: clean (also dropped the
  now-unused `Disabled` import).
