### PR TITLE
#5614: printer renders void type annotations (the /{...} suffix)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -41,6 +41,19 @@
     <xsl:param name="text" as="xs:string"/>
     <xsl:sequence select="replace($text, concat('a', $eo:cactoos, '(\d+)-(\d+)'), 'v$1_$2')"/>
   </xsl:function>
+  <!--
+  Render a stored signature (an atom's "/sig" or a void forma) as its EO
+  surface form. A single-name "Φ.name" re-resolves to its root on
+  reparse, so the implicit root is dropped; a multi-segment
+  "Φ.a.b.c" must stay rooted (a dotted signature is not re-homed) and
+  keeps an explicit "Q." root. Names with no "Φ." root pass through.
+  -->
+  <xsl:function name="eo:signature" as="xs:string">
+    <xsl:param name="sig" as="xs:string"/>
+    <xsl:variable name="root" select="concat($eo:program, '.')"/>
+    <xsl:variable name="rest" select="substring-after($sig, $root)"/>
+    <xsl:sequence select="if (starts-with($sig, $root)) then (if (contains($rest, '.')) then concat('Q.', $rest) else $rest) else $sig"/>
+  </xsl:function>
   <!-- PROGRAM -->
   <xsl:template match="object">
     <object>
@@ -138,7 +151,7 @@
       <xsl:attribute name="data">
         <xsl:value-of select="if (eo:has-data(.)) then 'yes' else 'no'"/>
       </xsl:attribute>
-      <xsl:apply-templates select="o[not(eo:void(.)) or @local]" mode="tree"/>
+      <xsl:apply-templates select="o[not(eo:void(.)) or @local or @types]" mode="tree"/>
     </line>
   </xsl:template>
   <!-- VOID WITH FILE-LOCAL HANDLE -->
@@ -148,8 +161,29 @@
   to preserve the void's anonymity (§9.2, R-9.2.3) instead of being
   collapsed into a public "[name]" bracket param (#5581).
   -->
-  <xsl:template match="o[eo:void(.) and @local]" mode="tree">
+  <xsl:template match="o[eo:void(.) and @local and not(@types)]" mode="tree">
     <line base="?" tail="{concat(' &gt;&gt; ', @local)}" abstract="no" test="no" reversed="no"/>
+  </xsl:template>
+  <!-- VOID WITH TYPE ANNOTATION -->
+  <!--
+  A void carrying a forma-list tail ("? &gt; name /{forma …}", R-3.4.8) —
+  the argument formas of an atom's error branch — is printed as a
+  vertical body line so its "/{...}" annotation survives. A bracket param
+  cannot express a type, so folding it into "[...]" would silently drop
+  the signature and change the object's shape while still parsing (#5614).
+  Each forma has its implicit Φ. root stripped, mirroring the atom's own
+  "/sig" rendering.
+  -->
+  <xsl:template match="o[eo:void(.) and @types]" mode="tree">
+    <xsl:variable name="formas" select="string-join(for $t in tokenize(@types, ' ') return eo:signature($t), ' ')"/>
+    <xsl:choose>
+      <xsl:when test="@local">
+        <line base="?" tail="{concat(' &gt;&gt; ', @local, ' /{', $formas, '}')}" abstract="no" test="no" reversed="no"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <line base="?" tail="{concat(' &gt; ', @name, ' /{', $formas, '}')}" abstract="no" test="no" reversed="no"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!-- BASED -->
   <xsl:template match="o[@base and not(eo:has-data(.))]" mode="head">
@@ -219,7 +253,7 @@
     -->
     <xsl:if test="not(eo:test-attr(.) and empty(o[eo:void(.)]))">
       <xsl:text>[</xsl:text>
-      <xsl:for-each select="o[eo:void(.) and not(@local)]">
+      <xsl:for-each select="o[eo:void(.) and not(@local) and not(@types)]">
         <xsl:if test="position()&gt;1">
           <xsl:text> </xsl:text>
         </xsl:if>
@@ -278,31 +312,14 @@
         <xsl:text>!</xsl:text>
       </xsl:if>
       <xsl:if test="eo:atom(.)">
-        <xsl:text> /</xsl:text>
-        <xsl:variable name="lambda-atom" select="string(./o[@name=$eo:lambda]/@atom)"/>
-        <xsl:choose>
-          <xsl:when test="starts-with($lambda-atom, 'Φ.')">
-            <xsl:variable name="rest" select="substring-after($lambda-atom, 'Φ.')"/>
-            <xsl:choose>
-              <!--
-              A multi-segment signature (e.g. "Φ.malloc.of.allocated") must
-              stay rooted: on reparse a dotted @atom is not re-homed, so
-              dropping the root would yield an XSD-invalid fqn. A single-name
-              signature (e.g. "Φ.bytes") re-resolves to its root on reparse,
-              so the implicit root is dropped for idiomatic output.
-              -->
-              <xsl:when test="contains($rest, '.')">
-                <xsl:value-of select="concat('Q.', $rest)"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$rest"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="$lambda-atom"/>
-          </xsl:otherwise>
-        </xsl:choose>
+        <!--
+        A multi-segment signature (e.g. "Φ.malloc.of.allocated") stays
+        rooted: on reparse a dotted @atom is not re-homed, so dropping the
+        root would yield an XSD-invalid fqn. A single-name signature (e.g.
+        "Φ.bytes") re-resolves to its root on reparse, so the implicit
+        root is dropped for idiomatic output.
+        -->
+        <xsl:value-of select="concat(' /', eo:signature(string(./o[@name=$eo:lambda]/@atom)))"/>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-type-annotation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-type-annotation.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A void carrying an atom error-branch forma-list ("? > name /{forma …}",
+# R-3.4.8) must print back as a vertical "? > name /{...}" body line, not
+# be folded into a "[name]" bracket param that silently drops the "/{...}"
+# type annotation (#5614). A single-name forma re-resolves to its root, so
+# its implicit "Φ." is dropped; a multi-segment forma keeps its "Q." root,
+# mirroring the atom's own "/sig" rendering.
+origin: |
+  +package org.eolang
+
+  [start len] > slice /bytes
+    ? > cant-slice /{string}
+    ? > bad-range /{string Q.a.b.c}
+
+printed: |
+  +package org.eolang
+
+  [start len] > slice /bytes
+    ? > cant-slice /{string}
+    ? > bad-range /{string Q.a.b.c}


### PR DESCRIPTION
Fixes #5614.

## Problem

The printer discarded the type annotation of a void attribute. For example, `eo-runtime/src/main/eo/bytes.eo` declares:

```
[start len] > slice /bytes
  ? > cant-slice /{string}
```

but after the `format` goal it became `[start len cant-slice] > slice /bytes` — the void `cant-slice` was folded into the params bracket and its `/{string}` type was gone. The parser keeps the annotation correctly (as `@types`); the loss happened purely in the printer.

The cause was in `eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl`: the `/type` suffix was emitted only for atoms (from the `λ`-atom child), and no code path ever read the `@types` attribute. A void carrying `@types` was rendered as a bare name and folded into `[...]`, which cannot express a type — silently changing the object's signature while still parsing.

## Fix

Render `@types` back as a `/{...}` suffix. When a void attribute has a non-empty `@types`, it is emitted as a vertical `? > name /{...}` body line (mirroring the parser's input form, with space-separated FQNs) rather than as a plain bracket param:

- Typed voids are kept out of the `[...]` head and off the `@local` (`>>`) branch.
- A new tree-mode template emits the `/{...}` suffix from `@types`, handling both the `? > name` and `? >> name` shapes.
- The `λ`-atom root-stripping (drop the implicit `Φ.` for single-name signatures, keep an explicit `Q.` for multi-segment ones) is extracted into a shared `eo:signature()` helper, reused by both the atom `/sig` and the void forma rendering.

## Tests

Added `eo-printer/.../print-packs/yaml/void-type-annotation.yaml`, a round-trip test covering a single-name forma (`/{string}`) and a multi-forma list with a rooted forma (`/{string Q.a.b.c}`). It exercises both `printsToEo` (exact output) and `printsToParseableEo` (reprints to the same EO). The full `eo-printer` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvdGh7XyPPMPnPxoJvun9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvdGh7XyPPMPnPxoJvun9f)_