### PR TITLE
Allow named arguments in only-phi formations

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -757,7 +757,7 @@ A line whose suffix is `> [params] > name` is an **`inline-phi-formation`**: the
 
 - The line may freely appear as a vertical arg of an enclosing expression — the rules above apply only to *its own* depth.
 
-The formation binds only `φ`, so its arguments may not introduce a second named attribute: **an only-phi argument may not carry a name suffix** (`> name`, `>>`, `+> name`). The ban follows the argument down through nested applications and resets inside a nested formation argument, where naming resumes as usual (§6.2). This is the one place a vertical-application argument may not be named (contrast C.3).
+An only-phi argument is an ordinary vertical-application argument and may carry a name suffix like any other (§6.2); the φ's arguments are named exactly as they would be under a plain `vapplication` head.
 
 Legal — a nested formation argument names its own attributes:
 
@@ -767,17 +767,17 @@ foo > [] >>
     z > w                             ← attribute of [y], named as usual
 ```
 
-Illegal — a name suffix on an only-phi argument:
+Legal — a named only-phi argument:
 
 ```
 foo > [] >>
-  bar > x                             ← rejected: only-phi argument cannot be named
+  bar > x                             ← ordinary named argument of foo
 ```
 
 ```
 foo > [] >>
   bar
-    baz > x                           ← rejected: still in argument position
+    baz > x                           ← named argument, deeper down
 ```
 
 ### 4.6 Triple-quoted text block
@@ -881,7 +881,7 @@ R-5.3.5. **Test depth.** If the popped entry's name suffix is `+>`, the popped e
   - the popped entry's parent's own `parent_kind` must be `top-level` (otherwise the parent is itself nested, also illegal).
 
   Either failure yields error `test attribute legal only as direct child of top-level object` (R-6.3.3 / §9.9). The first failure case covers a stray `+>` at indent 0; the second covers `+>` at indent ≥ 4.
-R-5.3.6. **Inline-phi argument rules.** An `inline-phi-formation` whose φ carries horizontal args is closed for deeper children (caught at child-push time via R-6.1.1). When its φ is bare, deeper children attach as φ's vertical arguments; because the formation binds only φ, such an argument may not be named — at close time an argument entry that carries a name suffix yields error `argument of an only-phi formation cannot carry a name suffix` (§9.9). The ban propagates down through nested applications and resets at a formation boundary (§4.5).
+R-5.3.6. **Inline-phi argument rules.** An `inline-phi-formation` whose φ carries horizontal args is closed for deeper children (caught at child-push time via R-6.1.1). When its φ is bare, deeper children attach as φ's vertical arguments; such an argument is an ordinary vertical-application argument and may carry a name suffix like any other (§4.5, §6.2).
 
 ### 5.4 End-of-file (FSM action)
 
@@ -1240,7 +1240,7 @@ For each outer kind, this table fixes the order of `<o>` children inside its emi
 | `hmethod` (single line, 0 hargs) | Emits a **sequence of sibling `<o>`s** under the enclosing parent: (1) the receiver of the chain as the first sibling; (2) one `<o base='.<methodname>' method=''>` per `.method` segment, in source order. Because the whole chain lives on **one source line**, only the last `.method` segment can carry a name suffix (the line's `> name`); intermediate segments on the same line have no syntactic place for their own name. (The intermediate-names provision of R-6.2.3 applies only to `vmethod` chains, where each `.method` is on its own line.) See R-9.0.3 for the convention. |
 | `happlication`, `vapplication` | The outer `<o>` carries `@base = head reference` (or, for chained heads, the last link's `<o>` is the outer one — R-9.0.3.1). Arguments emit as direct children of that `<o>` in source order. |
 | `bare-formation` | (1) void params from the `[...]` head, in source order; (2) all body children — plain, master, and `+>` test attributes — in source order as they appear in the body. The parser does **not** reorder children by category; the category distinction in §1.3 is about role and naming requirements, not emission order. |
-| `inline-phi-formation` | (1) void params from `> [params]` in source order; (2) the LHS expression as a single child with `@name='φ'`. When the LHS has no horizontal args this `φ` `<o>` stays open, and deeper-indent lines emit inside it as its vertical arguments (`@as='αN'`, per `vapplication`); at close time the φ `<o>` and the formation `<o>` are both closed. When the LHS has horizontal args the φ is closed at emit time and the line accepts no children (R-6.1.1). The formation's other attribute slots stay empty — its only bound attribute is `φ` — so an argument may not carry a name suffix (R-5.3.6). |
+| `inline-phi-formation` | (1) void params from `> [params]` in source order; (2) the LHS expression as a single child with `@name='φ'`. When the LHS has no horizontal args this `φ` `<o>` stays open, and deeper-indent lines emit inside it as its vertical arguments (`@as='αN'`, per `vapplication`); at close time the φ `<o>` and the formation `<o>` are both closed. When the LHS has horizontal args the φ is closed at emit time and the line accepts no children (R-6.1.1). φ's vertical arguments are named as usual (§4.5 / R-5.3.6). |
 | Atom (formation + `/sig`) | (1) void params in source order; (2) `<o name='λ' atom='<sig>'/>` marker; (3) test attributes (`+>`) in source order |
 | `bare-reversed` (vertical) | (1) the receiver's `<o>` first; (2) each method-arg `<o>` in source order |
 | `reversed-with-hargs` | same as `bare-reversed` — receiver first, args in source order |
@@ -1310,7 +1310,6 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application` |
 | `.method` continuation on an only-phi formation | `method continuation not allowed after only-phi formation` |
