### PR TITLE
#5444: require a blank line before every +> test attribute

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -107,6 +107,7 @@ final class TranspileIT {
             System.lineSeparator(),
             "[] > simple",
             "  \"hello\" > @",
+            "",
             "  [] +> tests-simple-works",
             "    true > @"
         ).getBytes(StandardCharsets.UTF_8);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/atom-with-tests.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/atom-with-tests.yaml
@@ -17,5 +17,6 @@ asserts:
   - //tests[contains(text(), 'void test_1()')]
 input: |
   [x] > foo /bytes
+
     [] +> test-1
       foo > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/live-object-with-test-suite.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/live-object-with-test-suite.yaml
@@ -23,6 +23,7 @@ asserts:
 input: |
   [name] > foo
     Q.tt.sprintf "Hello, %s!" (* name) > @
+
     [] +> formats-name
       eq. > @
         foo "Bar"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/removes-pluses-in-test-transpilation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/removes-pluses-in-test-transpilation.yaml
@@ -20,6 +20,7 @@ asserts:
 input: |
   [] > list
     [x] > bar
+
     [] +> tests-iterates-with-eachi
       eq. > @
         malloc.for

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-test.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-test.yaml
@@ -22,6 +22,8 @@ asserts:
 input: |
   [] > some
     7 > yes
+
     [] +> works
       1.eq 1 > @
+
     false > [] +> throws-on

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
@@ -26,6 +26,7 @@ asserts:
   - /object/class/tests[contains(text(), 'void b()')]
 input: |
   [] > a
+
     [] +> b
       [] > c
         d > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-as-tests-only-test-attributes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/transpiles-as-tests-only-test-attributes.yaml
@@ -16,6 +16,7 @@ asserts:
   - //java[not(contains(text(), 'void some_other_method()'))]
 input: |
   [] > foo
+
     [] +> runs-smoothly
       x > @
     [] > some-other-method

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -92,7 +92,7 @@ The terms below are used precisely throughout this document.
 
 A formation's body block contains child expressions. We distinguish two roles based on syntactic shape:
 
-- **Master child** — a child expression whose outer kind is `bare-formation`, `inline-phi-formation`, or whose name suffix is `/sig` (atom). I.e., children whose role is self-evident from the brackets (`[` head or `> [..] >` mid-line marker). A master child may carry an optional name suffix; it may be preceded by zero or one blank line (§6.5).
+- **Master child** — a child expression whose outer kind is `bare-formation`, `inline-phi-formation`, or whose name suffix is `/sig` (atom). I.e., children whose role is self-evident from the brackets (`[` head or `> [..] >` mid-line marker). A master child may carry an optional name suffix; it may be preceded by zero or one blank line, and when its name suffix is a `+>` test attribute the blank line is mandatory (§6.5).
 - **Plain child** — every other child expression: `head`, `hmethod`, `happlication`, `vapplication`, `vmethod`, `bare-reversed`, `reversed-with-hargs`, `compact-tuple`, or `text-block`. A plain child **must** carry a name suffix on its naming line (§6.2). A plain child may not be preceded by a blank line.
 
 The distinction is structural: master children open a sub-formation visible in the source via brackets, so a name is optional. Plain children would be visually indistinguishable from siblings without an explicit name suffix, so one is required.
@@ -926,7 +926,7 @@ R-6.4.2. A comment that is indented, follows a meta, follows an object, or opens
 
 R-6.5.1. Inside the top comment block: blank lines forbidden.
 R-6.5.2. After the top comment block: exactly one blank line separates it from the first meta or object. A block immediately followed by a meta or object, with no blank in between, is rejected: "a blank line must separate the top comment block from the rest of the file".
