### PR TITLE
#5485: reject exactly 2^63 in sprintf's %d conversion instead of saturating

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EOtt/SprintfArgs.java
@@ -38,6 +38,16 @@ final class SprintfArgs {
      */
     private static final char PERCENT = '%';
 
+    /**
+     * One past the largest {@code double} that still narrows to a valid
+     * {@code long} without saturating: {@code 2^63}, exactly one ulp above
+     * {@link Long#MAX_VALUE}. {@code (double) Long.MAX_VALUE} itself rounds
+     * up to this same value, so comparing against it directly (rather than
+     * against the rounded {@code Long.MAX_VALUE}) is what makes the {@code
+     * >=} guard in {@link #toLong(double)} exact.
+     */
+    private static final double LONG_UPPER_LIMIT = 0x1.0p63;
+
     static {
         SprintfArgs.CONVERSION.put('s', Dataized::asString);
         SprintfArgs.CONVERSION.put('d', element -> SprintfArgs.toLong(element.asNumber()));
@@ -144,7 +154,7 @@ final class SprintfArgs {
      * @return The number as {@code long}
      */
     private static long toLong(final double number) {
-        if (number < Long.MIN_VALUE || number > Long.MAX_VALUE) {
+        if (number < Long.MIN_VALUE || number >= SprintfArgs.LONG_UPPER_LIMIT) {
             throw new ExFailure(
                 "The number %s doesn't fit into long range for the '%%d' conversion",
                 number

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -77,6 +77,43 @@ final class SprintfArgsTest {
     }
 
     @Test
+    void rejectsExactlyTwoToThe63rdInsteadOfSaturating() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(9_223_372_036_854_775_808.0));
+        final ExFailure ex = Assertions.assertThrows(
+            ExFailure.class,
+            () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+            "2^63 is one past Long.MAX_VALUE and must be rejected, not silently "
+                + "saturated to Long.MAX_VALUE via narrowing (double) Long.MAX_VALUE "
+                + "rounds up to exactly this value, so the boundary check must "
+                + "compare against 2^63 directly rather than against Long.MAX_VALUE"
+        );
+        MatcherAssert.assertThat(
+            "the ExFailure message must name the out-of-range number",
+            ex.getMessage(),
+            Matchers.containsString("doesn't fit into long range")
+        );
+    }
+
+    @Test
+    void acceptsLargestDoubleThatTrulyFitsInLongRange() {
+        // 2^63 - 2048: the representable double one ulp below 2^63 at this
+        // magnitude (doubles have no exact representation for Long.MAX_VALUE
+        // itself — 9_223_372_036_854_775_807.0 as a literal already rounds
+        // up to 2^63, which is exactly the boundary this fix must reject).
+        final double justBelowLimit = 9_223_372_036_854_773_760.0;
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(justBelowLimit));
+        MatcherAssert.assertThat(
+            "a double strictly below 2^63 must still be accepted as a valid long",
+            new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+            Matchers.equalTo(new ListOf<>((long) justBelowLimit))
+        );
+    }
+
+    @Test
     void reportsUnsupportedFormatMessageInsteadOfDoubleFormatting() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -77,7 +77,7 @@ final class SprintfArgsTest {
     }
 
     @Test
-    void rejectsExactlyTwoToThe63rdInsteadOfSaturating() {
+    void rejectsTwoPowerSixtyThreeInsteadOfSaturating() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
         tuple.put("head", new Data.ToPhi(9_223_372_036_854_775_808.0));
@@ -94,18 +94,14 @@ final class SprintfArgsTest {
 
     @Test
     void acceptsLargestDoubleThatTrulyFitsInLongRange() {
-        // 2^63 - 2048: the representable double one ulp below 2^63 at this
-        // magnitude (doubles have no exact representation for Long.MAX_VALUE
-        // itself — 9_223_372_036_854_775_807.0 as a literal already rounds
-        // up to 2^63, which is exactly the boundary this fix must reject).
-        final double justBelowLimit = 9_223_372_036_854_773_760.0;
+        final double closest = 9_223_372_036_854_773_760.0;
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(justBelowLimit));
+        tuple.put("head", new Data.ToPhi(closest));
         MatcherAssert.assertThat(
-            "a double strictly below 2^63 must still be accepted as a valid long",
+            "a double strictly below 2^63 (the representable double one ulp below it, since Long.MAX_VALUE itself isn't exactly representable and rounds up to 2^63) must still be accepted as a valid long",
             new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
-            Matchers.equalTo(new ListOf<>((long) justBelowLimit))
+            Matchers.equalTo(new ListOf<>((long) closest))
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -81,14 +81,13 @@ final class SprintfArgsTest {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
         tuple.put("head", new Data.ToPhi(9_223_372_036_854_775_808.0));
-        final ExFailure ex = Assertions.assertThrows(
-            ExFailure.class,
-            () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
-            "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
-        );
         MatcherAssert.assertThat(
             "the ExFailure message must name the out-of-range number",
-            ex.getMessage(),
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
+            ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOtt/SprintfArgsTest.java
@@ -84,10 +84,7 @@ final class SprintfArgsTest {
         final ExFailure ex = Assertions.assertThrows(
             ExFailure.class,
             () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
-            "2^63 is one past Long.MAX_VALUE and must be rejected, not silently "
-                + "saturated to Long.MAX_VALUE via narrowing (double) Long.MAX_VALUE "
-                + "rounds up to exactly this value, so the boundary check must "
-                + "compare against 2^63 directly rather than against Long.MAX_VALUE"
+            "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
         );
         MatcherAssert.assertThat(
             "the ExFailure message must name the out-of-range number",


### PR DESCRIPTION
Closes #5485.

**Note:** this branch is stacked on top of #5491 (`fix/issue-5489-exfailure-double-format`), since both touch `SprintfArgs.toLong` and I wanted to avoid a guaranteed conflict. The diff below will show #5491's changes too until that one merges — once it does, this PR will automatically narrow down to just the `2^63` boundary fix.

## What was wrong

`toLong`'s docstring promises to *"reject a value outside long range instead of silently saturating to `Long.MAX_VALUE`/`MIN_VALUE` as `Double.longValue()` does"* — but the guard compared against `(double) Long.MAX_VALUE`, which itself rounds **up** to `2^63` (`Long.MAX_VALUE = 9223372036854775807` has no exact `double` representation at that magnitude — the nearest representable doubles are `2^63 - 2048` and `2^63`, and `9223372036854775807` is only `1` away from `2^63` vs. `2047` away from the other candidate, so it rounds up).

So for the single value `2^63`, `number > Long.MAX_VALUE` evaluated to `false` — both sides promote to the same `double`, `9.223372036854776E18` — the guard passed, and `(long) number` silently saturated to `Long.MAX_VALUE`. Exactly the behavior the docstring says this method avoids.

## What changed

- Compare against `2^63` directly (`0x1.0p63`, the exact hex double literal) with `>=`, instead of against the rounded-up `(double) Long.MAX_VALUE` with `>`.
- `Long.MIN_VALUE` needed no change: `-2^63` **is** exactly representable as a `double`, so the existing `<` comparison on that side was already exact.

## Verified reproduction / fix

```java
double n = 9223372036854775808.0;   // = 2^63
n > Long.MAX_VALUE;                  // false — both promote to the same double
(long) n;                            // 9223372036854775807, i.e. Long.MAX_VALUE — silent saturation
```

After the fix, `toLong(2^63)` throws `ExFailure: The number ... doesn't fit into long range for the '%d' conversion` instead.

## Tests added

- `rejectsExactlyTwoToThe63rdInsteadOfSaturating` — `2^63` is now rejected with the correct message (previously silently returned `Long.MAX_VALUE`).
- `acceptsLargestDoubleThatTrulyFitsInLongRange` — the largest double that truly fits below `2^63` (`2^63 - 2048`, the representable double one ulp below the boundary at this magnitude — note `9223372036854775807.0` as a literal already rounds up to `2^63`, so it can't be used to test the "just fits" side) still converts correctly.

## Verification

`SprintfArgsTest` — 6/6 green (4 existing/from #5491 + 2 new), run via direct JUnit Platform Launcher invocation since the local `mvn` transpile is currently broken on an unrelated `tt.regex` XSL error on this machine.
