### PR TITLE
Rename sprintf/sscanf and move range to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ argument: a copy of the object `printf`:
 # Says hello to Jeff.
 
 io.stdout > [] > app
-  string.printf
-    "Hello, %s!"
+  "Hello, %s!".printf
     * "Jeffrey"
 ```
 
@@ -126,10 +125,9 @@ This program can be written using horizontal notation:
 
 ```eo
 +alias io.stdout
-+alias string.printf
 
 [] > app
-  stdout (printf "Hello, %s!" (* "Jeffrey")) > @
+  stdout ("Hello, %s!".printf (* "Jeffrey")) > @
 ```
 
 The special attribute `@` denotes an object that is being
@@ -147,7 +145,7 @@ inside `app` and use it to build the output string:
 [] > app
   io.stdout (msg "Jeffrey") > @
   [name] > msg
-    string.printf "Hello, %s!" (* name) > @
+    "Hello, %s!".printf (* name) > @
 ```
 
 Now, the object `app` has two "attached" attributes: `@` and `msg`. The attribute
@@ -164,10 +162,10 @@ malloc.empty > [args] > app
       x.as-number.lt 6 > [i] >>
       seq * > [i] >>
         io.stdout
-          string.printf *1
-            "%d x %1$d = %d\n"
-            x
-            x.as-number.times x
+          "%d x %1$d = %d\n".printf
+            *
+              x
+              x.as-number.times x
         x.put
           x.as-number.plus 1
     true

--- a/README.md
+++ b/README.md
@@ -109,28 +109,27 @@ io.stdout "Hello, world!"
 Moreover, it's possible to use brackets in order to group arguments and avoid
 ambiguity. For example, instead of using a plain string `"Hello, world!"`
 we may want to create a copy of the object `stdout` with a more complex
-argument: a copy of the object `sprintf`:
+argument: a copy of the object `printf`:
 
 ```eo
 # Says hello to Jeff.
 
 io.stdout > [] > app
-  string.sprintf
+  string.printf
     "Hello, %s!"
     * "Jeffrey"
 ```
 
-Here, the object `sprintf` is also [abstract][abstract objects].
+Here, the object `printf` is also [abstract][abstract objects].
 It is being copied with two arguments: `"Hello, %s!"` and `"Jeffrey"`.
 This program can be written using horizontal notation:
 
 ```eo
 +alias io.stdout
-+alias string.sprintf
++alias string.printf
 
-# Also says hello to Jeff.
 [] > app
-  stdout (sprintf "Hello, %s!" (* "Jeffrey")) > @
+  stdout (printf "Hello, %s!" (* "Jeffrey")) > @
 ```
 
 The special attribute `@` denotes an object that is being
@@ -148,7 +147,7 @@ inside `app` and use it to build the output string:
 [] > app
   io.stdout (msg "Jeffrey") > @
   [name] > msg
