### PR TITLE
feat(#5544): make eo-printer penalties configurable

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -54,21 +54,21 @@ public final class MjFormat extends MjSafe {
      * Points charged for each level of indentation on a line.
      * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.penalty.indent")
+    @Parameter(property = "eo.penaltyIndent")
     private Integer penaltyIndent;
 
     /**
      * Points charged for each opening parenthesis.
      * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.penalty.bracket")
+    @Parameter(property = "eo.penaltyBracket")
     private Integer penaltyBracket;
 
     /**
      * Points charged for each character past the allowed width.
      * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.penalty.excess")
+    @Parameter(property = "eo.penaltyExcess")
     private Integer penaltyExcess;
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -8,13 +8,16 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.LinkedList;
+import java.util.Map;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.parser.EoSyntax;
+import org.eolang.printer.PenaltyKey;
 import org.eolang.printer.Xmir;
 
 /**
@@ -47,6 +50,41 @@ public final class MjFormat extends MjSafe {
     @Parameter(property = "eo.autoFix", required = true, defaultValue = "false")
     private boolean autoFix;
 
+    /**
+     * Points charged for each level of indentation on a line.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.penalty.indent")
+    private Integer penaltyIndent;
+
+    /**
+     * Points charged for each opening parenthesis.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.penalty.bracket")
+    private Integer penaltyBracket;
+
+    /**
+     * Points charged for each character past the allowed width.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.penalty.excess")
+    private Integer penaltyExcess;
+
+    /**
+     * The column after which characters start being charged.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.width")
+    private Integer width;
+
+    /**
+     * The width of a single indentation level, in spaces.
+     * @checkstyle MemberNameCheck (10 lines)
+     */
+    @Parameter(property = "eo.step")
+    private Integer step;
+
     @Override
     void exec() throws IOException {
         final Collection<TjForeign> sources = this.scopedTojos().withSources();
@@ -67,7 +105,9 @@ public final class MjFormat extends MjSafe {
      */
     private boolean reformat(final Path source) throws IOException {
         final String actual = new UncheckedText(new TextOf(source)).asString();
-        final String canonical = new Xmir(new EoSyntax(actual).parsed()).toEO();
+        final String canonical = new Xmir(
+            new EoSyntax(actual).parsed(), this.weights()
+        ).toEO();
         final Diff diff = new Diff(actual, canonical);
         final boolean diverged = !diff.same();
         if (diverged && this.autoFix) {
@@ -82,6 +122,35 @@ public final class MjFormat extends MjSafe {
             );
         }
         return diverged;
+    }
+
+    /**
+     * Assemble the overridden penalty weights from the Maven properties.
+     *
+     * <p>Only the properties that the user actually set are put into the
+     * map; every absent key falls back to its {@link PenaltyKey#fallback()}
+     * default inside the printer.</p>
+     *
+     * @return The weights, keyed by {@link PenaltyKey}
+     */
+    private Map<PenaltyKey, Integer> weights() {
+        final Map<PenaltyKey, Integer> map = new EnumMap<>(PenaltyKey.class);
+        if (this.penaltyIndent != null) {
+            map.put(PenaltyKey.INDENT, this.penaltyIndent);
+        }
+        if (this.penaltyBracket != null) {
+            map.put(PenaltyKey.BRACKET, this.penaltyBracket);
+        }
+        if (this.penaltyExcess != null) {
+            map.put(PenaltyKey.EXCESS, this.penaltyExcess);
+        }
+        if (this.width != null) {
+            map.put(PenaltyKey.WIDTH, this.width);
+        }
+        if (this.step != null) {
+            map.put(PenaltyKey.STEP, this.step);
+        }
+        return map;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -93,7 +93,7 @@ final class MjFormatTest {
                     .result()
                     .get("foo/x/main.eo")
             ).asString(),
-            Matchers.containsString(String.format("%n        org.eolang.io.stdout"))
+            Matchers.containsString("\n        org.eolang.io.stdout")
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -93,7 +93,9 @@ final class MjFormatTest {
                     .result()
                     .get("foo/x/main.eo")
             ).asString(),
-            Matchers.containsString("\n        org.eolang.io.stdout")
+            Matchers.containsString(
+                String.valueOf('\n').concat("        org.eolang.io.stdout")
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -80,6 +80,23 @@ final class MjFormatTest {
         );
     }
 
+    @Test
+    void appliesCustomIndentationStep(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the printer must indent with the configured number of spaces",
+            new TextOf(
+                new FakeMaven(temp)
+                    .with("autoFix", true)
+                    .with("step", 4)
+                    .withProgram(MjFormatTest.canonical(new HelloWorld().asString()))
+                    .execute(MjFormat.class)
+                    .result()
+                    .get("foo/x/main.eo")
+            ).asString(),
+            Matchers.containsString(String.format("%n        org.eolang.io.stdout"))
+        );
+    }
+
     /**
      * Reformat a program into its canonical EO layout.
      * @param program The EO program

--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.printer;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Penalty of a piece of EO source code.
  *
@@ -16,14 +19,21 @@ package org.eolang.printer;
  *
  * <ul>
  *   <li>every level of indentation on a line costs
- *   {@link #INDENT} points;</li>
- *   <li>every opening parenthesis costs {@link #BRACKET} points;</li>
- *   <li>every character sitting past the {@link #WIDTH}-th column
- *   costs {@link #OVERFLOW} point.</li>
+ *   {@link PenaltyKey#INDENT} points;</li>
+ *   <li>every opening parenthesis costs {@link PenaltyKey#BRACKET}
+ *   points;</li>
+ *   <li>every character sitting past the {@link PenaltyKey#WIDTH}-th
+ *   column costs {@link PenaltyKey#EXCESS} point.</li>
  * </ul>
  *
- * <p>For example, this snippet has a penalty of 15 (five indents,
- * three points each):</p>
+ * <p>All of these weights, together with the indentation
+ * {@link PenaltyKey#STEP}, are tunable: they are read from a
+ * {@code Map<PenaltyKey, Integer>} supplied to the constructor, and any
+ * key absent from that map falls back to its {@link PenaltyKey#fallback()}
+ * default.</p>
+ *
+ * <p>For example, with the default weights this snippet has a penalty of
+ * 15 (five indents, three points each):</p>
  *
  * <pre> [] &gt; foo
  *   gt. &gt; @
@@ -40,29 +50,9 @@ package org.eolang.printer;
 final class Penalty {
 
     /**
-     * Points charged for each level of indentation on a line.
+     * The default weights: an empty map, so every key uses its fallback.
      */
-    private static final int INDENT = 3;
-
-    /**
-     * Points charged for each opening parenthesis.
-     */
-    private static final int BRACKET = 7;
-
-    /**
-     * Points charged for each character past {@link #WIDTH}.
-     */
-    private static final int EXCESS = 1;
-
-    /**
-     * The column after which characters start being charged.
-     */
-    private static final int WIDTH = 80;
-
-    /**
-     * The width of a single indentation level, in spaces.
-     */
-    private static final int STEP = 2;
+    private static final Map<PenaltyKey, Integer> DEFAULTS = Collections.emptyMap();
 
     /**
      * The EO source code to score.
@@ -70,11 +60,26 @@ final class Penalty {
     private final String code;
 
     /**
-     * Ctor.
+     * The overridden weights, by key.
+     */
+    private final Map<PenaltyKey, Integer> weights;
+
+    /**
+     * Ctor, using the default weights for every key.
      * @param source The EO source code
      */
     Penalty(final String source) {
+        this(source, Penalty.DEFAULTS);
+    }
+
+    /**
+     * Ctor.
+     * @param source The EO source code
+     * @param config The overridden weights; absent keys use their defaults
+     */
+    Penalty(final String source, final Map<PenaltyKey, Integer> config) {
         this.code = source;
+        this.weights = config;
     }
 
     /**
@@ -84,11 +89,20 @@ final class Penalty {
     int points() {
         int total = 0;
         for (final String line : this.code.split(String.valueOf('\n'), -1)) {
-            total += Penalty.indents(line) * Penalty.INDENT;
-            total += Penalty.brackets(line) * Penalty.BRACKET;
-            total += Penalty.overflow(line) * Penalty.EXCESS;
+            total += this.indents(line) * this.weight(PenaltyKey.INDENT);
+            total += Penalty.brackets(line) * this.weight(PenaltyKey.BRACKET);
+            total += this.overflow(line) * this.weight(PenaltyKey.EXCESS);
         }
         return total;
+    }
+
+    /**
+     * The weight of a key, or its default if not overridden.
+     * @param key The key
+     * @return The weight in points
+     */
+    private int weight(final PenaltyKey key) {
+        return this.weights.getOrDefault(key, key.fallback());
     }
 
     /**
@@ -96,12 +110,21 @@ final class Penalty {
      * @param line The line
      * @return The number of levels
      */
-    private static int indents(final String line) {
+    private int indents(final String line) {
         int spaces = 0;
         while (spaces < line.length() && line.charAt(spaces) == ' ') {
             ++spaces;
         }
-        return spaces / Penalty.STEP;
+        return spaces / this.weight(PenaltyKey.STEP);
+    }
+
+    /**
+     * Count characters past the allowed width.
+     * @param line The line
+     * @return The number of overflowing characters
+     */
+    private int overflow(final String line) {
+        return Math.max(0, line.length() - this.weight(PenaltyKey.WIDTH));
     }
 
     /**
@@ -117,14 +140,5 @@ final class Penalty {
             }
         }
         return count;
-    }
-
-    /**
-     * Count characters past the allowed width.
-     * @param line The line
-     * @return The number of overflowing characters
-     */
-    private static int overflow(final String line) {
-        return Math.max(0, line.length() - Penalty.WIDTH);
     }
 }

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.printer;
+
+/**
+ * A tunable weight of the pretty-printer's {@link Penalty} function.
+ *
+ * <p>Each key names one knob of the penalty-based layout algorithm and
+ * carries the default that {@link Penalty} (and {@link Pretty}) falls back
+ * to when a weight is not supplied. A caller may override any subset of
+ * these by passing a {@code Map<PenaltyKey, Integer>} to {@link Pretty}
+ * or {@link Xmir}; absent keys keep their {@link #fallback()} value, so
+ * one aesthetic is no longer baked into the tool.</p>
+ *
+ * @since 0.57.0
+ * @checkstyle MagicNumberCheck (40 lines)
+ */
+public enum PenaltyKey {
+
+    /**
+     * Points charged for each level of indentation on a line.
+     */
+    INDENT(3),
+
+    /**
+     * Points charged for each opening parenthesis.
+     */
+    BRACKET(7),
+
+    /**
+     * Points charged for each character past {@link #WIDTH}.
+     */
+    EXCESS(1),
+
+    /**
+     * The column after which characters start being charged.
+     */
+    WIDTH(80),
+
+    /**
+     * The width of a single indentation level, in spaces.
+     */
+    STEP(2);
+
+    /**
+     * The value used when this key is not overridden.
+     */
+    private final int def;
+
+    /**
+     * Ctor.
+     * @param fallback The default value of this key
+     */
+    PenaltyKey(final int fallback) {
+        this.def = fallback;
+    }
+
+    /**
+     * The default value of this key.
+     * @return The value to use when the key is absent from the weights map
+     */
+    public int fallback() {
+        return this.def;
+    }
+}

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -6,7 +6,9 @@ package org.eolang.printer;
 
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -27,9 +29,9 @@ import java.util.stream.Collectors;
 final class Pretty {
 
     /**
-     * The width of a single indentation level, in spaces.
+     * The default weights: an empty map, so every key uses its fallback.
      */
-    private static final String STEP = "  ";
+    private static final Map<PenaltyKey, Integer> DEFAULTS = Collections.emptyMap();
 
     /**
      * The {@code <eo>} element produced by {@code to-eo-tree.xsl}.
@@ -37,11 +39,26 @@ final class Pretty {
     private final Xnav root;
 
     /**
-     * Ctor.
+     * The overridden penalty weights, by key.
+     */
+    private final Map<PenaltyKey, Integer> weights;
+
+    /**
+     * Ctor, using the default penalty weights.
      * @param element The {@code <eo>} element
      */
     Pretty(final Xnav element) {
+        this(element, Pretty.DEFAULTS);
+    }
+
+    /**
+     * Ctor.
+     * @param element The {@code <eo>} element
+     * @param config The overridden weights; absent keys use their defaults
+     */
+    Pretty(final Xnav element, final Map<PenaltyKey, Integer> config) {
         this.root = element;
+        this.weights = config;
     }
 
     /**
@@ -54,9 +71,19 @@ final class Pretty {
         );
         this.root.elements(Filter.withName("line"))
             .findFirst()
-            .map(line -> Pretty.layout(Pretty.Node.parse(line), 0))
+            .map(line -> this.layout(Pretty.Node.parse(line), 0))
             .ifPresent(out::append);
         return out.append('\n').toString();
+    }
+
+    /**
+     * A single level of indentation, whose width is the {@code STEP} weight.
+     * @return The indentation string
+     */
+    private String step() {
+        return " ".repeat(
+            this.weights.getOrDefault(PenaltyKey.STEP, PenaltyKey.STEP.fallback())
+        );
     }
 
     /**
@@ -66,11 +93,12 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block
      */
-    private static String layout(final Pretty.Node node, final int indent) {
-        String best = Pretty.vertical(node, indent);
-        final Optional<String> flat = Pretty.horizontal(node, indent);
+    private String layout(final Pretty.Node node, final int indent) {
+        String best = this.vertical(node, indent);
+        final Optional<String> flat = this.horizontal(node, indent);
         if (flat.isPresent()
-            && new Penalty(flat.get()).points() < new Penalty(best).points()) {
+            && new Penalty(flat.get(), this.weights).points()
+            < new Penalty(best, this.weights).points()) {
             best = flat.get();
         }
         return best;
@@ -83,12 +111,12 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block
      */
-    private static String vertical(final Pretty.Node node, final int indent) {
-        final StringBuilder block = new StringBuilder(Pretty.STEP.repeat(indent))
+    private String vertical(final Pretty.Node node, final int indent) {
+        final StringBuilder block = new StringBuilder(this.step().repeat(indent))
             .append(node.base)
             .append(node.tail);
         for (final Pretty.Node child : node.children) {
-            block.append('\n').append(Pretty.layout(child, indent + 1));
+            block.append('\n').append(this.layout(child, indent + 1));
         }
         return block.toString();
     }
@@ -100,13 +128,13 @@ final class Pretty {
      * @param indent The indentation level
      * @return The single line, or empty if inlining is impossible
      */
-    private static Optional<String> horizontal(final Pretty.Node node, final int indent) {
+    private Optional<String> horizontal(final Pretty.Node node, final int indent) {
         final Optional<String> result;
         if (node.abstractt || node.children.isEmpty()) {
             result = Optional.empty();
         } else {
             result = Pretty.inlined(node.children).map(
-                args -> new StringBuilder(Pretty.STEP.repeat(indent))
+                args -> new StringBuilder(this.step().repeat(indent))
                     .append(node.base)
                     .append(' ')
                     .append(args)

--- a/eo-printer/src/main/java/org/eolang/printer/Xmir.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Xmir.java
@@ -11,7 +11,9 @@ import com.yegor256.xsline.StClasspath;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Xsline;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.xml.namespace.NamespaceContext;
 import org.eolang.parser.TrFull;
 import org.w3c.dom.Node;
@@ -52,16 +54,36 @@ public final class Xmir implements XML {
     );
 
     /**
+     * The default weights: an empty map, so every key uses its fallback.
+     */
+    private static final Map<PenaltyKey, Integer> DEFAULTS = Collections.emptyMap();
+
+    /**
      * The XML.
      */
     private final XML xml;
 
     /**
-     * Ctor.
+     * The overridden penalty weights, by key.
+     */
+    private final Map<PenaltyKey, Integer> weights;
+
+    /**
+     * Ctor, using the default formatting weights.
      * @param src The source
      */
     public Xmir(final XML src) {
+        this(src, Xmir.DEFAULTS);
+    }
+
+    /**
+     * Ctor.
+     * @param src The source
+     * @param config The formatting weights; absent keys use their defaults
+     */
+    public Xmir(final XML src, final Map<PenaltyKey, Integer> config) {
         this.xml = src;
+        this.weights = config;
     }
 
     @Override
@@ -129,7 +151,8 @@ public final class Xmir implements XML {
         final XML xmir = Xmir.FOR_EO.pass(this.xml);
         Logger.debug(this, "XMIR after converting to EO tree:%n%s", xmir);
         return new Pretty(
-            new Xnav(xmir.inner()).element("object").element("eo")
+            new Xnav(xmir.inner()).element("object").element("eo"),
+            this.weights
         ).asString();
     }
 }

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.printer;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,53 @@ final class PenaltyTest {
             "Empty code should have zero penalty",
             new Penalty("").points(),
             Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void chargesDefaultsForAbsentKeys() {
+        MatcherAssert.assertThat(
+            "An empty weights map should behave exactly like the defaults",
+            new Penalty("42.gt (bar.hello 88) > [] > foo", Collections.emptyMap()).points(),
+            Matchers.equalTo(new Penalty("42.gt (bar.hello 88) > [] > foo").points())
+        );
+    }
+
+    @Test
+    void honoursOverriddenBracketWeight() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.BRACKET, 100);
+        MatcherAssert.assertThat(
+            "A single parenthesis should cost the overridden weight",
+            new Penalty("42.gt (bar.hello 88) > [] > foo", weights).points(),
+            Matchers.equalTo(100)
+        );
+    }
+
+    @Test
+    void honoursOverriddenStepWeight() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.STEP, 4);
+        MatcherAssert.assertThat(
+            "Two levels of four-space indentation should cost two indents",
+            new Penalty(
+                String.join(System.lineSeparator(), "[] > foo", "        bar"),
+                weights
+            ).points(),
+            Matchers.equalTo(6)
+        );
+    }
+
+    @Test
+    void honoursOverriddenWidthWeight() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.WIDTH, 40);
+        MatcherAssert.assertThat(
+            "Characters past the overridden 40th column should be charged",
+            new Penalty(
+                String.join("", java.util.Collections.nCopies(45, "x")), weights
+            ).points(),
+            Matchers.equalTo(5)
         );
     }
 


### PR DESCRIPTION
Closes #5544.

## Problem

The pretty-printer's penalty weights were hard-wired as `private static final int` constants in `Penalty.java` (`INDENT=3`, `BRACKET=7`, `EXCESS=1`, `WIDTH=80`, `STEP=2`). The `Penalty` constructor took only the source string, `Pretty` and `Xmir` passed no formatting configuration, and the `STEP` width was duplicated as the literal `"  "` in `Pretty.java` — a second copy that could silently drift from the constant.

## Changes

- **New `PenaltyKey` enum** (public, in `eo-printer`) — one key per knob (`INDENT`, `BRACKET`, `EXCESS`, `WIDTH`, `STEP`), each carrying its default via `fallback()`.
- **`Penalty`** now takes an optional `Map<PenaltyKey, Integer>` of overrides; any absent key falls back to its default. A convenience constructor keeps the all-defaults behavior.
- **`Pretty`** threads the same map through and derives the indentation string from the `STEP` weight, eliminating the duplicated `"  "` literal.
- **`Xmir`** gains a `Xmir(XML, Map<PenaltyKey, Integer>)` constructor and passes the weights to `Pretty`; the single-argument constructor still uses the defaults.
- **`MjFormat`** exposes each key as a Maven property — `eo.penaltyIndent`, `eo.penaltyBracket`, `eo.penaltyExcess`, `eo.width`, `eo.step` — and assembles only the properties the user actually set into the map before invoking the printer.

## Tests

- `PenaltyTest`: absent keys behave as defaults; overridden `BRACKET`, `STEP`, and `WIDTH` weights take effect.
- `MjFormatTest`: `eo.step` changes the printer's indentation end-to-end.

All existing `eo-printer` and `MjFormat` tests pass, and `qulice` is clean for both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)