### PR TITLE
Add the recovered atom to intercept a bottom

### DIFF
--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -1,0 +1,50 @@
+# Recover from a terminated computation (⊥).
+# Resolves `value` to its normal form; if that is a ⊥, behaves as
+# `alternative`, otherwise as `value`. This is the only way to intercept a
+# ⊥ and keep going: a ⊥ that is never recovered terminates the program.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[value alternative] > recovered /bytes
+
+  ++> tests-keeps-the-value-when-not-terminated
+    eq. > @
+      recovered 42 7
+      42
+
+  ++> tests-falls-back-to-alternative-when-terminated
+    eq. > @
+      recovered
+        2.as-i64.div 0.as-i64
+        7
+      7
+
+  ++> tests-recovers-the-inner-recovery
+    eq. > @
+      recovered
+        recovered
+          2.as-i64.div 0.as-i64
+          3.as-i64.div 0.as-i64
+        42
+      42
+
+  ++> tests-recovers-when-a-provided-fallback-terminates
+    eq. > @
+      recovered
+        2.as-i64.div
+          0.as-i64
+          T "cannot divide" > [msg]
+        42
+      42
+
+  ++> throws-when-both-are-terminated
+    recovered > @
+      2.as-i64.div 0.as-i64
+      5.as-i64.div 0.as-i64

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -105,6 +105,11 @@ public interface Data {
         }
 
         @Override
+        public Phi normalized() {
+            return this.object.normalized();
+        }
+
+        @Override
         public String φTerm() {
             return this.object.φTerm();
         }

--- a/eo-runtime/src/main/java/org/eolang/EOrecovered.java
+++ b/eo-runtime/src/main/java/org/eolang/EOrecovered.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+/**
+ * RECOVERED.
+ *
+ * <p>Resolves {@code value} to its normal form; if that is a terminated
+ * computation (⊥), behaves as {@code alternative}, otherwise as {@code value}.
+ * A ⊥ on both sides stays a ⊥, so an outer recovery can still intercept it.
+ * This is the only way to intercept a ⊥ and keep going.</p>
+ *
+ * @since 0.74.0
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@XmirObject(oname = "recovered")
+public final class EOrecovered extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOrecovered() {
+        super(new Attrs(
+            new Attr("value", new AtVoid("value")),
+            new Attr("alternative", new AtVoid("alternative"))
+        ));
+    }
+
+    @Override
+    public Phi lambda() {
+        final Phi picked = this.take("value").normalized();
+        final Phi result;
+        if (picked instanceof PhTerminator) {
+            result = this.take("alternative").normalized();
+        } else {
+            result = picked;
+        }
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -268,6 +268,25 @@ public class PhDefault implements Phi, Cloneable {
     }
 
     @Override
+    public Phi normalized() {
+        this.activate();
+        final Phi result;
+        if (this instanceof Atom) {
+            result = this.take(Phi.LAMBDA).normalized();
+        } else if (this.data == null && this.attrs.containsKey(Phi.PHI)) {
+            final Phi phi = this.take(Phi.PHI).normalized();
+            if (phi instanceof PhTerminator) {
+                result = phi;
+            } else {
+                result = this;
+            }
+        } else {
+            result = this;
+        }
+        return result;
+    }
+
+    @Override
     public String locator() {
         return "?";
     }

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -98,6 +98,11 @@ public final class PhLogged implements Phi {
     }
 
     @Override
+    public Phi normalized() {
+        return this.origin.normalized();
+    }
+
+    @Override
     public String φTerm() {
         return this.origin.φTerm();
     }

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -123,6 +123,11 @@ public class PhOnce implements Phi {
     }
 
     @Override
+    public Phi normalized() {
+        return this.object.get().normalized();
+    }
+
+    @Override
     public String φTerm() {
         final String result;
         if (this.term == null) {

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * A package object, coming from {@link Phi}.
  * @since 0.22
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class PhPackage implements Phi {
 
     /**
@@ -109,6 +110,11 @@ final class PhPackage implements Phi {
     @Override
     public byte[] delta() {
         throw new ExFailure("Can't take #data() from package object \"%s\"", this.pkg);
+    }
+
+    @Override
+    public Phi normalized() {
+        return this;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -152,6 +152,11 @@ public final class PhSafe implements Phi, Atom {
     }
 
     @Override
+    public Phi normalized() {
+        return this.through(this.origin::normalized);
+    }
+
+    @Override
     public Phi lambda() {
         return this.through(new AtomSafe(this.origin)::lambda, ".λ");
     }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -32,6 +32,7 @@ package org.eolang;
  *
  * @since 0.73.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class PhTerminator implements Phi {
 
     /**
@@ -111,6 +112,11 @@ public final class PhTerminator implements Phi {
             reason = new Dataized(this.cause).asString();
         }
         throw new ExFailure(reason);
+    }
+
+    @Override
+    public Phi normalized() {
+        return this;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -85,4 +85,20 @@ public interface Phi extends Data, Term {
      * @return Forma of it as {@link String}
      */
     String forma();
