### PR TITLE
#5568: print Unicode string glyphs instead of escaping to \uNNNN

### DIFF
--- a/eo-printer/pom.xml
+++ b/eo-printer/pom.xml
@@ -47,11 +47,6 @@
       <!-- version from parent POM -->
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <!-- version from parent POM -->
-    </dependency>
-    <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
       <!-- version from parent POM -->

--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
-import org.apache.commons.text.StringEscapeUtils;
 import org.eolang.parser.StXnav;
 
 /**
@@ -59,7 +58,7 @@ final class StUnhex extends StEnvelope {
             xnav -> xnav.node().setTextContent(
                 String.format(
                     "\"%s\"",
-                    StringEscapeUtils.escapeJava(
+                    StUnhex.escape(
                         new String(
                             StUnhex.buffer(
                                 StUnhex.undash(xnav.element("o").text().orElse(""))
@@ -127,6 +126,56 @@ final class StUnhex extends StEnvelope {
             buffer.position(0);
         }
         return buffer;
+    }
+
+    /**
+     * Escape a decoded string for an EO string literal. Only the
+     * characters an EO literal actually requires are escaped — the
+     * backslash, the double quote, and the control characters (as
+     * {@code \n}, {@code \t}, {@code \r}, {@code \b}, {@code \f}, or a
+     * {@code \\uXXXX} fallback). Printable Unicode glyphs are left
+     * intact, since EO sources are UTF-8.
+     * @param txt The decoded text
+     * @return The escaped text, ready to sit between double quotes
+     */
+    private static String escape(final String txt) {
+        final StringBuilder out = new StringBuilder(txt.length());
+        int idx = 0;
+        while (idx < txt.length()) {
+            final int point = txt.codePointAt(idx);
+            out.append(StUnhex.escaped(point));
+            idx += Character.charCount(point);
+        }
+        return out.toString();
+    }
+
+    /**
+     * Escape a single code point for an EO string literal.
+     * @param point The code point
+     * @return The verbatim glyph, or its escape sequence
+     */
+    private static String escaped(final int point) {
+        final String result;
+        if (point == '\\') {
+            result = "\\\\";
+        } else if (point == '"') {
+            result = "\\\"";
+        } else if (point == '\n') {
+            result = "\\n";
+        } else if (point == '\t') {
+            result = "\\t";
+        } else if (point == '\r') {
+            result = "\\r";
+        } else if (point == '\b') {
+            result = "\\b";
+        } else if (point == '\f') {
+            result = "\\f";
+        } else if (Character.isISOControl(point)) {
+            result = String.format("\\u%04x", point);
+        } else {
+            result = new String(Character.toChars(point));
+        }
+        return result;
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -156,34 +156,25 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
-    void keepsUnicodeGlyphsReadable(final Shift shift, final String type) {
+    void keepsGlyphsButEscapesControls(final Shift shift, final String type) {
         MatcherAssert.assertThat(
-            String.format("StUnhex by %s must keep Unicode glyphs readable, not escape them", type),
+            String.format(
+                "StUnhex by %s must keep glyphs readable and escape only control chars",
+                type
+            ),
             new Xsline(new StUnhex(shift)).pass(
                 new XMLDocument(
                     String.join(
                         "",
                         "<o base='Φ.string'><o base='Φ.bytes'>",
-                        "<o>D0-B4-D1-80-D1-83-D0-B3-20-E4-BD-A0-E5-A5-BD</o>",
+                        "<o>41-01-07-D0-B4-D1-80-D1-83-D0-B3</o>",
                         "</o></o>"
                     )
                 )
             ),
-            XhtmlMatchers.hasXPath("//o[text()='\"\u0434\u0440\u0443\u0433 \u4F60\u597D\"']")
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("shifts")
-    void escapesControlCharsAsUnicode(final Shift shift, final String type) {
-        MatcherAssert.assertThat(
-            String.format("StUnhex by %s must escape non-printable control chars", type),
-            new Xsline(new StUnhex(shift)).pass(
-                new XMLDocument(
-                    "<o base='Φ.string'><o base='Φ.bytes'><o>41-01-07-42</o></o></o>"
-                )
-            ),
-            XhtmlMatchers.hasXPath("//o[text()='\"A\\u0001\\u0007B\"']")
+            XhtmlMatchers.hasXPath(
+                "//o[text()='\"A\\u0001\\u0007\u0434\u0440\u0443\u0433\"']"
+            )
         );
     }
 

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -154,6 +154,39 @@ final class StUnhexTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void keepsUnicodeGlyphsReadable(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format("StUnhex by %s must keep Unicode glyphs readable, not escape them", type),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<o base='Φ.string'><o base='Φ.bytes'>",
+                        "<o>D0-B4-D1-80-D1-83-D0-B3-20-E4-BD-A0-E5-A5-BD</o>",
+                        "</o></o>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("//o[text()='\"\u0434\u0440\u0443\u0433 \u4F60\u597D\"']")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void escapesControlCharsAsUnicode(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format("StUnhex by %s must escape non-printable control chars", type),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<o base='Φ.string'><o base='Φ.bytes'><o>41-01-07-42</o></o></o>"
+                )
+            ),
+            XhtmlMatchers.hasXPath("//o[text()='\"A\\u0001\\u0007B\"']")
+        );
+    }
+
     private static Stream<Arguments> shifts() {
         return Stream.of(
             Arguments.of(StUnhex.XNAV, "xnav")

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/emoji.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/emoji.yaml
@@ -9,5 +9,5 @@ origin: |
 
 printed: |
   [] > main
-    "\uD83C\uDF35" > cactoos
-    "\uD83D\uDE00" > smile
+    "🌵" > cactoos
+    "😀" > smile

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
@@ -38,8 +38,8 @@ printed: |
       plus.
         this
           n.minus
-            "\u5BB6"
+            "家"
             x
-            * "Hello, \u0434\u0440\u0443\u0433" 2.18 true
-        bar (n.plus "hello, \u5927\u5BB6!")
+            * "Hello, друг" 2.18 true
+        bar (n.plus "hello, 大家!")
     4.55 > x!


### PR DESCRIPTION
Closes #5568.

`StUnhex` rendered every decoded string literal with `StringEscapeUtils.escapeJava`, which escapes the entire non-ASCII range to `\uNNNN`. A string like `"друг 你好"` printed as `"\u0434\u0440\u0443\u0433 \u4F60\u597D"` — readable EO turned unreadable and needlessly long.

This replaces `escapeJava` with a small custom escaper that escapes only what an EO string literal actually needs — the backslash, the double quote, and control characters (as `\n`, `\t`, `\r`, `\b`, `\f`, or a `\uXXXX` fallback for other ISO control code points) — and leaves printable Unicode intact, since EO sources are UTF-8. The escaping is the exact inverse of the parser's `Emissions.unescapeBody`, so the round-trip is preserved.

- `StUnhex.java`: new `escape`/`escaped` helpers; `commons-text` no longer used.
- `StUnhexTest`: two new cases — Unicode glyphs are kept readable, and non-printable control chars still fall back to `\uXXXX`.
- `emoji.yaml`, `idiomatic.yaml` print packs: `printed` expectations updated to glyphs.
- `eo-printer/pom.xml`: dropped the now-unused `commons-text` dependency.