### PR TITLE
fix(#5563): keep `&gt;&gt;` file-local handles so the printer prints readable names

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1199,7 +1199,7 @@ R-9.2.2. The cactus 🌵 is reserved — it is excluded from the `NAME` token (�
 
 Example: a `>>` suffix at `line=12, pos=5` emits `@name="a🌵12-5"`.
 
-R-9.2.3. **File-local handles (R-3.10.12).** A `>> name` suffix emits the object with its cactus `@name` **and** a `@local="name"` marker; references stay as plain `<o base='name'>`. The first-pass `resolve-local-names` reshape (right after `wrap-applications` / `resolve-self`, before `build-fqns`) collects the per-file `@local → @name` table, rewrites every `@base` equal to a handle into the matching cactus `@name`, and drops the `@local` markers; a handle declared twice is reported there as a `resolve-local-names` check error. Downstream passes see only ordinary references by the reserved cactus name.
+R-9.2.3. **File-local handles (R-3.10.12).** A `>> name` suffix emits the object with its cactus `@name` **and** a `@local="name"` marker; references stay as plain `<o base='name'>`. The first-pass `resolve-local-names` reshape (right after `wrap-applications` / `resolve-self`, before `build-fqns`) collects the per-file `@local → @name` table and rewrites every `@base` equal to a handle into the matching cactus `@name`; a handle declared twice is reported there as a `resolve-local-names` check error. The `@local` marker is **kept** on the declaring object so that the readable handle can be recovered from the otherwise-synthetic cactus name — in particular by the printer, which prints `? >> name` voids back under their handle rather than a `vL_P` placeholder (#5563). Downstream compilation passes reference the reserved cactus name and ignore the marker.
 
 ### 9.3 Source-token to XMIR-character mapping
 

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -323,8 +323,10 @@ final class Emit {
     /**
      * Add the {@code @local="name"} attribute to the most recently
      * opened {@code <o>} — the file-local handle of an anonymous
-     * ({@code >> name}) formation (§3.10 / §9.2), resolved and dropped
-     * by the {@code resolve-local-names} reshape.
+     * ({@code >> name}) formation (§3.10 / §9.2). The
+     * {@code resolve-local-names} reshape uses it to resolve references
+     * and keeps it on the declaring object so the readable handle can be
+     * recovered later (for example by the printer, see #5563).
      * @param name The file-local handle
      */
     void local(final String name) {

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -145,9 +145,9 @@
     <xs:attribute name="as" type="attribute-name"/>
     <xs:attribute name="local" type="attribute-name">
       <xs:annotation>
-        <xs:appinfo>The file-local handle of an anonymous ">> name" object</xs:appinfo>
+        <xs:appinfo>The file-local handle of an anonymous "&gt;&gt; name" object</xs:appinfo>
         <xs:documentation>
-          The readable file-local handle declared with the ">> name" suffix
+          The readable file-local handle declared with the "&gt;&gt; name" suffix
           (R-3.10.12). The object's externally visible "name" is a synthetic
           cactus identifier, unreachable from outside the file; this attribute
           preserves the human-written handle so that references to it can be

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -143,6 +143,19 @@
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="as" type="attribute-name"/>
+    <xs:attribute name="local" type="attribute-name">
+      <xs:annotation>
+        <xs:appinfo>The file-local handle of an anonymous ">> name" object</xs:appinfo>
+        <xs:documentation>
+          The readable file-local handle declared with the ">> name" suffix
+          (R-3.10.12). The object's externally visible "name" is a synthetic
+          cactus identifier, unreachable from outside the file; this attribute
+          preserves the human-written handle so that references to it can be
+          resolved within the file and the object can be printed back to EO
+          under its original name.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="loc" type="locator"/>
     <xs:attribute name="atom" type="fqn">
       <xs:annotation>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -7,9 +7,12 @@
   <!--
   The "&gt;&gt; foo" file-local handle (§3.10 / §9.2): the parser emits the
   anonymous object with its cactus @name plus a "@local='foo'" marker. We
-  build the per-file "handle -&gt; cactus-name" table, rewrite every @base
-  equal to a handle into that (reserved) cactus name, and drop the markers;
-  a handle declared more than once is an error.
+  build the per-file "handle -&gt; cactus-name" table and rewrite every @base
+  equal to a handle into that (reserved) cactus name; a handle declared more
+  than once is an error. The "@local" marker is deliberately kept on the
+  declaring object so that later passes (in particular the printer, see
+  #5563) can recover the readable handle from the otherwise-synthetic cactus
+  name instead of printing a placeholder like "vL_P".
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:key name="handle" match="o[@local]" use="@local"/>
@@ -20,7 +23,6 @@
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="o/@local"/>
   <xsl:template match="/object">
     <xsl:copy>
       <xsl:apply-templates select="(node() except errors)|@*"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-duplicate.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-duplicate.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /object/errors[count(error)=1]
   - /object/errors/error[@check='resolve-local-names' and @severity='error' and @line='4']
-  - /object[not(//o[@local])]
+  - /object[count(//o[@local='dup'])=2]
 input: |
   [] > app
     [n] >> dup

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names.yaml
@@ -6,9 +6,8 @@ sheets:
   - /org/eolang/parser/parse/resolve-local-names.xsl
 asserts:
   - /object[not(errors)]
-  - /object[not(//o[@local])]
   - /object[count(//o[@base='a🌵2-2'])=2]
-  - //o[@name='a🌵2-2']
+  - //o[@name='a🌵2-2' and @local='fibo']
 input: |
   [] > app
     [n] >> fibo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle-duplicate.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle-duplicate.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /object/errors[count(error)=1]
   - /object/errors/error[@check='resolve-local-names' and @severity='error' and @line='3']
-  - /object[not(//o[@local])]
+  - /object[count(//o[@local='dup'])=2]
 input: |
   [] > app
     ? >> dup

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle.yaml
@@ -6,9 +6,8 @@ sheets:
   - /org/eolang/parser/parse/resolve-local-names.xsl
 asserts:
   - /object[not(errors)]
-  - /object[not(//o[@local])]
-  - //o[@name='a🌵2-2' and @base='∅']
-  - //o[@name='a🌵3-2' and @base='∅']
+  - //o[@name='a🌵2-2' and @base='∅' and @local='left']
+  - //o[@name='a🌵3-2' and @base='∅' and @local='right']
   - //o[@base='a🌵3-2' and @name='φ']
 input: |
   [] > false

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/void-auto-named-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/void-auto-named-handle.yaml
@@ -5,10 +5,9 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - /object[not(//o[@local])]
   - /object/o[@name='foo'][count(o[@base='∅'])=2]
-  - /object/o[@name='foo']/o[@name='a🌵2-2' and @base='∅']
-  - /object/o[@name='foo']/o[@name='a🌵3-2' and @base='∅']
+  - /object/o[@name='foo']/o[@name='a🌵2-2' and @base='∅' and @local='left']
+  - /object/o[@name='foo']/o[@name='a🌵3-2' and @base='∅' and @local='right']
   - //o[@base='ξ.a🌵3-2' and @name='φ']
 input: |
   [] > foo

--- a/eo-printer/src/main/java/org/eolang/printer/Xmir.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Xmir.java
@@ -44,6 +44,7 @@ public final class Xmir implements XML {
         new TrFull(
             new TrDefault<>(
                 new StUnhex(),
+                new StClasspath("/org/eolang/printer/print/restore-local-names.xsl"),
                 new StClasspath("/org/eolang/printer/print/tuples-to-stars.xsl"),
                 new StClasspath("/org/eolang/printer/print/inline-cactoos.xsl"),
                 new StClasspath("/org/eolang/printer/print/dataized-to-const.xsl"),

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="eo xs" id="restore-local-names" version="2.0">
+  <!--
+  Inverse of the parser's "resolve-local-names" pass, applied before
+  printing (#5563). A void declared with a file-local handle
+  ("? &gt;&gt; name", R-3.10.12) keeps a synthetic cactus @name plus a
+  "@local='name'" marker; the parser resolves references to the cactus name
+  but the readable handle is preserved on the void. Here we put the handle
+  back: the void's @name becomes its handle and every @base segment that
+  points at that cactus name is rewritten to the handle, so the printer
+  emits "[name]" and "name" instead of a synthetic "vL_P" placeholder. A
+  non-void "&gt;&gt;" handle (on an anonymous formation) is left to the
+  existing "inline-cactoos" pass, so its @local marker is simply dropped.
+  -->
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:key name="void-handle" match="o[@local and @base=$eo:empty]" use="@name"/>
+  <!-- References: rewrite each cactus segment that names a handled void
+       back into the readable handle. -->
+  <xsl:template match="@base">
+    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then key('void-handle', $seg)[1]/@local else $seg), '.')"/>
+  </xsl:template>
+  <!-- Void declaration: promote the handle to the visible name. -->
+  <xsl:template match="o[@local and @base=$eo:empty]/@name">
+    <xsl:attribute name="name" select="../@local"/>
+  </xsl:template>
+  <!-- Drop the marker (already applied on voids above; unused on formations). -->
+  <xsl:template match="o/@local"/>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
@@ -12,5 +12,5 @@ origin: |
 printed: |
   +package org.eolang
 
-  [v4_2] > as-bool
-    v4_2.eq 01- > @
+  [bts] > as-bool
+    bts.eq 01- > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A void declared with a file-local handle ("? >> name", R-3.10.12) must
+# print back under that readable handle, not a synthetic "vL_P" placeholder
+# (#5563). The handle survives even when referenced from a sibling
+# attribute (here "^.wanted" inside "reclast").
+origin: |
+  +package tuple
+
+  [] > last-index-of
+    ? >> list
+    ? >> wanted
+    reclast list > @
+    [tup] > reclast
+      if. > @
+        tup.length.eq 0
+        -1
+        if.
+          tup.head.eq wanted
+          tup.tail.length
+          reclast tup.tail
+
+printed: |
+  +package tuple
+
+  [list wanted] > last-index-of
+    reclast list > @
+    [tup] > reclast
+      if. > @
+        tup.length.eq 0
+        -1
+        if. (tup.head.eq ^.wanted) tup.tail.length (^.reclast tup.tail)


### PR DESCRIPTION
Fixes #5563.

## Problem

A void declared with a file-local handle (`? >> name`, R-3.10.12) lost its readable name when round-tripped through `Xmir.toEO()`. Since the #5548 fix, the surviving cactus `@name` (e.g. `a🌵12-2`) was rewritten to a synthetic `v12_2` identifier via `eo:printable`, so `tuple/last-index-of.eo` (source `? >> list` / `? >> wanted`) printed as:

```
[v12_2 v13_2] > last-index-of
  reclast v12_2 > @
  ...
    tup.head.eq ^.v13_2
```

The meaningful handles `list` and `wanted` were gone (same for `bytes/xor.eo`, `bytes/array.eo`, and others). The synthetic name was only needed because `resolve-local-names` recorded the handle as `@local` and then **dropped it**, so the real handle never reached XMIR.

## Fix

Preserve the handle instead of discarding it, and teach the printer to use it.

- **`resolve-local-names.xsl`** no longer drops the `@local` marker — it stays on the declaring object. References are still rewritten to the reserved cactus `@name`, exactly as before, and the duplicate-handle error is unchanged.
- **`XMIR.xsd`** documents the now-persistent optional `@local` attribute on `o`.
- **`restore-local-names.xsl`** (new printer pass, run before `inline-cactoos`) inverts the parser rewrite for voids: the void's `@name` becomes its handle and every `@base` segment pointing at that cactus name is rewritten back to the handle. The `eo:printable` fallback in `to-eo-tree.xsl` still covers handle-less cactus names (bare `? >>`).

Result — the same file now prints:

```
[list wanted] > last-index-of
  reclast list > @
  ...
    if. (tup.head.eq ^.wanted) tup.tail.length (^.reclast tup.tail)
```

This is the bracket form R-3.4.7 already prescribes ("reverse printing canonicalises every void to the bracket form").

## Verification

- All 138 `eo-runtime/src/main/eo` files stay reparseable and idempotent through `Xmir.toEO()`, with no `vN_M` placeholders remaining (28 of them use `? >>` handles).
- Running the `org.eolang:lints` linter over parsed XMIR carrying `@local` reports no new defects; strict `XMIR.xsd` validation passes.
- Full `eo-parser` (1466) and `eo-printer` (77) test suites pass.

## Changes

- `resolve-local-names.xsl`: keep `@local` on the declaring object.
- `XMIR.xsd`: declare the optional `@local` attribute.
- `Xmir.java` + `restore-local-names.xsl`: printer-side inverse pass.
- `PARSER_SPEC.md` R-9.2.3 and `Emit#local` javadoc: document that the marker is kept.
- Updated parse-pack / eo-syntax / print-pack tests; added printer regression pack `void-local-handle.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToT9SZ33La4QLpUhwhLxyG)_