### PR TITLE
#5556: resolve a named binding `:name` against a `? >> name` void handle

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -8,7 +8,9 @@
   The "&gt;&gt; foo" file-local handle (§3.10 / §9.2): the parser emits the
   anonymous object with its cactus @name plus a "@local='foo'" marker. We
   build the per-file "handle -&gt; cactus-name" table and rewrite every @base
-  equal to a handle into that (reserved) cactus name; a handle declared more
+  (a dispatch, "foo &gt; @") and every @as (a named binding, "obj 42:foo")
+  equal to a handle into that (reserved) cactus name, so that a same-file
+  named binding actually fills the handle's void; a handle declared more
   than once is an error. The "@local" marker is deliberately kept on the
   declaring object so that later passes (in particular the printer, see
   #5563) can recover the readable handle from the otherwise-synthetic cactus
@@ -16,10 +18,15 @@
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:key name="handle" match="o[@local]" use="@local"/>
-  <xsl:template match="o[@base and key('handle', @base)]">
+  <xsl:template match="o[(@base and key('handle', @base)) or (@as and key('handle', @as))]">
     <xsl:copy>
-      <xsl:attribute name="base" select="key('handle', @base)[1]/@name"/>
-      <xsl:apply-templates select="@* except @base"/>
+      <xsl:if test="@base">
+        <xsl:attribute name="base" select="if (key('handle', @base)) then key('handle', @base)[1]/@name else @base"/>
+      </xsl:if>
+      <xsl:if test="@as">
+        <xsl:attribute name="as" select="if (key('handle', @as)) then key('handle', @as)[1]/@name else @as"/>
+      </xsl:if>
+      <xsl:apply-templates select="@* except (@base|@as)"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle-named-binding.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/void-local-handle-named-binding.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@as='age'])]
+  - //o[@as=string(//o[@local='age']/@name)]
+input: |
+  [] > app
+    human 42:age > @
+    [] > human
+      ? >> age
+      age > @


### PR DESCRIPTION
Closes #5556.

A void declared with the `>>` handle (`? >> age`) gets an auto-generated cactus attribute name, keeping `age` only as a file-local handle. `resolve-local-names.xsl` rewrites every `@base` dispatch reference equal to a handle into that cactus name — but it never touched `@as` binding targets. So a same-file named binding `human 42:age` was emitted as `@as='age'` and reached transpilation as `Bind("age", …)` against the literal name, while the void's real attribute is the cactus name — the bind never matched, even though the handle is visible in the same file.

This extends the template to rewrite `@as` the same way it already rewrites `@base`. The two are merged into one template so an object that carries both a handle `@base` and a handle `@as` is handled unambiguously; non-handle `@base`/`@as` values are copied through unchanged.

- `resolve-local-names.xsl`: rewrite `@as` handles to the cactus name.
- `void-local-handle-named-binding.yaml`: new parse pack — `human 42:age` against `? >> age` resolves to the void's cactus name and leaves no literal `@as='age'`.

Verified against the real parser output (the assertion fails on `master`, passes with the fix); full `eo-parser` suite is green. Scope is same-file resolution, as the issue notes; cross-file handle binding remains a separate design question.