-    string.sprintf "Hello, %s!" (* name) > @
+    string.printf "Hello, %s!" (* name) > @
 ```
 
 Now, the object `app` has two "attached" attributes: `@` and `msg`. The attribute
@@ -165,7 +164,7 @@ malloc.empty > [args] > app
       x.as-number.lt 6 > [i] >>
       seq * > [i] >>
         io.stdout
-          string.sprintf *1
+          string.printf *1
             "%d x %1$d = %d\n"
             x
             x.as-number.times x

--- a/eo-integration-tests/src/test/resources/snippets/decorated.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/decorated.yaml
@@ -9,13 +9,13 @@ args: ["snippets.foo"]
 eo: |
   +alias io.stdout
   +alias number.sine
-  +alias string.sprintf
+  +alias string.printf
   +package snippets
 
   [] > foo
     1.2345 > x
     stdout > @
-      sprintf
+      printf
         "Sin of %f is %f"
         *
           x

--- a/eo-integration-tests/src/test/resources/snippets/decorated.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/decorated.yaml
@@ -9,14 +9,12 @@ args: ["snippets.foo"]
 eo: |
   +alias io.stdout
   +alias number.sine
-  +alias string.printf
   +package snippets
 
   [] > foo
     1.2345 > x
     stdout > @
-      printf
-        "Sin of %f is %f"
+      "Sin of %f is %f".printf
         *
           x
           sine x

--- a/eo-integration-tests/src/test/resources/snippets/fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/fibo.yaml
@@ -8,7 +8,6 @@ file: snippets/fibo.eo
 args: ["snippets.fibo"]
 eo: |
   +alias io.stdout
-  +alias string.printf
   +package snippets
 
   [] > fibo
@@ -20,8 +19,7 @@ eo: |
           f (n.minus 1)
           f (n.minus 2)
     stdout > @
-      printf
-        "%d is the %dth number\n"
+      "%d is the %dth number\n".printf
         *
           f 6
           6

--- a/eo-integration-tests/src/test/resources/snippets/fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/fibo.yaml
@@ -8,7 +8,7 @@ file: snippets/fibo.eo
 args: ["snippets.fibo"]
 eo: |
   +alias io.stdout
-  +alias string.sprintf
+  +alias string.printf
   +package snippets
 
   [] > fibo
@@ -20,7 +20,7 @@ eo: |
           f (n.minus 1)
           f (n.minus 2)
     stdout > @
-      sprintf
+      printf
         "%d is the %dth number\n"
         *
           f 6

--- a/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
@@ -8,7 +8,6 @@ file: snippets/self-fibo.eo
 args: ["snippets.self-fibo"]
 eo: |
   +alias io.stdout
-  +alias string.printf
   +package snippets
 
   [] > self-fibo
@@ -21,8 +20,7 @@ eo: |
           % (n.minus 2)
     | 6 > num
     stdout > @
-      printf
-        "%d is the %dth number\n"
+      "%d is the %dth number\n".printf
         *
           num
           6

--- a/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/self-fibo.yaml
@@ -8,7 +8,7 @@ file: snippets/self-fibo.eo
 args: ["snippets.self-fibo"]
 eo: |
   +alias io.stdout
-  +alias string.sprintf
+  +alias string.printf
   +package snippets
 
   [] > self-fibo
@@ -21,7 +21,7 @@ eo: |
           % (n.minus 2)
     | 6 > num
     stdout > @
-      sprintf
+      printf
         "%d is the %dth number\n"
         *
           num

--- a/eo-integration-tests/src/test/resources/snippets/simple.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/simple.yaml
@@ -12,10 +12,10 @@ args: ["simple", "Jeff"]
 target: "eoc"
 eo: |
   +alias io.stdout
-  +alias string.sprintf
+  +alias string.printf
 
   [args] > simple
     stdout > @
-      sprintf *1
+      printf *1
         "Hello, %s"
         args.at 0

--- a/eo-integration-tests/src/test/resources/snippets/simple.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/simple.yaml
@@ -12,10 +12,8 @@ args: ["simple", "Jeff"]
 target: "eoc"
 eo: |
   +alias io.stdout
-  +alias string.printf
 
   [args] > simple
     stdout > @
-      printf *1
-        "Hello, %s"
-        args.at 0
+      "Hello, %s".printf
+        * (args.at 0)

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -2,7 +2,7 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,7 +15,7 @@
     bts.size.eq 2
     i16 bts
     cant-convert
-      sprintf
+      printf
         "Can't convert non 2 length bytes to i16, bytes are %x"
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -2,7 +2,6 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,8 +14,7 @@
     bts.size.eq 2
     i16 bts
     cant-convert
-      printf
-        "Can't convert non 2 length bytes to i16, bytes are %x"
+      "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * bts
 
   ++> throws-on-bytes-of-wrong-size-as-i16

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -2,7 +2,6 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,8 +14,7 @@
     bts.size.eq 4
     i32 bts
     cant-convert
-      printf
-        "Can't convert non 4 length bytes to i32, bytes are %x"
+      "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * bts
 
   ++> throws-on-bytes-of-wrong-size-as-i32

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -2,7 +2,7 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,7 +15,7 @@
     bts.size.eq 4
     i32 bts
     cant-convert
-      sprintf
+      printf
         "Can't convert non 4 length bytes to i32, bytes are %x"
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -2,7 +2,7 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,7 +15,7 @@
     bts.size.eq 8
     i64 bts
     cant-convert
-      sprintf
+      printf
         "Can't convert non 8 length bytes to i64, bytes are %x"
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -2,7 +2,6 @@
 # as two's complement. For any other length the `cant-convert` fallback
 # is returned.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -15,8 +14,7 @@
     bts.size.eq 8
     i64 bts
     cant-convert
-      printf
-        "Can't convert non 8 length bytes to i64, bytes are %x"
+      "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * bts
 
   ++> throws-on-bytes-of-wrong-size-as-i64

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -2,7 +2,7 @@
 # IEEE 754 double, mapping the special chains to `nan`, `pinf`, and `ninf`.
 # For any other length the `cant-convert` fallback is returned.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -24,7 +24,7 @@
           bts.size.eq 8
           number bts
           cant-convert
-            sprintf
+            printf
               "Can't convert non 8 length bytes to a number, bytes are %x"
               * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -2,7 +2,6 @@
 # IEEE 754 double, mapping the special chains to `nan`, `pinf`, and `ninf`.
 # For any other length the `cant-convert` fallback is returned.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
@@ -24,8 +23,7 @@
           bts.size.eq 8
           number bts
           cant-convert
-            printf
-              "Can't convert non 8 length bytes to a number, bytes are %x"
+            "Can't convert non 8 length bytes to a number, bytes are %x".printf
               * bts
 
   ++> throws-on-bytes-of-wrong-size-as-number

--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -1,7 +1,7 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 
-+alias string.sprintf
++alias string.printf
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
@@ -29,7 +29,7 @@
           outcome.eq 0
           ^
           T
-            sprintf
+            printf
               "Cant make the directory '%s': %s"
               * ^.path created.output
     called. > created
@@ -63,7 +63,7 @@
       Q.fs.file
         touch.as-bytes
       T
-        sprintf
+        printf
           "Directory %s does not exist, can't create temporary file"
           * file
 
@@ -71,7 +71,7 @@
 
   [mode scope] > open
     T > @
-      sprintf
+      printf
         "The file %s is a directory, can't open for I/O operations"
         * file
 

--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -1,7 +1,6 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 
-+alias string.printf
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
@@ -29,8 +28,7 @@
           outcome.eq 0
           ^
           T
-            printf
-              "Cant make the directory '%s': %s"
+            "Cant make the directory '%s': %s".printf
               * ^.path created.output
     called. > created
       if.
@@ -63,16 +61,14 @@
       Q.fs.file
         touch.as-bytes
       T
-        printf
-          "Directory %s does not exist, can't create temporary file"
+        "Directory %s does not exist, can't create temporary file".printf
           * file
 
     [] > touch /string
 
   [mode scope] > open
     T > @
-      printf
-        "The file %s is a directory, can't open for I/O operations"
+      "The file %s is a directory, can't open for I/O operations".printf
         * file
 
   ++> tests-makes-new-directory

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -5,7 +5,6 @@
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
@@ -45,8 +44,7 @@
       if.
         descriptor.eq -1
         T
-          printf
-            "Cant touch the file '%s': %s"
+          "Cant touch the file '%s': %s".printf
             * path created.output
         seq *
           closed
@@ -70,8 +68,7 @@
         outcome.eq 0
         ^
         T
-          printf
-            "Cant delete the file '%s': %s"
+          "Cant delete the file '%s': %s".printf
             * path removed.output
       ^
     called. > removed
@@ -105,8 +102,7 @@
       outcome.eq 0
       file target
       T
-        printf
-          "Cant move the file '%s' to '%s': %s"
+        "Cant move the file '%s' to '%s': %s".printf
           * path target renamed.output
     called. > renamed
       if.
@@ -122,8 +118,7 @@
       if.
         existing.and exists.not
         cant-open
-          printf
-            "File must exist for given access mod: '%s'"
+          "File must exist for given access mod: '%s'".printf
             * access
         seq *
           open-file
@@ -170,8 +165,7 @@
         if. > @
           descriptor.eq -1
           cant-open
-            printf
-              "Couldn't open file '%s': %s"
+            "Couldn't open file '%s': %s".printf
               * path opened.output
           seq *
             scope
@@ -219,8 +213,7 @@
                 if. > @
                   readable.not
                   T
-                    printf
-                      "Can't read from file with provided access mode '%s'"
+                    "Can't read from file with provided access mode '%s'".printf
                       * access
                   seq *
                     chunk
@@ -236,8 +229,7 @@
                 if. > @
                   writable.not
                   T
-                    printf
-                      "Can't write to file with provided access mode '%s'"
+                    "Can't write to file with provided access mode '%s'".printf
                       * access
                   seq *
                     code.
@@ -302,7 +294,7 @@
 
   ++> tests-moves-a-file
     and. > @
-      (temp.moved (printf "%s.dest" (* temp.path))).exists
+      (temp.moved ("%s.dest".printf (* temp.path))).exists
       temp.exists.not
     tmpdir.tmpfile > temp
 

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -5,7 +5,7 @@
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
@@ -45,7 +45,7 @@
       if.
         descriptor.eq -1
         T
-          sprintf
+          printf
             "Cant touch the file '%s': %s"
             * path created.output
         seq *
@@ -70,7 +70,7 @@
         outcome.eq 0
         ^
         T
-          sprintf
+          printf
             "Cant delete the file '%s': %s"
             * path removed.output
       ^
@@ -105,7 +105,7 @@
       outcome.eq 0
       file target
       T
-        sprintf
+        printf
           "Cant move the file '%s' to '%s': %s"
           * path target renamed.output
     called. > renamed
@@ -122,7 +122,7 @@
       if.
         existing.and exists.not
         cant-open
-          sprintf
+          printf
             "File must exist for given access mod: '%s'"
             * access
         seq *
@@ -170,7 +170,7 @@
         if. > @
           descriptor.eq -1
           cant-open
-            sprintf
+            printf
               "Couldn't open file '%s': %s"
               * path opened.output
           seq *
@@ -219,7 +219,7 @@
                 if. > @
                   readable.not
                   T
-                    sprintf
+                    printf
                       "Can't read from file with provided access mode '%s'"
                       * access
                   seq *
@@ -236,7 +236,7 @@
                 if. > @
                   writable.not
                   T
-                    sprintf
+                    printf
                       "Can't write to file with provided access mode '%s'"
                       * access
                   seq *
@@ -302,7 +302,7 @@
 
   ++> tests-moves-a-file
     and. > @
-      (temp.moved (sprintf "%s.dest" (* temp.path))).exists
+      (temp.moved (printf "%s.dest" (* temp.path))).exists
       temp.exists.not
     tmpdir.tmpfile > temp
 

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -1,7 +1,6 @@
 # Signed 16-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -54,8 +53,7 @@
     if. > @
       xval.eq zero
       cant-divide
-        printf
-          "Can't divide %d by i16 zero"
+        "Can't divide %d by i16 zero".printf
           * as-i32.as-i64.as-number
       if.
         or.

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -1,7 +1,7 @@
 # Signed 16-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -54,7 +54,7 @@
     if. > @
       xval.eq zero
       cant-divide
-        sprintf
+        printf
           "Can't divide %d by i16 zero"
           * as-i32.as-i64.as-number
       if.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -1,7 +1,6 @@
 # Signed 32-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -27,8 +26,7 @@
       ^.eq left.as-i32
       left
       cant-convert
-        printf
-          "Can't convert i32 number %d to i16 because it's out of i16 bounds"
+        "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
           * as-i64.as-number
     i16 (as-bytes.slice 2 2) > left
 
@@ -63,8 +61,7 @@
     if. > @
       xval.eq zero
       cant-divide
-        printf
-          "Can't divide %d by i32 zero"
+        "Can't divide %d by i32 zero".printf
           * as-i64.as-number
       if.
         or.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -1,7 +1,7 @@
 # Signed 32-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -27,7 +27,7 @@
       ^.eq left.as-i32
       left
       cant-convert
-        sprintf
+        printf
           "Can't convert i32 number %d to i16 because it's out of i16 bounds"
           * as-i64.as-number
     i16 (as-bytes.slice 2 2) > left
@@ -63,7 +63,7 @@
     if. > @
       xval.eq zero
       cant-divide
-        sprintf
+        printf
           "Can't divide %d by i32 zero"
           * as-i64.as-number
       if.

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -1,7 +1,7 @@
 # Signed 64-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +rt jvm org.eolang:eo-runtime:0.0.0
@@ -22,7 +22,7 @@
       ^.eq left.as-i64
       left
       cant-convert
-        sprintf
+        printf
           "Can't convert i64 number %d to i32 because it's out of i32 bounds"
           * as-number
     i32 (as-bytes.slice 4 4) > left

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -1,7 +1,6 @@
 # Signed 64-bit integer.
 # Here `as-bytes` must be a `bytes` object.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +rt jvm org.eolang:eo-runtime:0.0.0
@@ -22,8 +21,7 @@
       ^.eq left.as-i64
       left
       cant-convert
-        printf
-          "Can't convert i64 number %d to i32 because it's out of i32 bounds"
+        "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
           * as-number
     i32 (as-bytes.slice 4 4) > left
 

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -2,7 +2,7 @@
 # Here `pairs` must be a `tuple` of `map.entry` object.
 # The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
 
-+alias string.sprintf
++alias string.printf
 +alias tuple.contains
 +alias tuple.filtered
 +alias tuple.hash-code-of
@@ -73,7 +73,7 @@
         false > exists
         [cant-get] > get
           cant-get > @
-            sprintf
+            printf
               "Object by hash code %d from given key does not exists"
               * hash
 

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -2,7 +2,6 @@
 # Here `pairs` must be a `tuple` of `map.entry` object.
 # The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
 
-+alias string.printf
 +alias tuple.contains
 +alias tuple.filtered
 +alias tuple.hash-code-of
@@ -73,8 +72,7 @@
         false > exists
         [cant-get] > get
           cant-get > @
-            printf
-              "Object by hash code %d from given key does not exists"
+            "Object by hash code %d from given key does not exists".printf
               * hash
 
     (found key).exists > [key] > has

--- a/eo-runtime/src/main/eo/nk/socket.eo
+++ b/eo-runtime/src/main/eo/nk/socket.eo
@@ -45,7 +45,7 @@
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package nk
@@ -63,7 +63,7 @@
         raw > @
         win32 > raw
         "closesocket" > close-name
-        sprintf "WSA error code %d" (* (win32 "WSAGetLastError" *).code) > error-text
+        printf "WSA error code %d" (* (win32 "WSAGetLastError" *).code) > error-text
         (win32 "WSAStartup" (* win32.winsock-version-2-2)).code > startup
         if. > cleanup
           (win32 "WSACleanup" *).code.eq win32.socket-error
@@ -130,7 +130,7 @@
         if. > @
           sent.eq -1
           cant-send
-            sprintf
+            printf
               "Failed to send a message through the socket #%d because %s"
               * sockfd sys.error-text
           sent
@@ -144,7 +144,7 @@
         if. > @
           received.code.eq -1
           cant-receive
-            sprintf
+            printf
               "Failed to receive data from the socket #%d because %s"
               * sockfd sys.error-text
           received.output
@@ -157,7 +157,7 @@
       if. > @
         closed.eq -1
         T
-          sprintf
+          printf
             "Couldn't close the socket #%d because %s"
             * sockfd sys.error-text
         true
@@ -170,7 +170,7 @@
       if. > @
         (sys.startup.eq 0).not
         cant
-          sprintf
+          printf
             "Couldn't start up the sockets subsystem because %s"
             * sys.error-text
         seq *
@@ -180,7 +180,7 @@
       if. > result!
         sd.eq -1
         cant
-          sprintf
+          printf
             "Couldn't create a socket because %s"
             * sys.error-text
         seq *
@@ -190,7 +190,7 @@
       if. > used!
         addr.eq sys.inaddr-none
         cant
-          sprintf
+          printf
             "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s"
             * address sys.error-text
         scope
@@ -201,7 +201,7 @@
           if. > @
             connected.eq -1
             cant-connect
-              sprintf
+              printf
                 "Couldn't connect to %s:%d on socket #%d because %s"
                 * sock.address sock.port sock.sd sock.sys.error-text
             scope
@@ -220,13 +220,13 @@
           if. > @
             bound.eq -1
             cant-listen
-              sprintf
+              printf
                 "Couldn't bind the socket #%d to %s:%d because %s"
                 * sock.sd sock.address sock.port sock.sys.error-text
             if.
               listened.eq -1
               cant-listen
-                sprintf
+                printf
                   "Failed to listen to %s:%d on the socket #%d because %s"
                   * sock.address sock.port sock.sd sock.sys.error-text
               scope
@@ -237,7 +237,7 @@
                     if. > @
                       client.eq -1
                       cant-accept
-                        sprintf
+                        printf
                           "Failed to accept a connection on the socket #%d because %s"
                           * sock.sd sock.sys.error-text
                       seq *

--- a/eo-runtime/src/main/eo/nk/socket.eo
+++ b/eo-runtime/src/main/eo/nk/socket.eo
@@ -45,7 +45,6 @@
 +alias sm.os
 +alias sm.posix
 +alias sm.win32
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package nk
@@ -63,7 +62,7 @@
         raw > @
         win32 > raw
         "closesocket" > close-name
-        printf "WSA error code %d" (* (win32 "WSAGetLastError" *).code) > error-text
+        "WSA error code %d".printf (* (win32 "WSAGetLastError" *).code) > error-text
         (win32 "WSAStartup" (* win32.winsock-version-2-2)).code > startup
         if. > cleanup
           (win32 "WSACleanup" *).code.eq win32.socket-error
@@ -130,8 +129,7 @@
         if. > @
           sent.eq -1
           cant-send
-            printf
-              "Failed to send a message through the socket #%d because %s"
+            "Failed to send a message through the socket #%d because %s".printf
               * sockfd sys.error-text
           sent
         buffer > buff!
@@ -144,8 +142,7 @@
         if. > @
           received.code.eq -1
           cant-receive
-            printf
-              "Failed to receive data from the socket #%d because %s"
+            "Failed to receive data from the socket #%d because %s".printf
               * sockfd sys.error-text
           received.output
         called. > received
@@ -157,8 +154,7 @@
       if. > @
         closed.eq -1
         T
-          printf
-            "Couldn't close the socket #%d because %s"
+          "Couldn't close the socket #%d because %s".printf
             * sockfd sys.error-text
         true
       code. > closed
@@ -170,8 +166,7 @@
       if. > @
         (sys.startup.eq 0).not
         cant
-          printf
-            "Couldn't start up the sockets subsystem because %s"
+          "Couldn't start up the sockets subsystem because %s".printf
             * sys.error-text
         seq *
           result
@@ -180,8 +175,7 @@
       if. > result!
         sd.eq -1
         cant
-          printf
-            "Couldn't create a socket because %s"
+          "Couldn't create a socket because %s".printf
             * sys.error-text
         seq *
           used
@@ -190,8 +184,7 @@
       if. > used!
         addr.eq sys.inaddr-none
         cant
-          printf
-            "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s"
+          "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
             * address sys.error-text
         scope
 
@@ -201,8 +194,7 @@
           if. > @
             connected.eq -1
             cant-connect
-              printf
-                "Couldn't connect to %s:%d on socket #%d because %s"
+              "Couldn't connect to %s:%d on socket #%d because %s".printf
                 * sock.address sock.port sock.sd sock.sys.error-text
             scope
               sock.scoped-socket
@@ -220,14 +212,12 @@
           if. > @
             bound.eq -1
             cant-listen
-              printf
-                "Couldn't bind the socket #%d to %s:%d because %s"
+              "Couldn't bind the socket #%d to %s:%d because %s".printf
                 * sock.sd sock.address sock.port sock.sys.error-text
             if.
               listened.eq -1
               cant-listen
-                printf
-                  "Failed to listen to %s:%d on the socket #%d because %s"
+                "Failed to listen to %s:%d on the socket #%d because %s".printf
                   * sock.address sock.port sock.sd sock.sys.error-text
               scope
                 [] >>
@@ -237,8 +227,7 @@
                     if. > @
                       client.eq -1
                       cant-accept
-                        printf
-                          "Failed to accept a connection on the socket #%d because %s"
+                        "Failed to accept a connection on the socket #%d because %s".printf
                           * sock.sd sock.sys.error-text
                       seq *
                         handled

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -1,7 +1,6 @@
 # Object `number` is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +rt jvm org.eolang:eo-runtime:0.0.0
@@ -21,8 +20,7 @@
     if. > @
       out-of-range
       cant-convert
-        printf
-          "Can't convert number %f to i64 because it's out of i64 bounds"
+        "Can't convert number %f to i64 because it's out of i64 bounds".printf
           * ^
       if.
         exp.lt 1023

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -1,7 +1,7 @@
 # Object `number` is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +rt jvm org.eolang:eo-runtime:0.0.0
@@ -21,7 +21,7 @@
     if. > @
       out-of-range
       cant-convert
-        sprintf
+        printf
           "Can't convert number %f to i64 because it's out of i64 bounds"
           * ^
       if.

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -20,13 +20,14 @@
 # `1.plus 1` and also has object `next`. Since these objects are ints - they have
 # object `lt` by default.
 
++alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package tuple
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 [start end] > range
   if. > @

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -12,7 +12,7 @@
 # ```
 # .
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -43,7 +43,7 @@
       if. > @
         (index.plus csize).gt size
         T
