### PR TITLE
#5593 printer collapses self-reference to top-level object to bare name

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -152,6 +152,13 @@
     <xsl:variable name="rho-prefix" select="concat($eo:xi, '.', $eo:rho, '.')"/>
     <xsl:variable name="rest" select="substring-after(@base, $rho-prefix)"/>
     <xsl:variable name="first" select="if (contains($rest, '.')) then substring-before($rest, '.') else $rest"/>
+    <!-- The current program's "+package" and the "Φ.<package>." prefix a
+         self-reference to a same-file object carries after being homed
+         into the package (add-default-package / build-fqns). -->
+    <xsl:variable name="package" select="string(/object/metas/meta[head='package']/part[1])"/>
+    <xsl:variable name="self-prefix" select="concat($eo:program, '.', $package, '.')"/>
+    <xsl:variable name="self-rest" select="substring-after(@base, $self-prefix)"/>
+    <xsl:variable name="self-first" select="if (contains($self-rest, '.')) then substring-before($self-rest, '.') else $self-rest"/>
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
@@ -164,6 +171,17 @@
         <!-- The plain top-level name would be shadowed by an in-scope
              attribute, so keep the explicit Q. root to disambiguate. -->
         <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
+      </xsl:when>
+      <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
+        <!-- The base names this program's own top-level object through its
+             fully-qualified "Φ.<package>.<name>…" form. The source wrote it
+             bare and every other same-package reference prints bare, so drop
+             the redundant "Φ.<package>." prefix and render the bare name. If
+             an in-scope attribute shadows that name, this branch is skipped:
+             either the package segment is shadowed too (kept "Q."-rooted by
+             the branch above) or the qualified "<package>.<name>" survives
+             through the otherwise branch, both of which resolve correctly. -->
+        <xsl:value-of select="eo:translate-path($self-rest)"/>
       </xsl:when>
       <xsl:when test="starts-with(@base, $rho-prefix) and $first != '' and $first != $eo:rho and $first != $eo:phi and $first != $eo:xi and $first != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$first]) and exists(ancestor::o[not(@base)][2]/o[@name=$first])">
         <!-- The single leading "^." parent hop is redundant: the name is

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  +package tuple
+
+  [] > concat
+    ? >> list
+    ? >> passed
+    withouti > list3
+      Q.tuple.concat
+        * 0 1
+        * 2 3
+      0
+
+printed: |
+  +package tuple
+
+  [] > concat
+    ? >> list
+    ? >> passed
+    withouti > list3
+      concat
+        * 0 1
+        * 2 3
+      0


### PR DESCRIPTION
Closes #5593.

## Problem

`Xmir.toEO()` printed a reference to the file's own top-level object with a redundant package prefix instead of the bare name. Re-formatting `eo-runtime/src/main/eo/tuple/concat.eo` (which is `+package tuple` and defines `[] > concat`) rewrote the self-references inside its tests from bare `concat` to `tuple.concat`:

```
    withouti > list3
      concat            ->      tuple.concat
        * 0 1                     * 0 1
        * 2 3                     * 2 3
      0                         0
```

The parser homes a same-file reference into `Φ.tuple.concat`, while external package members stay bare in the XMIR the printer receives. The head template in `to-eo-tree.xsl` rendered that `Φ.tuple.concat` base through the `otherwise` branch (`eo:surface`), which only strips the `Φ.` root and keeps the whole package path, emitting `tuple.concat`. It never recognized that the base names the current program's own top-level object and should collapse to bare `concat`.

## Fix

Add a branch to the head template (`to-eo-tree.xsl`) that, for a `Φ.<package>.<name>…` base whose `<package>` equals the file's `+package` meta and whose first name segment is the top-level object (`/object/o[1]/@name`), renders the bare `<name>…` — the way the source wrote it and every other same-package reference prints. The branch is skipped when an in-scope attribute shadows the name: if the package segment itself is shadowed the existing `Q.`-root branch keeps it rooted, otherwise the qualified `<package>.<name>` survives through the `otherwise` branch, both of which resolve correctly.

## Tests

Added `self-reference.yaml` print-pack. It reproduced `tuple.concat` before the fix and now prints bare `concat`, and round-trips through both `printsToEo` and `printsToParseableEo`. Full `eo-printer` module test suite passes (97 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb6FPAFXqikpCtLnwDxSjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lb6FPAFXqikpCtLnwDxSjL)_