### PR TITLE
Fix #5635: collapse inline-phi hybrid when the one-liner overflows the width

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -51,6 +51,11 @@ final class Pretty {
     private final String tab;
 
     /**
+     * The column past which a line overflows, the {@code WIDTH} weight.
+     */
+    private final int width;
+
+    /**
      * Ctor, using the default penalty weights.
      * @param element The {@code <eo>} element
      */
@@ -62,13 +67,16 @@ final class Pretty {
      * Ctor.
      * @param element The {@code <eo>} element
      * @param config The overridden weights; absent keys use their defaults
-     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (12 lines)
      */
     Pretty(final Xnav element, final Map<PenaltyKey, Integer> config) {
         this.root = element;
         this.weights = config;
         this.tab = " ".repeat(
             config.getOrDefault(PenaltyKey.STEP, PenaltyKey.STEP.fallback())
+        );
+        this.width = config.getOrDefault(
+            PenaltyKey.WIDTH, PenaltyKey.WIDTH.fallback()
         );
     }
 
@@ -245,7 +253,11 @@ final class Pretty {
      * ({@code head ++> name} or {@code head > [params] > name}) with the
      * arguments laid out beneath, mirroring the ordinary {@code head > name}
      * plus vertical-args layout and saving one line and one indent level
-     * over the verbose shape (issue #5594). Either way the result is only a
+     * over the verbose shape (issue #5594). The flat one-liner is kept while
+     * it fits the {@code WIDTH} limit, but once it overflows (or cannot be
+     * built) the hybrid is used instead, rather than gating the hybrid behind
+     * the one-liner's absence and falling back to the verbose shape when the
+     * one-liner overflows (issue #5635). Either way the result is only a
      * candidate — the penalty/width check in {@link #shaped} keeps it only
      * when it beats the plain vertical rendering. A formation decoratee
      * (its bindings are vertical, not arguments) and a receiver-only
@@ -283,24 +295,20 @@ final class Pretty {
                 middle = " > ".concat(node.base);
             }
             final String marker = middle.concat(node.tail);
-            final Optional<String> value = Pretty.flat(
+            final Optional<String> flat = Pretty.flat(
                 new Pretty.Node(
                     decoratee.base, "", decoratee.abstractt,
                     false, decoratee.reversed, decoratee.data, decoratee.children
                 )
+            ).map(
+                inlined -> this.tab.repeat(indent).concat(inlined).concat(marker)
             );
             final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
                 && !(decoratee.reversed && decoratee.children.size() <= 1);
             final boolean unnamed = decoratee.children.stream()
                 .allMatch(Pretty.Node::nameless);
-            if (value.isPresent()) {
-                result = Optional.of(
-                    new StringBuilder(this.tab.repeat(indent))
-                        .append(value.get())
-                        .append(marker)
-                        .toString()
-                );
-            } else if (applied && unnamed) {
+            if (applied && unnamed
+                && flat.map(line -> line.length() > this.width).orElse(true)) {
                 result = Optional.of(
                     this.vertical(
                         new Pretty.Node(
@@ -310,6 +318,8 @@ final class Pretty {
                         indent
                     )
                 );
+            } else {
+                result = flat;
             }
         }
         return result;

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The phi decoratee inlines fully, but the flat one-liner overflows the width
+# limit and loses to the vertical form. The hybrid collapse is still cheaper
+# than the verbose " > @" fallback, so it must be built even when the one-liner
+# is available (issue #5635).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+origin: |
+  +package org.eolang
+
+  [] > cosine
+
+    ++> tests-cosine-of-pi-thirds-is-half
+      lt. > @
+        abs
+          minus.
+            (cosine (pi.div 3)).times 1000
+            500
+        1
+
+printed: |
+  +package org.eolang
+
+  [] > cosine
+
+    lt. ++> tests-cosine-of-pi-thirds-is-half
+      abs (minus. (times. (cosine (pi.div 3)) 1000) 500)
+      1

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -38,8 +38,7 @@ printed: |
     ? >> list
     ? >> wanted
     reclast list > @
-    [tup] > reclast
-      if. > @
-        tup.length.eq 0
-        -1
-        if. (tup.head.eq wanted) tup.tail.length (reclast tup.tail)
+    if. > [tup] > reclast
+      tup.length.eq 0
+      -1
+      if. (tup.head.eq wanted) tup.tail.length (reclast tup.tail)


### PR DESCRIPTION
Closes #5635.

## Problem

In `Pretty.phi()` the fully-flat inline-φ one-liner and the hybrid collapse were mutually exclusive:

```java
if (value.isPresent()) { /* flat one-liner */ }
else if (applied && unnamed) { /* hybrid */ }
```

So when a φ decoratee inlined on one line (`value.isPresent()`) but that line overflowed the width limit and lost to the vertical form, the hybrid collapse was never generated, and the formation fell back to the verbose ` > @` shape.

This is the residual case #5594 left open (that fix only added the hybrid for the `value.isEmpty()` branch). It showed up in `number/cosine.eo`, where nine identically-shaped `tests-cosine-*` attributes rendered two different ways: `tests-cosine-is-even-function` collapsed (its decoratee is rejected by `flat()`), while `tests-cosine-of-pi-thirds-is-half` and siblings stayed verbose because their decoratee inlined fully but too wide.

## Fix

Stop gating the hybrid behind the one-liner's absence. The flat one-liner is now kept only while it fits the `WIDTH` limit; once it overflows (or cannot be built), the hybrid is produced and `shaped()` weighs it against the plain vertical rendering — so the overflowing one-liner is dropped in favour of the cheaper hybrid instead of the verbose fallback.

The one-liner is still preferred over the hybrid whenever it fits, even when the multi-line hybrid would score a lower penalty (bracket cost), preserving existing behaviour.

`WIDTH` is now cached as a `width` field (like the existing `tab`) so the overflow check stays a single expression and `phi()` keeps its complexity within limits.

## Tests

- New print-pack `inline-phi-overflow.yaml` reproduces the exact `cosine.eo` case: the decoratee inlines but the one-liner overflows, and it now collapses to the hybrid `lt. ++> …`.
- `void-local-handle.yaml` updated: its `reclast` formation now collapses to the valid hybrid `if. > [tup] > reclast` (same shape as the existing `hybrid-phi-formation.yaml`), while still exercising the `? >> name` void-handle behaviour it targets.

All 132 `eo-printer` tests pass, and qulice is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X51NGYQPMde7ucsSmgF3T

---
_Generated by [Claude Code](https://claude.ai/code/session_015X51NGYQPMde7ucsSmgF3T)_