### PR TITLE
#5647: extract Pretty.Node into a package-private top-level class

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.printer;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A node of the intermediate line tree consumed by {@link Pretty}.
+ *
+ * <p>It mirrors one {@code <line>} element of the tree produced by
+ * {@code to-eo-tree.xsl}: the rendered head of an object, its optional
+ * name suffix, a few flags telling {@link Pretty} how to lay it out
+ * (formation, test attribute, reversed dispatch, data literal) and the
+ * children (arguments or bindings). The dependency runs one way only,
+ * {@link Pretty} reads a {@code Node}; a {@code Node} never refers back to
+ * {@link Pretty}. Its fields and the constructor are package-private so
+ * {@link Pretty} and its static helpers keep their direct field access,
+ * the same exposure a nested class would grant.</p>
+ *
+ * @since 0.57.0
+ */
+final class Node {
+
+    /**
+     * The rendered head of the object (base, method, formation
+     * params, data literal or {@code *}).
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final String base;
+
+    /**
+     * The rendered suffix ({@code > name}, {@code >>}, {@code !},
+     * {@code /atom} or {@code :label}), possibly empty.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final String tail;
+
+    /**
+     * Whether this object is a formation (its children are
+     * bindings, so it is laid out vertically, unless its only
+     * binding is the {@code φ} decoratee and the compact inline-phi
+     * form fits on one line).
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final boolean abstractt;
+
+    /**
+     * Whether this object is a test attribute ({@code +> name}),
+     * which R-6.5.3 requires to be preceded by a blank line.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final boolean test;
+
+    /**
+     * Whether this object is a reversed dispatch ({@code method.});
+     * a receiver-only one cannot be inlined as an argument.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final boolean reversed;
+
+    /**
+     * Whether this object is a data literal (number, string, bytes),
+     * so it may sit as a receiver in the suffix form of a reversed
+     * dispatch ({@code 5.plus} instead of {@code plus. 5}).
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final boolean data;
+
+    /**
+     * The children (arguments or bindings), in order.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    final List<Node> children;
+
+    /**
+     * Ctor.
+     * @param head The rendered head
+     * @param suffix The rendered suffix
+     * @param formation Whether it is a formation
+     * @param attr Whether it is a test attribute
+     * @param rev Whether it is a reversed dispatch
+     * @param literal Whether it is a data literal
+     * @param kids The children
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    Node(final String head, final String suffix, final boolean formation,
+        final boolean attr, final boolean rev, final boolean literal,
+        final List<Node> kids) {
+        this.base = head;
+        this.tail = suffix;
+        this.abstractt = formation;
+        this.test = attr;
+        this.reversed = rev;
+        this.data = literal;
+        this.children = kids;
+    }
+
+    /**
+     * Build a node from a {@code <line>} element.
+     * @param line The {@code <line>} element
+     * @return The node
+     */
+    static Node parse(final Xnav line) {
+        return new Node(
+            line.attribute("base").text().orElse(""),
+            line.attribute("tail").text().orElse(""),
+            "yes".equals(line.attribute("abstract").text().orElse("no")),
+            "yes".equals(line.attribute("test").text().orElse("no")),
+            "yes".equals(line.attribute("reversed").text().orElse("no")),
+            "yes".equals(line.attribute("data").text().orElse("no")),
+            line.elements(Filter.withName("line"))
+                .map(Node::parse)
+                .collect(Collectors.toList())
+        );
+    }
+
+    /**
+     * Whether this node carries no name suffix anywhere in its subtree.
+     *
+     * <p>A line is "named" when its {@code tail} holds a {@code > name},
+     * {@code > [params]} or {@code >>} suffix. This walks the node and all
+     * its descendants, so a named line nested below the top level — inside
+     * a tuple, a dispatch, or an application — is caught too. It decides
+     * whether a decoratee's whole subtree is safe to fold into a compact
+     * only-phi formation, which binds nothing but its {@code φ} decoratee
+     * (issue #5604).</p>
+     *
+     * @return True when neither this node nor any descendant is named
+     */
+    boolean nameless() {
+        return this.tail.isEmpty()
+            && this.children.stream().allMatch(Node::nameless);
+    }
+
+    /**
+     * Whether this node is a plain application whose last child is a
+     * tuple that can be glued to its head as a trailing {@code *}.
+     *
+     * <p>A formation lays its children out as bindings and a reversed
+     * dispatch keeps its receiver first, so neither is a plain
+     * application and neither qualifies. The star must be the head's
+     * only child: a bare trailing {@code *} absorbs the indented
+     * siblings beneath it into the tuple, so this round-trips only for
+     * the genuine {@code seq *} idiom. When a preceding argument shares
+     * the line ({@code sm.win32 "getenv" *}), the parser reads it as a
+     * complete application with an empty tuple and rejects the indented
+     * child, so the hybrid must not fire (issue #5622). The single child
+     * must itself be a gluable star (see {@link #stars()}).</p>
+     *
+     * <p>The head must also be a plain base, not a dotted method dispatch
+     * ({@code "literal".printf}, {@code 5.plus}). A bare trailing
+     * {@code *} is absorbed by the parser only after a plain leading
+     * application ({@code seq *}, {@code map *}, {@code switch *}); after
+     * a method dispatch it reads as a complete application with an empty
+     * tuple and rejects the indented elements. A data-receiver dispatch
+     * is stored reversed and so already fails the {@code !reversed} guard,
+     * but {@link Pretty#suffixed} rebuilds it as a non-reversed, single-child
+     * node whose base is exactly such a dispatch, and that alternative is
+     * weighed for the hybrid too — barring a dotted base here keeps it,
+     * and any genuine dotted dispatch, on the ordinary {@code * elem}
+     * child that round-trips (issue #5624).</p>
+     *
+     * @return True when the trailing-star hybrid form is applicable
+     */
+    boolean tuply() {
+        return this.gluer()
+            && this.children.size() == 1
+            && this.children.get(0).stars();
+    }
+
+    /**
+     * Whether this node is a plain application head onto which a
+     * trailing {@code *} may be glued: not a formation, not a reversed
+     * dispatch, and not a dotted method dispatch. See {@link #tuply()}
+     * for why a dotted base ({@code "literal".printf}, {@code 5.plus})
+     * is excluded (issue #5624).
+     * @return True when the head can carry a glued trailing star
+     */
+    boolean gluer() {
+        return !this.abstractt && !this.reversed && this.base.indexOf('.') < 0;
+    }
+
+    /**
+     * Whether this node is a non-empty, unnamed {@code *} tuple — one
+     * that may be glued to the tail of an applying object's line.
+     * @return True when this node is a gluable star
+     */
+    boolean stars() {
+        return "*".equals(this.base) && !this.abstractt
+            && !this.children.isEmpty() && this.tail.isEmpty();
+    }
+
+    /**
+     * Build the synthetic node that renders this tuple glued to the
+     * tail of {@code applier}'s line: {@code head *} on one line (with
+     * the applier's own name suffix), the tuple's elements as children.
+     *
+     * <p>The star is the applier's only child (see {@link #tuply()}), so
+     * nothing precedes it on the line — the head is the applier's bare
+     * base glued straight to the {@code *}.</p>
+     *
+     * @param applier The object applying this tuple
+     * @return The glued node, laid out vertically by the caller
+     */
+    Node glued(final Node applier) {
+        return new Node(
+            String.join(" ", applier.base, this.base), applier.tail,
+            false, false, false, false, this.children
+        );
+    }
+}

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Penalty-based pretty printer of EO code.
@@ -90,7 +89,7 @@ final class Pretty {
         );
         this.root.elements(Filter.withName("line"))
             .findFirst()
