### PR TITLE
feat(#5443): separated with and withi from tuple.list

### DIFF
--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -2,6 +2,7 @@
 
 +alias tuple.list
 +alias tuple.reducedi
++alias tuple.with
 +alias tuple.withouti
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -14,7 +15,7 @@
   reducedi > @
     list passed
     lst
-    accum.with item > [accum item index]
+    with accum item > [accum item index]
 
   ++> tests-concatenates-lists
     and. > @

--- a/eo-runtime/src/main/eo/tuple/list.eo
+++ b/eo-runtime/src/main/eo/tuple/list.eo
@@ -10,9 +10,6 @@
 # ```
 # .
 
-+alias tuple.back
-+alias tuple.concat
-+alias tuple.front
 +alias tuple.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -26,21 +23,6 @@
   origin > @
   0.eq origin.length > is-empty
   origin > sorted
-
-  [x] > with
-    list > @
-      origin.with x
-
-  [index item] > withi
-    concat > @
-      with.
-        front
-          ^
-          index
-        item
-      back
-        ^
-        origin.length.minus index
 
   ++> tests-list-should-not-be-empty
     not. > @
@@ -61,32 +43,6 @@
     (list xs).is-empty.not > @
     * > xs
       [f]
-
-  ++> tests-list-simple-with
-    eq. > @
-      with.
-        list
-          * 1 2
-        3
-      * 1 2 3
-
-  ++> tests-simple-insert
-    eq. > @
-      withi.
-        list
-          * 1 2 3 4 5
-        3
-        "hello"
-      * 1 2 3 "hello" 4 5
-
-  ++> tests-insert-with-zero-index
-    eq. > @
-      withi.
-        list
-          * 1 2 3 4 5
-        0
-        "hello"
-      * "hello" 1 2 3 4 5
 
   ++> tests-complex-objects-list-comparison
     list

--- a/eo-runtime/src/main/eo/tuple/with.eo
+++ b/eo-runtime/src/main/eo/tuple/with.eo
@@ -1,0 +1,21 @@
+# Append element `x` to the end of collection `lst`.
+
++alias tuple.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst x] > with
+  list > @
+    lst.with x
+
+  ++> tests-list-simple-with
+    eq. > @
+      with
+        list
+          * 1 2
+        3
+      * 1 2 3

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -1,0 +1,42 @@
+# Insert `item` into collection `lst` at the given `index`.
+
++alias tuple.back
++alias tuple.concat
++alias tuple.front
++alias tuple.list
++alias tuple.with
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst index item] > withi
+  concat > @
+    with
+      front
+        lst
+        index
+      item
+    back
+      lst
+      lst.length.minus index
+
+  ++> tests-simple-insert
+    eq. > @
+      withi
+        list
+          * 1 2 3 4 5
+        3
+        "hello"
+      * 1 2 3 "hello" 4 5
+
+  ++> tests-insert-with-zero-index
+    eq. > @
+      withi
+        list
+          * 1 2 3 4 5
+        0
+        "hello"
+      * "hello" 1 2 3 4 5


### PR DESCRIPTION
Extracted `list.with` and `list.withi` into standalone objects `tuple/with.eo` and `tuple/withi.eo`, with the list as an explicit first free attribute (`[lst x] > with`, `[lst index item] > withi`).

The moved tests (`tests-list-simple-with`, `tests-simple-insert`, `tests-insert-with-zero-index`) go with them and use free-function call syntax.

Because `concat` builds new lists via `accum.with`, it is updated to call the free `with` so list accumulators keep working after `list.with` is removed. Package is `tuple` (renamed from `ss` in #5486).

This continues dissolving `tuple.list` (#5443). Remaining on `list` after this: mainly `is-empty` / `sorted` (and whatever is still waiting on related extractionsctions such as `concat`, if that is not already merged).

Partial fix for #5443