-| Name suffix on an only-phi φ's argument | `argument of an only-phi formation cannot carry a name suffix` |
 | `.method` line at top level, deeper than parent, or with no same-indent sibling | `method continuation has no expression to attach to` |
 | Chained inline-phi suffix `expr > [a] > [b] > name` | `chained inline-phi suffixes are not allowed` |
 | Inline-phi without a name on the right (`expr > [params]` alone) | `inline-phi formation must carry a name on the right` |
@@ -1367,7 +1366,7 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 | `bare-reversed` | 1 line + body | yes (receiver+args) | yes (after) | `name.` vertical form |
 | `reversed-with-hargs` | 1 line | **no** | **no** | `name. arg1 arg2…` |
 | `compact-tuple` | 1 line + body | yes (tuple+direct args) | yes (after) | `head *N` |
-| `inline-phi-formation` | 1 line (+ body if bare φ) | yes if φ has 0 hargs (φ's vertical args); **no** if φ has hargs | **no** | `expr > [params] > name`; a bare φ opens for a vertical-argument block (§4.5), and its arguments may not be named (R-5.3.6) |
+| `inline-phi-formation` | 1 line (+ body if bare φ) | yes if φ has 0 hargs (φ's vertical args); **no** if φ has hargs | **no** | `expr > [params] > name`; a bare φ opens for a vertical-argument block (§4.5), and its arguments are named as usual (R-5.3.6) |
 | `vapplication` | multi-line | yes while in progress | yes after block closes | head + vertical block |
 | `vmethod` | multi-line | yes while in progress (only if last `.method` has 0 hargs) | yes (more `.method`s extend the chain; same-indent `.method` after block closes wraps it) | chain of `.method` continuations |
 | `vmethod-with-hargs` | multi-line | **no** | **no** | a `.method` continuation line that itself carries ≥1 horizontal args — closes the chain immediately |
@@ -1502,7 +1501,7 @@ Notable points:
 - **Horizontal reversed dispatch (`eq. (mod. y 4) 0`)** appears 4× in this snippet. R-3.8.2 and R-6.6.3 govern it.
 - **Receiver as paren group**: `(mod. y 4)` is the receiver of `.eq`. Per R-3.8.2, the first horizontal arg is always the receiver.
 - **`mod. y 4`**: receiver = `y` (just an identifier — receivers don't have to be paren groups), method arg = `4`. Same as `y.mod 4` in regular notation.
-- **`year!` on a vapp arg**: a vapplication's vertical args may each carry an independent name suffix. This is orthogonal to the all-or-nothing binding rule (R-6.6.2 governs `:label` bindings, not `> name` suffixes). The sole exception is an argument of an only-phi formation's φ, which may not be named (§4.5 / R-5.3.6), since that formation binds only `φ`.
+- **`year!` on a vapp arg**: a vapplication's vertical args may each carry an independent name suffix. This is orthogonal to the all-or-nothing binding rule (R-6.6.2 governs `:label` bindings, not `> name` suffixes). Arguments of an only-phi formation's φ are ordinary vertical-application arguments and may be named the same way (§4.5 / R-5.3.6).
 - **`:y` binding on `leap year:y`**: inside the paren group, `leap` is applied to `year` with binding `:y`. Single-arg application, all-or-nothing trivially satisfied.
 
 This snippet exercises hmethod chains, horizontal reversed dispatch, paren groups, vapplication, name suffixes with `!`, and `:label` bindings — every major construct except text blocks and compact tuples.

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -769,9 +769,7 @@ final class Eo implements Iterable<Directive> {
 
     /**
      * Report naming violations on the popped level: a plain child of a
-     * formation or top-level object that lacks a name (R-5.3.1), and an
-     * only-phi argument that carries one — the formation binds only φ,
-     * so its φ's arguments may not be named (§4.5).
+     * formation or top-level object that lacks a name (R-5.3.1).
      * @param level The level being closed
      * @param emit The directives sink
      */
@@ -782,12 +780,6 @@ final class Eo implements Iterable<Directive> {
             emit.error(
                 level.start(), level.indent(),
                 "object inside formation must have a name"
-            );
-        }
-        if (level.argument() && level.named()) {
-            emit.error(
-                level.start(), level.indent(),
-                "argument of an only-phi formation cannot carry a name suffix"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -86,15 +86,6 @@ final class Level {
     private boolean plain;
 
     /**
-     * True when this entry sits in argument position under an only-phi
-     * formation's φ — set by {@link Stack} as it propagates the flag
-     * down through nested applications and resets it at a formation
-     * boundary. Read at close time to reject a name suffix on such an
-     * argument (§4.5).
-     */
-    private boolean argument;
-
-    /**
      * For {@link Kind#COMPACT_TUPLE}: the {@code N} count from {@code *N}.
      */
     private int count;
@@ -240,34 +231,6 @@ final class Level {
      */
     boolean taken() {
         return this.taken;
-    }
-
-    /**
-     * Whether this entry is an argument of an only-phi formation's φ.
-     * @return Argument-position flag
-     */
-    boolean argument() {
-        return this.argument;
-    }
-
-    /**
-     * Whether a child pushed under this entry sits in argument position
-     * of an only-phi formation's φ (§4.5): true for a direct child of
-     * the only-phi entry, and for a deeper child that stays in argument
-     * position — the flag propagates down through nested applications
-     * but resets at a formation boundary, where naming resumes.
-     * @return True if a child of this entry is an only-phi argument
-     */
-    boolean argumentative() {
-        return this.kind == Kind.ONLY_PHI_FORMATION
-            || this.argument && !this.kind.formation();
-    }
-
-    /**
-     * Flag this entry as an argument of an only-phi formation's φ.
-     */
-    void argues() {
-        this.argument = true;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -38,9 +38,7 @@ import java.util.List;
  * a body block is {@code [x] > bar} whose φ is {@code foo} applied to
  * that block. With horizontal args the φ is already a full application
  * and the line is {@link Openness#HORIZONTAL_COMPLETED} — no body is
- * accepted. An only-phi argument may not carry a name suffix (the
- * formation binds only φ); the {@link Stack} flags such arguments and
- * the close-time check in {@link Eo} rejects a name on them.</p>
+ * accepted.</p>
  *
  * <p>This iteration accepts identifier and root LHS heads with
  * optional chains and identifier / INT / STAR / STRING / FLOAT /

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -166,7 +166,6 @@ final class Stack {
     ) {
         final Kind parent;
         final boolean patom;
-        final boolean argues;
         if (this.levels.isEmpty()) {
             if (indent != 0) {
                 throw new IllegalStateException(
@@ -177,7 +176,6 @@ final class Stack {
             }
             parent = Kind.TOP_LEVEL;
             patom = false;
-            argues = false;
         } else {
             final Level under = this.top();
             if (indent != under.indent() + Stack.STEP) {
@@ -190,16 +188,12 @@ final class Stack {
             }
             parent = under.kind();
             patom = under.atom();
-            argues = under.argumentative();
             under.observeVoid(kind, line, indent);
         }
         if (!this.levels.isEmpty()) {
             this.opener.beforeChild(this.top());
         }
         final Level fresh = new Level(indent, line, kind, openness, parent, patom);
-        if (argues) {
-            fresh.argues();
-        }
         this.levels.add(fresh);
         if (parent == Kind.BARE_REVERSED) {
             final Level host = this.levels.get(this.levels.size() - 2);
@@ -250,23 +244,17 @@ final class Stack {
         final int indent = old.indent();
         final Kind parent;
         final boolean patom;
-        final boolean argues;
         if (this.levels.isEmpty()) {
             parent = Kind.TOP_LEVEL;
             patom = false;
-            argues = false;
         } else {
             final Level under = this.top();
             parent = under.kind();
             patom = under.atom();
-            argues = under.argumentative();
             under.observeVoid(kind, line, indent);
             this.opener.beforeChild(under);
         }
         final Level fresh = new Level(indent, line, kind, openness, parent, patom);
-        if (argues) {
-            fresh.argues();
-        }
         this.levels.add(fresh);
         return fresh;
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-arg-with-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-arg-with-name.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 3
-message: |-
-  [3:4] error: 'argument of an only-phi formation cannot carry a name suffix'
-      bar > x
-      ^
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.foo']
+  - //o[@name='x']
 input: |
   [] > obj
     foo > [] >>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-deep-arg-with-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-deep-arg-with-name.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 4
-message: |-
-  [4:6] error: 'argument of an only-phi formation cannot carry a name suffix'
-        baz > x
-        ^
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.foo']
+  - //o[@name='x']
 input: |
   [] > obj
     foo > [] >>


### PR DESCRIPTION
Fixes #5598.

## Problem

The parser's check `argument of an only-phi formation cannot carry a name suffix` (in `Eo.checkNaming`) was outdated. Only-phi formations now permit named arguments, but the check still rejected them, turning legal EO into a parse error. It surfaced against the hybrid inline-phi shorthand the printer now emits (#5594), e.g.:

```
malloc.for > [sum] >>
  a
  [left] >>
    ...
```

where `[left] >>` is a legal anonymous formation sitting as an argument of `malloc.for`.

## Changes

- **`Eo.java`** — drop the argument-naming error branch in `checkNaming` (and update its Javadoc).
- **`Level.java`** — remove the now-dead only-phi argument flagging: the `argument` field, `argument()`, `argumentative()`, and `argues()`.
- **`Stack.java`** — remove the `argues` propagation in `push` and `replace`.
- **`LnOnlyPhi.java`** — remove the stale documentation about only-phi arguments not being nameable.
- **Test packs** — delete the two typo packs that asserted the stale error (`eo-typos/only-phi-arg-with-name.yaml`, `eo-typos/only-phi-deep-arg-with-name.yaml`) and invert them into passing `eo-syntax` packs that assert the named argument now parses without errors.
- **`PARSER_SPEC.md`** — update §4.5, R-5.3.6, the error table, and the emission table to reflect that only-phi arguments are ordinary vertical-application arguments and may be named.

## Verification

The full `eo-parser` test suite passes (`mvn test`): 1464 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUbT1fm19XgBTXNea415fS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUbT1fm19XgBTXNea415fS)_