-          sprintf
+          printf
             "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
             * csize index as-bytes
         reclen
@@ -67,7 +67,7 @@
                 (byte.and p4).eq r4
                 inclen index 4 accum
                 T
-                  sprintf
+                  printf
                     "Unknown byte format (%x), can't recognize character"
                     * byte
       as-bytes.slice index 1 > byte
@@ -76,13 +76,13 @@
     if. > @
       nstart.lt 0
       T
-        sprintf
+        printf
           "Start index must be >= 0, but was %d"
           * nstart
       if.
         nlen.lt 0
         T
-          sprintf
+          printf
             "Length to slice must be >= 0, but was %d"
             * nlen
         if.
@@ -95,7 +95,7 @@
         number bstart
         0
         nlen
-        sprintf
+        printf
           "Start index + length to slice (%d) is out of string bounds"
           * (nstart.plus nlen)
       bstart
@@ -103,7 +103,7 @@
       0
       0
       nstart
-      sprintf
+      printf
         "Start index (%d) is out of string bounds"
         * nstart
     nstart.plus nlen > end
@@ -125,7 +125,7 @@
       if. > @
         (index.plus csize).gt size
         T
-          sprintf
+          printf
             "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
             * csize index as-bytes
         recidx
@@ -154,7 +154,7 @@
                   (byte.and p4).eq r4
                   increase index 4 accum result cause
                   T
