### PR TITLE
#5395: fix daily workflow JDK version pin from 20 to 21

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,13 +16,13 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 20
+          java-version: 21
       - uses: actions/cache@v6
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-20-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-jdk-20-maven-
+            ${{ runner.os }}-jdk-21-maven-
       - run: .github/daily.sh ${{ github.workspace }}
   report-fail:
     name: Create issue on failure


### PR DESCRIPTION
Closes #5395.

The `daily` workflow's `setup-java` step pinned `java-version: 20`, but
`mvn clean install -Pqulice -PskipTests` (the first command in
`.github/daily.sh`) requires JDK 21 — `qulice-maven-plugin:0.27.6`
declares a hard plugin prerequisite of exactly JDK 21, so the build fails
immediately with:

```
[ERROR] The plugin com.qulice:qulice-maven-plugin:0.27.6 has unmet prerequisites:
[ERROR] 	Required Java version 21 is not met by current version: 20.0.2
```

before the actual load-testing script (`test-repetition.sh` against
`eo-parser`/`eo-maven-plugin`/`eo-runtime`) ever runs. This has been
failing on every scheduled run for at least the last 30 days.

Matches `java-version: 21` from `.github/workflows/qulice.yml`, which
passes. Also updated the `actions/cache` key and `restore-keys` from
`jdk-20` to `jdk-21` for consistency with the new JDK version.
