### PR TITLE
feat(#5443): separated front from ss.list

### DIFF
--- a/eo-runtime/src/main/eo/ss/front.eo
+++ b/eo-runtime/src/main/eo/ss/front.eo
@@ -1,0 +1,79 @@
+# Elements of `lst` before `index` (supports negative indices).
+
++alias ss.back
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst index] > front
+  if. > @
+    idx.eq 0
+    list *
+    if.
+      0.gt idx
+      back
+        lst
+        (number idx).neg
+      if.
+        (number idx).gte lst.length
+        lst
+        list
+          rechead lst
+  index > idx!
+
+  [tup] > rechead
+    if. > @
+      tup.length.eq idx
+      tup
+      rechead tup.tail
+
+  [] +> tests-simple-front
+    eq. > @
+      front
+        list
+          * 1 2 3 4 5
+        1
+      * 1
+
+  [] +> tests-list-front-with-zero-index
+    is-empty. > @
+      front
+        list
+          * 1 2 3
+        0
+
+  [] +> tests-list-front-with-length-index
+    eq. > @
+      front
+        list
+          * 1 2 3
+        3
+      * 1 2 3
+
+  [] +> tests-complex-front
+    eq. > @
+      front
+        list
+          * "foo" 2.2 00-01 "bar"
+        2
+      * "foo" 2.2
+
+  [] +> tests-front-with-negative
+    eq. > @
+      front
+        list
+          * 1 2 3
+        -1
+      * 3
+
+  [] +> tests-complex-front-with-negative
+    eq. > @
+      front
+        list
+          * "foo" 2.2 00-01 "bar"
+        -3
+      * 2.2 00-01 "bar"

--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -12,6 +12,7 @@
 
 +alias ss.eachi
 +alias ss.back
++alias ss.front
 +alias ss.list
 +alias ss.reducedi
 +alias ss.withouti
@@ -35,7 +36,9 @@
   [index item] > withi
     concat. > @
       with.
-        front index
+        front
+          ^
+          index
         item
       back
         ^
@@ -66,28 +69,6 @@
       list passed
       ^
       accum.with item > [accum item index]
-
-  [index] > front
-    if. > @
-      idx.eq 0
-      list *
-      if.
-        0.gt idx
-        back
-          ^
-          (number idx).neg
-        if.
-          (number idx).gte origin.length
-          ^
-          list
-            rechead origin
-    index > idx!
-
-    [tup] > rechead
-      if. > @
-        tup.length.eq idx
-        tup
-        rechead tup.tail
 
   [start end] > slice
     if. > @
@@ -234,53 +215,6 @@
           * 0 1
         * 2 4
       * 0 1 2 4
-
-  [] +> tests-simple-front
-    eq. > @
-      front.
-        list
-          * 1 2 3 4 5
-        1
-      * 1
-
-  [] +> tests-list-front-with-zero-index
-    is-empty. > @
-      front.
-        list
-          * 1 2 3
-        0
-
-  [] +> tests-list-front-with-length-index
-    eq. > @
-      front.
-        list
-          * 1 2 3
-        3
-      * 1 2 3
-
-  [] +> tests-complex-front
-    eq. > @
-      front.
-        list
-          * "foo" 2.2 00-01 "bar"
-        2
-      * "foo" 2.2
-
-  [] +> tests-front-with-negative
-    eq. > @
-      front.
-        list
-          * 1 2 3
-        -1
-      * 3
-
-  [] +> tests-complex-front-with-negative
-    eq. > @
-      front.
-        list
-          * "foo" 2.2 00-01 "bar"
-        -3
-      * 2.2 00-01 "bar"
 
   [] +> tests-simple-slice
     eq. > @


### PR DESCRIPTION
In this PR, I extracted the `front` object from `ss.list` into its own file `ss/front.eo`, mirroring the pattern used by other already-extracted siblings (`back`, `without`, `concat`, etc.) and matching the `ms.real` decomposition from #4751.

The new free-standing object takes the list as an explicit free attribute (`[lst index] > front`) instead of relying on `^`, and moves the `rechead` helper with it. The six front tests moved with it and were updated from method-call (`front.`) to free-function (`front`) syntax. The remaining call site in `list.withi` was updated the same way, with `+alias ss.front` added to `list.eo`.

`front` depends on `ss.back` (negative-index path). Because `back` is not on `master` yet, this branch includes that extraction as a prerequisite commit — merge the `back` PR first, then rebase this one if needed.

This is one of several extractions toward fully dissolving `ss.list` (#5443). Further PRs can extract `slice`, `shifted`, `with`/`withi`, `is-empty`, etc. one at a time, then delete `list.eo`.

Verified locally: `mvn clean install -Pqulice -PskipITs` passes, and the affected tests (`EOss.EOlistTest` 26/26, `EOss.EOfrontTest` 6/6, `EOss.EObackTest` 3/3) all pass.

Partial fix for #5443