### PR TITLE
#5514: make PhNest.put fail fast to protect shared package state

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhNest.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNest.java
@@ -21,6 +21,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * {@code number.power} reads the extension untouched, while {@code (number 42)}
  * copies into a plain number value.</p>
  *
+ * <p>A single instance is shared across every reference to the package, so it
+ * must never be written to directly: {@link #put(int, Phi)} and
+ * {@link #put(String, Phi)} fail fast, the sole exception being the one-time
+ * {@code ρ} wiring done while the package is being resolved. A caller that
+ * needs to bind arguments must {@link #copy()} first, which collapses this
+ * into a writable plain object.</p>
+ *
  * @since 0.62
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -69,12 +76,22 @@ final class PhNest implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        this.object().put(pos, object);
+        throw new ExFailure(
+            "Can't #put(%d, %s) to package object \"%s\" directly, make a copy first",
+            pos, object, this.pkg
+        );
     }
 
     @Override
     public void put(final String name, final Phi object) {
-        this.object().put(name, object);
+        if (Phi.RHO.equals(name)) {
+            this.object().put(name, object);
+        } else {
+            throw new ExFailure(
+                "Can't #put(%s, %s) to package object \"%s\" directly, make a copy first",
+                name, object, this.pkg
+            );
+        }
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhNestTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhNestTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PhNest}.
+ * @since 0.62
+ */
+final class PhNestTest {
+
+    @Test
+    void rejectsDirectPutByPosition() {
+        MatcherAssert.assertThat(
+            "Direct put by position into a package object must fail fast, but it didn't",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> Phi.Φ.take("number").put(0, new Data.ToPhi(42L)),
+                "Putting by position straight into a shared package object must be rejected"
+            ).getMessage(),
+            Matchers.containsString("make a copy first")
+        );
+    }
+
+    @Test
+    void rejectsDirectPutByName() {
+        MatcherAssert.assertThat(
+            "Direct put by name into a package object must fail fast, but it didn't",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> Phi.Φ.take("number").put("x", new Data.ToPhi(42L)),
+                "Putting by name straight into a shared package object must be rejected"
+            ).getMessage(),
+            Matchers.containsString("make a copy first")
+        );
+    }
+
+    @Test
+    void allowsPutAfterCopy() {
+        Assertions.assertDoesNotThrow(
+            () -> Phi.Φ.take("number").copy().put(0, new Data.ToPhi(42L)),
+            "A copy of a package object must accept a put, but it didn't"
+        );
+    }
+}


### PR DESCRIPTION
Closes #5514.

`PhPackage.dispatched` hands out the cached `PhNest` **without copying it**, so every `Φ.take("number")` (and `string`/`tuple`) returns the *same* instance. `PhNest.put` delegated to a lazily-cached singleton object, so any direct `put` mutated state shared across every reference to that package — a latent corruption hazard.

### Fix
Per @yegor256's direction, `put` now **fails fast**. There is exactly one legitimate direct write: the one-time `ρ` wiring that `PhPackage.take` performs on a freshly-loaded `PhNest` while resolving a package (`PhPackage.java:91`). So:

- `put(String, Phi)` accepts `ρ` (the wiring) and rejects every other name;
- `put(int, Phi)` is always rejected — positional argument binding must land on a copy, never on the shared instance.

A caller that needs to bind arguments must `copy()` first, which collapses the `PhNest` into a writable plain object (e.g. `(number 42)`).

> Note on scope: a blanket rejection of *all* puts breaks package resolution, because `PhPackage.take` sets `ρ` on the shared `PhNest` directly during first load. The `ρ` exception preserves that path; verified by running the full runtime suite.

### Changes
- `PhNest.java` — `put(int)` / `put(String)` fail fast (mirroring the existing `PhPackage.put(int)`), with the invariant documented on the class Javadoc.
- `PhNestTest.java` — new: rejects direct positional and named puts, and asserts a copy stays writable.

Verified locally: full `eo-runtime` suite is green (1521/1522; the single failure is the network-dependent `EOsocketTest.refusesConnectionViaSyscall`, unrelated).