### PR TITLE
Add pipe syntax for applying anonymous formations

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -202,6 +202,7 @@ Each non-blank, non-comment line is classified into exactly one shape, determine
 | `+` | otherwise | meta directive (§3.2) |
 | `#` | — | comment (§3.3) |
 | `.` | — | method-dispatch line (§3.5) |
+| `\|` | — | pipe-application line (§3.14) |
 | `[` | — | formation line (§3.4) |
 | `"""` (start of line, no other content) | — | text-block opener (§3.11) |
 | identifier | ends with `.` followed by space/EOL | reversed-dispatch line (§3.8) |
@@ -588,6 +589,52 @@ size.
 
 **Implication for the classifier.** Before §3.1 runs, the lexer must scan ahead: if a line's last non-whitespace character is `-` and that line contains a partial BYTES token, the lexer consumes additional lines until the BYTES token is complete, then emits a single virtual line for classification. The indent stack (§5) is unaffected — the multi-line BYTES is one expression at one indent.
 
+### 3.14 Pipe application — `| [arg…] [> name]`
+
+A line whose first non-space character is `|` is a *pipe-application line*. It applies arguments to the **same-indent predecessor** — the object declared on the lines just above it — without naming that object at the call site. This is the surface form of phi-calculus *formation-with-application* `⟦…⟧(…)`: the predecessor is formed, then the pipe supplies its arguments. The `|` reads as an up-arrow to "the object above".
+
+R-3.14.1. The `|` is followed by a single space, then either a horizontal argument list (§3.6) or nothing, then an optional name suffix (§3.10). Its tail is parsed exactly as an application's argument list plus suffix — the pipe supplies the arguments; the *head* is the implicit predecessor.
+
+R-3.14.2. **Predecessor requirement.** The stack top at the pipe's indent must be a **formation** (`bare-formation` or `inline-phi-formation`) or another **pipe-application**, and it must be **named** (an explicit `> name` or an auto-generated `>>`). A pipe with no predecessor (top-level / empty stack), a deeper-indent ("descending") pipe, or a pipe whose predecessor is an unnamed formation, a plain value, an application, or any `.method` dispatch is an error. The named requirement is what lets the pipe refer to the predecessor by name (R-3.14.7); an unnamed formation cannot be a pipe target — give it a `>>`.
+
+R-3.14.3. **Two forms**, distinguished by whether horizontal args are present on the line:
+  - **Horizontal form** — `| arg1 arg2 … [> name]` (≥1 arg): the args are the application arguments. The line takes no deeper-indent children (`vertical-completed`), but may still be wrapped by a same-indent `.method` (§3.5) or extended by a following pipe (chained application, R-3.14.5).
+  - **Vertical form** — `| [> name]` (0 args on the line): a deeper-indent argument block follows, exactly as under a `vapplication` head (§4.1). The args become the application arguments.
+
+R-3.14.4. **No pipe after `.method`.** A pipe may follow a formation or another pipe only. Once a `.method` has dispatched an attribute off the predecessor, the formation is no longer the object in hand, so a pipe after a `.method` line (of any completion state) is rejected. Cross-line ownership: §5.2 (R-5.2.4a / R-5.2.5a / R-5.2.11a). Conversely a `.method` **after** a pipe is legal (the pipe application is a complete value); a pipe after a pipe is legal (R-3.14.5).
+
+R-3.14.5. **Chaining.** Consecutive pipe lines build left-associated applications: `| a` then `| b` after formation `F` is `((F a) b)`, two applications. Each pipe in a chain is its own object and so must be named (R-3.14.2 applies to the *predecessor*, which for the second pipe is the first pipe). Contrast a single `| a b` (one application, two args).
+
+R-3.14.6. Name suffix per §3.10: `> name`, `>>`, or none (the last only when the pipe is an unnamed intermediate immediately wrapped by a `.method`, which names the whole chain). The atom signature `/sig` and the test attribute `+> name` are rejected — a pipe is an application, not a formation. All-or-nothing inline binding (§6.6) applies to the argument group.
+
+R-3.14.7. **Emission / XMIR.** A pipe line desugars to an ordinary application whose head is a reference to the (named) predecessor, and the predecessor object stays in place. So `| a > r` after a formation `F` (named `F`) is identical in XMIR to `F a > r`; `| a` then `| b` after `F >>` (auto-name `A`) is `A a` (auto-named) followed by `A′ b`. The parser emits the pipe line as a base-less `<o pipe=''>` with the args as children; the `wrap-applications` reshape (§9) sets `@base` from the preceding sibling's `@name` and drops `@pipe`, so every downstream pass (scope resolution, base rolling) treats it as a hand-written application.
+
+Outer kind: **`pipe-application`** (openness `open` for the vertical form's body, `vertical-completed` for the horizontal form).
+
+```
+[x] > foo                             ← named formation
+  x.plus x > @
+| 5 > foo5                            ← foo5 = foo applied to 5 (i.e. (5).plus 5)
+
+[a b] >>                              ← auto-named (anonymous) formation
+  a.plus b > @
+| 2 3 > pair                          ← one application, two args, referring to the auto-name
+```
+
+Illegal:
+
+```
+6 > six
+| 5 > n                               ← rejected: predecessor `six` is not a formation or pipe
+
+[x] > foo
+  ...
+.x
+| 6 > n                               ← rejected: pipe after a `.method`
+
+| 5 > n                               ← rejected: no object above
+```
+
 ---
 
 ## 4. Multi-line expressions and their outer kinds
@@ -749,9 +796,12 @@ R-5.2.3. **MethodDispatch line dispatch.** If the line's kind is `MethodDispatch
 
 R-5.2.4. **Non-MethodDispatch same-indent line.** If the line's kind is **not** MethodDispatch: the top entry is a *completed previous sibling*. Run close-time checks (§5.3) on it, then **replace** it with a new entry built from the new line. The new entry's `parent_kind` is read from the stack entry below.
 
+R-5.2.4a. **PipeApplication same-indent line.** A `PipeApplication` line (§3.14) is a Non-MethodDispatch line and so replaces the top per R-5.2.4, but first the top must satisfy R-3.14.2: its kind must be `bare-formation`, `inline-phi-formation`, or `pipe-application`, and it must be named. Otherwise error `a pipe must follow a named formation or another pipe` (§9.9). In particular a top whose kind is `vmethod` / `vmethod-with-hargs` (a `.method` was taken off the predecessor) fails this check — R-3.14.4.
+
 **Step C — Deeper line.** If the top entry now has indent < `N`:
 
-R-5.2.5. If the line's kind is `MethodDispatch`: error `method continuation has no expression to attach to`. A `.method` line at indent `N` requires a previous sibling expression at the same indent; a deeper-than-parent position has no such sibling. **This rule is the authoritative owner of the `.method`-as-deeper-line rejection**, including the bare-reversed-receiver edge case (a `.method` line as the first deeper child of a bare-reversed parent). R-5.2.9's "must not start with `.`" condition is enforced *via this rule*; R-5.2.9 itself only manages the `receiver_consumed?` flag.
+R-5.2.5. If the line's kind is `MethodDispatch`: error `method continuation has no expression to attach to`.
+R-5.2.5a. If the line's kind is `PipeApplication`: error `a pipe must follow a named formation or another pipe` — a deeper-indent ("descending") pipe has no same-indent predecessor to apply to. A `.method` line at indent `N` requires a previous sibling expression at the same indent; a deeper-than-parent position has no such sibling. **This rule is the authoritative owner of the `.method`-as-deeper-line rejection**, including the bare-reversed-receiver edge case (a `.method` line as the first deeper child of a bare-reversed parent). R-5.2.9's "must not start with `.`" condition is enforced *via this rule*; R-5.2.9 itself only manages the `receiver_consumed?` flag.
 R-5.2.6. The previous top's openness must be `open`. If `vertical-completed` or `horizontal-completed`: error `unexpected deeper-indent line — previous expression is closed for children`.
 R-5.2.7. `N` must equal `previous_top.indent + 2`. Otherwise: error `indent increased by more than one level`.
 R-5.2.8. Push a new entry. Its `parent_kind` is the previous top's `kind`.
@@ -761,6 +811,7 @@ R-5.2.9. If `parent_kind = bare-reversed` and the previous top's `receiver_consu
 
 R-5.2.10. If the line's kind is `MethodDispatch`: error `method continuation has no expression to attach to` (§9.9). A `.method` line requires a previous-sibling expression at the same indent; an empty stack has no such sibling.
 R-5.2.11. Otherwise: the line is the program's top-level object. Push a new entry with `parent_kind = top-level`. If the line's kind is `Meta` and a non-meta object has already been emitted: error (R-3.2.2).
+R-5.2.11a. If the line's kind is `PipeApplication`: error `a pipe must follow a named formation or another pipe` — an empty stack has no object above to apply to.
 
 ### 5.3 Close-time checks
 
@@ -1264,6 +1315,7 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 | `vapplication` | multi-line | yes while in progress | yes after block closes | head + vertical block |
 | `vmethod` | multi-line | yes while in progress (only if last `.method` has 0 hargs) | yes (more `.method`s extend the chain; same-indent `.method` after block closes wraps it) | chain of `.method` continuations |
 | `vmethod-with-hargs` | multi-line | **no** | **no** | a `.method` continuation line that itself carries ≥1 horizontal args — closes the chain immediately |
+| `pipe-application` | 1 line (+ body if 0 hargs) | yes if 0 hargs (vertical form's args) | yes (after) | `\| [args] [> name]`; applies args to the same-indent named formation/pipe above (§3.14) |
 | `text-block` | multi-line | n/a | yes (after closing `"""`) | `"""…"""` |
 
 **Horizontally-completed kinds (the single source of truth)** — these never receive deeper children and cannot be wrapped by same-indent `.method`:
@@ -1284,6 +1336,7 @@ Reproduced from §3.1 for convenience:
 | `+` | otherwise | meta (§3.2) |
 | `#` | — | comment (§3.3) |
 | `.` | — | method-dispatch line (§3.5) |
+| `\|` | — | pipe-application line (§3.14) |
 | `[` | — | formation (§3.4) |
 | `"""` alone | — | text-block opener (§3.11) |
 | identifier | `.` followed by space/EOL | reversed dispatch (§3.8) |

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -90,6 +90,7 @@ public final class Canonical implements UnaryOperator<XML> {
                 new TrFull(
                     new TrJoined<>(
                         new TrClasspath<>(
+                            "/org/eolang/parser/parse/wrap-applications.xsl",
                             "/org/eolang/parser/parse/validate-before-stars.xsl",
                             "/org/eolang/parser/parse/resolve-before-stars.xsl",
                             "/org/eolang/parser/parse/fragile-dispatch.xsl",

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -292,6 +292,16 @@ final class Emit {
     }
 
     /**
+     * Add the {@code @pipe=""} attribute to the most recently opened
+     * {@code <o>} — marks a base-less pipe-application node (§3.14 /
+     * §9.4) that the {@code wrap-applications} reshape rewrites into an
+     * application referring to the preceding sibling.
+     */
+    void pipe() {
+        this.append(new Directives().attr("pipe", ""));
+    }
+
+    /**
      * Add the {@code @star=""} attribute to the most recently opened
      * {@code <o>} (§9.4 compact-tuple wrapper marker and §9.4.2 star
      * head).

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -391,6 +391,8 @@ final class Eo implements Iterable<Directive> {
             line = new LnFormation(span);
         } else if (span.head() == '.') {
             line = new LnMethod(span);
+        } else if (span.head() == '|') {
+            line = new LnPipe(span);
         } else if (span.head() == '?') {
             line = Eo.questioned(span);
         } else if (span.head() >= 'a' && span.head() <= 'z') {

--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -100,6 +100,12 @@ enum Kind {
     VMETHOD_WITH_HARGS,
 
     /**
+     * Pipe application {@code | args} — applies arguments to the
+     * same-indent named formation or pipe above it (§3.14).
+     */
+    PIPE_APPLICATION,
+
+    /**
      * Triple-quoted {@code """…"""} text block.
      */
     TEXT_BLOCK,
@@ -139,5 +145,15 @@ enum Kind {
      */
     boolean formation() {
         return this == BARE_FORMATION || this == ONLY_PHI_FORMATION;
+    }
+
+    /**
+     * Whether a pipe application (§3.14) may attach to a predecessor of
+     * this kind — a formation or another pipe. Read by {@link LnPipe} to
+     * enforce R-3.14.2 / R-5.2.4a.
+     * @return True iff this kind may be a pipe's predecessor
+     */
+    boolean pipeable() {
+        return this.formation() || this == PIPE_APPLICATION;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.List;
+
+/**
+ * A pipe-application continuation line — §3.14 of the spec.
+ *
+ * <p>Form: {@code | [arg…] [> name]}. The {@code |} applies arguments to
+ * the <em>same-indent predecessor</em> — the object declared on the lines
+ * just above — without naming it at the call site. It is the surface form
+ * of phi-calculus formation-with-application {@code ⟦…⟧(…)}: the
+ * predecessor is formed, then the pipe supplies its arguments.</p>
+ *
+ * <p>The predecessor (stack top at the pipe's indent) must be a formation
+ * ({@link Kind#BARE_FORMATION} / {@link Kind#ONLY_PHI_FORMATION}) or
+ * another {@link Kind#PIPE_APPLICATION}, and must be named — a pipe refers
+ * to it by name, so an unnamed formation is not a valid target (R-3.14.2).
+ * A pipe after a {@code .method} dispatch is rejected (R-3.14.4): the
+ * attribute has already been taken, so the formation is no longer in
+ * hand.</p>
+ *
+ * <p>Two forms by whether horizontal args are present (R-3.14.3): the
+ * <em>horizontal</em> form {@code | a b} carries its args on the line and
+ * closes for children ({@link Openness#VERTICAL_COMPLETED}); the
+ * <em>vertical</em> form {@code |} with a deeper-indent body opens for a
+ * vertical-argument block exactly as a {@code vapplication} head, so it
+ * stays {@link Openness#OPEN}. Either way a following {@code .method} or
+ * pipe may extend it.</p>
+ *
+ * <p>Emission (R-3.14.7): the line emits a base-less {@code <o pipe=''>}
+ * with the args as children; the {@code wrap-applications} reshape sets
+ * {@code @base} from the preceding sibling's {@code @name} and drops
+ * {@code @pipe}, so downstream passes treat it as a hand-written
+ * application of the predecessor by name. The predecessor object stays in
+ * place.</p>
+ *
+ * @since 0.1
+ */
+final class LnPipe implements Line {
+
+    /**
+     * The line's source span.
+     */
+    private final Span span;
+
+    /**
+     * Ctor.
+     * @param source The source span
+     */
+    LnPipe(final Span source) {
+        this.span = source;
+    }
+
+    @Override
+    public void into(final Stack stack, final Globals globals, final Emit emit) {
+        Blanks.checkPlain(this.span, globals, emit);
+        this.precheck(stack);
+        final Tokens tokens = this.piped();
+        final List<Value> args = tokens.readArgs();
+        Bindings.checkAllOrNothing(args, this.span);
+        final Suffix suffix = new Suffix(
+            tokens.tail(), this.span, this.span.indent() + tokens.cursor()
+        );
+        if (suffix.atom() || suffix.test()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "a pipe application cannot declare an atom or a test attribute"
+            );
+        }
+        Comments.seal(globals, emit, this.span);
+        final Openness openness;
+        if (args.isEmpty()) {
+            openness = Openness.OPEN;
+        } else {
+            openness = Openness.VERTICAL_COMPLETED;
+        }
+        new Transition(stack, this.span).apply(
+            Kind.PIPE_APPLICATION, openness, suffix.present()
+        );
+        globals.clearBlanks();
+        globals.markEmitted();
+        emit.object(
+            suffix.attribute(this.span.line(), this.span.indent()),
+            null, this.span.line(), this.span.indent()
+        );
+        emit.pipe();
+        if (suffix.constant()) {
+            emit.constant();
+        }
+        for (final Value arg : args) {
+            Emissions.emitArg(emit, arg, this.span.line());
+        }
+    }
+
+    /**
+     * Validate the pipe has a legal predecessor — a same-indent
+     * formation or pipe that carries a name (R-3.14.2 / R-5.2.4a /
+     * R-5.2.5a / R-5.2.11a). An empty stack, a shallower top (descending
+     * pipe), an unnamed formation, or a non-pipeable kind (a plain value,
+     * an application, or a {@code .method} dispatch) all fail.
+     * @param stack Indent stack
+     */
+    private void precheck(final Stack stack) {
+        if (stack.empty()
+            || stack.top().indent() != this.span.indent()
+            || !stack.top().kind().pipeable()
+            || !stack.top().named()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "a pipe must follow a named formation or another pipe"
+            );
+        }
+    }
+
+    /**
+     * Build a token stream positioned just past the leading {@code | }
+     * marker. The {@code |} must be followed by a single space (before
+     * the argument list or suffix).
+     * @return Tokens positioned after {@code "| "}
+     */
+    private Tokens piped() {
+        final String body = this.span.body();
+        if (body.length() < 2 || body.charAt(1) != ' ') {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "a pipe `|` must be followed by a space"
+            );
+        }
+        final Tokens tokens = new Tokens(body, this.span);
+        tokens.seek(1);
+        return tokens;
+    }
+}

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="wrap-applications" version="2.0">
+  <!--
+  A pipe-application line (§3.14) emits a base-less marker node whose
+  head is the same-indent object above it:
+
+  <o name="foo"/>              (the formation, named)
+  <o pipe="" name="foo5">      (| 5 > foo5)
+    <o base="Φ.number">5</o>
+  </o>
+
+  We rewrite the @pipe node into an ordinary application whose @base
+  refers to the preceding sibling by its @name, and drop @pipe. The
+  preceding sibling (the formation, or a previous pipe) is left in
+  place, so `| 5 > foo5` after `[x] > foo` is identical in XMIR to
+  `foo 5 > foo5`. Chained pipes read the previous pipe's @name the same
+  way, building left-associated applications.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="o[@pipe]">
+    <xsl:copy>
+      <xsl:attribute name="base">
+        <xsl:value-of select="preceding-sibling::o[1]/@name"/>
+      </xsl:attribute>
+      <xsl:apply-templates select="@* except @pipe"/>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- Default copying -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/wrap-applications.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/wrap-applications.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@pipe])]
+  - //o[@base='foo' and @name='foo5' and count(o)=1]
+  - //o[@base='foo' and @name='foo5']/o[@base='Φ.number']
+  - //o[@name='foo' and not(@base)]
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    | 5 > foo5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-only-phi-hargs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-only-phi-hargs.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo5' and @base='ξ.foo']
+  - //o[@name='foo5']/o[@base='Φ.number']
+input: |
+  [] > app
+    x.plus x > [x] > foo
+    | 5 > foo5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-only-phi.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-only-phi.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo5' and @base='ξ.foo']
+  - //o[@name='foo5']/o[@base='Φ.number']
+input: |
+  [] > app
+    plus > [x] > foo
+      x
+      x
+    | 5 > foo5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-anonymous.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-anonymous.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='pair']
+  - //o[@name='pair' and count(o)=2]
+  - //o[@name='pair' and count(o[@base='Φ.number'])=2]
+input: |
+  [] > app
+    [a b] >>
+      a.plus b > @
+    | 2 3 > pair

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-application.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo5' and @base='ξ.foo' and count(o)=1]
+  - //o[@name='foo5']/o[@base='Φ.number']
+  - //o[@name='foo' and not(@base)]
+input: |
+  [] > app
+    [x] > foo
+      x.plus x > @
+    | 5 > foo5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='result']
+  - //o[@name='result' and count(o)=1]
+  - //o[@name='result']/o[@base='Φ.number']
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    | 1 >>
+    | 2 > result

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-then-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-then-method.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.neg' and @name='y']
+  - //o[@base='.neg']/o[1][contains(@base,'foo')]
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    | 5
+    .neg > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-bound.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-bound.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='ξ.add']/o[@as='foo' and @base='Φ.string']
+  - //o[@base='ξ.add']/o[@as='bar' and @base='Φ.number']
+input: |
+  [] > app
+    [x y] > add
+      x.plus y > @
+    | >>
+      "hello":foo
+      42:bar

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-named.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='app']/o[@name='foo' and @base='Φ.number']
+  - //o[@name='app']/o[@name='bar' and @base='Φ.number']
+  - //o[@base='ξ.add']/o[@base='ξ.foo']
+  - //o[@base='ξ.add']/o[@base='ξ.bar']
+input: |
+  [] > app
+    [x y] > add
+      x.plus y > @
+    | >>
+      2 > foo
+      3 > bar

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='ξ.add' and count(o)=2]
+  - //o[@base='ξ.add' and count(o[@base='Φ.number'])=2]
+input: |
+  [] > app
+    [x y] > add
+      x.plus y > @
+    | >>
+      2
+      3

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-method.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 5
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    .x
+    | 6 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-value.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-value.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+input: |
+  [] > app
+    5 > five
+    | 6 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-descending.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-descending.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+input: |
+  [] > app
+    [x] > foo
+      | 5 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-without-predecessor.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-without-predecessor.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+input: |
+  | 5 > n


