### PR TITLE
#5611: rename hyphenated names in numeric/bytes/file types (4/5)

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -28,7 +28,7 @@
   [] > size /number
 
   [start len] > slice /bytes
-    ? > cant-slice /{string}
+    ? > cantslice /{string}
 
   [b] > and /bytes
 

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -1,5 +1,5 @@
 # Bytes as a signed 16-bit integer `i16`: a 2-byte chain reinterpreted
-# as two's complement. For any other length the `cant-convert` fallback
+# as two's complement. For any other length the `cantconvert` fallback
 # is returned.
 
 +architect yegor256@gmail.com
@@ -9,11 +9,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts cant-convert] > as-i16
+[bts cantconvert] > as-i16
   if. > @
     bts.size.eq 2
     i16 bts
-    cant-convert
+    cantconvert
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -1,5 +1,5 @@
 # Bytes as a signed 32-bit integer `i32`: a 4-byte chain reinterpreted
-# as two's complement. For any other length the `cant-convert` fallback
+# as two's complement. For any other length the `cantconvert` fallback
 # is returned.
 
 +architect yegor256@gmail.com
@@ -9,11 +9,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts cant-convert] > as-i32
+[bts cantconvert] > as-i32
   if. > @
     bts.size.eq 4
     i32 bts
-    cant-convert
+    cantconvert
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -1,5 +1,5 @@
 # Bytes as a signed 64-bit integer `i64`: an 8-byte chain reinterpreted
-# as two's complement. For any other length the `cant-convert` fallback
+# as two's complement. For any other length the `cantconvert` fallback
 # is returned.
 
 +architect yegor256@gmail.com
@@ -9,11 +9,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts cant-convert] > as-i64
+[bts cantconvert] > as-i64
   if. > @
     bts.size.eq 8
     i64 bts
-    cant-convert
+    cantconvert
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * bts
 

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -1,6 +1,6 @@
 # Bytes as a floating-point `number`: an 8-byte chain reinterpreted as an
 # IEEE 754 double, mapping the special chains to `nan`, `pinf`, and `ninf`.
-# For any other length the `cant-convert` fallback is returned.
+# For any other length the `cantconvert` fallback is returned.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts cant-convert] > as-number
+[bts cantconvert] > as-number
   if. > @
     bts.eq nan.as-bytes
     nan
@@ -22,7 +22,7 @@
         if.
           bts.size.eq 8
           number bts
-          cant-convert
+          cantconvert
             "Can't convert non 8 length bytes to a number, bytes are %x".printf
               * bts
 

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -19,9 +19,9 @@
         timeb.time.times 1000
         timeb.millitm
       plus.
-        timeval.tv-sec.times 1000
+        timeval.tvsec.times 1000
         as-number.
-          timeval.tv-usec.as-i64.div 1000.as-i64
+          timeval.tvusec.as-i64.div 1000.as-i64
   (win32 "_ftime32_s" *).output > timeb
   (posix "gettimeofday" *).output > timeval
 

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -85,7 +85,7 @@
           output. > chunk!
             posix
               "read"
-              * posix.stdin-fileno size
+              * posix.stdinfileno size
 
     [buffer] > write
       (output-block.write buffer).@ > @
@@ -98,7 +98,7 @@
             code.
               posix
                 "write"
-                * posix.stdout-fileno buffer buffer.size
+                * posix.stdoutfileno buffer buffer.size
             output-block
 
   [] > windows-console
@@ -115,7 +115,7 @@
           output. > chunk!
             win32
               "_read"
-              * win32.stdin-fileno size
+              * win32.stdinfileno size
 
     [buffer] > write
       (output-block.write buffer).@ > @
@@ -128,7 +128,7 @@
             code.
               win32
                 "_write"
-                * win32.stdout-fileno buffer buffer.size
+                * win32.stdoutfileno buffer buffer.size
             output-block
 
   ++> tests-writes-to-console

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -33,7 +33,7 @@
       if.
         os.is-windows
         win32 "_mkdir" (* ^.path)
-        posix "mkdir" (* ^.path posix.mkdir-mode)
+        posix "mkdir" (* ^.path posix.mkdirmode)
     created.code > outcome
 
   [glob] > walk /tuple

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -16,11 +16,11 @@
   path > @
   (Q.path path).@ > as-path
 
-  [cant-check] > is-directory
+  [cantcheck] > is-directory
     if. > @
       info.code.eq 0
-      (info.output.st-mode.div 4096).floor.eq 4
-      cant-check
+      (info.output.stmode.div 4096).floor.eq 4
+      cantcheck
     called. > info
       if.
         os.is-windows
