### PR TITLE
Move bytes-as-array to bytes package as array

### DIFF
--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -4,12 +4,12 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package tuple
++package bytes
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > bytes-as-array
+[] > array
   ? >> bts
   slice-byte * 0 > @
   bts > data!
@@ -25,18 +25,18 @@
 
   ++> tests-converts-bytes-to-array
     eq. > @
-      bytes-as-array
+      array
         20-1F-EE-B5-FF
       * 20- 1F- EE- B5- FF-
 
   ++> tests-single-byte-to-array
     eq. > @
-      bytes-as-array
+      array
         1F-
       * 1F-
 
   ++> tests-zero-bytes-to-array
     eq. > @
-      bytes-as-array
+      array
         --
       *

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -1,6 +1,5 @@
 # Returns the `text` in lower case.
 
-+alias bytes.array
 +alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,8 +12,7 @@
 [text] > low-cased
   string > @
     reduced
-      array
-        text.as-bytes
+      text.as-bytes.array
       --
       [accum byte] >>
         accum.concat > @

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -1,6 +1,6 @@
 # Returns the `text` in lower case.
 
-+alias tuple.bytes-as-array
++alias bytes.array
 +alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,7 +13,7 @@
 [text] > low-cased
   string > @
     reduced
-      bytes-as-array
+      array
         text.as-bytes
       --
       [accum byte] >>

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -1,6 +1,5 @@
 # Returns the `text` in upper case.
 
-+alias bytes.array
 +alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,8 +12,7 @@
 [text] > up-cased
   string > @
     reduced
-      array
-        text.as-bytes
+      text.as-bytes.array
       --
       [accum byte] >>
         accum.concat > @

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -1,6 +1,6 @@
 # Returns the `text` in upper case.
 
-+alias tuple.bytes-as-array
++alias bytes.array
 +alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,7 +13,7 @@
 [text] > up-cased
   string > @
     reduced
-      bytes-as-array
+      array
         text.as-bytes
       --
       [accum byte] >>


### PR DESCRIPTION
Moves the `bytes-as-array` object out of the `tuple` package into the `bytes` package and renames it to a plain `array`. Its two string callers, `low-cased` and `up-cased`, now import `bytes.array` instead of `tuple.bytes-as-array`.

The object takes a `bytes` value and hands back a tuple of single-byte values. Its input is bytes and the operation is about bytes, so `bytes.array` reads truer to what it does than `tuple.bytes-as-array` did. The shorter name drops the redundant prefix now that the package already says "bytes".

Part of #5501. All 1550 eo-runtime unit tests pass locally.