### PR TITLE
Move system-clock to root as clock

### DIFF
--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -2,14 +2,16 @@
 # Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime32_s` on Windows.
 # Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
 
++alias sm.os
++alias sm.posix
++alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package sm
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > system-clock
+[] > clock
   as-i64. > @
     if.
       os.is-windows
@@ -24,4 +26,4 @@
   (posix "gettimeofday" *).output > timeval
 
   ++> tests-reads-positive-millis
-    system-clock.gt 0 > @
+    clock.gt 0 > @

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -1,6 +1,5 @@
 # Generates a pseudo-random number.
 
-+alias sm.system-clock
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
@@ -66,7 +65,7 @@
     35 > shift1
     17 > shift3
     clock.as-bytes > tbytes
-  clocked system-clock > pseudo
+  clocked clock > pseudo
 
   ++> tests-random-with-seed
     not. > @


### PR DESCRIPTION
This moves the wall-clock time source out of the sm package and into the root. The `sm.system-clock` object becomes the root object `clock`, so callers reach it by bare name with no package alias, the same way `seq` or `string` are used today. Its sole caller, `number.random`, is updated to drop the alias and pass `clock` directly.

The object reads the OS time syscall, so it needs the sm objects `os`, `posix` and `win32`; those are now brought in with explicit aliases. This continues the "packages are objects" cleanup under #5501.

All 1550 eo-runtime unit tests pass locally. The `clocked` object inside `number.random` keeps a void attribute also named `clock`; that attribute is local to `clocked`, so it does not clash with the new global object.