### PR TITLE
#5511: cache the classpath probe on the package-extension dispatch path

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/OnClasspath.java
+++ b/eo-runtime/src/main/java/org/eolang/OnClasspath.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cached check of whether a Java class is present on the classpath.
+ *
+ * <p>Package-extension dispatch probes the classpath with {@code Class.forName}
+ * on every attribute miss (an inner loop of dataization), and the answer for a
+ * given fully-qualified name never changes at runtime. This memoizes both the
+ * positive and the negative answer, so a given name pays the lookup and the
+ * caught {@link ClassNotFoundException} at most once.</p>
+ *
+ * @since 0.62
+ */
+final class OnClasspath {
+
+    /**
+     * Name to presence, cached across all lookups.
+     */
+    private static final Map<String, Boolean> CACHE = new ConcurrentHashMap<>(0);
+
+    private OnClasspath() {
+    }
+
+    /**
+     * Is there a Java class with this name on the classpath?
+     * @param cls The fully-qualified Java name
+     * @return TRUE if it exists
+     */
+    static boolean has(final String cls) {
+        return OnClasspath.CACHE.computeIfAbsent(cls, OnClasspath::probe);
+    }
+
+    /**
+     * Probe the classpath for a class, uncached.
+     * @param cls The fully-qualified Java name
+     * @return TRUE if it exists
+     */
+    private static boolean probe(final String cls) {
+        boolean found;
+        try {
+            Class.forName(cls);
+            found = true;
+        } catch (final ClassNotFoundException ex) {
+            found = false;
+        }
+        return found;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -67,6 +68,12 @@ public class PhDefault implements Phi, Cloneable {
      * No initial attributes.
      */
     private static final Map<String, Attribute> NONE = Collections.emptyMap();
+
+    /**
+     * Structural attribute names that can never be a package extension, so a
+     * miss on them must not probe the classpath.
+     */
+    private static final Set<String> SPECIAL = Set.of(Phi.LAMBDA, Phi.PHI, Phi.RHO);
 
     /**
      * Data.
@@ -395,9 +402,10 @@ public class PhDefault implements Phi, Cloneable {
     private Phi extension(final String name, final Phi bottom) {
         final String forma = this.forma();
         Phi found = bottom;
-        if (forma.startsWith(String.format("%s.", PhPackage.GLOBAL))) {
+        if (!PhDefault.SPECIAL.contains(name)
+            && forma.startsWith(String.format("%s.", PhPackage.GLOBAL))) {
             final String full = String.join(".", forma, name);
-            if (PhDefault.exists(new JavaPath(full).toString())) {
+            if (OnClasspath.has(new JavaPath(full).toString())) {
                 final Phi taken = Phi.Φ.take(full.substring(PhPackage.GLOBAL.length() + 1));
                 try {
                     taken.put(0, this);
@@ -412,22 +420,6 @@ public class PhDefault implements Phi, Cloneable {
                 }
                 found = taken;
             }
-        }
-        return found;
-    }
-
-    /**
-     * Is there a Java class with this name on the classpath?
-     * @param cls The fully-qualified Java name
-     * @return TRUE if it exists
-     */
-    private static boolean exists(final String cls) {
-        boolean found;
-        try {
-            Class.forName(cls);
-            found = true;
-        } catch (final ClassNotFoundException ex) {
-            found = false;
         }
         return found;
     }

--- a/eo-runtime/src/main/java/org/eolang/PhNest.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNest.java
@@ -130,14 +130,7 @@ final class PhNest implements Phi {
      * @return TRUE if it does
      */
     private boolean owns(final String name) {
-        boolean owns;
-        try {
-            Class.forName(new JavaPath(String.join(".", this.pkg, name)).toString());
-            owns = true;
-        } catch (final ClassNotFoundException ignored) {
-            owns = false;
-        }
-        return owns;
+        return OnClasspath.has(new JavaPath(String.join(".", this.pkg, name)).toString());
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link OnClasspath}.
+ * @since 0.62
+ */
+final class OnClasspathTest {
+
+    @Test
+    void findsExistingClass() {
+        MatcherAssert.assertThat(
+            "A class that exists must be reported as present, but it wasn't",
+            OnClasspath.has("org.eolang.PhDefault"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotFindMissingClass() {
+        MatcherAssert.assertThat(
+            "A class that is absent must be reported as missing, but it wasn't",
+            OnClasspath.has("org.eolang.ThereIsDefinitelyNoSuchClass"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void returnsSameAnswerOnRepeatedLookup() {
+        final String cls = "org.eolang.PhNest";
+        MatcherAssert.assertThat(
+            "The cached lookup must agree with itself on repeat, but it didn't",
+            OnClasspath.has(cls),
+            Matchers.is(OnClasspath.has(cls))
+        );
+    }
+}


### PR DESCRIPTION
Closes #5511.

Since #5505 ("packages are objects"), attribute dispatch falls back to a package-extension lookup whenever a `take` would resolve to `⊥`. That fallback probes the classpath with `Class.forName` **uncached**, on the innermost loop of dataization:

- `PhDefault.extension` → `exists(...)` → `Class.forName` on **every** attribute miss (a real absent attribute, an error path, `⊥` propagation), paying a caught `ClassNotFoundException` each time;
- `PhNest.owns` → `Class.forName` on **every** `take`, before its object cache.

The answer for a given fully-qualified name never changes at runtime.

### Fix
- New `OnClasspath` memoizes the probe — **both** the positive and the negative answer — keyed by the class name, so a given name is looked up at most once. Both probe sites route through it.
- `PhDefault.extension` additionally **skips the probe entirely** for the structural attribute names `λ`/`φ`/`ρ` (they can never be a package extension), so a miss on `ρ`/`φ`/`λ` no longer probes `Φ.<pkg>.ρ` at all.

Behaviour is unchanged — only the redundant classloader lookups and exception-driven control flow on the hot path are removed. `OnClasspath` caches the boolean existence, **not** the resolved `Phi`, so no mutable object is shared (cf. #5514).

### Changes
- `OnClasspath.java` (new) + `OnClasspathTest.java`.
- `PhDefault.java` — route through `OnClasspath`, drop the local `exists`, add the `λ`/`φ`/`ρ` guard.
- `PhNest.java` — `owns` routes through `OnClasspath`.

Verified locally: `eo-runtime` suite green apart from two failures unrelated to this change — the network-dependent `EOsocketTest.refusesConnectionViaSyscall` and `EOfileTest.tests_appending_data_to_file` (the latter tracked in #5503).