### PR TITLE
feat(#5443): move list.eq to tuple.eq

### DIFF
--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -43,21 +43,6 @@
         ^
         origin.length.minus index
 
-  [other] > eq
-    and. > @
-      eq.
-        origin.length
-        other.length
-      receq origin other
-
-    [first second] > receq
-      if. > @
-        first.length.eq 0
-        true
-        and.
-          first.head.eq second.head
-          receq first.tail second.tail
-
   [passed] > concat
     reducedi > @
       list passed
@@ -164,7 +149,7 @@
         * 4 0
         * 7 3
 
-  [] +> tests-equality-test
+  ++> tests-equality-test
     eq. > @
       list
         * 1 2 3

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -40,6 +40,19 @@
       x
       (length.plus 1).as-number
 
+  [other] > eq
+    and. > @
+      length.eq other.length
+      receq ^ other
+
+    [first second] > receq
+      if. > @
+        first.length.eq 0
+        true
+        and.
+          first.head.eq second.head
+          receq first.tail second.tail
+
   ++> tests-makes-tuple-through-special-syntax
     eq. > @
       (* 1 2).length
@@ -215,3 +228,25 @@
   ++> throws-on-out-of-tuple-bounds-with-negative-index
     arr.at -6 > @
     * 0 1 2 3 4 > arr
+
+  ++> tests-tuple-equality
+    eq. > @
+      * 1 2 3
+      * 1 2 3
+
+  ++> tests-tuple-not-equality
+    not. > @
+      eq.
+        * 1 2 3
+        * 3 2 1
+
+  ++> tests-tuple-nested-equality
+    eq. > @
+      *
+        * 0 1
+        * 4 0
+        * 7 3
+      *
+        * 0 1
+        * 4 0
+        * 7 3


### PR DESCRIPTION
Moved `list.eq` (and its `receq` helper) onto `tuple` as `tuple.eq`, per review feedback on the previous `ss.eq` approach.

`list` decorates a tuple via `origin > @`, so equality falls through to `tuple.eq` — no thin delegate on `list` and no free-standing `ss/eq.eo`. Existing `list` equality tests stay in place to exercise that fallthrough; new tuple-level equality tests cover the implementation directly.

Rebased/reset onto current `master` (includes merged `each` and related extractions).

Verified locally: `EOtupleTest` and `EOss.EOlistTest` pass.

Partial fix for #5443