@@ -51,8 +51,8 @@
     called. > created
       if.
         os.is-windows
-        win32 "_creat" (* path win32.create-mode)
-        posix "creat" (* path posix.create-mode)
+        win32 "_creat" (* path win32.createmode)
+        posix "creat" (* path posix.createmode)
     created.code > descriptor
     code. > closed
       if.
@@ -73,23 +73,23 @@
     called. > removed
       if.
         os.is-windows
-        win32 windows-name (* path)
-        posix posix-name (* path)
+        win32 windowsname (* path)
+        posix posixname (* path)
     removed.code > outcome
-    if. > windows-name
+    if. > windowsname
       is-directory
       "_rmdir"
       "_unlink"
-    if. > posix-name
+    if. > posixname
       is-directory
       "rmdir"
       "unlink"
 
-  [cant-measure] > size
+  [cantmeasure] > size
     if. > @
       info.code.eq 0
-      info.output.st-size
-      cant-measure
+      info.output.stsize
+      cantmeasure
     called. > info
       if.
         os.is-windows
@@ -110,13 +110,13 @@
         posix "rename" (* path target)
     renamed.code > outcome
 
-  [mode scope cant-open] > open
+  [mode scope cantopen] > open
     if. > @
       known.not
       T "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
         existing.and exists.not
-        cant-open
+        cantopen
           "File must exist for given access mod: '%s'".printf
             * access
         seq *
@@ -163,7 +163,7 @@
       [syscall] > open-through
         if. > @
           descriptor.eq -1
-          cant-open
+          cantopen
             "Couldn't open file '%s': %s".printf
               * path opened.output
           seq *
@@ -173,33 +173,33 @@
               syscall.close (* descriptor)
             true
         called. > opened
-          syscall.open (* path flags syscall.create-mode)
+          syscall.open (* path flags syscall.createmode)
         opened.code > descriptor
         plus. > flags
           plus.
             plus.
               direction
-              create-bit
-            truncate-bit
-          append-bit
+              createbit
+            truncatebit
+          appendbit
         if. > direction
           readable.and writable
-          syscall.o-rdwr
+          syscall.ordwr
           if.
             writable
-            syscall.o-wronly
-            syscall.o-rdonly
-        if. > create-bit
+            syscall.owronly
+            syscall.ordonly
+        if. > createbit
           existing.not
-          syscall.o-creat
+          syscall.ocreat
           0
-        if. > truncate-bit
+        if. > truncatebit
           truncate
-          syscall.o-trunc
+          syscall.otrunc
           0
-        if. > append-bit
+        if. > appendbit
           appending
-          syscall.o-append
+          syscall.oappend
           0
 
         [descriptor] > stream

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -49,10 +49,10 @@
 
   plus x.as-i16.neg > [x] > minus
 
-  [x cant-divide] > div
+  [x cantdivide] > div
     if. > @
       xval.eq zero
-      cant-divide
+      cantdivide
         "Can't divide %d by i16 zero".printf
           * as-i32.as-i64.as-number
       if.

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -21,11 +21,11 @@
       00-00-00-00
       FF-FF-FF-FF
 
-  [cant-convert] > as-i16
+  [cantconvert] > as-i16
     if. > @
       ^.eq left.as-i32
       left
-      cant-convert
+      cantconvert
         "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
           * as-i64.as-number
     i16 (as-bytes.slice 2 2) > left
@@ -57,10 +57,10 @@
 
   plus x.as-i32.neg > [x] > minus
 
-  [x cant-divide] > div
+  [x cantdivide] > div
     if. > @
       xval.eq zero
-      cant-divide
+      cantdivide
         "Can't divide %d by i32 zero".printf
           * as-i64.as-number
       if.

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -16,11 +16,11 @@
   as-i32.as-i16 > as-i16
   times -1.as-i64 > neg
 
-  [cant-convert] > as-i32
+  [cantconvert] > as-i32
     if. > @
       ^.eq left.as-i64
       left
-      cant-convert
+      cantconvert
         "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
           * as-number
     i32 (as-bytes.slice 4 4) > left
@@ -40,21 +40,21 @@
 
   [x] > gt
     if. > @
-      signs-differ
-      self-sign-clear
+      signsdiffer
+      selfsignclear
       and.
-        difference-sign-clear
+        differencesignclear
         (difference.as-bytes.eq zero).not
     ^.minus x > difference
     00-00-00-00-00-00-00-00 > zero
