### PR TITLE
Hide incoming attributes of bytes and tuple objects

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -7,7 +7,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts] > as-bool
+[] > as-bool
+  ? >> bts
   bts.eq 01- > @
 
   ++> tests-convertible-to-bool

--- a/eo-runtime/src/main/eo/bytes/as-bytes.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bytes.eo
@@ -9,7 +9,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts] > as-bytes
+[] > as-bytes
+  ? >> bts
   bts > @
 
   ++> tests-bytes-as-bytes-is-itself

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -8,7 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts x] > left
+[] > left
+  ? >> bts
+  ? >> x
   bts.right > @
     x.neg
 

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -8,14 +8,16 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts b] > xor
+[] > xor
+  ? >> b
+  ? >> x
   or. > @
     and.
-      bts
-      b.not
-    and.
-      bts.not
       b
+      x.not
+    and.
+      b.not
+      x
 
   ++> tests-xor-with-zero
     not. > @

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst index] > back
+[] > back
+  ? >> lst
+  ? >> index
   if. > @
     0.gt start
     lst

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -1,4 +1,4 @@
-# Elements of `lst` from `index` to the end (supports oversized index).
+# Elements of `list` from `index` to the end (supports oversized index).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,13 +8,13 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > back
-  ? >> lst
+  ? >> list
   ? >> index
   if. > @
     0.gt start
-    lst
+    list
     reducedi
-      lst
+      list
       *
       [accum item idx] >>
         if. > @
@@ -22,7 +22,7 @@
           accum.with item
           accum
   index > idx!
-  lst.length.minus idx > start!
+  list.length.minus idx > start!
 
   ++> tests-simple-back
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/bytes-as-array.eo
+++ b/eo-runtime/src/main/eo/tuple/bytes-as-array.eo
@@ -9,7 +9,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts] > bytes-as-array
+[] > bytes-as-array
+  ? >> bts
   slice-byte * 0 > @
   bts > data!
   data.size > len!

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -1,4 +1,4 @@
-# Concatenate `lst` with another collection `passed`.
+# Concatenate `list` with another collection `passed`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,11 +8,11 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > concat
-  ? >> lst
+  ? >> list
   ? >> passed
   reducedi > @
     passed
-    lst
+    list
     with accum item > [accum item index]
 
   ++> tests-concatenates-lists

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst passed] > concat
+[] > concat
+  ? >> lst
+  ? >> passed
   reducedi > @
     passed
     lst

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst element] > contains
+[] > contains
+  ? >> lst
+  ? >> element
   not. > @
     eq.
       -1

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -1,4 +1,4 @@
-# Returns `true` if `lst` contains `element`, `false` otherwise.
+# Returns `true` if `list` contains `element`, `false` otherwise.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,12 +8,12 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > contains
-  ? >> lst
+  ? >> list
   ? >> element
   not. > @
     eq.
       -1
-      index-of lst element
+      index-of list element
 
   ++> tests-list-contains-string
     contains > @

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -10,10 +10,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > each
-  ? >> lst
+  ? >> list
   ? >> func
   eachi > @
-    lst
+    list
     func item > [item index] >>
 
   [] +> tests-iterates-with-each

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -9,7 +9,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > each
+[] > each
+  ? >> lst
+  ? >> func
   eachi > @
     lst
     func item > [item index] >>

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -12,10 +12,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > eachi
-  ? >> lst
+  ? >> list
   ? >> func
   reducedi > @
-    lst
+    list
     true
     [acc item index] >>
       seq * > @

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -11,7 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > eachi
+[] > eachi
+  ? >> lst
+  ? >> func
   reducedi > @
     lst
     true

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -11,7 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > filtered
+[] > filtered
+  ? >> lst
+  ? >> func
   filteredi > @
     lst
     func item > [item index] >>

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -1,4 +1,4 @@
-# Filter `lst` without index with the function `func`.
+# Filter `list` without index with the function `func`.
 # Here `func` must be an abstract object
 # with one attribute for the element.
 # The result of dataization the `func`
@@ -12,10 +12,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > filtered
-  ? >> lst
+  ? >> list
   ? >> func
   filteredi > @
-    lst
+    list
     func item > [item index] >>
 
   ++> tests-simple-filtered

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -1,4 +1,4 @@
-# Filter `lst` with index with the function `func`.
+# Filter `list` with index with the function `func`.
 # Here `func` must be an abstract
 # object with two attributes. The first
 # one for the element, the second one
@@ -13,9 +13,9 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > filteredi
-  ? >> lst
+  ? >> list
   ? >> func
-  recfilter lst > @
+  recfilter list > @
 
   [tup] > recfilter
     if. > @

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -12,7 +12,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > filteredi
+[] > filteredi
+  ? >> lst
+  ? >> func
   recfilter lst > @
 
   [tup] > recfilter

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -1,4 +1,4 @@
-# Elements of `lst` before `index` (supports negative indices).
+# Elements of `list` before `index` (supports negative indices).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,7 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > front
-  ? >> lst
+  ? >> list
   ? >> index
   if. > @
     idx.eq 0
