### PR TITLE
feat(#5443): separated each from ss.list

### DIFF
--- a/eo-runtime/src/main/eo/ss/each.eo
+++ b/eo-runtime/src/main/eo/ss/each.eo
@@ -1,0 +1,28 @@
+# For each collection element dataize the object.
+# Here "func" must be an abstract object with one free attribute:
+# the element of the collection. The result of `func` must be dataizable.
+
++alias ss.eachi
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst func] > each
+  eachi > @
+    lst
+    func item > [item index] >>
+
+  [] +> tests-iterates-with-each
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            list
+              * 1 2 3
+            ^.m.put (^.m.as-number.plus i) > [i] >>
+      6

--- a/eo-runtime/src/main/eo/ss/each.eo
+++ b/eo-runtime/src/main/eo/ss/each.eo
@@ -26,3 +26,38 @@
               * 1 2 3
             ^.m.put (^.m.as-number.plus i) > [i] >>
       6
+
+  [] +> tests-each-empty-list
+    each > @
+      list *
+      false > [x]
+
+  [] +> tests-each-single-element
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            list
+              * 7
+            ^.m.put (^.m.as-number.plus i) > [i] >>
+      7
+
+  [] +> tests-each-returns-last-func-result
+    eq. > @
+      each
+        list
+          * 1 2 3
+        x > [x]
+      3
+
+  [] +> tests-each-sums-more-numbers
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            list
+              * 10 20 30
+            ^.m.put (^.m.as-number.plus i) > [i] >>
+      60

--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -10,7 +10,6 @@
 # ```
 # .
 
-+alias ss.eachi
 +alias ss.back
 +alias ss.list
 +alias ss.reducedi
@@ -40,11 +39,6 @@
       back
         ^
         origin.length.minus index
-
-  [func] > each
-    eachi > @
-      ^
-      func item > [item index] >>
 
   [other] > eq
     and. > @
@@ -188,17 +182,6 @@
         * 0 1
         * 4 0
         * 7 3
-
-  [] +> tests-iterates-with-each
-    eq. > @
-      malloc.for
-        0
-        [m]
-          list
-            * 1 2 3
-          .each > @
-            ^.m.put (^.m.as-number.plus i) > [i] >>
-      6
 
   [] +> tests-equality-test
     eq. > @


### PR DESCRIPTION
In this PR, I extracted the `each` object from `ss.list` into its own file `ss/each.eo`, mirroring the pattern used by other already-extracted siblings (`eachi`, `withouti`, `reduced`, etc.) and matching the `ms.real` decomposition from #4751.

The new free-standing object takes the list as an explicit free attribute (`[lst func] > each`) instead of relying on `^`. The `tests-iterates-with-each` test moved with it and was updated from method-call (`.each`) to free-function (`each`) syntax. The unused `+alias ss.eachi` was dropped from `list.eo` since `each` was its only consumer there.

This is one of several extractions toward fully dissolving `ss.list` (#5443). Independent of #5448 (`without`); further PRs can extract `eq`, `concat`, `front`, `back`, `slice`, `shifted`, `with`/`withi`, `is-empty`, etc. one at a time, then delete `list.eo`.

Verified locally: `mvn clean install -Pqulice -PskipITs` passes, and the affected tests (`EOss.EOlistTest` 35/35, `EOss.EOeachTest` 1/1) all pass.

Partial fix for #5443
