### PR TITLE
#5604 withhold hybrid inline-phi when a named line is nested below the decoratee's direct children

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -247,14 +247,18 @@ final class Pretty {
      * and keep the verbose layout; a reversed dispatch that also carries
      * arguments ({@code if.} with its branches) does get the hybrid.</p>
      *
-     * <p>The hybrid is also withheld when any decoratee argument carries a
-     * name suffix ({@code [left] >>}, {@code malloc.for > [b]}, {@code
-     * b.put > [m] >>}). Those arguments become the body of the collapsed
-     * only-phi formation, and an only-phi formation may hold nothing but its
-     * {@code φ} decoratee, so a named line there fails to parse with
-     * "argument of an only-phi formation cannot carry a name suffix"
-     * (issue #5598). Keeping the verbose {@code  > @} layout gives the
-     * decoratee its own scope, where named arguments are legal.</p>
+     * <p>The hybrid is also withheld when any line in the decoratee's whole
+     * subtree carries a name suffix ({@code [left] >>}, {@code malloc.for >
+     * [b]}, {@code b.put > [m] >>}). The decoratee's subtree becomes the body
+     * of the collapsed only-phi formation, and an only-phi formation may hold
+     * nothing but its {@code φ} decoratee, so a named line anywhere within it
+     * fails to parse with "an auto-named attribute cannot be a named attribute
+     * of an only-phi formation, which binds only its φ decoratee" (issues
+     * #5598, #5604). A direct child is not enough to check: the offending line
+     * may be nested deeper — inside a tuple, a dispatch, or an application —
+     * where a shallow guard would miss it (issue #5604). Keeping the verbose
+     * {@code  > @} layout gives the decoratee its own scope, where named
+     * arguments are legal.</p>
      *
      * @param node The formation node
      * @param indent The indentation level
@@ -281,7 +285,7 @@ final class Pretty {
             final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
                 && !(decoratee.reversed && decoratee.children.size() <= 1);
             final boolean unnamed = decoratee.children.stream()
-                .allMatch(kid -> kid.tail.isEmpty());
+                .allMatch(Pretty.Node::nameless);
             if (value.isPresent()) {
                 result = Optional.of(
                     new StringBuilder(this.step().repeat(indent))
@@ -456,6 +460,24 @@ final class Pretty {
                     .map(Pretty.Node::parse)
                     .collect(Collectors.toList())
             );
+        }
+
+        /**
+         * Whether this node carries no name suffix anywhere in its subtree.
+         *
+         * <p>A line is "named" when its {@code tail} holds a {@code > name},
+         * {@code > [params]} or {@code >>} suffix. This walks the node and all
+         * its descendants, so a named line nested below the top level — inside
+         * a tuple, a dispatch, or an application — is caught too. It decides
+         * whether a decoratee's whole subtree is safe to fold into a compact
+         * only-phi formation, which binds nothing but its {@code φ} decoratee
+         * (issue #5604).</p>
+         *
+         * @return True when neither this node nor any descendant is named
+         */
+        boolean nameless() {
+            return this.tail.isEmpty()
+                && this.children.stream().allMatch(Pretty.Node::nameless);
         }
     }
 }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-deep-named-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-deep-named-argument.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  +package org.eolang
+
+  [] > foo
+
+    ++> tests-reduce-list-with-index
+      eq. > @
+        6
+        reducedi
+          * 1 1
+          0
+          [a x i] >>
+            plus. > @
+              x
+              a
+printed: |
+  +package org.eolang
+
+  [] > foo
+
+    ++> tests-reduce-list-with-index
+      6.eq > @
+        reducedi
+          * 1 1
+          0
+          x.plus a > [a x i] >>


### PR DESCRIPTION
Fixes #5604.

## Problem

The `unnamed` guard added for #5598 in `Pretty.phi()` only inspected the *direct* children of a decoratee. When the offending auto-named line sat deeper in the decoratee's subtree — inside a tuple, a dispatch, or an application — the guard passed and the hybrid inline-phi collapse fired anyway, producing unparseable EO such as `x.plus > [a x i] >>` (`tuple/reducedi.eo`) and `m.put (f.read 12) > [f] >>` (`file.eo`). These fail to re-parse with:

> an auto-named attribute cannot be a named attribute of an only-phi formation, which binds only its φ decoratee

For example, in `reducedi.eo` the decoratee is `eq.`, whose direct children `6` and `reducedi …` are both unnamed, so the shallow guard saw nothing wrong — but `reducedi`'s own argument `[a x i] >>` is auto-named, and after the collapse it would bind to the enclosing compact only-phi formation.

## Fix

Extend the `unnamed` check to span the **entire** decoratee subtree. A new `Node.nameless()` method walks a node and all of its descendants, and the guard now withholds the hybrid whenever any descendant carries a name suffix (`> name`, `> [params]`, or a `>>` tail), keeping the verbose `> @` layout where the decoratee gets its own scope and those named arguments parse.

The recursive check lives on the nested `Node` class rather than on `Pretty` to stay within the method-count and cyclomatic-complexity limits enforced by qulice.

## Tests

Added `hybrid-phi-deep-named-argument.yaml`, a print-pack that reproduces the `reducedi.eo` shape (an only-phi test attribute whose decoratee subtree carries an auto-named `[a x i] >>` argument nested two levels down). It asserts the outer `eq. > @` stays verbose and the printed EO re-parses cleanly. Both `XmirTest.printsToEo` and `XmirTest.printsToParseableEo` exercise it.

All 105 `eo-printer` tests pass, and `qulice:check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1Guq2KvrN3btZhVVHbG57

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1Guq2KvrN3btZhVVHbG57)_