### PR TITLE
fix(#5584): render data-receiver dispatch in suffix form

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -299,8 +299,10 @@ final class Pretty {
 
     /**
      * Render a node inline, as it would appear as an argument (without
-     * its own name suffix), or empty if it can't be inlined safely.
-     * @param node The node
+     * its own name suffix), or empty if it can't be inlined safely. A
+     * data-receiver dispatch is inlined in its suffix shape ({@code
+     * 5.plus 3}), never the reversed one.
+     * @param given The node
      * @return The inlined content, or empty
      */
     private static Optional<String> flat(final Pretty.Node given) {

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -89,11 +89,40 @@ final class Pretty {
     /**
      * Lay out a node as a (possibly multi-line) block at the given
      * indentation, picking the rendering with the lowest penalty.
+     *
+     * <p>When the node is a reversed dispatch on a lone data receiver
+     * ({@code plus. 5 3}), its equivalent suffix shape ({@code 5.plus 3})
+     * is laid out too and the lower-penalty one is kept — the same
+     * penalty comparison that already decides inline versus vertical. The
+     * suffix shape is never longer and its vertical form has one fewer
+     * child line, so it can only tie or win; a tie (both fit the width)
+     * resolves to the suffix, the shorter and more readable form.</p>
+     *
      * @param node The node
      * @param indent The indentation level
      * @return The rendered block
      */
     private String layout(final Pretty.Node node, final int indent) {
+        String best = this.shaped(node, indent);
+        final Optional<Pretty.Node> suffix = Pretty.suffixed(node);
+        if (suffix.isPresent()) {
+            final String alt = this.shaped(suffix.get(), indent);
+            if (new Penalty(alt, this.weights).points()
+                <= new Penalty(best, this.weights).points()) {
+                best = alt;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Lay out a single shape of a node, picking the lower-penalty of its
+     * vertical and horizontal renderings.
+     * @param node The node
+     * @param indent The indentation level
+     * @return The rendered block
+     */
+    private String shaped(final Pretty.Node node, final int indent) {
         String best = this.vertical(node, indent);
         final Optional<String> flat = this.horizontal(node, indent);
         if (flat.isPresent()
@@ -102,6 +131,43 @@ final class Pretty {
             best = flat.get();
         }
         return best;
+    }
+
+    /**
+     * The suffix shape of a reversed dispatch on a lone data receiver, if
+     * this node is one.
+     *
+     * <p>A data-receiver dispatch is stored as a reversed head
+     * ({@code plus.}) whose first child is the data literal receiver, since
+     * a literal cannot fold into a dotted {@code @base} the way a named
+     * receiver does. This rebuilds it in suffix position — the receiver
+     * glued to the method ({@code 5.plus}) with the remaining arguments
+     * kept as children — so both shapes can be weighed against each other.
+     * A compound receiver (one with children of its own) has no suffix
+     * form and yields empty, leaving the reversed head untouched.</p>
+     *
+     * @param node The node
+     * @return The suffix-shaped node, or empty if it doesn't apply
+     */
+    private static Optional<Pretty.Node> suffixed(final Pretty.Node node) {
+        Optional<Pretty.Node> result = Optional.empty();
+        if (node.reversed && !node.children.isEmpty()) {
+            final Pretty.Node receiver = node.children.get(0);
+            if (receiver.data && receiver.children.isEmpty()
+                && receiver.tail.isEmpty()) {
+                result = Optional.of(
+                    new Pretty.Node(
+                        String.join(
+                            ".", receiver.base,
+                            node.base.substring(0, node.base.length() - 1)
+                        ),
+                        node.tail, node.abstractt, node.test, false, false,
+                        node.children.subList(1, node.children.size())
+                    )
+                );
+            }
+        }
+        return result;
     }
 
     /**
@@ -189,7 +255,7 @@ final class Pretty {
             result = Pretty.flat(
                 new Pretty.Node(
                     decoratee.base, "", decoratee.abstractt,
-                    false, decoratee.reversed, decoratee.children
+                    false, decoratee.reversed, decoratee.data, decoratee.children
                 )
             ).map(
                 value -> new StringBuilder(this.step().repeat(indent))
@@ -237,8 +303,9 @@ final class Pretty {
      * @param node The node
      * @return The inlined content, or empty
      */
-    private static Optional<String> flat(final Pretty.Node node) {
+    private static Optional<String> flat(final Pretty.Node given) {
         final Optional<String> result;
+        final Pretty.Node node = Pretty.suffixed(given).orElse(given);
         if (node.reversed && node.children.size() <= 1) {
             result = Optional.empty();
         } else if (node.abstractt || !node.tail.isEmpty() || "*".equals(node.base)) {
@@ -291,6 +358,13 @@ final class Pretty {
         private final boolean reversed;
 
         /**
+         * Whether this object is a data literal (number, string, bytes),
+         * so it may sit as a receiver in the suffix form of a reversed
+         * dispatch ({@code 5.plus} instead of {@code plus. 5}).
+         */
+        private final boolean data;
+
+        /**
          * The children (arguments or bindings), in order.
          */
         private final List<Pretty.Node> children;
@@ -302,16 +376,19 @@ final class Pretty {
          * @param formation Whether it is a formation
          * @param attr Whether it is a test attribute
          * @param rev Whether it is a reversed dispatch
+         * @param literal Whether it is a data literal
          * @param kids The children
          * @checkstyle ParameterNumberCheck (5 lines)
          */
         Node(final String head, final String suffix, final boolean formation,
-            final boolean attr, final boolean rev, final List<Pretty.Node> kids) {
+            final boolean attr, final boolean rev, final boolean literal,
+            final List<Pretty.Node> kids) {
             this.base = head;
             this.tail = suffix;
             this.abstractt = formation;
             this.test = attr;
             this.reversed = rev;
+            this.data = literal;
             this.children = kids;
         }
 
@@ -327,6 +404,7 @@ final class Pretty {
                 "yes".equals(line.attribute("abstract").text().orElse("no")),
                 "yes".equals(line.attribute("test").text().orElse("no")),
                 "yes".equals(line.attribute("reversed").text().orElse("no")),
+                "yes".equals(line.attribute("data").text().orElse("no")),
                 line.elements(Filter.withName("line"))
                     .map(Pretty.Node::parse)
                     .collect(Collectors.toList())

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -131,6 +131,9 @@
       <xsl:attribute name="reversed">
         <xsl:value-of select="if (@base and starts-with(@base, '.')) then 'yes' else 'no'"/>
       </xsl:attribute>
+      <xsl:attribute name="data">
+        <xsl:value-of select="if (eo:has-data(.)) then 'yes' else 'no'"/>
+      </xsl:attribute>
       <xsl:apply-templates select="o[not(eo:void(.))]" mode="tree"/>
     </line>
   </xsl:template>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/data-receiver-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/data-receiver-dispatch.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A dispatch whose receiver is a data literal (number, string, bytes) is
+# stored in XMIR as a reversed head ("plus.") over a data child, because a
+# literal can't fold into a dotted @base the way a named receiver does. The
+# printer weighs that reversed shape against the equivalent suffix shape
+# ("5.plus 3") and keeps the lower-penalty one, just as a named receiver
+# ("foo.plus 3") already prints in suffix form (#5584).
+origin: |
+  [foo] > app
+    5.plus 3 > a
+    -1.times 228 > b
+    "x".eq "y" > c
+    01-.eq 02- > d
+    foo.plus 3 > e
+
+printed: |
+  [foo] > app
+    5.plus 3 > a
+    -1.times 228 > b
+    "x".eq "y" > c
+    01-.eq 02- > d
+    foo.plus 3 > e

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
@@ -10,4 +10,4 @@ origin: |
         -1.times 228
 
 printed: |
-  io.stdout (string.sprintf "result is %d\n" (times. -1 228)) > [] > app
+  io.stdout (string.sprintf "result is %d\n" (-1.times 228)) > [] > app


### PR DESCRIPTION
Closes #5584.

## Problem

`Xmir.toEO()` rendered a method dispatch whose receiver is a data literal (number, string, bytes) **only** in the reversed form, never the equivalent suffix form:

```
5.plus 3      ->  plus. 5 3
-1.times 228  ->  times. -1 228
"x".eq "y"    ->  eq. "x" "y"
foo.plus 3    ->  foo.plus 3   (named receiver already kept as suffix)
```

The cause was representational, not a layout choice. A named receiver folds into a dotted `@base` (`foo.plus`) and prints as suffix, but a data receiver is a child under a reversed `.method` link, and `to-eo-tree.xsl` rendered any `@base` starting with `.` as the reversed `method.` head. The suffix form was therefore never offered to the penalty-based `Pretty` search — even though `5.plus 3` is usually shorter and easier to read than `plus. 5 3`.

## Fix

- `to-eo-tree.xsl` now marks every line-tree node with `data="yes"` / `data="no"` (via `eo:has-data`), so the layout engine can tell a lone data literal from a named reference.
- `Pretty` gains a `suffixed(...)` helper that rebuilds a reversed dispatch on a lone data receiver into its suffix shape (`5.plus 3` from `plus. 5 3`), gluing the receiver to the method and keeping the remaining arguments as children.
- `layout(...)` now lays out **both** shapes and keeps the lower-penalty one — the same penalty comparison already used to choose between inline and vertical layouts. The suffix shape is never longer, and its vertical form has one fewer child line, so it can only tie or win; on a tie the suffix form is kept as the shorter, more readable rendering. `flat(...)` applies the same rewrite so inlined arguments (`... (-1.times 228)`) render in suffix position too.

Compound receivers (`and. (true.eq 01-) (false.eq 00-)`) and named receivers (`foo.plus 3`) are unaffected — only a lone data receiver has a suffix form.

## Tests

- New pack `data-receiver-dispatch.yaml` covering number, string, and bytes receivers plus a named-receiver control.
- Updated `times.yaml` expectation from `times. -1 228` to `-1.times 228`.
- All `eo-printer` tests pass (`XmirTest` 65, `PenaltyTest`, `StUnhexTest`, `StEoLoggedTest`), including the `printsToParseableEo` round-trip check for every pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wSYSmZLiNv3FpVdXEjRY9

---
_Generated by [Claude Code](https://claude.ai/code/session_011wSYSmZLiNv3FpVdXEjRY9)_