### PR TITLE
#5598 withhold hybrid inline-phi when a decoratee argument is named

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -247,6 +247,15 @@ final class Pretty {
      * and keep the verbose layout; a reversed dispatch that also carries
      * arguments ({@code if.} with its branches) does get the hybrid.</p>
      *
+     * <p>The hybrid is also withheld when any decoratee argument carries a
+     * name suffix ({@code [left] >>}, {@code malloc.for > [b]}, {@code
+     * b.put > [m] >>}). Those arguments become the body of the collapsed
+     * only-phi formation, and an only-phi formation may hold nothing but its
+     * {@code φ} decoratee, so a named line there fails to parse with
+     * "argument of an only-phi formation cannot carry a name suffix"
+     * (issue #5598). Keeping the verbose {@code  > @} layout gives the
+     * decoratee its own scope, where named arguments are legal.</p>
+     *
      * @param node The formation node
      * @param indent The indentation level
      * @return The rendered block, or empty if the inline-phi form doesn't apply
@@ -269,6 +278,10 @@ final class Pretty {
                     false, decoratee.reversed, decoratee.data, decoratee.children
                 )
             );
+            final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
+                && !(decoratee.reversed && decoratee.children.size() <= 1);
+            final boolean unnamed = decoratee.children.stream()
+                .allMatch(kid -> kid.tail.isEmpty());
             if (value.isPresent()) {
                 result = Optional.of(
                     new StringBuilder(this.step().repeat(indent))
@@ -276,8 +289,7 @@ final class Pretty {
                         .append(marker)
                         .toString()
                 );
-            } else if (!decoratee.abstractt && !decoratee.children.isEmpty()
-                && !(decoratee.reversed && decoratee.children.size() <= 1)) {
+            } else if (applied && unnamed) {
                 result = Optional.of(
                     this.vertical(
                         new Pretty.Node(

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-named-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-named-argument.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  +package org.eolang
+
+  [x] > foo
+    malloc.of > @
+      8
+      [sum] >>
+        malloc.for > @
+          a
+          [left] >>
+            b > @
+printed: |
+  +package org.eolang
+
+  [x] > foo
+    malloc.of > @
+      8
+      [sum] >>
+        malloc.for > @
+          a
+          b > [left] >>


### PR DESCRIPTION
Fixes #5598.

## Problem

The hybrid inline-phi shorthand added in #5594 was emitted even when a decoratee's arguments carried a name suffix, producing EO that could not be re-parsed. Re-formatting files such as `eo-runtime/src/main/eo/number/integral.eo` collapsed

```
[sum] >>
  malloc.for > @
    a
    [left] >>
      ...
```

into

```
malloc.for > [sum] >>
  a
  [left] >>
    ...
```

The collapsed `malloc.for > [sum] >>` is the compact inline-phi form of the only-phi formation `[sum]`, so its indented body lines are the formation's own content. A named line such as `[left] >>` there reads as a second attribute of `[sum]`, but an only-phi formation may hold only its `φ` decoratee — so re-parsing failed with `argument of an only-phi formation cannot carry a name suffix`.

## Fix

In `Pretty.phi()` the hybrid branch now fires only when every decoratee argument has an empty tail (no `> name`, `> [params]`, or `>>` suffix). When any argument is named, the branch yields empty and the verbose ` > @` layout is kept, as before #5594 — that form gives the decoratee its own scope, where named arguments are legal.

The four-predicate guard is split across two local booleans (`applied`, `unnamed`) to stay within the project's boolean-expression-complexity and nesting limits.

## Tests

Added the print-pack `hybrid-phi-named-argument.yaml`, whose decoratee carries a `[left] >>` argument. The outer only-phi correctly stays verbose while the inner unnamed decoratee still collapses, demonstrating the guard is precise. Full `eo-printer` suite (103 tests) and qulice pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUWiRT2tEj7m5nvzx8X1mi)_