### PR TITLE
#5607 reformat xs3p.xsl to satisfy xcop

### DIFF
--- a/eo-parser/src/main/xs3p/xs3p.xsl
+++ b/eo-parser/src/main/xs3p/xs3p.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ppp="http://titanium.dstc.edu.au/xml/xs3p" version="1.0" exclude-result-prefixes="xsd ppp html" id="xs3p">
   <xsl:output method="xml" encoding="ISO-8859-1" standalone="yes" version="1.0" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" indent="yes"/>
@@ -15,57 +15,79 @@
   <!-- ******** Global Parameters ******** -->
   <!-- Title of XHTML document. -->
   <xsl:param name="title"/>
-  <!-- If 'true', sorts the top-level schema components by type,
-        then name. Otherwise, displays the components by the order that
-        they appear in the schema. -->
+  <!--
+  If 'true', sorts the top-level schema components by type,
+  then name. Otherwise, displays the components by the order that
+  they appear in the schema.
+  -->
   <xsl:param name="sortByComponent">true</xsl:param>
-  <!-- If 'true', XHTML document uses JavaScript for added
-        functionality, such as pop-up windows and information-
-        hiding.
-        Otherwise, XHTML document does not use JavaScript. -->
+  <!--
+  If 'true', XHTML document uses JavaScript for added
+  functionality, such as pop-up windows and information-
+  hiding.
+  Otherwise, XHTML document does not use JavaScript.
+  -->
   <xsl:param name="useJavaScript">true</xsl:param>
-  <!-- If 'true', prints all super-types in the
-        type hierarchy box.
-        Otherwise, prints the parent type only in the
-        type hierarchy box. -->
+  <!--
+  If 'true', prints all super-types in the
+  type hierarchy box.
+  Otherwise, prints the parent type only in the
+  type hierarchy box.
+  -->
   <xsl:param name="printAllSuperTypes">true</xsl:param>
-  <!-- If 'true', prints all sub-types in the
-        type hierarchy box.
-        Otherwise, prints the direct sub-types only in the
-        type hierarchy box. -->
+  <!--
+  If 'true', prints all sub-types in the
+  type hierarchy box.
+  Otherwise, prints the direct sub-types only in the
+  type hierarchy box.
+  -->
   <xsl:param name="printAllSubTypes">true</xsl:param>
   <!-- If 'true', prints out the Glossary section. -->
   <xsl:param name="printGlossary">true</xsl:param>
   <!-- If 'true', prints out the Legend section. -->
   <xsl:param name="printLegend">true</xsl:param>
-  <!-- If 'true', prints prefix matching namespace of schema
-        components in XML Instance Representation tables. -->
+  <!--
+  If 'true', prints prefix matching namespace of schema
+  components in XML Instance Representation tables.
+  -->
   <xsl:param name="printNSPrefixes">true</xsl:param>
-  <!-- If 'true', searches 'included' schemas for schema components
-        when generating links and XML Instance Representation tables. -->
+  <!--
+  If 'true', searches 'included' schemas for schema components
+  when generating links and XML Instance Representation tables.
+  -->
   <xsl:param name="searchIncludedSchemas">false</xsl:param>
-  <!-- If 'true', searches 'imported' schemas for schema components
-        when generating links and XML Instance Representation tables. -->
+  <!--
+  If 'true', searches 'imported' schemas for schema components
+  when generating links and XML Instance Representation tables.
+  -->
   <xsl:param name="searchImportedSchemas">false</xsl:param>
-  <!-- File containing the mapping from file locations of external
-        (e.g. included, imported, refined) schemas to file locations
-        of their XHTML documentation. -->
+  <!--
+  File containing the mapping from file locations of external
+  (e.g. included, imported, refined) schemas to file locations
+  of their XHTML documentation.
+  -->
   <xsl:param name="linksFile"/>
   <!-- Set the base URL for resolving links. -->
   <xsl:param name="baseURL"/>
-  <!-- Uses an external CSS stylesheet rather than using
-        internally-declared CSS properties. -->
+  <!--
+  Uses an external CSS stylesheet rather than using
+  internally-declared CSS properties.
+  -->
   <xsl:param name="externalCSSURL"/>
   <!-- ******** Constants ******** -->
   <!-- XML Schema Namespace -->
   <xsl:variable name="XSD_NS">http://www.w3.org/2001/XMLSchema</xsl:variable>
   <!-- XML Namespace -->
   <xsl:variable name="XML_NS">http://www.w3.org/XML/1998/namespace</xsl:variable>
-  <!-- Number of 'em' to indent from parent element's start tag to
-        child element's start tag -->
+  <!--
+  Number of 'em' to indent from parent element's start tag to
+  child element's start tag
+  -->
   <xsl:variable name="ELEM_INDENT">1.5</xsl:variable>
-  <!-- Number of 'em' to indent from parent element's start tag to
-        attribute's tag -->
+  <!--
+  Number of 'em' to indent from parent element's start tag to
+  attribute's tag
+  -->
   <xsl:variable name="ATTR_INDENT">0.5</xsl:variable>
   <!-- Title to use if none provided -->
   <xsl:variable name="DEFAULT_TITLE">XML Schema Documentation</xsl:variable>
@@ -92,18 +114,22 @@
   <xsl:variable name="STYPE_PREFIX" select="$TYPE_PREFIX"/>
   <!-- Glossary terms -->
   <xsl:variable name="TERM_PREFIX">term_</xsl:variable>
-  <!-- The original schema needs to be stored because when
-        calculating links for references, the links have to be
-        relative to the original schema. See 'PrintCompRef'
-        template. -->
+  <!--
+  The original schema needs to be stored because when
+  calculating links for references, the links have to be
+  relative to the original schema. See 'PrintCompRef'
+  template.
+  -->
   <xsl:variable name="ORIGINAL_SCHEMA" select="/xsd:schema"/>
   <!-- ******** Main Document ******** -->
   <!--
-     Main template that starts the process
-     -->
+  Main template that starts the process
+  -->
   <xsl:template match="/xsd:schema">
-    <!-- Check that links file is provided if searching external
-           schemas for components. -->
+    <!--
+    Check that links file is provided if searching external
+    schemas for components.
+    -->
     <xsl:if test="$linksFile='' and (normalize-space(translate($searchIncludedSchemas, 'TRUE', 'true'))='true' or normalize-space(translate($searchImportedSchemas, 'TRUE', 'true'))='true')">
       <xsl:call-template name="HandleError">
         <xsl:with-param name="isTerminating">true</xsl:with-param>
@@ -173,8 +199,10 @@
             <xsl:value-of select="$actualTitle"/>
           </a>
         </h1>
-        <!-- Buttons for displaying printer-friendly version, and
-                 expanding and collapsing all boxes -->
+        <!--
+        Buttons for displaying printer-friendly version, and
+        expanding and collapsing all boxes
+        -->
         <xsl:call-template name="GlobalControlButtons"/>
         <!-- Section: Table of Contents -->
         <h2>Table of Contents</h2>
@@ -263,9 +291,9 @@
     </html>
   </xsl:template>
   <!--
-     Prints out the table of Declared Namespaces for the
-     current schema.
-     -->
+  Prints out the table of Declared Namespaces for the
+  current schema.
+  -->
   <xsl:template match="xsd:schema" mode="namespaces">
     <table class="namespaces">
       <tr>
@@ -320,8 +348,8 @@
     </table>
   </xsl:template>
   <!--
-     Prints out the Table of Contents.
-     -->
+  Prints out the Table of Contents.
+  -->
   <xsl:template match="xsd:schema" mode="toc">
     <ul>
       <!-- Section: Schema Document Properties -->
@@ -392,9 +420,9 @@
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a link to a top-level schema component section in the
-     Table of Contents.
-     -->
+  Prints out a link to a top-level schema component section in the
+  Table of Contents.
+  -->
   <xsl:template match="xsd:*[@name]" mode="toc">
     <xsl:variable name="componentID">
       <xsl:call-template name="GetComponentID">
@@ -414,8 +442,8 @@
     </li>
   </xsl:template>
   <!--
-     Prints out the section for a top-level schema component.
-     -->
+  Prints out the section for a top-level schema component.
+  -->
   <xsl:template match="xsd:*[@name]" mode="topSection">
     <!-- Header -->
     <xsl:call-template name="ComponentSectionHeader">
@@ -437,9 +465,9 @@
     <xsl:call-template name="SectionFooter"/>
   </xsl:template>
   <!--
-     Prints out the buttons that can expand and collapse all boxes in
-     this page.
-     -->
+  Prints out the buttons that can expand and collapse all boxes in
+  this page.
+  -->
   <xsl:template name="GlobalControlButtons">
     <xsl:if test="normalize-space(translate($useJavaScript,'TRUE','true'))='true'">
       <div style="float: right;">
