### PR TITLE
#5589 render empty tuple as `*` shorthand

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
@@ -19,6 +19,17 @@
       <xsl:apply-templates select="$arg" mode="no-as"/>
     </xsl:copy>
   </xsl:template>
+  <!--
+    An empty tuple is stored as the bare "Φ.tuple.empty" base. Render it as
+    the "*" star shorthand with no elements, mirroring how non-empty tuples
+    are lowered to stars above.
+  -->
+  <xsl:template match="o[@base = 'Φ.tuple.empty']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="star"/>
+    </xsl:copy>
+  </xsl:template>
   <xsl:template match="o" mode="inner">
     <xsl:if test="@base = 'Φ.tuple'">
       <xsl:variable name="arg">

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/empty-tuple-to-star.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/empty-tuple-to-star.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/tuples-to-stars.xsl
+asserts:
+  - /object/o[@name='foo']/o[@name='empty' and @base='Φ.tuple.empty' and @star and count(o)=0]
+  - /object/o[@name='foo']/o[@name='nested']/o[@base='Φ.tuple.empty' and @star and count(o)=0]
+input: |
+  +package test
+
+  [] > foo
+    tuple.empty > empty
+    set > nested
+      tuple.empty

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-tuples.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-tuples.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  [] > main
+    * > empty
+    set * > s
+    slice-byte * 0 > sb
+
+printed: |
+  [] > main
+    * > empty
+    set > s
+      *
+    slice-byte > sb
+      *
+      0


### PR DESCRIPTION
Closes #5589.

## Problem

`Xmir.toEO()` lowered non-empty tuples to the `*` star form (via `eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl`), so `* a b c` round-trips fine, but the zero-element case fell through to the bare `tuple.empty` base. Sources written with `*` came back as `tuple.empty` after the format goal (e.g. `set.eo`, `bytes/array.eo`, `socket.eo`, `clock.eo`, `map.eo`, `range.eo`, `path.eo`) — a purely cosmetic but noisy readability regression, since `*` is the idiomatic empty tuple.

## Fix

Extend `tuples-to-stars.xsl` with a template that matches the `Φ.tuple.empty` object and emits the star form (`@star`) with no elements, mirroring how non-empty tuples are already lowered. An empty tuple now prints as `*` instead of `tuple.empty`.

The inner-mode handling for the innermost `Φ.tuple.empty` seed of a non-empty tuple is unaffected — that path is mode-specific and still emits nothing, so non-empty tuples keep rendering as `* a b c`.

## Tests

- `eo-packs/print/empty-tuple-to-star.yaml` — XSL-level assertions that a `tuple.empty` object (standalone and as an argument) gains `@star` with zero elements.
- `print-packs/yaml/empty-tuples.yaml` — end-to-end round-trip through `toEO()` confirming `*` is rendered instead of `tuple.empty`.

All 70 `XmirTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbN3RLaJ5dZ4YpQiZL3ssd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbN3RLaJ5dZ4YpQiZL3ssd)_