### PR TITLE
#5484: reject bytes.and/or/xor on operands of different lengths

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -158,6 +158,12 @@
         -7.as-bytes.or 23.as-bytes
         0.as-bytes
 
+  --> on-and-with-different-lengths
+    20-1F.and CA-FE-BE > @
+
+  --> on-or-with-different-lengths
+    20-1F.or CA-FE-BE > @
+
   ++> tests-not-with-zero
     not. > @
       eq.

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -62,3 +62,6 @@
     eq. > @
       (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
       FF-FF-FF-FF-FF-FF-FF-FF
+
+  --> on-xor-with-different-lengths
+    20-1F.xor CA-FE-BE > @

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -79,8 +79,8 @@
   [port] > htons
     as-i16. > @
       or.
-        (bts.and FF-).left 8
-        (bts.right 8).and FF-
+        (bts.and 00-FF).left 8
+        (bts.right 8).and 00-FF
     port.as-i16.as-bytes > bts
 
   [recv] > as-input

--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -40,8 +40,8 @@ final class BytesRaw implements Bytes {
     @Override
     public Bytes and(final Bytes other) {
         final byte[] first = this.take();
-        final byte[] second = other.take();
-        for (int index = 0; index < Math.min(first.length, second.length); index += 1) {
+        final byte[] second = BytesRaw.ofSameLength(first, other, "and");
+        for (int index = 0; index < first.length; index += 1) {
             first[index] = (byte) (first[index] & second[index]);
         }
         return new BytesOf(first);
@@ -50,8 +50,8 @@ final class BytesRaw implements Bytes {
     @Override
     public Bytes or(final Bytes other) {
         final byte[] first = this.take();
-        final byte[] second = other.take();
-        for (int index = 0; index < Math.min(first.length, second.length); index += 1) {
+        final byte[] second = BytesRaw.ofSameLength(first, other, "or");
+        for (int index = 0; index < first.length; index += 1) {
             first[index] = (byte) (first[index] | second[index]);
         }
         return new BytesOf(first);
@@ -60,8 +60,8 @@ final class BytesRaw implements Bytes {
     @Override
     public Bytes xor(final Bytes other) {
         final byte[] first = this.take();
-        final byte[] second = other.take();
-        for (int index = 0; index < Math.min(first.length, second.length); index += 1) {
+        final byte[] second = BytesRaw.ofSameLength(first, other, "xor");
+        for (int index = 0; index < first.length; index += 1) {
             first[index] = (byte) (first[index] ^ second[index]);
         }
         return new BytesOf(first);
@@ -176,6 +176,26 @@ final class BytesRaw implements Bytes {
     @Override
     public int hashCode() {
         return Arrays.hashCode(this.data);
+    }
+
+    /**
+     * Take the bytes of the other operand, checking they are of the same length.
+     * @param first The bytes of the receiver
+     * @param other The other operand
+     * @param operation The name of the operation, for the error message
+     * @return The bytes of the other operand
+     */
+    private static byte[] ofSameLength(
+        final byte[] first, final Bytes other, final String operation
+    ) {
+        final byte[] second = other.take();
+        if (first.length != second.length) {
+            throw new ExFailure(
+                "bytes.%s requires operands of the same length, got %d and %d",
+                operation, first.length, second.length
+            );
+        }
+        return second;
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -163,4 +163,37 @@ final class BytesOfTest {
             "sshift with negative bits should fail with ExFailure, but it didn't"
         );
     }
+
+    @Test
+    void doesNotSupportAndOfDifferentLength() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new BytesOf(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}).and(
+                new BytesOf(new byte[]{(byte) 0x0F})
+            ),
+            "'and' of operands with different lengths should fail with ExFailure, but it didn't"
+        );
+    }
+
+    @Test
+    void doesNotSupportOrOfDifferentLength() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new BytesOf(new byte[]{(byte) 0x01, (byte) 0x02}).or(
+                new BytesOf(new byte[]{(byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06})
+            ),
+            "'or' of operands with different lengths should fail with ExFailure, but it didn't"
+        );
+    }
+
+    @Test
+    void doesNotSupportXorOfDifferentLength() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new BytesOf(new byte[]{(byte) 0x01, (byte) 0x02}).xor(
+                new BytesOf(new byte[]{(byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06})
+            ),
+            "'xor' of operands with different lengths should fail with ExFailure, but it didn't"
+        );
+    }
 }


### PR DESCRIPTION
Closes #5484.

`BytesRaw.and`, `BytesRaw.or`, and `BytesRaw.xor` used to iterate only up to `Math.min(first.length, second.length)` and always return a result of `first.length`, silently producing wrong results when the two operands differ in length (trailing bytes of the longer operand were left untouched for `and`, and trailing bytes of the longer operand were dropped for `or`/`xor`).

This came up in #464 back in 2021, where `@yegor256` said "if two arrays are of different lengths, we must throw an exception", but that direction was never implemented and the issue was closed as stale.

This PR implements that direction: `and`, `or`, `xor` now throw `ExFailure` when the operand lengths differ, instead of silently dropping or ignoring bytes. The three methods share the length check through a new private `ofSameLength` helper, to avoid repeating the same check three times.

Added three tests in `BytesOfTest` (one per operation) that verify the exception is thrown for mismatched lengths, following the same pattern already used for `doesNotSupportNegativeBits`.

One real call site did rely on the old silent behavior: `socket.eo`'s `htons` computed `bts.and FF-`, where `bts` is 2 bytes (`i16.as-bytes`) and `FF-` is a 1-byte literal. Under the old code this happened to be a harmless no-op (AND-ing a byte with `0xFF` changes nothing, and the untouched second byte also stayed correct by coincidence), but it is now a length mismatch that throws. Fixed by using the length-matched 2-byte literal `00-FF` instead of `FF-` in both places in `htons`, which is also the semantically correct mask for isolating one byte of a 2-byte value. Verified locally: `EOsocketTest` fails deterministically (all 3 top-level tests, both single-threaded and under the repo's default concurrent JUnit5 execution) without this fix, and passes cleanly with it, matching a clean run against `upstream/master`.

All existing `bytes.eo` and other consumer tests (`i64.eo`, `i16.eo`, `i32.eo`, `number.eo`, `string.eo`, `file.eo`) pass unchanged, since every other call site already uses operands of equal length. Full local `eo-runtime` test suite (surefire) is clean.