-R-6.5.3. Before a master object (formation, atom, inline-phi formation, including `+>` test attributes): zero or one blank line.
+R-6.5.3. Before a master object (formation, atom, inline-phi formation): zero or one blank line. Before a `+>` test attribute: exactly one blank line; a test attribute sitting directly under the previous non-blank line is rejected: error "missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute".
 
 *Note on validation timing and indent attribution.* A blank line carries no indent or kind of its own. The legality of a blank line is determined by the *next* non-blank line: when that line is classified, the parser checks whether it is a master. If yes, the preceding blank is legal; if no (the next line is a plain child or a non-master continuation), the blank is reported as `blank line not allowed between non-master siblings` (§9.9), with the position of the offending blank line. The blank logically attaches to the indent of the *next non-blank line*, not to whatever was popped during Step A (§5.2.1) when that next line arrives — Step A pops change the stack but not the blank's identity. `pending_blank_count` (§5.1.1) is read at the point the next non-blank line classifies.
 R-6.5.4. Between two plain siblings: blank lines forbidden.

--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -9,8 +9,10 @@ package org.eolang.parser;
  * the spec.
  *
  * <p>R-6.5.3 caps consecutive blanks at one (enforced in
- * {@link LnBlank}). R-6.5.4 forbids a blank line before a plain child
- * or between two plain siblings — enforced here by
+ * {@link LnBlank}) and requires exactly one blank line in front of
+ * every {@code +>} test attribute — enforced here by
+ * {@link #checkTest}. R-6.5.4 forbids a blank line before a plain
+ * child or between two plain siblings — enforced here by
  * {@link #checkPlain}.</p>
  *
  * <p>R-6.5.5 requires exactly one blank line between the meta header
@@ -45,6 +47,23 @@ final class Blanks {
             emit.error(
                 span.line(), span.indent(),
                 "blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line"
+            );
+        }
+    }
+
+    /**
+     * Report a missing blank line in front of a {@code +>} test
+     * attribute — illegal per R-6.5.3, which requires exactly one
+     * blank line before every test attribute.
+     * @param span The offending line's span (used for error position)
+     * @param globals The global parser state
+     * @param emit The directives sink
+     */
+    static void checkTest(final Span span, final Globals globals, final Emit emit) {
+        if (globals.pendingBlanks() == 0) {
+            emit.error(
+                span.line(), span.indent(),
+                "missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -59,6 +59,9 @@ final class LnFormation implements Line {
         final Suffix suffix = new Suffix(
             tail, this.span, this.span.indent() + close + 1 + LnFormation.bindingWidth(binding)
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        }
         Comments.seal(globals, emit, this.span);
         this.transition(stack, suffix);
         globals.clearBlanks();

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -94,6 +94,9 @@ final class LnOnlyPhi implements Line {
         final Suffix suffix = new Suffix(
             body.substring(close + 1), this.span, this.span.indent() + close + 1
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        }
         final Span inner = new Span(
             " ".repeat(this.span.indent()).concat(lhs), this.span.line()
         );

--- a/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
@@ -216,6 +216,34 @@ final class LnFormationTest {
     }
 
     @Test
+    void rejectsPlusGreaterAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        new LnFormation(new Span("[] +> tests-foo", 2))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute with no blank line above must emit an R-6.5.3 error",
+            LnFormationTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsPlusGreaterAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Globals globals = new Globals();
+        globals.blank();
+        new LnFormation(new Span("[] +> tests-foo", 2))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute preceded by one blank line must not emit any error",
+            LnFormationTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
+    @Test
     void marksFirstObjectEmittedAfterPush() {
         final Globals globals = new Globals();
         new LnFormation(new Span("[] > foo", 1))

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -56,6 +56,34 @@ final class LnOnlyPhiTest {
     }
 
     @Test
+    void rejectsPlusGreaterAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        new LnOnlyPhi(new Span("false > [] +> throws-on", 2))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "an inline-phi `+>` test attribute with no blank line above must emit an R-6.5.3 error",
+            LnOnlyPhiTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsPlusGreaterAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Globals globals = new Globals();
+        globals.blank();
+        new LnOnlyPhi(new Span("false > [] +> throws-on", 2))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "an inline-phi `+>` test attribute preceded by one blank line must not emit any error",
+            LnOnlyPhiTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
+    @Test
     void emitsFormationWithName() {
         final Emit emit = new Emit();
         new LnOnlyPhi(new Span("right > [x] > left", 1))

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atom-with-tests.yaml
@@ -8,6 +8,7 @@ asserts:
   - //o[@name='λ' and @pos='0']
 input: |
   [format read] > sscanf /tuple
+
     [] +> tests-sscanf-with-string
       eq. > @
         "hello"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
@@ -12,7 +12,9 @@ input: |-
     eq. +> test-1
       foo
       "fox"
+
     [] +> test-2
       foo > @
+
     [] +> test-3
       foo > i

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/missing-blank-before-inline-phi-test.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/missing-blank-before-inline-phi-test.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:2] error: 'missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute'
+    false > [] +> throws-on
+    ^
+input: |
+  [] > foo
+    42 > @
+    false > [] +> throws-on

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/missing-blank-before-test.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/missing-blank-before-test.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:2] error: 'missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute'
+    [] +> tests-foo-works
+    ^
+input: |
+  [] > foo
+    42 > @
+    [] +> tests-foo-works
+      true > @

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -39,6 +39,7 @@
 +unlint mandatory-package
 
 [target] > dataized /bytes
+
   [] +> tests-dataized-does-not-do-recalculation
     eq. > @
       malloc.for

--- a/eo-runtime/src/main/eo/ms/ln.eo
+++ b/eo-runtime/src/main/eo/ms/ln.eo
@@ -51,6 +51,7 @@
           plus.
             1.div ((k.times 2).plus 1)
             squared.times (horner (k.plus 1))
+
   [] +> tests-ln-of-negative-float-is-nan
     is-nan. > @
       ln -2.2

--- a/eo-runtime/src/main/eo/ms/sqrt.eo
+++ b/eo-runtime/src/main/eo/ms/sqrt.eo
@@ -15,6 +15,7 @@
     (number num.as-bytes).lt 0
     nan
     power num 0.5
+
   [] +> tests-sqrt-zero
     eq. > @
       sqrt 0.0

--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -19,6 +19,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [format args] > sprintf /string
+
   [] +> tests-prints-simple-string
     eq. > @
       "Hello, Jeffrey!"

--- a/eo-runtime/src/main/eo/tt/sscanf.eo
+++ b/eo-runtime/src/main/eo/tt/sscanf.eo
@@ -20,6 +20,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [format read] > sscanf /tuple
+
   [] +> tests-sscanf-with-string
     eq. > @
       "hello"


### PR DESCRIPTION
Closes #5444.

The parser now requires exactly one blank line in front of every `+>` test attribute; a test sitting directly under the previous non-blank line is reported as an error (recoverable, emitted into XMIR like the sibling R-6.5.4 check).

Changes:
- `Blanks.checkTest` — new helper mirroring `Blanks.checkPlain`: reports `missing blank line before a '+>' test attribute (R-6.5.3)` when `pendingBlanks() == 0`.
- `LnFormation` and `LnOnlyPhi` call it when the suffix is a test, covering both forms: `[] +> name` and `false > [] +> throws-on`. The application form (`eq. +> name`) already forbids a preceding blank via `checkPlain`, so it is untouched.
- `PARSER_SPEC.md` — R-6.5.3 split: masters keep zero-or-one blank, `+>` tests require exactly one; the "Master child" definition in §1 updated accordingly.
- Five stdlib objects that violated the new rule got their blank inserted: `ms/sqrt.eo`, `ms/ln.eo`, `dataized.eo`, `tt/sprintf.eo`, `tt/sscanf.eo`.
- Tests: two new typo packs (formation and inline-phi forms, exact position and message), four unit tests in `LnFormationTest`/`LnOnlyPhiTest`, and ten existing fixtures (`eo-syntax`/`transpile-packs` yaml packs, `TranspileIT`) updated to satisfy the rule.

Verification:
- `mvn -pl eo-parser test`: 914 tests, 0 failures.
- `mvn -pl eo-maven-plugin test`: 343 tests, 0 failures.
- `mvn -pl eo-runtime install` (full transpile of the stdlib): BUILD SUCCESS.
- `mvn verify -Pqulice` clean on `eo-parser`, `eo-maven-plugin`, `eo-integration-tests`.