-                    sprintf
+                    printf
                       "Unknown byte format (%x), can't recognize character"
                       * byte
       as-bytes.slice index 1 > byte

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -12,7 +12,6 @@
 # ```
 # .
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -43,8 +42,7 @@
       if. > @
         (index.plus csize).gt size
         T
-          printf
-            "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
+          "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
             * csize index as-bytes
         reclen
           index.plus csize
@@ -67,8 +65,7 @@
                 (byte.and p4).eq r4
                 inclen index 4 accum
                 T
-                  printf
-                    "Unknown byte format (%x), can't recognize character"
+                  "Unknown byte format (%x), can't recognize character".printf
                     * byte
       as-bytes.slice index 1 > byte
 
@@ -76,14 +73,12 @@
     if. > @
       nstart.lt 0
       T
-        printf
-          "Start index must be >= 0, but was %d"
+        "Start index must be >= 0, but was %d".printf
           * nstart
       if.
         nlen.lt 0
         T
-          printf
-            "Length to slice must be >= 0, but was %d"
+          "Length to slice must be >= 0, but was %d".printf
             * nlen
         if.
           nlen.eq 0
@@ -95,16 +90,14 @@
         number bstart
         0
         nlen
-        printf
-          "Start index + length to slice (%d) is out of string bounds"
+        "Start index + length to slice (%d) is out of string bounds".printf
           * (nstart.plus nlen)
       bstart
     recidx > bstart!
       0
       0
       nstart
