### PR TITLE
#5520: drop redundant same-package +alias metas after auto-homing

### DIFF
--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -2,7 +2,6 @@
 # Apparently every directory is a file.
 
 +alias string.sprintf
-+alias fs.tmpdir
 +alias sm.os
 +alias sm.posix
 +alias sm.win32

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -1,14 +1,11 @@
 # Represents a file in the filesystem for reading and writing.
 
 +alias string.contains
-+alias fs.file
 +alias string.joined
 +alias sm.os
-+alias fs.path
 +alias sm.posix
 +alias sm.win32
 +alias string.sprintf
-+alias fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs

--- a/eo-runtime/src/main/eo/fs/path.eo
+++ b/eo-runtime/src/main/eo/fs/path.eo
@@ -1,8 +1,6 @@
 # Path `path` that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
 
-+alias fs.dir
-+alias fs.file
 +alias sm.os
 +alias tuple.reduced
 +alias string.regex

--- a/eo-runtime/src/main/eo/fs/tmpdir.eo
+++ b/eo-runtime/src/main/eo/fs/tmpdir.eo
@@ -7,8 +7,6 @@
 # takes the first environment variable in the list TMP, TEMP, USERPROFILE.
 # If none of these are found, it returns the Windows directory (C:\Windows).
 
-+alias fs.dir
-+alias fs.file
 +alias sm.getenv
 +alias sm.os
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/io/copied.eo
+++ b/eo-runtime/src/main/eo/io/copied.eo
@@ -10,12 +10,6 @@
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
-+alias io.bytes-as-input
-+alias io.dead-input
-+alias io.dead-output
-+alias io.input-length
-+alias io.malloc-as-output
-+alias io.tee-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io

--- a/eo-runtime/src/main/eo/io/input-as-bytes.eo
+++ b/eo-runtime/src/main/eo/io/input-as-bytes.eo
@@ -7,10 +7,6 @@
 # ```
 # After dataization, `bts` equals `01-02-03-04-05`.
 
-+alias io.bytes-as-input
-+alias io.copied
-+alias io.dead-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io

--- a/eo-runtime/src/main/eo/io/input-length.eo
+++ b/eo-runtime/src/main/eo/io/input-length.eo
@@ -1,8 +1,5 @@
 # Reads all the bytes from provided `input` and returns its length.
 
-+alias io.bytes-as-input
-+alias io.malloc-as-output
-+alias io.tee-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io

--- a/eo-runtime/src/main/eo/io/stdin.eo
+++ b/eo-runtime/src/main/eo/io/stdin.eo
@@ -13,7 +13,6 @@
 #
 # or just dataize `stdin` object.
 
-+alias io.console
 +alias sm.eol
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/io/stdout.eo
+++ b/eo-runtime/src/main/eo/io/stdout.eo
@@ -8,7 +8,6 @@
 #
 # Here the "Hello, world!" string is printed to the operating system console.
 
-+alias io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io

--- a/eo-runtime/src/main/eo/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/io/tee-input.eo
@@ -14,8 +14,6 @@
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
-+alias io.bytes-as-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io

--- a/eo-runtime/src/main/eo/sm/eol.eo
+++ b/eo-runtime/src/main/eo/sm/eol.eo
@@ -2,7 +2,6 @@
 # On UNIX systems, it returns "\n";
 # on Microsoft Windows systems it returns "\r\n".
 
-+alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm

--- a/eo-runtime/src/main/eo/sm/getenv.eo
+++ b/eo-runtime/src/main/eo/sm/getenv.eo
@@ -3,9 +3,6 @@
 #
 # See https://man7.org/linux/man-pages/man3/getenv.3.html.
 
-+alias sm.os
-+alias sm.posix
-+alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm

--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -3,7 +3,6 @@
 # the particular syscall.
 # See the linux syscall [table](https://filippo.io/linux-syscall-table) for more info.
 
-+alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm

--- a/eo-runtime/src/main/eo/sm/system-clock.eo
+++ b/eo-runtime/src/main/eo/sm/system-clock.eo
@@ -2,9 +2,6 @@
 # Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime32_s` on Windows.
 # Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
 
-+alias sm.os
-+alias sm.posix
-+alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm

--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -8,7 +8,6 @@
 # reference (https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference)
 # and the Winsock reference (https://learn.microsoft.com/en-us/windows/win32/api/winsock2).
 
