### PR TITLE
#5618: printer preserves `!` const marker on attributes nested inside a const-valued formation

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
@@ -18,7 +18,7 @@
           <xsl:attribute name="name" select="@name"/>
           <xsl:attribute name="const"/>
           <xsl:for-each select="$argument/o">
-            <xsl:copy-of select="."/>
+            <xsl:apply-templates select="."/>
           </xsl:for-each>
           <xsl:if test="eo:has-data($argument)">
             <xsl:value-of select="$argument"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  [] > mktemp
+    string > @
+      [] >>!
+        getenv "TEMP" > temp!
+        temp > @
+
+printed: |
+  [] > mktemp
+    string > @
+      [] >>!
+        getenv "TEMP" > temp!
+        temp > @


### PR DESCRIPTION
Fixes #5618.

## Problem

The printer dropped the `!` const marker whenever a constant attribute sat inside another constant. For the five environment lookups in `eo-runtime/src/main/eo/mktemp.eo` (bound inside the surrounding `[] >>!` formation, which is itself constant), the round-trip rewrote e.g.

```
getenv "TEMP" > temp!
```

into a bare, non-constant attribute with the raw desugaring left exposed:

```
as-bytes. > temp
  dataized (getenv "TEMP")
```

Dropping the marker is not cosmetic — `!` caches the value once, so a plain attribute re-reads the environment on every access.

## Root cause

`eo-printer/.../print/dataized-to-const.xsl` reverses the `const-to-dataized.xsl` lowering. When rebuilding an outer constant's value it copied the value's children with `<xsl:copy-of>`, which copies the subtree verbatim and never applies templates to it. So the inner `(dataized …).as-bytes` nodes were copied as-is and the template that turns them back into `@const` never fired — the reversal was not recursive, unlike the forward transform (`const-to-dataized.xsl` uses `<xsl:apply-templates>` on children).

## Fix

Change the `<xsl:copy-of select="."/>` at `dataized-to-const.xsl:21` to `<xsl:apply-templates select="."/>` so the reconstructed constant's children are walked recursively and nested constants are reversed too.

## Test

Added `const-nested-in-const.yaml` to the printer round-trip packs, mirroring the mktemp structure (a const attribute inside a const-valued formation). It reproduces the bug: without the fix the printed EO was `as-bytes. (dataized (getenv "TEMP")) > temp`; with the fix it round-trips back to `getenv "TEMP" > temp!`. All 111 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpVrSUfPPtKG3wdhrAmXM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpVrSUfPPtKG3wdhrAmXM6)_