### PR TITLE
feat(#5443): separated concat from tuple.list

### DIFF
--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -1,0 +1,39 @@
+# Concatenate `lst` with another collection `passed`.
+
++alias tuple.list
++alias tuple.reducedi
++alias tuple.withouti
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst passed] > concat
+  reducedi > @
+    list passed
+    lst
+    accum.with item > [accum item index]
+
+  ++> tests-concatenates-lists
+    and. > @
+      eq.
+        1
+        list3.at 0
+      eq.
+        list3
+        * 1 2 3
+    withouti > list3
+      concat
+        list (* 0 1)
+        list (* 2 3)
+      0
+
+  ++> tests-concatenates-with-tuple
+    eq. > @
+      concat
+        list
+          * 0 1
+        * 2 4
+      * 0 1 2 4

--- a/eo-runtime/src/main/eo/tuple/list.eo
+++ b/eo-runtime/src/main/eo/tuple/list.eo
@@ -11,10 +11,9 @@
 # .
 
 +alias tuple.back
++alias tuple.concat
 +alias tuple.front
 +alias tuple.list
-+alias tuple.reducedi
-+alias tuple.withouti
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
@@ -33,7 +32,7 @@
       origin.with x
 
   [index item] > withi
-    concat. > @
+    concat > @
       with.
         front
           ^
@@ -42,12 +41,6 @@
       back
         ^
         origin.length.minus index
-
-  [passed] > concat
-    reducedi > @
-      list passed
-      ^
-      accum.with item > [accum item index]
 
   ++> tests-list-should-not-be-empty
     not. > @
@@ -119,25 +112,3 @@
         list
           * 1 2 3
         * 3 2 1
-
-  ++> tests-concatenates-lists
-    and. > @
-      eq.
-        1
-        list3.at 0
-      eq.
-        list3
-        * 1 2 3
-    withouti > list3
-      concat.
-        list (* 0 1)
-        list (* 2 3)
-      0
-
-  ++> tests-concatenates-with-tuple
-    eq. > @
-      concat.
-        list
-          * 0 1
-        * 2 4
-      * 0 1 2 4


### PR DESCRIPTION
Extracted `list.concat` into standalone `tuple/concat.eo`, with `lst` as the first free attribute. `list.withi` now calls the free `concat`.

Rebasing note: after #5486, package `ss` was renamed to `tuple`, so this PR targets `tuple/list.eo` (not `ss/list.eo`).

Partial fix for #5443