### PR TITLE
Introduce bytes package for supplementary objects

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -1,16 +1,17 @@
-# Object `bytes` encapsulates a chain of bytes, providing bitwise operations,
-# numeric conversions, and byte manipulation methods. Objects like `number`, `string`,
-# and integer types (`i16`, `i32`, `i64`) use `bytes` as their internal representation.
+# Object `bytes` encapsulates a chain of bytes, providing the bitwise and
+# structural atoms every data object relies on. Objects like `number`, `string`,
+# and the integer types (`i16`, `i32`, `i64`) use `bytes` as their internal
+# representation, while conversions and derived operations live in the
+# `bytes` package (e.g. `bytes.as-number`, `bytes.xor`).
 #
 # Usage examples:
 # ```
 # bytes 01-02-03       # Creates a 3-byte sequence
 # FF-FF.and 00-FF      # Bitwise AND operation
-# as-bytes.as-number   # Convert 8-byte sequence to number
+# 01-02.as-number      # Convert 8-byte sequence to number
 # ```
 # .
 
-+alias string.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +rt jvm org.eolang:eo-runtime:0.0.0
@@ -21,56 +22,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-[data] > bytes
-  data > @
-  eq 01- > as-bool
-  bytes data > as-bytes
-
-  [cant-convert] > as-number
-    if. > @
-      eq nan.as-bytes
-      nan
-      if.
-        eq pinf.as-bytes
-        pinf
-        if.
-          eq ninf.as-bytes
-          ninf
-          if.
-            size.eq 8
-            number as-bytes
-            cant-convert
-              sprintf
-                "Can't convert non 8 length bytes to a number, bytes are %x"
-                * as-bytes
-
-  [cant-convert] > as-i64
-    if. > @
-      size.eq 8
-      i64 as-bytes
-      cant-convert
-        sprintf
-          "Can't convert non 8 length bytes to i64, bytes are %x"
-          * as-bytes
-
-  [cant-convert] > as-i32
-    if. > @
-      size.eq 4
-      i32 as-bytes
-      cant-convert
-        sprintf
-          "Can't convert non 4 length bytes to i32, bytes are %x"
-          * as-bytes
-
-  [cant-convert] > as-i16
-    if. > @
-      size.eq 2
-      i16 as-bytes
-      cant-convert
-        sprintf
-          "Can't convert non 2 length bytes to i16, bytes are %x"
-          * as-bytes
-
+[@] > bytes
   [b] > eq /bool
 
   [] > size /number
@@ -82,18 +34,7 @@
 
   [b] > or /bytes
 
-  [b] > xor
-    or. > @
-      and.
-        ^
-        b.not
-      and.
-        ^.not
-        b
-
   [] > not /bytes
-
-  right x.neg > [x] > left
 
   [x] > right /bytes
 
@@ -127,48 +68,6 @@
       string
         E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21
       "你好, друг!"
-
-  ++> tests-left-zero
-    not. > @
-      eq.
-        0.as-bytes.left 1
-        -1.as-bytes
-
-  ++> tests-left-with-zero
-    not. > @
-      eq.
-        2.as-bytes.left 0
-        -3.as-bytes
-
-  ++> tests-left-with-odd-neg
-    not. > @
-      eq.
-        -17.as-bytes.left 1
-        33.as-bytes
-
-  ++> tests-left-with-minus-one
-    eq. > @
-      eq.
-        -1.as-bytes.left 3
-        7.as-bytes
-      false
-
-  ++> tests-left-with-even-neg
-    eq. > @
-      FF-FF-FF-FF-FF-FF-FF-EE.left 2
-      00-00-00-00-00-00-00-47.not
-
-  ++> tests-left-with-even-plus
-    not. > @
-      eq.
-        4.as-bytes.left 3
-        -33.as-bytes
-
-  ++> tests-left-with-odd-plus
-    not. > @
-      eq.
-        5.as-bytes.left 3
-        -41.as-bytes
 
   ++> tests-right-with-zero
     not. > @
@@ -259,30 +158,6 @@
         -7.as-bytes.or 23.as-bytes
         0.as-bytes
 
