### PR TITLE
#5611: rename hyphenated names in sm/posix.eo (2/5)

### DIFF
--- a/eo-runtime/src/main/eo/sm/posix.eo
+++ b/eo-runtime/src/main/eo/sm/posix.eo
@@ -15,47 +15,47 @@
 
 [name args] > posix
   [] > @ /return
-  2 > af-inet
-  -1 > inaddr-none
-  6 > ipproto-tcp
-  0 > o-rdonly
-  1 > o-wronly
-  2 > o-rdwr
-  if. > o-creat
+  2 > afinet
+  -1 > inaddrnone
+  6 > ipprototcp
+  0 > ordonly
+  1 > owronly
+  2 > ordwr
+  if. > ocreat
     os.is-macos
     512
     64
-  if. > o-trunc
+  if. > otrunc
     os.is-macos
     1024
     512
-  if. > o-append
+  if. > oappend
     os.is-macos
     8
     1024
-  420 > create-mode
-  511 > mkdir-mode
-  1 > sock-stream
-  0 > stdin-fileno
-  1 > stdout-fileno
-  2 > stderr-fileno
+  420 > createmode
+  511 > mkdirmode
+  1 > sockstream
+  0 > stdinfileno
+  1 > stdoutfileno
+  2 > stderrfileno
   [code output] > return
     output > @
     return code output > called
 
-  [tv-sec tv-usec] > timeval
+  [tvsec tvusec] > timeval
 
-  [st-mode st-size] > stat
+  [stmode stsize] > stat
 
-  [sin-family sin-port sin-addr] > sockaddr-in
-    00-00-00-00-00-00-00-00 > sin-zero
+  [sinfamily sinport sinaddr] > sockaddr-in
+    00-00-00-00-00-00-00-00 > sinzero
     plus. > size
       plus.
         plus.
-          sin-family.size
-          sin-port.size
-        sin-addr.size
-      sin-zero.size
+          sinfamily.size
+          sinport.size
+        sinaddr.size
+      sinzero.size
 
   ++> tests-invokes-getpid-correctly
     or. > @
@@ -95,7 +95,7 @@
     code. > sd
       posix
         "socket"
-        * posix.af-inet posix.sock-stream posix.ipproto-tcp
+        * posix.afinet posix.sockstream posix.ipprototcp
 
   ++> tests-closes-posix-tcp-socket
     or. > @
@@ -113,7 +113,7 @@
     code. > sd
       posix
         "socket"
-        * posix.af-inet posix.sock-stream posix.ipproto-tcp
+        * posix.afinet posix.sockstream posix.ipprototcp
 
   ++> tests-returns-valid-posix-inet-addr-for-localhost
     or. > @

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/AcceptSyscall.java
@@ -44,10 +44,10 @@ public final class AcceptSyscall implements Syscall {
                 CStdLib.INSTANCE.accept(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new IntByReference(new Dataized(params[2]).asNumber().intValue())
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/BindSyscall.java
@@ -43,10 +43,10 @@ public final class BindSyscall implements Syscall {
                 CStdLib.INSTANCE.bind(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new Dataized(params[2]).asNumber().intValue()
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Posix/ConnectSyscall.java
@@ -43,10 +43,10 @@ public final class ConnectSyscall implements Syscall {
                 CStdLib.INSTANCE.connect(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new Dataized(params[2]).asNumber().intValue()
                 )


### PR DESCRIPTION
Part of #5611 (2 of 5, independent, no merge-order dependency).

The original single PR for #5611 was too large (469 lines changed against a 200-line CI limit) and got split into 5 smaller PRs by file group, each independently buildable and testable.

This one renames every hyphenated non-formation attribute name in `sm/posix.eo` flagged by the `compound-name` lint, most of which mirror POSIX struct field names (`sin_family`, `sin_port`, `tv_sec`, `st_mode`, and so on): `sin-family` to `sinfamily`, `sin-port` to `sinport`, `sin-addr` to `sinaddr`, `sin-zero` to `sinzero`, `af-inet` to `afinet`, `o-rdonly`/`o-wronly`/`o-rdwr`/`o-creat`/`o-trunc`/`o-append` to `ordonly`/`owronly`/`ordwr`/`ocreat`/`otrunc`/`oappend`, and the rest of the constants in that file, using the same pattern.

Three Java atoms (`AcceptSyscall`, `BindSyscall`, `ConnectSyscall`) read the `sockaddr-in` formation's `sin-*` attributes off the `Phi` object by hardcoded string literal (`params[1].take("sin-family")`, etc.). Missed in an earlier pass, this broke `EOsocketTest` with `the object is a terminated computation and cannot be used`, since the Java side asked for an attribute name that no longer existed on the EO side. Included here, paired with their matching `.eo` rename, since the two can't be split across separate PRs without leaving `master` broken between merges.

Verified locally: `eo-runtime` builds cleanly with this change.
