### PR TITLE
Fill formation void via inline binding

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -541,8 +541,9 @@ world""" > text-value                 ← multi-line string named text-value
 
 R-3.12.1. After an object body in an argument position, `:label` may appear, setting the attribute the argument attaches to.
 R-3.12.2. `:N` (digit) maps to `α0`, `α1`, … positional slot names.
-R-3.12.3. Binding is forbidden inside formation context — plain children carry their name via the name suffix, not the binding (§6.2).
+R-3.12.3. Binding on a formation child is restricted: a child carrying **both** an inline binding and a name suffix (`bar:tag > x`) is rejected, since a plain child carries its name via the suffix, not the binding (§6.2). A child carrying an inline binding and **no** name suffix (`42:x`) is instead an application argument that fills a void slot of the formation — see R-3.12.5. Binding is forbidden at top level.
 R-3.12.4. Binding rules in same-indent groups (§6.6) apply.
+R-3.12.5. **Void-filling argument — formation as formation-plus-application.** An unnamed formation body line of the form `value:name` (an inline binding, no name suffix) supplies `value` to the void `name` of the enclosing formation, exactly as `head arg:name` supplies an argument to an application. The whole formation is thereby read as a *formation applied to that argument* — the phi-calculus `⟦ … name ↦ ∅ ⟧(name ↦ value)`. The line emits an ordinary argument `<o base='…value…' as='name'/>` child of the formation `<o>` (§9.4, inline binding). The void declaration for `name` (from `[…]` or a `? > name` line) is kept; the argument fills it. This makes anonymous formations usable as functions (Haskell) or lambda expressions (Java). Example: `[x] > foo` with body `7 > a`, `x.plus a > @`, `42:x` binds `a → 7`, `φ → x.plus a`, and applies `x → 42`.
 
 ### 3.13 Multi-line BYTES literal
 
@@ -765,7 +766,7 @@ R-5.2.11. Otherwise: the line is the program's top-level object. Push a new entr
 
 When a level record is popped or replaced:
 
-R-5.3.1. **Naming check.** If `parent_kind = formation` or `parent_kind = top-level`, then `named?` must be true. Otherwise: error "object inside formation must have a name" at `start_line`.
+R-5.3.1. **Naming check.** If `parent_kind = formation` or `parent_kind = top-level`, then `named?` must be true, unless the child is a void-filling argument (`bound? = true`, R-3.12.5), which needs no name. Otherwise: error "object inside formation must have a name" at `start_line`.
 R-5.3.2. **Bare reversed completeness.** If `kind = bare-reversed` and `receiver_consumed? = false`: error "reversed dispatch missing receiver."
 R-5.3.3. **Compact tuple count.** If `kind = compact-tuple` and `child_count < compact_tuple_n`: error "compact tuple `*N` requires at least N children, got `child_count`."
 R-5.3.4. **Atom body.** If the popped entry's `parent_is_atom?` is true, the popped entry's kind must be `bare-formation` **AND** its name-suffix form must be `+>` (R-6.3.1). Otherwise: error `atom may contain only test attributes`. (`+>` is a name-suffix variant, not a property of the kind itself; this rule checks both fields.) Note: even when this check passes, the `+>` child must additionally satisfy the depth constraint of R-6.3.3 (verified separately by R-5.3.5); a `+>` child of a *nested* atom fails R-5.3.5 because tests are legal only at indent 2 of a top-level object.
@@ -826,7 +827,7 @@ x.put 2                               ← happlication, horizontally-completed
 
 ### 6.2 Naming inside formations
 
-R-6.2.1. Every expression that is a plain child of a formation **must carry a name suffix** on its naming line.
+R-6.2.1. Every expression that is a plain child of a formation **must carry a name suffix** on its naming line. The sole exception is a void-filling argument (R-3.12.5): a plain child carrying an inline binding (`value:name`) and no name suffix is an application argument to the formation, so it needs no name.
 R-6.2.2. The naming line per outer kind:
 
 | Outer kind | Naming line |

--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -82,8 +82,10 @@ final class Bindings {
      * binding mode and rejects mismatches. For {@code BARE_REVERSED}
      * parents the first child is the receiver (no binding allowed);
      * subsequent children participate in the all-or-nothing group. For
-     * formation / top-level parents, any binding is rejected per
-     * R-3.12.3.</p>
+     * a formation parent an <em>unnamed</em> bound child is an
+     * application argument that fills a void slot (a formation-plus-
+     * application, #5432); a binding on a <em>named</em> attribute is
+     * still rejected per R-3.12.3, as is any binding at top level.</p>
      *
      * @param stack Indent stack (the new child is already on top)
      * @param outer Outer binding label, or {@code null} when absent
@@ -91,12 +93,38 @@ final class Bindings {
      */
     static void observeChild(final Stack stack, final String outer, final Span span) {
         final Level parent = stack.below();
-        if (parent == null || parent.kind() == Kind.BARE_FORMATION) {
+        if (parent == null) {
             Bindings.rejectBinding(outer, span);
+        } else if (parent.kind() == Kind.BARE_FORMATION) {
+            Bindings.observeFormationChild(stack.top(), outer, span);
         } else if (parent.kind() == Kind.BARE_REVERSED) {
             Bindings.observeReversedChild(parent, outer, span);
         } else if (Bindings.tracksBindings(parent.kind())) {
             parent.observeBinding(outer != null, span);
+        }
+    }
+
+    /**
+     * Handle a child under a {@link Kind#BARE_FORMATION} parent. A
+     * binding on an unnamed child marks it as an application argument
+     * filling one of the formation's void slots (#5432); a binding on
+     * a named attribute is rejected — a name suffix and an inline
+     * binding cannot combine on a formation child (R-3.12.3).
+     * @param child The formation child (top of stack)
+     * @param outer Outer binding (may be {@code null})
+     * @param span Source span of the child
+     */
+    private static void observeFormationChild(
+        final Level child, final String outer, final Span span
+    ) {
+        if (outer != null) {
+            if (child.named()) {
+                throw new ParseError(
+                    span.line(), span.indent(),
+                    "binding allowed only in argument position"
+                );
+            }
+            child.bind();
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -699,7 +699,7 @@ final class Eo implements Iterable<Directive> {
      * @param emit The directives sink
      */
     private static void checkNaming(final Level level, final Emit emit) {
-        if (!level.named()
+        if (!level.named() && !level.bound()
             && (level.parent() == Kind.TOP_LEVEL
                 || level.parent() == Kind.BARE_FORMATION)) {
             emit.error(

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -86,6 +86,14 @@ final class Level {
     private boolean plain;
 
     /**
+     * True when this entry's naming line carried an inline binding
+     * ({@code :label} / {@code :N}). A bound child of a formation is an
+     * application argument that fills a void slot — a formation-plus-
+     * application (#5432) — so it needs no name suffix (R-6.2.1).
+     */
+    private boolean bound;
+
+    /**
      * True when this entry sits in argument position under an only-phi
      * formation's φ — set by {@link Stack} as it propagates the flag
      * down through nested applications and resets it at a formation
@@ -311,6 +319,21 @@ final class Level {
     }
 
     /**
+     * Whether this entry carried an inline binding on its naming line.
+     * @return Bound flag
+     */
+    boolean bound() {
+        return this.bound;
+    }
+
+    /**
+     * Flip {@link #bound()} to true.
+     */
+    void bind() {
+        this.bound = true;
+    }
+
+    /**
      * Flag this entry as an atom (formation with {@code /sig}).
      */
     void mark() {
@@ -390,13 +413,13 @@ final class Level {
      * picked up via {@link #upgradeArgBinding()} is reflected at
      * commit time.</p>
      *
-     * @param bound Whether the child carries an inline binding
+     * @param binding Whether the child carries an inline binding
      * @param span Source span of the child (for error positioning)
      */
-    void observeBinding(final boolean bound, final Span span) {
+    void observeBinding(final boolean binding, final Span span) {
         this.commitArg(span);
         this.argpending = true;
-        this.argbound = bound;
+        this.argbound = binding;
         this.argspan = span;
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -739,6 +739,21 @@ final class EoTest {
     }
 
     @Test
+    void acceptsVoidFillingArgumentInFormationBody() {
+        MatcherAssert.assertThat(
+            "an unnamed `value:void` body line fills a formation void, turning the formation into a formation-plus-application (#5432)",
+            EoTest.render(
+                "[x] > foo", "  7 > a", "  x.plus a > @", "  42:x"
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/object[not(errors)]",
+                "/object/o[@name='foo']/o[@base='∅' and @name='x']",
+                "/object/o[@name='foo']/o[@as='x']"
+            )
+        );
+    }
+
+    @Test
     void rejectsBindingOnVerticalReceiver() {
         MatcherAssert.assertThat(
             "the receiver of a vertical reversed dispatch cannot carry a binding either",

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -82,6 +82,28 @@ final class LevelTest {
     }
 
     @Test
+    void flipsBoundFlag() {
+        final Level level = new Level(
+            2, 3, Kind.HEAD, Openness.OPEN, Kind.BARE_FORMATION, false
+        );
+        level.bind();
+        MatcherAssert.assertThat(
+            "bound() must report true once bind() has been called",
+            level.bound(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void leavesBoundFlagFalseByDefault() {
+        MatcherAssert.assertThat(
+            "a fresh level cannot be bound before bind() is invoked",
+            new Level(0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false).bound(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void flipsAtomFlag() {
         final Level level = new Level(
             0, 1, Kind.BARE_FORMATION, Openness.OPEN, Kind.TOP_LEVEL, false

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/void-filled-in-formation-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/void-filled-in-formation-body.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='foo']/o[@base='∅' and @name='x']
+  - /object/o[@name='foo']/o[@name='a']
+  - /object/o[@name='foo']/o[@name='φ']
+  - /object/o[@name='foo']/o[@as='x' and not(@name)]
+input: |
+  [x] > foo
+    7 > a
+    x.plus a > @
+    42:x


### PR DESCRIPTION
This makes anonymous formations usable as functions. A body line of the form `value:name` (an inline binding with no name suffix) now fills the void `name` of the enclosing formation, so the whole thing reads as a formation applied to an argument — the phi-calculus `[ a -> 7, x -> ? ] ( x -> 42 )`. For example:

```
[x] > foo
  7 > a
  x.plus a > @
  42:x
```

binds `a -> 7`, `phi -> x.plus a`, and applies `x -> 42`. The `42:x` line emits an ordinary `<o base='...' as='x'/>` argument child of the formation, exactly like an application argument, while the void declaration for `x` is kept and filled. This is the `:x` spelling from the discussion in #5432, which mirrors application notation.

A binding that also carries a name suffix (`bar:tag > x`) stays rejected, since a named attribute is not an argument. The change touches the parser only: `Level` gains a `bound` flag, `Bindings.observeChild` accepts the void-filling argument, and the naming check lets it through. Spec rules R-3.12.3, R-3.12.5, R-5.3.1 and R-6.2.1 are updated to match.

Runtime dataization of an anonymous formation applied to its arguments is the natural next step and is left out of this PR; here I only teach the parser the syntax and the XMIR it emits.

Closes #5432