### PR TITLE
feat(#5443): separated is-empty from tuple.list

### DIFF
--- a/eo-runtime/src/main/eo/number/maximum.eo
+++ b/eo-runtime/src/main/eo/number/maximum.eo
@@ -2,6 +2,7 @@
 # decorator of `number` objects. An empty sequence has no maximum, so `cant-max`
 # is dataized with an explanatory message and stands in as the result.
 
++alias tuple.is-empty
 +alias tuple.list
 +alias tuple.reduced
 +architect yegor256@gmail.com
@@ -13,7 +14,7 @@
 
 [sequence cant-max] > maximum
   if. > @
-    lst.is-empty
+    is-empty lst
     cant-max "cannot get the maximum number from an empty sequence"
     reduced
       lst

--- a/eo-runtime/src/main/eo/number/minimum.eo
+++ b/eo-runtime/src/main/eo/number/minimum.eo
@@ -2,6 +2,7 @@
 # decorator of `number` objects. An empty sequence has no minimum, so `cant-min`
 # is dataized with an explanatory message and stands in as the result.
 
++alias tuple.is-empty
 +alias tuple.list
 +alias tuple.reduced
 +architect yegor256@gmail.com
@@ -13,7 +14,7 @@
 
 [sequence cant-min] > minimum
   if. > @
-    lst.is-empty
+    is-empty lst
     cant-min "cannot get the minimum number from an empty sequence"
     reduced
       lst

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -1,5 +1,6 @@
 # Elements of `lst` from `index` to the end (supports oversized index).
 
++alias tuple.is-empty
 +alias tuple.list
 +alias tuple.reducedi
 +architect yegor256@gmail.com
@@ -34,7 +35,7 @@
       * 4 5
 
   ++> tests-zero-index-in-back
-    is-empty. > @
+    is-empty > @
       back
         list
           * 1 2 3 4 5

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -5,6 +5,7 @@
 # for the index. The result of dataization
 # the `func` should be boolean, that is `true` or `false`.
 
++alias tuple.is-empty
 +alias tuple.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -44,7 +45,7 @@
       * "Hello"
 
   ++> tests-filteredi-with-empty-list
-    is-empty. > @
+    is-empty > @
       filteredi
         list
           *

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -1,6 +1,7 @@
 # Elements of `lst` before `index` (supports negative indices).
 
 +alias tuple.back
++alias tuple.is-empty
 +alias tuple.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -39,8 +40,8 @@
         1
       * 1
 
-  [] +> tests-list-front-with-zero-index
-    is-empty. > @
+  ++> tests-list-front-with-zero-index
+    is-empty > @
       front
         list
           * 1 2 3

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -1,0 +1,38 @@
+# True when collection `lst` has no elements.
+
++alias tuple.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[lst] > is-empty
+  0.eq lst.length > @
+
+  ++> tests-list-should-not-be-empty
+    not. > @
+      is-empty
+        list
+          * 1 2
+
+  ++> list-should-be-empty
+    is-empty > @
+      list *
+
+  ++> tests-list-should-not-be-empty-with-three-objects
+    not. > @
+      is-empty
+        list xs
+    * > xs
+      [x]
+      [y]
+      [z]
+
+  ++> tests-list-should-not-be-empty-with-one-anon-object
+    not. > @
+      is-empty
+        list xs
+    * > xs
+      [f]

--- a/eo-runtime/src/main/eo/tuple/list.eo
+++ b/eo-runtime/src/main/eo/tuple/list.eo
@@ -4,7 +4,6 @@
 # Usage examples:
 # ```
 # list (* 1 2 3)           # Create list from tuple
-# list.is-empty            # Check if empty
 # list.map [x] (x.plus 1)  # Map operation
 # list.filter [x] (x.gt 0) # Filter elements
 # ```
@@ -21,28 +20,7 @@
 
 [origin] > list
   origin > @
-  0.eq origin.length > is-empty
   origin > sorted
-
-  ++> tests-list-should-not-be-empty
-    not. > @
-      is-empty.
-        list
-          * 1 2
-
-  (list *).is-empty > [] +> list-should-be-empty
-
-  ++> tests-list-should-not-be-empty-with-three-objects
-    (list xs).is-empty.not > @
-    * > xs
-      [x]
-      [y]
-      [z]
-
-  ++> tests-list-should-not-be-empty-with-one-anon-object
-    (list xs).is-empty.not > @
-    * > xs
-      [f]
 
   ++> tests-complex-objects-list-comparison
     list

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -2,6 +2,7 @@
 # Here `start` and `end` must be `int`s. If they're not, the bottom object
 # is returned, which terminates on use.
 
++alias tuple.is-empty
 +alias tuple.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -31,11 +32,11 @@
       * 1 2 3 4 5 6 7 8 9
 
   ++> tests-range-of-numbers-from-ten-to-ten-is-empty
-    is-empty. > @
+    is-empty > @
       range-of-numbers 10 10
 
   ++> tests-range-of-descending-numbers-is-empty
-    is-empty. > @
+    is-empty > @
       range-of-numbers 10 1
 
   ++> tests-range-of-negative-numbers-works-as-well

--- a/eo-runtime/src/main/eo/tuple/range.eo
+++ b/eo-runtime/src/main/eo/tuple/range.eo
@@ -20,6 +20,7 @@
 # `1.plus 1` and also has object `next`. Since these objects are ints - they have
 # object `lt` by default.
 
++alias tuple.is-empty
 +alias tuple.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -83,7 +84,7 @@
       10
 
   ++> tests-range-with-wrong-items-is-an-empty-array
-    rng.is-empty > @
+    is-empty rng > @
     range > rng
       []
         y 10 > @

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -3,6 +3,7 @@
 # The first one for the accumulator, the second one
 # for the element of the collection and the third one for the index.
 
++alias tuple.is-empty
 +alias tuple.list
 +alias tuple.reducedi
 +architect yegor256@gmail.com
@@ -14,7 +15,7 @@
 
 [lst start func] > reducedi
   if. > @
-    lst.is-empty
+    is-empty lst
     start
     rec-reducedi lst
 


### PR DESCRIPTION
Extracted `list.is-empty` into standalone `tuple/is-empty.eo`, with the collection as an explicit free attribute (`[lst] > is-empty`).

The emptiness tests moved with it and were updated to free-function call syntax. Call sites that used `lst.is-empty` or inverted `is-empty.` (`reducedi`, `maximum`/`minimum`, `front`/`back`/`filteredi`/`range`/`range-of-numbers`) now call free `is-empty`.



Partial fix for #5443