-            .map(line -> this.layout(Pretty.Node.parse(line), 0))
+            .map(line -> this.layout(Node.parse(line), 0))
             .ifPresent(out::append);
         return out.append('\n').toString();
     }
@@ -111,9 +110,9 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block
      */
-    private String layout(final Pretty.Node node, final int indent) {
+    private String layout(final Node node, final int indent) {
         String best = this.shaped(node, indent);
-        final Optional<Pretty.Node> suffix = Pretty.suffixed(node);
+        final Optional<Node> suffix = Pretty.suffixed(node);
         if (suffix.isPresent()) {
             final String alt = this.shaped(suffix.get(), indent);
             if (new Penalty(alt, this.weights).points()
@@ -131,7 +130,7 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block
      */
-    private String shaped(final Pretty.Node node, final int indent) {
+    private String shaped(final Node node, final int indent) {
         String best = this.vertical(node, indent);
         final Optional<String> flat = this.horizontal(node, indent);
         if (flat.isPresent()
@@ -164,14 +163,14 @@ final class Pretty {
      * @param node The node
      * @return The suffix-shaped node, or empty if it doesn't apply
      */
-    private static Optional<Pretty.Node> suffixed(final Pretty.Node node) {
-        Optional<Pretty.Node> result = Optional.empty();
+    private static Optional<Node> suffixed(final Node node) {
+        Optional<Node> result = Optional.empty();
         if (node.reversed && !node.children.isEmpty()) {
-            final Pretty.Node receiver = node.children.get(0);
+            final Node receiver = node.children.get(0);
             if (receiver.data && receiver.children.isEmpty()
                 && receiver.tail.isEmpty()) {
                 result = Optional.of(
-                    new Pretty.Node(
+                    new Node(
                         String.join(
                             ".", receiver.base,
                             node.base.substring(0, node.base.length() - 1)
@@ -192,11 +191,11 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block
      */
-    private String vertical(final Pretty.Node node, final int indent) {
+    private String vertical(final Node node, final int indent) {
         final StringBuilder block = new StringBuilder(this.tab.repeat(indent))
             .append(node.base)
             .append(node.tail);
-        for (final Pretty.Node child : node.children) {
+        for (final Node child : node.children) {
             if (child.test) {
                 block.append('\n');
             }
@@ -212,7 +211,7 @@ final class Pretty {
      * @param indent The indentation level
      * @return The single line, or empty if inlining is impossible
      */
-    private Optional<String> horizontal(final Pretty.Node node, final int indent) {
+    private Optional<String> horizontal(final Node node, final int indent) {
         final Optional<String> result;
         if (node.abstractt) {
             result = this.phi(node, indent);
@@ -283,11 +282,11 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block, or empty if the inline-phi form doesn't apply
      */
-    private Optional<String> phi(final Pretty.Node node, final int indent) {
+    private Optional<String> phi(final Node node, final int indent) {
         Optional<String> result = Optional.empty();
         if (node.children.size() == 1
             && " > @".equals(node.children.get(0).tail)) {
-            final Pretty.Node decoratee = node.children.get(0);
+            final Node decoratee = node.children.get(0);
             final String middle;
             if (node.base.isEmpty()) {
                 middle = " ";
@@ -296,7 +295,7 @@ final class Pretty {
             }
             final String marker = middle.concat(node.tail);
             final Optional<String> flat = Pretty.flat(
-                new Pretty.Node(
+                new Node(
                     decoratee.base, "", decoratee.abstractt,
                     false, decoratee.reversed, decoratee.data, decoratee.children
                 )
@@ -306,12 +305,12 @@ final class Pretty {
             final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
                 && !(decoratee.reversed && decoratee.children.size() <= 1);
             final boolean unnamed = decoratee.children.stream()
-                .allMatch(Pretty.Node::nameless);
+                .allMatch(Node::nameless);
             if (applied && unnamed
                 && flat.map(line -> line.length() > this.width).orElse(true)) {
                 result = Optional.of(
                     this.vertical(
-                        new Pretty.Node(
+                        new Node(
                             decoratee.base, marker, false, false,
                             decoratee.reversed, decoratee.data, decoratee.children
                         ),
@@ -360,7 +359,7 @@ final class Pretty {
      * @param indent The indentation level
      * @return The rendered block, or empty if the trailing-star form doesn't apply
      */
-    private Optional<String> starred(final Pretty.Node node, final int indent) {
+    private Optional<String> starred(final Node node, final int indent) {
         Optional<String> result = Optional.empty();
         if (node.tuply()) {
             result = Optional.of(
@@ -387,10 +386,10 @@ final class Pretty {
      * @param args The arguments
      * @return The inlined string, or empty if any argument can't be inlined
      */
-    private static Optional<String> inlined(final List<Pretty.Node> args) {
+    private static Optional<String> inlined(final List<Node> args) {
         final StringBuilder joined = new StringBuilder();
         Optional<String> result = Optional.of("");
-        for (final Pretty.Node arg : args) {
+        for (final Node arg : args) {
             final Optional<String> flat = Pretty.flat(arg);
             if (flat.isEmpty()) {
                 result = Optional.empty();
@@ -416,9 +415,9 @@ final class Pretty {
      * @param given The node
      * @return The inlined content, or empty
      */
-    private static Optional<String> flat(final Pretty.Node given) {
+    private static Optional<String> flat(final Node given) {
         final Optional<String> result;
-        final Pretty.Node node = Pretty.suffixed(given).orElse(given);
+        final Node node = Pretty.suffixed(given).orElse(given);
         if (node.reversed && node.children.size() <= 1) {
             result = Optional.empty();
         } else if (node.abstractt || !node.tail.isEmpty() || "*".equals(node.base)) {
@@ -430,193 +429,5 @@ final class Pretty {
                 .map(args -> String.join(" ", node.base, args));
         }
         return result;
-    }
-
-    /**
-     * A node of the intermediate line tree.
-     * @since 0.57.0
-     */
-    private static final class Node {
-
-        /**
-         * The rendered head of the object (base, method, formation
-         * params, data literal or {@code *}).
-         */
-        private final String base;
-
-        /**
-         * The rendered suffix ({@code > name}, {@code >>}, {@code !},
-         * {@code /atom} or {@code :label}), possibly empty.
-         */
-        private final String tail;
-
-        /**
-         * Whether this object is a formation (its children are
-         * bindings, so it is laid out vertically, unless its only
-         * binding is the {@code φ} decoratee and the compact inline-phi
-         * form fits on one line).
-         */
-        private final boolean abstractt;
-
-        /**
-         * Whether this object is a test attribute ({@code +> name}),
-         * which R-6.5.3 requires to be preceded by a blank line.
-         */
-        private final boolean test;
-
-        /**
-         * Whether this object is a reversed dispatch ({@code method.});
-         * a receiver-only one cannot be inlined as an argument.
-         */
-        private final boolean reversed;
-
-        /**
-         * Whether this object is a data literal (number, string, bytes),
-         * so it may sit as a receiver in the suffix form of a reversed
-         * dispatch ({@code 5.plus} instead of {@code plus. 5}).
-         */
-        private final boolean data;
-
-        /**
-         * The children (arguments or bindings), in order.
-         */
-        private final List<Pretty.Node> children;
-
-        /**
-         * Ctor.
-         * @param head The rendered head
-         * @param suffix The rendered suffix
-         * @param formation Whether it is a formation
-         * @param attr Whether it is a test attribute
-         * @param rev Whether it is a reversed dispatch
-         * @param literal Whether it is a data literal
-         * @param kids The children
-         * @checkstyle ParameterNumberCheck (5 lines)
-         */
-        Node(final String head, final String suffix, final boolean formation,
-            final boolean attr, final boolean rev, final boolean literal,
-            final List<Pretty.Node> kids) {
-            this.base = head;
-            this.tail = suffix;
-            this.abstractt = formation;
-            this.test = attr;
-            this.reversed = rev;
-            this.data = literal;
-            this.children = kids;
-        }
-
-        /**
-         * Build a node from a {@code <line>} element.
-         * @param line The {@code <line>} element
-         * @return The node
-         */
-        static Pretty.Node parse(final Xnav line) {
-            return new Pretty.Node(
-                line.attribute("base").text().orElse(""),
-                line.attribute("tail").text().orElse(""),
-                "yes".equals(line.attribute("abstract").text().orElse("no")),
-                "yes".equals(line.attribute("test").text().orElse("no")),
-                "yes".equals(line.attribute("reversed").text().orElse("no")),
-                "yes".equals(line.attribute("data").text().orElse("no")),
-                line.elements(Filter.withName("line"))
-                    .map(Pretty.Node::parse)
-                    .collect(Collectors.toList())
-            );
-        }
-
-        /**
-         * Whether this node carries no name suffix anywhere in its subtree.
-         *
-         * <p>A line is "named" when its {@code tail} holds a {@code > name},
-         * {@code > [params]} or {@code >>} suffix. This walks the node and all
-         * its descendants, so a named line nested below the top level — inside
-         * a tuple, a dispatch, or an application — is caught too. It decides
-         * whether a decoratee's whole subtree is safe to fold into a compact
-         * only-phi formation, which binds nothing but its {@code φ} decoratee
-         * (issue #5604).</p>
-         *
-         * @return True when neither this node nor any descendant is named
-         */
-        boolean nameless() {
-            return this.tail.isEmpty()
-                && this.children.stream().allMatch(Pretty.Node::nameless);
-        }
-
-        /**
-         * Whether this node is a plain application whose last child is a
-         * tuple that can be glued to its head as a trailing {@code *}.
-         *
-         * <p>A formation lays its children out as bindings and a reversed
-         * dispatch keeps its receiver first, so neither is a plain
-         * application and neither qualifies. The star must be the head's
-         * only child: a bare trailing {@code *} absorbs the indented
-         * siblings beneath it into the tuple, so this round-trips only for
-         * the genuine {@code seq *} idiom. When a preceding argument shares
-         * the line ({@code sm.win32 "getenv" *}), the parser reads it as a
-         * complete application with an empty tuple and rejects the indented
-         * child, so the hybrid must not fire (issue #5622). The single child
-         * must itself be a gluable star (see {@link #stars()}).</p>
-         *
-         * <p>The head must also be a plain base, not a dotted method dispatch
-         * ({@code "literal".printf}, {@code 5.plus}). A bare trailing
-         * {@code *} is absorbed by the parser only after a plain leading
-         * application ({@code seq *}, {@code map *}, {@code switch *}); after
-         * a method dispatch it reads as a complete application with an empty
-         * tuple and rejects the indented elements. A data-receiver dispatch
-         * is stored reversed and so already fails the {@code !reversed} guard,
-         * but {@link #suffixed} rebuilds it as a non-reversed, single-child
-         * node whose base is exactly such a dispatch, and that alternative is
-         * weighed for the hybrid too — barring a dotted base here keeps it,
-         * and any genuine dotted dispatch, on the ordinary {@code * elem}
-         * child that round-trips (issue #5624).</p>
-         *
-         * @return True when the trailing-star hybrid form is applicable
-         */
-        boolean tuply() {
-            return this.gluer()
-                && this.children.size() == 1
-                && this.children.get(0).stars();
-        }
-
-        /**
-         * Whether this node is a plain application head onto which a
-         * trailing {@code *} may be glued: not a formation, not a reversed
-         * dispatch, and not a dotted method dispatch. See {@link #tuply()}
-         * for why a dotted base ({@code "literal".printf}, {@code 5.plus})
-         * is excluded (issue #5624).
-         * @return True when the head can carry a glued trailing star
-         */
-        boolean gluer() {
-            return !this.abstractt && !this.reversed && this.base.indexOf('.') < 0;
-        }
-
-        /**
-         * Whether this node is a non-empty, unnamed {@code *} tuple — one
-         * that may be glued to the tail of an applying object's line.
-         * @return True when this node is a gluable star
-         */
-        boolean stars() {
-            return "*".equals(this.base) && !this.abstractt
-                && !this.children.isEmpty() && this.tail.isEmpty();
-        }
-
-        /**
-         * Build the synthetic node that renders this tuple glued to the
-         * tail of {@code applier}'s line: {@code head *} on one line (with
-         * the applier's own name suffix), the tuple's elements as children.
-         *
-         * <p>The star is the applier's only child (see {@link #tuply()}), so
-         * nothing precedes it on the line — the head is the applier's bare
-         * base glued straight to the {@code *}.</p>
-         *
-         * @param applier The object applying this tuple
-         * @return The glued node, laid out vertically by the caller
-         */
-        Pretty.Node glued(final Pretty.Node applier) {
-            return new Pretty.Node(
-                String.join(" ", applier.base, this.base), applier.tail,
-                false, false, false, false, this.children
-            );
-        }
     }
 }


### PR DESCRIPTION
Closes #5647.

## What

`Node` was a `private static final` inner class of `Pretty` (~210 lines nested inside a 647-line file), inflating a class that should read as just the penalty-based layout algorithm. This lifts it out into its own `Node.java` as a package-private `final` class in the same package.

## Details

- **New `Node.java`**: the line-tree node — its seven fields (`base`, `tail`, `abstractt`, `test`, `reversed`, `data`, `children`), the constructor, and its behavior (`parse`, `nameless`, `tuply`, `gluer`, `stars`, `glued`).
- **Fields made package-private** (not `private`) so `Pretty` and its static helpers `suffixed`/`inlined`/`flat` keep their direct field access without introducing getters — the same state exposure that nesting granted before, now just top-level. Each field carries a `@checkstyle VisibilityModifierCheck` suppression, matching the repo's convention for intentionally package-visible fields.
- **`Pretty.java`**: nested class removed; all `Pretty.Node` references become `Node`; the now-unused `java.util.stream.Collectors` import (only used by `Node.parse`) is dropped. `Pretty` is left focused on layout, `Node` owns the tree.

The dependency runs one way only (`Pretty` → `Node`), so the extraction is behavior-preserving — a pure move with no logic changes.

On the issue's aside that `Node` holds seven attributes (over the 1–4 guideline): I kept the shape intact here so this change stays a clean, mechanical, reviewable extraction. Reworking the attribute shape is a separate concern that can follow.

## Verification

- `mvn -pl eo-printer test` — green.
- `mvn -pl eo-printer com.qulice:qulice-maven-plugin:0.27.6:check` (the CI-pinned qulice version) — `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013A82TEoRuMmwL1kdjjmhfo

---
_Generated by [Claude Code](https://claude.ai/code/session_013A82TEoRuMmwL1kdjjmhfo)_