### PR TITLE
#5438: remove unlint-non-existing-defect exclusion now that wpa#60 is fixed

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -236,16 +236,6 @@
             <configuration>
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
-                <!--
-                  @todo #5185:30min Remove this exclusion once WPA issue is fixed.
-                   The 'unlint-non-existing-defect' WPA rule incorrectly flags +unlint
-                   annotations for non-WPA rules (e.g. redundant-object, mandatory-package)
-                   as stale, even when those annotations suppress real defects from the
-                   file-level linter. This is a bug in WPA tracked at
-                   https://github.com/objectionary/wpa/issues/60 - remove this
-                   exclusion once that issue is resolved and a new WPA version is released.
-                -->
-                <lint>unlint-non-existing-defect</lint>
               </skipProgramLints>
               <skipSourceLints>
                 <!--


### PR DESCRIPTION
Closes #5438.

## What was wrong

Puzzle `5185-1173c13b` in `eo-runtime/pom.xml` excluded the `unlint-non-existing-defect` WPA rule because it incorrectly flagged `+unlint` annotations for non-WPA rules (`redundant-object`, `mandatory-package`, etc.) as stale — even when those annotations legitimately suppressed real file-level defects.

## What changed

[objectionary/wpa#60](https://github.com/objectionary/wpa/issues/60) was closed on 2026-07-14 and the fix ships in wpa `0.1.1`, which `eo-maven-plugin` already depends on (`eo-maven-plugin/pom.xml:40`). The exclusion — and its accompanying `@todo` — are no longer needed.

- Removed `<lint>unlint-non-existing-defect</lint>` from `skipProgramLints` and the surrounding `@todo` comment block.

The remaining `inconsistent-args` and `incorrect-number-of-attributes` exclusions are untouched (the latter tracked separately in #5439).

## Verification

Local `mvn -pl eo-runtime validate` passes. Full WPA behaviour verified by CI.
