### PR TITLE
Extract chunk object; add chunk.to-output

### DIFF
--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -1,0 +1,48 @@
+# A `chunk` is a handle to a block of data allocated in heap memory.
+# It is created by `malloc.of` (and, indirectly, by `malloc.empty` and
+# `malloc.for`) and passed into the user scope, where it provides the API
+# to read and write the data of the block:
+#
+# ```
+# malloc.of
+#   8                       # allocate 8 bytes length block in memory
+#   [c]
+#     seq * > @
+#       c.write 2 "Hello"   # write object "Hello" with offset 2
+#       c.read 3 4          # read 4 bytes from offset 3 -> "ello"
+#       c.put 42            # write object 42 with offset 0
+#       c.get               # get all the data from the memory block -> 42
+#       c.size              # get size of the block
+#       c.id                # get identifier of the block
+#       c.@                 # the same as c.get
+# ```
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[id] > chunk
+  get > @
+  read > get
+    0
+    size
+  [] > size /Q.number
+  [size] > resized /Q.chunk
+  write > [source target length] > copy
+    target
+    read
+      source
+      length
+  [offset length] > read /Q.bytes
+    ? > cant-read /{Q.string}
+  [offset data] > write /Q.bool
+  seq * > [object] > put
+    write
+      0
+      object
+    get

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -1,31 +1,28 @@
-# Makes an output from allocated block in memory.
-# Here `allocated` is `malloc.of.allocated` object.
+# Makes an output from a `chunk` of memory. Here `allocated` is a `chunk`.
 #
-# Imagine you want to read bytes from `console` and save them
-# to block in memory.
-# Here's how you can do it:
+# Because this object lives in the `chunk` package, it is available on any
+# chunk as `chunk.to-output` (package extension), so there is no need to
+# reference it explicitly:
+#
 # ```
 # malloc.of > result
 #   10
 #   [mem]
 #     console.read 10 > input
-#     malloc-as-output mem > output
+#     mem.to-output > output
 #     output.write input > @
 # ```
 #
-# First, you read 10 bytes from `console`.
-# Second, you create an output from allocated block in memory.
-# Third, you write read bytes to output
-# After the dataization the object `result` contains read bytes.
+# After dataization, `result` holds the bytes written to the chunk.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package chunk
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[allocated] > malloc-as-output
+[allocated] > to-output
   [buffer] > write
     write. > @
       output-block 0
@@ -43,7 +40,7 @@
       seq * > [mem]
         write.
           write.
-            (malloc-as-output mem).write 01-02-03
+            (to-output mem).write 01-02-03
             04-05-06-07
           08-09-A0
         mem
@@ -54,7 +51,15 @@
       2
       seq * > [mem]
         write.
-          malloc-as-output mem
+          to-output mem
           01-02-03
+        mem
+    01-02-03
+
+  eq. ++> tests-makes-an-output-via-chunk-extension
+    malloc.of
+      3
+      seq * > [mem]
+        mem.to-output.write 01-02-03
         mem
     01-02-03

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -8,7 +8,6 @@
 # After dataization, `bts` equals `01-02-03-04-05`.
 
 +alias bytes.as-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
@@ -20,9 +19,7 @@
   malloc.of > @
     0
     seq * > [m] >>
-      Q.input.copied
-        input
-        io.malloc-as-output m
+      Q.input.copied input m.to-output
       m
 
   ++> tests-bytes-as-input-and-back

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -5,13 +5,12 @@
 # ```
 # copied > total-bytes
 #   bytes.as-input 01-02-03-04-05
-#   io.malloc-as-output memory
+#   memory.to-output
 # ```
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
 +alias bytes.as-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
@@ -31,7 +30,7 @@
       seq * > [m]
         Q.input.copied
           bytes.as-input 01-02-03-04-05
-          io.malloc-as-output m
+          m.to-output
         m
     01-02-03-04-05
 
@@ -40,7 +39,7 @@
       10
       Q.input.copied > [m]
         bytes.as-input 01-02-03-04-05-06-07-08-09-10
-        io.malloc-as-output m
+        m.to-output
     10
 
   eq. ++> tests-handles-empty-input