@@ -491,11 +519,11 @@ if (gc != null) {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the section header of a top-level schema component.
-     Param(s):
-            component (Node) required
-              Top-level schema component
-     -->
+  Prints out the section header of a top-level schema component.
+  Param(s):
+  component (Node) required
+  Top-level schema component
+  -->
   <xsl:template name="ComponentSectionHeader">
     <xsl:param name="component"/>
     <xsl:variable name="componentID">
@@ -534,21 +562,23 @@ if (gc != null) {
     </h3>
   </xsl:template>
   <!--
-     Prints out footer for top-level sections.
-     -->
+  Prints out footer for top-level sections.
+  -->
   <xsl:template name="SectionFooter">
-    <!-- Link to top of page-->
+    <!-- Link to top of page -->
     <div style="text-align: right; clear: both;">
       <a href="#top">top</a>
     </div>
     <hr/>
   </xsl:template>
   <!--
-     Java Script code required by the entire HTML document.
-     -->
+  Java Script code required by the entire HTML document.
+  -->
   <xsl:template name="DocumentJSCode">
-    <!-- Get all IDs of XML Instance Representation boxes
-            and place them in an array. -->
+    <!--
+    Get all IDs of XML Instance Representation boxes
+    and place them in an array.
+    -->
     <xsl:text>/* IDs of XML Instance Representation boxes */
 </xsl:text>
     <xsl:text>var xiBoxes = new Array(</xsl:text>
@@ -564,8 +594,10 @@ if (gc != null) {
     </xsl:for-each>
     <xsl:text>);
 </xsl:text>
-    <!-- Get all IDs of Schema Component Representation boxes
-            and place them in an array. -->
+    <!--
+    Get all IDs of Schema Component Representation boxes
+    and place them in an array.
+    -->
     <xsl:text>/* IDs of Schema Component Representation boxes */
 </xsl:text>
     <xsl:text>var scBoxes = new Array('schema_scbox'</xsl:text>
@@ -878,8 +910,8 @@ function viewDocumentation(compDesc, compName, docTextArray) {
 </xsl:text>
   </xsl:template>
   <!--
-     CSS properties for the entire HTML document.
-     -->
+  CSS properties for the entire HTML document.
+  -->
   <xsl:template name="DocumentCSSStyles">
     <xsl:text>
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
@@ -1244,9 +1276,9 @@ div#legend div.hint {
 </xsl:text>
   </xsl:template>
   <!--
-     Print outs a legend describing the meaning of colors, bold items,
-     etc. in the top-level sections.
-     -->
+  Print outs a legend describing the meaning of colors, bold items,
+  etc. in the top-level sections.
+  -->
   <xsl:template name="Legend">
     <!-- Header -->
     <div style="float: left; width: 15em;">
@@ -1369,7 +1401,7 @@ div#legend div.hint {
         <li>For type derivations, the elements and attributes that have been added to or changed from the base type's content are shown in <span style="font-weight: bold">bold</span>.</li>
         <li>If an element/attribute has a fixed value, the fixed value is shown in green, e.g. country="Australia".</li>
         <li>Otherwise, the type of the element/attribute is displayed.
-               <ul><li>If the element/attribute's type is in the schema, a link is provided to it.</li><!--<li>An <em>E</em> symbol is shown if the element/attribute's type is located in an external schema.</li>--><li>For local simple type definitions, the constraints are displayed in angle brackets, e.g. &lt;&lt;<em>pattern</em> = [1-9][0-9]{3}&gt;&gt;.</li></ul>
+               <ul><li>If the element/attribute's type is in the schema, a link is provided to it.</li><!-- <li>An <em>E</em> symbol is shown if the element/attribute's type is located in an external schema.</li> --><li>For local simple type definitions, the constraints are displayed in angle brackets, e.g. &lt;&lt;<em>pattern</em> = [1-9][0-9]{3}&gt;&gt;.</li></ul>
             </li>
         <xsl:if test="normalize-space(translate($useJavaScript,'TRUE','true'))='true'">
           <li>If a local element/attribute has documentation, it will be displayed in a window that pops up when the question mark inside the attribute or next to the element is clicked, e.g. &lt;postcode&gt;.</li>
@@ -1421,8 +1453,8 @@ div#legend div.hint {
     <div class="hint">The Schema Component Representation table above displays the underlying XML representation of the schema component. (Annotations are not shown.)</div>
   </xsl:template>
   <!--
-     Print outs all terms for the glossary section.
-     -->
+  Print outs all terms for the glossary section.
+  -->
   <xsl:template name="Glossary">
     <xsl:call-template name="PrintGlossaryTerm">
       <xsl:with-param name="code">Abstract</xsl:with-param>
@@ -1622,17 +1654,17 @@ div#legend div.hint {
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out a term in the glossary section.
-     Param(s):
-            code (String) required
-              Unique ID of glossary term
-            term (String) required
-              Glossary term
-            description (Result Tree Fragment) required
-              Meaning of term; may contain HTML tags and links
-            link (String) optional
-              URI containing more info about term
-     -->
+  Prints out a term in the glossary section.
+  Param(s):
+  code (String) required
+  Unique ID of glossary term
+  term (String) required
+  Glossary term
+  description (Result Tree Fragment) required
+  Meaning of term; may contain HTML tags and links
+  link (String) optional
+  URI containing more info about term
+  -->
   <xsl:template name="PrintGlossaryTerm">
     <xsl:param name="code"/>
     <xsl:param name="term"/>
@@ -1657,14 +1689,14 @@ div#legend div.hint {
   </xsl:template>
   <!-- ******** Hierarchy table ******** -->
   <!--
-     Prints out substitution group hierarchy for
-     element declarations.
-     -->
+  Prints out substitution group hierarchy for
+  element declarations.
+  -->
   <xsl:template match="xsd:element" mode="hierarchy">
     <!--
-        Find out members of substitution group that this element
-        heads.
-        -->
+    Find out members of substitution group that this element
+    heads.
+    -->
     <xsl:variable name="members">
       <ul>
         <xsl:call-template name="PrintSGroupMembers">
@@ -1710,8 +1742,8 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out Hierarchy table for complex type definitions.
-     -->
+  Prints out Hierarchy table for complex type definitions.
+  -->
   <xsl:template match="xsd:complexType" mode="hierarchy">
     <table class="hierarchy">
       <!-- Print super types -->
@@ -1760,8 +1792,8 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out Hierarchy table for simple type definitions.
-     -->
+  Prints out Hierarchy table for simple type definitions.
+  -->
   <xsl:template match="xsd:simpleType" mode="hierarchy">
     <table class="hierarchy">
       <!-- Print super types -->
@@ -1810,21 +1842,21 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Unmatched template for 'hierarchy' mode
-     -->
+  Unmatched template for 'hierarchy' mode
+  -->
   <xsl:template match="*" mode="hierarchy"/>
   <!--
-     Prints out members, if any, of the substitution group that a
-     given element declaration heads.
-     Assumes it will be called within XHTML <ul> tags.
-     Param(s):
-            element (Node) required
-              Top-level element declaration
-            elementList (String) optional
-                List of elements in this call chain. Name of element starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out members, if any, of the substitution group that a
+  given element declaration heads.
+  Assumes it will be called within XHTML <ul> tags.
+  Param(s):
+  element (Node) required
+  Top-level element declaration
+  elementList (String) optional
+  List of elements in this call chain. Name of element starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSGroupMembers">
     <xsl:param name="element"/>
     <xsl:param name="elementList"/>
@@ -1864,11 +1896,12 @@ div#legend div.hint {
               <xsl:with-param name="name" select="@name"/>
             </xsl:call-template>
           </li>
-          <!-- Recursively find members of a substitution group that
-                    current element in list might head, since substitution
-                    groups are transitive (unless 'substitution' is
-                    blocked).
-                -->
+          <!--
+          Recursively find members of a substitution group that
+          current element in list might head, since substitution
+          groups are transitive (unless 'substitution' is
+          blocked).
+          -->
           <xsl:if test="not(contains($block, 'substitution'))">
             <xsl:call-template name="PrintSGroupMembers">
               <xsl:with-param name="element" select="."/>
@@ -1880,19 +1913,19 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out the super types of a given type definition.
-     Param(s):
-            type (Node) required
-                Type definition
-            isCallingType (boolean) optional
-                If true, 'type' is the type definition that starts
-                this call. Otherwise, this is a recursive call from
-                'PrintSupertypes' itself.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out the super types of a given type definition.
+  Param(s):
+  type (Node) required
+  Type definition
+  isCallingType (boolean) optional
+  If true, 'type' is the type definition that starts
+  this call. Otherwise, this is a recursive call from
+  'PrintSupertypes' itself.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSupertypes">
     <xsl:param name="type"/>
     <xsl:param name="isCallingType">true</xsl:param>
@@ -1964,7 +1997,7 @@ div#legend div.hint {
             <xsl:choose>
               <xsl:when test="normalize-space($baseTypeRef)='Local type definition'">
                 <xsl:value-of select="$baseTypeRef"/>
-                <!-- Symbol to indicate type derivation-->
+                <!-- Symbol to indicate type derivation -->
                 <xsl:text> &lt; </xsl:text>
               </xsl:when>
               <xsl:when test="normalize-space($baseTypeRef)!=''">
@@ -1997,9 +2030,10 @@ div#legend div.hint {
                 <xsl:text> &lt; </xsl:text>
               </xsl:when>
               <xsl:otherwise>
-                <!-- IGNORE: Base type may not be exist probably because
-                            current type does not be derived from another type.
-                        -->
+                <!--
+                IGNORE: Base type may not be exist probably because
+                current type does not be derived from another type.
+                -->
               </xsl:otherwise>
             </xsl:choose>
             <!-- Print out current type's name -->
@@ -2035,9 +2069,10 @@ div#legend div.hint {
                 </xsl:call-template>
               </xsl:when>
               <xsl:otherwise>
-                <!-- IGNORE: Base type may not be exist probably because
-                             current type does not be derived from another type.
-                        -->
+                <!--
+                IGNORE: Base type may not be exist probably because
+                current type does not be derived from another type.
+                -->
               </xsl:otherwise>
             </xsl:choose>
             <!-- Print out derivation method -->
@@ -2052,19 +2087,19 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out the sub types of a given complex type definition.
-     Param(s):
-            type (Node) required
-                Complex type definition
-            isCallingType (boolean) optional
-                If true, 'type' is the type definition that starts this
-                call. Otherwise, this is a recursive call from
-                'PrintComplexSubtypes' itself.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out the sub types of a given complex type definition.
+  Param(s):
+  type (Node) required
+  Complex type definition
+  isCallingType (boolean) optional
+  If true, 'type' is the type definition that starts this
+  call. Otherwise, this is a recursive call from
+  'PrintComplexSubtypes' itself.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintComplexSubtypes">
     <xsl:param name="type"/>
     <xsl:param name="isCallingType">true</xsl:param>
@@ -2115,19 +2150,19 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-        Prints out the sub types of a given simple type definition.
-        Param(s):
-            type (Node) required
-                Simple type definition
-            isCallingType (boolean) optional
-                If true, 'type' is the type definition that starts this
-                call. Otherwise, this is a recursive call from
-                'PrintSimpleSubtypes'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out the sub types of a given simple type definition.
+  Param(s):
+  type (Node) required
+  Simple type definition
+  isCallingType (boolean) optional
+  If true, 'type' is the type definition that starts this
+  call. Otherwise, this is a recursive call from
+  'PrintSimpleSubtypes'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSimpleSubtypes">
     <xsl:param name="type"/>
     <xsl:param name="isCallingType">true</xsl:param>
@@ -2218,9 +2253,9 @@ div#legend div.hint {
   </xsl:template>
   <!-- ******** Properties table ******** -->
   <!--
-     Prints out the contents of an 'appinfo' or a 'documentation'
-     element in the Properties table.
-     -->
+  Prints out the contents of an 'appinfo' or a 'documentation'
+  element in the Properties table.
+  -->
   <xsl:template match="xsd:appinfo | xsd:documentation" mode="properties">
     <!-- Print out children using XML pretty printer templates -->
     <xsl:choose>
@@ -2244,9 +2279,9 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the Properties table for a top-level
-     attribute declaration.
-     -->
+  Prints out the Properties table for a top-level
+  attribute declaration.
+  -->
   <xsl:template match="xsd:attribute" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2300,9 +2335,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out Properties table for a top-level
-     attribute group or model group definition.
-     -->
+  Prints out Properties table for a top-level
+  attribute group or model group definition.
+  -->
   <xsl:template match="xsd:attributeGroup | xsd:group" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2319,9 +2354,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out the Properties table for a top-level
-     complex type definition.
-     -->
+  Prints out the Properties table for a top-level
+  complex type definition.
+  -->
   <xsl:template match="xsd:complexType" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2408,9 +2443,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out the Properties table for a top-level
-     element declaration.
-     -->
+  Prints out the Properties table for a top-level
+  element declaration.
+  -->
   <xsl:template match="xsd:element" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2551,9 +2586,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out the Properties table for a top-level
-     notation declaration.
-     -->
+  Prints out the Properties table for a top-level
+  notation declaration.
+  -->
   <xsl:template match="xsd:notation" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2586,9 +2621,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out the Properties table for the root
-     schema element.
-     -->
+  Prints out the Properties table for the root
+  schema element.
+  -->
   <xsl:template match="xsd:schema" mode="properties">
     <table class="properties">
       <!-- Target Namespace -->
@@ -2731,9 +2766,9 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Prints out the Properties table for a top-level
-     simple type definition.
-     -->
+  Prints out the Properties table for a top-level
+  simple type definition.
+  -->
   <xsl:template match="xsd:simpleType" mode="properties">
     <table class="properties">
       <!-- Name -->
@@ -2787,17 +2822,17 @@ div#legend div.hint {
     </table>
   </xsl:template>
   <!--
-     Unmatched template for 'properties' mode
-     -->
+  Unmatched template for 'properties' mode
+  -->
   <xsl:template match="*" mode="properties"/>
   <!--
-     Prints out the rows to display 'annotation' elements of an
-     component in the Properties table. This template assumes it
-     will be called within an HTML 'table' element.
-        Param(s):
-            component (Node) required
-                Schema component
-     -->
+  Prints out the rows to display 'annotation' elements of an
+  component in the Properties table. This template assumes it
+  will be called within an HTML 'table' element.
+  Param(s):
+  component (Node) required
+  Schema component
+  -->
   <xsl:template name="PrintAnnotation">
     <xsl:param name="component"/>
     <xsl:if test="$component/xsd:annotation/xsd:documentation">
@@ -2830,16 +2865,16 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the constraints of simple content
-     to be displayed within a Properties table.
-     Param(s):
-            simpleContent (Node) required
-                Node containing the simple content
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-   -->
+  Prints out the constraints of simple content
+  to be displayed within a Properties table.
+  Param(s):
+  simpleContent (Node) required
+  Node containing the simple content
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSimpleConstraints">
     <xsl:param name="simpleContent"/>
     <xsl:param name="typeList"/>
@@ -2910,16 +2945,16 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out the constraints of simple content derived by
-     restriction, which is to be displayed in a Properties table.
-     Param(s):
-            restriction (Node) required
-                Node containing the restriction
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-   -->
+  Prints out the constraints of simple content derived by
+  restriction, which is to be displayed in a Properties table.
+  Param(s):
+  restriction (Node) required
+  Node containing the restriction
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSimpleRestriction">
     <xsl:param name="restriction"/>
     <xsl:param name="typeList"/>
@@ -3088,16 +3123,18 @@ div#legend div.hint {
   </xsl:template>
   <!-- ******** XML Instance Representation table ******** -->
   <!--
-     Prints out the XML Instance Representation table for a top-level
-     schema component.
-     Param(s):
-            component (Node) required
-              Top-level schema component
-     -->
+  Prints out the XML Instance Representation table for a top-level
+  schema component.
+  Param(s):
+  component (Node) required
+  Top-level schema component
+  -->
   <xsl:template name="SampleInstanceTable">
     <xsl:param name="component"/>
-    <!-- Not applicable for simple type definitions and notation
-      declarations -->
+    <!--
+    Not applicable for simple type definitions and notation
+    declarations
+    -->
     <xsl:if test="local-name($component)!='simpleType' and local-name($component)!='notation'">
       <xsl:variable name="componentID">
         <xsl:call-template name="GetComponentID">
@@ -3116,23 +3153,23 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation of an 'all'
-     model group.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this all model group;
-                if in current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance representation of an 'all'
+  model group.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this all model group;
+  if in current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:all" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3147,7 +3184,7 @@ div#legend div.hint {
           <xsl:with-param name="code">All</xsl:with-param>
           <xsl:with-param name="term">All</xsl:with-param>
         </xsl:call-template>
-        <!-- Min/max occurs information-->
+        <!-- Min/max occurs information -->
         <xsl:text> </xsl:text>
         <xsl:call-template name="PrintOccurs">
           <xsl:with-param name="component" select="."/>
@@ -3174,12 +3211,12 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation of an element
-     content wild card.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out a sample XML instance representation of an element
+  content wild card.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:any | xsd:anyAttribute" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <div class="other" style="margin-left: {$margin}em">
@@ -3198,26 +3235,26 @@ div#legend div.hint {
     </div>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation
-     of an attribute declaration.
-     Param(s):
-            subTypeAttrs (String) optional
-                List of attributes in sub-types of the type that
-                contains this attribute
-            isInherited (boolean) optional
-                If true, display attribute using 'inherited' CSS
-                class.
-            isNewField (boolean) optional
-                If true, display attribute using 'newFields' CSS
-                class.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            addBR (boolean) optional
-                If true, add <br/> before attribute.
-            schemaLoc (String) optional
-                Schema file containing this attribute declaration;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out a sample XML instance representation
+  of an attribute declaration.
+  Param(s):
+  subTypeAttrs (String) optional
+  List of attributes in sub-types of the type that
+  contains this attribute
+  isInherited (boolean) optional
+  If true, display attribute using 'inherited' CSS
+  class.
+  isNewField (boolean) optional
+  If true, display attribute using 'newFields' CSS
+  class.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  addBR (boolean) optional
+  If true, add <br/> before attribute.
+  schemaLoc (String) optional
+  Schema file containing this attribute declaration;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template match="xsd:attribute[@name]" mode="sample">
     <xsl:param name="subTypeAttrs"/>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3233,9 +3270,11 @@ div#legend div.hint {
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="contains($subTypeAttrs, concat('*', normalize-space($attrNS), '+', normalize-space(@name), '+'))">
-        <!-- IGNORE: Sub type has attribute with same name;
-                 Sub-type's attribute declaration will override this
-                 one. -->
+        <!--
+        IGNORE: Sub type has attribute with same name;
+        Sub-type's attribute declaration will override this
+        one.
+        -->
       </xsl:when>
       <xsl:when test="@use and normalize-space(@use)='prohibited'">
         <!-- IGNORE: Attribute is prohibited. -->
@@ -3289,10 +3328,12 @@ div#legend div.hint {
               <span class="type">anySimpleType</span>
             </xsl:otherwise>
           </xsl:choose>
-          <!-- Don't print occurrence info and documentation
-                    for global attributes. -->
+          <!--
+          Don't print occurrence info and documentation
+          for global attributes.
+          -->
           <xsl:if test="local-name(..)!='schema'">
-            <!-- Occurrence info-->
+            <!-- Occurrence info -->
             <xsl:text> </xsl:text>
             <xsl:call-template name="PrintOccurs">
               <xsl:with-param name="component" select="."/>
@@ -3308,26 +3349,26 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation
-     of an attribute reference.
-     Param(s):
-            subTypeAttrs (String) optional
-                List of attribute in sub-types of the type that
-                contains this attribute
-            isInherited (boolean) optional
-                If true, display attributes using 'inherited' CSS
-                class.
-            isNewField (boolean) optional
-                If true, display attributes using 'newFields' CSS
-                class.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            addBR (boolean) optional
-                If true, add <br/> before attribute.
-            schemaLoc (String) optional
-                Schema file containing this attribute reference;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out a sample XML instance representation
+  of an attribute reference.
+  Param(s):
+  subTypeAttrs (String) optional
+  List of attribute in sub-types of the type that
+  contains this attribute
+  isInherited (boolean) optional
+  If true, display attributes using 'inherited' CSS
+  class.
+  isNewField (boolean) optional
+  If true, display attributes using 'newFields' CSS
+  class.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  addBR (boolean) optional
+  If true, add <br/> before attribute.
+  schemaLoc (String) optional
+  Schema file containing this attribute reference;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template match="xsd:attribute[@ref]" mode="sample">
     <xsl:param name="subTypeAttrs"/>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3349,9 +3390,11 @@ div#legend div.hint {
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="contains($subTypeAttrs, concat('*', normalize-space($attrNS), '+', normalize-space($attrName), '+'))">
-        <!-- IGNORE: Sub type has attribute with same name;
-                 Sub-type's attribute declaration will override this
-                 one. -->
+        <!--
+        IGNORE: Sub type has attribute with same name;
+        Sub-type's attribute declaration will override this
+        one.
+        -->
       </xsl:when>
       <xsl:when test="@use and normalize-space(@use)='prohibited'">
         <!-- IGNORE: Attribute is prohibited. -->
@@ -3382,7 +3425,7 @@ div#legend div.hint {
             </span>
             <xsl:text> </xsl:text>
           </xsl:if>
-          <!-- Print occurs info-->
+          <!-- Print occurs info -->
           <xsl:call-template name="PrintOccurs">
             <xsl:with-param name="component" select="."/>
           </xsl:call-template>
@@ -3396,14 +3439,14 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation of an attribute
-     group definition.
-     Param(s):
-            schemaLoc (String) optional
-                Schema file containing this attribute group
-                definition; if in current schema, 'schemaLoc' is
-                set to 'this'.
-     -->
+  Prints out a sample XML instance representation of an attribute
+  group definition.
+  Param(s):
+  schemaLoc (String) optional
+  Schema file containing this attribute group
+  definition; if in current schema, 'schemaLoc' is
+  set to 'this'.
+  -->
   <xsl:template match="xsd:attributeGroup[@name]" mode="sample">
     <xsl:param name="schemaLoc">this</xsl:param>
     <xsl:for-each select="xsd:attribute | xsd:attributeGroup | xsd:anyAttribute">
@@ -3424,31 +3467,31 @@ div#legend div.hint {
     </xsl:for-each>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation of an attribute
-     group reference.
-     Param(s):
-            subTypeAttrs (String) optional
-                List of attributes in sub-types of the type that
-                contains this attribute group
-            isInherited (boolean) optional
-                If true, display attributes using 'inherited' CSS
-                class.
-            isNewField (boolean) optional
-                If true, display attributes using 'newFields' CSS
-                class.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            parentGroups (String) optional
-                List of parent attribute group definitions that
-                contain this attribute group. Used to prevent
-                infinite loops when displaying attribute group
-                definitions. In such a case, writes out an error
-                message and stops processing.
-            schemaLoc (String) optional
-                Schema file containing this attribute group
-                reference if in current schema, 'schemaLoc' is
-                set to 'this'.
-     -->
+  Prints out a sample XML instance representation of an attribute
+  group reference.
+  Param(s):
+  subTypeAttrs (String) optional
+  List of attributes in sub-types of the type that
+  contains this attribute group
+  isInherited (boolean) optional
+  If true, display attributes using 'inherited' CSS
+  class.
+  isNewField (boolean) optional
+  If true, display attributes using 'newFields' CSS
+  class.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  parentGroups (String) optional
+  List of parent attribute group definitions that
+  contain this attribute group. Used to prevent
+  infinite loops when displaying attribute group
+  definitions. In such a case, writes out an error
+  message and stops processing.
+  schemaLoc (String) optional
+  Schema file containing this attribute group
+  reference if in current schema, 'schemaLoc' is
+  set to 'this'.
+  -->
   <xsl:template match="xsd:attributeGroup[@ref]" mode="sample">
     <xsl:param name="subTypeAttrs"/>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3527,27 +3570,27 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a sample XML instance representation of a 'choice'
-     model group.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            parentGroups (String) optional
-                List of parent model group definitions that contain this
-                model group. Used to prevent infinite loops when
-                displaying model group definitions.
-            schemaLoc (String) optional
-                Schema file containing this choice model group;
-                if in current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance representation of a 'choice'
+  model group.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  parentGroups (String) optional
+  List of parent model group definitions that contain this
+  model group. Used to prevent infinite loops when
+  displaying model group definitions.
+  schemaLoc (String) optional
+  Schema file containing this choice model group;
+  if in current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:choice" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3591,12 +3634,12 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from a complex type definition.
-     Param(s):
-            schemaLoc (String) optional
-                Schema file containing this complex type definition;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out a sample XML instance from a complex type definition.
+  Param(s):
+  schemaLoc (String) optional
+  Schema file containing this complex type definition;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template match="xsd:complexType" mode="sample">
     <xsl:param name="schemaLoc">this</xsl:param>
     <xsl:param name="parentGroups"/>
@@ -3607,22 +3650,22 @@ div#legend div.hint {
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from an element declaration.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this element declaration;
-                if in current schema, 'schemaLoc' is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance from an element declaration.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this element declaration;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:element[@name]" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3653,8 +3696,10 @@ div#legend div.hint {
               </xsl:call-template>
             </xsl:variable>
             <xsl:choose>
-              <!-- Complex type was found in current
-                          schema. -->
+              <!--
+              Complex type was found in current
+              schema.
+              -->
               <xsl:when test="normalize-space($defLoc)='this'">
                 <xsl:variable name="ctype" select="key('complexType', $elemTypeName)"/>
                 <xsl:call-template name="PrintSampleComplexElement">
@@ -3670,8 +3715,10 @@ div#legend div.hint {
                   <xsl:with-param name="schemaLoc" select="$schemaLoc"/>
                 </xsl:call-template>
               </xsl:when>
-              <!-- Complex type was found in external
-                          schema. -->
+              <!--
+              Complex type was found in external
+              schema.
+              -->
               <xsl:otherwise>
                 <xsl:variable name="ctype" select="document($defLoc)/xsd:schema/xsd:complexType[@name=$elemTypeName]"/>
                 <xsl:call-template name="PrintSampleComplexElement">
@@ -3730,19 +3777,19 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from an element
-     reference.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this element reference;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out a sample XML instance from an element
+  reference.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this element reference;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template match="xsd:element[@ref]" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3759,16 +3806,16 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from a group definition.
-     Param(s):
-            schemaLoc (String) optional
-                Schema file containing this model group definition;
-                if in current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance from a group definition.
+  Param(s):
+  schemaLoc (String) optional
+  Schema file containing this model group definition;
+  if in current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:group[@name]" mode="sample">
     <xsl:param name="schemaLoc">this</xsl:param>
     <xsl:param name="typeList"/>
@@ -3779,28 +3826,28 @@ div#legend div.hint {
     </xsl:apply-templates>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from a group reference.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS
-                class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS
-                class.
-            parentGroups (String) optional
-                List of parent model group definitions that contain
-                this  model group. Used to prevent infinite loops
-                when displaying model group definitions.
-            schemaLoc (String) optional
-                Schema file containing this model group reference;
-                if in current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance from a group reference.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS
+  class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS
+  class.
+  parentGroups (String) optional
+  List of parent model group definitions that contain
+  this  model group. Used to prevent infinite loops
+  when displaying model group definitions.
+  schemaLoc (String) optional
+  Schema file containing this model group reference;
+  if in current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:group[@ref]" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3903,26 +3950,26 @@ div#legend div.hint {
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a sample XML instance from a 'sequence' model group.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            parentGroups (String) optional
-                List of parent model group definitions that contain
-                this model group. Used to prevent infinite loops when
-                displaying model group definitions.
-            schemaLoc (String) optional
-                Schema file containing this sequence model group;
-                if in current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample XML instance from a 'sequence' model group.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  parentGroups (String) optional
+  List of parent model group definitions that contain
+  this model group. Used to prevent infinite loops when
+  displaying model group definitions.
+  schemaLoc (String) optional
+  Schema file containing this sequence model group;
+  if in current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template match="xsd:sequence" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -3983,14 +4030,14 @@ div#legend div.hint {
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the constraints of a complex type with simple content
-     to be displayed within a sample XML instance.
-     Param(s):
-            schemaLoc (String) optional
-                Schema file containing this simple content
-                restriction; if in current schema, 'schemaLoc' is
-                set to 'this'
-     -->
+  Prints out the constraints of a complex type with simple content
+  to be displayed within a sample XML instance.
+  Param(s):
+  schemaLoc (String) optional
+  Schema file containing this simple content
+  restriction; if in current schema, 'schemaLoc' is
+  set to 'this'
+  -->
   <xsl:template match="xsd:simpleContent[xsd:restriction]" mode="sample">
     <xsl:param name="schemaLoc">this</xsl:param>
     <span class="constraint">
@@ -4001,13 +4048,13 @@ div#legend div.hint {
     </span>
   </xsl:template>
   <!--
-     Prints out the constraints of a simple type definition to be
-     displayed within a sample XML instance.
-     Param(s):
-            schemaLoc (String) optional
-                Schema file containing this simple type definition;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out the constraints of a simple type definition to be
+  displayed within a sample XML instance.
+  Param(s):
+  schemaLoc (String) optional
+  Schema file containing this simple type definition;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template match="xsd:simpleType" mode="sample">
     <xsl:param name="schemaLoc">this</xsl:param>
     <span class="constraint">
@@ -4018,15 +4065,15 @@ div#legend div.hint {
     </span>
   </xsl:template>
   <!--
-     Prints out the identity constraints of an element to be displayed
-     within a sample XML instance.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            schemaLoc (String) optional
-                Schema file containing this simple type definition;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out the identity constraints of an element to be displayed
+  within a sample XML instance.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  schemaLoc (String) optional
+  Schema file containing this simple type definition;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template match="xsd:unique | xsd:key | xsd:keyref" mode="sample">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="schemaLoc">this</xsl:param>
@@ -4099,23 +4146,25 @@ div#legend div.hint {
     </div>
   </xsl:template>
   <!--
-     Unmatched template for 'sample' mode
-     -->
+  Unmatched template for 'sample' mode
+  -->
   <xsl:template match="*" mode="sample"/>
   <!--
-     Prints out a link which will open up a window, displaying a
-     schema component's documentation.
-     Param(s):
-            component (Node) required
-                Schema component
+  Prints out a link which will open up a window, displaying a
+  schema component's documentation.
+  Param(s):
+  component (Node) required
+  Schema component
   -->
   <xsl:template name="PrintSampleDocumentation">
     <xsl:param name="component"/>
     <xsl:if test="normalize-space(translate($useJavaScript,'TRUE','true'))='true' and $component and $component/xsd:annotation/xsd:documentation">
       <xsl:variable name="documentation">
         <xsl:for-each select="$component/xsd:annotation/xsd:documentation">
-          <!-- Check for two dashes, which will break the JavaScript
-                    code -->
+          <!--
+          Check for two dashes, which will break the JavaScript
+          code
+          -->
           <xsl:if test="contains(., '--') or contains(@source, '--')">
             <xsl:call-template name="HandleError">
               <xsl:with-param name="isTerminating">true</xsl:with-param>
@@ -4174,13 +4223,13 @@ A local schema component contains two dashes in
     </xsl:if>
   </xsl:template>
   <!--
-     Translates occurrences of single and double quotes
-     in a piece of text with single and double quote
-     escape characters.
-     Param(s):
-            value (String) required
-                Text to translate
-     -->
+  Translates occurrences of single and double quotes
+  in a piece of text with single and double quote
+  escape characters.
+  Param(s):
+  value (String) required
+  Text to translate
+  -->
   <xsl:template name="EscapeQuotes">
     <xsl:param name="value"/>
     <xsl:variable name="noSingleQuotes">
@@ -4200,40 +4249,40 @@ A local schema component contains two dashes in
     <xsl:value-of select="$noDoubleQuotes"/>
   </xsl:template>
   <!--
-     Helper template for template, match="xsd:group[@ref]"
-     mode="sample". Basically prints out a group reference, for
-     which we are able to look up the group definition that it
-     is referring to. This template is a work-around because XSLT
-     doesn't have variables (in the traditional sense of
-     programming languages) and it doesn't allow you to query
-     result tree fragments.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            parentGroups (String) optional
-                List of parent model group definitions that contain this
-                model group. Used to prevent infinite loops when
-                displaying model group definitions.
-            occursInfo (Result tree fragment) required
-                Pre-formatted occurrence info of group reference
-            grpLink (Result tree fragment) required
-                Pre-formatted <a> link representing group reference
-            grpRef (Node) required
-                Group reference
-            grpDef (Node) required
-                Group definition that the reference is pointing to
-            grpDefLoc (String) optional
-                Schema file containing 'grpDef' group definition;
-                if current schema, 'schemaLoc' is set to 'this'
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Helper template for template, match="xsd:group[@ref]"
+  mode="sample". Basically prints out a group reference, for
+  which we are able to look up the group definition that it
+  is referring to. This template is a work-around because XSLT
+  doesn't have variables (in the traditional sense of
+  programming languages) and it doesn't allow you to query
+  result tree fragments.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  parentGroups (String) optional
+  List of parent model group definitions that contain this
+  model group. Used to prevent infinite loops when
+  displaying model group definitions.
+  occursInfo (Result tree fragment) required
+  Pre-formatted occurrence info of group reference
+  grpLink (Result tree fragment) required
+  Pre-formatted <a> link representing group reference
+  grpRef (Node) required
+  Group reference
+  grpDef (Node) required
+  Group definition that the reference is pointing to
+  grpDefLoc (String) optional
+  Schema file containing 'grpDef' group definition;
+  if current schema, 'schemaLoc' is set to 'this'
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleGroup">
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="isInherited">false</xsl:param>
@@ -4290,21 +4339,21 @@ A local schema component contains two dashes in
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a sample element instance in one line.
-     Param(s):
-            element (Node) required
-                Element declaration or reference
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display element using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display element using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this element declaration
-                or reference; if in current schema, 'schemaLoc' is
-                set to 'this'.
-     -->
+  Prints out a sample element instance in one line.
+  Param(s):
+  element (Node) required
+  Element declaration or reference
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display element using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display element using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this element declaration
+  or reference; if in current schema, 'schemaLoc' is
+  set to 'this'.
+  -->
   <xsl:template name="PrintSampleSimpleElement">
     <xsl:param name="element"/>
     <xsl:param name="margin">0</xsl:param>
@@ -4317,8 +4366,10 @@ A local schema component contains two dashes in
       <xsl:choose>
         <!-- Element reference -->
         <xsl:when test="$element/@ref">
-          <!-- Note: Prefix will be automatically written out
-                    in call to 'PrintElementRef'. -->
+          <!--
+          Note: Prefix will be automatically written out
+          in call to 'PrintElementRef'.
+          -->
           <xsl:call-template name="PrintElementRef">
             <xsl:with-param name="ref" select="@ref"/>
             <xsl:with-param name="schemaLoc" select="$schemaLoc"/>
@@ -4405,27 +4456,27 @@ A local schema component contains two dashes in
     </div>
   </xsl:template>
   <!--
-     Prints out a sample element instance that has complex content.
-     Param(s):
-            type (Node) required
-                Complex type definition
-            element (Node) optional
-                Element declaration
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display element using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display element using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this element declaration
-                or type definition; if in current schema, 'schemaLoc'
-                is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out a sample element instance that has complex content.
+  Param(s):
+  type (Node) required
+  Complex type definition
+  element (Node) optional
+  Element declaration
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display element using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display element using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this element declaration
+  or type definition; if in current schema, 'schemaLoc'
+  is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleComplexElement">
     <xsl:param name="type"/>
     <xsl:param name="element"/>
@@ -4566,7 +4617,7 @@ A local schema component contains two dashes in
               <!-- Print out restriction/extension information -->
               <xsl:choose>
                 <xsl:when test="false()">
-                  <!--<xsl:when test="$type/xsd:complexContent/xsd:restriction/@base">-->
+                  <!-- <xsl:when test="$type/xsd:complexContent/xsd:restriction/@base"> -->
                   <br/>
                   <span class="other" style="margin-left: {$ELEM_INDENT}em">
                     <xsl:text>&lt;!-- Restricts : </xsl:text>
@@ -4578,7 +4629,7 @@ A local schema component contains two dashes in
                   </span>
                 </xsl:when>
                 <xsl:when test="false()">
-                  <!--<xsl:when test="$type/xsd:complexContent/xsd:extension/@base">-->
+                  <!-- <xsl:when test="$type/xsd:complexContent/xsd:extension/@base"> -->
                   <br/>
                   <span class="other" style="margin-left: {$ELEM_INDENT}em">
                     <xsl:text>&lt;!-- Extends : </xsl:text>
@@ -4610,33 +4661,33 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out attributes of a complex type definition, including
-     those inherited from a base type.
-     Param(s):
-            type (Node) required
-                Complex type definition
-            subTypeAttrs (String) optional
-                List of attributes in sub-types of this current type
-                definition
-            isInherited (boolean) optional
-                If true, display attributes using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display attributes using 'newFields' CSS class.
-            fromTopCType (boolean) optional
-                Set to true if this is being displayed in the XML
-                Instance Representation table of a top-level complex
-                type definition, in which case, 'inherited' attributes
-                and elements are distinguished.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            schemaLoc (String) optional
-                Schema file containing this complex type definition;
-                if in current schema, 'schemaLoc' is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out attributes of a complex type definition, including
+  those inherited from a base type.
+  Param(s):
+  type (Node) required
+  Complex type definition
+  subTypeAttrs (String) optional
+  List of attributes in sub-types of this current type
+  definition
+  isInherited (boolean) optional
+  If true, display attributes using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display attributes using 'newFields' CSS class.
+  fromTopCType (boolean) optional
+  Set to true if this is being displayed in the XML
+  Instance Representation table of a top-level complex
+  type definition, in which case, 'inherited' attributes
+  and elements are distinguished.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  schemaLoc (String) optional
+  Schema file containing this complex type definition;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleTypeAttrs">
     <xsl:param name="type"/>
     <xsl:param name="subTypeAttrs"/>
@@ -4649,9 +4700,10 @@ A local schema component contains two dashes in
     <xsl:choose>
       <!-- Circular type hierarchy -->
       <xsl:when test="$type/@name and contains($typeList, concat('*', $type/@name, '+'))">
-        <!-- Do nothing.
-                 Error message will be written out by 'PrintSampleTypeContent' template.
-            -->
+        <!--
+        Do nothing.
+        Error message will be written out by 'PrintSampleTypeContent' template.
+        -->
       </xsl:when>
       <!-- Derivation -->
       <xsl:when test="$type/xsd:complexContent or $type/xsd:simpleContent">
@@ -4722,34 +4774,34 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Helper function 'PrintSampleTypeAttrs' template to
-     handle case of derived types.
-     Param(s):
-            derivationElem (Node) required
-                'restriction' or 'extension' element
-            subTypeAttrs (String) optional
-                List of attributes in sub-types of
-                this current type definition
-            isInherited (boolean) optional
-                If true, display attributes using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display attributes using 'newFields' CSS class.
-            fromTopCType (boolean) optional
-                Set to true if this is being displayed
-                in the XML Instance Representation table
-                of a top-level complex type definition, in
-                which case, 'inherited' attributes and
-                elements are distinguished.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            schemaLoc (String) optional
-                Schema file containing this derivation element;
-                if in current schema, 'schemaLoc' is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Helper function 'PrintSampleTypeAttrs' template to
+  handle case of derived types.
+  Param(s):
+  derivationElem (Node) required
+  'restriction' or 'extension' element
+  subTypeAttrs (String) optional
+  List of attributes in sub-types of
+  this current type definition
+  isInherited (boolean) optional
+  If true, display attributes using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display attributes using 'newFields' CSS class.
+  fromTopCType (boolean) optional
+  Set to true if this is being displayed
+  in the XML Instance Representation table
+  of a top-level complex type definition, in
+  which case, 'inherited' attributes and
+  elements are distinguished.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  schemaLoc (String) optional
+  Schema file containing this derivation element;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleDerivedTypeAttrs">
     <xsl:param name="derivationElem"/>
     <xsl:param name="subTypeAttrs"/>
@@ -4759,8 +4811,10 @@ A local schema component contains two dashes in
     <xsl:param name="margin">0</xsl:param>
     <xsl:param name="schemaLoc">this</xsl:param>
     <xsl:param name="typeList"/>
-    <!-- Get attributes from this type to add to
-            'subTypeAttrs' list for recursive call on base type -->
+    <!--
+    Get attributes from this type to add to
+    'subTypeAttrs' list for recursive call on base type
+    -->
     <xsl:variable name="thisAttrs">
       <xsl:call-template name="GetAttrList">
         <xsl:with-param name="list" select="$derivationElem"/>
@@ -4804,8 +4858,10 @@ A local schema component contains two dashes in
       </xsl:when>
       <!-- Complex type was not found. -->
       <xsl:when test="normalize-space($defLoc)='' or normalize-space($defLoc)='none' or normalize-space($defLoc)='xml' or normalize-space($defLoc)='xsd'">
-        <!-- IGNORE: Error message will be printed out be
-                 'PrintSampleTypeContent' template. -->
+        <!--
+        IGNORE: Error message will be printed out be
+        'PrintSampleTypeContent' template.
+        -->
       </xsl:when>
       <!-- Complex type was found in external schema. -->
       <xsl:otherwise>
@@ -4851,12 +4907,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Returns the names and namespaces of attributes
-     in a list of attributes and attribute groups.
-     Param(s):
-            list (Node) required
-                Node containing list of attributes and attribute groups
-     -->
+  Returns the names and namespaces of attributes
+  in a list of attributes and attribute groups.
+  Param(s):
+  list (Node) required
+  Node containing list of attributes and attribute groups
+  -->
   <xsl:template name="GetAttrList">
     <xsl:param name="list"/>
     <xsl:if test="$list">
@@ -4909,24 +4965,24 @@ A local schema component contains two dashes in
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out sample XML instances from a list of attributes and
-     attribute groups.
-     Param(s):
-            list (Node) required
-                Node containing list of attributes and attribute groups
-            subTypeAttrs (String) optional
-                List of attributes in sub-types of
-                the type definition containing this list
-            isInherited (boolean) optional
-                If true, display attributes using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display attributes using 'newFields' CSS class.
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            schemaLoc (String) optional
-                Schema file containing this attribute list;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out sample XML instances from a list of attributes and
+  attribute groups.
+  Param(s):
+  list (Node) required
+  Node containing list of attributes and attribute groups
+  subTypeAttrs (String) optional
+  List of attributes in sub-types of
+  the type definition containing this list
+  isInherited (boolean) optional
+  If true, display attributes using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display attributes using 'newFields' CSS class.
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  schemaLoc (String) optional
+  Schema file containing this attribute list;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template name="PrintSampleAttrList">
     <xsl:param name="list"/>
     <xsl:param name="subTypeAttrs"/>
@@ -4944,33 +5000,33 @@ A local schema component contains two dashes in
     </xsl:apply-templates>
   </xsl:template>
   <!--
-     Prints out the element content of a complex type definition,
-     including those inherited from a base type.
-     Param(s):
-            type (Node) required
-                Complex type definition
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            fromTopCType (boolean) optional
-                Set to true if this is being displayed in the XML
-                Instance Representation table of a top-level complex
-                type definition, in which case, 'inherited' attributes
-                and elements are distinguished.
-            addBR (boolean) optional
-                If true, can add <br/> before element content.
-                Applicable only if displaying complex content.
-            schemaLoc (String) optional
-                Schema file containing this type definition;
-                if in current schema, 'schemaLoc' is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out the element content of a complex type definition,
+  including those inherited from a base type.
+  Param(s):
+  type (Node) required
+  Complex type definition
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  fromTopCType (boolean) optional
+  Set to true if this is being displayed in the XML
+  Instance Representation table of a top-level complex
+  type definition, in which case, 'inherited' attributes
+  and elements are distinguished.
+  addBR (boolean) optional
+  If true, can add <br/> before element content.
+  Applicable only if displaying complex content.
+  schemaLoc (String) optional
+  Schema file containing this type definition;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleTypeContent">
     <xsl:param name="type"/>
     <xsl:param name="margin">0</xsl:param>
@@ -4990,7 +5046,7 @@ A local schema component contains two dashes in
       <!-- Derivation by restriction on complex content -->
       <xsl:when test="$type/xsd:complexContent/xsd:restriction">
         <xsl:variable name="restriction" select="$type/xsd:complexContent/xsd:restriction"/>
-        <!-- Test if base type is in schema to print out warning comment-->
+        <!-- Test if base type is in schema to print out warning comment -->
         <xsl:variable name="baseTypeName">
           <xsl:call-template name="GetRefName">
             <xsl:with-param name="ref" select="$restriction/@base"/>
@@ -5017,9 +5073,11 @@ A local schema component contains two dashes in
           </xsl:when>
           <!-- Complex type was found. -->
           <xsl:otherwise>
-            <!-- IGNORE element content of base type if by restriction,
-                       since current content will override restricted
-                       base type's content. -->
+            <!--
+            IGNORE element content of base type if by restriction,
+            since current content will override restricted
+            base type's content.
+            -->
           </xsl:otherwise>
         </xsl:choose>
         <!-- Print out content from this type -->
@@ -5158,7 +5216,7 @@ A local schema component contains two dashes in
       </xsl:when>
       <!-- Derivation by restriction on simple content -->
       <xsl:when test="$type/xsd:simpleContent/xsd:restriction">
-        <!-- Print out simple type constraints-->
+        <!-- Print out simple type constraints -->
         <span style="margin-left: {$margin}em">
           <xsl:text> </xsl:text>
           <xsl:apply-templates select="$type/xsd:simpleContent" mode="sample">
@@ -5197,25 +5255,25 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out sample XML instances from a list of
-     element particle.
-     Param(s):
-            list (Node) required
-                Node containing list of element particles
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            isInherited (boolean) optional
-                If true, display elements using 'inherited' CSS class.
-            isNewField (boolean) optional
-                If true, display elements using 'newFields' CSS class.
-            schemaLoc (String) optional
-                Schema file containing this particle list;
-                if in current schema, 'schemaLoc' is set to 'this'.
-            typeList (String) optional
-                List of types in this call chain. Name of type starts
-                with '*', and ends with '+'. (Used to prevent infinite
-                recursive loop.)
-     -->
+  Prints out sample XML instances from a list of
+  element particle.
+  Param(s):
+  list (Node) required
+  Node containing list of element particles
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  isInherited (boolean) optional
+  If true, display elements using 'inherited' CSS class.
+  isNewField (boolean) optional
+  If true, display elements using 'newFields' CSS class.
+  schemaLoc (String) optional
+  Schema file containing this particle list;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  typeList (String) optional
+  List of types in this call chain. Name of type starts
+  with '*', and ends with '+'. (Used to prevent infinite
+  recursive loop.)
+  -->
   <xsl:template name="PrintSampleParticleList">
     <xsl:param name="list"/>
     <xsl:param name="margin">0</xsl:param>
@@ -5236,15 +5294,15 @@ A local schema component contains two dashes in
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the constraints of simple content
-     to be displayed within a sample XML instance.
-     Param(s):
-            simpleContent (Node) required
-                Node containing with the simple content
-            schemaLoc (String) optional
-                Schema file containing these simple constraints;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out the constraints of simple content
+  to be displayed within a sample XML instance.
+  Param(s):
+  simpleContent (Node) required
+  Node containing with the simple content
+  schemaLoc (String) optional
+  Schema file containing these simple constraints;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template name="PrintSampleSimpleConstraints">
     <xsl:param name="simpleContent"/>
     <xsl:param name="schemaLoc">this</xsl:param>
@@ -5310,16 +5368,16 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out the constraints of simple content
-     derived by restriction, which is to be displayed
-     within a sample XML instance.
-     Param(s):
-            restriction (Node) required
-                Node containing with the restriction
-            schemaLoc (String) optional
-                Schema file containing this restriction element;
-                if in current schema, 'schemaLoc' is set to 'this'.
-     -->
+  Prints out the constraints of simple content
+  derived by restriction, which is to be displayed
+  within a sample XML instance.
+  Param(s):
+  restriction (Node) required
+  Node containing with the restriction
+  schemaLoc (String) optional
+  Schema file containing this restriction element;
+  if in current schema, 'schemaLoc' is set to 'this'.
+  -->
   <xsl:template name="PrintSampleSimpleRestriction">
     <xsl:param name="restriction"/>
     <xsl:param name="schemaLoc">this</xsl:param>
@@ -5431,12 +5489,12 @@ A local schema component contains two dashes in
   </xsl:template>
   <!-- ******** Schema Component Representation table ******** -->
   <!--
-     Prints out the Schema Component Representation table
-     for a top-level schema component.
-     Param(s):
-            component (Node) required
-              Top-level schema component
-     -->
+  Prints out the Schema Component Representation table
+  for a top-level schema component.
+  Param(s):
+  component (Node) required
+  Top-level schema component
+  -->
   <xsl:template name="SchemaComponentTable">
     <xsl:param name="component"/>
     <xsl:variable name="componentID">
@@ -5455,12 +5513,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     declarations.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  declarations.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:attribute[@name] | xsd:element[@name]" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5493,12 +5551,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     definitions and key/uniqueness constraints.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  definitions and key/uniqueness constraints.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:attributeGroup[@name] | xsd:complexType[@name] | xsd:simpleType[@name] | xsd:group[@name] | xsd:key | xsd:unique" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5520,12 +5578,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of attribute
-     references.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of attribute
+  references.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:attribute[@ref]" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5551,12 +5609,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of attribute group
-     references.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of attribute group
+  references.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:attributeGroup[@ref]" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5582,12 +5640,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of element
-     references.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of element
+  references.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:element[@ref]" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5613,12 +5671,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of model group
-     references.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of model group
+  references.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:group[@ref]" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5644,12 +5702,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     'appinfo' and 'documentation' elements.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  'appinfo' and 'documentation' elements.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:appinfo | xsd:documentation" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5677,12 +5735,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     key reference constraints.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  key reference constraints.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:keyref" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5715,12 +5773,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     derivations by extension and restrictions.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  derivations by extension and restrictions.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:extension | xsd:restriction" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5748,19 +5806,19 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     derivations by list.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  derivations by list.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:list" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
       <xsl:with-param name="component" select="."/>
       <xsl:with-param name="margin" select="$margin"/>
       <xsl:with-param name="attributes">
-        <!-- Attribute: itemType-->
+        <!-- Attribute: itemType -->
         <xsl:if test="@itemType">
           <xsl:call-template name="DisplayAttr">
             <xsl:with-param name="attrName">itemType</xsl:with-param>
@@ -5781,19 +5839,19 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     derivations by union.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  derivations by union.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:union" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
       <xsl:with-param name="component" select="."/>
       <xsl:with-param name="margin" select="$margin"/>
       <xsl:with-param name="attributes">
-        <!-- Attribute: memberTypes-->
+        <!-- Attribute: memberTypes -->
         <xsl:if test="@memberTypes">
           <xsl:call-template name="DisplayAttr">
             <xsl:with-param name="attrName">memberTypes</xsl:with-param>
@@ -5815,12 +5873,12 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out schema component representation of
-     the root schema element.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out schema component representation of
+  the root schema element.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="xsd:schema" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5844,11 +5902,11 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Default way to print out schema component representation.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Default way to print out schema component representation.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="*" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <xsl:call-template name="DisplaySchemaComponent">
@@ -5863,11 +5921,11 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Prints out comments in schema component representation.
-     Param(s):
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-     -->
+  Prints out comments in schema component representation.
+  Param(s):
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  -->
   <xsl:template match="comment()" mode="schemaComponent">
     <xsl:param name="margin">0</xsl:param>
     <div class="comment" style="margin-left: {$margin}em">
@@ -5877,32 +5935,32 @@ A local schema component contains two dashes in
     </div>
   </xsl:template>
   <!--
-     Displays a schema element in the correct format
-     for the Schema Component Representation table, e.g.
-     tags are one color, and content are another.
-     Param(s):
-            component (Node) required
-                Schema element to be displayed
-            attributes (Result Tree Fragment) optional
-                Pre-formatted attributes of schema element
-            margin (nonNegativeInteger) optional
-                Number of 'em' to indent from left
-            hasAnyContent (boolean) optional
-                Set to true if schema element can accept
-                child elements from namespaces other than
-                the schema namespace, e.g. 'documentation'
-                and 'appinfo'
-            includeFilter (String) optional
-                List of element names, sandwiched between the
-                characters, '*' and '+'. If specified, only the
-                child elements of the component with tags in
-                the list will be displayed.
-            excludeFilter (String) optional
-                List of element names, sandwiched between the
-                characters, '*' and '+'. If specified, display
-                all child elements of the component, except
-                those with tags in the list.
-     -->
+  Displays a schema element in the correct format
+  for the Schema Component Representation table, e.g.
+  tags are one color, and content are another.
+  Param(s):
+  component (Node) required
+  Schema element to be displayed
+  attributes (Result Tree Fragment) optional
+  Pre-formatted attributes of schema element
+  margin (nonNegativeInteger) optional
+  Number of 'em' to indent from left
+  hasAnyContent (boolean) optional
+  Set to true if schema element can accept
+  child elements from namespaces other than
+  the schema namespace, e.g. 'documentation'
+  and 'appinfo'
+  includeFilter (String) optional
+  List of element names, sandwiched between the
+  characters, '*' and '+'. If specified, only the
+  child elements of the component with tags in
+  the list will be displayed.
+  excludeFilter (String) optional
+  List of element names, sandwiched between the
+  characters, '*' and '+'. If specified, display
+  all child elements of the component, except
+  those with tags in the list.
+  -->
   <xsl:template name="DisplaySchemaComponent">
     <xsl:param name="component"/>
     <xsl:param name="attributes"/>
@@ -5980,15 +6038,15 @@ A local schema component contains two dashes in
     </div>
   </xsl:template>
   <!--
-     Displays a schema attribute in the correct format
-     for the Schema Component Representation table, e.g.
-     tags are one color, and content are another.
-     Param(s):
-            attrName (String) required
-                Name of attribute
-            attrValue (Result Tree Fragment) required
-                Value of attribute, which may be links
-     -->
+  Displays a schema attribute in the correct format
+  for the Schema Component Representation table, e.g.
+  tags are one color, and content are another.
+  Param(s):
+  attrName (String) required
+  Name of attribute
+  attrValue (Result Tree Fragment) required
+  Value of attribute, which may be links
+  -->
   <xsl:template name="DisplayAttr">
     <xsl:param name="attrName"/>
     <xsl:param name="attrValue"/>
@@ -6005,18 +6063,18 @@ A local schema component contains two dashes in
     <xsl:text>"</xsl:text>
   </xsl:template>
   <!--
-     Displays attributes from a schema element, unless
-     otherwise specified, in the correct format
-     for the Schema Component Representation table, e.g.
-     tags are one color, and content are another.
-     Param(s):
-            component (Node) required
-                Schema element whose attributes are to be displayed
-            attrsNotToDisplay (String) required
-                List of attributes not to be displayed
-                Each attribute name should prepended with '*'
-                and appended with '+'
-     -->
+  Displays attributes from a schema element, unless
+  otherwise specified, in the correct format
+  for the Schema Component Representation table, e.g.
+  tags are one color, and content are another.
+  Param(s):
+  component (Node) required
+  Schema element whose attributes are to be displayed
+  attrsNotToDisplay (String) required
+  List of attributes not to be displayed
+  Each attribute name should prepended with '*'
+  and appended with '+'
+  -->
   <xsl:template name="DisplayOtherAttributes">
     <xsl:param name="component"/>
     <xsl:param name="attrsNotToDisplay"/>
@@ -6032,8 +6090,8 @@ A local schema component contains two dashes in
   </xsl:template>
   <!-- ******** XML Pretty Printer ******** -->
   <!--
-     Puts XHTML elements into the result.
-     -->
+  Puts XHTML elements into the result.
+  -->
   <xsl:template match="html:*" mode="html">
     <xsl:element name="{local-name(.)}">
       <xsl:for-each select="@*">
@@ -6043,8 +6101,8 @@ A local schema component contains two dashes in
     </xsl:element>
   </xsl:template>
   <!--
-     Displays non-XHTML elements found within XHTML elements.
-     -->
+  Displays non-XHTML elements found within XHTML elements.
+  -->
   <xsl:template match="*" mode="html">
     <xsl:call-template name="WriteElement">
       <xsl:with-param name="element" select="."/>
@@ -6052,14 +6110,14 @@ A local schema component contains two dashes in
     </xsl:call-template>
   </xsl:template>
   <!--
-     Displays text node.
-     -->
+  Displays text node.
+  -->
   <xsl:template match="text()" mode="html">
     <xsl:value-of select="."/>
   </xsl:template>
   <!--
-     Displays an arbitrary XML element.
-     -->
+  Displays an arbitrary XML element.
+  -->
   <xsl:template match="*" mode="xpp">
     <code>
       <xsl:call-template name="WriteElement">
@@ -6069,14 +6127,14 @@ A local schema component contains two dashes in
     </code>
   </xsl:template>
   <!--
-     Displays an arbitrary XML text node.
-     -->
+  Displays an arbitrary XML text node.
+  -->
   <xsl:template match="text()" mode="xpp">
     <xsl:value-of select="."/>
   </xsl:template>
   <!--
-     Displays an XML comment.
-     -->
+  Displays an XML comment.
+  -->
   <xsl:template match="comment()" mode="xpp">
     <div class="comment">
       <xsl:text>&lt;--</xsl:text>
@@ -6085,14 +6143,14 @@ A local schema component contains two dashes in
     </div>
   </xsl:template>
   <!--
-     Displays an XML element in the documentation, e.g.
-     tags are escaped.
-     Param(s):
-            element (Node) required
-                XML element to display
-            mode (xpp|html) required
-                Which mode to invoke for child elements
-     -->
+  Displays an XML element in the documentation, e.g.
+  tags are escaped.
+  Param(s):
+  element (Node) required
+  XML element to display
+  mode (xpp|html) required
+  Which mode to invoke for child elements
+  -->
   <xsl:template name="WriteElement">
     <xsl:param name="element"/>
     <xsl:param name="mode">xpp</xsl:param>
@@ -6149,13 +6207,13 @@ A local schema component contains two dashes in
   </xsl:template>
   <!-- ******** Templates for Handling References ******** -->
   <!--
-     Prints out a reference to a term in the glossary section.
-     Param(s):
-            code (String) required
-              Unique ID of glossary term
-            term (String) optional
-              Glossary term
-     -->
+  Prints out a reference to a term in the glossary section.
+  Param(s):
+  code (String) required
+  Unique ID of glossary term
+  term (String) optional
+  Glossary term
+  -->
   <xsl:template name="PrintGlossaryTermRef">
     <xsl:param name="code"/>
     <xsl:param name="term"/>
@@ -6178,14 +6236,14 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a reference to a namespace in the schema.
-     Param(s):
-            prefix (String) required
-              Namespace prefix referenced
-            schemaLoc (String) optional
-                Schema file containing this namespace prefix;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out a reference to a namespace in the schema.
+  Param(s):
+  prefix (String) required
+  Namespace prefix referenced
+  schemaLoc (String) optional
+  Schema file containing this namespace prefix;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintNamespaceRef">
     <xsl:param name="prefix"/>
     <xsl:param name="schemaLoc">this</xsl:param>
@@ -6218,17 +6276,17 @@ A local schema component contains two dashes in
     </xsl:if>
   </xsl:template>
   <!--
-     Generates a link to an attribute.
-     Param(s):
-            name (String) optional
-                Name of attribute
-            ref (String) optional
-                Reference to attribute
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this attribute reference
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Generates a link to an attribute.
+  Param(s):
+  name (String) optional
+  Name of attribute
+  ref (String) optional
+  Reference to attribute
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this attribute reference
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintAttributeRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6251,17 +6309,17 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Generates a link to an attribute group.
-     Param(s):
-            name (String) optional
-                Name of attribute group
-            ref (String) optional
-                Reference to attribute group
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this attribute group reference
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Generates a link to an attribute group.
+  Param(s):
+  name (String) optional
+  Name of attribute group
+  ref (String) optional
+  Reference to attribute group
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this attribute group reference
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintAttributeGroupRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6284,17 +6342,17 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Generates a link to an element.
-     Param(s):
-            name (String) optional
-                Name of element
-            ref (String) optional
-                Reference to element
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this element reference
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Generates a link to an element.
+  Param(s):
+  name (String) optional
+  Name of element
+  ref (String) optional
+  Reference to element
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this element reference
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintElementRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6317,17 +6375,17 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Generates a link to a group.
-     Param(s):
-            name (String) optional
-                Name of group
-            ref (String) optional
-                Reference to group
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this group reference
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Generates a link to a group.
+  Param(s):
+  name (String) optional
+  Name of group
+  ref (String) optional
+  Reference to group
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this group reference
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintGroupRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6350,18 +6408,18 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Generates a link to a key/uniqueness constraint.
-     Param(s):
-            name (String) optional
-                Name of key/uniqueness constraint
-            ref (String) optional
-                Reference to key/uniqueness constraint
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this key/uniqueness constraint
-                reference; if in current schema, 'schemaLoc' is set
-                to 'this'
-     -->
+  Generates a link to a key/uniqueness constraint.
+  Param(s):
+  name (String) optional
+  Name of key/uniqueness constraint
+  ref (String) optional
+  Reference to key/uniqueness constraint
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this key/uniqueness constraint
+  reference; if in current schema, 'schemaLoc' is set
+  to 'this'
+  -->
   <xsl:template name="PrintKeyRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6384,18 +6442,18 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Generates a link to a type.
-     Param(s):
-            name (String) optional
-                Name of type
-            ref (String) optional
-                Reference to type
-            (One of 'name' and 'ref' must be provided.)
-            schemaLoc (String) optional
-                Schema file containing this type reference'
-                if in current schema, 'schemaLoc' is set
-                to 'this'
-     -->
+  Generates a link to a type.
+  Param(s):
+  name (String) optional
+  Name of type
+  ref (String) optional
+  Reference to type
+  (One of 'name' and 'ref' must be provided.)
+  schemaLoc (String) optional
+  Schema file containing this type reference'
+  if in current schema, 'schemaLoc' is set
+  to 'this'
+  -->
   <xsl:template name="PrintTypeRef">
     <xsl:param name="name"/>
     <xsl:param name="ref"/>
@@ -6422,34 +6480,34 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a link to a schema component's section.
-     Param(s):
-            baseFile (String) optional
-                Documentation file of schema containing this
-                component.
-                If this component belongs to the current schema,
-                omit this variable.
-                If this component is from an included or imported
-                schema, provide this variable.
-            name (String) required
-                Name of schema component
-            compType (String) required
-                Type of schema component
-            errMsg (String) optional
-                Sentence fragment.
-                If specified, link will open up an alert box with
-                an error message. For example, if 'errMsg' was set
-                to "could not be found", 'name' was "x", and
-                'compType' was "type", the error message would be:
-                "x" type definition could not be found.
-                The sentence fragment should not:
-                -start with a capital letter.
-                -have a space in front
-                -end with a period.
-            schemaLoc (String) optional
-                Schema file containing this component;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out a link to a schema component's section.
+  Param(s):
+  baseFile (String) optional
+  Documentation file of schema containing this
+  component.
+  If this component belongs to the current schema,
+  omit this variable.
+  If this component is from an included or imported
+  schema, provide this variable.
+  name (String) required
+  Name of schema component
+  compType (String) required
+  Type of schema component
+  errMsg (String) optional
+  Sentence fragment.
+  If specified, link will open up an alert box with
+  an error message. For example, if 'errMsg' was set
+  to "could not be found", 'name' was "x", and
+  'compType' was "type", the error message would be:
+  "x" type definition could not be found.
+  The sentence fragment should not:
+  -start with a capital letter.
+  -have a space in front
+  -end with a period.
+  schemaLoc (String) optional
+  Schema file containing this component;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintCompName">
     <xsl:param name="baseFile"/>
     <xsl:param name="name"/>
@@ -6517,8 +6575,10 @@ A local schema component contains two dashes in
           <xsl:text> </xsl:text>
           <xsl:value-of select="$errMsg"/>
         </xsl:when>
-        <!-- There exists a link to the schema component's
-                 documentation. -->
+        <!--
+        There exists a link to the schema component's
+        documentation.
+        -->
         <xsl:otherwise>
           <xsl:text>Jump to "</xsl:text>
           <xsl:value-of select="$name"/>
@@ -6541,8 +6601,10 @@ A local schema component contains two dashes in
         <xsl:when test="$errMsg!=''">
           <xsl:text>javascript:void(0)</xsl:text>
         </xsl:when>
-        <!-- There exists a link to the schema component's
-                 documentation. -->
+        <!--
+        There exists a link to the schema component's
+        documentation.
+        -->
         <xsl:otherwise>
           <!-- Base URI -->
           <xsl:value-of select="normalize-space($baseURI)"/>
@@ -6568,21 +6630,21 @@ A local schema component contains two dashes in
     </a>
   </xsl:template>
   <!--
-     Prints out a reference to a schema component.
-     This template will try to work out which schema that this
-     component belongs to and print out the appropriate link.
-     component.
-     It will also print out the namespace prefix given
-     in the reference.
-     Param(s):
-            ref (String) required
-                Reference to schema component
-            compType (String) required
-                Type of schema component
-            schemaLoc (String) optional
-                Schema file containing this component reference;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out a reference to a schema component.
+  This template will try to work out which schema that this
+  component belongs to and print out the appropriate link.
+  component.
+  It will also print out the namespace prefix given
+  in the reference.
+  Param(s):
+  ref (String) required
+  Reference to schema component
+  compType (String) required
+  Type of schema component
+  schemaLoc (String) optional
+  Schema file containing this component reference;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintCompRef">
     <xsl:param name="ref"/>
     <xsl:param name="compType"/>
@@ -6614,8 +6676,10 @@ A local schema component contains two dashes in
     <xsl:variable name="tnPrefix">
       <xsl:call-template name="GetThisPrefix"/>
     </xsl:variable>
-    <!-- Get file location of the schema component that is
-           being referenced. -->
+    <!--
+    Get file location of the schema component that is
+    being referenced.
+    -->
     <xsl:variable name="compLoc">
       <xsl:call-template name="FindComponent">
         <xsl:with-param name="ref" select="$ref"/>
@@ -6666,8 +6730,10 @@ A local schema component contains two dashes in
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-  <!-- ******** Templates for Finding Components in Different
-             Schema documents ******** -->
+  <!--
+  ******** Templates for Finding Components in Different
+  Schema documents ********
+  -->
   <!-- Special key words: xml, xsd, this, none -->
   <xsl:template name="FindComponent">
     <xsl:param name="ref"/>
@@ -6693,8 +6759,10 @@ A local schema component contains two dashes in
       <xsl:call-template name="GetXSDPrefix"/>
     </xsl:variable>
     <xsl:choose>
-      <!-- Schema component from XML Schema's namespace,
-              unless this schema is for XML Schema -->
+      <!--
+      Schema component from XML Schema's namespace,
+      unless this schema is for XML Schema
+      -->
       <xsl:when test="$refPrefix=$xsdPrefix and $xsdPrefix!=$tnPrefix">
         <xsl:text>xsd</xsl:text>
       </xsl:when>
@@ -6730,9 +6798,11 @@ A local schema component contains two dashes in
     <xsl:param name="schema"/>
     <xsl:param name="schemaFileLoc"/>
     <xsl:param name="schemasSearched"/>
-    <!-- Don't examine this schema if we've already
-           searched it. Prevents infinite recursion.
-           Also check if schema actually exists. -->
+    <!--
+    Don't examine this schema if we've already
+    searched it. Prevents infinite recursion.
+    Also check if schema actually exists.
+    -->
     <xsl:if test="$schema and not(contains($schemasSearched, concat('*', $schemaFileLoc, '+')))">
       <!-- Find out if the component is in this schema -->
       <xsl:variable name="thisResult">
@@ -6828,12 +6898,16 @@ A local schema component contains two dashes in
     <xsl:param name="schemasSearched"/>
     <xsl:param name="index">1</xsl:param>
     <xsl:if test="count($schema/xsd:include) &gt;= number($index)">
-      <!-- Get the 'schemaLocation' attribute of the 'include'
-              element in this schema at position, 'index'. -->
+      <!--
+      Get the 'schemaLocation' attribute of the 'include'
+      element in this schema at position, 'index'.
+      -->
       <xsl:variable name="schemaLoc" select="$schema/xsd:include[position()=$index]/@schemaLocation"/>
       <xsl:variable name="thisResult">
-        <!-- Search for the component in the current
-                 included schema. -->
+        <!--
+        Search for the component in the current
+        included schema.
+        -->
         <xsl:call-template name="FindComponentInSchema">
           <xsl:with-param name="name" select="$name"/>
           <xsl:with-param name="compType" select="$compType"/>
@@ -6868,12 +6942,16 @@ A local schema component contains two dashes in
     <xsl:param name="schemasSearched"/>
     <xsl:param name="index">1</xsl:param>
     <xsl:if test="count($schema/xsd:redefine) &gt;= number($index)">
-      <!-- Get the 'schemaLocation' attribute of the 'redefine'
-              element in this schema at position, 'index'. -->
+      <!--
+      Get the 'schemaLocation' attribute of the 'redefine'
+      element in this schema at position, 'index'.
+      -->
       <xsl:variable name="schemaLoc" select="$schema/xsd:redefine[position()=$index]/@schemaLocation"/>
       <xsl:variable name="thisResult">
-        <!-- Search for the component in the current
-                 redefined schema. -->
+        <!--
+        Search for the component in the current
+        redefined schema.
+        -->
         <xsl:call-template name="FindComponentInSchema">
           <xsl:with-param name="name" select="$name"/>
           <xsl:with-param name="compType" select="$compType"/>
@@ -6909,18 +6987,24 @@ A local schema component contains two dashes in
     <xsl:param name="schemasSearched"/>
     <xsl:param name="index">1</xsl:param>
     <xsl:if test="count($schema/xsd:import) &gt;= number($index)">
-      <!-- Get the 'namespace' attribute of the 'import'
-              element in this schema at position, 'index'. -->
+      <!--
+      Get the 'namespace' attribute of the 'import'
+      element in this schema at position, 'index'.
+      -->
       <xsl:variable name="schemaNS" select="$schema/xsd:import[position()=$index]/@namespace"/>
       <!-- Get the 'schemaLocation' attribute. -->
       <xsl:variable name="schemaLoc" select="$schema/xsd:import[position()=$index]/@schemaLocation"/>
       <xsl:variable name="thisResult">
-        <!-- Check that the imported schema has the matching
-                 namespace as the component that we're looking
-                 for. -->
+        <!--
+        Check that the imported schema has the matching
+        namespace as the component that we're looking
+        for.
+        -->
         <xsl:if test="normalize-space($compNS)=normalize-space($schemaNS)">
-          <!-- Search for the component in the current
-                    imported schema. -->
+          <!--
+          Search for the component in the current
+          imported schema.
+          -->
           <xsl:call-template name="FindComponentInSchema">
             <xsl:with-param name="name" select="$name"/>
             <xsl:with-param name="compType" select="$compType"/>
@@ -6952,27 +7036,27 @@ A local schema component contains two dashes in
   </xsl:template>
   <!-- ******** General Utility Templates ******** -->
   <!--
-     Creates a box that can be opened and closed, such
-     that the contents can be hidden away until a button
-     is pressed.
-     Param(s):
-            id (String) required
-              Unique ID of the 'div' box
-            caption (String) required
-              Text describing the contents of the box;
-              it will always be shown even when the box
-              is closed
-            contents (String) required
-              Contents of box, which may appear and disappear
-              with the press of a button.
-            anchor (String) optional
-              Anchor, e.g. <a name="...", for this box
-            styleClass (String) optional
-              Additional CSS class for the entire collapseable box
-            isOpened (String) optional
-              Set to true if initially opened, and
-              false if initially closed
-     -->
+  Creates a box that can be opened and closed, such
+  that the contents can be hidden away until a button
+  is pressed.
+  Param(s):
+  id (String) required
+  Unique ID of the 'div' box
+  caption (String) required
+  Text describing the contents of the box;
+  it will always be shown even when the box
+  is closed
+  contents (String) required
+  Contents of box, which may appear and disappear
+  with the press of a button.
+  anchor (String) optional
+  Anchor, e.g. <a name="...", for this box
+  styleClass (String) optional
+  Additional CSS class for the entire collapseable box
+  isOpened (String) optional
+  Set to true if initially opened, and
+  false if initially closed
+  -->
   <xsl:template name="CollapseableBox">
     <xsl:param name="id"/>
     <xsl:param name="caption"/>
@@ -6987,10 +7071,10 @@ A local schema component contains two dashes in
         <xsl:if test="normalize-space(translate($useJavaScript,'TRUE','true'))='true'">
           <input type="button" id="{$buttonID}" class="control" onclick="switchState('{$id}'); return false;" style="display: none"/>
           <!--
-                 Button's 'display' property is set to 'none',
-                 so that button will only be displayed if
-                 box can be successfully opened and closed.
-                 -->
+          Button's 'display' property is set to 'none',
+          so that button will only be displayed if
+          box can be successfully opened and closed.
+          -->
         </xsl:if>
         <!-- Box Title -->
         <xsl:text> </xsl:text>
@@ -7019,12 +7103,12 @@ A local schema component contains two dashes in
     </div>
   </xsl:template>
   <!--
-     Returns the namespace of an attribute
-     declaration or reference.
-     Param(s):
-            attribute (Node) required
-                Attribute declaration or reference
-     -->
+  Returns the namespace of an attribute
+  declaration or reference.
+  Param(s):
+  attribute (Node) required
+  Attribute declaration or reference
+  -->
   <xsl:template name="GetAttributeNS">
     <xsl:param name="attribute"/>
     <xsl:choose>
@@ -7042,12 +7126,12 @@ A local schema component contains two dashes in
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the description that can be used in
-     headers for a schema component.
-     Param(s):
-            component (Node) required
-                Schema component
-     -->
+  Returns the description that can be used in
+  headers for a schema component.
+  Param(s):
+  component (Node) required
+  Schema component
+  -->
   <xsl:template name="GetComponentDescription">
     <xsl:param name="component"/>
     <xsl:choose>
@@ -7092,13 +7176,13 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the unique identifier for a top-level schema
-     component. Returns the string "schema" if the 'component'
-     is the root schema element.
-     Param(s):
-            component (Node) required
-                Schema component
-     -->
+  Returns the unique identifier for a top-level schema
+  component. Returns the string "schema" if the 'component'
+  is the root schema element.
+  Param(s):
+  component (Node) required
+  Schema component
+  -->
   <xsl:template name="GetComponentID">
     <xsl:param name="component"/>
     <xsl:choose>
@@ -7116,12 +7200,12 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the prefix to add in front of a schema component
-     name when generating anchor names.
-     Param(s):
-            component (Node) required
-                Schema component
-     -->
+  Returns the prefix to add in front of a schema component
+  name when generating anchor names.
+  Param(s):
+  component (Node) required
+  Schema component
+  -->
   <xsl:template name="GetComponentPrefix">
     <xsl:param name="component"/>
     <xsl:choose>
@@ -7160,12 +7244,12 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns a glossary term reference for the
-     schema component type, if applicable.
-     Param(s):
-            component (Node) required
-                Schema component
-     -->
+  Returns a glossary term reference for the
+  schema component type, if applicable.
+  Param(s):
+  component (Node) required
+  Schema component
+  -->
   <xsl:template name="GetComponentTermRef">
     <xsl:param name="component"/>
     <xsl:choose>
@@ -7175,11 +7259,11 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the namespace prefix of an attribute.
-     Param(s):
-            attribute (Node) required
-                Attribute declaration or reference
-     -->
+  Returns the namespace prefix of an attribute.
+  Param(s):
+  attribute (Node) required
+  Attribute declaration or reference
+  -->
   <xsl:template name="GetAttributePrefix">
     <xsl:param name="attribute"/>
     <xsl:choose>
@@ -7202,11 +7286,11 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the namespace prefix of an element.
-     Param(s):
-            element (Node) required
-                Element declaration or reference
-     -->
+  Returns the namespace prefix of an element.
+  Param(s):
+  element (Node) required
+  Element declaration or reference
+  -->
   <xsl:template name="GetElementPrefix">
     <xsl:param name="element"/>
     <xsl:choose>
@@ -7229,11 +7313,11 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the local name of a reference.
-     Param(s):
-            ref (String) required
-                Reference
-     -->
+  Returns the local name of a reference.
+  Param(s):
+  ref (String) required
+  Reference
+  -->
   <xsl:template name="GetRefName">
     <xsl:param name="ref"/>
     <xsl:choose>
@@ -7248,22 +7332,22 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Returns the namespace prefix of a reference.
-     Param(s):
-            ref (String) required
-                Reference
-     -->
+  Returns the namespace prefix of a reference.
+  Param(s):
+  ref (String) required
+  Reference
+  -->
   <xsl:template name="GetRefPrefix">
     <xsl:param name="ref"/>
     <!-- Get namespace prefix -->
     <xsl:value-of select="substring-before($ref, ':')"/>
   </xsl:template>
   <!--
-     Returns the namespace of a reference.
-     Param(s):
-            ref (String) required
-                Reference
-     -->
+  Returns the namespace of a reference.
+  Param(s):
+  ref (String) required
+  Reference
+  -->
   <xsl:template name="GetRefNS">
     <xsl:param name="ref"/>
     <!-- Get namespace prefix -->
@@ -7272,30 +7356,30 @@ Unknown schema component, <xsl:value-of select="local-name($component)"/>.
     <xsl:value-of select="/xsd:schema/namespace::*[local-name(.)=normalize-space($refPrefix)]"/>
   </xsl:template>
   <!--
-     Returns the declared prefix of this schema's target namespace.
-     -->
+  Returns the declared prefix of this schema's target namespace.
+  -->
   <xsl:template name="GetThisPrefix">
     <xsl:if test="/xsd:schema/@targetNamespace">
       <xsl:value-of select="local-name(/xsd:schema/namespace::*[normalize-space(.)=normalize-space(/xsd:schema/@targetNamespace)])"/>
     </xsl:if>
   </xsl:template>
   <!--
-     Returns the declared prefix of XML Schema namespace.
-     -->
+  Returns the declared prefix of XML Schema namespace.
+  -->
   <xsl:template name="GetXSDPrefix">
     <xsl:value-of select="local-name(/xsd:schema/namespace::*[normalize-space(.)=$XSD_NS])"/>
   </xsl:template>
   <!--
-     Returns the schema documentation file location for a
-     given URI for a schema, done by looking up the file
-     specified in 'linksFile' variable.
-     It'll throw a fatal error if a value for 'linksFile' was
-     provided and the documentation file for 'uri' could not be
-     found.
-     Param(s):
-            uri (String) required
-              Location of schema file
-     -->
+  Returns the schema documentation file location for a
+  given URI for a schema, done by looking up the file
+  specified in 'linksFile' variable.
+  It'll throw a fatal error if a value for 'linksFile' was
+  provided and the documentation file for 'uri' could not be
+  found.
+  Param(s):
+  uri (String) required
+  Location of schema file
+  -->
   <xsl:template name="GetSchemaDocLocation">
     <xsl:param name="uri"/>
     <xsl:if test="$linksFile!=''">
@@ -7313,11 +7397,11 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out a boolean value.
-     Param(s):
-            boolean (String) required
-                Boolean value
-     -->
+  Prints out a boolean value.
+  Param(s):
+  boolean (String) required
+  Boolean value
+  -->
   <xsl:template name="PrintBoolean">
     <xsl:param name="boolean"/>
     <xsl:choose>
@@ -7330,18 +7414,18 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out a link to the namespace of a prefix,
-     and tacks on a colon in the end.
-     Param(s):
-            prefix (String) required
-                Namespace prefix
-            nolink (boolean) optional
-                If true, doesn't provide a link to the
-                namespace in the namespaces table.
-            schemaLoc (String) optional
-                Schema file containing this namespace prefix;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Prints out a link to the namespace of a prefix,
+  and tacks on a colon in the end.
+  Param(s):
+  prefix (String) required
+  Namespace prefix
+  nolink (boolean) optional
+  If true, doesn't provide a link to the
+  namespace in the namespaces table.
+  schemaLoc (String) optional
+  Schema file containing this namespace prefix;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintNSPrefix">
     <xsl:param name="prefix"/>
     <xsl:param name="nolink">false</xsl:param>
@@ -7362,15 +7446,15 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Prints out the min/max occurrences of a schema component.
-     Param(s):
-            component (Node) optional
-                Schema component
-            minOccurs (String) optional
-                Minimum occurrences
-            maxOccurs (String) optional
-                Maximum occurrences
-     -->
+  Prints out the min/max occurrences of a schema component.
+  Param(s):
+  component (Node) optional
+  Schema component
+  minOccurs (String) optional
+  Minimum occurrences
+  maxOccurs (String) optional
+  Maximum occurrences
+  -->
   <xsl:template name="PrintOccurs">
     <xsl:param name="component"/>
     <xsl:param name="minOccurs"/>
@@ -7450,12 +7534,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </span>
   </xsl:template>
   <!--
-     Translates occurrence of '#all' in 'block' value
-     of element declarations.
-     Param(s):
-            EBV (String) required
-                Value
-     -->
+  Translates occurrence of '#all' in 'block' value
+  of element declarations.
+  Param(s):
+  EBV (String) required
+  Value
+  -->
   <xsl:template name="PrintBlockSet">
     <xsl:param name="EBV"/>
     <xsl:choose>
@@ -7468,13 +7552,13 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Translates occurrence of '#all' in 'final' value
-     of element declarations, and 'block' and 'final' values
-     in complex type definitions.
-     Param(s):
-            EBV (String) required
-                Value
-     -->
+  Translates occurrence of '#all' in 'final' value
+  of element declarations, and 'block' and 'final' values
+  in complex type definitions.
+  Param(s):
+  EBV (String) required
+  Value
+  -->
   <xsl:template name="PrintDerivationSet">
     <xsl:param name="EBV"/>
     <xsl:choose>
@@ -7487,12 +7571,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Translates occurrence of '#all' in 'final' value
-     of simple type definitions.
-     Param(s):
-            EBV (String) required
-                Value
-     -->
+  Translates occurrence of '#all' in 'final' value
+  of simple type definitions.
+  Param(s):
+  EBV (String) required
+  Value
+  -->
   <xsl:template name="PrintSimpleDerivationSet">
     <xsl:param name="EBV"/>
     <xsl:choose>
@@ -7505,11 +7589,11 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Print out a URI. If it starts with 'http', a link is provided.
-     Param(s):
-            uri (String) required
-              URI to be printed
-     -->
+  Print out a URI. If it starts with 'http', a link is provided.
+  Param(s):
+  uri (String) required
+  URI to be printed
+  -->
   <xsl:template name="PrintURI">
     <xsl:param name="uri"/>
     <xsl:choose>
@@ -7524,15 +7608,15 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Print out a link to the documentation of schema document.
-     For this happen, the 'linksFile' variable must be provided,
-     it must point to an actual file, and in that file, there
-     must be a mapping from the schema file location to the
-     schema documentation file location.
-     Param(s):
-            uri (String) required
-              Location of schema file
-     -->
+  Print out a link to the documentation of schema document.
+  For this happen, the 'linksFile' variable must be provided,
+  it must point to an actual file, and in that file, there
+  must be a mapping from the schema file location to the
+  schema documentation file location.
+  Param(s):
+  uri (String) required
+  Location of schema file
+  -->
   <xsl:template name="PrintSchemaLink">
     <xsl:param name="uri"/>
     <xsl:variable name="docFileLoc">
@@ -7552,28 +7636,28 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Tokenises a whitespace-separated list of values, and
-     displays them appropriately.
-     Param(s):
-            value (String) required
-              Whitespace-separated list
-            compType (String) optional
-              Specify schema component type if values in list are
-              schema components, so appropriate links can be provided.
-            isInList (boolean) optional
-              If true, place each value within 'li' tags.
-              Assumes that this template is called within an HTML
-              list element.
-            separator (String) optional
-              Character(s) to use to separate resulting values in list.
-              Only used if 'isInList' is false.
-              If none is provided, uses a space character, ' '.
-            isFirst (boolean) optional
-              If false, it's a recursive call from 'PrintWhitespaceList'.
-            schemaLoc (String) optional
-                Schema file containing this all model group;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Tokenises a whitespace-separated list of values, and
+  displays them appropriately.
+  Param(s):
+  value (String) required
+  Whitespace-separated list
+  compType (String) optional
+  Specify schema component type if values in list are
+  schema components, so appropriate links can be provided.
+  isInList (boolean) optional
+  If true, place each value within 'li' tags.
+  Assumes that this template is called within an HTML
+  list element.
+  separator (String) optional
+  Character(s) to use to separate resulting values in list.
+  Only used if 'isInList' is false.
+  If none is provided, uses a space character, ' '.
+  isFirst (boolean) optional
+  If false, it's a recursive call from 'PrintWhitespaceList'.
+  schemaLoc (String) optional
+  Schema file containing this all model group;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintWhitespaceList">
     <xsl:param name="value"/>
     <xsl:param name="compType"/>
@@ -7608,7 +7692,7 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
         </xsl:if>
       </xsl:when>
       <xsl:otherwise>
-        <!-- No more whitespaces  -->
+        <!-- No more whitespaces -->
         <!-- Print out one last token -->
         <xsl:if test="normalize-space($value)!=''">
           <xsl:call-template name="PrintWhitespaceListToken">
@@ -7624,25 +7708,25 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Helper template for 'PrintWhitespaceList' template,
-     which prints out one token in the list.
-     Param(s):
-            token (String) required
-              Token to be printed
-            compType (String) optional
-              Schema component type of token, if applicable.
-            isInList (boolean) optional
-              If true, place token within 'li' tags.
-            separator (String) optional
-              Character(s) use to separate one token from another.
-              Only used if 'isInList' is false.
-              If none is provided, uses a space character, ' '.
-            isFirst (boolean) optional
-              If true, token is the first value in the list.
-            schemaLoc (String) optional
-                Schema file containing this all model group;
-                if in current schema, 'schemaLoc' is set to 'this'
-     -->
+  Helper template for 'PrintWhitespaceList' template,
+  which prints out one token in the list.
+  Param(s):
+  token (String) required
+  Token to be printed
+  compType (String) optional
+  Schema component type of token, if applicable.
+  isInList (boolean) optional
+  If true, place token within 'li' tags.
+  separator (String) optional
+  Character(s) use to separate one token from another.
+  Only used if 'isInList' is false.
+  If none is provided, uses a space character, ' '.
+  isFirst (boolean) optional
+  If true, token is the first value in the list.
+  schemaLoc (String) optional
+  Schema file containing this all model group;
+  if in current schema, 'schemaLoc' is set to 'this'
+  -->
   <xsl:template name="PrintWhitespaceListToken">
     <xsl:param name="token"/>
     <xsl:param name="compType"/>
@@ -7687,17 +7771,17 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Print out a wildcard.
-     Param(s):
-            componentType (attribute|element) required
-              XML Schema component type
-            namespaces (String) required
-              Namespace attribute of wildcard
-            processContents (String) required
-              Process contents attribute of wildcard
-            namespaces (String) required
-              Namespace attribute of wildcard
-     -->
+  Print out a wildcard.
+  Param(s):
+  componentType (attribute|element) required
+  XML Schema component type
+  namespaces (String) required
+  Namespace attribute of wildcard
+  processContents (String) required
+  Process contents attribute of wildcard
+  namespaces (String) required
+  Namespace attribute of wildcard
+  -->
   <xsl:template name="PrintWildcard">
     <xsl:param name="componentType">element</xsl:param>
     <xsl:param name="namespace"/>
@@ -7731,7 +7815,7 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
           </xsl:if>
         </xsl:variable>
         <!-- Specific namespaces -->
-        <!-- Remove '##targetNamespace' string if any-->
+        <!-- Remove '##targetNamespace' string if any -->
         <xsl:variable name="temp">
           <xsl:choose>
             <xsl:when test="$hasTargetNS='true'">
@@ -7811,12 +7895,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Print out the pattern property for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the pattern property for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintPatternFacet">
     <xsl:param name="simpleRestrict"/>
     <xsl:if test="$simpleRestrict/xsd:pattern">
@@ -7826,12 +7910,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Print out the total digits property for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the total digits property for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintTotalDigitsFacet">
     <xsl:param name="simpleRestrict"/>
     <xsl:if test="$simpleRestrict/xsd:totalDigits">
@@ -7841,12 +7925,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Print out the fraction digits property for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the fraction digits property for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintFractionDigitsFacet">
     <xsl:param name="simpleRestrict"/>
     <xsl:if test="$simpleRestrict/xsd:fractionDigits">
@@ -7858,12 +7942,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Print out the enumeration list for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the enumeration list for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintEnumFacets">
     <xsl:param name="simpleRestrict"/>
     <xsl:if test="$simpleRestrict/xsd:enumeration">
@@ -7881,12 +7965,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:if>
   </xsl:template>
   <!--
-     Print out the length property for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the length property for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintLengthFacets">
     <xsl:param name="simpleRestrict"/>
     <xsl:choose>
@@ -7914,12 +7998,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Print out the whitespace property for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the whitespace property for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintWhitespaceFacet">
     <xsl:param name="simpleRestrict"/>
     <xsl:variable name="facetValue" select="normalize-space(translate($simpleRestrict/xsd:whiteSpace/@value, 'ACELOPRSV', 'aceloprsv'))"/>
@@ -7948,12 +8032,12 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Print out the value ranges for derivations by
-     restriction on simple content.
-     Param(s):
-            simpleRestrict (Node) required
-              'restriction' element
-     -->
+  Print out the value ranges for derivations by
+  restriction on simple content.
+  Param(s):
+  simpleRestrict (Node) required
+  'restriction' element
+  -->
   <xsl:template name="PrintRangeFacets">
     <xsl:param name="simpleRestrict"/>
     <xsl:choose>
@@ -8013,54 +8097,66 @@ was not specified in the links file, <xsl:value-of select="$linksFile"/>.
     </xsl:choose>
   </xsl:template>
   <!--
-     Prints out JavaScript code.
-     NOTE: Javascript code is placed within comments to make it
-     work with current browsers. In strict XHTML, JavaScript code
-     should be placed within CDATA sections. However, most
-     browsers generate a syntax error if the page contains
-     CDATA sections. Placing Javascript code within comments
-     means that the code cannot contain two dashes.
-     Param(s):
-            code (Result Tree Fragment) required
-                Javascript code
+  Prints out JavaScript code.
+  NOTE: Javascript code is placed within comments to make it
+  work with current browsers. In strict XHTML, JavaScript code
+  should be placed within CDATA sections. However, most
+  browsers generate a syntax error if the page contains
+  CDATA sections. Placing Javascript code within comments
+  means that the code cannot contain two dashes.
+  Param(s):
+  code (Result Tree Fragment) required
+  Javascript code
   -->
   <xsl:template name="PrintJSCode">
     <xsl:param name="code"/>
     <script type="text/javascript">
-      <!-- If browsers start supporting CDATA sections,
-              uncomment the following piece of code. -->
-      <!-- <xsl:text disable-output-escaping="yes">
-&lt;![CDATA[
-</xsl:text> -->
-      <!-- If browsers start supporting CDATA sections,
-              remove the following piece of code. -->
+      <!--
+      If browsers start supporting CDATA sections,
+      uncomment the following piece of code.
+      -->
+      <!--
+      <xsl:text disable-output-escaping="yes">
+      &lt;![CDATA[
+      </xsl:text>
+      -->
+      <!--
+      If browsers start supporting CDATA sections,
+      remove the following piece of code.
+      -->
       <xsl:text disable-output-escaping="yes">
 &lt;!--
 </xsl:text>
       <xsl:value-of select="$code" disable-output-escaping="yes"/>
-      <!-- If browsers start supporting CDATA sections,
-              remove the following piece of code. -->
+      <!--
+      If browsers start supporting CDATA sections,
+      remove the following piece of code.
+      -->
       <xsl:text disable-output-escaping="yes">
 // --&gt;
 </xsl:text>
-      <!-- If browsers start supporting CDATA sections,
-              uncomment the following piece of code. -->
-      <!-- <xsl:text disable-output-escaping="yes">
-]]&gt;
-</xsl:text> -->
+      <!--
+      If browsers start supporting CDATA sections,
+      uncomment the following piece of code.
+      -->
+      <!--
+      <xsl:text disable-output-escaping="yes">
+      ]]&gt;
+      </xsl:text>
+      -->
     </script>
   </xsl:template>
   <!--
-     Translates occurrences of a string
-     in a piece of text with another string.
-     Param(s):
-            value (String) required
-                Text to translate
-            strToReplace (String) required
-                String to be replaced
-            replacementStr (String) required
-                Replacement text
-     -->
+  Translates occurrences of a string
+  in a piece of text with another string.
+  Param(s):
+  value (String) required
+  Text to translate
+  strToReplace (String) required
+  String to be replaced
+  replacementStr (String) required
+  Replacement text
+  -->
   <xsl:template name="TranslateStr">
     <xsl:param name="value"/>
     <xsl:param name="strToReplace"/>


### PR DESCRIPTION
## Problem

The `xcop` workflow fails on `master` because `eo-parser/src/main/xs3p/xs3p.xsl` no longer conforms to `xcop`'s XML formatting rules. The failure is unrelated to any functional change—it reproduces on an untouched `master` branch and causes otherwise valid pull requests to fail the `xcop` check.

For example:

- #5605 merged with the `xcop` check failing.
- #5606 failed only the `xcop` check, while `mvn`, `qulice`, and `pr-size` all passed.

Running locally:

```sh
xcop eo-parser/src/main/xs3p/xs3p.xsl
```

reports:

```text
Invalid XML formatting in eo-parser/src/main/xs3p/xs3p.xsl
```

The formatting issues are limited to comment indentation near the `TranslateStr` and `HandleError` templates at the end of the file.

## Fix

Reformatted `eo-parser/src/main/xs3p/xs3p.xsl` using `xcop` 0.10.2:

```sh
xcop --fix eo-parser/src/main/xs3p/xs3p.xsl
```

The resulting changes are formatting-only and do not modify the XSLT's behavior. The file now conforms to `xcop`'s XML formatting requirements.

## Verification

The reformatting was verified to be non-functional:

- `xsltproc` still generates the XMIR XSD documentation successfully.
- Generated HTML output is unchanged in behavior.

## Tests

- [x] `xcop eo-parser/src/main/xs3p/xs3p.xsl`
- [x] `xsltproc eo-parser/src/main/xs3p/xs3p.xsl eo-parser/src/main/resources/XMIR.xsd`
- [x] All `eo-parser` tests pass
- [x] `qulice:check`

Fixes #5607 