### PR TITLE
test(integration): #5429 combine proxy handlers instead of overwriting one with the other

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -23,6 +23,7 @@ import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eclipse.jetty.proxy.ProxyHandler;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.hamcrest.MatcherAssert;
@@ -43,8 +44,7 @@ final class ProxyIT {
     void checksThatProxyIsWorking() throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);
-        proxy.setHandler(new ProxyHandler.Forward());
-        proxy.setHandler(new ConnectHandler());
+        proxy.setHandler(ProxyIT.handler());
         proxy.start();
         try {
             MatcherAssert.assertThat(
@@ -61,12 +61,11 @@ final class ProxyIT {
     }
 
     @Test
-    @Disabled("flaky when resolving dependencies through the live proxy, see #5429")
+    @Disabled("still depends on live Maven Central through the proxy, see #5429")
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();
         final Server proxy = new Server(port);
-        proxy.setHandler(new ProxyHandler.Forward());
-        proxy.setHandler(new ConnectHandler());
+        proxy.setHandler(ProxyIT.handler());
         proxy.start();
         final String[] log = {""};
         try {
@@ -85,6 +84,25 @@ final class ProxyIT {
             log[0],
             Matchers.containsString("BUILD SUCCESS")
         );
+    }
+
+    /**
+     * Build a forward proxy handler that also tunnels CONNECT requests.
+     *
+     * <p>{@link ConnectHandler} is a handler wrapper: it serves {@code CONNECT}
+     * requests itself (HTTPS tunneling) and delegates every other request to
+     * the handler nested inside it. Nesting {@link ProxyHandler.Forward} into
+     * it therefore installs both behaviours at once. Calling
+     * {@code setHandler(...)} twice on the server, as it used to be done here,
+     * simply replaced the first handler with the second, so plain HTTP
+     * forwarding was never exercised (see #5110 and #5429).</p>
+     *
+     * @return The combined handler
+     */
+    private static Handler handler() {
+        final ConnectHandler connect = new ConnectHandler();
+        connect.setHandler(new ProxyHandler.Forward());
+        return connect;
     }
 
     private static void shutdown(final Server proxy) throws Exception {


### PR DESCRIPTION
Closes part of #5429.

## Problem

In `ProxyIT`, both test methods set up the local Jetty proxy like this:

```java
proxy.setHandler(new ProxyHandler.Forward());
proxy.setHandler(new ConnectHandler());
```

`Server.setHandler(...)` replaces the current handler, so the second call
discards `ProxyHandler.Forward` and only `ConnectHandler` (CONNECT tunneling)
was ever installed — plain HTTP forward proxying was never exercised. This is
a recurrence of #5110.

## Change

- Extract a shared `handler()` helper that nests `ProxyHandler.Forward` inside
  `ConnectHandler`. `ConnectHandler` is a handler *wrapper*: it serves `CONNECT`
  requests itself and delegates every other (plain HTTP) request to the nested
  handler, so both behaviours are installed at once — the correct Jetty‑12
  forward‑proxy setup.
- Both `checksThatProxyIsWorking` and `checksThatWeCanCompileTheProgramWithProxySet`
  now use this helper, removing the duplicated (and buggy) wiring.

## Not in this PR

`checksThatWeCanCompileTheProgramWithProxySet` stays `@Disabled`. Its flakiness
also comes from resolving `eo-runtime`/`jna` from **live Maven Central** through
the proxy (`@WeAreOnline`), which is the other half of the fix called out in
#5429. Removing that live‑network dependency (e.g. serving a local Maven repo
over HTTP through the forward proxy) and re-enabling the test is a larger,
network-dependent change left as follow-up so this PR stays small and verifiable.
The `@Disabled` reason is updated to reflect the true remaining cause.

## Verification

The new handler wiring was compiled and type-checked against `jetty-server`/
`jetty-proxy` 12.1.11: `ConnectHandler extends Handler.Wrapper` (exposes
`setHandler(Handler)`) and `ProxyHandler.Forward` is a `Handler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C81Kagkzi9vfibijdAsGtP

---
_Generated by [Claude Code](https://claude.ai/code/session_01C81Kagkzi9vfibijdAsGtP)_