### PR TITLE
#5152: enable ProxyIT.checksThatWeCanCompileTheProgramWithProxySet

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -27,26 +27,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
- * @todo #5078:60min Re-enable
- *  {@code checksThatWeCanCompileTheProgramWithProxySet} once the objectionary
- *  remote registry is re-published with the new parser's syntax. The test
- *  runs {@code mvn package} through a local proxy; the build pulls runtime
- *  sources from the registry, and those pulled {@code .eo} files
- *  ({@code tuple}/{@code seq}/{@code number}/...) still contain pre-spec
- *  syntax (fluent {@code .method} continuation after horizontal-completed
- *  lines, the {@code ?} name-suffix modifier, etc.) that the new spec-strict
- *  parser rejects, so {@code mvn package} fails before the proxy assertion
- *  ever runs. The local {@code eo-runtime/src/main/eo/} files are already
- *  rewritten and pass; only the registry needs the matching re-upload. To
- *  re-enable: publish the updated runtime to objectionary, then drop the
- *  {@link Disabled} annotation on the method.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
@@ -74,7 +60,6 @@ final class ProxyIT {
     }
 
     @Test
-    @Disabled("registry still serves pre-spec EO sources, see class javadoc")
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);


### PR DESCRIPTION
Closes #5152.

The `@todo #5078` puzzle said to re-enable
`checksThatWeCanCompileTheProgramWithProxySet` once the objectionary remote
registry is re-published with the new parser's syntax. Checked whether the
registry has caught up instead of guessing.

Verification (learned from a false-positive I hit on a sibling PR, so I
did this carefully this time):
- Wiped the local MjPull cache (`~/.eo/pulled`) and the `~/.m2` SNAPSHOT
  artifacts for `eo`, `eo-parser`, `eo-maven-plugin`, `eo-runtime` first, so
  nothing stale could mask the real registry state.
- Rebuilt `eo-runtime`/`eo-parser` fresh from this exact commit.
- Removed `@Disabled` locally and ran
  `mvn test -pl eo-integration-tests -Dtest=ProxyIT` against the real remote
  registry (network-gated by `@WeAreOnline`).
- Both tests pass: `tests="2" errors="0" skipped="0" failures="0"`.
- Ran `mvn checkstyle:check -pl eo-integration-tests`: clean (also dropped the
  now-unused `Disabled` import and the stale javadoc `@todo`).
