### PR TITLE
Move console.eo to the root package

### DIFF
--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -61,7 +61,6 @@
 +alias sm.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/eo-runtime/src/test/java/org/eolang/EO_io/InputOutputTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_io/InputOutputTest.java
@@ -66,7 +66,7 @@ final class InputOutputTest {
     /**
      * Console.
      */
-    private static final String CONSOLE = "io.console";
+    private static final String CONSOLE = "console";
 
     /**
      * Stdin.


### PR DESCRIPTION
One small step toward #5501 (consistent naming/layout for eo-runtime objects): move the `console` "resource object" to the root of the object layout.

## Changes

- Moved `eo-runtime/src/main/eo/io/console.eo` → `eo-runtime/src/main/eo/console.eo` and dropped the `+package io` meta.
- Updated the `CONSOLE` constant in `InputOutputTest` from `"io.console"` to `"console"`.

## Notes

- `stdin` and `stdout` (still in the `io` package) reference `console` unqualified; this keeps working because root objects resolve globally (same as `seq`, `true`, etc. already used unqualified there).
- No other references to `io.console` exist in the codebase.

This mirrors the earlier moves of `file`, `clock`, and `socket` to the root package.

Ref #5501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLJchPFobMcCUCiEB72sBz)_