### PR TITLE
#5396: assert IllegalStateException in MjLintTest.reportsWhenObjectNameFails

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -390,7 +390,7 @@ final class MjLintTest {
     @Test
     void reportsWhenObjectNameFails(@Mktmp final Path temp) {
         Assertions.assertThrows(
-            Exception.class,
+            IllegalStateException.class,
             () -> new FakeMaven(temp).withProgram("# App.").execute(new FakeMaven.Lint()),
             "MjLint's execution was not failed, but it should"
         );


### PR DESCRIPTION
Closes #5396.

Both `FakeMaven.withProgram(String...)` and `FakeMaven.execute(Class)` declare `throws IOException`, so with `Exception.class` asserted, SonarCloud rule `java:S5783` (CRITICAL, the single issue behind master's `new_reliability_rating = D`) flags the lambda as ambiguous: either call could be the one throwing.

Fixed by narrowing the asserted type to `IllegalStateException` — the exception `Moja.execute()` actually wraps every mojo failure into. `withProgram` can only throw `IOException`, so the assertion now unambiguously targets `execute`, with no structural changes to the test at all: same one-liner, no extra local, no suppressions.

Verification:
- `mvn test -pl eo-maven-plugin -Dtest=MjLintTest`: 17 tests, 0 failures, 0 errors.
- `mvn verify -Pqulice -DskipTests -pl eo-maven-plugin`: clean.