-    80-00-00-00-00-00-00-00 > sign-mask
-    ^.as-bytes.and sign-mask > self-sign
-    not. > signs-differ
+    80-00-00-00-00-00-00-00 > signmask
+    ^.as-bytes.and signmask > selfsign
+    not. > signsdiffer
       eq.
-        self-sign
-        x.as-bytes.and sign-mask
-    self-sign.eq zero > self-sign-clear
-    (difference.as-bytes.and sign-mask).eq zero > difference-sign-clear
+        selfsign
+        x.as-bytes.and signmask
+    selfsign.eq zero > selfsignclear
+    (difference.as-bytes.and signmask).eq zero > differencesignclear
 
   [x] > gte
     or. > @
@@ -83,7 +83,7 @@
     x > value!
 
   [x] > div /i64
-    ? > cant-divide /{string}
+    ? > cantdivide /{string}
 
   ++> tests-i64-has-valid-bytes
     eq. > @

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -93,7 +93,7 @@
           read source length
 
       [offset length] > read /bytes
-        ? > cant-read /{string}
+        ? > cantread /{string}
 
       [offset data] > write /bool
 

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -64,14 +64,14 @@
               tup.head.hash.eq hash
               [] >>
                 true > exists
-                [cant-get] > get
+                [cantget] > get
                   tup.head.value > @
               not-found
         (rec-key-search tup.tail).@ > prev
       [] > not-found
         false > exists
-        [cant-get] > get
-          cant-get > @
+        [cantget] > get
+          cantget > @
             "Object by hash code %d from given key does not exists".printf
               * hash
 

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -16,10 +16,10 @@
   as-i32.as-i16 > as-i16
   as-i64.as-i32 > as-i32
 
-  [cant-convert] > as-i64
+  [cantconvert] > as-i64
     if. > @
-      out-of-range
-      cant-convert
+      outofrange
+      cantconvert
         "Can't convert number %f to i64 because it's out of i64 bounds".printf
           * ^
       if.
@@ -37,7 +37,7 @@
     (as-bytes.and 80-00-00-00-00-00-00-00).eq 80-00-00-00-00-00-00-00 > negative
     ((as-bytes.and 7F-F0-00-00-00-00-00-00).right 52).as-i64.as-number > exp
     (as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF).or 00-10-00-00-00-00-00-00 > mantissa
-    or. > out-of-range
+    or. > outofrange
       exp.eq 2047
       or.
         exp.gt 1086

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -1,6 +1,6 @@
 # Calculate MOD.
 # An operation that finds the remainder after dividing `x` by `y`. When `y`
-# is zero, the result is the caller-supplied `cant-mod` fallback, or the
+# is zero, the result is the caller-supplied `cantmod` fallback, or the
 # bottom object when none was provided, which terminates on use.
 
 +architect yegor256@gmail.com
@@ -10,10 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x y cant-mod] > mod
+[x y cantmod] > mod
   if. > @
     divisor.eq 0
-    cant-mod "cannot calculate mod by zero"
+    cantmod "cannot calculate mod by zero"
     if.
       dividend.gt 0
       abs-mod

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -50,11 +50,11 @@
               if.
                 expo.gt 0
                 if.
-                  odd-power
+                  oddpower
                   ninf
                   pinf
                 if.
-                  odd-power
+                  oddpower
                   0.neg
                   0
           if.
@@ -75,7 +75,7 @@
                 pinf
   number num.as-bytes > base
   number x.as-bytes > expo
-  and. > odd-power
+  and. > oddpower
     expo.is-integer
     (expo.div 2).is-integer.not
 

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -42,7 +42,7 @@
             code.
               posix
                 "write"
-                * posix.stderr-fileno buffer buffer.size
+                * posix.stderrfileno buffer buffer.size
             output-block
 
   [] > windows-output
@@ -57,7 +57,7 @@
             code.
               win32
                 "_write"
-                * win32.stderr-fileno buffer buffer.size
+                * win32.stderrfileno buffer buffer.size
             output-block
 
   ++> tests-prints-to-stderr

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -28,7 +28,7 @@
   compile > @
 
   [] > compile /Q.string.regex.pattern
-    ? > cant-compile /{string}
+    ? > cantcompile /{string}
 
   [serialized] > pattern
     pattern serialized > compiled

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -24,10 +24,10 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-[cases empty-cases] > switch
+[cases emptycases] > switch
   if. > @
     cases.length.eq 0
-    empty-cases "Switch cases are empty"
+    emptycases "Switch cases are empty"
     if.
       true.eq found.match
       found.head

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -15,12 +15,12 @@
     T "Can't get head from the empty tuple"
     0
 
