### PR TITLE
refactor(#5501): move file to root

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -7,7 +7,6 @@
 +alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package fs
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/eo-runtime/src/main/eo/fs/dir.eo
+++ b/eo-runtime/src/main/eo/fs/dir.eo
@@ -23,7 +23,7 @@
       ^.exists
       ^
       seq *
-        (dir (Q.fs.file ^.as-path.dirname)).made
+        (dir (Q.file ^.as-path.dirname)).made
         if.
           outcome.eq 0
           ^
@@ -58,7 +58,7 @@
   [] > tmpfile
     if. > @
       ^.exists
-      Q.fs.file
+      Q.file
         touch.as-bytes
       T
         "Directory %s does not exist, can't create temporary file".printf

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -8,7 +8,6 @@
 # If none of these are found, it returns the Windows directory (C:\Windows).
 
 +alias fs.dir
-+alias fs.file
 +alias sm.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/java/org/eolang/EO_fs/EOdir$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_fs/EOdir$EOwalk.java
@@ -65,7 +65,7 @@ public final class EOdir$EOwalk extends PhDefault implements Atom {
                     .map(p -> p.substring(p.indexOf(path.toString())))
                     .filter(p -> matcher.matches(Paths.get(p))).map(
                         p -> {
-                            final Phi file = Phi.Φ.take("fs.file").copy();
+                            final Phi file = Phi.Φ.take("file").copy();
                             file.put(0, new ToPhi(p));
                             return file;
                         }


### PR DESCRIPTION
One small step toward the naming conventions discussed in #5501: promote the filesystem `file` object to the root package so it is reachable as a global object, mirroring the earlier `clock` move.

## Changes

- Move `eo-runtime/src/main/eo/fs/file.eo` → `eo-runtime/src/main/eo/file.eo` and drop its `+package fs` directive.
- Update callers to reference the root-level object:
  - `fs/dir.eo`: `Q.fs.file` → `Q.file` (two occurrences).
  - `mktemp.eo`: remove the now-redundant `+alias fs.file` (root objects need no alias).
  - `EO_fs/EOdir$EOwalk.java`: `Phi.Φ.take("fs.file")` → `Phi.Φ.take("file")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01652dHQ8Ecsta9xaNTy46Z9

---
_Generated by [Claude Code](https://claude.ai/code/session_01652dHQ8Ecsta9xaNTy46Z9)_