-      printf
-        "Start index (%d) is out of string bounds"
+      "Start index (%d) is out of string bounds".printf
         * nstart
     nstart.plus nlen > end
     len > lbts!
@@ -125,8 +118,7 @@
       if. > @
         (index.plus csize).gt size
         T
-          printf
-            "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
+          "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
             * csize index as-bytes
         recidx
           index.plus csize
@@ -154,8 +146,7 @@
                   (byte.and p4).eq r4
                   increase index 4 accum result cause
                   T
-                    printf
-                      "Unknown byte format (%x), can't recognize character"
+                    "Unknown byte format (%x), can't recognize character".printf
                       * byte
       as-bytes.slice index 1 > byte
 

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -13,8 +13,7 @@
   if. > @
     scanned.length.eq 0
     cant-parse
-      printf
-        "Can't convert text %s to number"
+      "Can't convert text %s to number".printf
         * text
     scanned.head
   (scanf "%f" text).at.^ > scanned

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -13,11 +13,11 @@
   if. > @
     scanned.length.eq 0
     cant-parse
-      sprintf
+      printf
         "Can't convert text %s to number"
         * text
     scanned.head
-  (sscanf "%f" text).at.^ > scanned
+  (scanf "%f" text).at.^ > scanned
 
   ++> tests-converts-text-to-number
     eq. > @

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -15,7 +15,7 @@
       0.gt index
       (number index).gte len
     out-of-bounds
-      sprintf
+      printf
         "Given index %d is out of text bounds"
         * index
     slice text index 1

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -15,8 +15,7 @@
       0.gt index
       (number index).gte len
     out-of-bounds
-      printf
-        "Given index %d is out of text bounds"
+      "Given index %d is out of text bounds".printf
         * index
     slice text index 1
   i > idx!

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -13,8 +13,7 @@
   if. > @
     1.gt limit
     cant-split
-      printf
-        "Invalid limit %d for nsplit, must be at least 1"
+      "Invalid limit %d for nsplit, must be at least 1".printf
         * limit
     if.
       text.size.eq 0

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -13,7 +13,7 @@
   if. > @
     1.gt limit
     cant-split
-      sprintf
+      printf
         "Invalid limit %d for nsplit, must be at least 1"
         * limit
     if.

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -1,4 +1,4 @@
-# Object `sprintf` allows you to format and output text depending
+# Object `printf` allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.
 #
 # When arguments are processed - they're dataized and converted to objects
@@ -18,147 +18,147 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[format args] > sprintf /string
+[format args] > printf /string
 
   ++> tests-prints-simple-string
     eq. > @
       "Hello, Jeffrey!"
-      sprintf
+      printf
         "Hello, %s!"
         * "Jeffrey"
 
   ++> tests-prints-complex-string
     eq. > @
       "Привет 3.140000 Jeff X!"
-      sprintf
+      printf
         "Привет %f %s %s!"
         * 3.14 "Jeff" "X"
 
   ++> tests-prints-bytes-string
     eq. > @
       "40-45-00-00-00-00-00-00"
-      sprintf
+      printf
         "%x"
         * 42.as-bytes
 
   ++> tests-formats-all-objects
     eq. > @
       "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
-      sprintf
+      printf
         "string %s, bytes %x, float %f, int %d, bool %b"
         * "Jeff" "Jeff".as-bytes 42.3 14 false
 
-  ++> throws-on-sprintf-with-arguments-that-does-not-match
-    sprintf > @
+  ++> throws-on-printf-with-arguments-that-does-not-match
+    printf > @
       "%s%s"
       * "Jeff"
 
-  ++> tests-sprintf-does-not-fail-if-arguments-more-than-formats
+  ++> tests-printf-does-not-fail-if-arguments-more-than-formats
     eq. > @
       "Hey"
-      sprintf
+      printf
         "%s"
         * "Hey" "Jeff"
 
-  ++> throws-on-sprintf-unsupported-format
-    sprintf "%o" * > @
+  ++> throws-on-printf-unsupported-format
+    printf "%o" * > @
 
-  ++> tests-sprintf-prints-percents
+  ++> tests-printf-prints-percents
     eq. > @
       "%Jeff"
-      sprintf
+      printf
         "%%%s"
         * "Jeff"
 
-  ++> tests-sprintf-does-not-print-i64
+  ++> tests-printf-does-not-print-i64
     not. > @
       eq.
-        sprintf
+        printf
           "%d"
           * 42.as-i64
         "42"
 
-  ++> tests-sprintf-prints-i64-as-number
+  ++> tests-printf-prints-i64-as-number
     eq. > @
       "42"
-      sprintf
+      printf
         "%d"
         * 42.as-i64.as-number
 
   ++> formats-numbered-substitution
     eq. > @
       "Hello, Jeff! Bye, Jeff!"
-      sprintf
+      printf
         "Hello, %s! Bye, %1$s!"
         * "Jeff"
 
-  ++> throws-on-sprintf-with-oversized-positional-index
-    sprintf > @
+  ++> throws-on-printf-with-oversized-positional-index
+    printf > @
       "%99999999999999999999$s"
       * "Jeff"
 
-  ++> throws-on-sprintf-with-zero-positional-index
-    sprintf > @
+  ++> throws-on-printf-with-zero-positional-index
+    printf > @
       "%0$s"
       * "first" "second"
 
   ++> formats-numbered-substitution-with-multiple-args
     eq. > @
       "This is the first; This is the first as well; The second; and the 3"
-      sprintf
+      printf
         "This is the %s; This is the %1$s as well; The %s; and the %d"
         * "first" "second" 3
 
   ++> formats-with-ordered-numbered-substitutions
     eq. > @
       "first second second is after first"
