### PR TITLE
#5437: remove redundant defect filter now that wpa#62 is fixed

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -389,13 +389,6 @@ final class Linting implements Step {
      * Run whole-program analysis.
      * @param pkg Map of program identifiers to their XMIR
      * @return List of defects found
-     * @todo #5185:30min Remove the redundant defect filter once WPA bug is fixed.
-     *  PkWpa unconditionally appends LtUnlintNonExistingDefectWpa even when excluded
-     *  via Program.without(), making the .without() call ineffective for that lint.
-     *  The workaround is to filter defects by rule name after collection. The WPA bug
-     *  is tracked at https://github.com/objectionary/wpa/issues/62 - remove the
-     *  .filter(defect -> !this.skipProgramLints.contains(defect.rule())) line once
-     *  that issue is resolved and a new WPA version is released.
      */
     private List<org.eolang.wpa.Defect> wpa(final Map<String, XML> pkg) {
         final List<org.eolang.wpa.Defect> defects = new ArrayList<>(0);
@@ -403,7 +396,6 @@ final class Linting implements Step {
             .without(this.skipProgramLints.toArray(new String[0]))
             .defects()
             .stream()
-            .filter(defect -> !this.skipProgramLints.contains(defect.rule()))
             .filter(defect -> this.skipExperimentalLints || !defect.experimental()).forEach(
                 defect -> {
                     final Node node = pkg.get(defect.object()).inner();


### PR DESCRIPTION
Closes #5437.

## What was wrong

Puzzle `5185-82d95125` in `Linting.java#wpa` was a workaround for [objectionary/wpa#62](https://github.com/objectionary/wpa/issues/62): `PkWpa` unconditionally appended `LtUnlintNonExistingDefectWpa`, so `Program.without()` was ineffective for that lint and defects had to be re-filtered post-collection with `.filter(defect -> !this.skipProgramLints.contains(defect.rule()))`.

## What changed

wpa#62 was closed on 2026-07-14 and the fix ships in wpa `0.1.1`, which eo-maven-plugin already depends on (`eo-maven-plugin/pom.xml:40`). The post-collection filter is now redundant — `Program.without()` handles the exclusion correctly.

- Dropped the `.filter(...)` line and the accompanying `@todo #5185:30min` block.

## Verification

`mvn -pl eo-maven-plugin test -Dtest=LintingTest,MjLintTest` — 18 tests green, 0 failures, no regressions.