-  ++> tests-xor-with-zero
-    not. > @
-      eq.
-        0.as-bytes.xor 29.as-bytes
-        -30.as-bytes
-
-  ++> tests-xor-with-two-neg
-    not. > @
-      eq.
-        -1.as-bytes.xor -123.as-bytes
-        -123.as-bytes
-
-  ++> tests-xor-with-two-plus
-    not. > @
-      eq.
-        53.as-bytes.xor 24.as-bytes
-        -46.as-bytes
-
-  ++> tests-xor-with-one-neg-one-plus
-    not. > @
-      eq.
-        -36.as-bytes.xor 43.as-bytes
-        8.as-bytes
-
   ++> tests-not-with-zero
     not. > @
       eq.
@@ -322,12 +197,6 @@
           1.as-bytes
           1.as-bytes
       1
-
-  ++> tests-convertible-to-bool
-    not. > @
-      eq.
-        01-.as-bool
-        00-.as-bool
 
   ++> tests-bitwise-works-negative
     eq. > @
@@ -380,16 +249,6 @@
           "world".as-bytes
       "hello world"
 
-  ++> tests-xor-works
-    eq. > @
-      00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
-      00-00-00-00-71-15-B3-4E
-
-  ++> tests-one-xor-one-as-number
-    eq. > @
-      (1.as-bytes.xor 1.as-bytes).as-number
-      0
-
   ++> tests-or-neg-bytes-with-leading-zeroes
     eq. > @
       00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
@@ -399,11 +258,6 @@
     eq. > @
       (00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00).as-number
       0
-
-  ++> tests-xor-neg-bytes-with-leading-zeroes
-    eq. > @
-      00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
-      FF-FF-FF-FF-8E-EA-4C-B1
 
   ++> tests-or-neg-bytes-without-leading-zeroes
     eq. > @
@@ -415,11 +269,6 @@
       (00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00).as-number
       0
 
