### PR TITLE
#5445: add ++> shorthand for [] +> test attribute declaration

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -198,6 +198,7 @@ Each non-blank, non-comment line is classified into exactly one shape, determine
 | First char (after indent) | Lookahead | Line shape |
 |---|---|---|
 | `+` | followed by digit | signed-number application (see §3.6) |
+| `+` | followed by `+>` | test-attribute shorthand — `++> name` desugars to `[] +> name` (§3.4 / R-6.3.6) |
 | `+` | otherwise | meta directive (§3.2) |
 | `#` | — | comment (§3.3) |
 | `.` | — | method-dispatch line (§3.5) |
@@ -878,6 +879,7 @@ R-6.3.4. Atoms may appear at any nesting depth, with two restrictions:
   - **(a)** A nested atom (one not at indent 0) cannot hold tests (R-6.3.3 — `+>` legal only at indent 2 of top-level) and cannot hold regular children (R-6.3.1 — atoms accept only test children). Therefore a nested atom's body must be **empty**.
   - **(b)** A nested atom is legal only when the containing formation is **not itself an atom**. Atoms inside atoms are rejected: an atom's body may contain only `+>` test attributes (R-6.3.1), and a master child (formation/atom) of an atom is therefore inadmissible regardless of body shape.
 R-6.3.5. A test attribute name must be a `NAME` token. `+> @` (PHI as test name) is rejected even though the underlying grammar's `tname : tarrow (PHI | NAME)` accepts it. Tests are named identifiers; `@` has no meaning as a test name.
+R-6.3.6. **Test-attribute shorthand.** A line whose first non-space characters are `++>` is sugar for a bare parameterless formation with a test suffix: `++> name` ≡ `[] +> name`. The two forms are equivalent in every respect after classification — same XMIR emission (§9.4), same depth constraint (R-6.3.3), same name rules (R-6.3.5). There is no ambiguity with meta directives: metas are legal only before the first object (R-3.2.2), and their names never start with `+`.
 
 Examples:
 

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -386,7 +386,7 @@ final class Eo implements Iterable<Directive> {
         } else if (span.head() == '#') {
             line = new LnComment(span);
         } else if (span.head() == '+' && !Eo.signedDigit(span)) {
-            line = new LnMeta(span);
+            line = Eo.plussed(span);
         } else if (span.head() == '[') {
             line = new LnFormation(span);
         } else if (span.head() == '.') {
@@ -422,6 +422,24 @@ final class Eo implements Iterable<Directive> {
                     "line shape not yet implemented in spec parser"
                 );
             };
