### PR TITLE
Float pipe predecessor up when it sits in an argument block

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/pipe-in-argument-block.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/pipe-in-argument-block.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java
+input: |
+  +package foo
+
+  [y] > app
+    y.plus > @
+      [x] >>
+        x.plus 1 > @
+      | 5

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -611,7 +611,27 @@ R-3.14.5. **Chaining.** Consecutive pipe lines build left-associated application
 
 R-3.14.6. Name suffix per §3.10: `> name`, `>>`, or none (the last only when the pipe is an unnamed intermediate immediately wrapped by a `.method`, which names the whole chain). The atom signature `/sig` and the test attribute `+> name` are rejected — a pipe is an application, not a formation. All-or-nothing inline binding (§6.6) applies to the argument group.
 
-R-3.14.7. **Emission / XMIR.** A pipe line desugars to an ordinary application whose head is a reference to the (named) predecessor, and the predecessor object stays in place. So `| a > r` after a formation `F` (named `F`) is identical in XMIR to `F a > r`; `| a` then `| b` after `F >>` (auto-name `A`) is `A a` (auto-named) followed by `A′ b`. The parser emits the pipe line as a base-less `<o pipe=''>` with the args as children; the `wrap-applications` reshape (§9) sets `@base` from the preceding sibling's `@name` and drops `@pipe`, so every downstream pass (scope resolution, base rolling) treats it as a hand-written application.
+R-3.14.7. **Emission / XMIR.** A pipe line desugars to an ordinary application whose head is a reference to the (named) predecessor. So `| a > r` after a formation `F` (named `F`) is identical in XMIR to `F a > r`; `| a` then `| b` after `F >>` (auto-name `A`) is `A a` (auto-named) followed by `A′ b`. The parser emits the pipe line as a base-less `<o pipe=''>` with the args as children; the `wrap-applications` reshape (§9) sets `@base` from the preceding sibling's `@name` and drops `@pipe`, so every downstream pass (scope resolution, base rolling) treats it as a hand-written application.
+
+R-3.14.8. **Predecessor placement — body vs argument block.** Where the predecessor formation ends up depends on where the pipe sits:
+  - **Body of a formation** (the pipe's parent is abstract): the predecessor stays in place as a named attribute alongside the pipe application, so both are visible to siblings. `[x] > foo` then `| 5 > foo5` yields two attributes, `foo` and `foo5 = foo 5`.
+  - **Argument block** (the pipe's parent is an application, so its siblings are collected as positional arguments): leaving the predecessor in place would make the enclosing application receive it *and* the pipe application as two arguments. Instead the predecessor **floats up** to the nearest enclosing abstract object (via `vars-float-up`, §9) and leaves no argument slot of its own, so the enclosing application receives exactly one argument — the pipe application referring to the floated definition. `wrap-applications` marks such a predecessor with a transient `@float-up`; `vars-float-up` consumes it. For example,
+
+    ```
+    [] > foo
+      bar > @
+        [] > hello
+        | 5
+    ```
+
+    is identical in XMIR to
+
+    ```
+    [] > foo
+      bar > @
+        $.hello 5
+      [] > hello
+    ```
 
 Outer kind: **`pipe-application`** (openness `open` for the vertical form's body, `vertical-completed` for the horizontal form).
 

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
@@ -43,7 +43,7 @@
       <xsl:if test="not(@name) and @as">
         <xsl:attribute name="as" select="@as"/>
       </xsl:if>
-      <xsl:apply-templates select="@* except @as"/>
+      <xsl:apply-templates select="@* except (@as, @float-up)"/>
       <xsl:apply-templates select="node()[not(self::o and eo:test-attr(.))]"/>
       <xsl:for-each select="o/descendant::o[@name]">
         <xsl:if test="ancestor::o[eo:abstract(.)][1]/generate-id() = generate-id($o)">
@@ -62,6 +62,14 @@
       <xsl:apply-templates select="@as"/>
     </xsl:element>
   </xsl:template>
+  <!--
+  A pipe predecessor in an argument block (@float-up, set by
+  wrap-applications for #5526): its definition floats up like any other
+  named object, but it leaves no in-place argument slot — the pipe
+  application that follows it is the sole argument. So we drop the
+  in-place occurrence entirely instead of replacing it with a reference.
+  -->
+  <xsl:template match="o[@float-up and @name and ancestor::o[1][not(eo:abstract(.))]]" priority="2"/>
   <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
@@ -19,6 +19,14 @@
   place, so `| 5 > foo5` after `[x] > foo` is identical in XMIR to
   `foo 5 > foo5`. Chained pipes read the previous pipe's @name the same
   way, building left-associated applications.
+
+  When the pipe sits inside an argument block (its parent has a @base,
+  so its siblings are collected as positional arguments), leaving the
+  predecessor formation in place would give the enclosing application
+  two arguments instead of one (#5526). We mark such a predecessor with
+  @float-up; `vars-float-up` then hoists its definition to the nearest
+  abstract object and drops the in-place argument slot, so only the pipe
+  application reaches the enclosing application.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@pipe]">
@@ -28,6 +36,13 @@
       </xsl:attribute>
       <xsl:apply-templates select="@* except @pipe"/>
       <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- Predecessor formation of a pipe in an argument block: float it up. -->
+  <xsl:template match="o[@name and not(@base) and ../@base and following-sibling::o[1][@pipe]]">
+    <xsl:copy>
+      <xsl:attribute name="float-up"/>
+      <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
   <!-- Default copying -->

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-floats-formation-up.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-floats-formation-up.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.bar' and count(o)=1]
+  - //o[@base='Φ.bar']/o[@base='ξ.hello' and o[@base='Φ.number']]
+  - //o[@name='foo']/o[@name='hello' and not(@base)]
+input: |
+  [] > foo
+    bar > @
+      [] > hello
+      | 5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-in-argument-block-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-in-argument-block-named.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='ξ.y.plus' and count(o)=1]
+  - //o[@base='ξ.y.plus']/o[@base='ξ.foo' and o[@base='Φ.number']]
+  - //o[@name='app']/o[@name='foo' and not(@base) and o[@base='∅' and @name='x']]
+input: |
+  [y] > app
+    y.plus > @
+      [x] > foo
+        x.plus 1 > @
+      | 5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-in-argument-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-in-argument-block.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='ξ.y.plus' and count(o)=1]
+  - //o[@base='ξ.y.plus']/o[starts-with(@base,'ξ.') and o[@base='Φ.number']]
+  - //o[@name='app']/o[not(@base) and o[@base='∅' and @name='x']]
+input: |
+  [y] > app
+    y.plus > @
+      [x] >>
+        x.plus 1 > @
+      | 5

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation-vertical.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation-vertical.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+input: |
+  [] > app
+    [a b]
+      a.plus b > @
+    | >>
+      2
+      3

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+input: |
+  [] > app
+    [x]
+      x.plus x > @
+    | 5 > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-in-argument-block.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-in-argument-block.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  [] > foo
+    bar > @
+      [] > hello
+      | 5
+
+printed: |
+  [] > foo
+    bar > @
+      hello 5
+    [] > hello

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  [] > app
+    [x] > foo
+      x.plus x > @
+    | 5 > foo5
+
+printed: |
+  [] > app
+    [x] > foo
+      x.plus x > @
+    foo 5 > foo5


### PR DESCRIPTION
A pipe that follows a named formation inside another object's argument block used to leave the formation as a separate positional argument, so the enclosing application received two arguments where it should get one. The recursive helper inlined in `number/sine.eo` hit this as `number.times` being handed two arguments.

`wrap-applications` now recognises a pipe predecessor that sits in an argument block — its parent carries a `@base`, so its siblings are collected as arguments — and marks it with a transient `@float-up`. `vars-float-up` hoists that formation's definition to the nearest abstract object and drops its in-place argument slot, leaving the pipe application (which refers to the floated definition) as the only argument. So

```
[] > foo
  bar > @
    [] > hello
    | 5
```

parses to the same XMIR as

```
[] > foo
  bar > @
    $.hello 5
  [] > hello
```

In a formation body nothing changes: the predecessor stays put as a named attribute next to the pipe application.

Pipes stay restricted to named formations, an auto-named `>>` included; a bare formation with a pipe is a parse error. New typo packs cover that, and printer packs confirm both a body pipe and an argument-block pipe round-trip.

Closes #5526
