### PR TITLE
fix(#5403): fold OS error reason into failed fs operation messages

### DIFF
--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -31,13 +31,14 @@
           ^
           T
             sprintf
-              "Cant make the directory '%s'"
-              * ^.path
-    code. > outcome
+              "Cant make the directory '%s': %s"
+              * ^.path created.output
+    called. > created
       if.
         os.is-windows
         win32 "_mkdir" (* ^.path)
         posix "mkdir" (* ^.path posix.mkdir-mode)
+    created.code > outcome
 
   [glob] > walk /tuple
 

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -49,16 +49,17 @@
         descriptor.eq -1
         T
           sprintf
-            "Cant touch the file '%s'"
-            * path
+            "Cant touch the file '%s': %s"
+            * path created.output
         seq *
           closed
           ^
-    code. > descriptor
+    called. > created
       if.
         os.is-windows
         win32 "_creat" (* path win32.create-mode)
         posix "creat" (* path posix.create-mode)
+    created.code > descriptor
     code. > closed
       if.
         os.is-windows
@@ -73,14 +74,15 @@
         ^
         T
           sprintf
-            "Cant delete the file '%s'"
-            * path
+            "Cant delete the file '%s': %s"
+            * path removed.output
       ^
-    code. > outcome
+    called. > removed
       if.
         os.is-windows
         win32 windows-name (* path)
         posix posix-name (* path)
+    removed.code > outcome
     if. > windows-name
       is-directory
       "_rmdir"
@@ -107,13 +109,14 @@
       file target
       T
         sprintf
-          "Cant move the file '%s' to '%s'"
-          * path target
-    code. > outcome
+          "Cant move the file '%s' to '%s': %s"
+          * path target renamed.output
+    called. > renamed
       if.
         os.is-windows
         win32 "rename" (* path target)
         posix "rename" (* path target)
+    renamed.code > outcome
 
   [mode scope cant-open] > open
     if. > @
@@ -171,16 +174,17 @@
           descriptor.eq -1
           cant-open
             sprintf
-              "Couldn't open file '%s'"
-              * path
+              "Couldn't open file '%s': %s"
+              * path opened.output
           seq *
             scope
               stream descriptor
             code.
               syscall.close (* descriptor)
             true
-        code. > descriptor
+        called. > opened
           syscall.open (* path flags syscall.create-mode)
+        opened.code > descriptor
         plus. > flags
           plus.
             plus.

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/CreatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/CreatSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,16 +35,12 @@ public final class CreatSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.creat(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue()
-                )
-            )
+        final int code = CStdLib.INSTANCE.creat(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asNumber().intValue()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/Errno.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/Errno.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_sm.Posix; // NOPMD
+
+import com.sun.jna.Native;
+import java.util.function.Supplier;
+import org.eolang.Data;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+
+/**
+ * The {@code output} of a file syscall's {@code return}, carrying the OS error
+ * reason when the native call failed.
+ *
+ * <p>libc reports a failure by returning {@code -1} and leaving the real cause
+ * in {@code errno}. This object reads {@code errno} straight away through
+ * {@link Native#getLastError()}, which JNA captures the instant the native call
+ * returns, and turns it into a human-readable message with {@code strerror}.
+ * That is why the wrapper builds it immediately after the call, before any other
+ * native call can overwrite the value. On success it stays an empty
+ * {@link PhDefault}, exactly what the wrappers put there before.</p>
+ *
+ * @since 0.74.0
+ */
+final class Errno implements Supplier<Phi> {
+
+    /**
+     * The code the native call returned.
+     */
+    private final int code;
+
+    /**
+     * Ctor.
+     * @param status The code the native call returned
+     */
+    Errno(final int status) {
+        this.code = status;
+    }
+
+    @Override
+    public Phi get() {
+        final Phi output;
+        if (this.code == -1) {
+            output = new Data.ToPhi(
+                CStdLib.INSTANCE.strerror(Native.getLastError())
+            );
+        } else {
+            output = new PhDefault();
+        }
+        return output;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/MkdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/MkdirSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,16 +35,12 @@ public final class MkdirSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.mkdir(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue()
-                )
-            )
+        final int code = CStdLib.INSTANCE.mkdir(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asNumber().intValue()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/OpenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/OpenSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,17 +35,13 @@ public final class OpenSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.open(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue(),
-                    new Dataized(params[2]).asNumber().intValue()
-                )
-            )
+        final int code = CStdLib.INSTANCE.open(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asNumber().intValue(),
+            new Dataized(params[2]).asNumber().intValue()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/RenameSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/RenameSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,16 +35,12 @@ public final class RenameSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.rename(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asString()
-                )
-            )
+        final int code = CStdLib.INSTANCE.rename(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asString()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/RmdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/RmdirSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,13 +35,9 @@ public final class RmdirSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.rmdir(new Dataized(params[0]).asString())
-            )
-        );
-        result.put(1, new PhDefault());
+        final int code = CStdLib.INSTANCE.rmdir(new Dataized(params[0]).asString());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/UnlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/UnlinkSyscall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Posix; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,13 +35,9 @@ public final class UnlinkSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.unlink(new Dataized(params[0]).asString())
-            )
-        );
-        result.put(1, new PhDefault());
+        final int code = CStdLib.INSTANCE.unlink(new Dataized(params[0]).asString());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/CreatFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,16 +35,12 @@ public final class CreatFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._creat(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue()
-                )
-            )
+        final int code = Msvcrt.INSTANCE._creat(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asNumber().intValue()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/Errno.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/Errno.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_sm.Win32; // NOPMD
+
+import java.util.function.Supplier;
+import org.eolang.Data;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+
+/**
+ * The {@code output} of a file function call's {@code return}, carrying the OS
+ * error reason when the native call failed.
+ *
+ * <p>The msvcrt file functions report a failure by returning {@code -1} and
+ * leaving the real cause in the CRT's per-thread {@code errno}. This object
+ * reads it straight away through {@link Msvcrt#_errno()} — before any other CRT
+ * call can overwrite it — and turns it into a human-readable message with
+ * {@code strerror}. On success it stays an empty {@link PhDefault}, exactly what
+ * the wrappers put there before.</p>
+ *
+ * @since 0.74.0
+ */
+final class Errno implements Supplier<Phi> {
+
+    /**
+     * The code the native call returned.
+     */
+    private final int code;
+
+    /**
+     * Ctor.
+     * @param status The code the native call returned
+     */
+    Errno(final int status) {
+        this.code = status;
+    }
+
+    @Override
+    public Phi get() {
+        final Phi output;
+        if (this.code == -1) {
+            output = new Data.ToPhi(
+                Msvcrt.INSTANCE.strerror(Msvcrt.INSTANCE._errno().getInt(0))
+            );
+        } else {
+            output = new PhDefault();
+        }
+        return output;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/MkdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/MkdirFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,13 +35,9 @@ public final class MkdirFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._mkdir(new Dataized(params[0]).asString())
-            )
-        );
-        result.put(1, new PhDefault());
+        final int code = Msvcrt.INSTANCE._mkdir(new Dataized(params[0]).asString());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/Msvcrt.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/Msvcrt.java
@@ -10,6 +10,7 @@ package org.eolang.EO_sm.Win32; // NOPMD
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
 /**
@@ -192,4 +193,23 @@ public interface Msvcrt extends Library {
      * @return Zero on success, -1 on error
      */
     int _dup2(int descriptor, int other);
+
+    /**
+     * Returns a pointer to the calling thread's {@code errno}.
+     *
+     * <p>The CRT keeps {@code errno} per thread and exposes it through this
+     * function; the {@code errno} macro itself expands to {@code (*_errno())}.
+     * Reading the pointed-to {@code int} right after a failed CRT call gives the
+     * code the call stored, the win32 counterpart of the posix {@code errno}.</p>
+     *
+     * @return Pointer to the calling thread's {@code errno}
+     */
+    Pointer _errno();
+
+    /**
+     * Converts a CRT {@code errno} value into a human-readable message.
+     * @param errnum The error number
+     * @return Error as a string
+     */
+    String strerror(int errnum);
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/OpenFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,17 +35,13 @@ public final class OpenFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._open(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue(),
-                    new Dataized(params[2]).asNumber().intValue()
-                )
-            )
+        final int code = Msvcrt.INSTANCE._open(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asNumber().intValue(),
+            new Dataized(params[2]).asNumber().intValue()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/RenameFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/RenameFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,16 +35,12 @@ public final class RenameFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE.rename(
-                    new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asString()
-                )
-            )
+        final int code = Msvcrt.INSTANCE.rename(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asString()
         );
