### PR TITLE
#5578: fold a fingerprint of transpile XSLs into the cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
+
+/**
+ * Short hex fingerprint of a set of classpath resources.
+ *
+ * <p>It reads each resource, in the given order, into one SHA-256
+ * digest and returns the first twelve hex characters. It is used to
+ * fold the content of the bundled transpile XSLs into the transpile
+ * cache key, so that a change in the transformation logic invalidates
+ * the cache even when the plugin version does not change (see #5578).</p>
+ *
+ * @since 0.63
+ */
+final class Fingerprint implements Supplier<String> {
+
+    /**
+     * Classpath resource paths to hash, in order.
+     */
+    private final String[] resources;
+
+    /**
+     * Ctor.
+     * @param res Classpath resource paths to hash
+     */
+    Fingerprint(final String... res) {
+        this.resources = res.clone();
+    }
+
+    @Override
+    public String get() {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (final String resource : this.resources) {
+                try (InputStream input = Fingerprint.class.getResourceAsStream(resource)) {
+                    if (input == null) {
+                        throw new IllegalStateException(
+                            String.format("Resource '%s' not found on classpath", resource)
+                        );
+                    }
+                    digest.update(input.readAllBytes());
+                }
+            }
+            final StringBuilder hex = new StringBuilder(64);
+            for (final byte octet : digest.digest()) {
+                hex.append(String.format("%02x", octet));
+            }
+            return hex.substring(0, 12);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException("Failed to read a resource while fingerprinting", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -20,6 +20,7 @@ import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,6 +85,24 @@ final class Transpiling implements Step {
      * Cache directory for transpiled sources.
      */
     private static final String CACHE = "transpiled";
+
+    /**
+     * The XSL steps of the transpile train, in order, ending with
+     * {@code to-java.xsl}. Kept as a single list so both the train in
+     * {@link #compiled(boolean)} and the cache-key fingerprint in
+     * {@link #version()} are derived from the same source.
+     */
+    private static final String[] XSLS = {
+        "/org/eolang/maven/transpile/set-locators.xsl",
+        "/org/eolang/maven/transpile/set-original-names.xsl",
+        "/org/eolang/maven/transpile/classes.xsl",
+        "/org/eolang/maven/transpile/tests.xsl",
+        "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
+        "/org/eolang/maven/transpile/package.xsl",
+        "/org/eolang/maven/transpile/attrs.xsl",
+        "/org/eolang/maven/transpile/data.xsl",
+        "/org/eolang/maven/transpile/to-java.xsl",
+    };
 
     /**
      * Java extension.
@@ -211,7 +230,7 @@ final class Transpiling implements Step {
         if (this.cacheEnabled) {
             new ConcurrentCache(
                 new Cache(
-                    new CachePath(cdir, this.version, hsh.get()),
+                    new CachePath(cdir, this.version(), hsh.get()),
                     src -> {
                         rewrite.compareAndSet(false, true);
                         final String res = transform.apply(xmir).toString();
@@ -309,24 +328,30 @@ final class Transpiling implements Step {
         return new TrFull(
             new TrJoined<>(
                 new TrClasspath<>(
-                    "/org/eolang/maven/transpile/set-locators.xsl",
-                    "/org/eolang/maven/transpile/set-original-names.xsl",
-                    "/org/eolang/maven/transpile/classes.xsl",
-                    "/org/eolang/maven/transpile/tests.xsl",
-                    "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
-                    "/org/eolang/maven/transpile/package.xsl",
-                    "/org/eolang/maven/transpile/attrs.xsl",
-                    "/org/eolang/maven/transpile/data.xsl"
+                    Arrays.copyOf(Transpiling.XSLS, Transpiling.XSLS.length - 1)
                 ).back(),
                 new TrDefault<>(
                     new StClasspath(
-                        "/org/eolang/maven/transpile/to-java.xsl",
+                        Transpiling.XSLS[Transpiling.XSLS.length - 1],
                         String.format("disclaimer %s", new Disclaimer()),
                         String.format("trackLocations %b", track)
                     )
                 )
             )
         );
+    }
+
+    /**
+     * Cache-key version segment: the plugin version combined with a
+     * fingerprint of the bundled transpile XSLs. Folding the XSL
+     * content in means that a change in the transformation logic
+     * invalidates the global transpile cache even when the plugin
+     * version is unchanged (a constant {@code -SNAPSHOT} during
+     * development), see #5578.
+     * @return The version segment for {@link CachePath}
+     */
+    private String version() {
+        return String.format("%s-%s", this.version, new Fingerprint(Transpiling.XSLS).get());
     }
 
     /**
@@ -421,7 +446,7 @@ final class Transpiling implements Step {
     private Supplier<Path> cached(final String hsh, final String jname) {
         return new CachePath(
             this.cacheDir.resolve(Transpiling.CACHE),
-            this.version,
+            this.version(),
             hsh,
             this.generatedDir.relativize(
                 new Place(jname).make(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FingerprintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FingerprintTest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Fingerprint}.
+ * @since 0.63
+ */
+final class FingerprintTest {
+
+    @Test
+    void producesTwelveHexCharacters() {
+        MatcherAssert.assertThat(
+            "the fingerprint must be twelve lowercase hex characters",
+            new Fingerprint(FingerprintTest.tojava()).get(),
+            Matchers.matchesPattern("[0-9a-f]{12}")
+        );
+    }
+
+    @Test
+    void isDeterministic() {
+        MatcherAssert.assertThat(
+            "the same resources must always yield the same fingerprint",
+            new Fingerprint(FingerprintTest.tojava(), FingerprintTest.classes()).get(),
+            Matchers.equalTo(
+                new Fingerprint(FingerprintTest.tojava(), FingerprintTest.classes()).get()
+            )
+        );
+    }
+
+    @Test
+    void changesWhenAnyResourceIsAddedOrChanged() {
+        MatcherAssert.assertThat(
+            "adding a resource to the set must change the fingerprint",
+            new Fingerprint(FingerprintTest.tojava()).get(),
+            Matchers.not(
+                Matchers.equalTo(
+                    new Fingerprint(FingerprintTest.tojava(), FingerprintTest.classes()).get()
+                )
+            )
+        );
+    }
+
+    @Test
+    void isSensitiveToResourceOrder() {
+        MatcherAssert.assertThat(
+            "reordering the resources must change the fingerprint",
+            new Fingerprint(FingerprintTest.tojava(), FingerprintTest.classes()).get(),
+            Matchers.not(
+                Matchers.equalTo(
+                    new Fingerprint(FingerprintTest.classes(), FingerprintTest.tojava()).get()
+                )
+            )
+        );
+    }
+
+    @Test
+    void failsOnMissingResource() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Fingerprint("/org/eolang/maven/transpile/does-not-exist.xsl").get(),
+            "a missing resource must fail loudly, not silently produce a wrong fingerprint"
+        );
+    }
+
+    /**
+     * A real bundled transpile XSL, used as a stable input.
+     * @return Classpath path of {@code to-java.xsl}
+     */
+    private static String tojava() {
+        return "/org/eolang/maven/transpile/to-java.xsl";
+    }
+
+    /**
+     * Another real bundled transpile XSL.
+     * @return Classpath path of {@code classes.xsl}
+     */
+    private static String classes() {
+        return "/org/eolang/maven/transpile/classes.xsl";
+    }
+}


### PR DESCRIPTION
Closes #5578.

The global transpile cache key was `base / semver / hash / tail`, where `semver` is only the plugin version. The transpiler's own XSL logic was not part of the key, so during development (constant `1.0-SNAPSHOT`, stable source hash) a change to `to-java.xsl` without a version bump left the cache serving Java from an earlier build.

This folds a fingerprint of the bundled transpile XSLs into the `semver` segment. `Transpiling.version()` now returns `<plugin-version>-<fingerprint>`, where the fingerprint is a short SHA-256 (first 12 hex chars) over the content of all nine transpile XSLs, in order. When any XSL changes, the fingerprint changes, so the cache path changes and the stale entry is no longer reused.

The XSL list is now a single `Transpiling.XSLS` constant used both to build the transpile train and to compute the fingerprint, so the two cannot drift apart (a future XSL added to the train is automatically included in the key).

The new `Fingerprint` class reads the given classpath resources into one digest and returns the short hex; it fails loudly on a missing resource instead of silently producing a wrong key.

Verification: `eo-maven-plugin` full suite with qulice, 373 tests, 0 failures. `FingerprintTest` covers determinism, sensitivity to the resource set and to order, and the missing-resource failure.