@@ -16,12 +16,12 @@
     if.
       0.gt idx
       back
-        lst
+        list
         (number idx).neg
       if.
-        (number idx).gte lst.length
-        lst
-        rechead lst
+        (number idx).gte list.length
+        list
+        rechead list
   index > idx!
 
   [tup] > rechead

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst index] > front
+[] > front
+  ? >> lst
+  ? >> index
   if. > @
     idx.eq 0
     *

--- a/eo-runtime/src/main/eo/tuple/hash-code-of.eo
+++ b/eo-runtime/src/main/eo/tuple/hash-code-of.eo
@@ -11,7 +11,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > hash-code-of
+[] > hash-code-of
+  ? >> input
   rec-hash-code 0 0 > @
   input.as-bytes > bts!
   bts.size > size!

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -8,7 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst wanted] > index-of
+[] > index-of
+  ? >> lst
+  ? >> wanted
   number > @
     recidx lst
 

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -1,5 +1,5 @@
-# Returns index of the first occurrence of `wanted` in `lst`.
-# If `lst` has no such element, returns -1.
+# Returns index of the first occurrence of `wanted` in `list`.
+# If `list` has no such element, returns -1.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,10 +9,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > index-of
-  ? >> lst
+  ? >> list
   ? >> wanted
   number > @
-    recidx lst
+    recidx list
 
   [tup] > recidx
     if. > @

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -1,4 +1,4 @@
-# True when collection `lst` has no elements.
+# True when collection `list` has no elements.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,8 +8,8 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > is-empty
-  ? >> lst
-  0.eq lst.length > @
+  ? >> list
+  0.eq list.length > @
 
   ++> tests-list-should-not-be-empty
     not. > @

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -7,7 +7,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst] > is-empty
+[] > is-empty
+  ? >> lst
   0.eq lst.length > @
 
   ++> tests-list-should-not-be-empty

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -8,7 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst wanted] > last-index-of
+[] > last-index-of
+  ? >> lst
+  ? >> wanted
   reclast lst > @
 
   [tup] > reclast

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -1,5 +1,5 @@
-# Returns index of the last occurrence of `wanted` in `lst`.
-# If `lst` has no such element, returns -1.
+# Returns index of the last occurrence of `wanted` in `list`.
+# If `list` has no such element, returns -1.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,9 +9,9 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > last-index-of
-  ? >> lst
+  ? >> list
   ? >> wanted
-  reclast lst > @
+  reclast list > @
 
   [tup] > reclast
     if. > @

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -1,4 +1,4 @@
-# Map `lst` without index. Here "func" must be an abstract
+# Map `list` without index. Here "func" must be an abstract
 # object with one free attribute, for the element
 # of the collection.
 
@@ -10,10 +10,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > mapped
-  ? >> lst
+  ? >> list
   ? >> func
   mappedi > @
-    lst
+    list
     func item > [item idx] >>
 
   ++> tests-simple-list-mapping

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -9,7 +9,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > mapped
+[] > mapped
+  ? >> lst
+  ? >> func
   mappedi > @
     lst
     func item > [item idx] >>

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -1,4 +1,4 @@
-# Map `lst` with index. Here "func" must be an abstract
+# Map `list` with index. Here "func" must be an abstract
 # object with two free attributes. The first
 # one for the element of the collection, the second one
 # for the index.
@@ -11,10 +11,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > mappedi
-  ? >> lst
+  ? >> list
   ? >> func
   reducedi > @
-    lst
+    list
     *
     [accum item idx] >>
       accum.with > @

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -10,7 +10,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst func] > mappedi
+[] > mappedi
+  ? >> lst
+  ? >> func
   reducedi > @
     lst
     *

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -10,14 +10,16 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 
-[start end] > range-of-numbers
+[] > range-of-numbers
+  ? >> start
+  ? >> end
   if. > @
     and.
       start.is-integer
       end.is-integer
     range
       [] >>
-        build ^.start > @
+        build start > @
         [num] > build
           num > @
           ^.build (1.plus @) > next

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -10,7 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst start func] > reduced
+[] > reduced
+  ? >> lst
+  ? >> start
+  ? >> func
   reducedi > @
     lst
     start

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -1,4 +1,4 @@
-# Reduce `lst` from "start" using the function "func".
+# Reduce `list` from "start" using the function "func".
 # Here "func" must be an abstract object with two free attributes.
 # The first one for the accumulator, the second one for the element
 # of the collection.
@@ -11,11 +11,11 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > reduced
-  ? >> lst
+  ? >> list
   ? >> start
   ? >> func
   reducedi > @
-    lst
+    list
     start
     func accum item > [accum item idx] >>
 

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -10,7 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst start func] > reducedi
+[] > reducedi
+  ? >> lst
+  ? >> start
+  ? >> func
   if. > @
     is-empty lst
     start

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -11,13 +11,13 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > reducedi
-  ? >> lst
+  ? >> list
   ? >> start
   ? >> func
   if. > @
-    is-empty lst
+    is-empty list
     start
