### PR TITLE
fix(#5564): drop redundant `^.` parent prefixes on auto-resolvable names

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -123,6 +123,11 @@
   </xsl:template>
   <!-- BASED -->
   <xsl:template match="o[@base and not(eo:has-data(.))]" mode="head">
+    <!-- A base of the form "ξ.ρ.name…" is a single parent hop onto a
+         name that lives in the enclosing scope. -->
+    <xsl:variable name="rho-prefix" select="concat($eo:xi, '.', $eo:rho, '.')"/>
+    <xsl:variable name="rest" select="substring-after(@base, $rho-prefix)"/>
+    <xsl:variable name="first" select="if (contains($rest, '.')) then substring-before($rest, '.') else $rest"/>
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
@@ -135,6 +140,12 @@
         <!-- The plain top-level name would be shadowed by an in-scope
              attribute, so keep the explicit Q. root to disambiguate. -->
         <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
+      </xsl:when>
+      <xsl:when test="starts-with(@base, $rho-prefix) and $first != '' and $first != $eo:rho and $first != $eo:phi and $first != $eo:xi and $first != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$first]) and exists(ancestor::o[not(@base)][2]/o[@name=$first])">
+        <!-- The single leading "^." parent hop is redundant: the name is
+             absent from the immediate scope but present in its parent, so
+             plain scope resolution re-derives the very same hop. Drop it. -->
+        <xsl:value-of select="eo:translate-path($rest)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="eo:surface(@base)"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
@@ -36,10 +36,10 @@ printed: |
     [] > base
       memory 0 > x
       [self v] > f
-        ^.x.write v > @
+        x.write v > @
       [self v] > g
         self.f self v > @
     [] > derived
-      ^.base > @
+      base > @
       [self v] > f
         self.g self v > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+origin: |
+  +package org.eolang
+
+  [x] > foo
+    [] > bar
+      ^.x > @
+    [x] > baz
+      ^.x > @
+
+printed: |
+  +package org.eolang
+
+  [x] > foo
+    [] > bar
+      x > @
+    [x] > baz
+      ^.x > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
@@ -18,4 +18,4 @@ printed: |
   [x] > dataized /bytes
 
     [] +> tests-something
-      ^.x.eq ^.x > @
+      x.eq x > @


### PR DESCRIPTION
Closes #5564.

## Problem

`Xmir.toEO()` printed an explicit `^.` (parent) prefix on every reference that resolves through the enclosing object. The new `format` goal spread these across `eo-runtime` (446 `^.` occurrences), e.g. `^.reclast`, `^.v13_2`, `^.separator`. Most were plain names in the source that the parser resolves to the parent automatically, so the explicit `^.` was pure noise: `^.reclast` and `reclast` produce identical XMIR.

## Fix

The `^` is emitted by the surface renderer in `eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl`. After `build-fqns` + `roll-bases`, such a reference has a rolled base of the form `ξ.ρ.name…` (a single parent hop onto a name from the enclosing scope).

The printer now drops that single leading `^.` hop when:
- the referenced name is **absent** from the immediate enclosing formation's scope, **and**
- the name **is present** in the parent formation.

Those two conditions guarantee that plain scope resolution re-derives exactly the same one-hop `ξ.ρ.name`, so the output stays semantically identical and round-trips cleanly. The hop is **kept** whenever a closer-scope binding would shadow the name (which would change resolution), and multi-hop (`^.^.x`), `^.@` (`ρ.φ`), and program-rooted (`Q.`) forms are all left untouched.

## Changes

- `to-eo-tree.xsl`: new `xsl:when` in the `BASED` head template that recognizes a redundant single `^.` hop and prints the bare name instead.
- `print-packs/yaml/redundant-parent.yaml`: new test covering both the drop case and the shadowed keep-`^.` case.
- `print-packs/yaml/test-attribute.yaml`, `print-packs/yaml/inheritance.yaml`: expected output updated to the cleaner form (`x.eq x`, `x.write v`, `base` instead of the `^.`-prefixed variants).

## Verification

All 77 `eo-printer` tests pass, including the round-trip `printsToParseableEo` check that re-parses and re-prints every fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpjDLen39dn19dCrdCcZ3R)_