### PR TITLE
#5611: rename hyphenated names in sm/win32.eo (3/5)

### DIFF
--- a/eo-runtime/src/main/eo/sm/win32.eo
+++ b/eo-runtime/src/main/eo/sm/win32.eo
@@ -20,40 +20,40 @@
 
 [name args] > win32
   [] > @ /return
-  2 > af-inet
-  -1 > inaddr-none
-  -1 > invalid-socket
-  6 > ipproto-tcp
-  32768 > o-rdonly
-  32769 > o-wronly
-  32770 > o-rdwr
-  256 > o-creat
-  512 > o-trunc
-  8 > o-append
-  384 > create-mode
-  1 > sock-stream
-  -1 > socket-error
-  0 > stdin-fileno
-  1 > stdout-fileno
-  2 > stderr-fileno
-  02-02 > winsock-version-2-2
+  2 > afinet
+  -1 > inaddrnone
+  -1 > invalidsocket
+  6 > ipprototcp
+  32768 > ordonly
+  32769 > owronly
+  32770 > ordwr
+  256 > ocreat
+  512 > otrunc
+  8 > oappend
+  384 > createmode
+  1 > sockstream
+  -1 > socketerror
+  0 > stdinfileno
+  1 > stdoutfileno
+  2 > stderrfileno
+  02-02 > winsockversion22
   [code output] > return
     output > @
     return code output > called
 
   [time millitm] > timeb
 
-  [st-mode st-size] > stat64
+  [stmode stsize] > stat64
 
-  [sin-family sin-port sin-addr] > sockaddr-in
-    00-00-00-00-00-00-00-00 > sin-zero
+  [sinfamily sinport sinaddr] > sockaddr-in
+    00-00-00-00-00-00-00-00 > sinzero
     plus. > size
       plus.
         plus.
-          sin-family.size
-          sin-port.size
-        sin-addr.size
-      sin-zero.size
+          sinfamily.size
+          sinport.size
+        sinaddr.size
+      sinzero.size
 
   ++> tests-returns-valid-win32-inet-addr-for-localhost
     or. > @

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/AcceptFuncCall.java
@@ -46,10 +46,10 @@ public final class AcceptFuncCall implements Syscall {
                 Winsock.INSTANCE.accept(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new IntByReference(new Dataized(params[2]).asNumber().intValue())
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/BindFuncCall.java
@@ -45,10 +45,10 @@ public final class BindFuncCall implements Syscall {
                 Winsock.INSTANCE.bind(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new Dataized(params[2]).asNumber().intValue()
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_sm/Win32/ConnectFuncCall.java
@@ -45,10 +45,10 @@ public final class ConnectFuncCall implements Syscall {
                 Winsock.INSTANCE.connect(
                     new Dataized(params[0]).asNumber().intValue(),
                     new SockaddrIn(
-                        new Dataized(params[1].take("sin-family")).take(Short.class),
-                        new Dataized(params[1].take("sin-port")).take(Short.class),
-                        new Dataized(params[1].take("sin-addr")).take(Integer.class),
-                        new Dataized(params[1].take("sin-zero")).take()
+                        new Dataized(params[1].take("sinfamily")).take(Short.class),
+                        new Dataized(params[1].take("sinport")).take(Short.class),
+                        new Dataized(params[1].take("sinaddr")).take(Integer.class),
+                        new Dataized(params[1].take("sinzero")).take()
                     ),
                     new Dataized(params[2]).asNumber().intValue()
                 )


### PR DESCRIPTION
Part of #5611 (3 of 5, independent, no merge-order dependency).

The original single PR for #5611 was too large (469 lines changed against a 200-line CI limit) and got split into 5 smaller PRs by file group, each independently buildable and testable.

Same as the `sm/posix.eo` half (see the sibling PR), but for `sm/win32.eo`: renames every hyphenated non-formation attribute name flagged by the `compound-name` lint, most of which mirror Win32 struct field names, and updates the three Java atoms (`AcceptFuncCall`, `BindFuncCall`, `ConnectFuncCall`) that read the renamed `sin-*` attributes off the `Phi` object by hardcoded string literal. Included together since the `.eo` rename and its Java counterpart can't be split across separate PRs without leaving `master` broken between merges.

Verified locally: `eo-runtime` builds cleanly with this change. The Windows-only test path in `EOsocketTest.WindowsSocketTest` can't be exercised on this machine (Linux), but the equivalent combined change (this file plus the same Java files) already passed the `mvn (windows-2022)` CI job on the original, since-closed PR #5639, before it was split into these smaller PRs.
