### PR TITLE
#5439: remove incorrect-number-of-attributes exclusion now that wpa#61 is fixed

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -246,16 +246,6 @@
                    exclusion once that issue is resolved and a new WPA version is released.
                 -->
                 <lint>unlint-non-existing-defect</lint>
-                <!--
-                  @todo #5185:30min Remove this exclusion once WPA issue is fixed.
-                   The 'incorrect-number-of-attributes' WPA rule falsely flags valid EO
-                   partial application as an error. Applying fewer arguments than the
-                   formal arity is legal in EO - remaining attributes are left void.
-                   This is a bug in WPA tracked at
-                   https://github.com/objectionary/wpa/issues/61 - remove this
-                   exclusion once that issue is resolved and a new WPA version is released.
-                -->
-                <lint>incorrect-number-of-attributes</lint>
               </skipProgramLints>
               <skipSourceLints>
                 <!--


### PR DESCRIPTION
Closes #5439.

## What was wrong

Puzzle `5185-8cc735bd` in `eo-runtime/pom.xml` excluded the `incorrect-number-of-attributes` WPA rule because it falsely flagged valid EO partial application as an error — applying fewer arguments than the formal arity is legal in EO (remaining attributes stay void).

## What changed

[objectionary/wpa#61](https://github.com/objectionary/wpa/issues/61) was closed on 2026-07-14 and the fix ships in wpa `0.1.1`, which `eo-maven-plugin` already depends on (`eo-maven-plugin/pom.xml:40`). The exclusion and its `@todo` can go — WPA now correctly permits partial application.

- Removed `<lint>incorrect-number-of-attributes</lint>` from `skipProgramLints` and the surrounding `@todo` comment block.

The remaining `inconsistent-args` and `unlint-non-existing-defect` exclusions are untouched (the latter tracked separately in #5438).

## Verification

Local `mvn -pl eo-runtime validate` passes. Full WPA behaviour verified by CI.