+
+    /**
+     * Resolve this object to its normal form, running dispatch, λ and φ but
+     * without extracting its data.
+     *
+     * <p>The point is to reveal whether the object is a terminated
+     * computation (⊥) without forcing it: a ⊥ — whether written as {@code T},
+     * produced by an unset void, or returned by a failing atom — surfaces here
+     * as a {@link PhTerminator} instance, detectable by identity. A genuine,
+     * unrecoverable failure encountered while resolving (a type violation, a
+     * missing Δ) propagates as an {@link ExFailure}, exactly as it would
+     * during dataization.</p>
+     *
+     * @return The object in its normal form
+     */
+    Phi normalized();
 }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PhTerminator}.
  * @since 0.73.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class PhTerminatorTest {
 
     @Test
@@ -113,6 +114,33 @@ final class PhTerminatorTest {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(Phi.RHO, new PhDefault()),
             "binding ρ onto the bottom object must not abort"
+        );
+    }
+
+    @Test
+    void resolvesADataValueToNonBottom() {
+        MatcherAssert.assertThat(
+            "resolving a real data value must not be seen as a bottom",
+            new Data.ToPhi(42L).normalized(),
+            Matchers.not(Matchers.instanceOf(PhTerminator.class))
+        );
+    }
+
+    @Test
+    void resolvesTheBottomToItself() {
+        MatcherAssert.assertThat(
+            "resolving the bottom object must reveal a bottom",
+            new PhTerminator().normalized(),
+            Matchers.instanceOf(PhTerminator.class)
+        );
+    }
+
+    @Test
+    void resolvesALazyDispatchToBottom() {
+        MatcherAssert.assertThat(
+            "a lazy dispatch that yields a bottom must resolve to a PhTerminator without forcing",
+            new PhDispatch(new PhDefault(), "missing").normalized(),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 }


### PR DESCRIPTION
Now that a failure is a ⊥ and nothing can catch it, there needs to be a sanctioned way to intercept one and keep going. This adds that primitive.

`recovered` takes an object and an alternative; it normalizes the object and, if that resolves to a ⊥, behaves as the alternative, otherwise as the object itself — returned as-is, not dataized, so a non-dataizable object (a plain formation with no Δ) survives. A ⊥ on both sides stays a ⊥, so an outer recovery can still intercept it.

Detecting the ⊥ without forcing it is the crux, since the object is usually a lazy application or dispatch. The new `Phi.normalized()` resolves an object through dispatch, λ and φ to reveal whether it is a ⊥: a ⊥ — written `T`, produced by an unset void, or returned by a failing atom (including one whose provided fallback itself ends in a ⊥) — comes back as a `PhTerminator` instance, any other object is returned unchanged, and a genuine, unrecoverable failure still throws `ExFailure`. No exception control flow, no dataization.

This is the runtime behind the `:?` substitution operator; the surface syntax is deliberately left for a later change. The eo2js runtime will need a matching atom in its own repo.
