### PR TITLE
Fix lossy UTF-8 decode in StUnhex string printing (#5620)

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -8,7 +8,10 @@ import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StEnvelope;
 import com.yegor256.xsline.StSequence;
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import org.eolang.parser.StXnav;
 
@@ -54,17 +57,13 @@ final class StUnhex extends StEnvelope {
         ),
         new StXnav(
             StUnhex.elements("string"),
-            xnav -> xnav.node().setTextContent(
-                String.format(
-                    "\"%s\"",
-                    StUnhex.escape(
-                        new String(
-                            StUnhex.buffer(
-                                StUnhex.undash(xnav.element("o").text().orElse(""))
-                            ).array(),
-                            StandardCharsets.UTF_8
-                        )
-                    )
+            xnav -> StUnhex.decode(
+                StUnhex.buffer(
+                    StUnhex.undash(xnav.element("o").text().orElse(""))
+                ).array()
+            ).ifPresent(
+                decoded -> xnav.node().setTextContent(
+                    String.format("\"%s\"", StUnhex.escape(decoded))
                 )
             )
         )
@@ -125,6 +124,34 @@ final class StUnhex extends StEnvelope {
             buffer.position(0);
         }
         return buffer;
+    }
+
+    /**
+     * Strictly decode UTF-8 bytes into a string.
+     * The lenient JDK decoder ({@code new String(bytes, UTF_8)}) silently
+     * replaces malformed or incomplete sequences with {@code U+FFFD}, which
+     * does not round-trip: re-parsing the printed literal yields the bytes
+     * {@code EF-BF-BD} instead of the original ones, so a pure formatting pass
+     * would change the program. A strict decoder reports such input instead,
+     * and this method returns {@link Optional#empty()} for it, leaving the
+     * caller to keep the explicit {@code Φ.string}/{@code Φ.bytes} structure.
+     * @param bytes The raw bytes
+     * @return The decoded string, or empty if the bytes are not valid UTF-8
+     */
+    private static Optional<String> decode(final byte[] bytes) {
+        Optional<String> result;
+        try {
+            result = Optional.of(
+                StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString()
+            );
+        } catch (final CharacterCodingException ex) {
+            result = Optional.empty();
+        }
+        return result;
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Test case for {@link StUnhex}.
  * @since 0.29.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class StUnhexTest {
 
     @ParameterizedTest
@@ -174,6 +175,25 @@ final class StUnhexTest {
             ),
             XhtmlMatchers.hasXPath(
                 "//o[text()='\"A\\u0001\\u0007\u0434\u0440\u0443\u0433\"']"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void keepsMalformedBytesUnconverted(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must not lossily decode invalid UTF-8, but it did",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.string'><o base='Φ.bytes'><o>F0-9F-98</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.string' and o[@base='Φ.bytes' and not(o) and text()='F0-9F-98']]"
             )
         );
     }


### PR DESCRIPTION
Fixes #5620.

## Problem

The `string` shift in `StUnhex` decoded any `Φ.string`-over-`Φ.bytes` with `new String(bytes, StandardCharsets.UTF_8)` — the lenient JDK decoder. An incomplete or invalid UTF-8 sequence (e.g. the truncated 4-byte emoji `F0-9F-98`, missing its final `80`) was silently replaced with `U+FFFD`, serialized back as the UTF-8 bytes `EF-BF-BD`.

As a result a pure formatting pass changed the program: `(string F0-9F-98).length` became `"�".length`, whose byte content is `EF-BF-BD`, not `F0-9F-98`. It does not round-trip, and it defeats the very case `throws-on-taking-length-of-incomplete-n4-byte-character` in `eo-runtime/src/main/eo/string.eo` exercises — an intentionally incomplete character was turned into a valid, complete one.

## Fix

`eo-printer/src/main/java/org/eolang/printer/StUnhex.java`

- Added a `decode` helper that decodes bytes through a strict `CharsetDecoder` with `CodingErrorAction.REPORT` (for both malformed input and unmappable characters), returning `Optional.empty()` when the bytes are not valid UTF-8.
- The `string` shift now only rewrites the node when the strict decode succeeds. When it fails, the conversion is skipped and the `Φ.string`/`Φ.bytes` structure is left in place, so it prints as an explicit bytes application (`string F0-9F-98`).

## Tests

`eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java`

- Added `keepsMalformedBytesUnconverted`, verifying that `F0-9F-98` is left as the `Φ.string`/`Φ.bytes` structure rather than lossily decoded.
- All existing `StUnhexTest` cases still pass (valid strings, glyphs, control-char escaping, empty strings), and the full `eo-printer` suite (110 tests) is green. Qulice (0.27.6) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011FCVZRGmTYHHcKaR74SSSu)_