### PR TITLE
feat(#5433): self-reference `%` for anonymous formations

### DIFF
--- a/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+out:
+  - ".*8 is the 6th number.*"
+file: snippets/self-fibo.eo
+args: ["snippets.self-fibo"]
+eo: |
+  +alias io.stdout
+  +alias string.sprintf
+  +package snippets
+
+  [] > self-fibo
+    [n] >>
+      if. > @
+        n.lt 2
+        n
+        plus.
+          % (n.minus 1)
+          % (n.minus 2)
+    | 6 > num
+    stdout > @
+      sprintf
+        "%d is the %dth number\n"
+        *
+          num
+          6

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -168,6 +168,7 @@ The parser recognises the following lexical tokens:
 | `ROOT` | `Q` |
 | `XI` | `$` |
 | `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A self-contained single-character token; carries no arguments and no chain. |
+| `SELF` | `%` — self-reference (§3.15). Sugar for the auto-name of the enclosing anonymous (`>>`-named) formation; substituted at compile time. A value: it may carry arguments (`% 5`) and a `.method` chain, like any other head. |
 | `VOID` | `?` — the vertical-void marker (§3.4). A `? > name` body line declares a void attribute, equivalent to listing `name` in `[…]`. |
 | `QDOT` | `?.` — the fragile-dispatch operator (§3.5). Accepted in every position the plain `.` dispatch is, recorded as `@fragile` in XMIR. A `?` immediately followed by `.` is `QDOT`; a `?` followed by space (`? > name`) is `VOID`. |
 | `INT` | optional sign, then `0` or non-zero digit string. |
@@ -210,6 +211,7 @@ Each non-blank, non-comment line is classified into exactly one shape, determine
 | literal (`"…"`, `42`, `--`, `AB-CD`, `0xFF`, signed number) | — | application starting with literal (§3.6) |
 | `*` | — | star tuple as application head (§3.6) |
 | `(` | — | application starting with group (§3.6) |
+| `%` | — | self-reference as application head (§3.15) |
 
 The classifier emits a **line-shape record**:
 
@@ -634,6 +636,35 @@ Illegal:
 
 | 5 > n                               ← rejected: no object above
 ```
+
+### 3.15 Self-reference — `%`
+
+A `%` token is *syntactic sugar for the auto-generated name of the anonymous formation that surrounds it* — the closest ancestor introduced by the `>>` suffix (§3.10). It is not a new reference mechanism: at compile time `%` is simply replaced by that name, exactly as if the (otherwise untypeable) auto-name had been written by hand. Its purpose is recursion without exposing a name — an anonymous helper (`fibo`, say) can call itself with `%` while staying inlined, invisible to the enclosing scope.
+
+R-3.15.1. `%` is a value: it is recognised wherever a value is expected — as a line head (`% (n.minus 1)`), as a horizontal argument, and inside a paren group — and takes horizontal arguments (§3.6) and a `.method` chain (§3.5) with the ordinary application shape.
+
+R-3.15.2. **Scope.** `%` stands for the **nearest enclosing anonymous formation** — the closest ancestor whose auto-generated name carries the cactus prefix (§9.2). A named formation (`> name`) is not a target; reference such an object by its name. A `%` with no enclosing anonymous formation is a compile-time error.
+
+R-3.15.3. **Emission / XMIR.** The parser emits a base-less `<o self=''>` marker; the `resolve-self` reshape (§9) substitutes the name — it sets `@base` to the enclosing anonymous formation's `@name` and drops `@self` — so every downstream pass sees a plain reference by the auto-name. A `%` outside any anonymous formation is rejected there with a `resolve-self` check error (a post-parse check, like the compact-tuple index check, not a §9.9 parser error).
+
+```
+io.stdout > @                         ← prints the 5th Fibonacci number
+  tt.sprintf *1
+    "The 5th Fibonacci number is %d\n"
+    [n] >>                            ← anonymous (auto-named) formation a🌵…
+      if. > @
+        n.lt 2
+        n
+        plus.
+          % (n.minus 1)               ← % = the anonymous formation's auto-name
+          % (n.minus 2)               ← % = the anonymous formation's auto-name
+    | 5                               ← applies the formation to 5 (§3.14)
+
+[] > app
+  % 6 > @                             ← rejected: no enclosing anonymous formation
+```
+
+Outer kind: that of the underlying application (§3.6), since `%` is just a head value.
 
 ---
 
@@ -1154,6 +1185,7 @@ Example: a `>>` suffix at `line=12, pos=5` emits `@name="a🌵12-5"`.
 | `^` (RHO) | `ρ` | `@base='ρ'` for parent reference |
 | `Q` (ROOT) | `Φ` | `@base='Φ...'` for root-rooted FQNs |
 | `$` (XI) | `ξ` | `@base='ξ'` for self reference |
+| `%` (SELF) | — | base-less `<o self=''>` marker; `resolve-self` (§9) later sets `@base` to the enclosing anonymous formation's auto-name (§3.15) |
 | `T` (TERM) | `⊥` | `@base='⊥'` for the bottom term |
 | atom signature head `Q` | `Φ` | `@atom='Φ....'` |
 

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -91,6 +91,7 @@ public final class Canonical implements UnaryOperator<XML> {
                     new TrJoined<>(
                         new TrClasspath<>(
                             "/org/eolang/parser/parse/wrap-applications.xsl",
+                            "/org/eolang/parser/parse/resolve-self.xsl",
                             "/org/eolang/parser/parse/validate-before-stars.xsl",
                             "/org/eolang/parser/parse/resolve-before-stars.xsl",
                             "/org/eolang/parser/parse/fragile-dispatch.xsl",

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -163,6 +163,9 @@ final class Emissions {
             emit.star();
         } else if (value.kind() == Value.Kind.ROOT) {
             emit.object(name, Emissions.rootBase(value.raw()), line, value.pos());
+        } else if (value.kind() == Value.Kind.SELF) {
+            emit.object(name, null, line, value.pos());
+            emit.self();
         } else if (value.kind() == Value.Kind.TERM) {
             emit.object(name, "⊥", line, value.pos());
         } else if (value.kind() == Value.Kind.GROUP) {
@@ -232,6 +235,7 @@ final class Emissions {
     static boolean chainable(final Value head) {
         return head.kind() == Value.Kind.IDENTIFIER
             || head.kind() == Value.Kind.ROOT
+            || head.kind() == Value.Kind.SELF
             || head.kind() == Value.Kind.GROUP
             || head.kind() == Value.Kind.INTEGER
             || head.kind() == Value.Kind.FLOAT

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -311,6 +311,16 @@ final class Emit {
     }
 
     /**
+     * Add the {@code @self=""} attribute to the most recently opened
+     * {@code <o>} — marks a base-less {@code %} self-reference node
+     * (§3.15 / §9.4) whose {@code @base} the {@code resolve-self} reshape
+     * fills in with the enclosing anonymous formation's auto-name.
+     */
+    void self() {
+        this.append(new Directives().attr("self", ""));
+    }
+
+    /**
      * Add the {@code @types="forma …"} attribute to the most recently
      * opened {@code <o>} — the space-separated forma-list of an atom's
      * vertical void error-branch (R-3.4.8). Each token is resolved like

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -405,6 +405,7 @@ final class Eo implements Iterable<Directive> {
             || span.head() == '@'
             || span.head() == '^'
             || span.head() == '$'
+            || span.head() == '%'
             || span.head() >= '0' && span.head() <= '9'
             || span.head() >= 'A' && span.head() <= 'F'
             || span.head() == '-'

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -128,6 +128,11 @@ final class Tokens {
                 Value.Kind.TERM, "T", this.span.indent() + this.cursor, this.cursor + 1
             );
             this.cursor = this.cursor + 1;
+        } else if (first == '%') {
+            value = new Value(
+                Value.Kind.SELF, "%", this.span.indent() + this.cursor, this.cursor + 1
+            );
+            this.cursor = this.cursor + 1;
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
         } else {

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -236,6 +236,14 @@ final class Value {
          * §3.13.1. Single-line form only in this iteration; multi-line
          * continuation lands in a later round.
          */
-        BYTES
+        BYTES,
+
+        /**
+         * {@code SELF} — the {@code %} self-reference (§3.15). Sugar for
+         * the auto-name of the enclosing anonymous ({@code >>}) formation;
+         * emitted as a base-less {@code <o self=''>} marker that the
+         * {@code resolve-self} reshape replaces with that name.
+         */
+        SELF
     }
 }

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-self.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-self.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" id="resolve-self" version="2.0">
+  <!--
+  The "%" self-reference (§3.15) is syntactic sugar for the auto-name of
+  the anonymous formation that surrounds it. The parser emits it as a
+  base-less "<o self=''>" marker; here we simply substitute the name:
+  set @base to the @name of the nearest enclosing anonymous formation
+  (the closest ancestor whose auto-name carries the cactus prefix, §9.2)
+  and drop @self. A "%" with no such ancestor is a compile-time error —
+  there is no name to substitute.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="o[@self]">
+    <xsl:copy>
+      <xsl:variable name="formation" select="ancestor::o[starts-with(@name, 'a🌵')][1]"/>
+      <xsl:if test="exists($formation)">
+        <xsl:attribute name="base" select="$formation/@name"/>
+      </xsl:if>
+      <xsl:apply-templates select="@* except @self"/>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="/object">
+    <xsl:copy>
+      <xsl:apply-templates select="(node() except errors)|@*"/>
+      <xsl:variable name="errors" as="element()*">
+        <xsl:for-each select="//o[@self and empty(ancestor::o[starts-with(@name, 'a🌵')])]">
+          <xsl:element name="error">
+            <xsl:attribute name="check" select="'resolve-self'"/>
+            <xsl:attribute name="line" select="if (@line) then @line else 0"/>
+            <xsl:attribute name="severity" select="'error'"/>
+            <xsl:text>The % self-reference is only allowed inside an anonymous formation</xsl:text>
+          </xsl:element>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:if test="not(empty($errors)) or exists(/object/errors)">
+        <errors>
+          <xsl:apply-templates select="/object/errors/error"/>
+          <xsl:copy-of select="$errors"/>
+        </errors>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -306,6 +306,19 @@ final class EmitTest {
     }
 
     @Test
+    void marksObjectAsSelf() {
+        final Emit emit = new Emit();
+        emit.object(null, null, 1, 0);
+        emit.self();
+        emit.close();
+        MatcherAssert.assertThat(
+            "self() must attach @self='' to the most recently opened <o>",
+            EmitTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/o[@self='' and not(@base)]")
+        );
+    }
+
+    @Test
     void setsTextContent() {
         final Emit emit = new Emit();
         emit.object(null, "Φ.bytes", 1, 0);

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -83,6 +83,15 @@ final class TokensTest {
     }
 
     @Test
+    void readsSelfValue() {
+        MatcherAssert.assertThat(
+            "readValue must recognise the `%` self-reference token",
+            new Tokens("% 5", new Span("% 5", 1)).readValue().kind(),
+            Matchers.equalTo(Value.Kind.SELF)
+        );
+    }
+
+    @Test
     void readsMethodChain() {
         final Tokens tokens = new Tokens("foo.bar.baz", new Span("foo.bar.baz", 1));
         tokens.readName();

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -56,7 +56,7 @@ final class ValueTest {
         MatcherAssert.assertThat(
             "Value.Kind must enumerate every kind the parser currently recognises",
             Value.Kind.values().length,
-            Matchers.equalTo(10)
+            Matchers.equalTo(11)
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-self-outside.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-self-outside.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-self.xsl
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[@check='resolve-self' and @severity='error' and @line='2']
+  - /object[not(//o[@self])]
+input: |
+  [] > app
+    % 6 > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-self.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-self.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-self.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@self])]
+  - /object[count(//o[@base='a🌵2-2'])=3]
+  - //o[@base='a🌵2-2']/o[@base='n']
+  - //o[@base='.plus' and @method]/o[@base='Φ.number']
+input: |
+  [] > app
+    [n] >>
+      plus. > @
+        % (n.minus 1)
+        % (n.minus 2)
+      %.plus 1 > x


### PR DESCRIPTION
Closes #5433.

## What

Adds the `%` token — **syntactic sugar for the auto-generated name of the anonymous formation (introduced by `>>`) that surrounds it**. It is not a new reference mechanism: at compile time `%` is simply replaced by that name, which is otherwise untypeable (the cactus is reserved). This lets an anonymous helper call itself recursively while staying inlined and invisible to the enclosing scope — the encapsulation the issue asks for.

```
io.stdout > @
  tt.sprintf *1
    "The 5th Fibonacci number is %d\n"
    [n] >>                       # anonymous (auto-named) formation
      if. > @
        n.lt 2
        n
        plus.
          % (n.minus 1)          # % = the anonymous formation's auto-name
          % (n.minus 2)          # % = the anonymous formation's auto-name
    | 5                          # applies the formation to 5 (the | pipe, #5432)
```

A `%` used **outside** any anonymous formation is a compile-time error — there is no name to substitute.

## How

- **Parser.** `%` is recognised as a value (`Value.Kind.SELF`) wherever a value is expected — head, argument, inside a paren group — with the ordinary application shape (it may carry args and a `.method` chain). It is emitted as a base-less `<o self=''>` marker (`Emit.self()`), mirroring how the `>>` pipe emits `<o pipe=''>`.
- **Substitution.** A new first-pass `resolve-self.xsl` (wired into `Canonical` right after `wrap-applications`) replaces the marker with the name: it sets `@base` to the `@name` of the nearest enclosing anonymous formation (the closest cactus-prefixed ancestor, §9.2) and drops `@self`. From there it is an ordinary reference by the auto-name — no new semantics, no changes below the parser front-end.
- **Error.** A `%` with no enclosing anonymous formation is reported by the reshape as a `resolve-self` check error (a post-parse check, like the compact-tuple index check).

This deliberately follows the pattern of #5432 (`|` pipe): a base-less marker at parse time, resolved by a small first-pass XSL. The canonical use combines both — recursion via `%`, application via `| N`.

## Tests

- `snippets/self-fibo.yaml` — end-to-end runtime (`SnippetIT`): an anonymous formation recursing via `%`, applied via `| 6`, prints `8 is the 6th number`.
- `eo-packs/parse/resolve-self.yaml` — the reshape in isolation: `@self` → `@base='a🌵…'`, args preserved.
- `eo-packs/parse/resolve-self-outside.yaml` — `%` outside an anonymous formation produces the `resolve-self` compile-time error.
- Unit tests for `Tokens` (`%` → `SELF`), `Emit.self()`, and the `Value.Kind` cardinality.

`PARSER_SPEC.md` gains §3.15 plus token-table, classification-table, and §9.3 entries.

All `eo-parser` tests pass; xcop and qulice (0.27.6) are clean; the diff is kept under the 200-line pr-size limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)