### PR TITLE
#5512: raise a clear error for implicit dispatch to a nullary extension

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -383,7 +383,10 @@ public class PhDefault implements Phi, Cloneable {
      * after this object's forma. If it exists, it is returned with this object
      * bound as its first argument, so {@code (number 42).power 3} reads as
      * {@code number.power 42 3}. When there's no such object, the terminated
-     * computation stays terminated.</p>
+     * computation stays terminated. When the object exists but has no free
+     * positional attribute to receive the bound object (for example a nullary
+     * constant like {@code number.pi}), a clear error is raised instead of the
+     * low-level "attribute is already set / no attributes here" message.</p>
      *
      * @param name The name of the absent attribute
      * @param bottom The terminated computation to keep when there's no such object
@@ -395,8 +398,19 @@ public class PhDefault implements Phi, Cloneable {
         if (forma.startsWith(String.format("%s.", PhPackage.GLOBAL))) {
             final String full = String.join(".", forma, name);
             if (PhDefault.exists(new JavaPath(full).toString())) {
-                found = Phi.Φ.take(full.substring(PhPackage.GLOBAL.length() + 1));
-                found.put(0, this);
+                final Phi taken = Phi.Φ.take(full.substring(PhPackage.GLOBAL.length() + 1));
+                try {
+                    taken.put(0, this);
+                } catch (final ExFailure ex) {
+                    throw new ExFailure(
+                        String.format(
+                            "Object '%s' takes no arguments, so it can't be applied to '%s' via the implicit '%s' form",
+                            full, forma, name
+                        ),
+                        ex
+                    );
+                }
+                found = taken;
             }
         }
         return found;

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -34,6 +34,19 @@ final class PhDefaultTest {
     }
 
     @Test
+    void failsClearlyForNullaryPackageExtension() {
+        MatcherAssert.assertThat(
+            "Implicit dispatch to a nullary extension must explain the real problem",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Data.ToPhi(42L).take("pi"),
+                "Applying a receiver to a nullary extension must be rejected"
+            ).getMessage(),
+            Matchers.containsString("takes no arguments")
+        );
+    }
+
+    @Test
     void printsDataAsTerm() {
         MatcherAssert.assertThat(
             "Object with data must render its bytes in φ-term, but it didnt",


### PR DESCRIPTION
Closes #5512.

The implicit package-extension fallback (`PhDefault.extension`, added in #5505) binds the receiver with `found.put(0, this)`, assuming the extension has a free first positional attribute. That breaks for a **nullary** extension — a constant under a package, such as `number.pi`.

### What was wrong
Evaluating `42.pi`:
1. `take("pi")` misses → `PhTerminator` → `extension("pi", ⊥)`;
2. class `Φ.number.pi` exists → guard passes;
3. `found.put(0, this)` → the object has no free positional slot → `ExFailure`.

So `42.pi` surfaced an internal message instead of explaining the problem, contradicting the method's own Javadoc.

> Note: the actual low-level message is `void attribute "as-bytes" is already set, can't reset` (not `"There are no attributes here"` as the report guessed) — because `pi`'s single positional attribute is *already bound* to its value `3.14159…`. The fix handles both shapes by catching the failing `put` rather than pre-checking arity.

### Fix
Per @yegor256's direction ("raise a message that names the real problem"), the failing `put(0, this)` is caught and re-raised as a clear `ExFailure` that names the extension and states it takes no arguments (original cause chained). The happy path — extensions with a free `α0`, e.g. `power` — is untouched.

### Changes
- `PhDefault.java` — catch the receiver-binding failure and raise a clear message; Javadoc updated.
- `PhDefaultTest.java` — new case asserting `42.pi` fails with "takes no arguments".

Verified locally: full `eo-runtime` suite green (1546/1547; the single failure is the network-dependent `EOsocketTest.refusesConnectionViaSyscall`, unrelated).