### PR DESCRIPTION
A `|` line applies arguments to the same-indent object declared just above it — a named formation or another pipe. That lets an anonymous formation be applied without inventing a call-site name, which is the phi-calculus formation-with-application `⟦…⟧(…)` that EO could not express before. There are three forms: horizontal `| a b > name`, vertical `|` with a deeper argument block, and consecutive pipes that build left-associated applications.

The pipe carries no new semantics. It desugars to an ordinary application that refers to the predecessor by name, and the predecessor stays in place, so nothing downstream (scope resolution, base rolling, the runtime) needs to know about it:

```
[x] > foo          |    [x] > foo
  x.plus x > @     |      x.plus x > @
| 5 > foo5         |    foo 5 > foo5
```

Both sides produce the same `<o base='ξ.foo' name='foo5'>`. A new first parse pass, `wrap-applications.xsl`, reads the preceding sibling's `@name` onto the pipe node and drops the `@pipe` marker; everything after it runs unchanged.

A pipe may follow only a formation or another pipe. Once a `.method` has taken an attribute off the formation the object is no longer in hand, so a pipe after a `.method` is rejected; a `.method` after a pipe is fine. The predecessor must be named (explicit or `>>`), since the pipe refers to it by name.

`PARSER_SPEC.md` gets §3.14 plus the classification and cross-line rules. Reverse printing has no `|` form — it renders the canonical application, same as other sugar.

Closes #5432
