### PR TITLE
#5493: report the actual byte length in Dataized.asBool()'s error message

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -114,8 +114,8 @@ public final class Dataized {
         final byte[] weak = this.take();
         if (weak.length != 1) {
             throw new ExFailure(
-                "Can't dataize given bytes of length > 1 to boolean, bytes are: %s",
-                Arrays.toString(weak)
+                "Can't dataize bytes of length %d to boolean, exactly 1 byte is required, bytes are: %s",
+                weak.length, Arrays.toString(weak)
             );
         }
         return weak[0] == 1;

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -65,4 +65,17 @@ final class DataizedTest {
             "requesting an unsupported type was expected to fail with ExFailure"
         );
     }
+
+    @Test
+    void reportsActualLengthWhenBoolIsEmpty() {
+        MatcherAssert.assertThat(
+            "the message must report the true (zero) length, not claim it's over one",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(new PhDefault(new byte[0])).asBool(),
+                "dataizing empty bytes as boolean was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.containsString("length 0")
+        );
+    }
 }


### PR DESCRIPTION
Closes #5493.

## What was wrong

`Dataized.asBool()` rejects any byte array whose length isn't exactly 1, but the error message hardcoded *"length > 1"* — which is false for the empty-bytes case (length 0), the other way `!= 1` can be true.

`sprintf`'s `%b` conversion calls `Dataized::asBool` directly (`EOtt/SprintfArgs.java:46`), so:

```eo
sprintf > @
  "%b"
  * --
```

surfaces:

```
Can't dataize given bytes of length > 1 to boolean, bytes are: []
```

— claiming the bytes are "of length > 1" while printing the empty array `[]` in the very same sentence. Anyone debugging from the message alone would look for a >1-byte value and never find the actual (0-byte) cause.

## What changed

Report the actual length instead of assuming which side of 1 it's on:

```java
"Can't dataize bytes of length %d to boolean, exactly 1 byte is required, bytes are: %s"
```

Only the diagnostic text changes — the validation logic (reject anything but exactly 1 byte) is unchanged.

## Verification

Added `reportsActualLengthWhenBoolIsEmpty` to `DataizedTest`, asserting the message names the true (zero) length. Used a raw `PhDefault(byte[])` rather than routing through the `bytes` EO object, so the test doesn't depend on `bytes.eo` transpilation.

Ran the full `DataizedTest` suite locally (manual javac + JUnit Platform Launcher, since this machine's `mvn` transpile is broken on an unrelated `tt.regex` XSL error, reproducing identically on a clean `master` checkout): new test passes; the one pre-existing failure (`failsWhenForcingTerminated`) is the same environmental issue (missing generated `EOstring` class), unrelated to this change.
