### PR TITLE
Move tmpdir to root as mktemp and getenv to root

### DIFF
--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -75,10 +75,10 @@
     and. > @
       d.exists
       d.is-directory
-    (tmpdir.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
+    (mktemp.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
 
   ++> tests-deletes-empty-directory
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .as-path
@@ -91,7 +91,7 @@
     .not > @
 
   ++> throws-on-opening-directory
-    tmpdir.open > @
+    mktemp.open > @
       "w"
       true > [d]
 
@@ -105,7 +105,7 @@
           d.deleted.exists.not
         first.exists.not
       second.exists.not
-    (dir tmpdir.tmpfile.deleted).made > d
+    (dir mktemp.tmpfile.deleted).made > d
     d.tmpfile > first
     d.tmpfile > second
 
@@ -121,7 +121,7 @@
           d.deleted.exists.not
         inner.exists.not
       f.exists.not
-    (dir tmpdir.tmpfile.deleted).made > d
+    (dir mktemp.tmpfile.deleted).made > d
     d.tmpfile > f
     (dir d.tmpfile.deleted).made > inner
 
@@ -133,7 +133,7 @@
         (d.resolved "x/y/z").as-dir.made
         (d.resolved "x/y/z/a.txt").as-file.touched
         (d.as-dir.walk "**/*.txt").length.eq 2
-    (dir tmpdir.tmpfile.deleted).made.as-path > d
+    (dir mktemp.tmpfile.deleted).made.as-path > d
 
   ++> throws-on-walking-absent-directory
-    (dir tmpdir.tmpfile.deleted).walk "**" > @
+    (dir mktemp.tmpfile.deleted).walk "**" > @

--- a/eo-runtime/src/main/eo/fs/file.eo
+++ b/eo-runtime/src/main/eo/fs/file.eo
@@ -244,43 +244,43 @@
 
   ++> tests-returns-self-after-deleting
     temp.deleted.path.eq temp.path > @
-    tmpdir.tmpfile > temp
+    mktemp.tmpfile > temp
 
   ++> tests-returns-self-after-touching
     temp.deleted.touched.path.eq temp.path > @
-    tmpdir.tmpfile > temp
+    mktemp.tmpfile > temp
 
   ++> tests-checks-file-does-not-exist-after-deleting
-    tmpdir.tmpfile.deleted.exists.not > @
+    mktemp.tmpfile.deleted.exists.not > @
 
   ++> tests-touches-a-file
-    tmpdir.tmpfile.deleted.touched.exists > @
+    mktemp.tmpfile.deleted.touched.exists > @
 
   ++> tests-measures-empty-file-after-touching
-    tmpdir.tmpfile.deleted.touched.size.eq 0 > @
+    mktemp.tmpfile.deleted.touched.size.eq 0 > @
 
   ++> throws-on-sizing-absent-file
-    tmpdir.tmpfile.deleted.size > @
+    mktemp.tmpfile.deleted.size > @
 
   ++> throws-on-checking-directory-of-absent-file
-    tmpdir.tmpfile.deleted.is-directory > @
+    mktemp.tmpfile.deleted.is-directory > @
 
   ++> tests-sizing-absent-file-returns-fallback
     eq. > @
       -1
-      tmpdir.tmpfile.deleted.size -1
+      mktemp.tmpfile.deleted.size -1
 
   ++> tests-checking-absent-file-returns-fallback
-    tmpdir.tmpfile.deleted.is-directory true > @
+    mktemp.tmpfile.deleted.is-directory true > @
 
   ++> tests-does-not-fail-on-double-touching
-    tmpdir.tmpfile.deleted.touched.touched.exists > @
+    mktemp.tmpfile.deleted.touched.touched.exists > @
 
   ++> tests-does-not-fail-on-double-deleting
-    tmpdir.tmpfile.deleted.deleted.exists.not > @
+    mktemp.tmpfile.deleted.deleted.exists.not > @
 
   ++> throws-an-error-on-touching-temp-file-in-absent-dir
-    (tmpdir.as-path.resolved "foo").@.tmpfile > @
+    (mktemp.as-path.resolved "foo").@.tmpfile > @
 
   ++> tests-resolves-and-touches
     and. > @
@@ -290,18 +290,18 @@
         joined
           Q.fs.path.separator
           * "foo" "bar"
-    tmpdir.as-path.resolved "foo/bar" > resolved
+    mktemp.as-path.resolved "foo/bar" > resolved
 
   ++> tests-moves-a-file
     and. > @
       (temp.moved ("%s.dest".printf (* temp.path))).exists
       temp.exists.not
-    tmpdir.tmpfile > temp
+    mktemp.tmpfile > temp
 
   ++> throws-on-opening-with-wrong-mode
     seq > @
       *
-        tmpdir
+        mktemp
         .tmpfile
         .open
           "x"
@@ -309,7 +309,7 @@
         true
 
   ++> throws-on-reading-from-not-existed-file
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open > @
@@ -317,7 +317,7 @@
       f > [f]
 
   ++> throws-on-reading-or-writing-from-not-existed-file
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open > @
@@ -327,7 +327,7 @@
   ++> tests-recovers-from-opening-missing-file-through-fallback
     eq. > @
       "recovered"
-      tmpdir
+      mktemp
       .tmpfile
       .deleted
       .open
@@ -336,7 +336,7 @@
         "recovered" > [reason]
 
   ++> tests-touches-absent-file-on-opening-for-writing
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open
@@ -345,7 +345,7 @@
     .exists > @
 
   ++> tests-touches-absent-file-on-opening-for-appending
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open
@@ -354,7 +354,7 @@
     .exists > @
 
   ++> tests-touches-absent-file-on-opening-for-writing-or-reading
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open
@@ -363,7 +363,7 @@
     .exists > @
 
   ++> tests-touches-absent-file-on-opening-for-reading-or-appending
-    tmpdir
+    mktemp
     .tmpfile
     .deleted
     .open
@@ -372,7 +372,7 @@
     .exists > @
 
   ++> tests-writes-data-to-file
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -381,7 +381,7 @@
     .eq 12 > @
 
   ++> tests-appending-data-to-file
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -393,7 +393,7 @@
     .eq 13 > @
 
   ++> tests-truncates-file-opened-for-writing
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -405,7 +405,7 @@
     .eq 0 > @
 
   ++> tests-truncates-file-opened-for-writing-or-reading
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -417,7 +417,7 @@
     .eq 0 > @
 
   ++> tests-does-not-truncate-file-opened-for-appending
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -429,7 +429,7 @@
     .eq 12 > @
 
   ++> tests-does-not-truncate-file-opened-for-reading-or-appending
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -441,7 +441,7 @@
     .eq 12 > @
 
   ++> tests-does-not-truncate-file-opened-for-reading
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "w"
@@ -453,7 +453,7 @@
     .eq 12 > @
 
   ++> throws-on-writing-with-wrong-mode
-    tmpdir
+    mktemp
     .tmpfile
     .open > @
       "r"
@@ -466,7 +466,7 @@
       [m]
         seq > @
           *
-            tmpdir
+            mktemp
             .tmpfile
             .open
               "w"
@@ -480,14 +480,14 @@
     .eq "Hello, world" > @
 
   ++> throws-on-reading-negative-size-from-file
-    tmpdir
+    mktemp
     .tmpfile
     .open > @
       "r"
       f.read -5 > [f]
 
   ++> throws-on-reading-from-file-with-wrong-mode
-    tmpdir
+    mktemp
     .tmpfile
     .open > @
       "w"
@@ -513,7 +513,7 @@
                     f.read 13
               m
     temp.path > src
-    tmpdir.tmpfile > temp
+    mktemp.tmpfile > temp
 
   ++> tests-writes-to-file-from-different-instances
     seq > @
@@ -543,7 +543,7 @@
                 m
         .eq "Shrek is love!"
     temp.path > src
-    tmpdir.tmpfile > temp
+    mktemp.tmpfile > temp
 
   ++> tests-reads-from-file-sequentially
     malloc
@@ -552,7 +552,7 @@
       [m]
         seq > @
           *
-            tmpdir
+            mktemp
             .tmpfile
             .open
               "w"
@@ -566,7 +566,7 @@
     .eq "world" > @
 
   ++> tests-writes-to-file-sequentially
-    tmpdir
+    mktemp
     .tmpfile
     .open
       "a+"

--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -3,9 +3,11 @@
 #
 # See https://man7.org/linux/man-pages/man3/getenv.3.html.
 
++alias sm.os
++alias sm.posix
++alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package sm
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -7,16 +7,17 @@
 # takes the first environment variable in the list TMP, TEMP, USERPROFILE.
 # If none of these are found, it returns the Windows directory (C:\Windows).
 
++alias fs.dir
++alias fs.file
 +alias sm.getenv
 +alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package fs
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > tmpdir
+[] > mktemp
   dir > @
     file
       string
@@ -53,10 +54,10 @@
           getenv "TMPDIR" > tmpdir!
           getenv "USERPROFILE" > userprofile!
 
-  tmpdir.exists > [] +> global-temp-dir-exists
+  mktemp.exists > [] +> global-temp-dir-exists
 
-  tmpdir.is-directory > [] +> global-temp-dir-is-directory
+  mktemp.is-directory > [] +> global-temp-dir-is-directory
 
-  tmpdir.path.eq tmpdir.path > [] +> returns-the-same-tmpdir
+  mktemp.path.eq mktemp.path > [] +> returns-the-same-tmpdir
 
-  tmpdir.tmpfile.exists > [] +> creates-tmpfile
+  mktemp.tmpfile.exists > [] +> creates-tmpfile

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -9,7 +9,6 @@
 
 +alias fs.dir
 +alias fs.file
-+alias sm.getenv
 +alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo


### PR DESCRIPTION
This moves two standard-library objects out of their packages and into the root. The `fs.tmpdir` object becomes the root object `mktemp`, and `sm.getenv` becomes the root object `getenv`. The `fs.file` and `fs.dir` tests that referenced `tmpdir`, and the alias list of `mktemp` itself, are updated to match.

Both objects are general enough to belong at the root, where callers reach them by bare name with no package alias, the same way `seq` or `string` are used today. This continues the "packages are objects" cleanup under #5501.

All 1550 eo-runtime unit tests pass locally. Nothing else in the tree references either object, so no other call sites needed touching.