### PR TITLE
feat(#5443): separated back from ss.list

### DIFF
--- a/eo-runtime/src/main/eo/ss/back.eo
+++ b/eo-runtime/src/main/eo/ss/back.eo
@@ -1,0 +1,49 @@
+# Elements of `lst` from `index` to the end (supports oversized index).
+
++alias ss.list
++alias ss.reducedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst index] > back
+  if. > @
+    0.gt start
+    lst
+    list
+      reducedi
+        lst
+        *
+        [accum item idx] >>
+          if. > @
+            idx.gte start
+            accum.with item
+            accum
+  index > idx!
+  lst.length.minus idx > start!
+
+  [] +> tests-simple-back
+    eq. > @
+      back
+        list
+          * 1 2 3 4 5
+        2
+      * 4 5
+
+  [] +> tests-zero-index-in-back
+    is-empty. > @
+      back
+        list
+          * 1 2 3 4 5
+        0
+
+  [] +> tests-large-index-in-back
+    eq. > @
+      back
+        list
+          * 1 2 3 4 5
+        10
+      * 1 2 3 4 5

--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -11,6 +11,7 @@
 # .
 
 +alias ss.eachi
++alias ss.back
 +alias ss.list
 +alias ss.reducedi
 +alias ss.withouti
@@ -37,6 +38,7 @@
         front index
         item
       back
+        ^
         origin.length.minus index
 
   [func] > each
@@ -71,7 +73,9 @@
       list *
       if.
         0.gt idx
-        back (number idx).neg
+        back
+          ^
+          (number idx).neg
         if.
           (number idx).gte origin.length
           ^
@@ -84,22 +88,6 @@
         tup.length.eq idx
         tup
         rechead tup.tail
-
-  [index] > back
-    if. > @
-      0.gt start
-      ^
-      list
-        reducedi
-          ^
-          *
-          [accum item idx] >>
-            if. > @
-              idx.gte start
-              accum.with item
-              accum
-    index > idx!
-    origin.length.minus idx > start!
 
   [start end] > slice
     if. > @
@@ -293,29 +281,6 @@
           * "foo" 2.2 00-01 "bar"
         -3
       * 2.2 00-01 "bar"
-
-  [] +> tests-simple-back
-    eq. > @
-      back.
-        list
-          * 1 2 3 4 5
-        2
-      * 4 5
-
-  [] +> tests-zero-index-in-back
-    is-empty. > @
-      back.
-        list
-          * 1 2 3 4 5
-        0
-
-  [] +> tests-large-index-in-back
-    eq. > @
-      back.
-        list
-          * 1 2 3 4 5
-        10
-      * 1 2 3 4 5
 
   [] +> tests-simple-slice
     eq. > @


### PR DESCRIPTION
In this PR, I extracted the `back` object from `ss.list` into its own file `ss/back.eo`, mirroring the pattern used by other already-extracted siblings (`without`, `concat`, `eachi`, etc.) and matching the `ms.real` decomposition from #4751.

The new free-standing object takes the list as an explicit free attribute (`[lst index] > back`) instead of relying on `^`. The three back tests moved with it and were updated from method-call (`back.`) to free-function (`back`) syntax. Remaining call sites in `list.front` and `list.withi` were updated the same way, with `+alias ss.back` added to `list.eo`.

This is one of several extractions toward fully dissolving `ss.list` (#5443). Further PRs can extract `front`, `slice`, `shifted`, `with`/`withi`, `is-empty`, etc. one at a time, then delete `list.eo`.

Verified locally: `mvn clean install -Pqulice -PskipITs` passes, and the affected tests (`EOss.EOlistTest` 32/32, `EOss.EObackTest` 3/3) all pass.

Partial fix for #5443