### PR TITLE
fix(#5581): print `? >> name` voids under their handle, not as `[name]`

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -11,10 +11,14 @@
   "@local='name'" marker; the parser resolves references to the cactus name
   but the readable handle is preserved on the void. Here we put the handle
   back: the void's @name becomes its handle and every @base segment that
-  points at that cactus name is rewritten to the handle, so the printer
-  emits "[name]" and "name" instead of a synthetic "vL_P" placeholder. A
-  non-void "&gt;&gt;" handle (on an anonymous formation) is left to the
-  existing "inline-cactoos" pass, so its @local marker is simply dropped.
+  points at that cactus name is rewritten to the handle, so references read
+  under the handle instead of a synthetic "vL_P" placeholder. The
+  "@local" marker is deliberately KEPT on the void (#5581) so that
+  "to-eo-tree" can print it back as a vertical "? &gt;&gt; name" line and
+  preserve the void's anonymity (§9.2, R-9.2.3), rather than collapsing it
+  into a public "[name]" bracket param. A non-void "&gt;&gt;" handle (on an
+  anonymous formation) is left to the existing "inline-cactoos" pass, so its
+  @local marker is simply dropped.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -28,8 +32,10 @@
   <xsl:template match="o[@local and @base=$eo:empty]/@name">
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
-  <!-- Drop the marker (already applied on voids above; unused on formations). -->
-  <xsl:template match="o/@local"/>
+  <!-- Keep the marker on voids so "to-eo-tree" restores the readable
+       "? &gt;&gt; name" handle; drop it on non-void formations, whose
+       handle is inlined away by the "inline-cactoos" pass. -->
+  <xsl:template match="o[not(@base=$eo:empty)]/@local"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -134,8 +134,16 @@
       <xsl:attribute name="data">
         <xsl:value-of select="if (eo:has-data(.)) then 'yes' else 'no'"/>
       </xsl:attribute>
-      <xsl:apply-templates select="o[not(eo:void(.))]" mode="tree"/>
+      <xsl:apply-templates select="o[not(eo:void(.)) or @local]" mode="tree"/>
     </line>
+  </xsl:template>
+  <!-- VOID WITH FILE-LOCAL HANDLE -->
+  <!-- A void declared "? &gt;&gt; name" (R-3.10.12) keeps its @local handle
+       through "restore-local-names"; it is printed as a vertical body line
+       to preserve the void's anonymity (§9.2, R-9.2.3) instead of being
+       collapsed into a public "[name]" bracket param (#5581). -->
+  <xsl:template match="o[eo:void(.) and @local]" mode="tree">
+    <line base="?" tail="{concat(' &gt;&gt; ', @local)}" abstract="no" test="no" reversed="no"/>
   </xsl:template>
   <!-- BASED -->
   <xsl:template match="o[@base and not(eo:has-data(.))]" mode="head">
@@ -175,7 +183,7 @@
          no head of its own. -->
     <xsl:if test="not(eo:test-attr(.) and empty(o[eo:void(.)]))">
       <xsl:text>[</xsl:text>
-      <xsl:for-each select="o[eo:void(.)]">
+      <xsl:for-each select="o[eo:void(.) and not(@local)]">
         <xsl:if test="position()&gt;1">
           <xsl:text> </xsl:text>
         </xsl:if>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
@@ -12,4 +12,6 @@ origin: |
 printed: |
   +package org.eolang
 
-  bts.eq 01- > [bts] > as-bool
+  [] > as-bool
+    ? >> bts
+    bts.eq 01- > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -3,8 +3,10 @@
 ---
 # yamllint disable rule:line-length
 # A void declared with a file-local handle ("? >> name", R-3.10.12) must
-# print back under that readable handle, not a synthetic "vL_P" placeholder
-# (#5563). The handle survives even when referenced from a sibling
+# print back under that readable handle as a vertical "? >> name" line,
+# not a synthetic "vL_P" placeholder (#5563) and not a public "[name]"
+# bracket param (#5581) — the ">>" form keeps the void anonymous (§9.2,
+# R-9.2.3). The handle survives even when referenced from a sibling
 # attribute (here "wanted" inside "reclast", whose redundant "^." parent
 # hop is dropped per #5564).
 origin: |
@@ -26,7 +28,9 @@ origin: |
 printed: |
   +package tuple
 
-  [list wanted] > last-index-of
+  [] > last-index-of
+    ? >> list
+    ? >> wanted
     reclast list > @
     [tup] > reclast
       if. > @


### PR DESCRIPTION
Closes #5581.

## Problem

`Xmir.toEO()` printed a void declared with a file-local handle — `? >> name` (R-3.10.12) — as a bracket parameter `[name]` instead of restoring the vertical `? >> name` line. For example `bytes/as-bool.eo`:

```
[] > as-bool
  ? >> bts
  bts.eq 01- > @
```

printed as `bts.eq 01- > [bts] > as-bool`.

This is wrong because the `>>` form exists to keep the void **anonymous**: its external name stays a hidden cactus name (§9.2) while `name` is only a file-local handle. Collapsing it to `[name]` promotes the void into a public positional attribute, so the printed text reparses to different XMIR — a lossy round-trip that changes the object's public surface. R-9.2.3 requires the `@local` marker be kept "in particular by the printer, which prints `? >> name` voids back under their handle".

## Fix

- **`restore-local-names.xsl`** — keep the `@local` marker on voids (it was being dropped after promoting the handle to `@name`). The marker is now dropped only on non-void formations, whose handle the `inline-cactoos` pass already inlines away. References still resolve to the handle as before (#5563).
- **`to-eo-tree.xsl`** — exclude `@local`-bearing voids from the `[...]` head loop and include them among the body children, emitting each as a vertical `? >> name` line.

Plain voids — `? > name` and `[name]` with no `@local` — still render inside the brackets, per R-3.4.7.

## Tests

Updated the two printer fixtures that captured the old buggy output (`cactus-void.yaml`, `void-local-handle.yaml`) to the correct round-trippable form. The full `eo-printer` suite (86 tests, including the print-then-reparse idempotency check) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xoXnMRPJZcquYE1ubj9oU

---
_Generated by [Claude Code](https://claude.ai/code/session_013xoXnMRPJZcquYE1ubj9oU)_