### PR TITLE
fix(#5583): keep root prefix on multi-segment atom signatures

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -233,7 +233,22 @@
         <xsl:variable name="lambda-atom" select="string(./o[@name=$eo:lambda]/@atom)"/>
         <xsl:choose>
           <xsl:when test="starts-with($lambda-atom, 'Φ.')">
-            <xsl:value-of select="substring-after($lambda-atom, 'Φ.')"/>
+            <xsl:variable name="rest" select="substring-after($lambda-atom, 'Φ.')"/>
+            <xsl:choose>
+              <!--
+                A multi-segment signature (e.g. "Φ.malloc.of.allocated") must
+                stay rooted: on reparse a dotted @atom is not re-homed, so
+                dropping the root would yield an XSD-invalid fqn. A single-name
+                signature (e.g. "Φ.bytes") re-resolves to its root on reparse,
+                so the implicit root is dropped for idiomatic output.
+              -->
+              <xsl:when test="contains($rest, '.')">
+                <xsl:value-of select="concat('Q.', $rest)"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="$rest"/>
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of select="$lambda-atom"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  +package org.eolang
+
+  [size] > resized /Q.malloc.of.allocated
+
+printed: |
+  +package org.eolang
+
+  [size] > resized /Q.malloc.of.allocated


### PR DESCRIPTION
Closes #5583.

## Problem

`Xmir.toEO()` dropped the implicit `Φ.` (`Q.`) root from every atom `/signature` in `eo-printer/.../print/to-eo-tree.xsl`. That is fine for ordinary single-name signatures (e.g. `Φ.bytes`) because they re-home to their root on reparse, but it breaks fully-qualified, multi-segment signatures.

For example the atom `resized` in `eo-runtime/src/main/eo/malloc.eo` has signature `@atom="Φ.malloc.of.allocated"`. The printer emitted `/malloc.of.allocated`. On reparse, `add-default-package.xsl` only re-homes dot-less `@atom` values, so a dotted signature stays unrooted as `@atom="malloc.of.allocated"` — which is not a valid `fqn` under the XMIR XSD (the pattern requires the value to start with `Φ`, `ξ`, or `.`). This made `integration.XmirIT.validatesWithXsd` fail with `cvc-pattern-valid: Value 'malloc.of.allocated' is not facet-valid ... for type 'fqn'`. The same affected `compile` (`Φ.string.regex.pattern`) and `matched-from-index` (`Φ.string.regex.pattern.match.matched`) in `string/regex.eo`.

## Fix

In the `Φ.`-signature branch, keep the signature rooted when it is multi-segment (contains a dot after the root) by rendering it as `Q.<rest>`, so it round-trips back to `Φ.<rest>` and stays XSD-valid. Single-name signatures continue to have the implicit root dropped, so idiomatic output like `/bytes` and `/number` is unchanged.

## Tests

- Added `eo-printer/.../print-packs/yaml/atom-rooted-signature.yaml`, which round-trips a `/Q.malloc.of.allocated` atom signature through both `printsToEo` and `printsToParseableEo`.
- `XmirTest` passes in full (65/65), confirming existing single-name atom packs (`test-attribute`, `idiomatic`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYrpUbq3Y26qAg4WDwrBTy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYrpUbq3Y26qAg4WDwrBTy)_