-      sprintf
+      printf
         "%s %s %2$s is after %1$s"
         * "first" "second"
 
   ++> truncates-positive-float-towards-zero-as-decimal
     eq. > @
       "42"
-      sprintf
+      printf
         "%d"
         * 42.321
 
   ++> truncates-negative-float-towards-zero-as-decimal
     eq. > @
       "-7"
-      sprintf
+      printf
         "%d"
         * -7.89
 
   ++> truncates-rather-than-rounds-float-as-decimal
     eq. > @
       "9"
-      sprintf
+      printf
         "%d"
         * 9.99
 
   ++> throws-on-formatting-huge-number-as-decimal
-    sprintf > @
+    printf > @
       "%d"
       * 1.0e30
 
   ++> formats-float-always-with-six-fraction-digits
     eq. > @
       "1.250000"
-      sprintf
+      printf
         "%f"
         * 1.25
 
   ++> rounds-float-carrying-into-integer-part
     eq. > @
       "1.000000"
-      sprintf
+      printf
         "%f"
         * 0.9999999
 
   ++> formats-zero-float-with-six-fraction-digits
     eq. > @
       "0.000000"
-      sprintf
+      printf
         "%f"
         * 0.0

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -13,8 +13,7 @@
   if. > @
     0.gt amount
     cant-repeat
-      printf
-        "Can't repeat text %d times"
+      "Can't repeat text %d times".printf
         * amount
     string result
   times > amount!

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -13,7 +13,7 @@
   if. > @
     0.gt amount
     cant-repeat
-      sprintf
+      printf
         "Can't repeat text %d times"
         * amount
     string result

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -17,87 +17,87 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[format read] > sscanf /tuple
+[format read] > scanf /tuple
 
-  ++> tests-sscanf-with-string
+  ++> tests-scanf-with-string
     eq. > @
       "hello"
       head.
-        sscanf "%s" "hello"
+        scanf "%s" "hello"
 
-  ++> tests-sscanf-with-int
+  ++> tests-scanf-with-int
     eq. > @
       33
       head.
-        sscanf "%d" "33"
+        scanf "%d" "33"
 
-  ++> tests-sscanf-with-negative-int
+  ++> tests-scanf-with-negative-int
     eq. > @
       -42
       head.
-        sscanf "%d" "-42"
+        scanf "%d" "-42"
 
-  ++> tests-sscanf-with-positive-signed-int
+  ++> tests-scanf-with-positive-signed-int
     eq. > @
       42
       head.
-        sscanf "%d" "+42"
+        scanf "%d" "+42"
 
-  ++> tests-sscanf-with-float
+  ++> tests-scanf-with-float
     eq. > @
       0.24
       head.
-        sscanf "%f" "0.24"
+        scanf "%f" "0.24"
 
-  ++> throws-on-sscanf-with-wrong-format
-    sscanf "%l" "error" > @
+  ++> throws-on-scanf-with-wrong-format
+    scanf "%l" "error" > @
 
-  ++> throws-on-sscanf-with-oversized-int
-    sscanf "%d" "99999999999999999999" > @
+  ++> throws-on-scanf-with-oversized-int
+    scanf "%d" "99999999999999999999" > @
 
-  ++> tests-sscanf-with-string-int-float
+  ++> tests-scanf-with-string-int-float
     eq. > @
-      sscanf
+      scanf
         "%s %d %f"
         "hello 33 0.24"
       * "hello" 33 0.24
 
-  ++> tests-sscanf-with-string-with-ending
+  ++> tests-scanf-with-string-with-ending
     eq. > @
       "hello"
       head.
-        sscanf "%s!" "hello!"
+        scanf "%s!" "hello!"
 
-  ++> tests-sscanf-with-complex-string
+  ++> tests-scanf-with-complex-string
     eq. > @
       "test"
       head.
-        sscanf "some%sstring" "someteststring"
+        scanf "some%sstring" "someteststring"
 
-  ++> tests-sscanf-with-complex-int
+  ++> tests-scanf-with-complex-int
     eq. > @
       734987259
       head.
-        sscanf "!%d!" "!734987259!"
+        scanf "!%d!" "!734987259!"
 
-  ++> tests-sscanf-with-complex-float
+  ++> tests-scanf-with-complex-float
     eq. > @
       1991.01
       head.
-        sscanf "this will be=%f" "this will be=1991.01"
+        scanf "this will be=%f" "this will be=1991.01"
 
-  ++> tests-sscanf-with-sprintf
+  ++> tests-scanf-with-printf
     eq. > @
-      sscanf
+      scanf
         "%s is about %d?"
-        sprintf
+        printf
           "%s is about %d?"
           * "This" 8
       * "This" 8
 
-  ++> tests-sscanf-complex-case
+  ++> tests-scanf-complex-case
     eq. > @
-      sscanf
+      scanf
         "Im%d %s old and this is! Let's calculate %f + %f= %f"
         "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
       *

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -3,7 +3,6 @@
 # The first one for the accumulator, the second one for the element
 # of the collection.
 
-+alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
@@ -32,7 +31,6 @@
         ""
         [acc item]
           acc.concat > @
-            printf
-              "%d"
+            "%d".printf
               * item
       "01"

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -3,7 +3,7 @@
 # The first one for the accumulator, the second one for the element
 # of the collection.
 
-+alias string.sprintf
++alias string.printf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
@@ -32,7 +32,7 @@
         ""
         [acc item]
           acc.concat > @
-            sprintf
+            printf
               "%d"
               * item
       "01"

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -4,7 +4,7 @@
 # while > last
 #   i.lt 5 > [i]
 #   [i]
-#     Q.string.sprintf > @
+#     Q.string.printf > @
 #       "Iteration %d\n"
 #       * i
 # ```

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -4,8 +4,7 @@
 # while > last
 #   i.lt 5 > [i]
 #   [i]