-  [i out-of-bounds] > at
+  [i outofbounds] > at
     if. > @
       or.
         0.gt index
         length.lte index
-      out-of-bounds "Given index is out of tuple bounds"
+      outofbounds "Given index is out of tuple bounds"
       at-fast ^
     i > idx!
     if. > index!

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -1,5 +1,5 @@
 # Maximum `number` in `sequence`, which must be a `tuple` or any `tuple`
-# decorator of `number` objects. An empty sequence has no maximum, so `cant-max`
+# decorator of `number` objects. An empty sequence has no maximum, so `cantmax`
 # is dataized with an explanatory message and stands in as the result.
 
 +architect yegor256@gmail.com
@@ -9,10 +9,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-max] > maximum
+[sequence cantmax] > maximum
   if. > @
     is-empty lst
-    cant-max "cannot get the maximum number from an empty sequence"
+    cantmax "cannot get the maximum number from an empty sequence"
     reduced
       lst
       ninf

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -1,5 +1,5 @@
 # Minimum `number` in `sequence`, which must be a `tuple` or any `tuple`
-# decorator of `number` objects. An empty sequence has no minimum, so `cant-min`
+# decorator of `number` objects. An empty sequence has no minimum, so `cantmin`
 # is dataized with an explanatory message and stands in as the result.
 
 +architect yegor256@gmail.com
@@ -9,10 +9,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-min] > minimum
+[sequence cantmin] > minimum
   if. > @
     is-empty lst
-    cant-min "cannot get the minimum number from an empty sequence"
+    cantmin "cannot get the minimum number from an empty sequence"
     reduced
       lst
       pinf

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOcompile.java
@@ -37,7 +37,7 @@ public final class EOregex$EOcompile extends PhDefault implements Atom {
     /**
      * Name of the error-branch void that holds the caller's compile fallback.
      */
-    private static final String FALLBACK = "cant-compile";
+    private static final String FALLBACK = "cantcompile";
 
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
@@ -23,7 +23,7 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
     /**
      * Name of the error-branch void that holds the caller's slice fallback.
      */
-    private static final String FALLBACK = "cant-slice";
+    private static final String FALLBACK = "cantslice";
 
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOi64$EOdiv.java
@@ -21,7 +21,7 @@ public final class EOi64$EOdiv extends PhDefault implements Atom {
     /**
      * Name of the error-branch void that holds the caller's divide-by-zero fallback.
      */
-    private static final String FALLBACK = "cant-divide";
+    private static final String FALLBACK = "cantdivide";
 
     /**
      * Ctor.

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof$EOallocated$EOread.java
@@ -21,7 +21,7 @@ public final class EOmalloc$EOof$EOallocated$EOread extends PhDefault implements
     /**
      * Name of the error-branch void that holds the caller's read fallback.
      */
-    private static final String FALLBACK = "cant-read";
+    private static final String FALLBACK = "cantread";
 
     /**
      * Ctor.


### PR DESCRIPTION
Part of #5611 (4 of 5, independent, no merge-order dependency).

The original single PR for #5611 was too large (469 lines changed against a 200-line CI limit) and got split into 5 smaller PRs by file group, each independently buildable and testable.

This one renames every hyphenated non-formation attribute name flagged by the `compound-name` lint in the numeric, bytes, and file/console/clock groups: `file.eo`, `console.eo`, `stderr.eo`, `clock.eo`, `directory.eo`, `i64.eo`, `i32.eo`, `i16.eo`, `number.eo`, `map.eo`, `bytes.eo`, `bytes/as-i16.eo`, `bytes/as-i32.eo`, `bytes/as-i64.eo`, `bytes/as-number.eo`, `malloc.eo`, `tuple.eo`, `switch.eo`, `tuple/maximum.eo`, `tuple/minimum.eo`, `number/mod.eo`, `number/power.eo`, `string/regex.eo`.

Four Java atoms (`EOi64$EOdiv`, `EObytes$EOslice`, `EOregex$EOcompile`, `EOmalloc$EOof$EOallocated$EOread`) each hold a `FALLBACK` string constant matching the renamed attribute name (`cant-divide`, `cant-slice`, `cant-compile`, `cant-read`), used to `.take(FALLBACK)` the corresponding void attribute. Included here, paired with their matching `.eo` files, since the two can't be split across separate PRs without leaving `master` broken between merges.

Verified locally: `eo-runtime` builds cleanly and its full test suite passes with this change.
