### PR TITLE
#5440: drop dir.is-directory stub so it inherits the real check

### DIFF
--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -18,7 +18,6 @@
 
 [file] > dir
   file > @
-  true > is-directory
 
   [] > made
     if. > @
@@ -141,3 +140,6 @@
 
   ++> throws-on-walking-absent-directory
     (dir tmpdir.tmpfile.deleted).walk "**" > @
+
+  ++> tests-reports-not-a-directory-when-wrapping-regular-file
+    (dir tmpdir.tmpfile.deleted.touched).is-directory.not > @


### PR DESCRIPTION
Closes #5440.

## What was wrong

`dir.eo:21` declared `true > is-directory`, shadowing the real check inherited from the decorated `file`. `file.is-directory` (file.eo:24-34) performs a `stat` syscall and inspects `st-mode` for `S_IFDIR`. The stub discarded that logic — a `dir` pointing at a regular file, or at an absent path, still reported `is-directory` as `true`, and tests like `tests-makes-new-directory` were asserting on a constant rather than on the filesystem state.

## What changed

- Dropped the `true > is-directory` line so `dir.is-directory` inherits from `file`.
- Added a regression test that wraps a freshly `touched` regular file in `dir` and asserts `is-directory.not`.

## Why existing tests keep passing

All in-tree callers of the inherited `is-directory` (no explicit `cant-check` fallback) work on paths that exist:

- `d.is-directory` — `tests-makes-new-directory` (dir just `made`)
- `inner.is-directory` — `tests-deletes-directory-with-file-and-dir` (dir just `made`)
- `tmpdir.is-directory` — `tmpdir.eo`
- `is-directory` in `file.deleted` — file must exist to reach that branch

For all of these `stat.code == 0`, so the `cant-check` void attribute is never dataized. The happy-path behaviour is preserved; only the misuse path is corrected.