-+alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm

--- a/eo-runtime/src/main/eo/string/as-char.eo
+++ b/eo-runtime/src/main/eo/string/as-char.eo
@@ -1,7 +1,6 @@
 # Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
 # The number is read as a 64-bit integer and its least-significant byte is taken.
 
-+alias string.as-ascii
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -1,7 +1,6 @@
 # Writes the number `n` as signed decimal digits, truncating its fraction
 # towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
 
-+alias string.as-char
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -2,8 +2,6 @@
 # digits, rounding to the nearest unit in the last place, so that `2.5` with
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
 
-+alias string.as-char
-+alias string.as-decimal
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -1,8 +1,6 @@
 # Writes the bytes `bts` as uppercase hexadecimal pairs joined by a hyphen,
 # so that the two bytes `0x4A 0x65` become `4A-65`.
 
-+alias string.as-ascii
-+alias string.as-char
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -2,8 +2,6 @@
 # If the text is not numeric, the `cant-parse` fallback is returned,
 # or the bottom object when unbound.
 
-+alias string.sprintf
-+alias string.sscanf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -2,8 +2,6 @@
 # If 0 > index >= ^.length, the `out-of-bounds` fallback is returned,
 # or the bottom object when unbound.
 
-+alias string.slice
-+alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -1,6 +1,5 @@
 # Checks if `text` contains all elements from `substrings`.
 
-+alias string.contains
 +alias tuple.reduced
 +alias tuple.mapped
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -1,6 +1,5 @@
 # Checks if `text` contains any element from `substrings`.
 
-+alias string.contains
 +alias tuple.reduced
 +alias tuple.mapped
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -1,6 +1,5 @@
 # Checks if `text` contains `substring`.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -1,6 +1,5 @@
 # Checks that `text` ends with `substring`.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -1,7 +1,6 @@
 # Returns index of `substring` in `text`.
 # If no `substring` was found, it returns -1.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -1,7 +1,6 @@
 # Check that all signs in `text` are letters.
 # Works only for english letters.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -1,7 +1,6 @@
 # Check that all signs in `text` are numbers or letters.
 # Works only for english letters.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -1,6 +1,5 @@
 # Check that all signs in `text` are ASCII characters.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -1,7 +1,6 @@
 # Check that all signs in `text` are decimal digits.
 # Works only for english digits.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -1,7 +1,6 @@
 # Returns last index of `substring` in `text`.
 # If no element was found, it returns -1.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -1,6 +1,5 @@
 # Returns the `text` in lower case.
 
-+alias string.as-ascii
 +alias tuple.bytes-as-array
 +alias tuple.reduced
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -2,8 +2,6 @@
 # The last element contains the remainder of the string after splitting.
 # If `limit` < 1, the `cant-split` fallback is returned, or the bottom object when unbound.
 
-+alias string.slice
-+alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -2,7 +2,6 @@
 # If `times` < 0, the `cant-repeat` fallback is returned, or the bottom object when unbound.
 # If `times` == 0, empty text is returned.
 
-+alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -3,7 +3,6 @@
 # The `replacement` here is a `string` that would be pasted instead of
 # matched text in original one.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -1,6 +1,5 @@
 # Returns a `tuple` of `strings`: `text` separated by `delimiter`.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/sscanf.eo
+++ b/eo-runtime/src/main/eo/string/sscanf.eo
@@ -8,7 +8,6 @@
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
 
-+alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -1,6 +1,5 @@
 # Checks that `text` starts with `substring`.
 
-+alias string.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -5,8 +5,6 @@
 # `string.trimmed-left` and `string.trimmed-right`, so the strip-set matches
 # `String.strip()` in Java for the ASCII range.
 
-+alias string.trimmed-left
-+alias string.trimmed-right
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -1,6 +1,5 @@
 # Returns the `text` in upper case.
 
-+alias string.as-ascii
 +alias tuple.bytes-as-array
 +alias tuple.reduced
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -1,7 +1,5 @@
 # Elements of `lst` from `index` to the end (supports oversized index).
 
-+alias tuple.is-empty
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/tuple/bytes-as-array.eo
@@ -2,7 +2,6 @@
 # Here `bts` is `bytes` objects, the return value is `tuple` where
 # each element is one `byte`.
 
