### PR TITLE
Restrict trailing-star hybrid to the sole-child `seq *` idiom (#5622)

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -332,9 +332,14 @@ final class Pretty {
      * ambiguity.</p>
      *
      * <p>It applies only to a plain (non-formation, non-reversed)
-     * application whose final child is a non-empty, unnamed star; any
-     * preceding arguments must inline. The elements are always laid out
-     * vertically, so the genuinely ambiguous fully-horizontal
+     * application whose sole child is a non-empty, unnamed star. The star
+     * must be the only child: a bare trailing {@code *} absorbs the
+     * indented siblings into the tuple, so the shape round-trips only when
+     * nothing else shares the head's line. A preceding argument
+     * ({@code sm.win32 "getenv" *}) would make the parser read a complete
+     * application with an empty tuple and reject the indented child, so
+     * {@link #tuply()} bars that case (issue #5622). The elements are always
+     * laid out vertically, so the genuinely ambiguous fully-horizontal
      * {@code head * a b} — the before-star territory — is never produced
      * here. The result is only a candidate: {@link #shaped} keeps it only
      * when its penalty beats the plain vertical and horizontal renderings,
@@ -348,11 +353,8 @@ final class Pretty {
     private Optional<String> starred(final Pretty.Node node, final int indent) {
         Optional<String> result = Optional.empty();
         if (node.tuply()) {
-            final List<Pretty.Node> kids = node.children;
-            result = Pretty.inlined(kids.subList(0, kids.size() - 1)).map(
-                args -> this.vertical(
-                    kids.get(kids.size() - 1).glued(node, args), indent
-                )
+            result = Optional.of(
+                this.vertical(node.children.get(0).glued(node), indent)
             );
         }
         return result;
@@ -536,15 +538,21 @@ final class Pretty {
          *
          * <p>A formation lays its children out as bindings and a reversed
          * dispatch keeps its receiver first, so neither is a plain
-         * application and neither qualifies. The last child must itself be
-         * a gluable star (see {@link #stars()}).</p>
+         * application and neither qualifies. The star must be the head's
+         * only child: a bare trailing {@code *} absorbs the indented
+         * siblings beneath it into the tuple, so this round-trips only for
+         * the genuine {@code seq *} idiom. When a preceding argument shares
+         * the line ({@code sm.win32 "getenv" *}), the parser reads it as a
+         * complete application with an empty tuple and rejects the indented
+         * child, so the hybrid must not fire (issue #5622). The single child
+         * must itself be a gluable star (see {@link #stars()}).</p>
          *
          * @return True when the trailing-star hybrid form is applicable
          */
         boolean tuply() {
-            final int last = this.children.size() - 1;
-            return !this.abstractt && !this.reversed && last >= 0
-                && this.children.get(last).stars();
+            return !this.abstractt && !this.reversed
+                && this.children.size() == 1
+                && this.children.get(0).stars();
         }
 
         /**
@@ -561,19 +569,17 @@ final class Pretty {
          * Build the synthetic node that renders this tuple glued to the
          * tail of {@code applier}'s line: {@code head *} on one line (with
          * the applier's own name suffix), the tuple's elements as children.
+         *
+         * <p>The star is the applier's only child (see {@link #tuply()}), so
+         * nothing precedes it on the line — the head is the applier's bare
+         * base glued straight to the {@code *}.</p>
+         *
          * @param applier The object applying this tuple
-         * @param args The applier's inlined leading arguments, if any
          * @return The glued node, laid out vertically by the caller
          */
-        Pretty.Node glued(final Pretty.Node applier, final String args) {
-            final String head;
-            if (args.isEmpty()) {
-                head = applier.base;
-            } else {
-                head = String.join(" ", applier.base, args);
-            }
+        Pretty.Node glued(final Pretty.Node applier) {
             return new Pretty.Node(
-                String.join(" ", head, this.base), applier.tail,
+                String.join(" ", applier.base, this.base), applier.tail,
                 false, false, false, false, this.children
             );
         }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+origin: |
+  [] > main
+    sm.win32 > getenv
+      "getenv"
+      * name
+
+printed: |
+  [] > main
+    sm.win32 > getenv
+      "getenv"
+      * name


### PR DESCRIPTION
Fixes #5622.

## Problem

The printer's trailing-star hybrid (`Pretty.starred()`, gated by `Pretty.Node.tuply()`) rendered *any* application whose last child was a non-empty star as `head *` on one line with the tuple elements indented beneath. `tuply()` only checked that the last child was a star — never that it was the *only* child.

When a star followed other arguments on the line, e.g. `getenv.eo`:

```
sm.win32
  "getenv"
  * name
```

it was rewritten to `sm.win32 "getenv" *` with `name` indented below. That form is not valid EO: re-parsing reads the line as a complete application with an empty tuple and rejects the indented child (`unexpected deeper-indent line — previous expression is closed for children`). After error recovery the tuple element `name` is dropped and `*` becomes `Φ.tuple.empty` — so a second `format` pass silently deletes the argument. The format was therefore both **non-idempotent** and **lossy** (9 of 139 runtime sources diverged; `socket.eo` lost an entire `code.` subtree).

## Fix

The bare trailing `*` hybrid only round-trips for the genuine `seq *` idiom, where the star is the head's **sole** applied argument and absorbs exactly the indented siblings into the tuple. `tuply()` now requires `this.children.size() == 1`, so the hybrid fires only in that case. Multi-argument applications fall back to the ordinary vertical rendering, keeping the tuple as an inline `* name` child that round-trips cleanly.

`starred()` and `Pretty.Node.glued()` are simplified accordingly — with no leading arguments possible before the star, the argument-inlining path and `glued()`'s `args` parameter are removed.

## Verification

- Added print-pack `trailing-star-after-args.yaml` reproducing the `getenv` case; it now prints identically to its origin and re-prints to the same EO (idempotent, lossless).
- The `seq *` idiom regression is covered by the existing `seq-star-idiom.yaml` pack.
- `mvn -pl eo-printer test` — all 92 `XmirTest` cases pass (0 failures).
- `mvn -pl eo-printer verify` (qulice, checkstyle, PMD, spotbugs) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NbcGsUKEHV8tGfqGxm2GH

---
_Generated by [Claude Code](https://claude.ai/code/session_016NbcGsUKEHV8tGfqGxm2GH)_