### PR TITLE
feat(#5516): add `format` goal to enforce canonical EO layout

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * A colored unified diff between two multi-line texts.
+ *
+ * <p>Both sides are split into lines and aligned by their longest
+ * common subsequence. The result is rendered in the familiar unified
+ * style: common lines are prefixed with a space, deletions with
+ * {@code -} highlighted in red, and additions with {@code +} highlighted
+ * in green. When the two texts are identical, {@link #colored()} returns
+ * an empty string and {@link #same()} returns {@code true}.</p>
+ *
+ * @since 0.57.0
+ */
+final class Diff {
+
+    /**
+     * ANSI escape that resets all coloring.
+     */
+    private static final String RESET = "\u001b[0m";
+
+    /**
+     * ANSI escape that turns the text red (used for deletions).
+     */
+    private static final String RED = "\u001b[31m";
+
+    /**
+     * ANSI escape that turns the text green (used for additions).
+     */
+    private static final String GREEN = "\u001b[32m";
+
+    /**
+     * The text before the change.
+     */
+    private final String before;
+
+    /**
+     * The text after the change.
+     */
+    private final String after;
+
+    /**
+     * Ctor.
+     * @param before The text before the change
+     * @param after The text after the change
+     */
+    Diff(final String before, final String after) {
+        this.before = before;
+        this.after = after;
+    }
+
+    /**
+     * Are the two texts identical?
+     * @return TRUE if there is nothing to show
+     */
+    boolean same() {
+        return this.before.equals(this.after);
+    }
+
+    /**
+     * Render the difference as a colored unified diff.
+     * @return The diff, or an empty string if the texts are identical
+     */
+    String colored() {
+        final String result;
+        if (this.same()) {
+            result = "";
+        } else {
+            result = Diff.render(Diff.lines(this.before), Diff.lines(this.after));
+        }
+        return result;
+    }
+
+    /**
+     * Split a text into lines.
+     * @param text The text
+     * @return The lines
+     */
+    private static List<String> lines(final String text) {
+        return text.lines().collect(Collectors.toList());
+    }
+
+    /**
+     * Render the unified diff of two already-split texts.
+     * @param before The lines before the change
+     * @param after The lines after the change
+     * @return The colored unified diff
+     */
+    private static String render(final List<String> before, final List<String> after) {
+        final int[][] lcs = Diff.lcs(before, after);
+        final StringBuilder out = new StringBuilder(0);
+        int row = 0;
+        int col = 0;
+        while (row < before.size() && col < after.size()) {
+            if (before.get(row).equals(after.get(col))) {
+                Diff.common(out, before.get(row));
+                row += 1;
+                col += 1;
+            } else if (lcs[row + 1][col] >= lcs[row][col + 1]) {
+                Diff.deleted(out, before.get(row));
+                row += 1;
+            } else {
+                Diff.added(out, after.get(col));
+                col += 1;
+            }
+        }
+        Diff.drain(out, before.subList(row, before.size()), Diff::deleted);
+        Diff.drain(out, after.subList(col, after.size()), Diff::added);
+        return out.toString();
+    }
+
+    /**
+     * Build the longest-common-subsequence length table.
+     * @param before The lines before the change
+     * @param after The lines after the change
+     * @return The table, sized {@code (before + 1) x (after + 1)}
+     */
+    private static int[][] lcs(final List<String> before, final List<String> after) {
+        final int rows = before.size();
+        final int cols = after.size();
+        final int[][] table = new int[rows + 1][cols + 1];
+        for (int row = rows - 1; row >= 0; row -= 1) {
+            for (int col = cols - 1; col >= 0; col -= 1) {
+                if (before.get(row).equals(after.get(col))) {
+                    table[row][col] = table[row + 1][col + 1] + 1;
+                } else {
+                    table[row][col] = Math.max(table[row + 1][col], table[row][col + 1]);
+                }
+            }
+        }
+        return table;
+    }
+
+    /**
+     * Append the tail of one side that has no counterpart on the other.
+     * @param out The output
+     * @param tail The remaining lines of one side
+     * @param appender How to append a single line (as deletion or addition)
+     */
+    private static void drain(
+        final StringBuilder out, final List<String> tail,
+        final BiConsumer<? super StringBuilder, ? super String> appender
+    ) {
+        for (final String line : tail) {
+            appender.accept(out, line);
+        }
+    }
+
+    /**
+     * Append a common (unchanged) line.
+     * @param out The output
+     * @param line The line
+     */
+    private static void common(final StringBuilder out, final String line) {
+        out.append(' ').append(line).append('\n');
+    }
+
+    /**
+     * Append a deleted line, in red.
+     * @param out The output
+     * @param line The line
+     */
+    private static void deleted(final StringBuilder out, final String line) {
+        out.append(Diff.RED).append('-').append(line).append(Diff.RESET).append('\n');
+    }
+
+    /**
+     * Append an added line, in green.
+     * @param out The output
+     * @param line The line
+     */
+    private static void added(final StringBuilder out, final String line) {
+        out.append(Diff.GREEN).append('+').append(line).append(Diff.RESET).append('\n');
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+import org.eolang.parser.EoSyntax;
+import org.eolang.printer.Xmir;
+
+/**
+ * Enforce the canonical layout of {@code .eo} sources.
+ *
+ * <p>This goal walks through all registered {@code .eo} sources (see
+ * {@link MjRegister}), reformats every one of them in memory by parsing
+ * it to XMIR and printing it back with {@link Xmir#toEO()}, and compares
+ * the result against what is on disk. In its default "check" mode, it
+ * prints a colored unified {@link Diff} for every file that diverges from
+ * the canonical form and fails the build. When {@link #autoFix} is turned
+ * on (via the {@code eo.autoFix} property), it overwrites the divergent
+ * files with their canonical form instead of failing, much like
+ * {@code gofmt -w} or {@code spotless:apply}.</p>
+ *
+ * @since 0.57.0
+ */
+@Mojo(
+    name = "format",
+    defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+    threadSafe = true
+)
+public final class MjFormat extends MjSafe {
+
+    /**
+     * Overwrite divergent sources with their canonical form instead of
+     * failing the build.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.autoFix", required = true, defaultValue = "false")
+    private boolean autoFix;
+
+    @Override
+    void exec() throws IOException {
+        final Collection<TjForeign> sources = this.scopedTojos().withSources();
+        final Collection<Path> divergent = new LinkedList<>();
+        for (final TjForeign tojo : sources) {
+            if (this.reformat(tojo.source())) {
+                divergent.add(tojo.source());
+            }
+        }
+        this.report(sources.size(), divergent);
+    }
+
+    /**
+     * Reformat a single source, either fixing it or reporting the diff.
+     * @param source The path of the {@code .eo} file
+     * @return TRUE if the file diverged from the canonical form
+     * @throws IOException If fails to read or write the file
+     */
+    private boolean reformat(final Path source) throws IOException {
+        final String actual = new UncheckedText(new TextOf(source)).asString();
+        final String canonical = new Xmir(new EoSyntax(actual).parsed()).toEO();
+        final Diff diff = new Diff(actual, canonical);
+        final boolean diverged = !diff.same();
+        if (diverged && this.autoFix) {
+            new Saved(canonical, source).value();
+            Logger.info(this, "Reformatted %[file]s", source);
+        } else if (diverged) {
+            Logger.warn(
+                this,
+                "%[file]s is not formatted canonically:%n%s",
+                source,
+                diff.colored()
+            );
+        }
+        return diverged;
+    }
+
+    /**
+     * Report the outcome, failing the build if needed.
+     * @param total The number of registered sources
+     * @param divergent The sources that diverged from the canonical form
+     */
+    private void report(final int total, final Collection<Path> divergent) {
+        if (divergent.isEmpty()) {
+            Logger.info(this, "All %d EO source(s) are formatted canonically", total);
+        } else if (this.autoFix) {
+            Logger.info(
+                this, "Reformatted %d of %d EO source(s)", divergent.size(), total
+            );
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "%d of %d EO source(s) are not formatted canonically; %s",
+                    divergent.size(),
+                    total,
+                    "run with -Deo.autoFix to reformat them automatically"
+                )
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link Diff}.
+ * @since 0.57.0
+ */
+final class DiffTest {
+
+    @Test
+    void detectsIdenticalTexts() {
+        MatcherAssert.assertThat(
+            "identical texts must be reported as the same",
+            new Diff(
+                String.format("a%nb%nc"), String.format("a%nb%nc")
+            ).same(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rendersNothingForIdenticalTexts() {
+        MatcherAssert.assertThat(
+            "identical texts must produce an empty diff",
+            new Diff(String.format("a%nb"), String.format("a%nb")).colored(),
+            Matchers.isEmptyString()
+        );
+    }
+
+    @Test
+    void detectsDifferentTexts() {
+        MatcherAssert.assertThat(
+            "different texts must not be reported as the same",
+            new Diff(String.format("a%nb"), String.format("a%nc")).same(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void highlightsRemovedAndAddedLines() {
+        MatcherAssert.assertThat(
+            "the diff must keep the common line and color the changed ones",
+            new Diff(String.format("a%nb%nc"), String.format("a%nB%nc")).colored(),
+            Matchers.stringContainsInOrder(" a", "[31m-b", "[32m+B", " c")
+        );
+    }
+
+    @Test
+    void highlightsTrailingAdditions() {
+        MatcherAssert.assertThat(
+            "extra trailing lines must be shown as additions",
+            new Diff("a", String.format("a%nb")).colored(),
+            Matchers.containsString("[32m+b")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -65,7 +65,7 @@ final class MjFormatTest {
     }
 
     @Test
-    void autoFixReformatsDivergentSource(@Mktmp final Path temp) throws Exception {
+    void reformatsDivergentSourceWhenAutoFixIsOn(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the divergent source must be rewritten into its canonical form",
             new TextOf(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.cactoos.text.TextOf;
+import org.eolang.parser.EoSyntax;
+import org.eolang.printer.Xmir;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test cases for {@link MjFormat}.
+ * @since 0.57.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class MjFormatTest {
+
+    @Test
+    void passesWhenSourceIsCanonical(@Mktmp final Path temp) throws IOException {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp)
+                .withProgram(MjFormatTest.canonical(new HelloWorld().asString()))
+                .execute(MjFormat.class),
+            "canonical source must pass the format check without failing the build"
+        );
+    }
+
+    @Test
+    void keepsCanonicalSourceUntouched(@Mktmp final Path temp) throws Exception {
+        final String canonical = MjFormatTest.canonical(new HelloWorld().asString());
+        MatcherAssert.assertThat(
+            "the canonical source must be left exactly as it was",
+            new TextOf(
+                new FakeMaven(temp)
+                    .withProgram(canonical)
+                    .execute(MjFormat.class)
+                    .result()
+                    .get("foo/x/main.eo")
+            ).asString(),
+            Matchers.equalTo(canonical)
+        );
+    }
+
+    @Test
+    void failsWhenSourceDiverges(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a divergent source must fail the build in check mode",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new FakeMaven(temp)
+                    .withProgram(MjFormatTest.divergent(new HelloWorld().asString()))
+                    .execute(MjFormat.class)
+            ).getMessage(),
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void autoFixReformatsDivergentSource(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the divergent source must be rewritten into its canonical form",
+            new TextOf(
+                new FakeMaven(temp)
+                    .with("autoFix", true)
+                    .withProgram(MjFormatTest.divergent(new HelloWorld().asString()))
+                    .execute(MjFormat.class)
+                    .result()
+                    .get("foo/x/main.eo")
+            ).asString(),
+            Matchers.equalTo(MjFormatTest.canonical(new HelloWorld().asString()))
+        );
+    }
+
+    /**
+     * Reformat a program into its canonical EO layout.
+     * @param program The EO program
+     * @return The canonical EO representation
+     * @throws IOException If fails to parse the program
+     */
+    private static String canonical(final String program) throws IOException {
+        return new Xmir(new EoSyntax(program).parsed()).toEO();
+    }
+
+    /**
+     * A non-canonical variant of the program, with extra blank lines.
+     * @param program The EO program
+     * @return An EO text that diverges from the canonical layout
+     * @throws IOException If fails to parse the program
+     */
+    private static String divergent(final String program) throws IOException {
+        return String.format("%s%n%n", MjFormatTest.canonical(program));
+    }
+}


### PR DESCRIPTION
Closes #5516.

## What & Why

`eo-maven-plugin` already has a `print` goal that turns XMIR back into EO, but there was no way to *enforce* a canonical layout on `.eo` sources — the equivalent of `gofmt`/`spotless:check`. This PR adds a new `format` goal for exactly that.

## How it works

New mojo **`MjFormat`** (goal `format`):

- Iterates over all **registered** `.eo` sources (`scopedTojos().withSources()`).
- Reformats each one **in memory** by parsing it to XMIR with `EoSyntax` and printing it back with `Xmir.toEO()`.
- Compares the canonical text against the version on disk.

Two modes:

- **Check mode** (default): prints a colored unified diff for every file that diverges from the canonical form and **fails the build**.
- **Auto-fix mode** (`-Deo.autoFix`): overwrites the divergent files with their canonical form instead of failing, like `gofmt -w` / `spotless:apply`.

New helper **`Diff`**: renders a colored unified diff between two multi-line texts using a longest-common-subsequence alignment (common lines prefixed with a space, deletions `-` in red, additions `+` in green).

## Tests

- `DiffTest` — LCS alignment, identical-text detection, colored add/remove markers, trailing additions.
- `MjFormatTest` — passes on canonical sources, leaves them untouched, fails on divergent sources in check mode, and rewrites them to canonical form under `autoFix`.

All new tests pass and `qulice` is clean for the added files.

## Note on prerequisite

Issue #5516 lists #5430 (penalty-based pretty printing) as a prerequisite so diffs are not noisy; the penalty-based `Pretty` printer is already in place, so `Xmir.toEO()` output is stable enough to compare against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W72brzvhmCjWR8XtYdyH3)_