### PR TITLE
#5419: reject out-of-range \NNN octal escapes instead of silently emitting a multi-byte value

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -24,6 +24,11 @@ import java.util.List;
 final class Emissions {
 
     /**
+     * Maximum value of a {@code \NNN} octal byte escape (0o377, one byte).
+     */
+    private static final int MAX_OCTAL_BYTE = 0xFF;
+
+    /**
      * No instances.
      */
     private Emissions() {
@@ -144,7 +149,7 @@ final class Emissions {
                 unescaped = Emissions.unescape(value.raw());
             } catch (final NumberFormatException ex) {
                 final ParseError error = new ParseError(
-                    line, value.pos(), "invalid unicode escape in string literal"
+                    line, value.pos(), "invalid unicode or octal escape in string literal"
                 );
                 error.initCause(ex);
                 throw error;
@@ -361,6 +366,14 @@ final class Emissions {
             && body.charAt(cursor) >= '0' && body.charAt(cursor) <= '7') {
             value = value * 8 + body.charAt(cursor) - '0';
             cursor = cursor + 1;
+        }
+        if (value > Emissions.MAX_OCTAL_BYTE) {
+            throw new NumberFormatException(
+                String.format(
+                    "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
+                    body.substring(start, cursor), value
+                )
+            );
         }
         out.append((char) value);
         return cursor;

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -586,6 +586,19 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void rejectsOutOfRangeOctalEscape() throws Exception {
+        MatcherAssert.assertThat(
+            "an out-of-range \\NNN octal escape (value > 0o377) must show up as an /object/errors/error entry, not silently emit a multi-byte value",
+            EoSyntaxTest.raw(
+                String.join(String.valueOf((char) 10), "[] > foo", "  \"\\477\" > @")
+            ).toString(),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'octal')]"
+            )
+        );
+    }
+
+    @Test
     void emitsProgramMetadataAttributes() throws Exception {
         MatcherAssert.assertThat(
             "the <object> root must carry the standard program metadata attributes",


### PR DESCRIPTION
Closes #5419.

Per `PARSER_SPEC.md` R-9.7.3, a `\NNN` octal escape must have value ≤ 0o377
(255) — one byte, with the grammar's leading digit (when 3 digits are
present) restricted to `[0-3]` precisely so the decoded value can never
exceed a single byte. `Emissions.appendOctal` greedily consumed up to 3
digits in `[0-7]` with no check on the resulting value, so a leading digit
of 4-7 (decoded value 256-511) was silently accepted and, once fed into the
`Φ.bytes` UTF-8 carrier, produced a 2-byte sequence instead of the single
byte the escape claims to represent (`"\477"` → `C4 BF`, `"\777"` → `C7 BF`,
`"\400"` → `C4 80`).

`appendOctal` now throws `NumberFormatException` when the decoded value
exceeds `0o377`. This is caught by the existing `STRING`-value handling in
`Emissions.emit`, which already converts a `NumberFormatException` from the
sibling `\uXXXX` unicode-escape path into a proper `ParseError` — the same
mechanism now covers octal, surfacing as an `/object/errors/error` entry
instead of corrupting the byte carrier.

Note: while investigating, I found that octal escapes with an in-range
value ≥ 128 (e.g. `\377` = 255, perfectly valid per spec) *also* currently
produce a 2-byte UTF-8 sequence rather than a single raw byte, because the
decoded `char` later goes through UTF-8 string encoding regardless of its
value. That's a separate, deeper issue (the escape's "one byte" promise
isn't kept for the *entire* upper half of the valid range, not just the
overflow case this PR closes) — I didn't fold it into this PR since fixing
it changes how the byte carrier itself is populated, a larger change than
"reject an out-of-range value." Happy to file it separately if useful.

Verification:
- Added `EoSyntaxTest.rejectsOutOfRangeOctalEscape`, confirming `"\477"`
  now surfaces an `/object/errors/error` entry mentioning `octal` instead
  of silently parsing.
- Full `eo-parser` test suite: 1455 tests, 0 failures, 0 errors.
- `mvn clean verify -Pqulice -DskipTests -pl eo-parser`: clean.
