### PR TITLE
fix(#5562): printer emits `++>` shorthand instead of `[] +>`

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -143,14 +143,19 @@
   </xsl:template>
   <!-- ABSTRACT OR ATOM -->
   <xsl:template match="o[eo:abstract(.) and not(eo:has-data(.))]" mode="head">
-    <xsl:text>[</xsl:text>
-    <xsl:for-each select="o[eo:void(.)]">
-      <xsl:if test="position()&gt;1">
-        <xsl:text> </xsl:text>
-      </xsl:if>
-      <xsl:value-of select="@name"/>
-    </xsl:for-each>
-    <xsl:text>]</xsl:text>
+    <!-- A test attribute with no void params collapses its empty `[]`
+         head into the `++&gt;` suffix (see the tail template), so it emits
+         no head of its own. -->
+    <xsl:if test="not(eo:test-attr(.) and empty(o[eo:void(.)]))">
+      <xsl:text>[</xsl:text>
+      <xsl:for-each select="o[eo:void(.)]">
+        <xsl:if test="position()&gt;1">
+          <xsl:text> </xsl:text>
+        </xsl:if>
+        <xsl:value-of select="@name"/>
+      </xsl:for-each>
+      <xsl:text>]</xsl:text>
+    </xsl:if>
   </xsl:template>
   <!-- TAIL: SUFFIX, NAME, CONST, ATOM -->
   <xsl:template match="o" mode="tail">
@@ -168,7 +173,17 @@
     <xsl:if test="@name">
       <xsl:choose>
         <xsl:when test="eo:test-attr(.)">
-          <xsl:text> +&gt; </xsl:text>
+          <xsl:choose>
+            <!-- No void params: collapse the empty `[]` head into a
+                 single `++&gt; name` head (the head template emits
+                 nothing in this case). -->
+            <xsl:when test="empty(o[eo:void(.)])">
+              <xsl:text>++&gt; </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text> +&gt; </xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
           <xsl:value-of select="substring-after(@name, '+')"/>
         </xsl:when>
         <xsl:when test="starts-with(@name, concat('a', $eo:cactoos))">

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
@@ -17,5 +17,5 @@ printed: |
 
   [x] > dataized /bytes
 
-    [] +> tests-something
+    ++> tests-something
       ^.x.eq ^.x > @


### PR DESCRIPTION
Fixes #5562.

## Problem

Since the #5548 fix (#5554), `Xmir.toEO()` printed every test attribute as the verbose `[] +> name`, undoing the `++>` shorthand added to the parser in #5445. Running the `format` goal on `eo-runtime` therefore rewrote all the concise `++> tests-…` declarations into the noisy `[] +> tests-…` form. A canonicalizing printer should emit the shorter, preferred sugar, not expand it back.

## Fix

In `to-eo-tree.xsl`:

- **Abstract-head renderer**: a test attribute (`eo:test-attr`) with an empty void list now emits no head at all, instead of the boilerplate `[]`.
- **Tail renderer**: for such a test attribute the suffix collapses into a single `++> name` head (no leading space, no separate `[]`). Test attributes that carry void params — should any exist — still print the `[params] +> name` form.

The `Pretty` blank-line rule for test attributes is unchanged.

## Tests

- Updated `test-attribute.yaml` print-pack to expect `++> tests-something`. This also fixes the round-trip: the pack's `origin` already used `++>`, so `printsToEo` and `printsToParseableEo` (idempotency) now both hold.
- Full `eo-printer` suite green (75 tests, including all 53 `XmirTest` cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBH5Zw4qLqJ59hthAvVd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgBH5Zw4qLqJ59hthAvVd1)_