### PR TITLE
#5591 do not wrap single data-receiver dispatch argument in parentheses

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -272,7 +272,18 @@ final class Pretty {
 
     /**
      * Inline a list of arguments into one space-separated string,
-     * wrapping in parentheses those that take arguments themselves.
+     * wrapping in parentheses only those that apply arguments of their
+     * own (a real application such as {@code 5.plus 3}).
+     *
+     * <p>The guard weighs the argument in its effective (suffix-resolved)
+     * shape, not its raw one. A data-receiver dispatch such as
+     * {@code 01-.as-bool} is stored as a reversed head over a data child,
+     * so its raw node has a child (the receiver) yet it takes no arguments
+     * and is a single token — {@link #suffixed} folds the receiver back
+     * into the base, leaving no children, so it inlines bare. Wrapping it
+     * as {@code (01-.as-bool)} would produce EO that fails to parse with
+     * "redundant parentheses around a single token" (#5591).</p>
+     *
      * @param args The arguments
      * @return The inlined string, or empty if any argument can't be inlined
      */
@@ -288,7 +299,7 @@ final class Pretty {
             if (joined.length() > 0) {
                 joined.append(' ');
             }
-            if (arg.children.isEmpty()) {
+            if (Pretty.suffixed(arg).orElse(arg).children.isEmpty()) {
                 joined.append(flat.get());
             } else {
                 joined.append('(').append(flat.get()).append(')');

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# When a reversed dispatch ("eq.") inlines its arguments, an argument that is
+# itself a data-receiver dispatch ("01-.as-bool") is a single token: it has a
+# receiver child but takes no arguments of its own. It must inline bare, never
+# wrapped as "(01-.as-bool)", which would produce EO that fails to parse with
+# "redundant parentheses around a single token" (#5591). Only an argument that
+# actually applies arguments (and therefore contains a space, like "5.plus 3")
+# gets parenthesized.
+origin: |
+  [] > app
+    not. > @
+      eq.
+        01-.as-bool
+        00-.as-bool
+
+printed: |
+  [] > app
+    not. > @
+      eq. 01-.as-bool 00-.as-bool


### PR DESCRIPTION
Fixes #5591.

## Problem

`Xmir.toEO()` wrapped a single dispatch token in redundant parentheses when inlining the arguments of a reversed dispatch. The `inlined()` method in `Pretty.java` parenthesized every argument whose node had children:

```java
if (arg.children.isEmpty()) {
    joined.append(flat.get());
} else {
    joined.append('(').append(flat.get()).append(')');
}
```

A data-receiver dispatch such as `01-.as-bool` is stored in XMIR as a reversed head over a data child, so its raw node has a child (the receiver `01-`) but takes no arguments of its own — it is a single token. The `!children.isEmpty()` guard therefore wrapped it as `(01-.as-bool)`, producing EO that no longer parses (`redundant parentheses around a single token`), which broke the `format` goal on `bytes/as-bool.eo`, `number/is-nan.eo`, `number/is-integer.eo`, `recovered.eo`, `bytes/as-i64.eo`, `bytes/as-i32.eo`, and `i16.eo`.

## Fix

The guard now weighs each argument in its **suffix-resolved** (effective) shape via `suffixed()`. For a data-receiver dispatch the receiver is folded back into the base (`01-.as-bool`), leaving no children, so it inlines bare. Only a genuine application that actually applies arguments (such as `5.plus 3`) still gets wrapped.

A structural check is used rather than the "contains a space" heuristic suggested in the issue, because a string literal like `"result is %d\n"` is a single token that legitimately contains spaces — the space-based rule would wrongly parenthesize it (and did, breaking an existing print-pack test).

## Tests

- Added print-pack `reversed-with-data-receiver-args.yaml` covering a reversed `eq.` whose arguments are data-receiver dispatches; it asserts both exact output and round-trip parseability.
- All 72 `XmirTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8GVNraU9CKFcJL6mb37HN)_