### PR TITLE
#5487: reject non-positive positional index in sprintf

### DIFF
--- a/eo-runtime/src/main/eo/tt/sprintf.eo
+++ b/eo-runtime/src/main/eo/tt/sprintf.eo
@@ -97,6 +97,11 @@
       "%99999999999999999999$s"
       * "Jeff"
 
+  ++> throws-on-sprintf-with-zero-positional-index
+    sprintf > @
+      "%0$s"
+      * "first" "second"
+
   ++> formats-numbered-substitution-with-multiple-args
     eq. > @
       "This is the first; This is the first as well; The second; and the 3"

--- a/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
@@ -97,6 +97,12 @@ final class SprintfArgs {
                         ex
                     );
                 }
+                if (arg < 0L) {
+                    throw new ExFailure(
+                        "The argument index %s must be a positive number (1-based) for the '%%N$' conversion",
+                        digits
+                    );
+                }
             } else {
                 arg = auto;
                 auto += 1L;


### PR DESCRIPTION
Closes #5487.

## What was wrong

`sprintf`'s `%N$` positional-index syntax is documented and tested as 1-based (`%1$s` refers to the first argument). `%0$s` is a malformed reference — there is no "argument 0" — but was silently accepted.

`SprintfArgs.formatted()` (`eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java`) converts the 1-based digit string to a 0-based index: `arg = Long.parseLong(digits) - 1L`. For `digits = "0"`, `arg = -1`. The only bounds check present was `arg >= this.length` (upper bound) — nothing rejected negative values, so `-1` sailed through.

That `-1` then reached `tuple.at` (`eo-runtime/src/main/eo/tuple.eo:18-29`), which supports Python-style negative indexing **on purpose** (`arr.at -1` returns the last element — see `tests-tuple-with-negative-index-gets-last`). So `%0$s` silently resolved to the **last** argument instead of raising the same "index out of bounds" error already thrown for `%99999999999999999999$s` (`throws-on-sprintf-with-oversized-positional-index`).

## Verified reproduction

Ran `SprintfArgs` directly against a 2-argument tuple shaped like the existing `returnsCorrectArgumentsForMixedSubstitutions` fixture (`length=2`, logical args `["first", "second"]`):

```java
new SprintfArgs("%0$s", 2L, tuple.take("at")).formatted()
```
Before the fix: returns `["second"]`, no error.
After the fix: throws `ExFailure: The argument index 0 must be a positive number (1-based) for the '%N$' conversion`.

## What changed

- Added a lower-bound check right after the positional-index parse: `arg < 0L` throws `ExFailure`, symmetric with the existing upper-bound check.
- Added `throws-on-sprintf-with-zero-positional-index` next to the existing oversized-index test in `sprintf.eo`.

## A second bug found in passing

While writing the fix, my first attempt used `new ExFailure(String.format(fmt, args))` (pre-formatting, then passing the single resulting string) — this crashed with `UnknownFormatConversionException` instead of throwing my intended message. Root cause: `ExFailure(String, Object...)` formats its `cause` argument internally; passing an *already-formatted* string as the sole argument makes it get formatted **again** with zero args, and since my message ended in a literal `'%N$'` (surviving the first pass's `%%` → `%` unescaping), the second pass tried to parse it as a live conversion.

I fixed my own code by using the idiomatic direct call (`ExFailure(fmt, args)`, one pass, matching `Data.java:167-170` and most of the codebase) — but found the exact same defect already present in `SprintfArgs.toLong` and `SprintfArgs.fmt` (plus `EOsscanf.converted`), silently turning their intended `ExFailure` messages into raw `MissingFormatArgumentException`/`UnknownFormatConversionException` leaks. That's a distinct, pre-existing bug unrelated to this one — filed separately as #5489 rather than folding an unrelated fix into this PR.

## Verification

`SprintfArgsTest` (2 existing tests) run green against the patched `SprintfArgs.java` — confirmed via direct JUnit Platform Launcher invocation, since the local `mvn` transpile is currently broken on an unrelated `tt.regex` XSL error on this machine (reproduces identically on a clean `master` checkout, not something this PR introduces).