-+alias tuple.bytes-as-array
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -1,8 +1,5 @@
 # Concatenate `lst` with another collection `passed`.
 
-+alias tuple.reducedi
-+alias tuple.with
-+alias tuple.withouti
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -1,6 +1,5 @@
 # Returns `true` if `lst` contains `element`, `false` otherwise.
 
-+alias tuple.index-of
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -2,7 +2,6 @@
 # Here "func" must be an abstract object with one free attribute:
 # the element of the collection. The result of `func` must be dataizable.
 
-+alias tuple.eachi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -4,7 +4,6 @@
 # collection and its index.
 # The result of `func` must be dataizable.
 
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -4,7 +4,6 @@
 # The result of dataization the `func`
 # should be boolean, that is `true` or `false`.
 
-+alias tuple.filteredi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -5,7 +5,6 @@
 # for the index. The result of dataization
 # the `func` should be boolean, that is `true` or `false`.
 
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -1,7 +1,5 @@
 # Elements of `lst` before `index` (supports negative indices).
 
-+alias tuple.back
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/map.eo
+++ b/eo-runtime/src/main/eo/tuple/map.eo
@@ -2,10 +2,6 @@
 # Here `pairs` must be a `tuple` of `map.entry` object.
 # The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
 
-+alias tuple.contains
-+alias tuple.filtered
-+alias tuple.hash-code-of
-+alias tuple.mapped
 +alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -2,7 +2,6 @@
 # object with one free attribute, for the element
 # of the collection.
 
-+alias tuple.mappedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -3,7 +3,6 @@
 # one for the element of the collection, the second one
 # for the index.
 
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -2,8 +2,6 @@
 # Here `start` and `end` must be `int`s. If they're not, the bottom object
 # is returned, which terminates on use.
 
-+alias tuple.is-empty
-+alias tuple.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/range.eo
+++ b/eo-runtime/src/main/eo/tuple/range.eo
@@ -20,7 +20,6 @@
 # `1.plus 1` and also has object `next`. Since these objects are ints - they have
 # object `lt` by default.
 
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -3,7 +3,6 @@
 # The first one for the accumulator, the second one for the element
 # of the collection.
 
-+alias tuple.reducedi
 +alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -3,8 +3,6 @@
 # The first one for the accumulator, the second one
 # for the element of the collection and the third one for the index.
 
-+alias tuple.is-empty
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/set.eo
+++ b/eo-runtime/src/main/eo/tuple/set.eo
@@ -1,7 +1,5 @@
 # Set - is an unordered `list` of unique objects.
 
-+alias tuple.map
-+alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -1,6 +1,5 @@
 # Drop the first `shift` elements of `lst`.
 
-+alias tuple.slice
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -1,7 +1,6 @@
 # Sublist of `lst` from `start` (inclusive) to `end` (exclusive).
 # Supports negative indices and clamps to list bounds.
 
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -1,9 +1,5 @@
 # Insert `item` into collection `lst` at the given `index`.
 
-+alias tuple.back
-+alias tuple.concat
-+alias tuple.front
-+alias tuple.with
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -1,6 +1,5 @@
 # Create a new list without all occurrences of `element` in `lst`.
 
-+alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -1,6 +1,5 @@
 # Create a new list without the i-th element of `lst`.
 
-+alias tuple.reducedi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple


### PR DESCRIPTION
Closes #5520.

Since #5425 the compiler auto-homes a bare reference to an object in the same package, so a hand-written `+alias <pkg>.<name>` whose `<pkg>` equals the file's own `+package` is dead weight. This removes all of them.

For every `.eo` file that has a `+package P` meta, the `+alias P.<name>` lines are deleted, and every cross-package alias is left untouched. For example `string/at.eo` loses `+alias string.slice` and `+alias string.sprintf` (both same-package), while `tuple/reduced.eo` loses `+alias tuple.list` and `+alias tuple.reducedi` but keeps `+alias string.sprintf`. Root-package files like `string.eo` keep their `+alias string.sprintf` because their package is not `string`.

100 aliases removed across 62 files, pure deletion, no other changes:
string 31, tuple 35, io 17, sm 9, fs 8.

Verification: `mvn -pl eo-runtime clean install` reaches the Java compilation stage, which means register, parse, assemble, lint and transpile all pass with the aliases gone, so every bare reference still resolves via auto-homing (the lint stage would flag any unresolved reference).
