### PR TITLE
feat(#5443): separated without from ss.list

### DIFF
--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -12,7 +12,6 @@
 
 +alias ss.eachi
 +alias ss.list
-+alias ss.reduced
 +alias ss.reducedi
 +alias ss.withouti
 +architect yegor256@gmail.com
@@ -44,17 +43,6 @@
     eachi > @
       ^
       func item > [item index] >>
-
-  [element] > without
-    list > @
-      reduced
-        ^
-        *
-        [accum item] >>
-          if. > @
-            element.eq item
-            accum
-            accum.with item
 
   [other] > eq
     and. > @
@@ -223,14 +211,6 @@
           .each > @
             ^.m.put (^.m.as-number.plus i) > [i] >>
       6
-
-  [] +> tests-list-without
-    eq. > @
-      without.
-        list
-          * 1 2 1 2 1 5
-        2
-      * 1 1 1 5
 
   [] +> tests-equality-test
     eq. > @

--- a/eo-runtime/src/main/eo/ss/without.eo
+++ b/eo-runtime/src/main/eo/ss/without.eo
@@ -1,0 +1,29 @@
+# Create a new list without all occurrences of `element` in `lst`.
+
++alias ss.list
++alias ss.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst element] > without
+  list > @
+    reduced
+      lst
+      *
+      [accum item] >>
+        if. > @
+          element.eq item
+          accum
+          accum.with item
+
+  [] +> tests-list-without
+    eq. > @
+      without
+        list
+          * 1 2 1 2 1 5
+        2
+      * 1 1 1 5


### PR DESCRIPTION
In this PR, I extracted the `without` object from `ss.list` into its own file `ss/without.eo`, mirroring the pattern used by other already-extracted siblings (`withouti`, `reduced`, `eachi`, `mappedi`, etc.) and matching the `ms.real` decomposition from #4751.

The new free-standing object takes the list as an explicit free attribute (`[lst element] > without`) instead of relying on `^`. The `tests-list-without` test moved with it and was updated from method-call (`without.`) to free-function (`without`) syntax. The unused `+alias ss.reduced` was dropped from `list.eo` since `without` was its only consumer there.

This is one of several extractions toward fully dissolving `ss.list` (#5443); future PRs can extract `each`, `eq`, `concat`, `front`, `back`, `slice`, `shifted`, `with`/`withi`, `is-empty`, etc. one at a time, then delete `list.eo`.

Verified locally: `mvn clean install -Pqulice -PskipITs` passes, and the affected tests (`EOss.EOlistTest` 35/35, `EOss.EOwithoutTest` 1/1) all pass.

Partial fix for #5443