### PR TITLE
#5596 print large whole doubles with EO exponent notation

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -7,7 +7,6 @@ package org.eolang.printer;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StEnvelope;
 import com.yegor256.xsline.StSequence;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
@@ -88,7 +87,7 @@ final class StUnhex extends StEnvelope {
 
     /**
      * Convert given number to string.
-     * Prints as int if fractional part of number is 0.
+     * Prints as int when the fractional part is zero and the magnitude fits in long.
      * @param num Number to convert
      * @return Number converted to string
      */
@@ -100,7 +99,7 @@ final class StUnhex extends StEnvelope {
             } else if (Math.abs(num) < 0x1p63) {
                 str = Long.toString(num.longValue());
             } else {
-                str = BigDecimal.valueOf(num).toBigInteger().toString();
+                str = Double.toString(num).replace('E', 'e');
             }
         } else {
             str = Double.toString(num);

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -133,7 +133,7 @@ final class StUnhexTest {
                     "<p><o base='Φ.number'><o base='Φ.bytes'><o>43-E1-58-E4-60-91-3D-00</o></o></o></p>"
                 )
             ),
-            XhtmlMatchers.hasXPath("//o[text()='10000000000000000000']")
+            XhtmlMatchers.hasXPath("//o[text()='1.0e19']")
         );
     }
 


### PR DESCRIPTION
Fixes #5596 

## Problem

`Xmir.toEO()` expands large-magnitude whole doubles into full decimal form instead of preserving scientific notation. For example, reformatting `eo-runtime/src/main/eo/tuple/hash-code.eo` changes:

```eo
42.42e42 > bigval!
```

into:

```eo
42420000000000000000000000000000000000000000 > bigval!
```

Both literals represent the same IEEE-754 double (`4.242e43`), so round-tripping remains correct and the existing tests pass. However, the expanded decimal form is significantly less readable.

The issue originates in `StUnhex.number()` (`eo-printer/src/main/java/org/eolang/printer/StUnhex.java`). For whole-valued doubles with magnitude ≥ `2^63`, the method currently executes:

```java
BigDecimal.valueOf(num).toBigInteger().toString()
```

which emits the full decimal expansion. Other cases already produce appropriate output:

- Small whole numbers use `Long.toString()`.
- Non-whole doubles use `Double.toString()`, which preserves scientific notation when appropriate.

As a result, only large whole-valued doubles lose exponent notation.

## Fix

Update the `|n| ≥ 2^63` branch of `StUnhex.number()` to derive the literal from `Double.toString(num)` and convert the exponent marker from uppercase `E` to lowercase `e`, matching EO syntax (for example, `1.0e19` and `4.242e43`).

The existing `0x1p63` threshold continues to ensure ordinary integers are emitted as plain decimal values. Only values that previously went through the `BigDecimal` path are affected.

## Tests

Updated `convertsBigIntegerValuedDoubleFromHexToEo` in `StUnhexTest` to expect:

```text
1.0e19
```

instead of:

```text
10000000000000000000
```

for the hexadecimal input:

```text
43-E1-58-E4-60-91-3D-00
```

All **105** `eo-printer` tests pass, and `qulice:check` completes successfully.