+        }
+        return line;
+    }
+
+    /**
+     * Classify a {@code +}-headed non-number line (§3.1): the
+     * {@code ++>} test-attribute shorthand desugars to a bare
+     * formation with a {@code +>} suffix (R-6.3.6); anything else is
+     * a meta directive (§3.2).
+     * @param span The line span
+     * @return The line shape
+     */
+    private static Line plussed(final Span span) {
+        final Line line;
+        if (span.body().startsWith("++>")) {
+            line = new LnFormation(span);
+        } else {
+            line = new LnMeta(span);
         }
         return line;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -16,7 +16,9 @@ import java.util.List;
  * parameter name (R-3.4.3). No leading/trailing space inside the
  * brackets (R-3.4.4); exactly one space between parameter names
  * (R-3.4.5). The line may carry an optional name suffix per §3.10,
- * including the atom-signature form {@code > name /sig}.</p>
+ * including the atom-signature form {@code > name /sig}. The shorthand
+ * {@code ++> name} is accepted as sugar for {@code [] +> name} — a
+ * parameterless formation carrying a test suffix (R-6.3.6).</p>
  *
  * <p>Cross-line behaviour: pushes a new {@link Level} at this line's
  * indent (Step C/D) or replaces the current top (Step B), with
@@ -26,7 +28,6 @@ import java.util.List;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class LnFormation implements Line {
 
     /**
@@ -46,19 +47,31 @@ final class LnFormation implements Line {
     public void into(final Stack stack, final Globals globals, final Emit emit) {
         Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
-        final int close = LnFormation.findClosing(body, this.span);
-        final List<String> params = LnFormation.params(body, close, this.span);
-        final String raw = body.substring(close + 1);
-        final String binding = LnFormation.outerBinding(raw);
-        final String tail;
-        if (binding == null) {
-            tail = raw;
+        final List<String> params;
+        final String binding;
+        final Suffix suffix;
+        if (body.startsWith("++>")) {
+            params = new ArrayList<>(0);
+            binding = null;
+            suffix = new Suffix(
+                body.substring(1), this.span, this.span.indent() + 1
+            );
         } else {
-            tail = raw.substring(1 + binding.length());
+            final int close = LnFormation.findClosing(body, this.span);
+            params = LnFormation.params(body, close, this.span);
+            final String raw = body.substring(close + 1);
+            binding = LnFormation.outerBinding(raw);
+            final String tail;
+            if (binding == null) {
+                tail = raw;
+            } else {
+                tail = raw.substring(1 + binding.length());
+            }
+            suffix = new Suffix(
+                tail, this.span,
+                this.span.indent() + close + 1 + LnFormation.bindingWidth(binding)
+            );
         }
-        final Suffix suffix = new Suffix(
-            tail, this.span, this.span.indent() + close + 1 + LnFormation.bindingWidth(binding)
-        );
         if (suffix.test()) {
             Blanks.checkTest(this.span, globals, emit);
         }

--- a/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
@@ -149,6 +149,41 @@ final class LnFormationTest {
     }
 
     @Test
+    void emitsPlusPlusGreaterShorthandAsPlusPrefixedAttribute() {
+        final Emit emit = new Emit();
+        new LnFormation(new Span("++> tests-foo", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `++> name` shorthand must emit the same <o name='+<name>'> as `[] +> name`",
+            LnFormationTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/o[@name='+tests-foo' and not(o)]")
+        );
+    }
+
+    @Test
+    void pushesFormationKindForPlusPlusGreaterShorthand() {
+        final Stack stack = new Stack();
+        new LnFormation(new Span("++> tests-foo", 1))
+            .into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "a `++> name` shorthand must push the same BARE_FORMATION level as `[] +> name`",
+            stack.top().kind(),
+            Matchers.equalTo(Kind.BARE_FORMATION)
+        );
+    }
+
+    @Test
+    void rejectsPhiAsPlusPlusGreaterShorthandName() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnFormation(new Span("++> @", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "`++> @` must be rejected per R-6.3.5, exactly as `[] +> @` is"
+        );
+    }
+
+    @Test
     void emitsConstMarkerAttribute() {
         final Emit emit = new Emit();
         new LnFormation(new Span("[] > foo!", 1))

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-shorthand.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-shorthand.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='fibo']/o[@name='+fibo-first-equals-to-one']
+  - /object/o[@name='fibo']/o[@name='+fibo-fits-the-shorthand' and count(o)=1]
+input: |
+  [n] > fibo
+    if. > @
+      n.lt 2
+      1
+      plus.
+        fibo (n.minus 1)
+        fibo (n.minus 2)
+
+    ++> fibo-first-equals-to-one
+      eq. > @
+        1
+        fibo 1
+
+    ++> fibo-fits-the-shorthand
+      true > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/test-shorthand-with-phi-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/test-shorthand-with-phi-name.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:6] error: 'test attribute name must be an identifier, not @'
+    ++> @
+        ^
+input: |
+  [] > foo
+
+    ++> @
+      true > @

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -22,31 +22,31 @@
 
   if true (01-.eq x) > [x] > or
 
-  [] +> tests-compares-two-bools
+  ++> tests-compares-two-bools
     eq. > @
       true
       true
 
-  [] +> tests-true-as-bool
+  ++> tests-true-as-bool
     true.as-bool > @
 
-  [] +> tests-compares-two-different-bool-types
+  ++> tests-compares-two-different-bool-types
     not. > @
       eq.
         true
         42
 
-  [] +> tests-compares-bool-to-bytes
+  ++> tests-compares-bool-to-bytes
     and. > @
       true.eq 01-
       false.eq 00-
 
-  [] +> tests-compares-bool-to-bytes-reverse
+  ++> tests-compares-bool-to-bytes-reverse
     and. > @
       01-.as-bytes.eq true
       00-.as-bytes.eq false
 
-  [] +> tests-forks-on-true-condition
+  ++> tests-forks-on-true-condition
     eq. > @
       if.
         5.eq 5
@@ -54,7 +54,7 @@
         42
       123
 
-  [] +> tests-takes-parent-object
+  ++> tests-takes-parent-object
     eq. > @
       a 42
       42
@@ -63,7 +63,7 @@
       [] > take
         ^.x > @
 
-  [] +> tests-takes-parent-through-attribute
+  ++> tests-takes-parent-through-attribute
     [] > @
       [] > @
         [] > @
@@ -72,13 +72,13 @@
             42
     42 > x
 
-  [] +> throws-when-applies-to-closed-object
+  ++> throws-when-applies-to-closed-object
     closed true > @
     [x] > a
       x > @
     a false > closed
 
-  [] +> tests-app-that-calls-func
+  ++> tests-app-that-calls-func
     eq. > @
       output
       2
@@ -90,7 +90,7 @@
         1 > a
     app > output
 
-  [] +> tests-extract-attribute-from-decoratee
+  ++> tests-extract-attribute-from-decoratee
     eq. > @
       a.foo
       43
@@ -101,7 +101,7 @@
           42
           1
 
-  [] +> tests-nesting-blah-test
+  ++> tests-nesting-blah-test
     eq. > @
       blah0 0
       39
@@ -186,7 +186,7 @@
                                                                                   [x] > blah39
                                                                                     x > @
 
-  [] +> tests-compiles-correctly-with-long-duplicate-names
+  ++> tests-compiles-correctly-with-long-duplicate-names
     true > @
     [] > long-object-name
       [] > long-object-name
@@ -195,23 +195,23 @@
             [] > long-object-name
               42 > x
 
-  [] +> tests-true-not-is-false
+  ++> tests-true-not-is-false
     eq. > @
       true.not
       false
 
-  [] +> tests-compares-bool-to-string
+  ++> tests-compares-bool-to-string
     and. > @
       true.eq "\001"
       false.eq "\000"
 
-  [] +> tests-true-and-false-is-false
+  ++> tests-true-and-false-is-false
     not. > @
       and.
         true
         false
 
-  [] +> tests-forks-on-false-condition
+  ++> tests-forks-on-false-condition
     eq. > @
       if.
         5.eq 8

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -99,7 +99,7 @@
 
   [b] > concat /bytes
 
-  [] +> tests-takes-part-of-bytes
+  ++> tests-takes-part-of-bytes
     eq. > @
       slice.
         20-1F-EE-B5-90
@@ -107,7 +107,7 @@
         3
       1F-EE-B5
 
-  [] +> tests-size-of-part-is-correct
+  ++> tests-size-of-part-is-correct
     eq. > @
       size.
         slice.
@@ -116,98 +116,98 @@
           3
       3
 
-  [] +> tests-counts-size-of-bytes
+  ++> tests-counts-size-of-bytes
     eq. > @
       size.
         F1-20-5F-EC-B5-90-32
       7
 
-  [] +> tests-turns-bytes-into-a-string
+  ++> tests-turns-bytes-into-a-string
     eq. > @
       string
         E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21
       "你好, друг!"
 
-  [] +> tests-left-zero
+  ++> tests-left-zero
     not. > @
       eq.
         0.as-bytes.left 1
         -1.as-bytes
 
-  [] +> tests-left-with-zero
+  ++> tests-left-with-zero
     not. > @
       eq.
         2.as-bytes.left 0
         -3.as-bytes
 
-  [] +> tests-left-with-odd-neg
+  ++> tests-left-with-odd-neg
     not. > @
       eq.
         -17.as-bytes.left 1
         33.as-bytes
 
-  [] +> tests-left-with-minus-one
+  ++> tests-left-with-minus-one
     eq. > @
       eq.
         -1.as-bytes.left 3
         7.as-bytes
       false
 
-  [] +> tests-left-with-even-neg
+  ++> tests-left-with-even-neg
     eq. > @
       FF-FF-FF-FF-FF-FF-FF-EE.left 2
       00-00-00-00-00-00-00-47.not
 
-  [] +> tests-left-with-even-plus
+  ++> tests-left-with-even-plus
     not. > @
       eq.
         4.as-bytes.left 3
         -33.as-bytes
 
-  [] +> tests-left-with-odd-plus
+  ++> tests-left-with-odd-plus
     not. > @
       eq.
         5.as-bytes.left 3
         -41.as-bytes
 
-  [] +> tests-right-with-zero
+  ++> tests-right-with-zero
     not. > @
       eq.
         0.as-bytes.right 2
         -1.as-bytes
 
-  [] +> tests-right-with-odd-neg
+  ++> tests-right-with-odd-neg
     not. > @
       eq.
         -37.as-bytes.right 3
         4.as-bytes
 
-  [] +> tests-right-with-minus-one
+  ++> tests-right-with-minus-one
     not. > @
       eq.
         -1.as-bytes.right 4
         0.as-bytes
 
-  [] +> tests-right-with-even-neg
+  ++> tests-right-with-even-neg
     not. > @
       eq.
         -38.as-bytes.right 1
         18.as-bytes
 
-  [] +> tests-right-with-even-plus
+  ++> tests-right-with-even-plus
     eq. > @
       eq.
         36.as-bytes.right 2
         -10.as-bytes
       false
 
-  [] +> tests-right-with-odd-plus
+  ++> tests-right-with-odd-plus
     not. > @
       eq.
         37.as-bytes.right 3
         -5.as-bytes
 
-  [] +> tests-and-with-zero
+  ++> tests-and-with-zero
     not. > @
       eq.
         and.
@@ -215,13 +215,13 @@
           32.as-bytes
         -1.as-bytes
 
-  [] +> tests-and-with-two-neg
+  ++> tests-and-with-two-neg
     not. > @
       eq.
         -6.as-bytes.and -4.as-bytes
         7.as-bytes
 
-  [] +> tests-and-with-two-plus
+  ++> tests-and-with-two-plus
     not. > @
       eq.
         and.
@@ -229,93 +229,93 @@
           10.as-bytes
         -1.as-bytes
 
-  [] +> tests-and-with-one-neg-one-plus
+  ++> tests-and-with-one-neg-one-plus
     not. > @
       eq.
         -7.as-bytes.and 7.as-bytes
         -2.as-bytes
 
-  [] +> tests-or-with-zero
+  ++> tests-or-with-zero
     not. > @
       eq.
         -11.as-bytes.or 0.as-bytes
         10.as-bytes
 
-  [] +> tests-or-with-two-neg
+  ++> tests-or-with-two-neg
     not. > @
       eq.
         -27.as-bytes.or -13.as-bytes
         8.as-bytes
 
-  [] +> tests-or-with-two-plus
+  ++> tests-or-with-two-plus
     not. > @
       eq.
         5.as-bytes.or 14.as-bytes
         -16.as-bytes
 
-  [] +> tests-or-with-one-neg-one-plus
+  ++> tests-or-with-one-neg-one-plus
     not. > @
       eq.
         -7.as-bytes.or 23.as-bytes
         0.as-bytes
 
-  [] +> tests-xor-with-zero
+  ++> tests-xor-with-zero
     not. > @
       eq.
         0.as-bytes.xor 29.as-bytes
         -30.as-bytes
 
-  [] +> tests-xor-with-two-neg
+  ++> tests-xor-with-two-neg
     not. > @
       eq.
         -1.as-bytes.xor -123.as-bytes
         -123.as-bytes
 
-  [] +> tests-xor-with-two-plus
+  ++> tests-xor-with-two-plus
     not. > @
       eq.
         53.as-bytes.xor 24.as-bytes
         -46.as-bytes
 
-  [] +> tests-xor-with-one-neg-one-plus
+  ++> tests-xor-with-one-neg-one-plus
     not. > @
       eq.
         -36.as-bytes.xor 43.as-bytes
         8.as-bytes
 
-  [] +> tests-not-with-zero
+  ++> tests-not-with-zero
     not. > @
       eq.
         0.as-bytes
         0.as-bytes.not
 
-  [] +> tests-not-with-neg
+  ++> tests-not-with-neg
     not. > @
       eq.
         -1.as-bytes
         -1.as-bytes.not
 
-  [] +> tests-not-with-plus
+  ++> tests-not-with-plus
     not. > @
       eq.
         53.as-bytes
         53.as-bytes.not
 
-  [] +> tests-conjunction-of-bytes
+  ++> tests-conjunction-of-bytes
     eq. > @
       a.and b
       02-23-C0-05-5E-70-10
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  [] +> tests-written-in-several-lines
+  ++> tests-written-in-several-lines
     eq. > @
       size.
         CA-FE-
         BE-BE
       4
 
-  [] +> tests-bitwise-works
+  ++> tests-bitwise-works
     eq. > @
       as-number.
         and.
@@ -323,13 +323,13 @@
           1.as-bytes
       1
 
-  [] +> tests-convertible-to-bool
+  ++> tests-convertible-to-bool
     not. > @
       eq.
         01-.as-bool
         00-.as-bool
 
-  [] +> tests-bitwise-works-negative
+  ++> tests-bitwise-works-negative
     eq. > @
       as-number.
         or.
@@ -337,42 +337,42 @@
           00-00-00-00-00-00-00-7F.as-bytes
       FF-FF-FF-FF-FF-FF-FF-FF
 
-  [] +> tests-concatenation-of-bytes
+  ++> tests-concatenation-of-bytes
     eq. > @
       a.concat b
       02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  [] +> tests-concat-bools-as-bytes
+  ++> tests-concat-bools-as-bytes
     eq. > @
       concat.
         true.as-bytes
         false.as-bytes
       01-00
 
-  [] +> tests-concat-with-empty
+  ++> tests-concat-with-empty
     eq. > @
       concat.
         05-5E-78
         --
       05-5E-78
 
-  [] +> tests-concat-empty-with
+  ++> tests-concat-empty-with
     eq. > @
       concat.
         --
         05-5E-78
       05-5E-78
 
-  [] +> tests-concat-empty
+  ++> tests-concat-empty
     eq. > @
       concat.
         --
         --
       --
 
-  [] +> tests-concat-strings
+  ++> tests-concat-strings
     eq. > @
       string
         concat.
@@ -380,78 +380,78 @@
           "world".as-bytes
       "hello world"
 
-  [] +> tests-xor-works
+  ++> tests-xor-works
     eq. > @
       00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
       00-00-00-00-71-15-B3-4E
 
-  [] +> tests-one-xor-one-as-number
+  ++> tests-one-xor-one-as-number
     eq. > @
       (1.as-bytes.xor 1.as-bytes).as-number
       0
 
-  [] +> tests-or-neg-bytes-with-leading-zeroes
+  ++> tests-or-neg-bytes-with-leading-zeroes
     eq. > @
       00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-8E-EA-4C-B1
 
-  [] +> tests-and-neg-bytes-as-number-with-leading-zeroes
+  ++> tests-and-neg-bytes-as-number-with-leading-zeroes
     eq. > @
       (00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00).as-number
       0
 
-  [] +> tests-xor-neg-bytes-with-leading-zeroes
+  ++> tests-xor-neg-bytes-with-leading-zeroes
     eq. > @
       00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-8E-EA-4C-B1
 
-  [] +> tests-or-neg-bytes-without-leading-zeroes
+  ++> tests-or-neg-bytes-without-leading-zeroes
     eq. > @
       00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-FF-FF-FF-FF
 
-  [] +> tests-and-neg-bytes-as-number-without-leading-zeroes
+  ++> tests-and-neg-bytes-as-number-without-leading-zeroes
     eq. > @
       (00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00).as-number
       0
 
-  [] +> tests-xor-neg-bytes-as-number-without-leading-zeroes
+  ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
     eq. > @
       (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
       FF-FF-FF-FF-FF-FF-FF-FF
 
-  [] +> tests-or-neg-bytes-as-number-with-zero
+  ++> tests-or-neg-bytes-as-number-with-zero
     eq. > @
       (-4294967296.as-bytes.or 0.as-bytes).as-number
       -4294967296
 
-  [] +> tests-or-neg-bytes-with-one
+  ++> tests-or-neg-bytes-with-one
     eq. > @
       FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
       FF-FF-FF-FF-00-00-00-01
 
-  [] +> throws-on-bytes-of-wrong-size-as-number
+  ++> throws-on-bytes-of-wrong-size-as-number
     01-01-01-01.as-number > @
 
-  [] +> tests-wrong-size-as-number-returns-provided-fallback
+  ++> tests-wrong-size-as-number-returns-provided-fallback
     eq. > @
       "recovered"
       01-01-01-01.as-number
         "recovered" > [msg]
 
-  [] +> throws-on-bytes-of-wrong-size-as-i64
+  ++> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
 
-  [] +> tests-wrong-size-as-i64-returns-provided-fallback
+  ++> tests-wrong-size-as-i64-returns-provided-fallback
     eq. > @
       "recovered"
       01-01-01-01.as-i64
         "recovered" > [msg]
 
-  [] +> throws-on-out-of-bounds-slice
+  ++> throws-on-out-of-bounds-slice
     20-1F-EE-B5-90.slice 3 10 > @
 
-  [] +> tests-out-of-bounds-slice-returns-provided-fallback
+  ++> tests-out-of-bounds-slice-returns-provided-fallback
     eq. > @
       "recovered"
       20-1F-EE-B5-90.slice
@@ -459,7 +459,7 @@
         10
         "recovered" > [msg]
 
-  [] +> tests-slice-with-overflowing-start-plus-len-returns-fallback
+  ++> tests-slice-with-overflowing-start-plus-len-returns-fallback
     eq. > @
       "recovered"
       20-1F-EE-B5-90.slice
@@ -467,17 +467,17 @@
         2000000000
         "recovered" > [msg]
 
-  [] +> tests-bytes-converts-to-i64
+  ++> tests-bytes-converts-to-i64
     eq. > @
       00-00-00-00-00-00-00-2A.as-i64
       42.as-i64
 
-  [] +> tests-bytes-converts-to-i64-and-back
+  ++> tests-bytes-converts-to-i64-and-back
     eq. > @
       00-00-00-00-00-00-00-33.as-i64.as-bytes
       00-00-00-00-00-00-00-33
 
-  [] +> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
+  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
     not. > @
       eq.
         00-00-00-00-00-00-00-2A.as-i64.as-bytes

--- a/eo-runtime/src/main/eo/cti.eo
+++ b/eo-runtime/src/main/eo/cti.eo
@@ -17,7 +17,7 @@
 [delegate level message] > cti
   delegate > @
 
-  [] +> tests-prints-warning-and-delegates
+  ++> tests-prints-warning-and-delegates
     eq. > @
       cti
         2.times 2

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -40,7 +40,7 @@
 
 [target] > dataized /bytes
 
-  [] +> tests-dataized-does-not-do-recalculation
+  ++> tests-dataized-does-not-do-recalculation
     eq. > @
       malloc.for
         0
@@ -56,7 +56,7 @@
             ^.m.put (^.m.as-number.plus 1) > @
       1
 
-  [] +> tests-dataizes-as-bytes-behaves-as-exclamationed
+  ++> tests-dataizes-as-bytes-behaves-as-exclamationed
     seq > @
       *
         cached1

--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -75,13 +75,13 @@
         "The file %s is a directory, can't open for I/O operations"
         * file
 
-  [] +> tests-makes-new-directory
+  ++> tests-makes-new-directory
     and. > @
       d.exists
       d.is-directory
     (tmpdir.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
 
-  [] +> tests-deletes-empty-directory
+  ++> tests-deletes-empty-directory
     tmpdir
     .tmpfile
     .deleted
@@ -94,12 +94,12 @@
     .exists
     .not > @
 
-  [] +> throws-on-opening-directory
+  ++> throws-on-opening-directory
     tmpdir.open > @
       "w"
       true > [d]
 
-  [] +> tests-deletes-directory-with-files-recursively
+  ++> tests-deletes-directory-with-files-recursively
     and. > @
       and.
         and.
@@ -113,7 +113,7 @@
     d.tmpfile > first
     d.tmpfile > second
 
-  [] +> tests-deletes-directory-with-file-and-dir
+  ++> tests-deletes-directory-with-file-and-dir
     and. > @
       and.
         and.
@@ -129,7 +129,7 @@
     d.tmpfile > f
     (dir d.tmpfile.deleted).made > inner
 
-  [] +> tests-walks-recursively
+  ++> tests-walks-recursively
     seq > @
       *
         (d.resolved "foo/bar").as-dir.made
@@ -139,5 +139,5 @@
         (d.as-dir.walk "**/*.tt").length.eq 2
     (dir tmpdir.tmpfile.deleted).made.as-path > d
 
-  [] +> throws-on-walking-absent-directory
+  ++> throws-on-walking-absent-directory
     (dir tmpdir.tmpfile.deleted).walk "**" > @

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -243,53 +243,53 @@
                       syscall.write (* descriptor buffer buffer.size):args
                     output-block
 
-  [] +> tests-check-if-current-directory-is-directory
+  ++> tests-check-if-current-directory-is-directory
     (file ".").is-directory > @
 
-  [] +> tests-check-if-absent-file-does-not-exist
+  ++> tests-check-if-absent-file-does-not-exist
     (file "absent.tt").exists.not > @
 
-  [] +> tests-returns-self-after-deleting
+  ++> tests-returns-self-after-deleting
     temp.deleted.path.eq temp.path > @
     tmpdir.tmpfile > temp
 
-  [] +> tests-returns-self-after-touching
+  ++> tests-returns-self-after-touching
     temp.deleted.touched.path.eq temp.path > @
     tmpdir.tmpfile > temp
 
-  [] +> tests-checks-file-does-not-exist-after-deleting
+  ++> tests-checks-file-does-not-exist-after-deleting
     tmpdir.tmpfile.deleted.exists.not > @
 
-  [] +> tests-touches-a-file
+  ++> tests-touches-a-file
     tmpdir.tmpfile.deleted.touched.exists > @
 
-  [] +> tests-measures-empty-file-after-touching
+  ++> tests-measures-empty-file-after-touching
     tmpdir.tmpfile.deleted.touched.size.eq 0 > @
 
-  [] +> throws-on-sizing-absent-file
+  ++> throws-on-sizing-absent-file
     tmpdir.tmpfile.deleted.size > @
 
-  [] +> throws-on-checking-directory-of-absent-file
+  ++> throws-on-checking-directory-of-absent-file
     tmpdir.tmpfile.deleted.is-directory > @
 
-  [] +> tests-sizing-absent-file-returns-fallback
+  ++> tests-sizing-absent-file-returns-fallback
     eq. > @
       -1
       tmpdir.tmpfile.deleted.size -1
 
-  [] +> tests-checking-absent-file-returns-fallback
+  ++> tests-checking-absent-file-returns-fallback
     tmpdir.tmpfile.deleted.is-directory true > @
 
-  [] +> tests-does-not-fail-on-double-touching
+  ++> tests-does-not-fail-on-double-touching
     tmpdir.tmpfile.deleted.touched.touched.exists > @
 
-  [] +> tests-does-not-fail-on-double-deleting
+  ++> tests-does-not-fail-on-double-deleting
     tmpdir.tmpfile.deleted.deleted.exists.not > @
 
-  [] +> throws-an-error-on-touching-temp-file-in-absent-dir
+  ++> throws-an-error-on-touching-temp-file-in-absent-dir
     (tmpdir.as-path.resolved "foo").@.tmpfile > @
 
-  [] +> tests-resolves-and-touches
+  ++> tests-resolves-and-touches
     and. > @
       resolved.as-dir.made.tmpfile.exists
       contains
@@ -299,13 +299,13 @@
           * "foo" "bar"
     tmpdir.as-path.resolved "foo/bar" > resolved
 
-  [] +> tests-moves-a-file
+  ++> tests-moves-a-file
     and. > @
       (temp.moved (sprintf "%s.dest" (* temp.path))).exists
       temp.exists.not
     tmpdir.tmpfile > temp
 
-  [] +> throws-on-opening-with-wrong-mode
+  ++> throws-on-opening-with-wrong-mode
     seq > @
       *
         tmpdir
@@ -315,7 +315,7 @@
           true > [f]
         true
 
-  [] +> throws-on-reading-from-not-existed-file
+  ++> throws-on-reading-from-not-existed-file
     tmpdir
     .tmpfile
     .deleted
@@ -323,7 +323,7 @@
       "r"
       f > [f]
 
-  [] +> throws-on-reading-or-writing-from-not-existed-file
+  ++> throws-on-reading-or-writing-from-not-existed-file
     tmpdir
     .tmpfile
     .deleted
@@ -331,7 +331,7 @@
       "r+"
       f > [f]
 
-  [] +> tests-recovers-from-opening-missing-file-through-fallback
+  ++> tests-recovers-from-opening-missing-file-through-fallback
     eq. > @
       "recovered"
       tmpdir
@@ -342,7 +342,7 @@
         f > [f]
         "recovered" > [reason]
 
-  [] +> tests-touches-absent-file-on-opening-for-writing
+  ++> tests-touches-absent-file-on-opening-for-writing
     tmpdir
     .tmpfile
     .deleted
@@ -351,7 +351,7 @@
       true > [f]
     .exists > @
 
-  [] +> tests-touches-absent-file-on-opening-for-appending
+  ++> tests-touches-absent-file-on-opening-for-appending
     tmpdir
     .tmpfile
     .deleted
@@ -360,7 +360,7 @@
       true > [f]
     .exists > @
 
-  [] +> tests-touches-absent-file-on-opening-for-writing-or-reading
+  ++> tests-touches-absent-file-on-opening-for-writing-or-reading
     tmpdir
     .tmpfile
     .deleted
@@ -369,7 +369,7 @@
       true > [f]
     .exists > @
 
-  [] +> tests-touches-absent-file-on-opening-for-reading-or-appending
+  ++> tests-touches-absent-file-on-opening-for-reading-or-appending
     tmpdir
     .tmpfile
     .deleted
@@ -378,7 +378,7 @@
       true > [f]
     .exists > @
 
-  [] +> tests-writes-data-to-file
+  ++> tests-writes-data-to-file
     tmpdir
     .tmpfile
     .open
@@ -387,7 +387,7 @@
     .size
     .eq 12 > @
 
-  [] +> tests-appending-data-to-file
+  ++> tests-appending-data-to-file
     tmpdir
     .tmpfile
     .open
@@ -399,7 +399,7 @@
     .size
     .eq 13 > @
 
-  [] +> tests-truncates-file-opened-for-writing
+  ++> tests-truncates-file-opened-for-writing
     tmpdir
     .tmpfile
     .open
@@ -411,7 +411,7 @@
     .size
     .eq 0 > @
 
-  [] +> tests-truncates-file-opened-for-writing-or-reading
+  ++> tests-truncates-file-opened-for-writing-or-reading
     tmpdir
     .tmpfile
     .open
@@ -423,7 +423,7 @@
     .size
     .eq 0 > @
 
-  [] +> tests-does-not-truncate-file-opened-for-appending
+  ++> tests-does-not-truncate-file-opened-for-appending
     tmpdir
     .tmpfile
     .open
@@ -435,7 +435,7 @@
     .size
     .eq 12 > @
 
-  [] +> tests-does-not-truncate-file-opened-for-reading-or-appending
+  ++> tests-does-not-truncate-file-opened-for-reading-or-appending
     tmpdir
     .tmpfile
     .open
@@ -447,7 +447,7 @@
     .size
     .eq 12 > @
 
-  [] +> tests-does-not-truncate-file-opened-for-reading
+  ++> tests-does-not-truncate-file-opened-for-reading
     tmpdir
     .tmpfile
     .open
@@ -459,14 +459,14 @@
     .size
     .eq 12 > @
 
-  [] +> throws-on-writing-with-wrong-mode
+  ++> throws-on-writing-with-wrong-mode
     tmpdir
     .tmpfile
     .open > @
       "r"
       f.write "Hello" > [f]
 
-  [] +> tests-reads-from-file
+  ++> tests-reads-from-file
     malloc
     .of
       12
@@ -486,21 +486,21 @@
             m
     .eq "Hello, world" > @
 
-  [] +> throws-on-reading-negative-size-from-file
+  ++> throws-on-reading-negative-size-from-file
     tmpdir
     .tmpfile
     .open > @
       "r"
       f.read -5 > [f]
 
-  [] +> throws-on-reading-from-file-with-wrong-mode
+  ++> throws-on-reading-from-file-with-wrong-mode
     tmpdir
     .tmpfile
     .open > @
       "w"
       f.read 12 > [f]
 
-  [] +> tests-reads-from-file-from-different-instances
+  ++> tests-reads-from-file-from-different-instances
     seq * > @
       temp.open
         "w"
@@ -522,7 +522,7 @@
     temp.path > src
     tmpdir.tmpfile > temp
 
-  [] +> tests-writes-to-file-from-different-instances
+  ++> tests-writes-to-file-from-different-instances
     seq > @
       *
         temp
@@ -552,7 +552,7 @@
     temp.path > src
     tmpdir.tmpfile > temp
 
-  [] +> tests-reads-from-file-sequentially
+  ++> tests-reads-from-file-sequentially
     malloc
     .of
       5
@@ -572,7 +572,7 @@
             m
     .eq "world" > @
 
-  [] +> tests-writes-to-file-sequentially
+  ++> tests-writes-to-file-sequentially
     tmpdir
     .tmpfile
     .open

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -355,7 +355,7 @@
         uri > pth!
         string pth > txt
 
-  [] +> tests-determines-separator-depending-on-os
+  ++> tests-determines-separator-depending-on-os
     eq. > @
       path.separator
       if.
@@ -363,184 +363,184 @@
         path.win32.separator
         path.posix.separator
 
-  [] +> tests-detects-absolute-posix-path
+  ++> tests-detects-absolute-posix-path
     and. > @
       (path.posix "/var/www/html").is-absolute
       (path.posix "foo/bar/baz").is-absolute.not
 
-  [] +> tests-detects-absolute-win32-path
+  ++> tests-detects-absolute-win32-path
     and. > @
       and.
         (path.win32 "C:\\Windows\\Users").is-absolute
         (path.win32 "\\Windows\\Users").is-absolute
       (path.win32 "temp\\var").is-absolute.not
 
-  [] +> tests-normalizes-posix-path
+  ++> tests-normalizes-posix-path
     eq. > @
       (path.posix "/foo/bar/.//./baz//../x/").normalized
       "/foo/bar/x/"
 
-  [] +> tests-normalizes-posix-relative-path
+  ++> tests-normalizes-posix-relative-path
     eq. > @
       (path.posix "../../foo/./bar/../x/../y").normalized
       "../../foo/y"
 
-  [] +> tests-normalizes-empty-posix-path-to-current-dir
+  ++> tests-normalizes-empty-posix-path-to-current-dir
     eq. > @
       (path.posix "").normalized
       "."
 
-  [] +> tests-normalizes-path-to-root
+  ++> tests-normalizes-path-to-root
     eq. > @
       (path.posix "/foo/bar/baz/../../../../").normalized
       "/"
 
-  [] +> tests-normalizes-absolute-win32-path-without-drive
+  ++> tests-normalizes-absolute-win32-path-without-drive
     eq. > @
       (path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\").normalized
       "\\Windows\\App\\Local\\"
 
-  [] +> tests-normalizes-absolute-win32-path-with-drive
+  ++> tests-normalizes-absolute-win32-path-with-drive
     eq. > @
       (path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal").normalized
       "C:\\Users\\AppLocal"
 
-  [] +> tests-normalizes-relative-win32-path
+  ++> tests-normalizes-relative-win32-path
     eq. > @
       (path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\").normalized
       "..\\..\\foo\\x\\y\\"
 
-  [] +> tests-normalizes-empty-win32-driveless-path-to-current-dir
+  ++> tests-normalizes-empty-win32-driveless-path-to-current-dir
     eq. > @
       (path.win32 "").normalized
       "."
 
-  [] +> tests-normalizes-win32-path-down-to-drive-with-separator
+  ++> tests-normalizes-win32-path-down-to-drive-with-separator
     eq. > @
       (path.win32 "C:\\Windows\\..").normalized
       "C:\\"
 
-  [] +> tests-normalizes-win32-path-down-to-drive-without-separator
+  ++> tests-normalizes-win32-path-down-to-drive-without-separator
     eq. > @
       (path.win32 "C:hello\\..").normalized
       "C:"
 
-  [] +> tests-normalizes-win32-path-with-replacing-slashes
+  ++> tests-normalizes-win32-path-with-replacing-slashes
     eq. > @
       (path.win32 "/var/www/../html/").normalized
       "\\var\\html\\"
 
-  [] +> tests-resolves-posix-absolute-path-against-other-absolute-path
+  ++> tests-resolves-posix-absolute-path-against-other-absolute-path
     eq. > @
       (path.posix "/var/temp").resolved "/www/html"
       "/www/html"
 
-  [] +> tests-resolves-posix-absolute-path-against-other-relative-path
+  ++> tests-resolves-posix-absolute-path-against-other-relative-path
     eq. > @
       (path.posix "/var/temp").resolved "./www/html"
       "/var/temp/www/html"
 
-  [] +> tests-resolves-posix-relative-path-against-other-absolute-path
+  ++> tests-resolves-posix-relative-path-against-other-absolute-path
     eq. > @
       (path.posix "./var/temp").resolved "/www/html"
       "/www/html"
 
-  [] +> tests-resolves-posix-relative-path-against-other-relative-path
+  ++> tests-resolves-posix-relative-path-against-other-relative-path
     eq. > @
       (path.posix "./var/temp").resolved "../www/html"
       "var/www/html"
 
-  [] +> tests-resolves-win32-relative-path-against-other-relative-path
+  ++> tests-resolves-win32-relative-path-against-other-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved ".\\..\\x"
       "temp\\x"
 
-  [] +> tests-resolves-win32-relative-path-against-other-drive-relative-path
+  ++> tests-resolves-win32-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved "C:\\Windows\\Users"
       "C:\\Windows\\Users"
 
-  [] +> tests-resolves-win32-relative-path-against-other-root-relative-path
+  ++> tests-resolves-win32-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved "\\Windows\\Users"
       "\\Windows\\Users"
 
-  [] +> tests-resolves-win32-drive-relative-path-against-other-relative-path
+  ++> tests-resolves-win32-drive-relative-path-against-other-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved ".\\var\\temp"
       "C:\\users\\local\\var\\temp"
 
-  [] +> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
+  ++> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved "D:\\local\\var"
       "D:\\local\\var"
 
-  [] +> tests-resolves-win32-drive-relative-path-against-other-root-relative-path
+  ++> tests-resolves-win32-drive-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved "\\local\\var"
       "C:\\local\\var"
 
-  [] +> tests-resolves-win32-root-relative-path-against-other-relative-path
+  ++> tests-resolves-win32-root-relative-path-against-other-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved ".\\hello\\var"
       "\\users\\local\\hello\\var"
 
-  [] +> tests-resolves-win32-root-relative-path-against-other-drive-relative-path
+  ++> tests-resolves-win32-root-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved "D:\\hello\\var"
       "D:\\hello\\var"
 
-  [] +> tests-resolves-win32-root-relative-path-against-other-root-relative-path
+  ++> tests-resolves-win32-root-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved "\\hello\\var"
       "\\hello\\var"
 
-  [] +> tests-takes-valid-basename
+  ++> tests-takes-valid-basename
     eq. > @
       basename.
         path.joined
           * "var" "www" "html" "hello.eo"
       "hello.eo"
 
-  [] +> tests-returns-empty-basename-from-path-ended-with-separator
+  ++> tests-returns-empty-basename-from-path-ended-with-separator
     eq. > @
       basename.
         path.joined
           * "var" "www" "html" path.separator
       ""
 
-  [] +> tests-returns-base-with-backslash-in-path-on-posix
+  ++> tests-returns-base-with-backslash-in-path-on-posix
     eq. > @
       (path.posix "/var/www/html/foo\\bar").basename
       "foo\\bar"
 
-  [] +> tests-returns-the-same-string-if-no-separator-is-found
+  ++> tests-returns-the-same-string-if-no-separator-is-found
     eq. > @
       (path "Somebody").basename
       "Somebody"
 
-  [] +> tests-takes-file-extname
+  ++> tests-takes-file-extname
     eq. > @
       extname.
         path.joined
           * "var" "www" "hello.txt"
       ".txt"
 
-  [] +> tests-does-not-take-extname-on-file-without-extension
+  ++> tests-does-not-take-extname-on-file-without-extension
     eq. > @
       extname.
         path.joined
           * "var" "www" "html"
       ""
 
-  [] +> tests-does-not-take-extname-if-ends-with-separator
+  ++> tests-does-not-take-extname-if-ends-with-separator
     eq. > @
       extname.
         path.joined
           * "var" "www" path.separator
       ""
 
-  [] +> tests-returns-valid-dirname-from-file-path
+  ++> tests-returns-valid-dirname-from-file-path
     eq. > @
       dirname.
         path.joined
@@ -548,7 +548,7 @@
       path.joined
         * "var" "www"
 
-  [] +> tests-returns-valid-dirname-from-dir-path
+  ++> tests-returns-valid-dirname-from-dir-path
     eq. > @
       dirname.
         path.joined
@@ -556,7 +556,7 @@
       path.joined
         * "var" "www"
 
-  [] +> tests-returns-valid-dirname-from-file-path-without-extension
+  ++> tests-returns-valid-dirname-from-file-path-without-extension
     eq. > @
       dirname.
         path.joined

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -68,159 +68,159 @@
     x.as-i16 > xval
     00-00 > zero
 
-  [] +> tests-i16-has-valid-bytes
+  ++> tests-i16-has-valid-bytes
     eq. > @
       42.as-i64.as-i32.as-i16.as-bytes
       00-2A
 
-  [] +> tests-negative-i16-has-valid-bytes
+  ++> tests-negative-i16-has-valid-bytes
     eq. > @
       -200.as-i64.as-i32.as-i16.as-bytes
       FF-38
 
-  [] +> tests-i16-less-true
+  ++> tests-i16-less-true
     lt. > @
       10.as-i64.as-i32.as-i16
       50.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-less-equal
+  ++> tests-i16-less-equal
     not. > @
       lt.
         10.as-i64.as-i32.as-i16
         10.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-less-false
+  ++> tests-i16-less-false
     not. > @
       lt.
         10.as-i64.as-i32.as-i16
         -5.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-greater-true
+  ++> tests-i16-greater-true
     gt. > @
       -200.as-i64.as-i32.as-i16
       -1000.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-greater-false
+  ++> tests-i16-greater-false
     not. > @
       gt.
         0.as-i64.as-i32.as-i16
         100.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-greater-equal
+  ++> tests-i16-greater-equal
     not. > @
       gt.
         0.as-i64.as-i32.as-i16
         0.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-lte-true
+  ++> tests-i16-lte-true
     lte. > @
       -200.as-i64.as-i32.as-i16
       -100.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-lte-equal
+  ++> tests-i16-lte-equal
     lte. > @
       50.as-i64.as-i32.as-i16
       50.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-lte-false
+  ++> tests-i16-lte-false
     not. > @
       lte.
         0.as-i64.as-i32.as-i16
         -10.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-gte-true
+  ++> tests-i16-gte-true
     gte. > @
       -1000.as-i64.as-i32.as-i16
       -1100.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-gte-equal
+  ++> tests-i16-gte-equal
     gte. > @
       113.as-i64.as-i32.as-i16
       113.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-gte-false
+  ++> tests-i16-gte-false
     not. > @
       gte.
         0.as-i64.as-i32.as-i16
         10.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-zero-eq-to-i16-zero
+  ++> tests-i16-zero-eq-to-i16-zero
     eq. > @
       0.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-eq-true
+  ++> tests-i16-eq-true
     eq. > @
       123.as-i64.as-i32.as-i16
       123.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-eq-false
+  ++> tests-i16-eq-false
     not. > @
       eq.
         123.as-i64.as-i32.as-i16
         42.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-one-plus-i16-one
+  ++> tests-i16-one-plus-i16-one
     eq. > @
       1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
       2.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-plus-with-overflow
+  ++> tests-i16-plus-with-overflow
     eq. > @
       32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
       -32768.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-one-minus-i16-one
+  ++> tests-i16-one-minus-i16-one
     eq. > @
       1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-minus-with-overflow
+  ++> tests-i16-minus-with-overflow
     eq. > @
       -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
       32767.as-i64.as-i32.as-i16
 
   2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] +> throws-on-division-i16-by-i16-zero
 
-  [] +> tests-i16-div-by-zero-returns-provided-fallback
+  ++> tests-i16-div-by-zero-returns-provided-fallback
     eq. > @
       "recovered"
       2.as-i64.as-i32.as-i16.div
         0.as-i64.as-i32.as-i16
         "recovered" > [msg]
 
-  [] +> tests-i16-div-by-i16-one
+  ++> tests-i16-div-by-i16-one
     eq. > @
       dividend.div 1.as-i64.as-i32.as-i16
       dividend
     -235.as-i64.as-i32.as-i16 > dividend
 
-  [] +> tests-i16-div-with-remainder
+  ++> tests-i16-div-with-remainder
     eq. > @
       13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
       -2.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-div-less-than-i16-one
+  ++> tests-i16-div-less-than-i16-one
     lt. > @
       1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
       1.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-multiply-by-zero
+  ++> tests-i16-multiply-by-zero
     eq. > @
       1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-times-with-overflow
+  ++> tests-i16-times-with-overflow
     eq. > @
       32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
       -2.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-times-wraps-modulo-2-pow-16
+  ++> tests-i16-times-wraps-modulo-2-pow-16
     eq. > @
       256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
-  [] +> tests-i16-times-wraps-large-positive-product
+  ++> tests-i16-times-wraps-large-positive-product
     eq. > @
       300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
       24464.as-i64.as-i32.as-i16

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -77,137 +77,137 @@
     x.as-i32 > xval
     00-00-00-00 > zero
 
-  [] +> tests-i32-has-valid-bytes
+  ++> tests-i32-has-valid-bytes
     eq. > @
       42.as-i64.as-i32.as-bytes
       00-00-00-2A
 
-  [] +> tests-negative-i32-has-valid-bytes
+  ++> tests-negative-i32-has-valid-bytes
     eq. > @
       -200.as-i64.as-i32.as-bytes
       FF-FF-FF-38
 
-  [] +> tests-i32-to-i16-and-back
+  ++> tests-i32-to-i16-and-back
     eq. > @
       123.as-i64.as-i32
       123.as-i64.as-i32.as-i16.as-i32
 
-  [] +> tests-negative-i32-to-i16-and-back
+  ++> tests-negative-i32-to-i16-and-back
     eq. > @
       -123.as-i64.as-i32
       -123.as-i64.as-i32.as-i16.as-i32
 
-  [] +> throws-on-converting-i16-max-plus-one-to-i16
+  ++> throws-on-converting-i16-max-plus-one-to-i16
     32768.as-i64.as-i32.as-i16 > @
 
-  [] +> throws-on-converting-i16-min-minus-one-to-i16
+  ++> throws-on-converting-i16-min-minus-one-to-i16
     -32769.as-i64.as-i32.as-i16 > @
 
-  [] +> tests-i32-less-true
+  ++> tests-i32-less-true
     lt. > @
       10.as-i64.as-i32
       50.as-i64.as-i32
 
-  [] +> tests-i32-less-equal
+  ++> tests-i32-less-equal
     not. > @
       lt.
         10.as-i64.as-i32
         10.as-i64.as-i32
 
-  [] +> tests-i32-less-false
+  ++> tests-i32-less-false
     not. > @
       lt.
         10.as-i64.as-i32
         -5.as-i64.as-i32
 
-  [] +> tests-i32-greater-true
+  ++> tests-i32-greater-true
     gt. > @
       -200.as-i64.as-i32
       -1000.as-i64.as-i32
 
-  [] +> tests-i32-greater-false
+  ++> tests-i32-greater-false
     not. > @
       gt.
         0.as-i64.as-i32
         100.as-i64.as-i32
 
-  [] +> tests-i32-greater-equal
+  ++> tests-i32-greater-equal
     not. > @
       gt.
         0.as-i64.as-i32
         0.as-i64.as-i32
 
-  [] +> tests-i32-lte-true
+  ++> tests-i32-lte-true
     lte. > @
       -200.as-i64.as-i32
       -100.as-i64.as-i32
 
-  [] +> tests-i32-lte-equal
+  ++> tests-i32-lte-equal
     lte. > @
       50.as-i64.as-i32
       50.as-i64.as-i32
 
-  [] +> tests-i32-lte-false
+  ++> tests-i32-lte-false
     not. > @
       lte.
         0.as-i64.as-i32
         -10.as-i64.as-i32
 
-  [] +> tests-i32-gte-true
+  ++> tests-i32-gte-true
     gte. > @
       -1000.as-i64.as-i32
       -1100.as-i64.as-i32
 
-  [] +> tests-i32-gte-equal
+  ++> tests-i32-gte-equal
     gte. > @
       113.as-i64.as-i32
       113.as-i64.as-i32
 
-  [] +> tests-i32-gte-false
+  ++> tests-i32-gte-false
     not. > @
       gte.
         0.as-i64.as-i32
         10.as-i64.as-i32
 
-  [] +> tests-i32-zero-eq-to-i32-zero
+  ++> tests-i32-zero-eq-to-i32-zero
     eq. > @
       0.as-i64.as-i32
       0.as-i64.as-i32
 
-  [] +> tests-i32-eq-true
+  ++> tests-i32-eq-true
     eq. > @
       123.as-i64.as-i32
       123.as-i64.as-i32
 
-  [] +> tests-i32-eq-false
+  ++> tests-i32-eq-false
     not. > @
       eq.
         123.as-i64.as-i32
         42.as-i64.as-i32
 
-  [] +> tests-i32-one-plus-i32-one
+  ++> tests-i32-one-plus-i32-one
     eq. > @
       1.as-i64.as-i32.plus 1.as-i64.as-i32
       2.as-i64.as-i32
 
-  [] +> tests-i32-plus-with-overflow
+  ++> tests-i32-plus-with-overflow
     eq. > @
       2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
       -2147483648.as-i64.as-i32
 
-  [] +> tests-i32-one-minus-i32-one
+  ++> tests-i32-one-minus-i32-one
     eq. > @
       1.as-i64.as-i32.minus 1.as-i64.as-i32
       0.as-i64.as-i32
 
-  [] +> tests-i32-minus-with-overflow
+  ++> tests-i32-minus-with-overflow
     eq. > @
       -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
       2147483647.as-i64.as-i32
 
   2.as-i64.as-i32.div 0.as-i64.as-i32 > [] +> throws-on-division-i32-by-i32-zero
 
-  [] +> tests-i32-div-by-zero-returns-provided-fallback
+  ++> tests-i32-div-by-zero-returns-provided-fallback
     eq. > @
       "recovered"
       2.as-i64.as-i32.div
@@ -216,44 +216,44 @@
 
   247483647.as-i64.as-i32.as-i16 > [] +> throws-on-converting-to-i16-if-out-of-bounds
 
-  [] +> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
+  ++> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
     eq. > @
       "recovered"
       247483647.as-i64.as-i32.as-i16
         "recovered" > [msg]
 
-  [] +> tests-i32-div-by-i32-one
+  ++> tests-i32-div-by-i32-one
     eq. > @
       dividend.div 1.as-i64.as-i32
       dividend
     -235.as-i64.as-i32 > dividend
 
-  [] +> tests-i32-div-with-remainder
+  ++> tests-i32-div-with-remainder
     eq. > @
       13.as-i64.as-i32.div -5.as-i64.as-i32
       -2.as-i64.as-i32
 
-  [] +> tests-i32-div-less-than-i32-one
+  ++> tests-i32-div-less-than-i32-one
     lt. > @
       1.as-i64.as-i32.div 5.as-i64.as-i32
       1.as-i64.as-i32
 
-  [] +> tests-i32-multiply-by-zero
+  ++> tests-i32-multiply-by-zero
     eq. > @
       1000.as-i64.as-i32.times 0.as-i64.as-i32
       0.as-i64.as-i32
 
-  [] +> tests-i32-times-with-overflow
+  ++> tests-i32-times-with-overflow
     eq. > @
       2147483647.as-i64.as-i32.times 2.as-i64.as-i32
       -2.as-i64.as-i32
 
-  [] +> tests-i32-times-wraps-modulo-2-pow-32
+  ++> tests-i32-times-wraps-modulo-2-pow-32
     eq. > @
       65536.as-i64.as-i32.times 65536.as-i64.as-i32
       0.as-i64.as-i32
 
-  [] +> tests-i32-times-wraps-large-positive-product
+  ++> tests-i32-times-wraps-large-positive-product
     eq. > @
       100000.as-i64.as-i32.times 100000.as-i64.as-i32
       1410065408.as-i64.as-i32

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -59,41 +59,41 @@
   [x] > div /i64
     ? > cant-divide /{string}
 
-  [] +> tests-i64-has-valid-bytes
+  ++> tests-i64-has-valid-bytes
     eq. > @
       42.as-i64.as-bytes
       00-00-00-00-00-00-00-2A
 
-  [] +> tests-i64-as-bytes-is-not-equal-to-number-bytes
+  ++> tests-i64-as-bytes-is-not-equal-to-number-bytes
     not. > @
       eq.
         i64 234.as-bytes
         234.as-i64.as-bytes
 
-  [] +> tests-i64-to-i32-and-back
+  ++> tests-i64-to-i32-and-back
     eq. > @
       234.as-i64
       234.as-i64.as-i32.as-i64
 
-  [] +> tests-negative-i64-to-i32-and-back
+  ++> tests-negative-i64-to-i32-and-back
     eq. > @
       -234.as-i64
       -234.as-i64.as-i32.as-i64
 
   3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
 
-  [] +> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+  ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
     eq. > @
       "recovered"
       3147483647.as-i64.as-i32
         "recovered" > [msg]
 
-  [] +> tests-i64-i32-max-converts-without-error
+  ++> tests-i64-i32-max-converts-without-error
     eq. > @
       2147483647.as-i64
       2147483647.as-i64.as-i32.as-i64
 
-  [] +> tests-i64-i32-min-converts-without-error
+  ++> tests-i64-i32-min-converts-without-error
     eq. > @
       -2147483648.as-i64
       -2147483648.as-i64.as-i32.as-i64
@@ -102,135 +102,135 @@
 
   -2147483649.as-i64.as-i32 > [] +> throws-on-converting-i32-min-minus-one-to-i32
 
-  [] +> tests-i64-less-true
+  ++> tests-i64-less-true
     lt. > @
       10.as-i64
       50.as-i64
 
-  [] +> tests-i64-less-equal
+  ++> tests-i64-less-equal
     not. > @
       lt.
         10.as-i64
         10.as-i64
 
-  [] +> tests-i64-less-false
+  ++> tests-i64-less-false
     not. > @
       lt.
         10.as-i64
         -5.as-i64
 
-  [] +> tests-i64-less-across-full-range
+  ++> tests-i64-less-across-full-range
     lt. > @
       -9223372036854775808.as-i64
       1.as-i64
 
-  [] +> tests-i64-less-with-large-difference
+  ++> tests-i64-less-with-large-difference
     not. > @
       lt.
         5000000000000000000.as-i64
         -5000000000000000000.as-i64
 
-  [] +> tests-i64-greater-true
+  ++> tests-i64-greater-true
     gt. > @
       -200.as-i64
       -1000.as-i64
 
-  [] +> tests-i64-greater-false
+  ++> tests-i64-greater-false
     not. > @
       gt.
         0.as-i64
         100.as-i64
 
-  [] +> tests-i64-greater-equal
+  ++> tests-i64-greater-equal
     not. > @
       gt.
         0.as-i64
         0.as-i64
 
-  [] +> tests-i64-lte-true
+  ++> tests-i64-lte-true
     lte. > @
       -200.as-i64
       -100.as-i64
 
-  [] +> tests-i64-lte-equal
+  ++> tests-i64-lte-equal
     lte. > @
       50.as-i64
       50.as-i64
 
-  [] +> tests-i64-lte-false
+  ++> tests-i64-lte-false
     not. > @
       lte.
         0.as-i64
         -10.as-i64
 
-  [] +> tests-i64-gte-true
+  ++> tests-i64-gte-true
     gte. > @
       -1000.as-i64
       -1100.as-i64
 
-  [] +> tests-i64-gte-equal
+  ++> tests-i64-gte-equal
     gte. > @
       113.as-i64
       113.as-i64
 
-  [] +> tests-i64-gte-false
+  ++> tests-i64-gte-false
     not. > @
       gte.
         0.as-i64
         10.as-i64
 
-  [] +> tests-i64-zero-eq-to-i64-zero
+  ++> tests-i64-zero-eq-to-i64-zero
     eq. > @
       0.@
       0.@
 
-  [] +> tests-i64-eq-true
+  ++> tests-i64-eq-true
     eq. > @
       123.@
       123.@
 
-  [] +> tests-i64-eq-false
+  ++> tests-i64-eq-false
     not. > @
       eq.
         123.@
         42.@
 
-  [] +> tests-i64-one-plus-i64-one
+  ++> tests-i64-one-plus-i64-one
     eq. > @
       1.as-i64.plus 1.as-i64
       2.as-i64
 
-  [] +> tests-i64-one-minus-i64-one
+  ++> tests-i64-one-minus-i64-one
     eq. > @
       1.as-i64.minus 1.as-i64
       0.as-i64
 
   2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
 
-  [] +> tests-i64-div-by-zero-returns-provided-fallback
+  ++> tests-i64-div-by-zero-returns-provided-fallback
     eq. > @
       "recovered"
       2.as-i64.div
         0.as-i64
         "recovered" > [msg]
 
-  [] +> tests-i64-div-by-i64-one
+  ++> tests-i64-div-by-i64-one
     eq. > @
       dividend.div 1.as-i64
       dividend
     -235.as-i64 > dividend
 
-  [] +> tests-i64-div-with-remainder
+  ++> tests-i64-div-with-remainder
     eq. > @
       13.as-i64.div -5.as-i64
       -2.as-i64
 
-  [] +> tests-i64-div-less-than-i64-one
+  ++> tests-i64-div-less-than-i64-one
     lt. > @
       1.as-i64.div 5.as-i64
       1.as-i64
 
-  [] +> tests-i64-multiply-by-zero
+  ++> tests-i64-multiply-by-zero
     eq. > @
       1000.as-i64.times 0.as-i64
       0.as-i64

--- a/eo-runtime/src/main/eo/io/bytes-as-input.eo
+++ b/eo-runtime/src/main/eo/io/bytes-as-input.eo
@@ -56,7 +56,7 @@
           available
         size > requested!
 
-  [] +> tests-makes-an-input-from-bytes-and-reads
+  ++> tests-makes-an-input-from-bytes-and-reads
     and. > @
       and.
         and.

--- a/eo-runtime/src/main/eo/io/console.eo
+++ b/eo-runtime/src/main/eo/io/console.eo
@@ -132,6 +132,6 @@
                 * win32.std-output-handle buffer buffer.size
             output-block
 
-  [] +> tests-writes-to-console
+  ++> tests-writes-to-console
     console.write > @
       "Hello, console-test!\n"

--- a/eo-runtime/src/main/eo/io/copied.eo
+++ b/eo-runtime/src/main/eo/io/copied.eo
@@ -29,7 +29,7 @@
       input
       output
 
-  [] +> tests-copies-all-bytes-and-returns-length
+  ++> tests-copies-all-bytes-and-returns-length
     eq. > @
       malloc.of
         5
@@ -42,7 +42,7 @@
               m
       01-02-03-04-05
 
-  [] +> tests-returns-correct-byte-count
+  ++> tests-returns-correct-byte-count
     eq. > @
       malloc.of
         10
@@ -52,7 +52,7 @@
             malloc-as-output m
       10
 
-  [] +> tests-handles-empty-input
+  ++> tests-handles-empty-input
     eq. > @
       malloc.of
         0
@@ -65,7 +65,7 @@
               m
       --
 
-  [] +> tests-returns-zero-for-empty-input
+  ++> tests-returns-zero-for-empty-input
     eq. > @
       malloc.of
         0
@@ -75,7 +75,7 @@
             malloc-as-output m
       0
 
-  [] +> tests-handles-large-data
+  ++> tests-handles-large-data
     eq. > @
       20
       malloc.of
@@ -85,7 +85,7 @@
             bytes-as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
             malloc-as-output m
 
-  [] +> tests-handles-dead-input
+  ++> tests-handles-dead-input
     eq. > @
       copied
         dead-input

--- a/eo-runtime/src/main/eo/io/dead-input.eo
+++ b/eo-runtime/src/main/eo/io/dead-input.eo
@@ -17,7 +17,7 @@
 
       input-block > [size] > read
 
-  [] +> tests-reads-empty-bytes
+  ++> tests-reads-empty-bytes
     and. > @
       i1.eq --
       (i1.read 10).eq --

--- a/eo-runtime/src/main/eo/io/input-as-bytes.eo
+++ b/eo-runtime/src/main/eo/io/input-as-bytes.eo
@@ -26,11 +26,11 @@
         copied input (malloc-as-output m)
         m
 
-  [] +> tests-bytes-to-input-and-back
+  ++> tests-bytes-to-input-and-back
     eq. > @
       input-as-bytes (bytes-as-input bts)
       bts
     01-02-03-04-05-06-07-08 > bts
 
-  [] +> tests-returns-empty-bytes-from-dead-input
+  ++> tests-returns-empty-bytes-from-dead-input
     (input-as-bytes dead-input).eq -- > @

--- a/eo-runtime/src/main/eo/io/input-length.eo
+++ b/eo-runtime/src/main/eo/io/input-length.eo
@@ -22,14 +22,14 @@
         length.plus chunk.size
     (input.read 4096).read.^ > chunk
 
-  [] +> tests-reads-all-bytes-and-returns-length
+  ++> tests-reads-all-bytes-and-returns-length
     eq. > @
       input-length
         bytes-as-input
           01-02-03-04-05-06-07-08-09-10
       10
 
-  [] +> tests-copies-all-bytes-to-output-and-returns-length
+  ++> tests-copies-all-bytes-to-output-and-returns-length
     eq. > @
       malloc.of
         10

--- a/eo-runtime/src/main/eo/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/io/malloc-as-output.eo
@@ -39,7 +39,7 @@
           output-block
             offset.plus buffer.size
 
-  [] +> tests-makes-an-output-from-malloc-and-writes
+  ++> tests-makes-an-output-from-malloc-and-writes
     eq. > @
       malloc.of
         10
@@ -50,7 +50,7 @@
               mem
       01-02-03-04-05-06-07-08-09-A0
 
-  [] +> writes-larger-data-than-provided-block
+  ++> writes-larger-data-than-provided-block
     eq. > @
       malloc.of
         2

--- a/eo-runtime/src/main/eo/io/stdout.eo
+++ b/eo-runtime/src/main/eo/io/stdout.eo
@@ -21,6 +21,6 @@
     console.write text
     true
 
-  [] +> tests-prints-to-console
+  ++> tests-prints-to-console
     stdout > @
       "Hello, stdout-test!\n"

--- a/eo-runtime/src/main/eo/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/io/tee-input.eo
@@ -41,7 +41,7 @@
         (input.read size).read.^ > chunk
         (output.write chunk).write.^ > written
 
-  [] +> tests-reads-from-bytes-and-writes-to-memory
+  ++> tests-reads-from-bytes-and-writes-to-memory
     eq. > @
       malloc.of
         5
@@ -53,7 +53,7 @@
             5
       01-02-03-04-05
 
-  [] +> tests-reads-from-bytes-and-writes-to-memory-by-portions
+  ++> tests-reads-from-bytes-and-writes-to-memory-by-portions
     eq. > @
       malloc.of
         5
@@ -72,7 +72,7 @@
               m
       01-02-03-04-05
 
-  [] +> tests-reads-from-bytes-and-writes-to-two-memory-blocks
+  ++> tests-reads-from-bytes-and-writes-to-two-memory-blocks
     eq. > @
       malloc.of
         6

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -102,7 +102,7 @@
           write 0 object
           get
 
-  [] +> tests-writes-into-memory-of
+  ++> tests-writes-into-memory-of
     mem.eq 10 > @
     malloc.of > mem
       8
@@ -112,20 +112,20 @@
             m.write 0 10
             m
 
-  [] +> tests-puts-into-memory-for
+  ++> tests-puts-into-memory-for
     mem.eq 10 > @
     malloc.for > mem
       0
       m.put 10 > [m]
 
-  [] +> tests-returns-size-from-scope
+  ++> tests-returns-size-from-scope
     eq. > @
       malloc.of
         5
         m.size > [m]
       5
 
-  [] +> tests-malloc-scope-is-dataized-twice
+  ++> tests-malloc-scope-is-dataized-twice
     eq. > @
       2
       malloc.for
@@ -139,14 +139,14 @@
             1
             f.put (f.as-number.plus 1) > [s] >>
 
-  [] +> tests-malloc-for-writes-first-init-value
+  ++> tests-malloc-for-writes-first-init-value
     eq. > @
       malloc.for
         42
         m > [m]
       42
 
-  [] +> tests-malloc-puts-over-the-previous-data
+  ++> tests-malloc-puts-over-the-previous-data
     eq. > @
       42.as-bytes.concat
         "orld!".as-bytes
@@ -159,7 +159,7 @@
             m.put "Hello, world!"
             m.put 42
 
-  [] +> tests-malloc-rewrites-and-increments-itself
+  ++> tests-malloc-rewrites-and-increments-itself
     mem.eq 6 > @
     malloc.of > mem
       8
@@ -169,53 +169,53 @@
             m.write 0 1
             m.put (m.as-number.plus 5)
 
-  [] +> tests-writes-into-two-malloc-objects
+  ++> tests-writes-into-two-malloc-objects
     and. > @
       (malloc.of 8 (m.put 10 > [m])).eq 10
       (malloc.of 8 (m.put 20 > [m])).eq 20
 
-  [] +> throws-on-overflow-boolean-malloc
+  ++> throws-on-overflow-boolean-malloc
     malloc.for > @
       false
       m.put 86124867.88 > [m]
 
-  [] +> throws-on-overflow-string-malloc
+  ++> throws-on-overflow-string-malloc
     malloc.for > @
       "Hello"
       m.put "Much longer string!" > [m]
 
-  [] +> tests-malloc-is-strictly-sized-int
+  ++> tests-malloc-is-strictly-sized-int
     eq. > @
       malloc.for
         12248
         m.put 2556 > [m]
       2556
 
-  [] +> tests-malloc-is-strictly-typed-float
+  ++> tests-malloc-is-strictly-typed-float
     eq. > @
       malloc.for
         245.88
         m.put 82.22 > [m]
       82.22
 
-  [] +> tests-memory-is-strictly-sized-string
+  ++> tests-memory-is-strictly-sized-string
     eq. > @
       malloc.for
         "Hello"
         m.put "Prot" > [m]
       "Proto"
 
-  [] +> tests-malloc-is-strictly-typed-bool
+  ++> tests-malloc-is-strictly-typed-bool
     malloc.for > @
       false
       m.put true > [m]
 
-  [] +> tests-malloc-gives-id-to-allocated-block
+  ++> tests-malloc-gives-id-to-allocated-block
     malloc.of > @
       1
       m.put (m.id.gt 0) > [m]
 
-  [] +> tests-malloc-allocates-right-size-block
+  ++> tests-malloc-allocates-right-size-block
     malloc.of > @
       1
       [b]
@@ -223,7 +223,7 @@
           10
           b.put (m.size.eq 10) > [m] >>
 
-  [] +> tests-malloc-writes-and-reads
+  ++> tests-malloc-writes-and-reads
     malloc.of > @
       1
       [b]
@@ -239,7 +239,7 @@
                     m.read 0 12
                     "Hello, Jeff!"
 
-  [] +> tests-malloc-concacts-strings-with-offset
+  ++> tests-malloc-concacts-strings-with-offset
     malloc.of > @
       1
       [b]
@@ -253,7 +253,7 @@
                 b.put
                   (m.read 0 3).eq "XYX"
 
-  [] +> writes-beyond-offset-and-resizes
+  ++> writes-beyond-offset-and-resizes
     malloc.of > @
       1
       [m]
@@ -261,7 +261,7 @@
           m.write 1 true
           m.size.eq 2
 
-  [] +> tests-malloc-reads-with-offset-and-length
+  ++> tests-malloc-reads-with-offset-and-length
     malloc.of > @
       1
       [b]
@@ -274,7 +274,7 @@
                 b.put
                   (m.read 2 5).eq "Hello"
 
-  [] +> tests-malloc-read-over-a-limit-returns-fallback
+  ++> tests-malloc-read-over-a-limit-returns-fallback
     eq. > @
       01-02
       malloc.of
@@ -285,19 +285,19 @@
             10
             01-02 > [ex]
 
-  [] +> throws-on-reading-over-a-limit-without-fallback
+  ++> throws-on-reading-over-a-limit-without-fallback
     malloc.for > @
       10
       m.read 0 100 > [m]
 
-  [] +> tests-allocates-zero-bytes
+  ++> tests-allocates-zero-bytes
     eq. > @
       0
       malloc.of
         0
         m.size > [m]
 
-  [] +> tests-malloc-increases-block-size
+  ++> tests-malloc-increases-block-size
     malloc.of > @
       1
       [b]
@@ -309,7 +309,7 @@
                 (m.resized 6).size.eq 6
                 m.get.eq 01-02-03-04-00-00
 
-  [] +> tests-malloc-decreases-block-size
+  ++> tests-malloc-decreases-block-size
     malloc.of > @
       1
       [b]
@@ -321,21 +321,21 @@
                 (m.resized 3).size.eq 3
                 m.get.eq 01-02-03
 
-  [] +> throws-on-changing-size-to-negative
+  ++> throws-on-changing-size-to-negative
     malloc.of > @
       1
       m.resized -1 > [m]
 
-  [] +> throws-on-changing-size-to-fractional
+  ++> throws-on-changing-size-to-fractional
     malloc.of > @
       1
       m.resized 1.5 > [m]
 
-  [] +> tests-malloc-empty-is-empty
+  ++> tests-malloc-empty-is-empty
     malloc.empty > @
       m.size.eq 0 > [m]
 
-  [] +> tests-copies-data-inside-itself
+  ++> tests-copies-data-inside-itself
     malloc.for > @
       01-02-03-04-05
       [m]
@@ -343,7 +343,7 @@
           m.copy 1 2 2
           m.get.eq 01-02-02-03-05
 
-  [] +> tests-copies-data-from-start-to-end
+  ++> tests-copies-data-from-start-to-end
     malloc.for > @
       01-02-03-04-05-06
       [m]
@@ -351,12 +351,12 @@
           m.copy 0 3 3
           m.get.eq 01-02-03-01-02-03
 
-  [] +> throws-on-copying-with-wrong-source
+  ++> throws-on-copying-with-wrong-source
     malloc.for > @
       0
       m.copy 9 1 1 > [m]
 
-  [] +> copies-and-resizes-to-target
+  ++> copies-and-resizes-to-target
     malloc.for > @
       0
       [m]
@@ -364,12 +364,12 @@
           m.copy 3 9 1
           m.size.eq 10
 
-  [] +> throws-on-copying-with-wrong-length
+  ++> throws-on-copying-with-wrong-length
     malloc.for > @
       0
       m.copy 3 1 9 > [m]
 
-  [] +> tests-calculates-only-once
+  ++> tests-calculates-only-once
     eq. > @
       malloc.for
         0
@@ -385,7 +385,7 @@
                 42
       1
 
-  [] +> tests-recursion-without-arguments
+  ++> tests-recursion-without-arguments
     eq. > @
       malloc.for
         4
@@ -401,7 +401,7 @@
             ^.func n
         n
 
-  [] +> tests-constant-defends-against-side-effects
+  ++> tests-constant-defends-against-side-effects
     eq. > @
       malloc.for
         7

--- a/eo-runtime/src/main/eo/ms/abs.eo
+++ b/eo-runtime/src/main/eo/ms/abs.eo
@@ -14,27 +14,27 @@
     value.neg
   number num.as-bytes > value
 
-  [] +> tests-abs-int-positive
+  ++> tests-abs-int-positive
     eq. > @
       abs 3
       3
 
-  [] +> tests-abs-int-negative
+  ++> tests-abs-int-negative
     eq. > @
       abs -3
       3
 
-  [] +> tests-abs-zero
+  ++> tests-abs-zero
     eq. > @
       abs 0
       0
 
-  [] +> tests-abs-float-positive
+  ++> tests-abs-float-positive
     eq. > @
       abs 13.5
       13.5
 
-  [] +> tests-abs-float-negative
+  ++> tests-abs-float-negative
     eq. > @
       abs -17.9
       17.9

--- a/eo-runtime/src/main/eo/ms/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/ms/arc-cosine.eo
@@ -18,22 +18,22 @@
     pi.div 2
     arc-sine num
 
-  [] +> tests-arc-cosine-of-one-is-zero
+  ++> tests-arc-cosine-of-one-is-zero
     eq. > @
       arc-cosine 1
       0
 
-  [] +> tests-arc-cosine-of-zero-is-pi-halves
+  ++> tests-arc-cosine-of-zero-is-pi-halves
     eq. > @
       arc-cosine 0
       pi.div 2
 
-  [] +> tests-arc-cosine-of-negative-one-is-pi
+  ++> tests-arc-cosine-of-negative-one-is-pi
     eq. > @
       arc-cosine -1
       pi
 
-  [] +> tests-arc-cosine-of-point-six
+  ++> tests-arc-cosine-of-point-six
     lt. > @
       abs
         minus.
@@ -41,7 +41,7 @@
           927.295
       1
 
-  [] +> tests-arc-cosine-of-negative-point-six
+  ++> tests-arc-cosine-of-negative-point-six
     lt. > @
       abs
         minus.
@@ -49,22 +49,22 @@
           2214.297
       1
 
-  [] +> tests-arc-cosine-above-one-is-nan
+  ++> tests-arc-cosine-above-one-is-nan
     is-nan. > @
       arc-cosine 2
 
-  [] +> tests-arc-cosine-below-minus-one-is-nan
+  ++> tests-arc-cosine-below-minus-one-is-nan
     is-nan. > @
       arc-cosine -2
 
-  [] +> tests-arc-cosine-of-nan-is-nan
+  ++> tests-arc-cosine-of-nan-is-nan
     is-nan. > @
       arc-cosine nan
 
-  [] +> tests-arc-cosine-of-positive-infinity-is-nan
+  ++> tests-arc-cosine-of-positive-infinity-is-nan
     is-nan. > @
       arc-cosine pinf
 
-  [] +> tests-arc-cosine-of-negative-infinity-is-nan
+  ++> tests-arc-cosine-of-negative-infinity-is-nan
     is-nan. > @
       arc-cosine ninf

--- a/eo-runtime/src/main/eo/ms/arc-sine.eo
+++ b/eo-runtime/src/main/eo/ms/arc-sine.eo
@@ -48,12 +48,12 @@
               (depth.times 2).times ((depth.times 2).plus 1)
             poly (depth.plus 1)
 
-  [] +> tests-arc-sine-of-zero-is-zero
+  ++> tests-arc-sine-of-zero-is-zero
     eq. > @
       arc-sine 0
       0
 
-  [] +> tests-arc-sine-of-one-is-pi-halves
+  ++> tests-arc-sine-of-one-is-pi-halves
     lt. > @
       abs
         minus.
@@ -61,7 +61,7 @@
           (pi.div 2).times 1000
       1
 
-  [] +> tests-arc-sine-of-negative-one-is-minus-pi-halves
+  ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
     lt. > @
       abs
         minus.
@@ -69,7 +69,7 @@
           (pi.div 2).neg.times 1000
       1
 
-  [] +> tests-arc-sine-of-half-is-pi-sixths
+  ++> tests-arc-sine-of-half-is-pi-sixths
     lt. > @
       abs
         minus.
@@ -77,7 +77,7 @@
           (pi.div 6).times 1000
       1
 
-  [] +> tests-arc-sine-of-negative-half-is-minus-pi-sixths
+  ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
     lt. > @
       abs
         minus.
@@ -85,7 +85,7 @@
           (pi.div 6).neg.times 1000
       1
 
-  [] +> tests-arc-sine-of-point-six
+  ++> tests-arc-sine-of-point-six
     lt. > @
       abs
         minus.
@@ -93,7 +93,7 @@
           643.5
       1
 
-  [] +> tests-arc-sine-is-odd-function
+  ++> tests-arc-sine-is-odd-function
     lt. > @
       abs
         times.
@@ -103,22 +103,22 @@
           1000
       1
 
-  [] +> tests-arc-sine-above-one-is-nan
+  ++> tests-arc-sine-above-one-is-nan
     is-nan. > @
       arc-sine 2
 
-  [] +> tests-arc-sine-below-minus-one-is-nan
+  ++> tests-arc-sine-below-minus-one-is-nan
     is-nan. > @
       arc-sine -2
 
-  [] +> tests-arc-sine-of-nan-is-nan
+  ++> tests-arc-sine-of-nan-is-nan
     is-nan. > @
       arc-sine nan
 
-  [] +> tests-arc-sine-of-positive-infinity-is-nan
+  ++> tests-arc-sine-of-positive-infinity-is-nan
     is-nan. > @
       arc-sine pinf
 
-  [] +> tests-arc-sine-of-negative-infinity-is-nan
+  ++> tests-arc-sine-of-negative-infinity-is-nan
     is-nan. > @
       arc-sine ninf

--- a/eo-runtime/src/main/eo/ms/cosine.eo
+++ b/eo-runtime/src/main/eo/ms/cosine.eo
@@ -14,7 +14,7 @@
 [num] > cosine
   sine (num.plus (pi.div 2)) > @
 
-  [] +> tests-cosine-of-zero-is-one
+  ++> tests-cosine-of-zero-is-one
     lt. > @
       abs
         minus.
@@ -22,13 +22,13 @@
           1000
       1
 
-  [] +> tests-cosine-of-pi-halves-is-zero
+  ++> tests-cosine-of-pi-halves-is-zero
     lt. > @
       abs
         (cosine (pi.div 2)).times 1000
       1
 
-  [] +> tests-cosine-of-pi-is-minus-one
+  ++> tests-cosine-of-pi-is-minus-one
     lt. > @
       abs
         minus.
@@ -36,7 +36,7 @@
           -1000
       1
 
-  [] +> tests-cosine-of-pi-thirds-is-half
+  ++> tests-cosine-of-pi-thirds-is-half
     lt. > @
       abs
         minus.
@@ -44,7 +44,7 @@
           500
       1
 
-  [] +> tests-cosine-is-even-function
+  ++> tests-cosine-is-even-function
     lt. > @
       abs
         times.
@@ -54,7 +54,7 @@
           1000
       1
 
-  [] +> tests-cosine-reduces-large-angle
+  ++> tests-cosine-reduces-large-angle
     lt. > @
       abs
         minus.
@@ -62,7 +62,7 @@
           500
       1
 
-  [] +> tests-cosine-of-seventeen-radians
+  ++> tests-cosine-of-seventeen-radians
     lt. > @
       abs
         minus.
@@ -70,14 +70,14 @@
           -275
       1
 
-  [] +> tests-cosine-of-nan-is-nan
+  ++> tests-cosine-of-nan-is-nan
     is-nan. > @
       cosine nan
 
-  [] +> tests-cosine-of-positive-infinity-is-nan
+  ++> tests-cosine-of-positive-infinity-is-nan
     is-nan. > @
       cosine pinf
 
-  [] +> tests-cosine-of-negative-infinity-is-nan
+  ++> tests-cosine-of-negative-infinity-is-nan
     is-nan. > @
       cosine ninf

--- a/eo-runtime/src/main/eo/ms/degrees.eo
+++ b/eo-runtime/src/main/eo/ms/degrees.eo
@@ -16,12 +16,12 @@
     pi
   number num.as-bytes > value
 
-  [] +> tests-degrees-of-zero-is-zero
+  ++> tests-degrees-of-zero-is-zero
     eq. > @
       degrees 0
       0
 
-  [] +> tests-degrees-of-pi-is-half-turn
+  ++> tests-degrees-of-pi-is-half-turn
     lt. > @
       abs
         minus.
@@ -29,7 +29,7 @@
           180
       0.0001
 
-  [] +> tests-degrees-of-pi-halves-is-quarter-turn
+  ++> tests-degrees-of-pi-halves-is-quarter-turn
     lt. > @
       abs
         minus.
@@ -37,7 +37,7 @@
           90
       0.0001
 
-  [] +> tests-degrees-of-two-pi-is-full-turn
+  ++> tests-degrees-of-two-pi-is-full-turn
     lt. > @
       abs
         minus.
@@ -45,7 +45,7 @@
           360
       0.0001
 
-  [] +> tests-degrees-of-negative-pi-is-minus-half-turn
+  ++> tests-degrees-of-negative-pi-is-minus-half-turn
     lt. > @
       abs
         minus.
@@ -53,6 +53,6 @@
           -180
       0.0001
 
-  [] +> tests-degrees-of-nan-is-nan
+  ++> tests-degrees-of-nan-is-nan
     is-nan. > @
       degrees nan

--- a/eo-runtime/src/main/eo/ms/exp.eo
+++ b/eo-runtime/src/main/eo/ms/exp.eo
@@ -13,7 +13,7 @@
 [num] > exp
   power e num > @
 
-  [] +> tests-exp-check-n0
+  ++> tests-exp-check-n0
     lt. > @
       abs
         minus.
@@ -21,7 +21,7 @@
           exp 1
       0.00000001
 
-  [] +> tests-exp-check-n1
+  ++> tests-exp-check-n1
     lt. > @
       abs
         minus.
@@ -29,7 +29,7 @@
           exp -1
       0.00000001
 
-  [] +> tests-exp-check-n2
+  ++> tests-exp-check-n2
     lt. > @
       abs
         minus.
@@ -37,7 +37,7 @@
           exp 5
       0.0000001
 
-  [] +> tests-exp-check-n3
+  ++> tests-exp-check-n3
     lt. > @
       abs
         minus.
@@ -45,16 +45,16 @@
           exp -10
       0.000000000001
 
-  [] +> tests-exp-check-nan
+  ++> tests-exp-check-nan
     is-nan. > @
       exp nan
 
-  [] +> tests-exp-check-infinity-n1
+  ++> tests-exp-check-infinity-n1
     eq. > @
       exp pinf
       pinf
 
-  [] +> tests-exp-check-infinity-n2
+  ++> tests-exp-check-infinity-n2
     eq. > @
       exp ninf
       0

--- a/eo-runtime/src/main/eo/ms/integral.eo
+++ b/eo-runtime/src/main/eo/ms/integral.eo
@@ -52,7 +52,7 @@
                 a.plus b
           fun b
 
-  [] +> tests-calculates-lineal-integral
+  ++> tests-calculates-lineal-integral
     close-to > @
       as-number.
         integral
@@ -76,7 +76,7 @@
           value
           value.neg
 
-  [] +> tests-calculates-quadratic-integral
+  ++> tests-calculates-quadratic-integral
     close-to > @
       as-number.
         integral
@@ -100,7 +100,7 @@
           value
           value.neg
 
-  [] +> tests-calculates-cube-integral
+  ++> tests-calculates-cube-integral
     close-to > @
       as-number.
         integral

--- a/eo-runtime/src/main/eo/ms/ln.eo
+++ b/eo-runtime/src/main/eo/ms/ln.eo
@@ -52,30 +52,30 @@
             1.div ((k.times 2).plus 1)
             squared.times (horner (k.plus 1))
 
-  [] +> tests-ln-of-negative-float-is-nan
+  ++> tests-ln-of-negative-float-is-nan
     is-nan. > @
       ln -2.2
 
-  [] +> tests-ln-of-zero-is-negative-infinity
+  ++> tests-ln-of-zero-is-negative-infinity
     eq. > @
       ln 0
       ninf
 
-  [] +> tests-ln-of-one-is-zero
+  ++> tests-ln-of-one-is-zero
     eq. > @
       ln 1
       0
 
-  [] +> tests-ln-of-e-one-is-one
+  ++> tests-ln-of-e-one-is-one
     eq. > @
       ln e
       1
 
-  [] +> tests-ln-of-negative-int-is-nan
+  ++> tests-ln-of-negative-int-is-nan
     is-nan. > @
       ln -42
 
-  [] +> tests-ln-of-twenty
+  ++> tests-ln-of-twenty
     lt. > @
       abs
         minus.
@@ -83,7 +83,7 @@
           2.995732273553991
       0.00000000001
 
-  [] +> tests-ln-fraction
+  ++> tests-ln-fraction
     lt. > @
       abs
         minus.
@@ -91,20 +91,20 @@
           -0.6931471805599453
       0.00000000001
 
-  [] +> tests-ln-positive-infinity
+  ++> tests-ln-positive-infinity
     eq. > @
       ln pinf
       pinf
 
-  [] +> tests-ln-negative-infinity
+  ++> tests-ln-negative-infinity
     is-nan. > @
       ln ninf
 
-  [] +> tests-ln-nan
+  ++> tests-ln-nan
     is-nan. > @
       ln nan
 
-  [] +> tests-ln-monotonic
+  ++> tests-ln-monotonic
     lt. > @
       ln 2
       ln 3

--- a/eo-runtime/src/main/eo/ms/maximum.eo
+++ b/eo-runtime/src/main/eo/ms/maximum.eo
@@ -27,29 +27,29 @@
 
   (maximum *) > [] +> throws-on-taking-maximum-from-empty-sequence
 
-  [] +> tests-maximum-of-empty-returns-provided-fallback
+  ++> tests-maximum-of-empty-returns-provided-fallback
     eq. > @
       "recovered"
       maximum
         *
         "recovered" > [msg]
 
-  [] +> tests-maximum-of-one-item-array
+  ++> tests-maximum-of-one-item-array
     eq. > @
       maximum (* 42)
       42
 
-  [] +> tests-maximum-of-array-is-first
+  ++> tests-maximum-of-array-is-first
     eq. > @
       maximum (* 25 12 -2)
       25
 
-  [] +> tests-maximum-of-array-is-in-the-center
+  ++> tests-maximum-of-array-is-in-the-center
     eq. > @
       maximum (* 12 25 -2)
       25
 
-  [] +> tests-maximum-of-array-is-last
+  ++> tests-maximum-of-array-is-last
     eq. > @
       maximum (* 12 -2 25)
       25

--- a/eo-runtime/src/main/eo/ms/minimum.eo
+++ b/eo-runtime/src/main/eo/ms/minimum.eo
@@ -27,29 +27,29 @@
 
   (minimum *) > [] +> throws-on-taking-minimum-from-empty-sequence
 
-  [] +> tests-minimum-of-empty-returns-provided-fallback
+  ++> tests-minimum-of-empty-returns-provided-fallback
     eq. > @
       "recovered"
       minimum
         *
         "recovered" > [msg]
 
-  [] +> tests-minimum-of-one-item-array
+  ++> tests-minimum-of-one-item-array
     eq. > @
       minimum (* 42)
       42
 
-  [] +> tests-minimum-of-array-is-first
+  ++> tests-minimum-of-array-is-first
     eq. > @
       minimum (* -2 25 12)
       -2
 
-  [] +> tests-minimum-of-array-is-in-the-center
+  ++> tests-minimum-of-array-is-in-the-center
     eq. > @
       minimum (* 12 -2 25)
       -2
 
-  [] +> tests-minimum-of-array-is-last
+  ++> tests-minimum-of-array-is-last
     eq. > @
       minimum (* 12 25 -2)
       -2

--- a/eo-runtime/src/main/eo/ms/mod.eo
+++ b/eo-runtime/src/main/eo/ms/mod.eo
@@ -31,32 +31,32 @@
     abs dividend > absx
     abs divisor > absy
 
-  [] +> tests-mod-n1-n2
+  ++> tests-mod-n1-n2
     eq. > @
       mod 1 2
       1
 
-  [] +> tests-mod-n0-n5
+  ++> tests-mod-n0-n5
     eq. > @
       mod 0 5
       0
 
-  [] +> tests-mod-n0-n15-neg
+  ++> tests-mod-n0-n15-neg
     eq. > @
       mod 0 -15
       0
 
-  [] +> tests-mod-n1-neg-n7
+  ++> tests-mod-n1-neg-n7
     eq. > @
       mod -1 7
       -1
 
-  [] +> tests-mod-n16-n200-neg
+  ++> tests-mod-n16-n200-neg
     eq. > @
       mod 16 -200
       16
 
-  [] +> tests-div-mod-compatibility
+  ++> tests-div-mod-compatibility
     eq. > @
       plus.
         mod dividend divisor
@@ -67,20 +67,20 @@
     -13 > dividend
     5 > divisor
 
-  [] +> tests-mod-dividend-less-than-divisor
+  ++> tests-mod-dividend-less-than-divisor
     eq. > @
       mod -1 5
       -1
 
-  [] +> tests-mod-dividend-by-one
+  ++> tests-mod-dividend-by-one
     eq. > @
       mod 133 1
       0
 
-  [] +> throws-on-mod-by-zero
+  ++> throws-on-mod-by-zero
     mod 5 0 > @
 
-  [] +> tests-mod-by-zero-returns-provided-fallback
+  ++> tests-mod-by-zero-returns-provided-fallback
     eq. > @
       "recovered"
       mod

--- a/eo-runtime/src/main/eo/ms/power.eo
+++ b/eo-runtime/src/main/eo/ms/power.eo
@@ -112,209 +112,209 @@
             r.div j
             fraction (j.plus 1)
 
-  [] +> tests-power-of-two-to-four
+  ++> tests-power-of-two-to-four
     eq. > @
       power 2 4
       16
 
-  [] +> tests-power-of-zero-exponent
+  ++> tests-power-of-zero-exponent
     eq. > @
       power 2 0
       1
 
-  [] +> tests-power-large-negative-exponent
+  ++> tests-power-large-negative-exponent
     eq. > @
       power 984782 -12341
       0
 
-  [] +> tests-power-of-three-squared
+  ++> tests-power-of-three-squared
     eq. > @
       power 3 2
       9
 
-  [] +> tests-power-of-zero-base
+  ++> tests-power-of-zero-base
     eq. > @
       power 0 145
       0
 
-  [] +> tests-power-zero-to-negative-odd
+  ++> tests-power-zero-to-negative-odd
     eq. > @
       power 0 -567
       pinf
 
-  [] +> tests-power-nan-to-nan-is-nan
+  ++> tests-power-nan-to-nan-is-nan
     is-nan. > @
       power nan nan
 
-  [] +> tests-power-nan-to-any-is-nan
+  ++> tests-power-nan-to-any-is-nan
     is-nan. > @
       power nan 42
 
-  [] +> tests-power-any-to-nan-is-nan
+  ++> tests-power-any-to-nan-is-nan
     is-nan. > @
       power 52 nan
 
-  [] +> tests-power-int-to-zero-is-one
+  ++> tests-power-int-to-zero-is-one
     eq. > @
       power 42 0
       1
 
-  [] +> tests-power-float-to-zero-is-one
+  ++> tests-power-float-to-zero-is-one
     eq. > @
       power 42.5 0
       1
 
-  [] +> tests-power-zero-to-negative-is-positive-infinity
+  ++> tests-power-zero-to-negative-is-positive-infinity
     eq. > @
       power 0 -52
       pinf
 
-  [] +> tests-power-zero-to-negative-infinity-is-positive-infinity
+  ++> tests-power-zero-to-negative-infinity-is-positive-infinity
     eq. > @
       power 0 ninf
       pinf
 
-  [] +> tests-power-positive-int-to-negative-infinity-is-zero
+  ++> tests-power-positive-int-to-negative-infinity-is-zero
     eq. > @
       power 42 ninf
       0
 
-  [] +> tests-power-positive-float-to-negative-infinity-is-zero
+  ++> tests-power-positive-float-to-negative-infinity-is-zero
     eq. > @
       power 42.5 ninf
       0
 
-  [] +> tests-power-negative-int-to-negative-infinity-is-zero
+  ++> tests-power-negative-int-to-negative-infinity-is-zero
     eq. > @
       power -42 ninf
       0
 
-  [] +> tests-power-negative-float-to-negative-infinity-is-zero
+  ++> tests-power-negative-float-to-negative-infinity-is-zero
     eq. > @
       power -42.5 ninf
       0
 
-  [] +> tests-power-positive-infinity-to-negative-infinity-is-zero
+  ++> tests-power-positive-infinity-to-negative-infinity-is-zero
     eq. > @
       power pinf ninf
       0
 
-  [] +> tests-power-negative-infinity-to-negative-infinity-is-zero
+  ++> tests-power-negative-infinity-to-negative-infinity-is-zero
     eq. > @
       power ninf ninf
       0
 
-  [] +> tests-power-positive-infinity-to-negative-int-is-zero
+  ++> tests-power-positive-infinity-to-negative-int-is-zero
     eq. > @
       power pinf -42
       0
 
-  [] +> tests-power-positive-infinity-to-negative-float-is-zero
+  ++> tests-power-positive-infinity-to-negative-float-is-zero
     eq. > @
       power pinf -42.2
       0.0
 
-  [] +> tests-power-two-to-minus-one
+  ++> tests-power-two-to-minus-one
     eq. > @
       power 2 -1
       0.5
 
-  [] +> tests-power-two-to-minus-two
+  ++> tests-power-two-to-minus-two
     eq. > @
       power 2 -2
       0.25
 
-  [] +> tests-power-two-to-minus-three
+  ++> tests-power-two-to-minus-three
     eq. > @
       power 2 -3
       0.125
 
-  [] +> tests-power-four-to-minus-three
+  ++> tests-power-four-to-minus-three
     eq. > @
       power 4 -3.0
       0.015625
 
-  [] +> tests-power-zero-to-positive-int-is-zero
+  ++> tests-power-zero-to-positive-int-is-zero
     eq. > @
       power 0 4
       0
 
-  [] +> tests-power-zero-to-positive-float-is-zero
+  ++> tests-power-zero-to-positive-float-is-zero
     eq. > @
       power 0 4.2
       0
 
-  [] +> tests-power-zero-to-positive-infinity-is-zero
+  ++> tests-power-zero-to-positive-infinity-is-zero
     eq. > @
       power 0 pinf
       0
 
-  [] +> tests-power-negative-int-to-positive-infinity-is-positive-infinity
+  ++> tests-power-negative-int-to-positive-infinity-is-positive-infinity
     eq. > @
       power -10 pinf
       pinf
 
-  [] +> tests-power-negative-float-to-positive-infinity-is-positive-infinity
+  ++> tests-power-negative-float-to-positive-infinity-is-positive-infinity
     eq. > @
       power -4.2 pinf
       pinf
 
-  [] +> tests-power-positive-int-to-positive-infinity-is-positive-infinity
+  ++> tests-power-positive-int-to-positive-infinity-is-positive-infinity
     eq. > @
       power 42 pinf
       pinf
 
-  [] +> tests-power-positive-float-to-positive-infinity-is-positive-infinity
+  ++> tests-power-positive-float-to-positive-infinity-is-positive-infinity
     eq. > @
       power 42.5 pinf
       pinf
 
-  [] +> tests-power-positive-infinity-to-positive-int-is-positive-infinity
+  ++> tests-power-positive-infinity-to-positive-int-is-positive-infinity
     eq. > @
       power pinf 42
       pinf
 
-  [] +> tests-power-positive-infinity-to-positive-float-is-positive-infinity
+  ++> tests-power-positive-infinity-to-positive-float-is-positive-infinity
     eq. > @
       power pinf 10.8
       pinf
 
-  [] +> tests-power-positive-infinity-to-positive-infinity-is-positive-infinity
+  ++> tests-power-positive-infinity-to-positive-infinity-is-positive-infinity
     eq. > @
       power pinf pinf
       pinf
 
-  [] +> tests-power-negative-infinity-to-positive-float-is-positive-infinity
+  ++> tests-power-negative-infinity-to-positive-float-is-positive-infinity
     eq. > @
       power ninf 9.9
       pinf
 
-  [] +> tests-power-negative-infinity-to-even-int-is-positive-infinity
+  ++> tests-power-negative-infinity-to-even-int-is-positive-infinity
     eq. > @
       power ninf 10
       pinf
 
-  [] +> tests-power-negative-infinity-to-odd-int-is-negative-infinity
+  ++> tests-power-negative-infinity-to-odd-int-is-negative-infinity
     eq. > @
       power ninf 9
       ninf
 
-  [] +> tests-power-positive-int-to-positive-int
+  ++> tests-power-positive-int-to-positive-int
     eq. > @
       power 2 3
       8
 
-  [] +> tests-power-positive-float-to-positive-int
+  ++> tests-power-positive-float-to-positive-int
     eq. > @
       power 3.5 4
       150.0625
 
-  [] +> tests-power-four-to-five
+  ++> tests-power-four-to-five
     eq. > @
       power 4 5
       1024
 
-  [] +> tests-power-square-root-of-nine
+  ++> tests-power-square-root-of-nine
     lt. > @
       abs
         minus.
@@ -322,7 +322,7 @@
           3
       0.000000001
 
-  [] +> tests-power-square-root-of-two
+  ++> tests-power-square-root-of-two
     lt. > @
       abs
         minus.
@@ -330,7 +330,7 @@
           1.4142135623730951
       0.000000001
 
-  [] +> tests-power-cube-root-of-twenty-seven
+  ++> tests-power-cube-root-of-twenty-seven
     lt. > @
       abs
         minus.
@@ -338,6 +338,6 @@
           3
       0.000000001
 
-  [] +> tests-power-fractional-of-negative-is-nan
+  ++> tests-power-fractional-of-negative-is-nan
     is-nan. > @
       power -4 0.5

--- a/eo-runtime/src/main/eo/ms/radians.eo
+++ b/eo-runtime/src/main/eo/ms/radians.eo
@@ -16,12 +16,12 @@
     180.0
   number num.as-bytes > value
 
-  [] +> tests-radians-of-zero-is-zero
+  ++> tests-radians-of-zero-is-zero
     eq. > @
       radians 0
       0
 
-  [] +> tests-radians-of-half-turn-is-pi
+  ++> tests-radians-of-half-turn-is-pi
     lt. > @
       abs
         minus.
@@ -29,7 +29,7 @@
           pi
       0.0001
 
-  [] +> tests-radians-of-quarter-turn-is-pi-halves
+  ++> tests-radians-of-quarter-turn-is-pi-halves
     lt. > @
       abs
         minus.
@@ -37,7 +37,7 @@
           pi.div 2
       0.0001
 
-  [] +> tests-radians-of-full-turn-is-two-pi
+  ++> tests-radians-of-full-turn-is-two-pi
     lt. > @
       abs
         minus.
@@ -45,7 +45,7 @@
           pi.times 2
       0.0001
 
-  [] +> tests-radians-of-negative-half-turn-is-minus-pi
+  ++> tests-radians-of-negative-half-turn-is-minus-pi
     lt. > @
       abs
         minus.
@@ -53,6 +53,6 @@
           pi.neg
       0.0001
 
-  [] +> tests-radians-of-nan-is-nan
+  ++> tests-radians-of-nan-is-nan
     is-nan. > @
       radians nan

--- a/eo-runtime/src/main/eo/ms/random.eo
+++ b/eo-runtime/src/main/eo/ms/random.eo
@@ -68,19 +68,19 @@
     clock.as-bytes > tbytes
   clocked system-clock > pseudo
 
-  [] +> tests-random-with-seed
+  ++> tests-random-with-seed
     not. > @
       eq.
         r.next
         r.next.next
     random 51 > r
 
-  [] +> tests-seeded-randoms-are-equal
+  ++> tests-seeded-randoms-are-equal
     eq. > @
       (random 1654).next.next.next
       (random 1654).next.next.next
 
-  [] +> tests-random-is-in-range
+  ++> tests-random-is-in-range
     and. > @
       and.
         and.
@@ -94,7 +94,7 @@
         (rand.next.next.lt 0).not
     (random 123).next > rand
 
-  [] +> tests-two-random-numbers-not-equal
+  ++> tests-two-random-numbers-not-equal
     not. > @
       eq.
         random.clocked 123.as-i64

--- a/eo-runtime/src/main/eo/ms/sine.eo
+++ b/eo-runtime/src/main/eo/ms/sine.eo
@@ -39,12 +39,12 @@
             (depth.times 2).times ((depth.times 2).plus 1)
           factor (depth.plus 1)
 
-  [] +> tests-sine-of-zero-is-zero
+  ++> tests-sine-of-zero-is-zero
     eq. > @
       sine 0
       0
 
-  [] +> tests-sine-of-pi-halves-is-one
+  ++> tests-sine-of-pi-halves-is-one
     lt. > @
       abs
         minus.
@@ -52,7 +52,7 @@
           1000
       1
 
-  [] +> tests-sine-of-pi-sixths-is-half
+  ++> tests-sine-of-pi-sixths-is-half
     lt. > @
       abs
         minus.
@@ -60,13 +60,13 @@
           500
       1
 
-  [] +> tests-sine-of-pi-is-zero
+  ++> tests-sine-of-pi-is-zero
     lt. > @
       abs
         (sine pi).times 1000
       1
 
-  [] +> tests-sine-of-negative-pi-halves-is-minus-one
+  ++> tests-sine-of-negative-pi-halves-is-minus-one
     lt. > @
       abs
         minus.
@@ -74,7 +74,7 @@
           -1000
       1
 
-  [] +> tests-sine-of-three-pi-halves-is-minus-one
+  ++> tests-sine-of-three-pi-halves-is-minus-one
     lt. > @
       abs
         minus.
@@ -82,7 +82,7 @@
           -1000
       1
 
-  [] +> tests-sine-is-odd-function
+  ++> tests-sine-is-odd-function
     lt. > @
       abs
         times.
@@ -92,13 +92,13 @@
           1000
       1
 
-  [] +> tests-sine-of-two-pi-is-zero
+  ++> tests-sine-of-two-pi-is-zero
     lt. > @
       abs
         (sine (pi.times 2)).times 1000
       1
 
-  [] +> tests-sine-reduces-large-angle
+  ++> tests-sine-reduces-large-angle
     lt. > @
       abs
         minus.
@@ -106,7 +106,7 @@
           500
       1
 
-  [] +> tests-sine-of-seventeen-radians
+  ++> tests-sine-of-seventeen-radians
     lt. > @
       abs
         minus.
@@ -114,14 +114,14 @@
           -961
       1
 
-  [] +> tests-sine-of-nan-is-nan
+  ++> tests-sine-of-nan-is-nan
     is-nan. > @
       sine nan
 
-  [] +> tests-sine-of-positive-infinity-is-nan
+  ++> tests-sine-of-positive-infinity-is-nan
     is-nan. > @
       sine pinf
 
-  [] +> tests-sine-of-negative-infinity-is-nan
+  ++> tests-sine-of-negative-infinity-is-nan
     is-nan. > @
       sine ninf

--- a/eo-runtime/src/main/eo/ms/sqrt.eo
+++ b/eo-runtime/src/main/eo/ms/sqrt.eo
@@ -16,17 +16,17 @@
     nan
     power num 0.5
 
-  [] +> tests-sqrt-zero
+  ++> tests-sqrt-zero
     eq. > @
       sqrt 0.0
       0.0
 
-  [] +> tests-sqrt-one
+  ++> tests-sqrt-one
     eq. > @
       sqrt 1.0
       1.0
 
-  [] +> tests-sqrt-four
+  ++> tests-sqrt-four
     lt. > @
       abs
         minus.
@@ -34,7 +34,7 @@
           2.0
       0.000000001
 
-  [] +> tests-sqrt-two
+  ++> tests-sqrt-two
     lt. > @
       abs
         minus.
@@ -42,7 +42,7 @@
           1.4142135623730951
       0.000000001
 
-  [] +> tests-sqrt-point-five
+  ++> tests-sqrt-point-five
     lt. > @
       abs
         minus.
@@ -50,7 +50,7 @@
           0.5
       0.000000001
 
-  [] +> tests-sqrt-check-zero-input
+  ++> tests-sqrt-check-zero-input
     lt. > @
       abs
         minus.
@@ -58,11 +58,11 @@
           sqrt 0
       0.00000000001
 
-  [] +> tests-sqrt-check-negative-input
+  ++> tests-sqrt-check-negative-input
     is-nan. > @
       sqrt -0.1
 
-  [] +> tests-sqrt-check-float-input
+  ++> tests-sqrt-check-float-input
     lt. > @
       abs
         minus.
@@ -70,15 +70,15 @@
           sqrt 4
       0.00000000001
 
-  [] +> tests-sqrt-check-nan-input
+  ++> tests-sqrt-check-nan-input
     is-nan. > @
       sqrt nan
 
-  [] +> tests-sqrt-check-infinity-n1
+  ++> tests-sqrt-check-infinity-n1
     eq. > @
       sqrt pinf
       pinf
 
-  [] +> tests-sqrt-check-infinity-n2
+  ++> tests-sqrt-check-infinity-n2
     is-nan. > @
       sqrt ninf

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -4,7 +4,7 @@
 # code, by wrapping the original body inside `nop`:
 #
 # ```
-# [] +> works-just-fine
+# ++> works-just-fine
 #   nop > @
 #     "doesn't work for now"
 # ```
@@ -22,8 +22,8 @@
 [x] > nop
   true > @
 
-  [] +> tests-nop-is-true
+  ++> tests-nop-is-true
     nop "anything" > @
 
-  [] +> tests-nop-with-number-is-true
+  ++> tests-nop-with-number-is-true
     nop 42 > @

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -94,12 +94,12 @@
         trunc
     ^.as-i64.as-number > trunc
 
-  [] +> tests-int-less-true
+  ++> tests-int-less-true
     lt. > @
       10
       50
 
-  [] +> tests-int-less-equal
+  ++> tests-int-less-equal
     eq. > @
       not.
         lt.
@@ -107,7 +107,7 @@
           10
       true
 
-  [] +> tests-int-less-false
+  ++> tests-int-less-false
     eq. > @
       not.
         lt.
@@ -115,14 +115,14 @@
           -5
       true
 
-  [] +> tests-int-greater-true
+  ++> tests-int-greater-true
     eq. > @
       gt.
         -200
         -1000
       true
 
-  [] +> tests-int-greater-false
+  ++> tests-int-greater-false
     eq. > @
       not.
         gt.
@@ -130,7 +130,7 @@
           100
       true
 
-  [] +> tests-int-greater-equal
+  ++> tests-int-greater-equal
     eq. > @
       not.
         gt.
@@ -138,21 +138,21 @@
           0
       true
 
-  [] +> tests-int-leq-true
+  ++> tests-int-leq-true
     eq. > @
       lte.
         -200
         -100
       true
 
-  [] +> tests-int-leq-equal
+  ++> tests-int-leq-equal
     eq. > @
       lte.
         50
         50
       true
 
-  [] +> tests-int-leq-false
+  ++> tests-int-leq-false
     eq. > @
       not.
         lte.
@@ -160,21 +160,21 @@
           -10
       true
 
-  [] +> tests-int-gte-true
+  ++> tests-int-gte-true
     eq. > @
       gte.
         -1000
         -1100
       true
 
-  [] +> tests-int-gte-equal
+  ++> tests-int-gte-equal
     eq. > @
       gte.
         113
         113
       true
 
-  [] +> tests-int-gte-false
+  ++> tests-int-gte-false
     eq. > @
       not.
         gte.
@@ -182,7 +182,7 @@
           10
       true
 
-  [] +> tests-int-equal-to-nan-and-infinites-is-false
+  ++> tests-int-equal-to-nan-and-infinites-is-false
     eq. > @
       and.
         and.
@@ -197,28 +197,28 @@
         (42.eq ninf).eq false
       true
 
-  [] +> tests-int-zero-eq-to-zero
+  ++> tests-int-zero-eq-to-zero
     eq. > @
       eq.
         0
         0
       true
 
-  [] +> tests-int-zero-eq-to-float-zero
+  ++> tests-int-zero-eq-to-float-zero
     eq. > @
       eq.
         0
         0.0
       true
 
-  [] +> tests-int-eq-true
+  ++> tests-int-eq-true
     eq. > @
       eq.
         123
         123
       true
 
-  [] +> tests-int-eq-false
+  ++> tests-int-eq-false
     eq. > @
       not.
         eq.
@@ -226,22 +226,22 @@
           42
       true
 
-  [] +> tests-one-plus-one
+  ++> tests-one-plus-one
     eq. > @
       1.plus 1
       2
 
-  [] +> tests-one-minus-one
+  ++> tests-one-minus-one
     eq. > @
       1.minus 1
       0
 
-  [] +> tests-compares-two-different-number-types
+  ++> tests-compares-two-different-number-types
     eq. > @
       68.eq "12345678"
       false
 
-  [] +> tests-calculates-fibonacci-number-with-recursion
+  ++> tests-calculates-fibonacci-number-with-recursion
     eq. > @
       fibo 4
       3
@@ -253,7 +253,7 @@
           fibo (n.minus 1)
           fibo (n.minus 2)
 
-  [] +> tests-calculates-fibonacci-number-with-tail
+  ++> tests-calculates-fibonacci-number-with-tail
     eq. > @
       fibonacci 4
       3
@@ -276,96 +276,96 @@
           minus1.plus minus2
           rec (n.minus 1) (minus1.plus minus2) minus1
 
-  [] +> tests-zero-division
+  ++> tests-zero-division
     seq > @
       *
         2.div 0
         true
 
-  [] +> tests-division-by-one
+  ++> tests-division-by-one
     eq. > @
       dividend.div 1
       dividend
     -235 > dividend
 
-  [] +> tests-div-for-dividend-greater-than-zero
+  ++> tests-div-for-dividend-greater-than-zero
     eq. > @
       256.div 16
       16
 
-  [] +> tests-div-with-remainder
+  ++> tests-div-with-remainder
     eq. > @
       floor.
         13.div -5
       -3
 
-  [] +> tests-floor-positive-fraction
+  ++> tests-floor-positive-fraction
     eq. > @
       3.7.floor
       3
 
-  [] +> tests-floor-negative-fraction
+  ++> tests-floor-negative-fraction
     eq. > @
       -3.7.floor
       -4
 
-  [] +> tests-floor-negative-small-fraction
+  ++> tests-floor-negative-small-fraction
     eq. > @
       -0.1.floor
       -1
 
-  [] +> tests-floor-of-integer
+  ++> tests-floor-of-integer
     eq. > @
       42.floor
       42
 
-  [] +> tests-floor-of-negative-integer
+  ++> tests-floor-of-negative-integer
     eq. > @
       -5.floor
       -5
 
-  [] +> tests-floor-of-large-positive-integer
+  ++> tests-floor-of-large-positive-integer
     eq. > @
       100000000000000000000.floor
       100000000000000000000
 
-  [] +> tests-floor-of-large-negative-integer
+  ++> tests-floor-of-large-negative-integer
     eq. > @
       -100000000000000000000.floor
       -100000000000000000000
 
-  [] +> tests-floor-of-zero
+  ++> tests-floor-of-zero
     eq. > @
       0.floor
       0
 
-  [] +> tests-div-less-than-one
+  ++> tests-div-less-than-one
     lt. > @
       1.div 5
       1
 
-  [] +> tests-to-bytes-and-backwards
+  ++> tests-to-bytes-and-backwards
     eq. > @
       as-bytes.
         42
       42
 
-  [] +> tests-as-bytes-equals-to-int
+  ++> tests-as-bytes-equals-to-int
     eq. > @
       42
       42.as-bytes
 
-  [] +> tests-as-bytes-equals-to-int-backwards
+  ++> tests-as-bytes-equals-to-int-backwards
     eq. > @
       42.as-bytes
       42
 
-  [] +> tests-multiply-by-zero
+  ++> tests-multiply-by-zero
     eq. > @
       1000.times 0
       0
 
-  [] +> tests-simple-number-is-not-nan
+  ++> tests-simple-number-is-not-nan
     42.5.is-nan.not > @
 
   32.is-integer > [] +> int-number-is-integer
@@ -374,149 +374,149 @@
 
   32.is-finite > [] +> simple-number-is-finite
 
-  [] +> tests-number-with-nan-bytes-is-nan
+  ++> tests-number-with-nan-bytes-is-nan
     (number nan.as-bytes).is-nan > @
 
-  [] +> tests-number-with-infinite-bytes-is-not-finite
+  ++> tests-number-with-infinite-bytes-is-not-finite
     (number pinf.as-bytes).is-finite.not > @
 
-  [] +> tests-positive-infinity-is-equal-to-one-div-zero
+  ++> tests-positive-infinity-is-equal-to-one-div-zero
     eq. > @
       pinf
       1.0.div 0.0
 
-  [] +> tests-positive-infinity-eq-positive-infinity
+  ++> tests-positive-infinity-eq-positive-infinity
     eq. > @
       pinf
       pinf
 
-  [] +> tests-positive-infinity-not-eq-negative-infinity
+  ++> tests-positive-infinity-not-eq-negative-infinity
     not. > @
       eq.
         pinf
         ninf
 
-  [] +> tests-positive-infinity-not-eq-nan
+  ++> tests-positive-infinity-not-eq-nan
     not. > @
       eq.
         pinf
         nan
 
-  [] +> tests-positive-infinity-not-eq-int
+  ++> tests-positive-infinity-not-eq-int
     not. > @
       eq.
         pinf
         42
 
-  [] +> tests-positive-infinity-not-eq-float
+  ++> tests-positive-infinity-not-eq-float
     not. > @
       eq.
         pinf
         42.5
 
-  [] +> tests-positive-infinity-lt-positive-infinity
+  ++> tests-positive-infinity-lt-positive-infinity
     eq. > @
       pinf.lt pinf
       false
 
-  [] +> tests-positive-infinity-not-lt-negative-infinity
+  ++> tests-positive-infinity-not-lt-negative-infinity
     eq. > @
       pinf.lt ninf
       false
 
-  [] +> tests-positive-infinity-not-lt-nan
+  ++> tests-positive-infinity-not-lt-nan
     eq. > @
       pinf.lt nan
       false
 
-  [] +> tests-positive-infinity-not-lt-int
+  ++> tests-positive-infinity-not-lt-int
     eq. > @
       pinf.lt 42
       false
 
-  [] +> tests-positive-infinity-not-lt-float
+  ++> tests-positive-infinity-not-lt-float
     eq. > @
       pinf.lt 42.5
       false
 
-  [] +> tests-positive-infinity-lte-positive-infinity
+  ++> tests-positive-infinity-lte-positive-infinity
     eq. > @
       pinf.lte pinf
       true
 
-  [] +> tests-positive-infinity-not-lte-negative-infinity
+  ++> tests-positive-infinity-not-lte-negative-infinity
     eq. > @
       pinf.lte ninf
       false
 
-  [] +> tests-positive-infinity-not-lte-nan
+  ++> tests-positive-infinity-not-lte-nan
     eq. > @
       pinf.lte nan
       false
 
-  [] +> tests-positive-infinity-not-lte-int
+  ++> tests-positive-infinity-not-lte-int
     eq. > @
       pinf.lte 42
       false
 
-  [] +> tests-positive-infinity-not-lte-float
+  ++> tests-positive-infinity-not-lte-float
     eq. > @
       pinf.lte 42.5
       false
 
-  [] +> tests-positive-infinity-gt-positive-infinity
+  ++> tests-positive-infinity-gt-positive-infinity
     not. > @
       gt.
         pinf
         pinf
 
-  [] +> tests-positive-infinity-gt-negative-infinity
+  ++> tests-positive-infinity-gt-negative-infinity
     gt. > @
       pinf
       ninf
 
-  [] +> tests-positive-infinity-not-gt-nan
+  ++> tests-positive-infinity-not-gt-nan
     not. > @
       gt.
         pinf
         nan
 
-  [] +> tests-positive-infinity-gt-int
+  ++> tests-positive-infinity-gt-int
     gt. > @
       pinf
       42
 
-  [] +> tests-positive-infinity-gt-float
+  ++> tests-positive-infinity-gt-float
     gt. > @
       pinf
       42.5
 
-  [] +> tests-positive-infinity-gte-positive-infinity
+  ++> tests-positive-infinity-gte-positive-infinity
     eq. > @
       pinf.gte pinf
       true
 
-  [] +> tests-positive-infinity-gte-negative-infinity
+  ++> tests-positive-infinity-gte-negative-infinity
     eq. > @
       pinf.gte ninf
       true
 
-  [] +> tests-positive-infinity-not-gte-nan
+  ++> tests-positive-infinity-not-gte-nan
     eq. > @
       pinf.gte nan
       false
 
-  [] +> tests-positive-infinity-gte-int
+  ++> tests-positive-infinity-gte-int
     eq. > @
       pinf.gte 42
       true
 
-  [] +> tests-positive-infinity-gte-float
+  ++> tests-positive-infinity-gte-float
     eq. > @
       pinf.gte 42.5
       true
 
-  [] +> tests-float-equal-to-nan-and-infinites-is-false-highload
+  ++> tests-float-equal-to-nan-and-infinites-is-false-highload
     eq. > @
       and.
         and.
@@ -543,645 +543,645 @@
         (42.5.eq ninf).eq false
       true
 
-  [] +> tests-positive-infinity-times-float-zero
+  ++> tests-positive-infinity-times-float-zero
     eq. > @
       as-bytes.
         pinf.times 0.0
       nan.as-bytes
 
-  [] +> tests-positive-infinity-times-neg-float-zero
+  ++> tests-positive-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
         pinf.times -0.0
       nan.as-bytes
 
-  [] +> tests-positive-infinity-times-int-zero
+  ++> tests-positive-infinity-times-int-zero
     eq. > @
       as-bytes.
         pinf.times 0
       nan.as-bytes
 
-  [] +> tests-positive-infinity-times-nan
+  ++> tests-positive-infinity-times-nan
     eq. > @
       as-bytes.
         pinf.times nan
       nan.as-bytes
 
-  [] +> tests-positive-infinity-times-negative-infinity
+  ++> tests-positive-infinity-times-negative-infinity
     eq. > @
       pinf.times ninf
       ninf
 
-  [] +> tests-positive-infinity-times-positive-infinity
+  ++> tests-positive-infinity-times-positive-infinity
     eq. > @
       pinf.times pinf
       pinf
 
-  [] +> tests-positive-infinity-times-positive-float
+  ++> tests-positive-infinity-times-positive-float
     eq. > @
       pinf.times 42.5
       pinf
 
-  [] +> tests-positive-infinity-times-positive-int
+  ++> tests-positive-infinity-times-positive-int
     eq. > @
       pinf.times 42
       pinf
 
-  [] +> tests-positive-infinity-times-negative-float
+  ++> tests-positive-infinity-times-negative-float
     eq. > @
       pinf.times -42.5
       ninf
 
-  [] +> tests-positive-infinity-times-negative-int
+  ++> tests-positive-infinity-times-negative-int
     eq. > @
       pinf.times -42
       ninf
 
-  [] +> tests-positive-infinity-plus-nan
+  ++> tests-positive-infinity-plus-nan
     eq. > @
       as-bytes.
         pinf.plus nan
       nan.as-bytes
 
-  [] +> tests-positive-infinity-plus-negative-infinity
+  ++> tests-positive-infinity-plus-negative-infinity
     eq. > @
       as-bytes.
         pinf.plus ninf
       nan.as-bytes
 
-  [] +> tests-positive-infinity-plus-positive-infinity
+  ++> tests-positive-infinity-plus-positive-infinity
     eq. > @
       pinf.plus pinf
       pinf
 
-  [] +> tests-positive-infinity-plus-positive-float
+  ++> tests-positive-infinity-plus-positive-float
     eq. > @
       pinf.plus 42.5
       pinf
 
-  [] +> tests-positive-infinity-neg-is-negative-infinity
+  ++> tests-positive-infinity-neg-is-negative-infinity
     eq. > @
       pinf.neg
       ninf
 
-  [] +> tests-positive-infinity-minus-nan
+  ++> tests-positive-infinity-minus-nan
     eq. > @
       as-bytes.
         pinf.minus nan
       nan.as-bytes
 
-  [] +> tests-positive-infinity-minus-positive-infinity
+  ++> tests-positive-infinity-minus-positive-infinity
     eq. > @
       as-bytes.
         pinf.minus pinf
       nan.as-bytes
 
-  [] +> tests-positive-infinity-minus-negative-infinity
+  ++> tests-positive-infinity-minus-negative-infinity
     eq. > @
       pinf.minus ninf
       pinf
 
-  [] +> tests-positive-infinity-minus-positive-float
+  ++> tests-positive-infinity-minus-positive-float
     eq. > @
       pinf.minus 42.5
       pinf
 
-  [] +> tests-positive-infinity-minus-positive-int
+  ++> tests-positive-infinity-minus-positive-int
     eq. > @
       pinf.minus 42
       pinf
 
-  [] +> tests-positive-infinity-minus-negative-float
+  ++> tests-positive-infinity-minus-negative-float
     eq. > @
       pinf.minus -42.5
       pinf
 
-  [] +> tests-positive-infinity-minus-negative-int
+  ++> tests-positive-infinity-minus-negative-int
     eq. > @
       pinf.minus -42
       pinf
 
-  [] +> tests-positive-infinity-div-float-zero
+  ++> tests-positive-infinity-div-float-zero
     eq. > @
       pinf.div 0.0
       pinf
 
-  [] +> tests-positive-infinity-div-neg-float-zero
+  ++> tests-positive-infinity-div-neg-float-zero
     eq. > @
       pinf.div -0.0
       ninf
 
-  [] +> tests-positive-infinity-div-int-zero
+  ++> tests-positive-infinity-div-int-zero
     eq. > @
       pinf.div 0
       pinf
 
-  [] +> tests-positive-infinity-div-neg-int-zero
+  ++> tests-positive-infinity-div-neg-int-zero
     eq. > @
       pinf.div -0
       ninf
 
-  [] +> tests-positive-infinity-div-nan
+  ++> tests-positive-infinity-div-nan
     eq. > @
       as-bytes.
         pinf.div nan
       nan.as-bytes
 
-  [] +> tests-positive-infinity-div-negative-infinity
+  ++> tests-positive-infinity-div-negative-infinity
     eq. > @
       as-bytes.
         pinf.div ninf
       nan.as-bytes
 
-  [] +> tests-positive-infinity-div-positive-infinity
+  ++> tests-positive-infinity-div-positive-infinity
     eq. > @
       as-bytes.
         pinf.div pinf
       nan.as-bytes
 
-  [] +> tests-positive-infinity-div-positive-float
+  ++> tests-positive-infinity-div-positive-float
     eq. > @
       pinf.div 42.5
       pinf
 
-  [] +> tests-positive-infinity-div-positive-int
+  ++> tests-positive-infinity-div-positive-int
     eq. > @
       pinf.div 42
       pinf
 
-  [] +> tests-positive-infinity-div-negative-float
+  ++> tests-positive-infinity-div-negative-float
     eq. > @
       pinf.div -42.5
       ninf
 
-  [] +> tests-positive-infinity-div-negative-int
+  ++> tests-positive-infinity-div-negative-int
     eq. > @
       pinf.div -42
       ninf
 
-  [] +> tests-positive-infinity-as-bytes-is-valid
+  ++> tests-positive-infinity-as-bytes-is-valid
     eq. > @
       pinf.as-bytes
       (1.0.div 0.0).as-bytes
 
-  [] +> tests-positive-infinity-floor-is-equal-to-self
+  ++> tests-positive-infinity-floor-is-equal-to-self
     pinf.floor.eq pinf > @
 
-  [] +> tests-positive-infinity-is-not-nan
+  ++> tests-positive-infinity-is-not-nan
     pinf.is-nan.not > @
 
-  [] +> tests-positive-infinity-is-not-finite
+  ++> tests-positive-infinity-is-not-finite
     pinf.is-finite.not > @
 
-  [] +> tests-positive-infinity-is-not-integer
+  ++> tests-positive-infinity-is-not-integer
     pinf.is-integer.not > @
 
-  [] +> tests-negative-infinity-is-equal-to-one-div-zero
+  ++> tests-negative-infinity-is-equal-to-one-div-zero
     eq. > @
       ninf
       -1.0.div 0.0
 
-  [] +> tests-negative-infinity-eq-negative-infinity
+  ++> tests-negative-infinity-eq-negative-infinity
     eq. > @
       ninf
       ninf
 
-  [] +> tests-negative-infinity-not-eq-positive-infinity
+  ++> tests-negative-infinity-not-eq-positive-infinity
     not. > @
       eq.
         ninf
         pinf
 
-  [] +> tests-negative-infinity-not-eq-nan
+  ++> tests-negative-infinity-not-eq-nan
     not. > @
       eq.
         ninf
         nan
 
-  [] +> tests-negative-infinity-not-eq-int
+  ++> tests-negative-infinity-not-eq-int
     not. > @
       eq.
         ninf
         42
 
-  [] +> tests-negative-infinity-not-eq-float
+  ++> tests-negative-infinity-not-eq-float
     not. > @
       eq.
         ninf
         42.5
 
-  [] +> tests-negative-infinity-lt-negative-infinity
+  ++> tests-negative-infinity-lt-negative-infinity
     eq. > @
       ninf.lt ninf
       false
 
-  [] +> tests-negative-infinity-lt-positive-infinity
+  ++> tests-negative-infinity-lt-positive-infinity
     eq. > @
       ninf.lt pinf
       true
 
-  [] +> tests-negative-infinity-not-lt-nan
+  ++> tests-negative-infinity-not-lt-nan
     eq. > @
       ninf.lt nan
       false
 
-  [] +> tests-negative-infinity-lt-int
+  ++> tests-negative-infinity-lt-int
     lt. > @
       ninf
       42
 
-  [] +> tests-negative-infinity-lt-float
+  ++> tests-negative-infinity-lt-float
     lt. > @
       ninf
       42.5
 
-  [] +> tests-negative-infinity-lte-negative-infinity
+  ++> tests-negative-infinity-lte-negative-infinity
     eq. > @
       ninf.lte ninf
       true
 
-  [] +> tests-negative-infinity-lte-positive-infinity
+  ++> tests-negative-infinity-lte-positive-infinity
     eq. > @
       ninf.lte pinf
       true
 
-  [] +> tests-negative-infinity-not-lte-nan
+  ++> tests-negative-infinity-not-lte-nan
     eq. > @
       ninf.lte nan
       false
 
-  [] +> tests-negative-infinity-lte-int
+  ++> tests-negative-infinity-lte-int
     eq. > @
       ninf.lte 42
       true
 
-  [] +> tests-negative-infinity-lte-float
+  ++> tests-negative-infinity-lte-float
     eq. > @
       ninf.lte 42.5
       true
 
-  [] +> tests-negative-infinity-gt-negative-infinity
+  ++> tests-negative-infinity-gt-negative-infinity
     not. > @
       gt.
         ninf
         ninf
 
-  [] +> tests-negative-infinity-not-gt-positive-infinity
+  ++> tests-negative-infinity-not-gt-positive-infinity
     eq. > @
       ninf.gt pinf
       false
 
-  [] +> tests-negative-infinity-not-gt-nan
+  ++> tests-negative-infinity-not-gt-nan
     eq. > @
       ninf.gt nan
       false
 
-  [] +> tests-negative-infinity-not-gt-int
+  ++> tests-negative-infinity-not-gt-int
     eq. > @
       ninf.gt 42
       false
 
-  [] +> tests-negative-infinity-not-gt-float
+  ++> tests-negative-infinity-not-gt-float
     eq. > @
       ninf.gt 42.5
       false
 
-  [] +> tests-negative-infinity-gte-negative-infinity
+  ++> tests-negative-infinity-gte-negative-infinity
     eq. > @
       ninf.gte ninf
       true
 
-  [] +> tests-negative-infinity-not-gte-positive-infinity
+  ++> tests-negative-infinity-not-gte-positive-infinity
     eq. > @
       ninf.gte pinf
       false
 
-  [] +> tests-negative-infinity-not-gte-nan
+  ++> tests-negative-infinity-not-gte-nan
     eq. > @
       ninf.gte nan
       false
 
-  [] +> tests-negative-infinity-not-gte-int
+  ++> tests-negative-infinity-not-gte-int
     eq. > @
       ninf.gte 42
       false
 
-  [] +> tests-negative-infinity-not-gte-float
+  ++> tests-negative-infinity-not-gte-float
     eq. > @
       ninf.gte 42.5
       false
 
-  [] +> tests-negative-infinity-times-float-zero
+  ++> tests-negative-infinity-times-float-zero
     eq. > @
       as-bytes.
         ninf.times 0.0
       nan.as-bytes
 
-  [] +> tests-negative-infinity-times-neg-float-zero
+  ++> tests-negative-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
         ninf.times -0.0
       nan.as-bytes
 
-  [] +> tests-negative-infinity-times-int-zero
+  ++> tests-negative-infinity-times-int-zero
     eq. > @
       as-bytes.
         ninf.times 0
       nan.as-bytes
 
-  [] +> tests-negative-infinity-times-nan
+  ++> tests-negative-infinity-times-nan
     eq. > @
       as-bytes.
         ninf.times nan
       nan.as-bytes
 
-  [] +> tests-negative-infinity-times-positive-infinity
+  ++> tests-negative-infinity-times-positive-infinity
     eq. > @
       ninf.times pinf
       ninf
 
-  [] +> tests-negative-infinity-times-negative-infinity
+  ++> tests-negative-infinity-times-negative-infinity
     eq. > @
       ninf.times ninf
       pinf
 
-  [] +> tests-negative-infinity-times-positive-float
+  ++> tests-negative-infinity-times-positive-float
     eq. > @
       ninf.times 42.5
       ninf
 
-  [] +> tests-negative-infinity-times-positive-int
+  ++> tests-negative-infinity-times-positive-int
     eq. > @
       ninf.times 42
       ninf
 
-  [] +> tests-negative-infinity-times-negative-float
+  ++> tests-negative-infinity-times-negative-float
     eq. > @
       ninf.times -42.5
       pinf
 
-  [] +> tests-negative-infinity-times-negative-int
+  ++> tests-negative-infinity-times-negative-int
     eq. > @
       ninf.times -42
       pinf
 
-  [] +> tests-negative-infinity-plus-nan
+  ++> tests-negative-infinity-plus-nan
     eq. > @
       as-bytes.
         ninf.plus nan
       nan.as-bytes
 
-  [] +> tests-negative-infinity-plus-positive-infinity
+  ++> tests-negative-infinity-plus-positive-infinity
     eq. > @
       as-bytes.
         ninf.plus pinf
       nan.as-bytes
 
-  [] +> tests-negative-infinity-plus-negative-infinity
+  ++> tests-negative-infinity-plus-negative-infinity
     eq. > @
       ninf
       ninf.plus ninf
 
-  [] +> tests-negative-infinity-plus-positive-float
+  ++> tests-negative-infinity-plus-positive-float
     eq. > @
       ninf.plus 42.5
       ninf
 
-  [] +> tests-negative-infinity-plus-positive-int
+  ++> tests-negative-infinity-plus-positive-int
     eq. > @
       ninf.plus 42
       ninf
 
-  [] +> tests-negative-infinity-plus-negative-float
+  ++> tests-negative-infinity-plus-negative-float
     eq. > @
       ninf.plus -42.5
       ninf
 
-  [] +> tests-negative-infinity-plus-negative-int
+  ++> tests-negative-infinity-plus-negative-int
     eq. > @
       ninf.plus -42
       ninf
 
-  [] +> tests-negative-infinity-neg-is-positive-infinity
+  ++> tests-negative-infinity-neg-is-positive-infinity
     eq. > @
       ninf.neg
       pinf
 
-  [] +> tests-negative-infinity-minus-nan
+  ++> tests-negative-infinity-minus-nan
     eq. > @
       as-bytes.
         ninf.minus nan
       nan.as-bytes
 
-  [] +> tests-negative-infinity-minus-negative-infinity
+  ++> tests-negative-infinity-minus-negative-infinity
     eq. > @
       as-bytes.
         ninf.minus ninf
       nan.as-bytes
 
-  [] +> tests-negative-infinity-minus-positive-infinity
+  ++> tests-negative-infinity-minus-positive-infinity
     eq. > @
       ninf.minus pinf
       ninf
 
-  [] +> tests-negative-infinity-minus-positive-float
+  ++> tests-negative-infinity-minus-positive-float
     eq. > @
       ninf.minus 42.5
       ninf
 
-  [] +> tests-negative-infinity-minus-positive-int
+  ++> tests-negative-infinity-minus-positive-int
     eq. > @
       ninf.minus 42
       ninf
 
-  [] +> tests-negative-infinity-minus-negative-float
+  ++> tests-negative-infinity-minus-negative-float
     eq. > @
       ninf.minus -42.5
       ninf
 
-  [] +> tests-negative-infinity-minus-negative-int
+  ++> tests-negative-infinity-minus-negative-int
     eq. > @
       ninf.minus -42
       ninf
 
-  [] +> tests-negative-infinity-div-float-zero
+  ++> tests-negative-infinity-div-float-zero
     eq. > @
       ninf.div 0.0
       ninf
 
-  [] +> tests-negative-infinity-div-neg-float-zero
+  ++> tests-negative-infinity-div-neg-float-zero
     eq. > @
       ninf.div -0.0
       pinf
 
-  [] +> tests-negative-infinity-div-int-zero
+  ++> tests-negative-infinity-div-int-zero
     eq. > @
       ninf.div 0
       ninf
 
-  [] +> tests-negative-infinity-div-neg-int-zero
+  ++> tests-negative-infinity-div-neg-int-zero
     eq. > @
       ninf.div -0
       pinf
 
-  [] +> tests-negative-infinity-div-nan
+  ++> tests-negative-infinity-div-nan
     eq. > @
       as-bytes.
         ninf.div nan
       nan.as-bytes
 
-  [] +> tests-negative-infinity-div-positive-infinity
+  ++> tests-negative-infinity-div-positive-infinity
     eq. > @
       as-bytes.
         ninf.div pinf
       nan.as-bytes
 
-  [] +> tests-negative-infinity-div-negative-infinity
+  ++> tests-negative-infinity-div-negative-infinity
     eq. > @
       as-bytes.
         ninf.div ninf
       nan.as-bytes
 
-  [] +> tests-negative-infinity-div-positive-float
+  ++> tests-negative-infinity-div-positive-float
     eq. > @
       ninf.div 42.5
       ninf
 
-  [] +> tests-negative-infinity-div-positive-int
+  ++> tests-negative-infinity-div-positive-int
     eq. > @
       ninf.div 42
       ninf
 
-  [] +> tests-negative-infinity-div-negative-float
+  ++> tests-negative-infinity-div-negative-float
     eq. > @
       ninf.div -42.5
       pinf
 
-  [] +> tests-negative-infinity-div-negative-int
+  ++> tests-negative-infinity-div-negative-int
     eq. > @
       ninf.div -42
       pinf
 
-  [] +> tests-negative-infinity-as-bytes-is-valid
+  ++> tests-negative-infinity-as-bytes-is-valid
     eq. > @
       ninf.as-bytes
       (-1.0.div 0.0).as-bytes
 
-  [] +> tests-negative-infinity-floor-is-equal-to-self
+  ++> tests-negative-infinity-floor-is-equal-to-self
     ninf.floor.eq ninf > @
 
-  [] +> tests-negative-infinity-is-not-nan
+  ++> tests-negative-infinity-is-not-nan
     ninf.is-nan.not > @
 
-  [] +> tests-negative-infinity-is-not-finite
+  ++> tests-negative-infinity-is-not-finite
     ninf.is-finite.not > @
 
-  [] +> tests-negative-infinity-is-not-integer
+  ++> tests-negative-infinity-is-not-integer
     ninf.is-integer.not > @
 
-  [] +> tests-nan-not-eq-number
+  ++> tests-nan-not-eq-number
     not. > @
       eq.
         nan
         42
 
-  [] +> tests-nan-not-eq-nan
+  ++> tests-nan-not-eq-nan
     not. > @
       eq.
         nan
         nan
 
-  [] +> tests-nan-not-lt-number
+  ++> tests-nan-not-lt-number
     eq. > @
       nan.lt 42
       false
 
-  [] +> tests-nan-not-lt-nan
+  ++> tests-nan-not-lt-nan
     eq. > @
       nan.lt nan
       false
 
-  [] +> tests-nan-not-lte-number
+  ++> tests-nan-not-lte-number
     eq. > @
       nan.lte 42
       false
 
-  [] +> tests-nan-not-lte-nan
+  ++> tests-nan-not-lte-nan
     eq. > @
       nan.lte nan
       false
 
-  [] +> tests-nan-not-gt-number
+  ++> tests-nan-not-gt-number
     eq. > @
       nan.gt 42
       false
 
-  [] +> tests-nan-not-gt-nan
+  ++> tests-nan-not-gt-nan
     eq. > @
       nan.gt nan
       false
 
-  [] +> tests-nan-not-gte-number
+  ++> tests-nan-not-gte-number
     eq. > @
       nan.gte 42
       false
 
-  [] +> tests-nan-not-gte-nan
+  ++> tests-nan-not-gte-nan
     eq. > @
       nan.gte nan
       false
 
-  [] +> tests-nan-times-number-is-nan
+  ++> tests-nan-times-number-is-nan
     eq. > @
       (nan.times 42).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-times-nan-is-nan
+  ++> tests-nan-times-nan-is-nan
     eq. > @
       (nan.times nan).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-div-number-is-nan
+  ++> tests-nan-div-number-is-nan
     eq. > @
       (nan.div 42).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-div-nan-is-nan
+  ++> tests-nan-div-nan-is-nan
     eq. > @
       (nan.div nan).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-plus-number-is-nan
+  ++> tests-nan-plus-number-is-nan
     eq. > @
       (nan.plus 42).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-plus-nan-is-nan
+  ++> tests-nan-plus-nan-is-nan
     eq. > @
       (nan.plus nan).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-neg-is-nan
+  ++> tests-nan-neg-is-nan
     eq. > @
       nan.@.as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-minus-number-is-nan
+  ++> tests-nan-minus-number-is-nan
     eq. > @
       (nan.minus 42).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-minus-nan-is-nan
+  ++> tests-nan-minus-nan-is-nan
     eq. > @
       (nan.minus nan).as-bytes
       nan.as-bytes
 
-  [] +> tests-nan-as-bytes-is-bytes-of-zero-div-zero
+  ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
     eq. > @
       nan.as-bytes
       (0.0.div 0.0).as-bytes
 
-  [] +> tests-nan-floor-is-nan
+  ++> tests-nan-floor-is-nan
     eq. > @
       nan.floor.as-bytes
       nan.as-bytes
@@ -1190,10 +1190,10 @@
 
   nan.is-finite.not > [] +> nan-is-not-finite
 
-  [] +> throws-on-converting-huge-number-to-i64
+  ++> throws-on-converting-huge-number-to-i64
     1.0e30.as-i64 > @
 
-  [] +> throws-on-converting-long-max-boundary-to-i64
+  ++> throws-on-converting-long-max-boundary-to-i64
     9.223372036854776e18.as-i64 > @
 
   nan.is-integer.not > [] +> nan-is-not-integer

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -30,7 +30,7 @@
         steps.head
         steps.head
 
-  [] +> tests-seq-single-dataization-float-less
+  ++> tests-seq-single-dataization-float-less
     malloc.of > @
       1
       [b]
@@ -44,7 +44,7 @@
                   m.as-number
               1.1
 
-  [] +> tests-seq-single-dataization-float-greater
+  ++> tests-seq-single-dataization-float-greater
     malloc.of > @
       1
       [b]
@@ -58,7 +58,7 @@
                   m.as-number
               0.9
 
-  [] +> tests-seq-single-dataization-int-less
+  ++> tests-seq-single-dataization-int-less
     malloc.of > @
       1
       [b]
@@ -72,7 +72,7 @@
                   m.as-number
               2
 
-  [] +> tests-seq-single-dataization-int-less-or-equal
+  ++> tests-seq-single-dataization-int-less-or-equal
     malloc.of > @
       1
       [b]
@@ -86,7 +86,7 @@
                   m.as-number
               1
 
-  [] +> tests-very-long-seq
+  ++> tests-very-long-seq
     eq. > @
       true
       seq
@@ -134,7 +134,7 @@
           true
           true
 
-  [] +> tests-seq-single-dataization-int-equal-to-test
+  ++> tests-seq-single-dataization-int-equal-to-test
     malloc.of > @
       1
       [b]
@@ -149,7 +149,7 @@
                   m.as-number
               1
 
-  [] +> tests-seq-single-dataization-int-equal-to-cache-problem-test
+  ++> tests-seq-single-dataization-int-equal-to-cache-problem-test
     malloc.of > @
       1
       [b]
@@ -166,7 +166,7 @@
                   m
               1
 
-  [] +> tests-seq-calculates-and-returns
+  ++> tests-seq-calculates-and-returns
     eq. > @
       1
       seq
@@ -174,7 +174,7 @@
           0
           1
 
-  [] +> tests-seq-calculates-and-returns-object
+  ++> tests-seq-calculates-and-returns-object
     eq. > @
       "Hello!"
       seq

--- a/eo-runtime/src/main/eo/sm/os.eo
+++ b/eo-runtime/src/main/eo/sm/os.eo
@@ -24,7 +24,7 @@
 
   [] > name /string
 
-  [] +> tests-checks-os-family
+  ++> tests-checks-os-family
     or. > @
       or.
         os.is-windows

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -57,7 +57,7 @@
         sin-addr.size
       sin-zero.size
 
-  [] +> tests-invokes-getpid-correctly
+  ++> tests-invokes-getpid-correctly
     or. > @
       os.is-windows
       gt.
@@ -67,7 +67,7 @@
             tuple.empty
         0
 
-  [] +> tests-opens-and-closes-file-via-syscall
+  ++> tests-opens-and-closes-file-via-syscall
     or. > @
       os.is-windows
       seq
@@ -82,7 +82,7 @@
         "open"
         * "/dev/null" 0 0
 
-  [] +> tests-opens-posix-tcp-socket
+  ++> tests-opens-posix-tcp-socket
     or. > @
       os.is-windows
       seq
@@ -97,7 +97,7 @@
         "socket"
         * posix.af-inet posix.sock-stream posix.ipproto-tcp
 
-  [] +> tests-closes-posix-tcp-socket
+  ++> tests-closes-posix-tcp-socket
     or. > @
       os.is-windows
       seq
@@ -115,7 +115,7 @@
         "socket"
         * posix.af-inet posix.sock-stream posix.ipproto-tcp
 
-  [] +> tests-returns-valid-posix-inet-addr-for-localhost
+  ++> tests-returns-valid-posix-inet-addr-for-localhost
     or. > @
       os.is-windows
       (code. (posix "inet_addr" (* "127.0.0.1"))).eq 16777343

--- a/eo-runtime/src/main/eo/sm/system-clock.eo
+++ b/eo-runtime/src/main/eo/sm/system-clock.eo
@@ -23,5 +23,5 @@
           timeval.tv-usec.as-i64.div 1000.as-i64
   (posix "gettimeofday" *).output > timeval
 
-  [] +> tests-reads-positive-millis
+  ++> tests-reads-positive-millis
     system-clock.gt 0 > @

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -53,7 +53,7 @@
         sin-addr.size
       sin-zero.size
 
-  [] +> tests-returns-valid-win32-inet-addr-for-localhost
+  ++> tests-returns-valid-win32-inet-addr-for-localhost
     or. > @
       os.is-windows.not
       (code. (win32 "inet_addr" (* "127.0.0.1"))).eq 16777343

--- a/eo-runtime/src/main/eo/ss/back.eo
+++ b/eo-runtime/src/main/eo/ss/back.eo
@@ -25,7 +25,7 @@
   index > idx!
   lst.length.minus idx > start!
 
-  [] +> tests-simple-back
+  ++> tests-simple-back
     eq. > @
       back
         list
@@ -33,14 +33,14 @@
         2
       * 4 5
 
-  [] +> tests-zero-index-in-back
+  ++> tests-zero-index-in-back
     is-empty. > @
       back
         list
           * 1 2 3 4 5
         0
 
-  [] +> tests-large-index-in-back
+  ++> tests-large-index-in-back
     eq. > @
       back
         list

--- a/eo-runtime/src/main/eo/ss/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/ss/bytes-as-array.eo
@@ -24,21 +24,21 @@
         (index.plus 1).as-number
       tup
 
-  [] +> tests-converts-bytes-to-array
+  ++> tests-converts-bytes-to-array
     eq. > @
       list
         bytes-as-array
           20-1F-EE-B5-FF
       * 20- 1F- EE- B5- FF-
 
-  [] +> tests-single-byte-to-array
+  ++> tests-single-byte-to-array
     eq. > @
       list
         bytes-as-array
           1F-
       * 1F-
 
-  [] +> tests-zero-bytes-to-array
+  ++> tests-zero-bytes-to-array
     eq. > @
       list
         bytes-as-array

--- a/eo-runtime/src/main/eo/ss/contains.eo
+++ b/eo-runtime/src/main/eo/ss/contains.eo
@@ -15,19 +15,19 @@
       -1
       index-of lst element
 
-  [] +> tests-list-contains-string
+  ++> tests-list-contains-string
     contains > @
       list
         * "qwerty" "asdfgh" 3 "qwerty"
       "qwerty"
 
-  [] +> tests-list-contains-number
+  ++> tests-list-contains-number
     contains > @
       list
         * "qwerty" "asdfgh" 3 "qwerty"
       3
 
-  [] +> tests-list-does-not-contain
+  ++> tests-list-does-not-contain
     not. > @
       contains
         list

--- a/eo-runtime/src/main/eo/ss/eachi.eo
+++ b/eo-runtime/src/main/eo/ss/eachi.eo
@@ -22,7 +22,7 @@
         acc
         func item index
 
-  [] +> tests-iterates-with-eachi
+  ++> tests-iterates-with-eachi
     eq. > @
       malloc.for
         0

--- a/eo-runtime/src/main/eo/ss/filtered.eo
+++ b/eo-runtime/src/main/eo/ss/filtered.eo
@@ -18,7 +18,7 @@
     lst
     func item > [item index] >>
 
-  [] +> tests-simple-filtered
+  ++> tests-simple-filtered
     eq. > @
       filtered
         list
@@ -26,7 +26,7 @@
         v.gt 2 > [v]
       * 3 4 5
 
-  [] +> tests-filtered-with-bools
+  ++> tests-filtered-with-bools
     eq. > @
       filtered
         list

--- a/eo-runtime/src/main/eo/ss/filteredi.eo
+++ b/eo-runtime/src/main/eo/ss/filteredi.eo
@@ -27,7 +27,7 @@
         next
     recfilter tup.tail > next
 
-  [] +> tests-filteredi-with-lt
+  ++> tests-filteredi-with-lt
     eq. > @
       filteredi
         list
@@ -35,7 +35,7 @@
         v.lt 3 > [v i]
       * 1 2
 
-  [] +> tests-filteredi-with-string-length
+  ++> tests-filteredi-with-string-length
     eq. > @
       filteredi
         list
@@ -43,14 +43,14 @@
         v.length.gt 4 > [v i]
       * "Hello"
 
-  [] +> tests-filteredi-with-empty-list
+  ++> tests-filteredi-with-empty-list
     is-empty. > @
       filteredi
         list
           *
         v.lt 3 > [v i]
 
-  [] +> tests-filteredi-by-index
+  ++> tests-filteredi-by-index
     eq. > @
       filteredi
         list
@@ -58,7 +58,7 @@
         i.gt 0 > [v i]
       * 1 4
 
-  [] +> tests-filteredi-with-bools
+  ++> tests-filteredi-with-bools
     eq. > @
       filteredi
         list

--- a/eo-runtime/src/main/eo/ss/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/ss/hash-code-of.eo
@@ -29,12 +29,12 @@
               bts.slice index 1
         (index.plus 1).as-number
 
-  [] +> tests-hash-code-of-bools-is-number
+  ++> tests-hash-code-of-bools-is-number
     and. > @
       (hash-code-of true).as-bytes.size.eq 8
       (hash-code-of false).as-bytes.size.eq 8
 
-  [] +> tests-hash-code-of-int-is-int
+  ++> tests-hash-code-of-int-is-int
     eq. > @
       1
       div.
@@ -42,30 +42,30 @@
         number hash
     hash-code-of 42 > hash!
 
-  [] +> tests-hash-codes-of-the-same-nums-are-equal
+  ++> tests-hash-codes-of-the-same-nums-are-equal
     eq. > @
       hash-code-of num
       hash-code-of num
     123456789012345678 > num
 
-  [] +> tests-hash-codes-of-the-same-ints-are-equal
+  ++> tests-hash-codes-of-the-same-ints-are-equal
     eq. > @
       hash-code-of 42
       hash-code-of 42
 
-  [] +> tests-hash-codes-of-different-ints-are-not-equal
+  ++> tests-hash-codes-of-different-ints-are-not-equal
     not. > @
       eq.
         hash-code-of 42
         hash-code-of 24
 
-  [] +> tests-hash-codes-of-different-sign-ints-are-not-equal
+  ++> tests-hash-codes-of-different-sign-ints-are-not-equal
     not. > @
       eq.
         hash-code-of 42
         hash-code-of -42
 
-  [] +> tests-hash-code-of-string-is-int
+  ++> tests-hash-code-of-string-is-int
     eq. > @
       1
       div.
@@ -73,24 +73,24 @@
         number strhash
     hash-code-of "hello" > strhash!
 
-  [] +> tests-hash-codes-of-the-same-strings-are-equal
+  ++> tests-hash-codes-of-the-same-strings-are-equal
     eq. > @
       hash-code-of "Hello"
       hash-code-of "Hello"
 
-  [] +> tests-hash-codes-of-same-length-strings-are-not-equal
+  ++> tests-hash-codes-of-same-length-strings-are-not-equal
     not. > @
       eq.
         hash-code-of "one"
         hash-code-of "two"
 
-  [] +> tests-hash-codes-of-different-strings-are-not-equal
+  ++> tests-hash-codes-of-different-strings-are-not-equal
     not. > @
       eq.
         hash-code-of "hello"
         hash-code-of "bye!!!"
 
-  [] +> tests-hash-code-of-abstract-object-is-int
+  ++> tests-hash-code-of-abstract-object-is-int
     eq. > @
       1
       div.
@@ -100,7 +100,7 @@
       x > @
     hash-code-of (obj 42) > objhash!
 
-  [] +> tests-hash-codes-of-the-same-abstract-objects-are-equal
+  ++> tests-hash-codes-of-the-same-abstract-objects-are-equal
     eq. > @
       hash-code-of val
       hash-code-of val
@@ -108,7 +108,7 @@
       x > @
     obj 42 > val
 
-  [] +> tests-hash-codes-of-different-abstract-objects-are-not-equal
+  ++> tests-hash-codes-of-different-abstract-objects-are-not-equal
     not. > @
       eq.
         hash-code-of (obj 42)
@@ -116,7 +116,7 @@
     [x] > obj
       x > @
 
-  [] +> tests-hash-code-of-float-is-int
+  ++> tests-hash-code-of-float-is-int
     eq. > @
       1
       div.
@@ -124,25 +124,25 @@
         number flthash
     hash-code-of 42.42 > flthash!
 
-  [] +> tests-hash-codes-of-the-same-floats-are-equal
+  ++> tests-hash-codes-of-the-same-floats-are-equal
     eq. > @
       hash-code-of emergency
       hash-code-of emergency
     0.911 > emergency
 
-  [] +> tests-hash-codes-of-the-same-bigvals-are-equal
+  ++> tests-hash-codes-of-the-same-bigvals-are-equal
     eq. > @
       hash-code-of bigval
       hash-code-of bigval
     42.42e42 > bigval!
 
-  [] +> tests-hash-codes-of-different-floats-are-not-equal
+  ++> tests-hash-codes-of-different-floats-are-not-equal
     not. > @
       eq.
         hash-code-of 3.14
         hash-code-of 2.72
 
-  [] +> tests-hash-codes-of-different-sign-floats-are-not-equal
+  ++> tests-hash-codes-of-different-sign-floats-are-not-equal
     not. > @
       eq.
         hash-code-of 3.22

--- a/eo-runtime/src/main/eo/ss/index-of.eo
+++ b/eo-runtime/src/main/eo/ss/index-of.eo
@@ -26,7 +26,7 @@
         next
     recidx tup.tail > next!
 
-  [] +> tests-returns-index-of
+  ++> tests-returns-index-of
     eq. > @
       1
       index-of
@@ -34,7 +34,7 @@
           * 1 2 3
         2
 
-  [] +> tests-returns-first-index-of-element
+  ++> tests-returns-first-index-of-element
     eq. > @
       0
       index-of
@@ -42,7 +42,7 @@
           * -1 2 -1
         -1
 
-  [] +> tests-does-not-find-index-of
+  ++> tests-does-not-find-index-of
     eq. > @
       -1
       index-of
@@ -50,7 +50,7 @@
           * "qwerty" 2 3
         7
 
-  [] +> tests-finds-index-of-string
+  ++> tests-finds-index-of-string
     eq. > @
       1
       index-of

--- a/eo-runtime/src/main/eo/ss/last-index-of.eo
+++ b/eo-runtime/src/main/eo/ss/last-index-of.eo
@@ -21,7 +21,7 @@
         tup.tail.length
         reclast tup.tail
 
-  [] +> tests-finds-last-index-of
+  ++> tests-finds-last-index-of
     eq. > @
       1
       last-index-of
@@ -29,7 +29,7 @@
           * "qwerty" 2 3
         2
 
-  [] +> tests-finds-last-index-of-repeated
+  ++> tests-finds-last-index-of-repeated
     eq. > @
       2
       last-index-of
@@ -37,7 +37,7 @@
           * 24 42 24
         24
 
-  [] +> tests-last-index-of-not-found
+  ++> tests-last-index-of-not-found
     eq. > @
       -1
       last-index-of
@@ -45,14 +45,14 @@
           * 1 2 3
         0
 
-  [] +> tests-last-index-of-empty
+  ++> tests-last-index-of-empty
     eq. > @
       -1
       last-index-of
         list *
         "abc"
 
-  [] +> tests-last-index-of-unicode
+  ++> tests-last-index-of-unicode
     eq. > @
       3
       last-index-of

--- a/eo-runtime/src/main/eo/ss/list.eo
+++ b/eo-runtime/src/main/eo/ss/list.eo
@@ -131,7 +131,7 @@
       shift
       origin.length
 
-  [] +> tests-list-should-not-be-empty
+  ++> tests-list-should-not-be-empty
     not. > @
       is-empty.
         list
@@ -139,19 +139,19 @@
 
   (list *).is-empty > [] +> list-should-be-empty
 
-  [] +> tests-list-should-not-be-empty-with-three-objects
+  ++> tests-list-should-not-be-empty-with-three-objects
     (list xs).is-empty.not > @
     * > xs
       [x]
       [y]
       [z]
 
-  [] +> tests-list-should-not-be-empty-with-one-anon-object
+  ++> tests-list-should-not-be-empty-with-one-anon-object
     (list xs).is-empty.not > @
     * > xs
       [f]
 
-  [] +> tests-list-simple-with
+  ++> tests-list-simple-with
     eq. > @
       with.
         list
@@ -159,7 +159,7 @@
         3
       * 1 2 3
 
-  [] +> tests-simple-insert
+  ++> tests-simple-insert
     eq. > @
       withi.
         list
@@ -168,7 +168,7 @@
         "hello"
       * 1 2 3 "hello" 4 5
 
-  [] +> tests-insert-with-zero-index
+  ++> tests-insert-with-zero-index
     eq. > @
       withi.
         list
@@ -177,7 +177,7 @@
         "hello"
       * "hello" 1 2 3 4 5
 
-  [] +> tests-complex-objects-list-comparison
+  ++> tests-complex-objects-list-comparison
     list
       *
         list (* 0 1)
@@ -189,7 +189,7 @@
         * 4 0
         * 7 3
 
-  [] +> tests-iterates-with-each
+  ++> tests-iterates-with-each
     eq. > @
       malloc.for
         0
@@ -200,20 +200,20 @@
             ^.m.put (^.m.as-number.plus i) > [i] >>
       6
 
-  [] +> tests-equality-test
+  ++> tests-equality-test
     eq. > @
       list
         * 1 2 3
       * 1 2 3
 
-  [] +> tests-not-equality-test
+  ++> tests-not-equality-test
     not. > @
       eq.
         list
           * 1 2 3
         * 3 2 1
 
-  [] +> tests-concatenates-lists
+  ++> tests-concatenates-lists
     and. > @
       eq.
         1
@@ -227,7 +227,7 @@
         list (* 2 3)
       0
 
-  [] +> tests-concatenates-with-tuple
+  ++> tests-concatenates-with-tuple
     eq. > @
       concat.
         list
@@ -235,7 +235,7 @@
         * 2 4
       * 0 1 2 4
 
-  [] +> tests-simple-front
+  ++> tests-simple-front
     eq. > @
       front.
         list
@@ -243,14 +243,14 @@
         1
       * 1
 
-  [] +> tests-list-front-with-zero-index
+  ++> tests-list-front-with-zero-index
     is-empty. > @
       front.
         list
           * 1 2 3
         0
 
-  [] +> tests-list-front-with-length-index
+  ++> tests-list-front-with-length-index
     eq. > @
       front.
         list
@@ -258,7 +258,7 @@
         3
       * 1 2 3
 
-  [] +> tests-complex-front
+  ++> tests-complex-front
     eq. > @
       front.
         list
@@ -266,7 +266,7 @@
         2
       * "foo" 2.2
 
-  [] +> tests-front-with-negative
+  ++> tests-front-with-negative
     eq. > @
       front.
         list
@@ -274,7 +274,7 @@
         -1
       * 3
 
-  [] +> tests-complex-front-with-negative
+  ++> tests-complex-front-with-negative
     eq. > @
       front.
         list
@@ -282,7 +282,7 @@
         -3
       * 2.2 00-01 "bar"
 
-  [] +> tests-simple-slice
+  ++> tests-simple-slice
     eq. > @
       slice.
         list
@@ -291,7 +291,7 @@
         5
       * 2 3 4 5
 
-  [] +> tests-slice-with-negative-start
+  ++> tests-slice-with-negative-start
     eq. > @
       slice.
         list
@@ -300,7 +300,7 @@
         6
       * 0 3 8
 
-  [] +> tests-slice-with-negative-end
+  ++> tests-slice-with-negative-end
     eq. > @
       slice.
         list
@@ -309,7 +309,7 @@
         -1
       * "a" 2 3.0 "xyz" 82.42
 
-  [] +> tests-slice-with-negative-start-and-end
+  ++> tests-slice-with-negative-start-and-end
     eq. > @
       slice.
         list
@@ -318,7 +318,7 @@
         -1
       * 23 0 0
 
-  [] +> tests-slice-with-end-gt-length
+  ++> tests-slice-with-end-gt-length
     eq. > @
       slice.
         list
@@ -327,7 +327,7 @@
         10
       * "bar" "buzz"
 
-  [] +> tests-slice-with-start-lt-negative-length
+  ++> tests-slice-with-start-lt-negative-length
     eq. > @
       slice.
         list
@@ -336,7 +336,7 @@
         3
       * 9 99 999
 
-  [] +> tests-slice-with-end-lt-negative-length
+  ++> tests-slice-with-end-lt-negative-length
     eq. > @
       slice.
         list
@@ -345,7 +345,7 @@
         -9
       list *
 
-  [] +> tests-slice-with-start-gte-end-both-positive
+  ++> tests-slice-with-start-gte-end-both-positive
     eq. > @
       slice.
         list
@@ -354,7 +354,7 @@
         0
       list *
 
-  [] +> tests-slice-with-start-gte-end-both-negative
+  ++> tests-slice-with-start-gte-end-both-negative
     eq. > @
       slice.
         list
@@ -363,7 +363,7 @@
         -5
       list *
 
-  [] +> tests-slice-with-negative-start-gte-end
+  ++> tests-slice-with-negative-start-gte-end
     eq. > @
       slice.
         list
@@ -372,7 +372,7 @@
         3
       list *
 
-  [] +> tests-slice-with-start-gte-negative-end
+  ++> tests-slice-with-start-gte-negative-end
     eq. > @
       slice.
         list
@@ -381,7 +381,7 @@
         -5
       list *
 
-  [] +> tests-shifted-with-shift-less-than-length
+  ++> tests-shifted-with-shift-less-than-length
     eq. > @
       shifted.
         list
@@ -389,7 +389,7 @@
         2
       * 3 4 5
 
-  [] +> tests-shifted-with-shift-greater-than-length
+  ++> tests-shifted-with-shift-greater-than-length
     eq. > @
       shifted.
         list

--- a/eo-runtime/src/main/eo/ss/map.eo
+++ b/eo-runtime/src/main/eo/ss/map.eo
@@ -106,7 +106,7 @@
             (hash.eq entry.hash).not > [entry] >>
       hash-code-of key > hash!
 
-  [] +> tests-map-rebuilds-itself
+  ++> tests-map-rebuilds-itself
     2.eq mp.size > @
     map > mp
       *
@@ -115,7 +115,7 @@
         map.entry 2 1
         map.entry 2 1
 
-  [] +> tests-map-rebuilds-itself-only-once
+  ++> tests-map-rebuilds-itself-only-once
     eq. > @
       1
       malloc.for
@@ -132,7 +132,7 @@
                 m.put (m.as-number.plus 1)
                 1
 
-  [] +> tests-returns-list-of-keys
+  ++> tests-returns-list-of-keys
     eq. > @
       keys.
         map
@@ -142,7 +142,7 @@
             map.entry 3 4
       * 1 2 3
 
-  [] +> tests-returns-list-of-values
+  ++> tests-returns-list-of-values
     eq. > @
       values.
         map
@@ -152,7 +152,7 @@
             map.entry 3 4
       * 2 3 4
 
-  [] +> tests-finds-element-by-key-in-map
+  ++> tests-finds-element-by-key-in-map
     2.eq found.get > @
     mp.found "two" > found
     map > mp
@@ -161,7 +161,7 @@
         map.entry "two" 2
         map.entry "three" 3
 
-  [] +> tests-does-not-find-element-by-key-in-hash-map
+  ++> tests-does-not-find-element-by-key-in-hash-map
     not. > @
       exists.
         found.
@@ -171,7 +171,7 @@
               map.entry "two" 2
           "three"
 
-  [] +> tests-has-element-with-key-in-hash-map
+  ++> tests-has-element-with-key-in-hash-map
     has. > @
       map
         *
@@ -179,7 +179,7 @@
           map.entry "two" 2
       "two"
 
-  [] +> tests-does-not-have-element-by-key-in-hash-map
+  ++> tests-does-not-have-element-by-key-in-hash-map
     not. > @
       has.
         map
@@ -188,7 +188,7 @@
             map.entry "two" 2
         "three"
 
-  [] +> tests-does-not-change-map-without-non-existed-element
+  ++> tests-does-not-change-map-without-non-existed-element
     eq. > @
       size.
         without.
@@ -198,7 +198,7 @@
           "two"
       1
 
-  [] +> tests-removes-element-from-map-by-key
+  ++> tests-removes-element-from-map-by-key
     and. > @
       1.eq mp.size
       (mp.has "one").not
@@ -208,7 +208,7 @@
         map.entry "two" 2
     .without "one" > mp
 
-  [] +> tests-adds-new-pair-to-hash-map
+  ++> tests-adds-new-pair-to-hash-map
     and. > @
       2.eq mp.size
       mp.has "two"
@@ -217,7 +217,7 @@
         map.entry "one" 1
     .with "two" 2 > mp
 
-  [] +> tests-replaces-value-if-pair-with-key-exists-in-map
+  ++> tests-replaces-value-if-pair-with-key-exists-in-map
     and. > @
       2.eq mp.size
       3.eq (mp.found "two").get
@@ -227,7 +227,7 @@
         map.entry "two" 2
     .with "two" 3 > mp
 
-  [] +> tests-map-get-missing-returns-provided-fallback
+  ++> tests-map-get-missing-returns-provided-fallback
     eq. > @
       "recovered"
       (mp.found "absent").get
@@ -236,7 +236,7 @@
       *
         map.entry "one" 1
 
-  [] +> throws-on-map-get-missing-without-fallback
+  ++> throws-on-map-get-missing-without-fallback
     (mp.found "absent").get > @
     map > mp
       *

--- a/eo-runtime/src/main/eo/ss/mapped.eo
+++ b/eo-runtime/src/main/eo/ss/mapped.eo
@@ -16,7 +16,7 @@
     lst
     func item > [item idx] >>
 
-  [] +> tests-simple-list-mapping
+  ++> tests-simple-list-mapping
     eq. > @
       mapped
         list

--- a/eo-runtime/src/main/eo/ss/mappedi.eo
+++ b/eo-runtime/src/main/eo/ss/mappedi.eo
@@ -21,7 +21,7 @@
         accum.with > @
           func item idx
 
-  [] +> tests-list-mappedi-should-work
+  ++> tests-list-mappedi-should-work
     eq. > @
       mappedi
         list

--- a/eo-runtime/src/main/eo/ss/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/ss/range-of-numbers.eo
@@ -25,29 +25,29 @@
       end
     T "Some of the arguments are not integers"
 
-  [] +> tests-simple-range-of-numbers-from-one-to-ten
+  ++> tests-simple-range-of-numbers-from-one-to-ten
     eq. > @
       range-of-numbers 1 10
       * 1 2 3 4 5 6 7 8 9
 
-  [] +> tests-range-of-numbers-from-ten-to-ten-is-empty
+  ++> tests-range-of-numbers-from-ten-to-ten-is-empty
     is-empty. > @
       range-of-numbers 10 10
 
-  [] +> tests-range-of-descending-numbers-is-empty
+  ++> tests-range-of-descending-numbers-is-empty
     is-empty. > @
       range-of-numbers 10 1
 
-  [] +> tests-range-of-negative-numbers-works-as-well
+  ++> tests-range-of-negative-numbers-works-as-well
     eq. > @
       range-of-numbers -5 0
       * -5 -4 -3 -2 -1
 
-  [] +> throws-on-range-of-numbers-with-non-number-start
+  ++> throws-on-range-of-numbers-with-non-number-start
     range-of-numbers 1.2 3 > @
 
-  [] +> throws-on-range-of-numbers-with-not-number-end
+  ++> throws-on-range-of-numbers-with-not-number-end
     range-of-numbers 1 2.5 > @
 
-  [] +> throws-on-range-of-not-numbers
+  ++> throws-on-range-of-not-numbers
     range-of-numbers 1.5 5.2 > @

--- a/eo-runtime/src/main/eo/ss/range.eo
+++ b/eo-runtime/src/main/eo/ss/range.eo
@@ -46,7 +46,7 @@
         current.next
       acc
 
-  [] +> tests-simple-range-from-one-to-ten
+  ++> tests-simple-range-from-one-to-ten
     eq. > @
       rng
       * 1 2 3 4 5 6 7 8 9
@@ -58,7 +58,7 @@
           ^.build (1.plus @) > next
       10
 
-  [] +> tests-simple-range-with-floats-from-one-to-five
+  ++> tests-simple-range-with-floats-from-one-to-five
     eq. > @
       rng
       * 1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5
@@ -70,7 +70,7 @@
           ^.x (0.5.plus @) > next
       5.0
 
-  [] +> tests-range-with-out-of-bounds
+  ++> tests-range-with-out-of-bounds
     eq. > @
       rng
       * 1 6
@@ -82,7 +82,7 @@
           ^.b (5.plus @) > next
       10
 
-  [] +> tests-range-with-wrong-items-is-an-empty-array
+  ++> tests-range-with-wrong-items-is-an-empty-array
     rng.is-empty > @
     range > rng
       []

--- a/eo-runtime/src/main/eo/ss/reduced.eo
+++ b/eo-runtime/src/main/eo/ss/reduced.eo
@@ -19,7 +19,7 @@
     start
     func accum item > [accum item idx] >>
 
-  [] +> tests-list-reduce-without-index
+  ++> tests-list-reduce-without-index
     eq. > @
       reduced
         list
@@ -28,7 +28,7 @@
         a.times x > [a x]
       -24
 
-  [] +> tests-list-reduced-printing
+  ++> tests-list-reduced-printing
     eq. > @
       reduced
         list

--- a/eo-runtime/src/main/eo/ss/reducedi.eo
+++ b/eo-runtime/src/main/eo/ss/reducedi.eo
@@ -30,7 +30,7 @@
         tup.head
         tup.tail.length
 
-  [] +> tests-reduce-list-with-index
+  ++> tests-reduce-list-with-index
     eq. > @
       6
       reducedi
@@ -43,7 +43,7 @@
             a.plus
               (* 2 2).at i
 
-  [] +> tests-list-reducedi-long-int-array
+  ++> tests-list-reducedi-long-int-array
     eq. > @
       reducedi
         list
@@ -52,7 +52,7 @@
         x.plus a > [a x i]
       1
 
-  [] +> tests-list-reducedi-bools-array
+  ++> tests-list-reducedi-bools-array
     not. > @
       reducedi
         list
@@ -60,7 +60,7 @@
         true
         x.and a > [a x i]
 
-  [] +> tests-list-reducedi-nested-functions
+  ++> tests-list-reducedi-nested-functions
     eq. > @
       reducedi
         list

--- a/eo-runtime/src/main/eo/ss/set.eo
+++ b/eo-runtime/src/main/eo/ss/set.eo
@@ -33,13 +33,13 @@
 
     mp.has item > [item] > has
 
-  [] +> tests-set-rebuilds-itself
+  ++> tests-set-rebuilds-itself
     eq. > @
       set
         * 1 2 2
       * 1 2
 
-  [] +> tests-does-not-append-existed-item-to-set
+  ++> tests-does-not-append-existed-item-to-set
     eq. > @
       size.
         with.
@@ -48,7 +48,7 @@
           1
       2
 
-  [] +> tests-appends-new-item-to-set
+  ++> tests-appends-new-item-to-set
     has. > @
       with.
         set
@@ -56,7 +56,7 @@
         3
       3
 
-  [] +> tests-empty-set-has-size-of-zero
+  ++> tests-empty-set-has-size-of-zero
     set
       *
     .size

--- a/eo-runtime/src/main/eo/ss/without.eo
+++ b/eo-runtime/src/main/eo/ss/without.eo
@@ -20,7 +20,7 @@
           accum
           accum.with item
 
-  [] +> tests-list-without
+  ++> tests-list-without
     eq. > @
       without
         list

--- a/eo-runtime/src/main/eo/ss/withouti.eo
+++ b/eo-runtime/src/main/eo/ss/withouti.eo
@@ -20,7 +20,7 @@
           accum
           accum.with item
 
-  [] +> tests-list-withouti
+  ++> tests-list-withouti
     eq. > @
       withouti
         list
@@ -28,7 +28,7 @@
         1
       * 1 3
 
-  [] +> tests-list-withouti-complex-case
+  ++> tests-list-withouti-complex-case
     eq. > @
       foo
         * 1 "text" "f"
@@ -38,7 +38,7 @@
         list a
         0
 
-  [] +> tests-list-withouti-nested-array
+  ++> tests-list-withouti-nested-array
     eq. > @
       withouti
         list

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -159,78 +159,78 @@
                       * byte
       as-bytes.slice index 1 > byte
 
-  [] +> tests-calculates-length-of-spaces-only
+  ++> tests-calculates-length-of-spaces-only
     eq. > @
       " ".length
       1
 
-  [] +> tests-turns-string-into-bytes
+  ++> tests-turns-string-into-bytes
     eq. > @
       "€ друг".as-bytes
       E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
 
-  [] +> tests-bytes-equal-to-string
+  ++> tests-bytes-equal-to-string
     eq. > @
       D0-B4-D1-80-D1-83-D0-B3
       "друг"
 
-  [] +> tests-string-equals-to-bytes
+  ++> tests-string-equals-to-bytes
     eq. > @
       "друг"
       D0-B4-D1-80-D1-83-D0-B3
 
-  [] +> tests-reads-the-length-with-n2-byte-characters
+  ++> tests-reads-the-length-with-n2-byte-characters
     and. > @
       str.length.eq 12
       str.as-bytes.size.eq 16
     "Hello, друг!" > str
 
-  [] +> tests-reads-the-length-with-n3-byte-characters
+  ++> tests-reads-the-length-with-n3-byte-characters
     and. > @
       str.length.eq 16
       str.as-bytes.size.eq 18
     "The अ devanagari" > str
 
-  [] +> tests-reads-the-length-with-n4-byte-characters
+  ++> tests-reads-the-length-with-n4-byte-characters
     and. > @
       str.length.eq 11
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
 
-  [] +> throws-on-taking-length-of-incomplete-n4-byte-character
+  ++> throws-on-taking-length-of-incomplete-n4-byte-character
     (string F0-9F-98).length > @
 
-  [] +> tests-compares-two-different-string-types
+  ++> tests-compares-two-different-string-types
     not. > @
       eq.
         "Hello"
         42
 
-  [] +> tests-compares-string-with-nan
+  ++> tests-compares-string-with-nan
     not. > @
       eq.
         nan
         "друг"
 
-  [] +> tests-compares-string-with-positive-infinity
+  ++> tests-compares-string-with-positive-infinity
     eq. > @
       pinf.eq "друг"
       false
 
-  [] +> tests-compares-string-with-negative-infinity
+  ++> tests-compares-string-with-negative-infinity
     not. > @
       eq.
         ninf
         "друг"
 
-  [] +> tests-text-block-one-line
+  ++> tests-text-block-one-line
     eq. > @
       """
       Abc
       """
       "Abc"
 
-  [] +> tests-text-block-tree-lines
+  ++> tests-text-block-tree-lines
     eq. > @
       """
       e
@@ -239,7 +239,7 @@
       """.as-bytes
       65-0A-65-0A-65
 
-  [] +> tests-text-block-with-margin
+  ++> tests-text-block-with-margin
     eq. > @
       """
        z
@@ -248,25 +248,25 @@
       """.as-bytes
       7A-0A-20-20-79-0A-20-78
 
-  [] +> tests-compares-two-different-strings
+  ++> tests-compares-two-different-strings
     not. > @
       eq.
         "Hello"
         "Good bye"
 
-  [] +> tests-supports-escape-sequences
+  ++> tests-supports-escape-sequences
     eq. > @
       "Hello, \u0434\u0440\u0443\u0433!\n"
       "Hello, друг!\n"
 
-  [] +> tests-supports-escape-sequences-in-text
+  ++> tests-supports-escape-sequences-in-text
     eq. > @
       """
       Hello, \u0434\u0440\u0443\u0433!\n
       """
       "Hello, друг!\n"
 
-  [] +> tests-preserves-indentation-in-text
+  ++> tests-preserves-indentation-in-text
     eq. > @
       """
       a
@@ -275,113 +275,113 @@
       """
       "a\n b\n  c"
 
-  [] +> tests-compares-two-strings
+  ++> tests-compares-two-strings
     eq. > @
       eq.
         "x"
         "x"
       true
 
-  [] +> tests-one-symbol-string-compares
+  ++> tests-one-symbol-string-compares
     eq. > @
       "Ф"
       "Ф"
 
-  [] +> tests-supports-escape-sequences-line-break
+  ++> tests-supports-escape-sequences-line-break
     eq. > @
       "\n"
       "\012"
 
-  [] +> tests-supports-escape-sequences-unicode
+  ++> tests-supports-escape-sequences-unicode
     eq. > @
       "\u0424"
       "Ф"
 
-  [] +> tests-slice-from-start
+  ++> tests-slice-from-start
     eq. > @
       "hello".slice 0 1
       "h"
 
-  [] +> tests-slice-in-the-middle
+  ++> tests-slice-in-the-middle
     eq. > @
       "hello".slice 2 3
       "llo"
 
-  [] +> tests-slice-from-the-end
+  ++> tests-slice-from-the-end
     eq. > @
       "hello".slice 4 1
       "o"
 
-  [] +> tests-slice-empty-string
+  ++> tests-slice-empty-string
     eq. > @
       "".slice 0 0
       ""
 
-  [] +> tests-no-slice-string
+  ++> tests-no-slice-string
     eq. > @
       "no slice".slice 0 0
       ""
 
-  [] +> tests-slice-escape-sequences-line-break
+  ++> tests-slice-escape-sequences-line-break
     eq. > @
       "\n".slice
         0
         "\n".length
       "\012"
 
-  [] +> tests-slice-escape-sequences-unicode
+  ++> tests-slice-escape-sequences-unicode
     eq. > @
       "\u0424".slice
         0
         "\u0424".length
       "Ф"
 
-  [] +> tests-slice-with-n2-byte-characters
+  ++> tests-slice-with-n2-byte-characters
     eq. > @
       "привет".slice 1 2
       "ри"
 
-  [] +> tests-slice-with-n3-byte-characters
+  ++> tests-slice-with-n3-byte-characters
     eq. > @
       "The अ is अ".slice 1 6
       "he अ i"
 
-  [] +> tests-slice-with-n4-byte-characters
+  ++> tests-slice-with-n4-byte-characters
     eq. > @
       "One 😀 and 😀 another".slice 3 8
       " 😀 and 😀"
 
-  [] +> tests-slice-foreign-literals
+  ++> tests-slice-foreign-literals
     eq. > @
       "hello, 大家!".slice
         7
         1
       "大"
 
-  [] +> throws-on-slicing-start-below-zero
+  ++> throws-on-slicing-start-below-zero
     slice. > @
       "some string"
       -1
       1
 
-  [] +> throws-on-slicing-end-below-start
+  ++> throws-on-slicing-end-below-start
     slice. > @
       "some string"
       2
       -1
 
-  [] +> throws-on-slicing-end-greater-actual
+  ++> throws-on-slicing-end-greater-actual
     slice. > @
       "some string"
       7
       5
 
-  [] +> tests-unescapes-slashes
+  ++> tests-unescapes-slashes
     eq. > @
       "x\\b\\f\\u\\r\\t\\n\\'"
       78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
-  [] +> tests-unescapes-symbols
+  ++> tests-unescapes-symbols
     eq. > @
       "\b\f\n\r\t\u27E6"
       08-0C-0A-0D-09-E2-9F-A6

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -45,7 +45,7 @@
         tup.head.tail.head > match!
     (rec-case tup.tail).@ > previous
 
-  [] +> tests-switch-simple-case
+  ++> tests-switch-simple-case
     eq. > @
       switch
         *
@@ -57,7 +57,7 @@
             "2"
       "2"
 
-  [] +> tests-switch-strings-case
+  ++> tests-switch-strings-case
     eq. > @
       switch
         *
@@ -73,7 +73,7 @@
       "password is correct!"
     "swordfish" > password
 
-  [] +> tests-switch-with-several-true-cases
+  ++> tests-switch-with-several-true-cases
     eq. > @
       switch
         *
@@ -88,7 +88,7 @@
             "TRUE2"
       "TRUE1"
 
-  [] +> tests-switch-with-all-false-cases
+  ++> tests-switch-with-all-false-cases
     switch > @
       *
         *
@@ -98,17 +98,17 @@
           false
           "false2"
 
-  [] +> throws-on-empty-switch
+  ++> throws-on-empty-switch
     switch * > @
 
-  [] +> tests-empty-switch-returns-provided-fallback
+  ++> tests-empty-switch-returns-provided-fallback
     eq. > @
       "recovered"
       switch
         *
         "recovered" > [msg]
 
-  [] +> tests-switch-complex-case
+  ++> tests-switch-complex-case
     eq. > @
       switch
         *

--- a/eo-runtime/src/main/eo/tt/as-ascii.eo
+++ b/eo-runtime/src/main/eo/tt/as-ascii.eo
@@ -16,47 +16,47 @@
         00-
         char.as-bytes
 
-  [] +> tests-reads-code-of-uppercase-letter
+  ++> tests-reads-code-of-uppercase-letter
     eq. > @
       65
       as-ascii "A"
 
-  [] +> tests-reads-code-of-last-uppercase-letter
+  ++> tests-reads-code-of-last-uppercase-letter
     eq. > @
       90
       as-ascii "Z"
 
-  [] +> tests-reads-code-of-lowercase-letter
+  ++> tests-reads-code-of-lowercase-letter
     eq. > @
       97
       as-ascii "a"
 
-  [] +> tests-reads-code-of-last-lowercase-letter
+  ++> tests-reads-code-of-last-lowercase-letter
     eq. > @
       122
       as-ascii "z"
 
-  [] +> tests-reads-code-of-zero-digit
+  ++> tests-reads-code-of-zero-digit
     eq. > @
       48
       as-ascii "0"
 
-  [] +> tests-reads-code-of-nine-digit
+  ++> tests-reads-code-of-nine-digit
     eq. > @
       57
       as-ascii "9"
 
-  [] +> tests-reads-code-of-space
+  ++> tests-reads-code-of-space
     eq. > @
       32
       as-ascii " "
 
-  [] +> tests-reads-code-of-punctuation
+  ++> tests-reads-code-of-punctuation
     eq. > @
       33
       as-ascii "!"
 
-  [] +> tests-reads-code-of-last-printable
+  ++> tests-reads-code-of-last-printable
     eq. > @
       126
       as-ascii "~"

--- a/eo-runtime/src/main/eo/tt/as-char.eo
+++ b/eo-runtime/src/main/eo/tt/as-char.eo
@@ -12,37 +12,37 @@
 [code] > as-char
   code.as-i64.as-bytes.slice 7 1 > @
 
-  [] +> tests-writes-byte-of-uppercase-letter
+  ++> tests-writes-byte-of-uppercase-letter
     eq. > @
       "A"
       string (as-char 65)
 
-  [] +> tests-writes-byte-of-last-uppercase-letter
+  ++> tests-writes-byte-of-last-uppercase-letter
     eq. > @
       "Z"
       string (as-char 90)
 
-  [] +> tests-writes-byte-of-lowercase-letter
+  ++> tests-writes-byte-of-lowercase-letter
     eq. > @
       "z"
       string (as-char 122)
 
-  [] +> tests-writes-byte-of-zero-digit
+  ++> tests-writes-byte-of-zero-digit
     eq. > @
       "0"
       string (as-char 48)
 
-  [] +> tests-writes-byte-of-space
+  ++> tests-writes-byte-of-space
     eq. > @
       " "
       string (as-char 32)
 
-  [] +> tests-writes-byte-of-last-printable
+  ++> tests-writes-byte-of-last-printable
     eq. > @
       "~"
       string (as-char 126)
 
-  [] +> tests-round-trips-through-as-ascii
+  ++> tests-round-trips-through-as-ascii
     eq. > @
       "!"
       string (as-char (as-ascii "!"))

--- a/eo-runtime/src/main/eo/tt/as-decimal.eo
+++ b/eo-runtime/src/main/eo/tt/as-decimal.eo
@@ -22,37 +22,37 @@
       concat. (digits q) (as-char ((n.minus (q.times 10)).floor.plus 48))
     (n.div 10).floor > q
 
-  [] +> tests-writes-single-digit
+  ++> tests-writes-single-digit
     eq. > @
       "7"
       string (as-decimal 7)
 
-  [] +> tests-writes-zero
+  ++> tests-writes-zero
     eq. > @
       "0"
       string (as-decimal 0)
 
-  [] +> tests-writes-multi-digit-number
+  ++> tests-writes-multi-digit-number
     eq. > @
       "31415"
       string (as-decimal 31415)
 
-  [] +> tests-writes-negative-number
+  ++> tests-writes-negative-number
     eq. > @
       "-42"
       string (as-decimal -42)
 
-  [] +> tests-truncates-positive-fraction
+  ++> tests-truncates-positive-fraction
     eq. > @
       "42"
       string (as-decimal 42.987)
 
-  [] +> tests-truncates-negative-fraction
+  ++> tests-truncates-negative-fraction
     eq. > @
       "-7"
       string (as-decimal -7.89)
 
-  [] +> tests-writes-number-with-inner-zero
+  ++> tests-writes-number-with-inner-zero
     eq. > @
       "105"
       string (as-decimal 105)

--- a/eo-runtime/src/main/eo/tt/as-fixed.eo
+++ b/eo-runtime/src/main/eo/tt/as-fixed.eo
@@ -38,37 +38,37 @@
         (count.minus 1).as-number
         concat. (as-char ((value.minus ((value.div 10).floor.times 10)).floor.plus 48)) acc
 
-  [] +> tests-pads-with-trailing-zeros
+  ++> tests-pads-with-trailing-zeros
     eq. > @
       "1.250000"
       string (as-fixed 1.25 6)
 
-  [] +> tests-writes-negative-value
+  ++> tests-writes-negative-value
     eq. > @
       "-2.500000"
       string (as-fixed -2.5 6)
 
-  [] +> tests-rounds-to-last-place
+  ++> tests-rounds-to-last-place
     eq. > @
       "0.123457"
       string (as-fixed 0.123456789 6)
 
-  [] +> tests-carries-rounding-into-integer-part
+  ++> tests-carries-rounding-into-integer-part
     eq. > @
       "1.000000"
       string (as-fixed 0.9999999 6)
 
-  [] +> tests-writes-zero
+  ++> tests-writes-zero
     eq. > @
       "0.000000"
       string (as-fixed 0.0 6)
 
-  [] +> tests-honours-custom-places
+  ++> tests-honours-custom-places
     eq. > @
       "3.14"
       string (as-fixed 3.14159 2)
 
-  [] +> tests-writes-single-place
+  ++> tests-writes-single-place
     eq. > @
       "2.5"
       string (as-fixed 2.5 1)

--- a/eo-runtime/src/main/eo/tt/as-hex.eo
+++ b/eo-runtime/src/main/eo/tt/as-hex.eo
@@ -32,27 +32,27 @@
       as-char (h.plus 48)
       as-char (h.plus 55)
 
-  [] +> tests-writes-single-byte
+  ++> tests-writes-single-byte
     eq. > @
       "41"
       string (as-hex "A".as-bytes)
 
-  [] +> tests-joins-bytes-with-hyphens
+  ++> tests-joins-bytes-with-hyphens
     eq. > @
       "4A-65-66-66"
       string (as-hex "Jeff".as-bytes)
 
-  [] +> tests-writes-letter-nibbles
+  ++> tests-writes-letter-nibbles
     eq. > @
       "00-00-00-00-00-00-00-FF"
       string (as-hex 255.as-i64.as-bytes)
 
-  [] +> tests-writes-number-bytes
+  ++> tests-writes-number-bytes
     eq. > @
       "40-45-00-00-00-00-00-00"
       string (as-hex 42.as-bytes)
 
-  [] +> tests-writes-empty-bytes
+  ++> tests-writes-empty-bytes
     eq. > @
       ""
       string (as-hex --)

--- a/eo-runtime/src/main/eo/tt/as-number.eo
+++ b/eo-runtime/src/main/eo/tt/as-number.eo
@@ -21,22 +21,22 @@
     scanned.head
   (sscanf "%f" text).at.^ > scanned
 
-  [] +> tests-converts-text-to-number
+  ++> tests-converts-text-to-number
     eq. > @
       5
       as-number "5"
 
-  [] +> throws-on-converting-text-to-number
+  ++> throws-on-converting-text-to-number
     as-number "Hello" > @
 
-  [] +> tests-non-numeric-text-returns-provided-fallback
+  ++> tests-non-numeric-text-returns-provided-fallback
     eq. > @
       42
       as-number
         "Hello"
         42 > [msg]
 
-  [] +> tests-converts-float-text-to-number
+  ++> tests-converts-float-text-to-number
     eq. > @
       3.14
       as-number "3.14"

--- a/eo-runtime/src/main/eo/tt/at.eo
+++ b/eo-runtime/src/main/eo/tt/at.eo
@@ -28,25 +28,25 @@
     idx
   text.length > len!
 
-  [] +> tests-returns-first-char
+  ++> tests-returns-first-char
     eq. > @
       "s"
       at "some" 0
 
-  [] +> tests-returns-third-char
+  ++> tests-returns-third-char
     eq. > @
       "m"
       at "some" 2
 
-  [] +> tests-returns-char-at-negative-index
+  ++> tests-returns-char-at-negative-index
     eq. > @
       "m"
       at "some" -2
 
-  [] +> throws-on-text-at-index-more-than-length
+  ++> throws-on-text-at-index-more-than-length
     at "some" 10 > @
 
-  [] +> tests-text-at-out-of-bounds-returns-provided-fallback
+  ++> tests-text-at-out-of-bounds-returns-provided-fallback
     eq. > @
       "recovered"
       at

--- a/eo-runtime/src/main/eo/tt/chained.eo
+++ b/eo-runtime/src/main/eo/tt/chained.eo
@@ -20,7 +20,7 @@
         text.as-bytes
         accum.concat str.as-bytes > [accum str]
 
-  [] +> tests-chains-with-other-strings
+  ++> tests-chains-with-other-strings
     eq. > @
       "Hello, world!"
       chained
@@ -30,7 +30,7 @@
           "world"
           "!"
 
-  [] +> tests-returns-same-text-on-chaining-with-no-strings
+  ++> tests-returns-same-text-on-chaining-with-no-strings
     eq. > @
       "Some"
       chained

--- a/eo-runtime/src/main/eo/tt/contains-all.eo
+++ b/eo-runtime/src/main/eo/tt/contains-all.eo
@@ -20,20 +20,20 @@
     x.and a > [a x]
   text > txt!
 
-  [] +> tests-successful-contains-all
+  ++> tests-successful-contains-all
     contains-all "abcdefghijk" (list (* "abc" "ghi")) > @
 
-  [] +> tests-not-contains-all
+  ++> tests-not-contains-all
     not. > @
       contains-all "qwerty" (list (* "qer" "ty" "abc"))
 
-  [] +> tests-contains-all-vert
+  ++> tests-contains-all-vert
     contains-all > @
       "Hello, world!"
       list (* "ell" " " "," "d!")
 
-  [] +> test-contains-all-without-substrings
+  ++> test-contains-all-without-substrings
     contains-all "xyz" (list *) > @
 
-  [] +> tests-contains-all-for-empty-text-and-without-substrings
+  ++> tests-contains-all-for-empty-text-and-without-substrings
     contains-all "" (list *) > @

--- a/eo-runtime/src/main/eo/tt/contains-any.eo
+++ b/eo-runtime/src/main/eo/tt/contains-any.eo
@@ -20,22 +20,22 @@
     x.or a > [a x]
   text > txt!
 
-  [] +> tests-successful-contains-any
+  ++> tests-successful-contains-any
     contains-any "Good morning" (list (* "oo" "goo")) > @
 
-  [] +> tests-not-contains-any
+  ++> tests-not-contains-any
     not. > @
       contains-any "xyzw" (list (* "yx" "zyx" "wx" "abc"))
 
-  [] +> tests-contains-any-vert
+  ++> tests-contains-any-vert
     contains-any > @
       "foo bar buzz"
       list (* "bar" " " "o")
 
-  [] +> test-contains-any-without-substrings
+  ++> test-contains-any-without-substrings
     not. > @
       contains-any "text" (list *)
 
-  [] +> tests-contains-any-for-empty-text-and-without-substrings
+  ++> tests-contains-any-for-empty-text-and-without-substrings
     not. > @
       contains-any "" (list *)

--- a/eo-runtime/src/main/eo/tt/contains.eo
+++ b/eo-runtime/src/main/eo/tt/contains.eo
@@ -33,9 +33,9 @@
       slice txt idx slen
       sub
 
-  [] +> tests-text-contains-substring
+  ++> tests-text-contains-substring
     contains "Hello, world!" "o, wo" > @
 
-  [] +> tests-text-does-not-contain-substring
+  ++> tests-text-does-not-contain-substring
     not. > @
       contains "Hello, world!" "Hey"

--- a/eo-runtime/src/main/eo/tt/ends-with.eo
+++ b/eo-runtime/src/main/eo/tt/ends-with.eo
@@ -22,9 +22,9 @@
   txt.size > tlen!
   text > txt!
 
-  [] +> tests-ends-with-substring
+  ++> tests-ends-with-substring
     ends-with "Hello world!" "world!" > @
 
-  [] +> tests-does-not-end-with-substring
+  ++> tests-does-not-end-with-substring
     not. > @
       ends-with "Hello world!" "Hello"

--- a/eo-runtime/src/main/eo/tt/index-of.eo
+++ b/eo-runtime/src/main/eo/tt/index-of.eo
@@ -44,38 +44,38 @@
       slice txt idx slen
       sub
 
-  [] +> tests-index-of-non-existed-substring-with-more-length
+  ++> tests-index-of-non-existed-substring-with-more-length
     eq. > @
       -1
       index-of "Hello" "Somebody"
 
-  [] +> tests-index-of-non-existed-substring-with-same-length
+  ++> tests-index-of-non-existed-substring-with-same-length
     eq. > @
       -1
       index-of "Hello" "world"
 
-  [] +> tests-index-of-non-existed-substring-with-utf
+  ++> tests-index-of-non-existed-substring-with-utf
     eq. > @
       -1
       index-of
         "привет, друг!"
         "x"
 
-  [] +> tests-index-of-existed-substring-with-utf
+  ++> tests-index-of-existed-substring-with-utf
     eq. > @
       3
       index-of
         "привет, друг!"
         "в"
 
-  [] +> tests-returns-valid-index-of-substring
+  ++> tests-returns-valid-index-of-substring
     eq. > @
       6
       index-of
         "Hello \n world"
         "\n"
 
-  [] +> tests-returns-valid-index-of-substring-in-the-end
+  ++> tests-returns-valid-index-of-substring-in-the-end
     eq. > @
       6
       index-of "Hello world" "world"

--- a/eo-runtime/src/main/eo/tt/is-alpha.eo
+++ b/eo-runtime/src/main/eo/tt/is-alpha.eo
@@ -12,16 +12,16 @@
 [text] > is-alpha
   (regex "/^[a-zA-Z]+$/").matches text > @
 
-  [] +> tests-checks-if-simple-text-is-alpha
+  ++> tests-checks-if-simple-text-is-alpha
     is-alpha > @
       "eEo"
 
-  [] +> tests-checks-if-text-with-number-is-not-alpha
+  ++> tests-checks-if-text-with-number-is-not-alpha
     not. > @
       is-alpha
         "ab3d"
 
-  [] +> tests-checks-if-text-with-dashes-is-not-alpha
+  ++> tests-checks-if-text-with-dashes-is-not-alpha
     not. > @
       is-alpha
         "-w-"

--- a/eo-runtime/src/main/eo/tt/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/tt/is-alphanumeric.eo
@@ -13,15 +13,15 @@
   (regex "/^[A-Za-z0-9]+$/").matches > @
     text
 
-  [] +> tests-checks-if-simple-text-is-alphanumeric
+  ++> tests-checks-if-simple-text-is-alphanumeric
     is-alphanumeric > @
       "eEo"
 
-  [] +> tests-checks-if-text-with-number-is-alphanumeric
+  ++> tests-checks-if-text-with-number-is-alphanumeric
     is-alphanumeric > @
       "ab3d"
 
-  [] +> tests-checks-if-text-with-dashes-is-not-alphanumeric
+  ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
     not. > @
       is-alphanumeric
         "-w-"

--- a/eo-runtime/src/main/eo/tt/is-ascii.eo
+++ b/eo-runtime/src/main/eo/tt/is-ascii.eo
@@ -11,15 +11,15 @@
 [text] > is-ascii
   (regex "/^[\\x00-\\x7F]*$/").matches text > @
 
-  [] +> tests-checks-if-text-is-ascii
+  ++> tests-checks-if-text-is-ascii
     is-ascii > @
       "H311oW"
 
-  [] +> tests-checks-if-emoji-is-not-ascii
+  ++> tests-checks-if-emoji-is-not-ascii
     not. > @
       is-ascii
         "🌵"
 
-  [] +> tests-checks-if-string-of-numbers-is-ascii
+  ++> tests-checks-if-string-of-numbers-is-ascii
     is-ascii > @
       "123"

--- a/eo-runtime/src/main/eo/tt/is-digit.eo
+++ b/eo-runtime/src/main/eo/tt/is-digit.eo
@@ -12,34 +12,34 @@
 [text] > is-digit
   (regex "/^[0-9]+$/").matches text > @
 
-  [] +> tests-checks-if-number-text-is-digit
+  ++> tests-checks-if-number-text-is-digit
     is-digit > @
       "2026"
 
-  [] +> tests-checks-if-text-with-letter-is-not-digit
+  ++> tests-checks-if-text-with-letter-is-not-digit
     not. > @
       is-digit
         "1a2"
 
-  [] +> tests-checks-if-single-digit-is-digit
+  ++> tests-checks-if-single-digit-is-digit
     is-digit > @
       "7"
 
-  [] +> tests-checks-if-empty-text-is-not-digit
+  ++> tests-checks-if-empty-text-is-not-digit
     not. > @
       is-digit
         ""
 
-  [] +> tests-checks-if-text-with-space-is-not-digit
+  ++> tests-checks-if-text-with-space-is-not-digit
     not. > @
       is-digit
         "12 34"
 
-  [] +> tests-checks-if-text-with-special-character-is-not-digit
+  ++> tests-checks-if-text-with-special-character-is-not-digit
     not. > @
       is-digit
         "1🌵2"
 
-  [] +> tests-checks-if-very-long-number-is-digit
+  ++> tests-checks-if-very-long-number-is-digit
     is-digit > @
       "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/tt/joined.eo
+++ b/eo-runtime/src/main/eo/tt/joined.eo
@@ -28,21 +28,21 @@
           acc
         tup.tail
 
-  [] +> tests-joined-no-strings
+  ++> tests-joined-no-strings
     eq. > @
       ""
       joined
         "-"
         *
 
-  [] +> tests-joined-one-string
+  ++> tests-joined-one-string
     eq. > @
       "some"
       joined
         "-"
         * "some"
 
-  [] +> tests-joined-many-strings
+  ++> tests-joined-many-strings
     eq. > @
       "hello-world-dear-friend"
       joined

--- a/eo-runtime/src/main/eo/tt/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tt/last-index-of.eo
@@ -44,29 +44,29 @@
       slice txt idx slen
       sub
 
-  [] +> tests-finds-last-index-of-substring
+  ++> tests-finds-last-index-of-substring
     eq. > @
       5
       last-index-of "Hey, Hey, Hey" "Hey,"
 
-  [] +> tests-finds-last-index-of-the-same-string
+  ++> tests-finds-last-index-of-the-same-string
     eq. > @
       0
       last-index-of "Hello" "Hello"
 
-  [] +> tests-last-index-of-non-existed-substring
+  ++> tests-last-index-of-non-existed-substring
     eq. > @
       -1
       last-index-of "Hello, world" "somebody"
 
-  [] +> tests-last-index-of-non-existed-substring-with-utf
+  ++> tests-last-index-of-non-existed-substring-with-utf
     eq. > @
       -1
       last-index-of
         "привет, друг!"
         "x"
 
-  [] +> tests-last-index-of-existed-substring-with-utf
+  ++> tests-last-index-of-existed-substring-with-utf
     eq. > @
       3
       last-index-of

--- a/eo-runtime/src/main/eo/tt/low-cased.eo
+++ b/eo-runtime/src/main/eo/tt/low-cased.eo
@@ -39,12 +39,12 @@
   as-ascii "Z" > maxcode
   as-ascii "A" > mincode
 
-  [] +> tests-converts-text-to-lower-case
+  ++> tests-converts-text-to-lower-case
     eq. > @
       "hello"
       low-cased "HELLO"
 
-  [] +> tests-converts-text-with-low-letters-to-lower-case
+  ++> tests-converts-text-with-low-letters-to-lower-case
     eq. > @
       "hello"
       low-cased "HeLlO"

--- a/eo-runtime/src/main/eo/tt/nsplit.eo
+++ b/eo-runtime/src/main/eo/tt/nsplit.eo
@@ -63,7 +63,7 @@
             (current.plus 1).as-number
             count
 
-  [] +> tests-nsplit-with-limit-two
+  ++> tests-nsplit-with-limit-two
     eq. > @
       list
         nsplit
@@ -72,7 +72,7 @@
           2
       * "Cookie:" "a=1; b=2"
 
-  [] +> tests-nsplit-with-dashes-limit-two
+  ++> tests-nsplit-with-dashes-limit-two
     eq. > @
       list
         nsplit
@@ -81,7 +81,7 @@
           2
       * "a" "b-c-d"
 
-  [] +> tests-nsplit-with-limit-one
+  ++> tests-nsplit-with-limit-one
     eq. > @
       list
         nsplit
@@ -90,7 +90,7 @@
           1
       * "a-b-c"
 
-  [] +> tests-nsplit-with-high-limit
+  ++> tests-nsplit-with-high-limit
     eq. > @
       list
         nsplit
@@ -99,19 +99,19 @@
           10
       * "a" "b" "c"
 
-  [] +> throws-on-nsplit-with-limit-zero
+  ++> throws-on-nsplit-with-limit-zero
     nsplit > @
       "text"
       "-"
       0
 
-  [] +> throws-on-nsplit-with-negative-limit
+  ++> throws-on-nsplit-with-negative-limit
     nsplit > @
       "text"
       "-"
       -1
 
-  [] +> tests-nsplit-invalid-limit-returns-provided-fallback
+  ++> tests-nsplit-invalid-limit-returns-provided-fallback
     eq. > @
       "fallback"
       nsplit
@@ -120,7 +120,7 @@
         0
         "fallback" > [msg]
 
-  [] +> tests-nsplit-with-empty-strings
+  ++> tests-nsplit-with-empty-strings
     eq. > @
       list
         nsplit
@@ -129,7 +129,7 @@
           3
       * "" "a" "b-c"
 
-  [] +> tests-nsplit-with-multi-char-delimiter
+  ++> tests-nsplit-with-multi-char-delimiter
     eq. > @
       list
         nsplit

--- a/eo-runtime/src/main/eo/tt/regex.eo
+++ b/eo-runtime/src/main/eo/tt/regex.eo
@@ -58,13 +58,13 @@
 
         groups.at index > [index] > group
 
-  [] +> tests-matches-regex-against-the-pattern
+  ++> tests-matches-regex-against-the-pattern
     (regex "/[a-z]+/").compiled.matches "hello" > @
 
-  [] +> tests-does-not-matches-regex-against-the-pattern
+  ++> tests-does-not-matches-regex-against-the-pattern
     ((regex "/[a-z]+/").compiled.matches "123").not > @
 
-  [] +> tests-matched-sequence-has-right-border-indexes
+  ++> tests-matched-sequence-has-right-border-indexes
     and. > @
       0.eq n.start
       and.
@@ -72,10 +72,10 @@
         6.eq n.to
     ((regex "/[a-z]+/").match "!hello!").next > n
 
-  [] +> tests-regex-returns-valid-matched-string-sequence
+  ++> tests-regex-returns-valid-matched-string-sequence
     ((regex "/[a-z]+/").match "!hello!").next.text.eq "hello" > @
 
-  [] +> tests-regex-returns-valid-second-matched-block
+  ++> tests-regex-returns-valid-second-matched-block
     and. > @
       and.
         and.
@@ -87,105 +87,105 @@
       second.to.eq 12
     ((regex "/[a-z]+/").match "!hello!world!").next.next > second
 
-  [] +> throws-on-getting-next-on-not-matched-block
+  ++> throws-on-getting-next-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.next > @
 
-  [] +> throws-on-getting-from-position-on-not-matched-block
+  ++> throws-on-getting-from-position-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.from > @
 
-  [] +> throws-on-getting-to-position-on-not-matched-block
+  ++> throws-on-getting-to-position-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.to > @
 
-  [] +> throws-on-getting-groups-count-on-not-matched-block
+  ++> throws-on-getting-groups-count-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.count > @
 
-  [] +> throws-on-getting-groups-on-not-matched-block
+  ++> throws-on-getting-groups-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.groups > @
 
-  [] +> throws-on-getting-specified-group-on-not-matched-block
+  ++> throws-on-getting-specified-group-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.group 1 > @
 
-  [] +> throws-on-getting-text-on-not-matched-block
+  ++> throws-on-getting-text-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.text > @
 
-  [] +> tests-regex-matches-dotall-option
+  ++> tests-regex-matches-dotall-option
     regex
       "/(.*)/s"
     .compiled
     .matches > @
       "too \\n many \\n line \\n Feed\\n"
 
-  [] +> tests-regex-matches-with-case-insensitive-option
+  ++> tests-regex-matches-with-case-insensitive-option
     regex
       "/(string)/i"
     .compiled
     .matches > @
       "StRiNg"
 
-  [] +> tests-regex-matches-with-multiline-option
+  ++> tests-regex-matches-with-multiline-option
     regex
       "/(^([0-9]+).*)/m"
     .compiled
     .matches > @
       "1 bottle of water on the wall. \\n1 bottle of water."
 
-  [] +> tests-regex-matches-entire-pattern
+  ++> tests-regex-matches-entire-pattern
     regex
       "/[0-9]/\\d+/"
     .compiled
     .matches > @
       "2/75"
 
-  [] +> tests-regex-matches-with-regex-unix-lines
+  ++> tests-regex-matches-with-regex-unix-lines
     regex
       "/(.+)/d"
     .compiled
     .matches > @
       "A\\r\\nB\\rC\\nD"
 
-  [] +> tests-regex-matches-with-regex-case-insensitive-and-caps
+  ++> tests-regex-matches-with-regex-case-insensitive-and-caps
     regex
       "/(word)/i"
     .compiled
     .matches > @
       "WORD"
 
-  [] +> tests-regex-ignores-comments-in-string
+  ++> tests-regex-ignores-comments-in-string
     regex
       "/(\\d) #ignore this comment/x"
     .compiled
     .matches > @
       "4"
 
-  [] +> tests-regex-matches-with-unicode-case-and-insensitive
+  ++> tests-regex-matches-with-unicode-case-and-insensitive
     regex
       "/(yildirim)/ui"
     .compiled
     .matches > @
       "Yıldırım"
 
-  [] +> throws-on-missing-first-slash-in-regex
+  ++> throws-on-missing-first-slash-in-regex
     (regex "(.)+").compiled > @
 
-  [] +> throws-on-missing-closing-slash-in-regex
+  ++> throws-on-missing-closing-slash-in-regex
     (regex "/pattern").compiled > @
 
-  [] +> tests-invalid-regex-syntax-returns-provided-fallback
+  ++> tests-invalid-regex-syntax-returns-provided-fallback
     eq. > @
       "recovered"
       (regex "/[a-z/").compile
         "recovered" > [msg]
 
-  [] +> tests-missing-slash-returns-provided-fallback
+  ++> tests-missing-slash-returns-provided-fallback
     eq. > @
       "no-slash"
       (regex "(.)+").compile
         "no-slash" > [msg]
 
-  [] +> throws-on-compiling-invalid-regex-without-fallback
+  ++> throws-on-compiling-invalid-regex-without-fallback
     (regex "/[a-z/").compile > @
 
-  [] +> tests-regex-contains-valid-groups-on-each-matched-block
+  ++> tests-regex-contains-valid-groups-on-each-matched-block
     and. > @
       and.
         and.

--- a/eo-runtime/src/main/eo/tt/repeated.eo
+++ b/eo-runtime/src/main/eo/tt/repeated.eo
@@ -33,12 +33,12 @@
         accum.concat bts
         (index.plus 1).as-number
 
-  [] +> throws-on-text-repeating-less-than-zero-times
+  ++> throws-on-text-repeating-less-than-zero-times
     repeated > @
       ""
       -1
 
-  [] +> tests-text-repeated-negative-times-returns-provided-fallback
+  ++> tests-text-repeated-negative-times-returns-provided-fallback
     eq. > @
       "recovered"
       repeated
@@ -46,12 +46,12 @@
         -1
         "recovered" > [msg]
 
-  [] +> tests-text-repeated-zero-times-is-empty
+  ++> tests-text-repeated-zero-times-is-empty
     eq. > @
       ""
       repeated "some" 0
 
-  [] +> tests-text-repeated-five-times
+  ++> tests-text-repeated-five-times
     eq. > @
       "heyheyheyheyhey"
       repeated "hey" 5

--- a/eo-runtime/src/main/eo/tt/replaced.eo
+++ b/eo-runtime/src/main/eo/tt/replaced.eo
@@ -39,7 +39,7 @@
             start
             reinit.length.minus start
 
-  [] +> tests-does-not-replaces-if-regex-not-found
+  ++> tests-does-not-replaces-if-regex-not-found
     replaced
       "Hello, world"
       regex
@@ -48,7 +48,7 @@
     .eq > @
       "Hello, world"
 
-  [] +> tests-replaces-digits-with-string
+  ++> tests-replaces-digits-with-string
     replaced
       "Hell0, w0rld"
       regex
@@ -57,7 +57,7 @@
     .eq > @
       "Hello, world"
 
-  [] +> tests-replaces-slashes-to-windows-separator
+  ++> tests-replaces-slashes-to-windows-separator
     replaced
       "C:\\Windows/foo\\bar/hello.txt"
       regex
@@ -66,7 +66,7 @@
     .eq > @
       "C:\\Windows\\foo\\bar\\hello.txt"
 
-  [] +> tests-replaces-windows-path-with-slash
+  ++> tests-replaces-windows-path-with-slash
     replaced
       "C:\\Windows\\Users\\AppLocal\\shrek"
       regex
@@ -75,7 +75,7 @@
     .eq > @
       "C/Windows/Users/AppLocal/shrek"
 
-  [] +> tests-sanitizes-windows-path-with-regex
+  ++> tests-sanitizes-windows-path-with-regex
     replaced
       "foo\\bar<:>?*\"|baz\\asdf"
       regex

--- a/eo-runtime/src/main/eo/tt/slice.eo
+++ b/eo-runtime/src/main/eo/tt/slice.eo
@@ -12,7 +12,7 @@
 [text start len] > slice
   text.slice start len > @
 
-  [] +> tests-text-slices-the-origin-string
+  ++> tests-text-slices-the-origin-string
     eq. > @
       slice "Hello, world!" 7 5
       "world"

--- a/eo-runtime/src/main/eo/tt/split.eo
+++ b/eo-runtime/src/main/eo/tt/split.eo
@@ -48,19 +48,19 @@
             start
             (current.plus 1).as-number
 
-  [] +> tests-splits-text-by-dash
+  ++> tests-splits-text-by-dash
     eq. > @
       list
         split "a-b-c" "-"
       * "a" "b" "c"
 
-  [] +> tests-splits-text-with-empty-strings
+  ++> tests-splits-text-with-empty-strings
     eq. > @
       list
         split "-a-b-" "-"
       * "" "a" "b" ""
 
-  [] +> tests-splits-and-returns-strings
+  ++> tests-splits-and-returns-strings
     eq. > @
       length.
         at.
@@ -70,7 +70,7 @@
           1
       6
 
-  [] +> tests-splits-text-by-multi-char-delimiter
+  ++> tests-splits-text-by-multi-char-delimiter
     eq. > @
       list
         split "a::b::c" "::"

--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -20,57 +20,57 @@
 
 [format args] > sprintf /string
 
-  [] +> tests-prints-simple-string
+  ++> tests-prints-simple-string
     eq. > @
       "Hello, Jeffrey!"
       sprintf
         "Hello, %s!"
         * "Jeffrey"
 
-  [] +> tests-prints-complex-string
+  ++> tests-prints-complex-string
     eq. > @
       "Привет 3.140000 Jeff X!"
       sprintf
         "Привет %f %s %s!"
         * 3.14 "Jeff" "X"
 
-  [] +> tests-prints-bytes-string
+  ++> tests-prints-bytes-string
     eq. > @
       "40-45-00-00-00-00-00-00"
       sprintf
         "%x"
         * 42.as-bytes
 
-  [] +> tests-formats-all-objects
+  ++> tests-formats-all-objects
     eq. > @
       "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
       sprintf
         "string %s, bytes %x, float %f, int %d, bool %b"
         * "Jeff" "Jeff".as-bytes 42.3 14 false
 
-  [] +> throws-on-sprintf-with-arguments-that-does-not-match
+  ++> throws-on-sprintf-with-arguments-that-does-not-match
     sprintf > @
       "%s%s"
       * "Jeff"
 
-  [] +> tests-sprintf-does-not-fail-if-arguments-more-than-formats
+  ++> tests-sprintf-does-not-fail-if-arguments-more-than-formats
     eq. > @
       "Hey"
       sprintf
         "%s"
         * "Hey" "Jeff"
 
-  [] +> throws-on-sprintf-unsupported-format
+  ++> throws-on-sprintf-unsupported-format
     sprintf "%o" * > @
 
-  [] +> tests-sprintf-prints-percents
+  ++> tests-sprintf-prints-percents
     eq. > @
       "%Jeff"
       sprintf
         "%%%s"
         * "Jeff"
 
-  [] +> tests-sprintf-does-not-print-i64
+  ++> tests-sprintf-does-not-print-i64
     not. > @
       eq.
         sprintf
@@ -78,80 +78,80 @@
           * 42.as-i64
         "42"
 
-  [] +> tests-sprintf-prints-i64-as-number
+  ++> tests-sprintf-prints-i64-as-number
     eq. > @
       "42"
       sprintf
         "%d"
         * 42.as-i64.as-number
 
-  [] +> formats-numbered-substitution
+  ++> formats-numbered-substitution
     eq. > @
       "Hello, Jeff! Bye, Jeff!"
       sprintf
         "Hello, %s! Bye, %1$s!"
         * "Jeff"
 
-  [] +> throws-on-sprintf-with-oversized-positional-index
+  ++> throws-on-sprintf-with-oversized-positional-index
     sprintf > @
       "%99999999999999999999$s"
       * "Jeff"
 
-  [] +> formats-numbered-substitution-with-multiple-args
+  ++> formats-numbered-substitution-with-multiple-args
     eq. > @
       "This is the first; This is the first as well; The second; and the 3"
       sprintf
         "This is the %s; This is the %1$s as well; The %s; and the %d"
         * "first" "second" 3
 
-  [] +> formats-with-ordered-numbered-substitutions
+  ++> formats-with-ordered-numbered-substitutions
     eq. > @
       "first second second is after first"
       sprintf
         "%s %s %2$s is after %1$s"
         * "first" "second"
 
-  [] +> truncates-positive-float-towards-zero-as-decimal
+  ++> truncates-positive-float-towards-zero-as-decimal
     eq. > @
       "42"
       sprintf
         "%d"
         * 42.321
 
-  [] +> truncates-negative-float-towards-zero-as-decimal
+  ++> truncates-negative-float-towards-zero-as-decimal
     eq. > @
       "-7"
       sprintf
         "%d"
         * -7.89
 
-  [] +> truncates-rather-than-rounds-float-as-decimal
+  ++> truncates-rather-than-rounds-float-as-decimal
     eq. > @
       "9"
       sprintf
         "%d"
         * 9.99
 
-  [] +> throws-on-formatting-huge-number-as-decimal
+  ++> throws-on-formatting-huge-number-as-decimal
     sprintf > @
       "%d"
       * 1.0e30
 
-  [] +> formats-float-always-with-six-fraction-digits
+  ++> formats-float-always-with-six-fraction-digits
     eq. > @
       "1.250000"
       sprintf
         "%f"
         * 1.25
 
-  [] +> rounds-float-carrying-into-integer-part
+  ++> rounds-float-carrying-into-integer-part
     eq. > @
       "1.000000"
       sprintf
         "%f"
         * 0.9999999
 
-  [] +> formats-zero-float-with-six-fraction-digits
+  ++> formats-zero-float-with-six-fraction-digits
     eq. > @
       "0.000000"
       sprintf

--- a/eo-runtime/src/main/eo/tt/sscanf.eo
+++ b/eo-runtime/src/main/eo/tt/sscanf.eo
@@ -21,43 +21,43 @@
 
 [format read] > sscanf /tuple
 
-  [] +> tests-sscanf-with-string
+  ++> tests-sscanf-with-string
     eq. > @
       "hello"
       head.
         sscanf "%s" "hello"
 
-  [] +> tests-sscanf-with-int
+  ++> tests-sscanf-with-int
     eq. > @
       33
       head.
         sscanf "%d" "33"
 
-  [] +> tests-sscanf-with-negative-int
+  ++> tests-sscanf-with-negative-int
     eq. > @
       -42
       head.
         sscanf "%d" "-42"
 
-  [] +> tests-sscanf-with-positive-signed-int
+  ++> tests-sscanf-with-positive-signed-int
     eq. > @
       42
       head.
         sscanf "%d" "+42"
 
-  [] +> tests-sscanf-with-float
+  ++> tests-sscanf-with-float
     eq. > @
       0.24
       head.
         sscanf "%f" "0.24"
 
-  [] +> throws-on-sscanf-with-wrong-format
+  ++> throws-on-sscanf-with-wrong-format
     sscanf "%l" "error" > @
 
-  [] +> throws-on-sscanf-with-oversized-int
+  ++> throws-on-sscanf-with-oversized-int
     sscanf "%d" "99999999999999999999" > @
 
-  [] +> tests-sscanf-with-string-int-float
+  ++> tests-sscanf-with-string-int-float
     eq. > @
       list
         sscanf
@@ -65,31 +65,31 @@
           "hello 33 0.24"
       * "hello" 33 0.24
 
-  [] +> tests-sscanf-with-string-with-ending
+  ++> tests-sscanf-with-string-with-ending
     eq. > @
       "hello"
       head.
         sscanf "%s!" "hello!"
 
-  [] +> tests-sscanf-with-complex-string
+  ++> tests-sscanf-with-complex-string
     eq. > @
       "test"
       head.
         sscanf "some%sstring" "someteststring"
 
-  [] +> tests-sscanf-with-complex-int
+  ++> tests-sscanf-with-complex-int
     eq. > @
       734987259
       head.
         sscanf "!%d!" "!734987259!"
 
-  [] +> tests-sscanf-with-complex-float
+  ++> tests-sscanf-with-complex-float
     eq. > @
       1991.01
       head.
         sscanf "this will be=%f" "this will be=1991.01"
 
-  [] +> tests-sscanf-with-sprintf
+  ++> tests-sscanf-with-sprintf
     eq. > @
       list
         sscanf
@@ -99,7 +99,7 @@
             * "This" 8
       * "This" 8
 
-  [] +> tests-sscanf-complex-case
+  ++> tests-sscanf-complex-case
     eq. > @
       list
         sscanf

--- a/eo-runtime/src/main/eo/tt/starts-with.eo
+++ b/eo-runtime/src/main/eo/tt/starts-with.eo
@@ -17,9 +17,9 @@
   txt.size > tlen!
   text > txt!
 
-  [] +> tests-starts-with-substring
+  ++> tests-starts-with-substring
     starts-with "Hello, world" "Hello" > @
 
-  [] +> tests-does-not-start-with-substring
+  ++> tests-does-not-start-with-substring
     not. > @
       starts-with "Hello, world" "world"

--- a/eo-runtime/src/main/eo/tt/string-buffer.eo
+++ b/eo-runtime/src/main/eo/tt/string-buffer.eo
@@ -14,15 +14,15 @@
       string
         buf.as-bytes.concat str.as-bytes
 
-  [] +> tests-string-buffer-decorates-string
+  ++> tests-string-buffer-decorates-string
     (string-buffer "Hello").eq "Hello" > @
 
-  [] +> tests-string-buffer-builds-simple-string
+  ++> tests-string-buffer-builds-simple-string
     eq. > @
       ((string-buffer "Hello").with ", ").with "Jeff"
       "Hello, Jeff"
 
-  [] +> tests-string-buffer-decorates-string-after-building
+  ++> tests-string-buffer-decorates-string-after-building
     eq. > @
       ((string-buffer "Hi, ").with "Mark").length
       8

--- a/eo-runtime/src/main/eo/tt/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed-left.eo
@@ -46,47 +46,47 @@
               c.eq 0C-
               c.eq 0D-
 
-  [] +> tests-trimmed-left-empty-text
+  ++> tests-trimmed-left-empty-text
     eq. > @
       trimmed-left ""
       ""
 
-  [] +> tests-text-trimmed-left-one-space
+  ++> tests-text-trimmed-left-one-space
     eq. > @
       trimmed-left " s"
       "s"
 
-  [] +> tests-text-trimmed-left-many-spaces
+  ++> tests-text-trimmed-left-many-spaces
     eq. > @
       trimmed-left "     some"
       "some"
 
-  [] +> tests-text-trimmed-left-only-spaces
+  ++> tests-text-trimmed-left-only-spaces
     eq. > @
       trimmed-left "     "
       ""
 
-  [] +> tests-trimmed-left-strips-tab
+  ++> tests-trimmed-left-strips-tab
     eq. > @
       trimmed-left "\tvalue"
       "value"
 
-  [] +> tests-trimmed-left-strips-lf
+  ++> tests-trimmed-left-strips-lf
     eq. > @
       trimmed-left "\nvalue"
       "value"
 
-  [] +> tests-trimmed-left-strips-ff
+  ++> tests-trimmed-left-strips-ff
     eq. > @
       trimmed-left "\fvalue"
       "value"
 
-  [] +> tests-trimmed-left-strips-cr
+  ++> tests-trimmed-left-strips-cr
     eq. > @
       trimmed-left "\rvalue"
       "value"
 
-  [] +> tests-trimmed-left-strips-mixed-ws
+  ++> tests-trimmed-left-strips-mixed-ws
     eq. > @
       trimmed-left " \t\n\f\rvalue"
       "value"

--- a/eo-runtime/src/main/eo/tt/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed-right.eo
@@ -46,47 +46,47 @@
               c.eq 0C-
               c.eq 0D-
 
-  [] +> tests-trimmed-right-empty-text
+  ++> tests-trimmed-right-empty-text
     eq. > @
       trimmed-right ""
       ""
 
-  [] +> tests-text-trimmed-right-one-space
+  ++> tests-text-trimmed-right-one-space
     eq. > @
       trimmed-right "s "
       "s"
 
-  [] +> tests-text-trimmed-right-many-spaces
+  ++> tests-text-trimmed-right-many-spaces
     eq. > @
       trimmed-right "some     "
       "some"
 
-  [] +> tests-text-trimmed-right-only-spaces
+  ++> tests-text-trimmed-right-only-spaces
     eq. > @
       trimmed-right "     "
       ""
 
-  [] +> tests-trimmed-right-strips-tab
+  ++> tests-trimmed-right-strips-tab
     eq. > @
       trimmed-right "value\t"
       "value"
 
-  [] +> tests-trimmed-right-strips-lf
+  ++> tests-trimmed-right-strips-lf
     eq. > @
       trimmed-right "value\n"
       "value"
 
-  [] +> tests-trimmed-right-strips-ff
+  ++> tests-trimmed-right-strips-ff
     eq. > @
       trimmed-right "value\f"
       "value"
 
-  [] +> tests-trimmed-right-strips-cr
+  ++> tests-trimmed-right-strips-cr
     eq. > @
       trimmed-right "value\r"
       "value"
 
-  [] +> tests-trimmed-right-strips-mixed-ws
+  ++> tests-trimmed-right-strips-mixed-ws
     eq. > @
       trimmed-right "value \t\n\f\r"
       "value"

--- a/eo-runtime/src/main/eo/tt/trimmed.eo
+++ b/eo-runtime/src/main/eo/tt/trimmed.eo
@@ -22,47 +22,47 @@
       trimmed-right
         text
 
-  [] +> tests-text-trimmed-one-space-left
+  ++> tests-text-trimmed-one-space-left
     eq. > @
       trimmed " some"
       "some"
 
-  [] +> tests-text-trimmed-one-space-right
+  ++> tests-text-trimmed-one-space-right
     eq. > @
       trimmed "some "
       "some"
 
-  [] +> tests-text-trimmed-one-space-both
+  ++> tests-text-trimmed-one-space-both
     eq. > @
       trimmed " some "
       "some"
 
-  [] +> tests-text-trimmed-many-spaces
+  ++> tests-text-trimmed-many-spaces
     eq. > @
       trimmed "    some     "
       "some"
 
-  [] +> tests-text-trimmed-empty
+  ++> tests-text-trimmed-empty
     eq. > @
       trimmed ""
       ""
 
-  [] +> tests-text-trimmed-only-spaces
+  ++> tests-text-trimmed-only-spaces
     eq. > @
       trimmed "        "
       ""
 
-  [] +> tests-trimmed-strips-mixed-ws-both-sides
+  ++> tests-trimmed-strips-mixed-ws-both-sides
     eq. > @
       trimmed " \t\n\f\rvalue \t\n\f\r"
       "value"
 
-  [] +> tests-trimmed-preserves-inner-content
+  ++> tests-trimmed-preserves-inner-content
     eq. > @
       trimmed "no-whitespace"
       "no-whitespace"
 
-  [] +> tests-trimmed-preserves-inner-whitespace
+  ++> tests-trimmed-preserves-inner-whitespace
     eq. > @
       trimmed "\t hello world \n"
       "hello world"

--- a/eo-runtime/src/main/eo/tt/up-cased.eo
+++ b/eo-runtime/src/main/eo/tt/up-cased.eo
@@ -39,12 +39,12 @@
   as-ascii "z" > maxcode!
   as-ascii "a" > mincode!
 
-  [] +> tests-converts-text-to-upper-case
+  ++> tests-converts-text-to-upper-case
     eq. > @
       "HELLO"
       up-cased "hello"
 
-  [] +> tests-converts-text-with-upper-letters-to-upper-case
+  ++> tests-converts-text-with-upper-letters-to-upper-case
     eq. > @
       "HELLO"
       up-cased "HeLlO"

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -40,23 +40,23 @@
       x
       (length.plus 1).as-number
 
-  [] +> tests-makes-tuple-through-special-syntax
+  ++> tests-makes-tuple-through-special-syntax
     eq. > @
       (* 1 2).length
       2
 
-  [] +> tests-gets-lengths-of-empty-tuple-through-special-syntax
+  ++> tests-gets-lengths-of-empty-tuple-through-special-syntax
     eq. > @
       *.length
       0
 
-  [] +> tests-empty-tuple-length
+  ++> tests-empty-tuple-length
     eq. > @
       (arr *).elements.length
       0
     [elements] > arr
 
-  [] +> tests-non-empty-tuple-length-test
+  ++> tests-non-empty-tuple-length-test
     eq. > @
       arr
         * "a" "b" "c" "d" "e"
@@ -65,20 +65,20 @@
       5
     [elements] > arr
 
-  [] +> tests-tuple-as-a-bound-attribute-size-0
+  ++> tests-tuple-as-a-bound-attribute-size-0
     eq. > @
       tup.length
       0
     * > tup
 
-  [] +> tests-tuple-as-a-bound-attribute-size-1
+  ++> tests-tuple-as-a-bound-attribute-size-1
     eq. > @
       tup.at 0
       100
     * > tup
       100
 
-  [] +> tests-tuple-as-a-bound-attribute-size-2
+  ++> tests-tuple-as-a-bound-attribute-size-2
     and. > @
       eq.
         arr.at 0
@@ -90,7 +90,7 @@
       1
       2
 
-  [] +> tests-tuple-with
+  ++> tests-tuple-with
     and. > @
       and.
         and.
@@ -110,12 +110,12 @@
       * 1 2 3
       "with"
 
-  [] +> throws-on-wrong-tuple-at
+  ++> throws-on-wrong-tuple-at
     at. > @
       * 1 2 3 4
       20
 
-  [] +> tests-out-of-bounds-at-returns-provided-fallback
+  ++> tests-out-of-bounds-at-returns-provided-fallback
     eq. > @
       "recovered"
       at.
@@ -123,7 +123,7 @@
         20
         "recovered" > [msg]
 
-  [] +> tests-tuple-fluent-with
+  ++> tests-tuple-fluent-with
     and. > @
       and.
         eq.
@@ -137,7 +137,7 @@
         3
     ((*.with 1).with 2).with 3 > arr
 
-  [] +> tests-tuple-fluent-with-indented
+  ++> tests-tuple-fluent-with-indented
     and. > @
       and.
         eq.
@@ -151,42 +151,42 @@
         3
     ((*.with 1).with 2).with 3 > arr
 
-  [] +> tests-gets-lengths-of-empty-tuple
+  ++> tests-gets-lengths-of-empty-tuple
     eq. > @
       a.length
       0
     tuple.empty > a
 
-  [] +> tests-gets-lengths-of-empty-tuple-without-additional-obj
+  ++> tests-gets-lengths-of-empty-tuple-without-additional-obj
     eq. > @
       tuple.empty.length
       0
 
-  [] +> throws-on-getting-head-from-empty-tuple
+  ++> throws-on-getting-head-from-empty-tuple
     tuple.empty.head > @
 
-  [] +> throws-on-getting-tail-from-empty-tuple
+  ++> throws-on-getting-tail-from-empty-tuple
     tuple.empty.tail > @
 
-  [] +> tests-creates-empty-tuple-with-number
+  ++> tests-creates-empty-tuple-with-number
     eq. > @
       a.at 0
       3
     tuple.empty.with 3 > a
 
-  [] +> tests-at-fast-with-first-element
+  ++> tests-at-fast-with-first-element
     eq. > @
       (arr.at 0).at-fast arr
       100
     * 100 101 102 > arr
 
-  [] +> tests-at-fast-with-last-element
+  ++> tests-at-fast-with-last-element
     eq. > @
       (arr.at 2).at-fast arr
       102
     * 100 101 102 > arr
 
-  [] +> tests-tuple-empty-fluent-with-indented-keyword
+  ++> tests-tuple-empty-fluent-with-indented-keyword
     and. > @
       and.
         eq.
@@ -200,18 +200,18 @@
         3
     ((tuple.empty.with 1).with 2).with 3 > arr
 
-  [] +> tests-tuple-with-negative-index-gets-last
+  ++> tests-tuple-with-negative-index-gets-last
     eq. > @
       arr.at -1
       4
     * 0 1 2 3 4 > arr
 
-  [] +> tests-tuple-with-negative-index-gets-first
+  ++> tests-tuple-with-negative-index-gets-first
     eq. > @
       arr.at -5
       0
     * 0 1 2 3 4 > arr
 
-  [] +> throws-on-out-of-tuple-bounds-with-negative-index
+  ++> throws-on-out-of-tuple-bounds-with-negative-index
     arr.at -6 > @
     * 0 1 2 3 4 > arr

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -45,7 +45,7 @@
       current
     body index > current
 
-  [] +> tests-while-dataizes-only-first-cycle
+  ++> tests-while-dataizes-only-first-cycle
     eq. > @
       0
       malloc.for
@@ -55,13 +55,13 @@
             i.eq 0 > [i]
             m.put i > [i] >>
 
-  [] +> tests-simple-while-with-false-first
+  ++> tests-simple-while-with-false-first
     not. > @
       while
         false > [i]
         true > [i]
 
-  [] +> tests-simple-bool-expression-via-malloc-in-while
+  ++> tests-simple-bool-expression-via-malloc-in-while
     eq. > @
       malloc.for
         true
@@ -71,7 +71,7 @@
             m.put false > [i] >>
       false
 
-  [] +> tests-last-while-dataization-object
+  ++> tests-last-while-dataization-object
     eq. > @
       malloc.for
         0
@@ -81,13 +81,13 @@
             m.put (m.as-number.plus 1) > [i] >>
       3
 
-  [] +> tests-last-while-dataization-object-with-false-condition
+  ++> tests-last-while-dataization-object-with-false-condition
     not. > @
       while
         1.gt 2 > [i]
         true > [i]
 
-  [] +> tests-while-simple-iteration
+  ++> tests-while-simple-iteration
     eq. > @
       malloc.for
         0
@@ -97,7 +97,7 @@
             m.put i > [i] >>
       9
 
-  [] +> tests-iterating-tuple-with-while-using-internal-iterator
+  ++> tests-iterating-tuple-with-while-using-internal-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
     malloc.for > data
@@ -123,7 +123,7 @@
                         iter.as-number.plus 1
     arr.length.plus -1 > max
 
-  [] +> tests-iterating-tuple-with-while-using-external-iterator
+  ++> tests-iterating-tuple-with-while-using-external-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
     malloc.for > data
@@ -144,7 +144,7 @@
                       iter.as-number.plus 1
     arr.length.plus -1 > max
 
-  [] +> tests-iterating-tuple-with-while-without-body-multiple
+  ++> tests-iterating-tuple-with-while-without-body-multiple
     data.eq arr.length > @
     * 1 1 1 > arr
     malloc.for > data
@@ -173,7 +173,7 @@
                 acc
     arr.length > max
 
-  [] +> tests-iterating-tuple-with-while-without-body-single
+  ++> tests-iterating-tuple-with-while-without-body-single
     data.eq arr.length > @
     * 1 > arr
     malloc.for > data


### PR DESCRIPTION
Closes #5445.

`++> name` is now accepted as a shorthand for `[] +> name`. The desugaring is front-end only:

- `Eo.classify` — a `+`-headed non-number line dispatches through a new private `plussed(span)`: `++>` classifies as a formation line, anything else stays a meta directive (extracting the method also keeps `classify` under the PMD NPath threshold).
- `LnFormation` — on a `++>` head the params list is empty and the suffix is parsed from `body.substring(1)`, which is exactly `+> name` at its true source column, so every error position and every `@line`/`@pos` in XMIR matches the source with no drift. From there the existing `Suffix`/emission path runs unchanged — the emitted XMIR is byte-for-byte the same as for `[] +> name`. The class-level `@SuppressWarnings("PMD.UnnecessaryLocalRule")` became unnecessary after the restructuring and was removed (qulice flags unused suppressions).
- `PARSER_SPEC.md` — a `+` / `++>` row in the §3.1 classification table and a new rule R-6.3.6 stating the equivalence; there is no ambiguity with metas since metas are legal only before the first object (R-3.2.2).

Tests: three unit tests in `LnFormationTest` (same emission as `[] +>`, same `BARE_FORMATION` level, `++> @` rejected per R-6.3.5), a positive `eo-syntax` pack with two `++>` tests inside an object, and a typo pack checking the exact error position for `++> @`.

Existing `[] +> name` declarations stay legal; nothing in the stdlib is touched.

Verification: `mvn -pl eo-parser verify -Pqulice`: 1460 tests, 0 failures, qulice clean.
