### PR TITLE
fix(#5513): bind package-extension receiver into α0 consistently

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -381,8 +381,12 @@ public class PhDefault implements Phi, Cloneable {
      * <p>When {@code (number 42).power} finds no {@code power} attribute, the
      * runtime looks for an object {@code Φ.number.power} in the package named
      * after this object's forma. If it exists, it is returned with this object
-     * bound as its first argument, so {@code (number 42).power 3} reads as
-     * {@code number.power 42 3}. When there's no such object, the terminated
+     * bound as its first argument ({@code α0}), so {@code (number 42).power 3}
+     * reads as {@code number.power 42 3}. The receiver of a package extension
+     * always lives in {@code α0}: implicit dispatch binds it here, while
+     * explicit dispatch through the namespace ({@code number.power 42 3})
+     * leaves the slot for the caller to fill (see {@code PhNest.extension}).
+     * When there's no such object, the terminated
      * computation stays terminated. When the object exists but has no free
      * positional attribute to receive the bound object (for example a nullary
      * constant like {@code number.pi}), a clear error is raised instead of the

--- a/eo-runtime/src/main/java/org/eolang/PhNest.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNest.java
@@ -142,15 +142,25 @@ final class PhNest implements Phi {
 
     /**
      * Take an extension object from the package, as it is, without binding.
+     *
+     * <p>The receiver of a package extension always lives in positional
+     * attribute {@code α0}, never in {@code ρ}. Explicit dispatch through the
+     * package namespace (for example {@code number.power 2 4}) is a plain
+     * access: nothing is bound here and the caller supplies every argument,
+     * the first of which plays the receiver's role. This mirrors implicit
+     * dispatch, where {@link PhDefault} binds the receiver into {@code α0} of
+     * the same extension (see {@code PhDefault.extension}). Binding {@code ρ}
+     * here would be misleading — the package object standing behind
+     * {@code number} is not a usable receiver value — so it is deliberately
+     * left untouched.</p>
+     *
      * @param name The name of the extension
      * @return The extension object
      */
     private Phi extension(final String name) {
         final String fqn = String.join(".", this.pkg, name);
         if (!this.objects.containsKey(fqn)) {
-            final Phi loaded = PhNest.load(new JavaPath(fqn).toString());
-            loaded.put(Phi.RHO, this);
-            this.objects.put(fqn, loaded);
+            this.objects.put(fqn, PhNest.load(new JavaPath(fqn).toString()));
         }
         return this.objects.get(fqn).copy();
     }

--- a/eo-runtime/src/test/java/org/eolang/PhNestTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhNestTest.java
@@ -48,4 +48,13 @@ final class PhNestTest {
             "A copy of a package object must accept a put, but it didn't"
         );
     }
+
+    @Test
+    void handsOutExtensionWithoutBindingPackageAsRho() {
+        MatcherAssert.assertThat(
+            "Explicit dispatch must leave ρ unbound so the receiver convention stays α0-only, but ρ was set",
+            Phi.Φ.take("number").take("power").hasRho(),
+            Matchers.is(false)
+        );
+    }
 }


### PR DESCRIPTION
Closes #5513.

## Problem

Two dispatch paths resolve a package extension and bound the receiver into **different slots**:

- **Implicit** — `(number 42).power 3` — `PhDefault.extension` binds the receiver into **positional attribute `α0`** (`found.put(0, this)`).
- **Explicit** — `number.power 2 4` — `PhNest.extension` bound the package object into **`ρ`** (`loaded.put(Phi.RHO, this)`).

So the same extension, reached the two documented ways, saw its receiver in `α0` one way and in `ρ` the other.

## Fix

Every package extension in the base library reads its receiver from a **positional attribute** (`num`, `x`, `sequence`, …), never from `ρ` — so `α0` is the real convention, and `PhDefault` already follows it.

The issue suggested making `PhNest` do `loaded.put(0, this)` instead. That does not work for the explicit form: there `this` is the **abstract `number` package object** (`[as-bytes] > number`, with `as-bytes` unset), not a concrete value. Binding it into `α0` overflows `power`'s two voids (`num`, `x`) and leaves `num.as-bytes` unresolvable, so `number.power 2 4` — a supported, tested form — would break.

Instead, this PR **removes the spurious `ρ` binding** in `PhNest.extension`. The receiver of a package extension now always lives in `α0` in both forms:

- implicit dispatch auto-binds the left-hand value into `α0`;
- explicit namespace dispatch is a plain access that leaves the slot for the caller to fill as the first argument.

`ρ` is no longer the receiver in either path, which is exactly the inconsistency the issue reports. The convention is now documented on both `PhNest.extension` and `PhDefault.extension`.

## Changes

- `eo-runtime/.../PhNest.java` — drop `loaded.put(Phi.RHO, this)`; document the `α0` convention.
- `eo-runtime/.../PhDefault.java` — document that the receiver always lives in `α0`, cross-referencing `PhNest`.
- `eo-runtime/.../PhNestTest.java` — regression test asserting an extension taken through the namespace is handed out without `ρ` bound.

## Verification

- `PhNestTest` — 4/4 pass (incl. the new regression test).
- `EOpowerTest` — 48/48 pass, covering both dispatch paths: `2.power 4`, `3.power 2`, and `number.power 2 4`.
- Full `eo-runtime` suite — 1542 tests, no functional failures. (The only red test, `MainTest.printsVersion`, is an environmental artifact: the sandbox JVM echoes `Picked up JAVA_TOOL_OPTIONS: …` to stderr, polluting the `--version` capture; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WnhmEgyoPvv1n6DBJryju

---
_Generated by [Claude Code](https://claude.ai/code/session_011WnhmEgyoPvv1n6DBJryju)_