### PR TITLE
fix(#5568): print Unicode glyphs instead of escaping to \uNNNN

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
-import org.apache.commons.text.StringEscapeUtils;
 import org.eolang.parser.StXnav;
 
 /**
@@ -59,7 +58,7 @@ final class StUnhex extends StEnvelope {
             xnav -> xnav.node().setTextContent(
                 String.format(
                     "\"%s\"",
-                    StringEscapeUtils.escapeJava(
+                    StUnhex.escape(
                         new String(
                             StUnhex.buffer(
                                 StUnhex.undash(xnav.element("o").text().orElse(""))
@@ -107,6 +106,82 @@ final class StUnhex extends StEnvelope {
             str = Double.toString(num);
         }
         return str;
+    }
+
+    /**
+     * Escape a decoded string for printing as an EO string literal.
+     *
+     * <p>Unlike {@code StringEscapeUtils.escapeJava}, which escapes the
+     * entire non-ASCII range to {@code \\uNNNN}, this escaper leaves
+     * printable Unicode glyphs intact (EO sources are UTF-8). Only the
+     * backslash, the double quote and non-printable/control characters
+     * are escaped; the latter fall back to {@code \\uNNNN}.</p>
+     * @param txt The decoded text
+     * @return The escaped text, ready to sit between the quotes
+     */
+    private static String escape(final String txt) {
+        final StringBuilder out = new StringBuilder(txt.length());
+        int idx = 0;
+        while (idx < txt.length()) {
+            final int cpnt = txt.codePointAt(idx);
+            out.append(StUnhex.glyph(cpnt));
+            idx += Character.charCount(cpnt);
+        }
+        return out.toString();
+    }
+
+    /**
+     * Escape a single code point for an EO string literal.
+     * @param cpnt The code point
+     * @return The escaped representation
+     */
+    private static String glyph(final int cpnt) {
+        final String escaped;
+        if (cpnt == '\\') {
+            escaped = "\\\\";
+        } else if (cpnt == '"') {
+            escaped = "\\\"";
+        } else if (cpnt == '\n') {
+            escaped = "\\n";
+        } else if (cpnt == '\t') {
+            escaped = "\\t";
+        } else if (cpnt == '\r') {
+            escaped = "\\r";
+        } else if (cpnt == '\b') {
+            escaped = "\\b";
+        } else if (cpnt == '\f') {
+            escaped = "\\f";
+        } else if (StUnhex.printable(cpnt)) {
+            escaped = new String(Character.toChars(cpnt));
+        } else {
+            final StringBuilder unicode = new StringBuilder(6);
+            for (final char unit : Character.toChars(cpnt)) {
+                unicode.append(String.format("\\u%04X", (int) unit));
+            }
+            escaped = unicode.toString();
+        }
+        return escaped;
+    }
+
+    /**
+     * Whether the code point can be rendered as a glyph inside a UTF-8
+     * EO source, rather than needing a {@code \\uNNNN} escape.
+     * @param cpnt The code point
+     * @return TRUE if it is safe to print verbatim
+     */
+    private static boolean printable(final int cpnt) {
+        final boolean safe;
+        if (Character.isISOControl(cpnt) || !Character.isDefined(cpnt)) {
+            safe = false;
+        } else {
+            final int type = Character.getType(cpnt);
+            safe = type != Character.CONTROL
+                && type != Character.FORMAT
+                && type != Character.SURROGATE
+                && type != Character.PRIVATE_USE
+                && type != Character.UNASSIGNED;
+        }
+        return safe;
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -80,6 +80,49 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
+    void keepsUnicodeGlyphsInsteadOfEscaping(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must keep readable Unicode glyphs, but it escaped them",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<p><o base='Φ.string'><o base='Φ.bytes'>",
+                        "<o>E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21</o></o></o>",
+                        "<o base='Φ.string'><o base='Φ.bytes'>",
+                        "<o>68-65-6C-6C-6F-20-E4-BD-A0-E5-A5-BD</o></o></o></p>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "//o[text()='\"你好, друг!\"']",
+                "//o[text()='\"hello 你好\"']"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void escapesControlCharactersToUnicode(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must escape non-printable characters to \\uNNNN",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<o base='Φ.string'><o base='Φ.bytes'><o>41-00-42</o></o></o>"
+                )
+            ),
+            XhtmlMatchers.hasXPath("//o[text()='\"A\\u0000B\"']")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
     void convertsEmptyStringFromHexToEo(final Shift shift, final String type) {
         MatcherAssert.assertThat(
             String.format("StUnhex by %s must convert empty string", type),


### PR DESCRIPTION
Closes #5568.

## Problem

`Xmir.toEO()` escaped every non-ASCII character of a string literal to `\uNNNN`, rendering readable strings unreadable. For example `"你好, друг!"` printed as `"你好, друг!"` and `"hello 你好"` printed as `"hello 你好"` — ASCII survived but every code point above U+007F was escaped.

The cause was `eo-printer/.../StUnhex.java`, which rendered the decoded UTF-8 string with Apache Commons Text `StringEscapeUtils.escapeJava(...)`. That helper is meant for Java source literals and escapes the whole non-ASCII range; it is the wrong tool for EO, whose sources are UTF-8 and can carry the glyphs directly.

## Fix

Replaced the `escapeJava` call with a small custom escaper (`StUnhex.escape`) that escapes only what an EO string literal actually requires:

- backslash → `\\` and double quote → `\"`;
- the common control escapes `\n`, `\t`, `\r`, `\b`, `\f` (round-trips through the parser's `Emissions.unescapeBody`);
- other non-printable/control code points fall back to `\uNNNN`;
- every printable Unicode code point passes through verbatim.

Printability is decided by `Character.isISOControl` / `Character.isDefined` plus the Unicode general category (control, format, surrogate, private-use and unassigned code points are escaped). The Apache Commons Text import is no longer needed and was removed.

## Tests

Added two cases to `StUnhexTest`:

- `keepsUnicodeGlyphsInsteadOfEscaping` — verifies `"你好, друг!"` and `"hello 你好"` print as readable glyphs;
- `escapesControlCharactersToUnicode` — verifies a NUL byte still escapes to ``.

All existing `StUnhexTest` cases (including the `\n`/`\t` ones) continue to pass, and `mvn -Pqulice validate` is clean for the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgsfAM8mGsn78k5DRGP8Qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgsfAM8mGsn78k5DRGP8Qo)_