-        result.put(1, new PhDefault());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/RmdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/RmdirFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,13 +35,9 @@ public final class RmdirFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._rmdir(new Dataized(params[0]).asString())
-            )
-        );
-        result.put(1, new PhDefault());
+        final int code = Msvcrt.INSTANCE._rmdir(new Dataized(params[0]).asString());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/UnlinkFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/UnlinkFuncCall.java
@@ -11,7 +11,6 @@ package org.eolang.EO_sm.Win32; // NOPMD
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.EO_sm.Syscall;
-import org.eolang.PhDefault;
 import org.eolang.Phi;
 
 /**
@@ -36,13 +35,9 @@ public final class UnlinkFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._unlink(new Dataized(params[0]).asString())
-            )
-        );
-        result.put(1, new PhDefault());
+        final int code = Msvcrt.INSTANCE._unlink(new Dataized(params[0]).asString());
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
         return result;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EO_sm/EOposixTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_sm/EOposixTest.java
@@ -51,4 +51,30 @@ final class EOposixTest {
             )
         );
     }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void reportsReasonWhenOpenFails() {
+        MatcherAssert.assertThat(
+            "Failed \"open\" should carry the OS error reason in its output",
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        Phi.Φ.take("sm.posix").copy(),
+                        "name",
+                        new Data.ToPhi("open")
+                    ),
+                    "args",
+                    new Data.ToPhi(
+                        new Phi[]{
+                            new Data.ToPhi("/eo-5403-absent-directory/file.txt"),
+                            new Data.ToPhi(0),
+                            new Data.ToPhi(0),
+                        }
+                    )
+                ).take("output")
+            ).asString(),
+            Matchers.containsString("No such file")
+        );
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/EO_sm/EOwin32Test.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_sm/EOwin32Test.java
@@ -57,6 +57,32 @@ final class EOwin32Test {
         );
     }
 
+    @Test
+    @DisabledOnOs({OS.LINUX, OS.MAC})
+    void reportsReasonWhenOpenFails() {
+        MatcherAssert.assertThat(
+            "Failed \"_open\" should carry the OS error reason in its output",
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        Phi.Φ.take("sm.win32").copy(),
+                        "name",
+                        new Data.ToPhi("_open")
+                    ),
+                    "args",
+                    new Data.ToPhi(
+                        new Phi[]{
+                            new Data.ToPhi("C:\\eo-5403-absent-directory\\file.txt"),
+                            new Data.ToPhi(0),
+                            new Data.ToPhi(0),
+                        }
+                    )
+                ).take("output")
+            ).asString(),
+            Matchers.containsString("No such file")
+        );
+    }
+
     /**
      * Test case for {@link Winsock}.
      * @since 0.40


### PR DESCRIPTION
The fs syscall wrappers moved from java.nio to JNA (#5386) but dropped errno on failure, so file operations panicked with generic messages like "Couldn't open file '%s'" or "Cant delete the file '%s'", losing the distinction between permission-denied, no-such-file, disk-full, etc.

Each POSIX and Win32 wrapper (open, creat, mkdir, rename, rmdir, unlink) now captures the OS error immediately after a failing native call, before any other native/JNA call can clobber it, and exposes a human-readable reason through the syscall return's output slot:
  - POSIX: Native.getLastError() + strerror.
  - Win32: the CRT per-thread errno via _errno() + strerror. A small Errno helper per package does the capture-and-format; it stays an empty output on success, exactly as the wrappers produced before.

fs/file.eo (open, touched, deleted, moved) and fs/dir.eo (made) fold the reason into their fallback messages, e.g.
"Couldn't open file '%s': No such file or directory".


Claude-Session: https://claude.ai/code/session_01FJe73q8kncgR4LXm5sDmHG