-#     Q.string.printf > @
-#       "Iteration %d\n"
+#     "Iteration %d\n".printf > @
 #       * i
 # ```
 #

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -22,17 +22,17 @@ import org.eolang.Phi;
 import org.eolang.XmirObject;
 
 /**
- * Sprintf.
+ * Printf.
  * @since 0.39.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "sprintf")
-public final class EOsprintf extends PhDefault implements Atom {
+@XmirObject(oname = "printf")
+public final class EOprintf extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
-    public EOsprintf() {
+    public EOprintf() {
         super(new Attrs(
             new Attr("format", new AtVoid("format")),
             new Attr("args", new AtVoid("args"))
@@ -46,7 +46,7 @@ public final class EOsprintf extends PhDefault implements Atom {
             String.format(
                 Locale.US,
                 format.replaceAll("%\\d+\\$([a-zA-Z])", "%s").replaceAll("%x", "%s"),
-                new SprintfArgs(
+                new PrintfArgs(
                     format,
                     Expect.at(this, "args")
                         .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOscanf.java
@@ -28,12 +28,12 @@ import org.eolang.Phi;
 import org.eolang.XmirObject;
 
 /**
- * Sscanf.
+ * Scanf.
  * @since 0.39
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "sscanf")
-public final class EOsscanf extends PhDefault implements Atom {
+@XmirObject(oname = "scanf")
+public final class EOscanf extends PhDefault implements Atom {
 
     /**
      * Character conversion.
@@ -41,9 +41,9 @@ public final class EOsscanf extends PhDefault implements Atom {
     private static final Map<Character, Function<String, Phi>> CONVERSION = new HashMap<>();
 
     static {
-        EOsscanf.CONVERSION.put('s', ToPhi::new);
-        EOsscanf.CONVERSION.put('d', str -> new Data.ToPhi(EOsscanf.parsed(str)));
-        EOsscanf.CONVERSION.put('f', str -> new Data.ToPhi(Double.parseDouble(str)));
+        EOscanf.CONVERSION.put('s', ToPhi::new);
+        EOscanf.CONVERSION.put('d', str -> new Data.ToPhi(EOscanf.parsed(str)));
+        EOscanf.CONVERSION.put('f', str -> new Data.ToPhi(Double.parseDouble(str)));
     }
 
     /**
@@ -56,7 +56,7 @@ public final class EOsscanf extends PhDefault implements Atom {
      * @checkstyle CyclomaticComplexityCheck (75 lines)
      * @checkstyle NestedIfDepthCheck (75 lines)
      */
