### PR TITLE
#5489: stop ExFailure from double-formatting error messages

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/EOsscanf.java
@@ -151,10 +151,8 @@ public final class EOsscanf extends PhDefault implements Atom {
     private static Phi converted(final char symbol, final String str) {
         if (!EOsscanf.CONVERSION.containsKey(symbol)) {
             throw new ExFailure(
-                String.format(
-                    "The format %c is unsupported, only %s formats can be used",
-                    symbol, "%s, %d, %f"
-                )
+                "The format %c is unsupported, only %s formats can be used",
+                symbol, "%s, %d, %f"
             );
         }
         return EOsscanf.CONVERSION.get(symbol).apply(str);

--- a/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
@@ -109,10 +109,8 @@ final class SprintfArgs {
             }
             if (arg >= this.length) {
                 throw new ExFailure(
-                    String.format(
-                        "The argument index %d is out of bounds (total arguments: %d)",
-                        arg, this.length
-                    )
+                    "The argument index %d is out of bounds (total arguments: %d)",
+                    arg, this.length
                 );
             }
             final Phi taken = this.retriever.copy();
@@ -131,10 +129,8 @@ final class SprintfArgs {
     private static Object fmt(final char symbol, final Dataized element) {
         if (!SprintfArgs.CONVERSION.containsKey(symbol)) {
             throw new ExFailure(
-                String.format(
-                    "The format %c is unsupported, only %s formats can be used",
-                    symbol, "%s, %d, %f, %x, %b"
-                )
+                "The format %c is unsupported, only %s formats can be used",
+                symbol, "%s, %d, %f, %x, %b"
             );
         }
         return SprintfArgs.CONVERSION.get(symbol).apply(element);
@@ -150,10 +146,8 @@ final class SprintfArgs {
     private static long toLong(final double number) {
         if (number < Long.MIN_VALUE || number > Long.MAX_VALUE) {
             throw new ExFailure(
-                String.format(
-                    "The number %s doesn't fit into long range for the '%%d' conversion",
-                    number
-                )
+                "The number %s doesn't fit into long range for the '%%d' conversion",
+                number
             );
         }
         return (long) number;

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -70,8 +70,7 @@ final class SprintfArgsTest {
             "must throw ExFailure, not an internal java.util.Formatter exception"
         );
         MatcherAssert.assertThat(
-            "the ExFailure message must name the out-of-range number, "
-                + "not be swallowed by a second, accidental format pass",
+            "the ExFailure message must name the out-of-range number, not be swallowed by a second, accidental format pass",
             ex.getMessage(),
             Matchers.containsString("doesn't fit into long range")
         );
@@ -88,8 +87,7 @@ final class SprintfArgsTest {
             "must throw ExFailure, not an internal java.util.Formatter exception"
         );
         MatcherAssert.assertThat(
-            "the ExFailure message must name the unsupported format char, "
-                + "not be swallowed by a second, accidental format pass",
+            "the ExFailure message must name the unsupported format char, not be swallowed by a second, accidental format pass",
             ex.getMessage(),
             Matchers.containsString("is unsupported")
         );

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -11,9 +11,11 @@ package org.eolang.EOtt; // NOPMD
 
 import org.cactoos.list.ListOf;
 import org.eolang.Data;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,6 +56,42 @@ final class SprintfArgsTest {
                 tuple.take("at")
             ).formatted(),
             Matchers.equalTo(new ListOf<>(first, first, second))
+        );
+    }
+
+    @Test
+    void reportsOutOfLongRangeMessageInsteadOfDoubleFormatting() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(1.0e30));
+        final ExFailure ex = Assertions.assertThrows(
+            ExFailure.class,
+            () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+            "must throw ExFailure, not an internal java.util.Formatter exception"
+        );
+        MatcherAssert.assertThat(
+            "the ExFailure message must name the out-of-range number, "
+                + "not be swallowed by a second, accidental format pass",
+            ex.getMessage(),
+            Matchers.containsString("doesn't fit into long range")
+        );
+    }
+
+    @Test
+    void reportsUnsupportedFormatMessageInsteadOfDoubleFormatting() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi("x"));
+        final ExFailure ex = Assertions.assertThrows(
+            ExFailure.class,
+            () -> new SprintfArgs("%z", 1L, tuple.take("at")).formatted(),
+            "must throw ExFailure, not an internal java.util.Formatter exception"
+        );
+        MatcherAssert.assertThat(
+            "the ExFailure message must name the unsupported format char, "
+                + "not be swallowed by a second, accidental format pass",
+            ex.getMessage(),
+            Matchers.containsString("is unsupported")
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link SprintfArgs}.
  * @since 0.57.4
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class SprintfArgsTest {
 
     @Test
@@ -64,14 +65,13 @@ final class SprintfArgsTest {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
         tuple.put("head", new Data.ToPhi(1.0e30));
-        final ExFailure ex = Assertions.assertThrows(
-            ExFailure.class,
-            () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
-            "must throw ExFailure, not an internal java.util.Formatter exception"
-        );
         MatcherAssert.assertThat(
             "the ExFailure message must name the out-of-range number, not be swallowed by a second, accidental format pass",
-            ex.getMessage(),
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                "must throw ExFailure, not an internal java.util.Formatter exception"
+            ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
         );
     }
@@ -81,14 +81,13 @@ final class SprintfArgsTest {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
         tuple.put("head", new Data.ToPhi("x"));
-        final ExFailure ex = Assertions.assertThrows(
-            ExFailure.class,
-            () -> new SprintfArgs("%z", 1L, tuple.take("at")).formatted(),
-            "must throw ExFailure, not an internal java.util.Formatter exception"
-        );
         MatcherAssert.assertThat(
             "the ExFailure message must name the unsupported format char, not be swallowed by a second, accidental format pass",
-            ex.getMessage(),
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new SprintfArgs("%z", 1L, tuple.take("at")).formatted(),
+                "must throw ExFailure, not an internal java.util.Formatter exception"
+            ).getMessage(),
             Matchers.containsString("is unsupported")
         );
     }


### PR DESCRIPTION
Closes #5489.

## What was wrong

`ExFailure` has two constructors:
```java
public ExFailure(final String cause, final Object... args) {
    this(String.format(cause, args), (Throwable) null);   // formats internally
}
public ExFailure(final String cause, final Throwable root) {
    super(cause, root);                                    // no formatting
}
```

Three call sites pre-formatted their message manually via `String.format(...)` and passed the single resulting string to `ExFailure`. With no second argument, that resolves to the varargs constructor with an **empty** `args` array — so the already-formatted message gets run through `String.format` a second, unintended time.

This is a no-op when no literal `%` survives the first pass, but breaks in two ways that actually occur here:

- **`SprintfArgs.toLong`** — message ends in a literal `'%d'` (from an intentional `%%d` escape meant to *show* the conversion character to the user). The second pass sees a live `%d` with zero args and throws `java.util.MissingFormatArgumentException` instead of the intended *"doesn't fit into long range"* `ExFailure`.
- **`SprintfArgs.fmt`** and **`EOsscanf.converted`** (both: unsupported format char) — substitute a literal flag list like `"%s, %d, %f, %x, %b"` into the message via `%s`. Since `%s` copies the value verbatim, that whole percent-sign sequence survives into the "formatted" string. The second pass sees five live conversions with zero args and throws `java.util.UnknownFormatConversionException` instead of the intended *"is unsupported"* `ExFailure`.

## What changed

Switched these three call sites to the idiomatic direct `ExFailure(fmt, args)` form (matching `Data.java`, `Dataized.java`, and most other call sites in the codebase), which lets the constructor perform exactly one format pass. Also cleaned up `SprintfArgs`' `arg >= this.length` check, which had the same fragile shape though it happened to be harmless in practice (its message has no literal `%` survivors).

`EOsscanf.parsed` is untouched: it passes a second `Throwable` argument, which resolves to the non-varargs `ExFailure(String, Throwable)` overload and never double-formats.

Added two regression tests to `SprintfArgsTest` asserting the actual `ExFailure` **message text** (not just its type) for the out-of-long-range and unsupported-format-char paths.

## Verified reproduction (before fix) / verified fix

Confirmed via direct `SprintfArgs` invocation (reflection, since the class is package-private):

```java
new SprintfArgs("%d", 1L, tupleWith(1.0e30)).formatted();
// before: THREW java.util.MissingFormatArgumentException: Format specifier '%d'
// after:  THREW org.eolang.ExFailure: The number 1.0E30 doesn't fit into long range for the '%d' conversion

new SprintfArgs("%z", 1L, tupleWith("x")).formatted();
// before: THREW java.util.UnknownFormatConversionException: Conversion = 's'
// after:  THREW org.eolang.ExFailure: The format z is unsupported, only %s, %d, %f, %x, %b formats can be used
```

## Verification

`SprintfArgsTest` — 4/4 green (2 existing + 2 new), run via direct JUnit Platform Launcher invocation since the local `mvn` transpile is currently broken on an unrelated `tt.regex` XSL error on this machine (reproduces identically on a clean `master` checkout).
