### PR TITLE
#5465: allow BYTES literals to carry a method chain on horizontal args

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -235,7 +235,8 @@ final class Emissions {
             || head.kind() == Value.Kind.GROUP
             || head.kind() == Value.Kind.INTEGER
             || head.kind() == Value.Kind.FLOAT
-            || head.kind() == Value.Kind.STRING;
+            || head.kind() == Value.Kind.STRING
+            || head.kind() == Value.Kind.BYTES;
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -135,6 +135,34 @@ final class TokensTest {
     }
 
     @Test
+    void readsChainOnHorizontalBytesArg() {
+        final Tokens tokens = new Tokens(
+            "foo 00-01.as-i64", new Span("foo 00-01.as-i64", 1)
+        );
+        tokens.readName();
+        final List<Value> args = tokens.readArgs();
+        MatcherAssert.assertThat(
+            "a BYTES arg of the form `head.m1` must carry its chain — 1 link here",
+            args.get(0).chain(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void consumesEntireChainOnBytesArg() {
+        final Tokens tokens = new Tokens(
+            "foo 00-01.as-i64", new Span("foo 00-01.as-i64", 1)
+        );
+        tokens.readName();
+        tokens.readArgs();
+        MatcherAssert.assertThat(
+            "after reading a BYTES arg, its `.method` tail must not be left dangling",
+            tokens.tail(),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
     void stopsArgsBeforeSuffixMarker() {
         final Tokens tokens = new Tokens("foo a > x", new Span("foo a > x", 1));
         tokens.readName();


### PR DESCRIPTION
Closes #5465.

## What was wrong

`Tokens.readArgs()` (`eo-parser/src/main/java/org/eolang/parser/Tokens.java:565`) reads a `.method` chain on a horizontal argument only when `Emissions.chainable()` returns true. The whitelist covered `IDENTIFIER`, `ROOT`, `GROUP`, `INTEGER`, `FLOAT`, `STRING` — but not `BYTES`. So

```eo
[] > foo
  x.plus 00-00-00-00-00-00-00-01.as-i64 > @
```

failed with `trailing garbage after expression`, while

```eo
  x.plus 1.as-i64 > @
```

parsed fine. In head position the chain is read unconditionally, which is why `00-00-00-00-00-00-00-2A.as-i64` on its own line already works (see `eo-runtime/src/main/eo/bytes.eo:472`).

Worse, the parser blocked its own suggested workaround: `x.plus (00-01.as-i64) > @` was rejected by the redundant-parens lint, which recommended exactly the form the first error had refused. There was no legal horizontal spelling at all — this was hit while writing pure-EO code for #5442.

## What changed

- `Emissions.chainable()` now includes `Value.Kind.BYTES`.
- Two new `TokensTest` cases mirror the existing IDENTIFIER coverage: one asserts the chain is captured on a BYTES arg, the other asserts the reader consumes it fully with no dangling `.method` tail.

After the fix, the redundant-parens suggestion is also actually followable, so both errors surface a valid single spelling.

## Verification

- `mvn -pl eo-parser test -Dtest=TokensTest` — 45/45 green (43 existing + 2 new).
- `mvn -pl eo-parser test -Dtest='*Emissions*,*Tokens*,*Parser*'` — 45/45 green.