-  ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
-    eq. > @
-      (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
-      FF-FF-FF-FF-FF-FF-FF-FF
-
   ++> tests-or-neg-bytes-as-number-with-zero
     eq. > @
       (-4294967296.as-bytes.or 0.as-bytes).as-number
@@ -429,24 +278,6 @@
     eq. > @
       FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
       FF-FF-FF-FF-00-00-00-01
-
-  ++> throws-on-bytes-of-wrong-size-as-number
-    01-01-01-01.as-number > @
-
-  ++> tests-wrong-size-as-number-returns-provided-fallback
-    eq. > @
-      "recovered"
-      01-01-01-01.as-number
-        "recovered" > [msg]
-
-  ++> throws-on-bytes-of-wrong-size-as-i64
-    01-01-01-01.as-i64 > @
-
-  ++> tests-wrong-size-as-i64-returns-provided-fallback
-    eq. > @
-      "recovered"
-      01-01-01-01.as-i64
-        "recovered" > [msg]
 
   ++> throws-on-out-of-bounds-slice
     20-1F-EE-B5-90.slice 3 10 > @
@@ -466,19 +297,3 @@
         2000000000
         2000000000
         "recovered" > [msg]
-
-  ++> tests-bytes-converts-to-i64
-    eq. > @
-      00-00-00-00-00-00-00-2A.as-i64
-      42.as-i64
-
-  ++> tests-bytes-converts-to-i64-and-back
-    eq. > @
-      00-00-00-00-00-00-00-33.as-i64.as-bytes
-      00-00-00-00-00-00-00-33
-
-  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
-    not. > @
-      eq.
-        00-00-00-00-00-00-00-2A.as-i64.as-bytes
-        42.as-bytes

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -1,0 +1,17 @@
+# Bytes as a boolean: TRUE when the single byte equals `01-`, FALSE otherwise.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts] > as-bool
+  bts.eq 01- > @
+
+  ++> tests-convertible-to-bool
+    not. > @
+      eq.
+        01-.as-bool
+        00-.as-bool

--- a/eo-runtime/src/main/eo/bytes/as-bytes.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bytes.eo
@@ -1,0 +1,18 @@
+# Bytes as bytes: the very same chain of bytes, unchanged.
+# This identity mapping lets every data object expose its raw content
+# uniformly through `as-bytes`, with `bytes` returning itself.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts] > as-bytes
+  bts > @
+
+  ++> tests-bytes-as-bytes-is-itself
+    eq. > @
+      20-1F-EE.as-bytes
+      20-1F-EE

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -1,0 +1,28 @@
+# Bytes as a signed 16-bit integer `i16`: a 2-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++alias string.sprintf
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts cant-convert] > as-i16
+  if. > @
+    bts.size.eq 2
+    i16 bts
+    cant-convert
+      sprintf
+        "Can't convert non 2 length bytes to i16, bytes are %x"
+        * bts
+
+  ++> throws-on-bytes-of-wrong-size-as-i16
+    01-01-01.as-i16 > @
+
+  ++> tests-bytes-converts-to-i16-and-back
+    eq. > @
+      00-33.as-i16.as-bytes
+      00-33

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -1,0 +1,28 @@
+# Bytes as a signed 32-bit integer `i32`: a 4-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++alias string.sprintf
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts cant-convert] > as-i32
+  if. > @
+    bts.size.eq 4
+    i32 bts
+    cant-convert
+      sprintf
+        "Can't convert non 4 length bytes to i32, bytes are %x"
+        * bts
+
+  ++> throws-on-bytes-of-wrong-size-as-i32
+    01-01-01-01-01.as-i32 > @
+
+  ++> tests-bytes-converts-to-i32-and-back
+    eq. > @
+      00-00-00-33.as-i32.as-bytes
+      00-00-00-33

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -1,0 +1,45 @@
+# Bytes as a signed 64-bit integer `i64`: an 8-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++alias string.sprintf
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts cant-convert] > as-i64
+  if. > @
+    bts.size.eq 8
+    i64 bts
+    cant-convert
+      sprintf
+        "Can't convert non 8 length bytes to i64, bytes are %x"
+        * bts
+
+  ++> throws-on-bytes-of-wrong-size-as-i64
+    01-01-01-01.as-i64 > @
+
+  ++> tests-wrong-size-as-i64-returns-provided-fallback
+    eq. > @
+      "recovered"
+      01-01-01-01.as-i64
+        "recovered" > [msg]
+
+  ++> tests-bytes-converts-to-i64
+    eq. > @
+      00-00-00-00-00-00-00-2A.as-i64
+      42.as-i64
+
+  ++> tests-bytes-converts-to-i64-and-back
+    eq. > @
+      00-00-00-00-00-00-00-33.as-i64.as-bytes
+      00-00-00-00-00-00-00-33
+
+  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
+    not. > @
+      eq.
+        00-00-00-00-00-00-00-2A.as-i64.as-bytes
+        42.as-bytes

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -1,0 +1,38 @@
+# Bytes as a floating-point `number`: an 8-byte chain reinterpreted as an
+# IEEE 754 double, mapping the special chains to `nan`, `pinf`, and `ninf`.
+# For any other length the `cant-convert` fallback is returned.
+
++alias string.sprintf
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts cant-convert] > as-number
+  if. > @
+    bts.eq nan.as-bytes
+    nan
+    if.
+      bts.eq pinf.as-bytes
+      pinf
+      if.
+        bts.eq ninf.as-bytes
+        ninf
+        if.
+          bts.size.eq 8
+          number bts
+          cant-convert
+            sprintf
+              "Can't convert non 8 length bytes to a number, bytes are %x"
+              * bts
+
+  ++> throws-on-bytes-of-wrong-size-as-number
+    01-01-01-01.as-number > @
+
+  ++> tests-wrong-size-as-number-returns-provided-fallback
+    eq. > @
+      "recovered"
+      01-01-01-01.as-number
+        "recovered" > [msg]

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -1,0 +1,55 @@
+# Left bit shift of the byte chain `bts` by `x` bits, expressed as a
+# right shift by the negated amount.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts x] > left
+  bts.right > @
+    x.neg
+
+  ++> tests-left-zero
+    not. > @
+      eq.
+        0.as-bytes.left 1
+        -1.as-bytes
+
+  ++> tests-left-with-zero
+    not. > @
+      eq.
+        2.as-bytes.left 0
+        -3.as-bytes
+
+  ++> tests-left-with-odd-neg
+    not. > @
+      eq.
+        -17.as-bytes.left 1
+        33.as-bytes
+
+  ++> tests-left-with-minus-one
+    eq. > @
+      eq.
+        -1.as-bytes.left 3
+        7.as-bytes
+      false
+
+  ++> tests-left-with-even-neg
+    eq. > @
+      FF-FF-FF-FF-FF-FF-FF-EE.left 2
+      00-00-00-00-00-00-00-47.not
+
+  ++> tests-left-with-even-plus
+    not. > @
+      eq.
+        4.as-bytes.left 3
+        -33.as-bytes
+
+  ++> tests-left-with-odd-plus
+    not. > @
+      eq.
+        5.as-bytes.left 3
+        -41.as-bytes

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -1,0 +1,62 @@
+# Bitwise exclusive OR of the byte chain `bts` with another chain `b`,
+# derived from the `and`, `or`, and `not` atoms.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[bts b] > xor
+  or. > @
+    and.
+      bts
+      b.not
+    and.
+      bts.not
+      b
+
+  ++> tests-xor-with-zero
+    not. > @
+      eq.
+        0.as-bytes.xor 29.as-bytes
+        -30.as-bytes
+
+  ++> tests-xor-with-two-neg
+    not. > @
+      eq.
+        -1.as-bytes.xor -123.as-bytes
+        -123.as-bytes
+
+  ++> tests-xor-with-two-plus
+    not. > @
+      eq.
+        53.as-bytes.xor 24.as-bytes
+        -46.as-bytes
+
+  ++> tests-xor-with-one-neg-one-plus
+    not. > @
+      eq.
+        -36.as-bytes.xor 43.as-bytes
+        8.as-bytes
+
+  ++> tests-xor-works
+    eq. > @
+      00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
+      00-00-00-00-71-15-B3-4E
+
+  ++> tests-one-xor-one-as-number
+    eq. > @
+      (1.as-bytes.xor 1.as-bytes).as-number
+      0
+
+  ++> tests-xor-neg-bytes-with-leading-zeroes
+    eq. > @
+      00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
+      FF-FF-FF-FF-8E-EA-4C-B1
+
+  ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
+    eq. > @
+      (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
+      FF-FF-FF-FF-FF-FF-FF-FF

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -332,7 +332,7 @@ public class PhDefault implements Phi, Cloneable {
         final String name = this.oname();
         final String result;
         if (this.literal(name)) {
-            final byte[] raw = this.attrs.get("as-bytes").get().take("data").delta();
+            final byte[] raw = this.attrs.get("as-bytes").get().delta();
             if ("string".equals(name)) {
                 result = String.format("\"%s\"", new String(raw, StandardCharsets.UTF_8));
             } else {


### PR DESCRIPTION
This carves the non-atom objects out of the core `bytes` object and into a new `bytes` package, following the layout proposed in #5501. The `bytes` object is left with only its eight atoms (`eq`, `size`, `slice`, `and`, `or`, `not`, `right`, `concat`), while `left`, `xor`, `as-bool`, `as-number`, `as-i16`, `as-i32`, and `as-i64` become standalone objects under `eo-runtime/src/main/eo/bytes/`, reached through the same package dispatch that already serves `number`, `string`, and `tuple`. The void data attribute is renamed to `@`, so a bytes literal is now `[@] > bytes` with no separate `data` alias.

The issue suggested dropping `as-bytes` entirely. It turns out to be load-bearing: the `eq` atom reads `b.as-bytes`, the const (`!`) operator expands to `(dataized ...).as-bytes`, and `bool` (and therefore `true`/`false`) reaches it by decoration. So instead of deleting it I moved it into the package as an identity object, which keeps all three paths working through dispatch while still emptying it out of the core object. Removing it for real would mean rewiring the `eq` atom and the const transform, which feels like its own issue. Renaming `data` to `@` also needed a one-line fix in the φ-term renderer, which used to look up the bytes value by the hard-coded `data` name and now follows the decoratee.

All 1546 eo-runtime tests pass, including the moved tests now living beside their objects in the package.

Refs #5501