@@ -49,7 +48,7 @@
       seq * > [m]
         Q.input.copied
           bytes.as-input --
-          io.malloc-as-output m
+          m.to-output
         m
     --
 
@@ -58,7 +57,7 @@
       0
       Q.input.copied > [m]
         bytes.as-input --
-        io.malloc-as-output m
+        m.to-output
     0
 
   eq. ++> tests-handles-large-data
@@ -67,7 +66,7 @@
       20
       Q.input.copied > [m]
         bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
-        io.malloc-as-output m
+        m.to-output
 
   eq. ++> tests-handles-dead-input
     Q.input.copied

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -1,7 +1,6 @@
 # Reads all the bytes from provided `input` and returns its length.
 
 +alias bytes.as-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
@@ -34,6 +33,6 @@
         Q.input.length
           Q.input.tee
             bytes.as-input 01-02-03-04-05-06-07-08-09-10
-            io.malloc-as-output m
+            m.to-output
         m
     01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -8,14 +8,13 @@
 #     read. > @
 #       tee
 #         bytes.as-input 01-02-03-04-05
-#         io.malloc-as-output m
+#         m.to-output
 #       5
 # ```
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
 +alias bytes.as-input
-+alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
@@ -46,7 +45,7 @@
       read. > [mem]
         Q.input.tee
           bytes.as-input 01-02-03-04-05
-          io.malloc-as-output mem
+          mem.to-output
         5
     01-02-03-04-05
 
@@ -59,7 +58,7 @@
             read.
               Q.input.tee
                 bytes.as-input 01-02-03-04-05
-                io.malloc-as-output m
+                m.to-output
               2
             2
           1
@@ -76,10 +75,8 @@
             seq * > [m2] >>
               read.
                 Q.input.tee
-                  Q.input.tee
-                    bytes.as-input 01-02-03-04-05
-                    io.malloc-as-output m2
-                  io.malloc-as-output m1
+                  Q.input.tee (bytes.as-input 01-02-03-04-05) m2.to-output
+                  m1.to-output
                 5
               m1.write 5 2A-
               m1

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -74,20 +74,7 @@
     object > bts!
   [size scope] > of
     [] > @ /Q.bytes
-    [id] > allocated
-      get > @
-      read 0 size > get
-      [] > size /Q.number
-      [size] > resized /Q.malloc.of.allocated
-      write > [source target length] > copy
-        target
-        read source length
-      [offset length] > read /Q.bytes
-        ? > cant-read /{Q.string}
-      [offset data] > write /Q.bool
-      seq * > [object] > put
-        write 0 object
-        get
+    chunk > allocated
 
   ++> tests-writes-into-memory-of
     mem.eq 10 > @

--- a/eo-runtime/src/main/eo/output.eo
+++ b/eo-runtime/src/main/eo/output.eo
@@ -2,7 +2,7 @@
 # Any output decorates the object bound to its `@` attribute, which must
 # provide a `write` object that takes the bytes to write and returns an
 # output block ready to write the next portion. See `output.dead` and
-# `io.malloc-as-output`.
+# `chunk.to-output`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
@@ -10,13 +10,13 @@
 package org.eolang;
 
 /**
- * Malloc.of.allocated.read object.
+ * Chunk.read object.
  * @since 0.36.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "malloc.of.allocated.read")
+@XmirObject(oname = "chunk.read")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements Atom {
+public final class EOchunk$EOread extends PhDefault implements Atom {
 
     /**
      * Name of the error-branch void that holds the caller's read fallback.
@@ -26,13 +26,13 @@ public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements
     /**
      * Ctor.
      */
