### PR TITLE
#5333: fix intermittent transpile corruption from a shared, non-thread-safe XSL train

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -62,24 +62,36 @@ final class Transpiling implements Step {
     static final String PRE = "5-pre-transpile";
 
     /**
-     * Parsing train with XSLs.
+     * Parsing train with XSLs, one instance per thread.
+     * <p>
+     *     A single shared instance is deliberately avoided: {@link TrClasspath}
+     *     and {@link StClasspath} compile their XSL stylesheets lazily on
+     *     first use, and that lazy compilation is not thread-safe. Sharing one
+     *     instance across the {@link Threaded} worker pool races on the same
+     *     underlying compilation cache and can produce truncated or garbled
+     *     Java output. Keeping one instance per thread still lets each worker
+     *     thread reuse its own compiled stylesheets across the sources it
+     *     processes.
+     * </p>
      */
-    static final Train<Shift> TRAIN = new TrFull(
-        new TrJoined<>(
-            new TrClasspath<>(
-                "/org/eolang/maven/transpile/set-locators.xsl",
-                "/org/eolang/maven/transpile/set-original-names.xsl",
-                "/org/eolang/maven/transpile/classes.xsl",
-                "/org/eolang/maven/transpile/tests.xsl",
-                "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
-                "/org/eolang/maven/transpile/package.xsl",
-                "/org/eolang/maven/transpile/attrs.xsl",
-                "/org/eolang/maven/transpile/data.xsl"
-            ).back(),
-            new TrDefault<>(
-                new StClasspath(
-                    "/org/eolang/maven/transpile/to-java.xsl",
-                    String.format("disclaimer %s", new Disclaimer())
+    private static final ThreadLocal<Train<Shift>> TRAIN = ThreadLocal.withInitial(
+        () -> new TrFull(
+            new TrJoined<>(
+                new TrClasspath<>(
+                    "/org/eolang/maven/transpile/set-locators.xsl",
+                    "/org/eolang/maven/transpile/set-original-names.xsl",
+                    "/org/eolang/maven/transpile/classes.xsl",
+                    "/org/eolang/maven/transpile/tests.xsl",
+                    "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
+                    "/org/eolang/maven/transpile/package.xsl",
+                    "/org/eolang/maven/transpile/attrs.xsl",
+                    "/org/eolang/maven/transpile/data.xsl"
+                ).back(),
+                new TrDefault<>(
+                    new StClasspath(
+                        "/org/eolang/maven/transpile/to-java.xsl",
+                        String.format("disclaimer %s", new Disclaimer())
+                    )
                 )
             )
         )
@@ -305,7 +317,7 @@ final class Transpiling implements Step {
      * @return XSL transformation function
      */
     private Function<XML, XML> transpilation(final Path source) {
-        final Train<Shift> measured = this.measured(Transpiling.TRAIN);
+        final Train<Shift> measured = this.measured(Transpiling.TRAIN.get());
         final Function<XML, XML> func;
         if (this.trackTransformationSteps) {
             func = xml -> new Xsline(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -305,7 +306,7 @@ final class MjTranspileTest {
     }
 
     @Test
-    void transpilesSeveralEoProgramsInParallel(@Mktmp final Path temp) throws IOException {
+    void transpilesSeveralEoProgramsInParallel(@Mktmp final Path temp) throws Exception {
         final int total = 30;
         final FakeMaven maven = new FakeMaven(temp);
         for (int prog = 1; prog < total; ++prog) {
@@ -316,16 +317,51 @@ final class MjTranspileTest {
                 String.format("foo/x/%s.eo", main)
             );
         }
-        MatcherAssert.assertThat(
-            "All programs must be transpiled",
-            Files.list(
+        final List<Path> files;
+        try (
+            Stream<Path> list = Files.list(
                 maven
                     .execute(new FakeMaven.Transpile())
                     .generatedPath()
                     .resolve("org/eolang/EOfoo/EOx")
-            ).count(),
-            Matchers.equalTo((long) total)
+            )
+        ) {
+            files = list.collect(Collectors.toList());
+        }
+        MatcherAssert.assertThat(
+            "All programs must be transpiled",
+            files.size(),
+            Matchers.equalTo(total)
         );
+        for (final Path file : files) {
+            final String java = new TextOf(file).asString();
+            if (file.getFileName().toString().startsWith("EOmain")) {
+                MatcherAssert.assertThat(
+                    String.format(
+                        "Generated %s must contain a class declaration, not be truncated/garbled by a concurrent transpilation race",
+                        file
+                    ),
+                    java,
+                    Matchers.containsString("class EOmain")
+                );
+            }
+            MatcherAssert.assertThat(
+                String.format(
+                    "Generated %s must have balanced braces, not be truncated/garbled by a concurrent transpilation race",
+                    file
+                ),
+                MjTranspileTest.balanced(java, '{', '}'),
+                Matchers.equalTo(true)
+            );
+            MatcherAssert.assertThat(
+                String.format(
+                    "Generated %s must have balanced parentheses, not be truncated/garbled by a concurrent transpilation race",
+                    file
+                ),
+                MjTranspileTest.balanced(java, '(', ')'),
+                Matchers.equalTo(true)
+            );
+        }
     }
 
     @Test
@@ -396,5 +432,30 @@ final class MjTranspileTest {
      */
     private static String filename(final Path path) {
         return path.getFileName().toString();
+    }
+
+    /**
+     * Check that every opening bracket has a matching closing one, in order.
+     * @param text Text to check
+     * @param open Opening bracket character
+     * @param close Closing bracket character
+     * @return TRUE if brackets are balanced
+     */
+    private static boolean balanced(final String text, final char open, final char close) {
+        int depth = 0;
+        boolean valid = true;
+        for (int idx = 0; idx < text.length(); ++idx) {
+            final char chr = text.charAt(idx);
+            if (chr == open) {
+                depth = depth + 1;
+            } else if (chr == close) {
+                depth = depth - 1;
+            }
+            if (depth < 0) {
+                valid = false;
+                break;
+            }
+        }
+        return valid && depth == 0;
     }
 }


### PR DESCRIPTION
Closes #5333.

## Root cause

`Transpiling.TRAIN` was a single `static final Train<Shift>` shared across
every worker thread in the `Threaded` pool used to transpile all `.eo` files
in parallel. `TrClasspath`/`StClasspath` compile their XSL stylesheets
lazily on first use, and that compilation is not thread-safe — this is the
exact same root-cause shape as #5209/#5234, which fixed the analogous race
in the lint phase's `LtByXsl` (a lazily-compiled, `Unchecked(Sticky(...))`
XSL cache shared across the lint thread pool).

Concurrent threads racing on the same lazy-compilation cache inside the
shared `TRAIN`'s `Shift` objects could produce a truncated or garbled Java
file for whichever object happened to be mid-compilation when another
thread's compilation interfered — matching the observed symptom exactly:
a syntax error in a generated file whose EO source was untouched and
correct, disappearing on retry of the identical commit.

## Fix

Switch `TRAIN` from a shared `static final Train<Shift>` to a
`ThreadLocal<Train<Shift>>`. Each worker thread now gets its own
independently-compiled train — no shared lazy-compilation state to race
on — while still reusing its own compiled stylesheets across every source
it processes, so most of the caching benefit from compiling once is kept
(only the pool size, `availableProcessors() * 2`, worth of redundant
compilations happen instead of one).

## Testing

- Strengthened the existing `transpilesSeveralEoProgramsInParallel` test:
  it previously only checked the *count* of generated files, which
  wouldn't have caught this bug (file count stays correct even when a
  file's content is corrupted). It now also verifies each generated file
  contains the expected class declaration and has balanced braces/parens.
- Ran the full `eo-maven-plugin` module test suite locally (`mvn test -pl
  eo-maven-plugin`): 343 tests, 0 failures, 0 errors, 5 skipped (unchanged
  from before this PR).
- `mvn clean verify -Pqulice -DskipTests -pl eo-maven-plugin`: clean.

Note: like the original bug, this race is inherently intermittent — I
cannot deterministically reproduce the exact corruption in a unit test
(that's the nature of the bug per #5333's own description: "a clean local
build compiled without error, and simply re-running the job on the
identical commit turned it green"). The fix follows the established,
already-accepted precedent from #5209/#5234 for the identical failure
mode in a sibling XSL pipeline.