-    rec-reducedi lst
+    rec-reducedi list
 
   [tup] > rec-reducedi
     if. > @

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -1,4 +1,4 @@
-# Drop the first `shift` elements of `lst`.
+# Drop the first `shift` elements of `list`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,12 +8,12 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > shifted
-  ? >> lst
+  ? >> list
   ? >> shift
   slice > @
-    lst
+    list
     shift
-    lst.length
+    list.length
 
   ++> tests-shifted-with-shift-less-than-length
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst shift] > shifted
+[] > shifted
+  ? >> lst
+  ? >> shift
   slice > @
     lst
     shift

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -1,4 +1,4 @@
-# Sublist of `lst` from `start` (inclusive) to `end` (exclusive).
+# Sublist of `list` from `start` (inclusive) to `end` (exclusive).
 # Supports negative indices and clamps to list bounds.
 
 +architect yegor256@gmail.com
@@ -9,14 +9,14 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > slice
-  ? >> lst
+  ? >> list
   ? >> start
   ? >> end
   if. > @
     (number s).gte e
     *
     reducedi
-      lst
+      list
       *
       [accum item idx] >>
         if. > @
@@ -28,22 +28,22 @@
   if. > e!
     end.gte 0
     if.
-      end.gte lst.length
-      lst.length
+      end.gte list.length
+      list.length
       end
     if.
-      lst.length.neg.lte end
-      end.plus lst.length
+      list.length.neg.lte end
+      end.plus list.length
       0
   if. > s!
     start.gte 0
     if.
-      start.gte lst.length
-      lst.length
+      start.gte list.length
+      list.length
       start
     if.
-      lst.length.neg.lte start
-      start.plus lst.length
+      list.length.neg.lte start
+      start.plus list.length
       0
 
   ++> tests-simple-slice

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -8,7 +8,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst start end] > slice
+[] > slice
+  ? >> lst
+  ? >> start
+  ? >> end
   if. > @
     (number s).gte e
     *

--- a/eo-runtime/src/main/eo/tuple/with.eo
+++ b/eo-runtime/src/main/eo/tuple/with.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst x] > with
+[] > with
+  ? >> lst
+  ? >> x
   lst.with x > @
 
   ++> tests-list-simple-with

--- a/eo-runtime/src/main/eo/tuple/with.eo
+++ b/eo-runtime/src/main/eo/tuple/with.eo
@@ -1,4 +1,4 @@
-# Append element `x` to the end of collection `lst`.
+# Append element `x` to the end of collection `list`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,9 +8,9 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > with
-  ? >> lst
+  ? >> list
   ? >> x
-  lst.with x > @
+  list.with x > @
 
   ++> tests-list-simple-with
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -1,4 +1,4 @@
-# Insert `item` into collection `lst` at the given `index`.
+# Insert `item` into collection `list` at the given `index`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,18 +8,18 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > withi
-  ? >> lst
+  ? >> list
   ? >> index
   ? >> item
   concat > @
     with
       front
-        lst
+        list
         index
       item
     back
-      lst
-      lst.length.minus index
+      list
+      list.length.minus index
 
   ++> tests-simple-insert
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -7,7 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst index item] > withi
+[] > withi
+  ? >> lst
+  ? >> index
+  ? >> item
   concat > @
     with
       front

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -1,4 +1,4 @@
-# Create a new list without all occurrences of `element` in `lst`.
+# Create a new list without all occurrences of `element` in `list`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,10 +8,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > without
-  ? >> lst
+  ? >> list
   ? >> element
   reduced > @
-    lst
+    list
     *
     [accum item] >>
       if. > @

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst element] > without
+[] > without
+  ? >> lst
+  ? >> element
   reduced > @
     lst
     *

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -7,7 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst i] > withouti
+[] > withouti
+  ? >> lst
+  ? >> i
   reducedi > @
     lst
     *

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -1,4 +1,4 @@
-# Create a new list without the i-th element of `lst`.
+# Create a new list without the i-th element of `list`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,10 +8,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > withouti
-  ? >> lst
+  ? >> list
   ? >> i
   reducedi > @
-    lst
+    list
     *
     [accum item idx] >>
       if. > @


### PR DESCRIPTION
This makes the incoming arguments of the standard objects in the `bytes/` and `tuple/` packages private. Each object drops its public `[a b]` void-attribute signature and instead declares the arguments as anonymous `? >> a` handles inside the body. The arguments stay reachable by name everywhere in the same file, but they are no longer part of the object's public surface, so nobody outside can reach into `some-tuple.each.func` and friends.

Why this helps: these attributes were only ever meant as inputs, never as a public API. Exposing them let callers depend on internals that are really implementation detail. The `? >>` file-local handle (from #5525) gives us exactly the visibility we want without changing any behavior.

Twenty-eight files change across the two packages. The six `cant-*` fallback objects — `as-i16`, `as-i32`, `as-i64`, `as-number`, `minimum`, `maximum` — are deliberately left alone for a later pass. One small follow-on: in `range-of-numbers` a nested child used to read `^.start`, which no longer resolves once `start` is anonymous, so it now reads the `start` handle directly. All 1550 eo-runtime unit tests pass.