-    public EOsscanf() {
+    public EOscanf() {
         super(new Attrs(
             new Attr("format", new AtVoid("format")),
             new Attr("read", new AtVoid("read"))
@@ -71,9 +71,9 @@ public final class EOsscanf extends PhDefault implements Atom {
         boolean literal = false;
         for (int idx = 0; idx < format.length(); ++idx) {
             final char sym = format.charAt(idx);
-            if (sym == EOsscanf.PERCENT) {
+            if (sym == EOscanf.PERCENT) {
                 if (literal) {
-                    regex.append(EOsscanf.PERCENT);
+                    regex.append(EOscanf.PERCENT);
                     literal = false;
                 } else {
                     literal = true;
@@ -107,13 +107,13 @@ public final class EOsscanf extends PhDefault implements Atom {
         if (matcher.find()) {
             int index = 1;
             while (true) {
-                final int idx = frmt.indexOf(EOsscanf.PERCENT);
+                final int idx = frmt.indexOf(EOscanf.PERCENT);
                 if (idx == -1) {
                     break;
                 }
                 final char sym = frmt.charAt(idx + 1);
-                if (sym != EOsscanf.PERCENT) {
-                    output.add(EOsscanf.converted(sym, matcher.group(index)));
+                if (sym != EOscanf.PERCENT) {
+                    output.add(EOscanf.converted(sym, matcher.group(index)));
                     ++index;
                 }
                 frmt = frmt.substring(idx + 2);
@@ -149,12 +149,12 @@ public final class EOsscanf extends PhDefault implements Atom {
      * @return Phi object depending on format symbol
      */
     private static Phi converted(final char symbol, final String str) {
-        if (!EOsscanf.CONVERSION.containsKey(symbol)) {
+        if (!EOscanf.CONVERSION.containsKey(symbol)) {
             throw new ExFailure(
                 "The format %c is unsupported, only %s formats can be used",
                 symbol, "%s, %d, %f"
             );
         }
-        return EOsscanf.CONVERSION.get(symbol).apply(str);
+        return EOscanf.CONVERSION.get(symbol).apply(str);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -23,10 +23,10 @@ import org.eolang.ExFailure;
 import org.eolang.Phi;
 
 /**
- * Sprintf arguments.
+ * Printf arguments.
  * @since 0.57.4
  */
-final class SprintfArgs {
+final class PrintfArgs {
 
     /**
      * Character conversion.
@@ -49,11 +49,11 @@ final class SprintfArgs {
     private static final double LONG_UPPER_LIMIT = 0x1.0p63;
 
     static {
-        SprintfArgs.CONVERSION.put('s', Dataized::asString);
-        SprintfArgs.CONVERSION.put('d', element -> SprintfArgs.toLong(element.asNumber()));
-        SprintfArgs.CONVERSION.put('f', Dataized::asNumber);
-        SprintfArgs.CONVERSION.put('x', element -> SprintfArgs.bytesToHex(element.take()));
-        SprintfArgs.CONVERSION.put('b', Dataized::asBool);
+        PrintfArgs.CONVERSION.put('s', Dataized::asString);
+        PrintfArgs.CONVERSION.put('d', element -> PrintfArgs.toLong(element.asNumber()));
+        PrintfArgs.CONVERSION.put('f', Dataized::asNumber);
+        PrintfArgs.CONVERSION.put('x', element -> PrintfArgs.bytesToHex(element.take()));
+        PrintfArgs.CONVERSION.put('b', Dataized::asBool);
     }
 
     /**
@@ -77,7 +77,7 @@ final class SprintfArgs {
      * @param len The length
      * @param phi Phi attribute
      */
-    SprintfArgs(final String fmt, final long len, final Phi phi) {
+    PrintfArgs(final String fmt, final long len, final Phi phi) {
         this.format = fmt;
         this.length = len;
         this.retriever = phi;
@@ -90,7 +90,7 @@ final class SprintfArgs {
         while (matcher.find()) {
             final String positional = matcher.group(1);
             final char symbol = matcher.group(2).charAt(0);
-            if (symbol == SprintfArgs.PERCENT) {
+            if (symbol == PrintfArgs.PERCENT) {
                 continue;
             }
             final long arg;
@@ -125,7 +125,7 @@ final class SprintfArgs {
             }
             final Phi taken = this.retriever.copy();
             taken.put(0, new Data.ToPhi(arg));
-            arguments.add(SprintfArgs.fmt(symbol, new Dataized(taken)));
+            arguments.add(PrintfArgs.fmt(symbol, new Dataized(taken)));
         }
         return arguments;
     }
@@ -137,13 +137,13 @@ final class SprintfArgs {
      * @return Formatted object
      */
     private static Object fmt(final char symbol, final Dataized element) {
-        if (!SprintfArgs.CONVERSION.containsKey(symbol)) {
+        if (!PrintfArgs.CONVERSION.containsKey(symbol)) {
             throw new ExFailure(
                 "The format %c is unsupported, only %s formats can be used",
                 symbol, "%s, %d, %f, %x, %b"
             );
         }
-        return SprintfArgs.CONVERSION.get(symbol).apply(element);
+        return PrintfArgs.CONVERSION.get(symbol).apply(element);
     }
 
     /**
@@ -154,7 +154,7 @@ final class SprintfArgs {
      * @return The number as {@code long}
      */
     private static long toLong(final double number) {
-        if (number < Long.MIN_VALUE || number >= SprintfArgs.LONG_UPPER_LIMIT) {
+        if (number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
             throw new ExFailure(
                 "The number %s doesn't fit into long range for the '%%d' conversion",
                 number

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link SprintfArgs}.
+ * Tests for {@link PrintfArgs}.
  * @since 0.57.4
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class SprintfArgsTest {
+final class PrintfArgsTest {
 
     @Test
     void returnsArgumentsForNumberedSubstitution() {
@@ -32,8 +32,8 @@ final class SprintfArgsTest {
         final String expected = "Jeff";
         tuple.put("head", new Data.ToPhi(expected));
         MatcherAssert.assertThat(
-            "The sprintf args do not match with expected",
-            new SprintfArgs("Hello, %s! Bye, %1$s!", 1L, tuple.take("at")).formatted(),
+            "The printf args do not match with expected",
+            new PrintfArgs("Hello, %s! Bye, %1$s!", 1L, tuple.take("at")).formatted(),
             Matchers.equalTo(new ListOf<>(expected, expected))
         );
     }
@@ -50,8 +50,8 @@ final class SprintfArgsTest {
         tuple.put("head", new Data.ToPhi(second));
         tuple.put("tail", root);
         MatcherAssert.assertThat(
-            "The sprintf args do not match with expected",
-            new SprintfArgs(
+            "The printf args do not match with expected",
+            new PrintfArgs(
                 "This is the %s! This is %1$s as well! This is the %s",
                 3L,
                 tuple.take("at")
@@ -69,7 +69,7 @@ final class SprintfArgsTest {
             "the ExFailure message must name the out-of-range number, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -85,7 +85,7 @@ final class SprintfArgsTest {
             "the ExFailure message must name the out-of-range number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
                 "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -100,7 +100,7 @@ final class SprintfArgsTest {
         tuple.put("head", new Data.ToPhi(closest));
         MatcherAssert.assertThat(
             "a double strictly below 2^63 (the representable double one ulp below it, since Long.MAX_VALUE itself isn't exactly representable and rounds up to 2^63) must still be accepted as a valid long",
-            new SprintfArgs("%d", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
             Matchers.equalTo(new ListOf<>((long) closest))
         );
     }
@@ -114,7 +114,7 @@ final class SprintfArgsTest {
             "the ExFailure message must name the unsupported format char, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new SprintfArgs("%z", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%z", 1L, tuple.take("at")).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("is unsupported")

--- a/eo-runtime/src/test/java/org/eolang/EO_string/ScanfNegativeIntegerTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/ScanfNegativeIntegerTest.java
@@ -18,17 +18,17 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@code string.sscanf} with signed integer inputs.
+ * Tests for {@code string.scanf} with signed integer inputs.
  * @since 0.57.4
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
-final class SscanfNegativeIntegerTest {
+final class ScanfNegativeIntegerTest {
 
     @Test
     void parsesNegativeIntegerWithDecimalFormat() {
         MatcherAssert.assertThat(
-            "sscanf with \"%d\" should preserve the leading minus sign for negative integers",
-            new Dataized(SscanfNegativeIntegerTest.first("%d", "-42")).asNumber().longValue(),
+            "scanf with \"%d\" should preserve the leading minus sign for negative integers",
+            new Dataized(ScanfNegativeIntegerTest.first("%d", "-42")).asNumber().longValue(),
             Matchers.equalTo(-42L)
         );
     }
@@ -36,8 +36,8 @@ final class SscanfNegativeIntegerTest {
     @Test
     void parsesPositiveIntegerWithLeadingPlusSign() {
         MatcherAssert.assertThat(
-            "sscanf with \"%d\" should accept an optional leading plus sign",
-            new Dataized(SscanfNegativeIntegerTest.first("%d", "+42")).asNumber().longValue(),
+            "scanf with \"%d\" should accept an optional leading plus sign",
+            new Dataized(ScanfNegativeIntegerTest.first("%d", "+42")).asNumber().longValue(),
             Matchers.equalTo(42L)
         );
     }
@@ -45,22 +45,22 @@ final class SscanfNegativeIntegerTest {
     @Test
     void parsesPlainPositiveIntegerWithDecimalFormat() {
         MatcherAssert.assertThat(
-            "sscanf with \"%d\" should still parse plain unsigned integers",
-            new Dataized(SscanfNegativeIntegerTest.first("%d", "42")).asNumber().longValue(),
+            "scanf with \"%d\" should still parse plain unsigned integers",
+            new Dataized(ScanfNegativeIntegerTest.first("%d", "42")).asNumber().longValue(),
             Matchers.equalTo(42L)
         );
     }
 
     /**
-     * Build a {@code string.sscanf} call and return the first parsed item.
-     * @param format Format string for {@code sscanf}
-     * @param read Input string for {@code sscanf}
+     * Build a {@code string.scanf} call and return the first parsed item.
+     * @param format Format string for {@code scanf}
+     * @param read Input string for {@code scanf}
      * @return Phi at index 0 of the resulting tuple
      */
     private static Phi first(final String format, final String read) {
         final Phi item = new PhApplication(
             new PhApplication(
-                Phi.Φ.take("string.sscanf").copy(),
+                Phi.Φ.take("string.scanf").copy(),
                 "format", new Data.ToPhi(format)
             ),
             "read", new Data.ToPhi(read)

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -8,7 +8,7 @@ import com.yegor256.Together;
 import java.security.SecureRandom;
 import org.cactoos.set.SetOf;
 import org.eolang.EO_org.EO_eolang.EOdummy;
-import org.eolang.EO_string.EOsprintf;
+import org.eolang.EO_string.EOprintf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -482,8 +482,8 @@ final class PhDefaultTest {
     void keepsSubPackageInForma() {
         MatcherAssert.assertThat(
             "forma must keep the EO sub-package without its EO marker, but it didnt",
-            new EOsprintf().forma(),
-            Matchers.equalTo("Φ.string.sprintf")
+            new EOprintf().forma(),
+            Matchers.equalTo("Φ.string.printf")
         );
     }
 


### PR DESCRIPTION
This renames the standard-library object `string.sprintf` to `string.printf` and `string.sscanf` to `string.scanf`. The rename covers the two `.eo` objects, their JVM atoms (`EOsprintf`/`EOsscanf`), the `SprintfArgs` helper, both Java tests, and every caller that aliased or called them. It also moves `range` out of the `tuple` package up to the root.

The old `s`-prefixed names came from C's string-formatting family, but in EO these objects just format and parse strings, so the shorter names read better. `range` builds a general list from any object that has `next`/`lt`, so it never belonged under `tuple`; at the root it stays reachable by bare name and now aliases `tuple.is-empty` for its own test.

All 1550 eo-runtime unit tests pass. This continues the naming work under #5501.