### PR TITLE
#5629: fail with ExFailure on scanf format ending in dangling %

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -55,6 +55,9 @@
   --> on-scanf-with-oversized-int
     scanf "%d" "99999999999999999999" > @
 
+  --> on-scanf-with-dangling-percent
+    scanf "hello%" "hello" > @
+
   ++> tests-scanf-with-string-int-float
     eq. > @
       scanf

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOscanf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOscanf.java
@@ -99,6 +99,12 @@ public final class EOscanf extends PhDefault implements Atom {
                 }
             }
         }
+        if (literal) {
+            throw new ExFailure(
+                "The format string '%s' ends with a dangling '%%' and no specifier after it",
+                format
+            );
+        }
         final Matcher matcher = Pattern.compile(regex.toString()).matcher(
             new Dataized(this.take("read")).asString()
         );

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.ExFailure;
+import org.eolang.PhApplication;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link EOscanf}.
+ * @since 0.40
+ */
+final class EOscanfTest {
+
+    @Test
+    void failsWithClearMessageOnDanglingPercent() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new Dataized(EOscanfTest.scanned("hello%", "hello")).take(),
+            "scanf with a dangling '%' at the end of the format should fail with ExFailure, but it didn't"
+        );
+    }
+
+    /**
+     * Build a {@code string.scanf} call.
+     * @param format Format string for {@code scanf}
+     * @param read Input string for {@code scanf}
+     * @return The resulting tuple
+     */
+    private static Phi scanned(final String format, final String read) {
+        return new PhApplication(
+            new PhApplication(
+                Phi.Φ.take("string.scanf").copy(),
+                "format", new Data.ToPhi(format)
+            ),
+            "read", new Data.ToPhi(read)
+        );
+    }
+}


### PR DESCRIPTION
Closes #5629.

`EOscanf.lambda()` builds the match regex in a first loop, where a trailing lone `%` sets `literal = true` and appends nothing, without raising any error for the dangling, never-completed specifier. The extraction loop then locates that `%` via `frmt.indexOf('%')` and reads the following char with `frmt.charAt(idx + 1)`. When the `%` is the last character of the format, `idx + 1 == frmt.length()`, and a raw `java.lang.StringIndexOutOfBoundsException` escapes instead of a proper `ExFailure`.

This adds a check right after the first loop: if `literal` is still `true` once the loop ends, the format string has a dangling `%` with no specifier after it, so it now fails fast with a clear `ExFailure`, matching the existing pattern used for an unsupported specifier (the `default:` branch a few lines above).

Added `EOscanfTest` (a Java unit test asserting `ExFailure` is thrown for `scanf "hello%" "hello"`) and a `--> on-scanf-with-dangling-percent` EO-level example in `scanf.eo`, next to the two existing `on-scanf-with-*` negative examples for this object.

Verified locally: the new tests pass, `EOstringTest` (51 tests) and the generated `EOscanfEOAtomTest` (15 tests, including the new example) pass, and qulice is clean.