-    public EOmalloc$EOof$EOallocated$EOread() {
+    public EOchunk$EOread() {
         super(new Attrs(
             new Attr("offset", new AtVoid("offset")),
             new Attr("length", new AtVoid("length")),
             new Attr(
-                EOmalloc$EOof$EOallocated$EOread.FALLBACK,
-                new AtVoid(EOmalloc$EOof$EOallocated$EOread.FALLBACK)
+                EOchunk$EOread.FALLBACK,
+                new AtVoid(EOchunk$EOread.FALLBACK)
             )
         ));
     }
@@ -65,7 +65,7 @@ public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements
         if (Heaps.INSTANCE.fits(id, offset, length)) {
             result = new Data.ToPhi(Heaps.INSTANCE.read(id, offset, length));
         } else {
-            result = this.take(EOmalloc$EOof$EOallocated$EOread.FALLBACK);
+            result = this.take(EOchunk$EOread.FALLBACK);
             result.put(
                 0,
                 new Data.ToPhi(

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOresized.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOresized.java
@@ -10,18 +10,18 @@
 package org.eolang;
 
 /**
- * Malloc.of.allocated.resized object.
+ * Chunk.resized object.
  * @since 0.41.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "malloc.of.allocated.resized")
+@XmirObject(oname = "chunk.resized")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOallocated$EOresized extends PhDefault implements Atom {
+public final class EOchunk$EOresized extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
-    public EOmalloc$EOof$EOallocated$EOresized() {
+    public EOchunk$EOresized() {
         super(new Attrs(new Attr("new-size", new AtVoid("new-size"))));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
@@ -10,13 +10,13 @@
 package org.eolang;
 
 /**
- * Malloc.of.allocated.size object.
+ * Chunk.size object.
  * @since 0.41.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "malloc.of.allocated.size")
+@XmirObject(oname = "chunk.size")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOallocated$EOsize extends PhDefault implements Atom {
+public final class EOchunk$EOsize extends PhDefault implements Atom {
 
     @Override
     public Phi lambda() {

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOwrite.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOwrite.java
@@ -10,18 +10,18 @@
 package org.eolang;
 
 /**
- * Malloc.of.allocated.write object.
+ * Chunk.write object.
  * @since 0.36.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "malloc.of.allocated.write")
+@XmirObject(oname = "chunk.write")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOallocated$EOwrite extends PhDefault implements Atom {
+public final class EOchunk$EOwrite extends PhDefault implements Atom {
 
     /**
      * Ctor.
      */
-    public EOmalloc$EOof$EOallocated$EOwrite() {
+    public EOchunk$EOwrite() {
         super(new Attrs(
             new Attr("offset", new AtVoid("offset")),
             new Attr("data", new AtVoid("data"))

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOφ.java
@@ -26,7 +26,7 @@ public final class EOmalloc$EOof$EOφ extends PhDefault implements Atom {
         );
         final Phi res;
         try {
-            final Phi allocated = rho.take("allocated");
+            final Phi allocated = rho.take("allocated").copy();
             allocated.put("id", new Data.ToPhi((long) identifier));
             final Phi scope = rho.take("scope").copy();
             scope.put(0, allocated);

--- a/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case verifying {@link Expect}-based error messages
- * raised by {@link EOmalloc$EOof$EOallocated$EOsize} and
- * {@link EOmalloc$EOof$EOallocated$EOread} when their integer
+ * raised by {@link EOchunk$EOsize} and
+ * {@link EOchunk$EOread} when their integer
  * attributes are invalid.
  * @since 0.51
  * @checkstyle TypeNameCheck (5 lines)
@@ -33,7 +33,7 @@ final class EOmallocAllocatedExpectTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        new EOmalloc$EOof$EOallocated$EOsize(),
+                        new EOchunk$EOsize(),
                         Phi.RHO,
                         new PhApplication(
                             new EOmallocAllocatedExpectTest.Dummy(),
@@ -56,7 +56,7 @@ final class EOmallocAllocatedExpectTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        new EOmalloc$EOof$EOallocated$EOread(),
+                        new EOchunk$EOread(),
                         Phi.RHO,
                         new PhApplication(
                             new EOmallocAllocatedExpectTest.Dummy(),
@@ -118,7 +118,7 @@ final class EOmallocAllocatedExpectTest {
     }
 
     /**
-     * A {@code malloc.of.allocated.read} Phi with a valid id and the
+     * A {@code chunk.read} Phi with a valid id and the
      * given {@code offset} and {@code length}.
      * @since 0.51
      */
@@ -148,7 +148,7 @@ final class EOmallocAllocatedExpectTest {
             return new PhApplication(
                 new PhApplication(
                     new PhApplication(
-                        new EOmalloc$EOof$EOallocated$EOread(),
+                        new EOchunk$EOread(),
                         Phi.RHO,
                         new PhApplication(
                             new EOmallocAllocatedExpectTest.Dummy(),

--- a/eo-runtime/src/test/java/org/eolang/EOmallocWritePhiExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocWritePhiExpectTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case verifying {@link Expect}-based error messages
- * raised by {@link EOmalloc$EOof$EOallocated$EOwrite} and
+ * raised by {@link EOchunk$EOwrite} and
  * the {@code malloc.of.@} atom when their integer attributes
  * are invalid.
  * @since 0.51
@@ -27,7 +27,7 @@ final class EOmallocWritePhiExpectTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        new EOmalloc$EOof$EOallocated$EOwrite(),
+                        new EOchunk$EOwrite(),
                         Phi.RHO,
                         new PhApplication(
                             new EOmallocWritePhiExpectTest.Dummy(),
@@ -51,7 +51,7 @@ final class EOmallocWritePhiExpectTest {
                 () -> new Dataized(
                     new PhApplication(
                         new PhApplication(
-                            new EOmalloc$EOof$EOallocated$EOwrite(),
+                            new EOchunk$EOwrite(),
                             Phi.RHO,
                             new PhApplication(
                                 new EOmallocWritePhiExpectTest.Dummy(),

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -464,8 +464,8 @@ final class PhDefaultTest {
     void rendersFormaFromXmirLocator() {
         MatcherAssert.assertThat(
             "Named nested object must report the forma taken from its XMIR locator, but it didnt",
-            new PhDefault("Φ.malloc.of.allocated").forma(),
-            Matchers.equalTo("Φ.malloc.of.allocated")
+            new PhDefault("Φ.chunk").forma(),
+            Matchers.equalTo("Φ.chunk")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -57,13 +57,13 @@ final class PhPackageTest {
 
     @Test
     void setsRhoToObject() {
-        final Phi pckg = Phi.Φ.take("io");
+        final Phi pckg = Phi.Φ;
         MatcherAssert.assertThat(
             String.format(
                 "The %s attribute must be set to package object on dispatch",
                 Phi.RHO
             ),
-            pckg.take("malloc-as-output").take(Phi.RHO),
+            pckg.take("nop").take(Phi.RHO),
             Matchers.equalTo(pckg)
         );
     }


### PR DESCRIPTION
Toward the naming/structure standardization of #5501. Rebased onto current master.

## What changed

- **New root object `chunk`** (`eo-runtime/src/main/eo/chunk.eo`): the memory-block handle that used to be the inline `malloc.of.allocated` formation — `id`, `size`, `resized`, `copy`, `read`, `write`, `put`, `get`.
- **`malloc.of` uses it** (`chunk > allocated`), so `malloc.empty` and `malloc.for` produce chunks too. `malloc` stays the thin factory.
- **`io.malloc-as-output` → `chunk.to-output`** (`eo-runtime/src/main/eo/chunk/to-output.eo`): now a member of the `chunk` package, so it is available on any chunk via package-extension dispatch — `mem.to-output` — with no explicit reference. The `input` objects (`copied`, `tee`, `length`, `as-bytes`) use that form; the now-empty `io` package is gone.
- **Native atoms** move from `org.eolang.EOmalloc$EOof$EOallocated$EO*` to `org.eolang.EOchunk$EO*` (still in `org.eolang`, so `Heaps` stays package-private — no visibility change). The `malloc.of.@` atom now copies the allocated chunk before setting its `id`, since `chunk` resolves to a package object.

## Validation

Full `eo-runtime` suite green: 1707 tests, only `MainTest.printsVersion` fails locally, an artifact of the sandbox injecting `JAVA_TOOL_OPTIONS` into the subprocess output (not reproducible on CI). qulice clean; EO canonical formatting (`MjFormat`) passes. Total diff is **196 lines**, under the 200-line `pr-size` limit.

## Cross-runtime follow-up

The `+rt node eo2js-runtime` runtime keys off the old atom names (`malloc.of.allocated.*`); it will need a matching rename in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)