### PR TITLE
#5648: emit compact-tuple marker `*N` for trailing tuples after leading args

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -6,6 +6,7 @@ package org.eolang.printer;
 
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -139,50 +140,72 @@ final class Node {
 
     /**
      * Whether this node is a plain application whose last child is a
-     * tuple that can be glued to its head as a trailing {@code *}.
+     * tuple that can be compacted onto its head as a trailing
+     * {@code *N} marker.
      *
      * <p>A formation lays its children out as bindings and a reversed
      * dispatch keeps its receiver first, so neither is a plain
-     * application and neither qualifies. The star must be the head's
-     * only child: a bare trailing {@code *} absorbs the indented
-     * siblings beneath it into the tuple, so this round-trips only for
-     * the genuine {@code seq *} idiom. When a preceding argument shares
-     * the line ({@code sm.win32 "getenv" *}), the parser reads it as a
-     * complete application with an empty tuple and rejects the indented
-     * child, so the hybrid must not fire (issue #5622). The single child
-     * must itself be a gluable star (see {@link #stars()}).</p>
+     * application and neither qualifies (a reversed compact-tuple head
+     * such as {@code joined. *1} is not yet parseable). A bare tuple
+     * head ({@code base == "*"}) is a tuple literal, not an object
+     * applying a trailing tuple, so it is excluded too: its own elements
+     * are already tuple elements and gluing a {@code *N} marker onto it
+     * ({@code * *2}) would be a confusing self-application, never the
+     * intended compaction. The last child must itself be a gluable star
+     * (see {@link #stars()}); any leading children are the {@code N}
+     * positional arguments the marker keeps in front of the tuple.</p>
      *
-     * <p>The head must also be a plain base, not a dotted method dispatch
-     * ({@code "literal".printf}, {@code 5.plus}). A bare trailing
+     * <p>When the star is the sole child ({@code N == 0}) the head must
+     * be a plain base, not a dotted method dispatch
+     * ({@code "literal".printf}, {@code 5.plus}). The bare trailing
      * {@code *} is absorbed by the parser only after a plain leading
-     * application ({@code seq *}, {@code map *}, {@code switch *}); after
-     * a method dispatch it reads as a complete application with an empty
-     * tuple and rejects the indented elements. A data-receiver dispatch
-     * is stored reversed and so already fails the {@code !reversed} guard,
-     * but {@link Pretty#suffixed} rebuilds it as a non-reversed, single-child
-     * node whose base is exactly such a dispatch, and that alternative is
-     * weighed for the hybrid too — barring a dotted base here keeps it,
-     * and any genuine dotted dispatch, on the ordinary {@code * elem}
-     * child that round-trips (issue #5624).</p>
+     * application ({@code seq *}, {@code map *}); after a method dispatch
+     * it reads as a complete application with an empty tuple and rejects
+     * the indented elements. A data-receiver dispatch is stored reversed
+     * and so already fails the {@code !reversed} guard, but
+     * {@link Pretty#suffixed} rebuilds it as a non-reversed, single-child
+     * node whose base is exactly such a dispatch — barring a dotted base
+     * for {@code N == 0} keeps it, and any genuine dotted dispatch, on the
+     * ordinary {@code * elem} child that round-trips (issues #5622,
+     * #5624). With {@code N >= 1} the count sits on the head's line, so
+     * the {@code *N} marker round-trips after a dotted dispatch too
+     * ({@code string.sprintf *1}) and a dotted base is allowed
+     * (issue #5648).</p>
      *
      * @return True when the trailing-star hybrid form is applicable
      */
     boolean tuply() {
-        return this.gluer()
-            && this.children.size() == 1
-            && this.children.get(0).stars();
+        final int size = this.children.size();
+        return size > 0
+            && this.marked()
+            && this.children.get(size - 1).stars()
+            && this.absorbed(size);
     }
 
     /**
-     * Whether this node is a plain application head onto which a
-     * trailing {@code *} may be glued: not a formation, not a reversed
-     * dispatch, and not a dotted method dispatch. See {@link #tuply()}
-     * for why a dotted base ({@code "literal".printf}, {@code 5.plus})
-     * is excluded (issue #5624).
-     * @return True when the head can carry a glued trailing star
+     * Whether this head can carry a trailing-star marker at all: not a
+     * formation (its children are bindings), not a reversed dispatch (a
+     * reversed compact-tuple head is not yet parseable), and not a bare
+     * tuple literal ({@code base == "*"}), whose elements are already
+     * tuple elements.
+     * @return True when the head may take a {@code *N} marker
      */
-    boolean gluer() {
-        return !this.abstractt && !this.reversed && this.base.indexOf('.') < 0;
+    boolean marked() {
+        return !this.abstractt && !this.reversed && !"*".equals(this.base);
+    }
+
+    /**
+     * Whether the trailing tuple is absorbed correctly at the given
+     * child count. With {@code N >= 1} leading arguments the {@code *N}
+     * marker sits on the head's line, so a dotted method dispatch is
+     * fine; with the bare {@code *} ({@code N == 0}) the head must be a
+     * plain base, since after a method dispatch the parser reads a
+     * complete application with an empty tuple (issues #5622, #5624).
+     * @param size The number of children
+     * @return True when the shape round-trips at this count
+     */
+    boolean absorbed(final int size) {
+        return size > 1 || this.base.indexOf('.') < 0;
     }
 
     /**
@@ -196,21 +219,36 @@ final class Node {
     }
 
     /**
-     * Build the synthetic node that renders this tuple glued to the
-     * tail of {@code applier}'s line: {@code head *} on one line (with
-     * the applier's own name suffix), the tuple's elements as children.
+     * Build the synthetic node that renders this application with its
+     * trailing tuple compacted to a {@code *N} marker: {@code head *N}
+     * on one line (with the node's own name suffix), every argument as
+     * an indented child.
      *
-     * <p>The star is the applier's only child (see {@link #tuply()}), so
-     * nothing precedes it on the line — the head is the applier's bare
-     * base glued straight to the {@code *}.</p>
+     * <p>The last child is the gluable star (see {@link #tuply()}); the
+     * {@code N} children in front of it are the leading positional
+     * arguments the marker keeps. The head line carries {@code head *N},
+     * where {@code N} is that leading count, and the children are the
+     * leading arguments followed by the tuple's own elements. When
+     * {@code N == 0} the bare {@code *} is written (the {@code seq *}
+     * idiom), matching the parser's default count of zero.</p>
      *
-     * @param applier The object applying this tuple
      * @return The glued node, laid out vertically by the caller
      */
-    Node glued(final Node applier) {
+    Node glued() {
+        final int last = this.children.size() - 1;
+        final List<Node> kids = new ArrayList<>(
+            this.children.subList(0, last)
+        );
+        kids.addAll(this.children.get(last).children);
+        final String marker;
+        if (last == 0) {
+            marker = "*";
+        } else {
+            marker = "*".concat(Integer.toString(last));
+        }
         return new Node(
-            String.join(" ", applier.base, this.base), applier.tail,
-            false, false, false, false, this.children
+            String.join(" ", this.base, marker), this.tail,
+            false, false, false, false, kids
         );
     }
 }

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -20,10 +20,13 @@ import java.util.Optional;
  * EO source. For every object it considers a few renderings — a
  * vertical one, where the arguments go on their own indented lines, a
  * horizontal one, where they are inlined (wrapped in parentheses when
- * needed), and, for a tuple applied at the tail, a hybrid that glues
- * the {@code *} to the head's line — and keeps the one with the
- * smaller {@link Penalty}. The decision is made recursively,
- * bottom-up.</p>
+ * needed), and, for a tuple applied at the tail, a hybrid that carries
+ * the {@code *N} compact-tuple marker on the head's line — and keeps the
+ * one with the smaller {@link Penalty}. The decision is made recursively,
+ * bottom-up. The one exception to the penalty vote is the {@code *N}
+ * marker for {@code N >= 1} leading arguments (issue #5648): being the
+ * canonical spelling of a tuple applied after positional arguments, it is
+ * always emitted, never the verbose {@code * elem} child.</p>
  *
  * @since 0.57.0
  */
@@ -126,25 +129,40 @@ final class Pretty {
     /**
      * Lay out a single shape of a node, picking the lowest-penalty of its
      * vertical, horizontal and trailing-star renderings.
+     *
+     * <p>The compact-tuple {@code *N} marker for {@code N >= 1} leading
+     * arguments (issue #5648) is an exception to the penalty vote: it is the
+     * canonical spelling of a tuple applied after positional arguments, so it
+     * is emitted whenever it applies, even when the verbose {@code * elem}
+     * child inlines onto fewer lines. The bare {@code *} idiom
+     * ({@code N == 0}) stays a mere candidate — a short tuple that fits
+     * inline as {@code seq}, {@code * 1 2} on the next line is left alone.</p>
+     *
      * @param node The node
      * @param indent The indentation level
      * @return The rendered block
      */
     private String shaped(final Node node, final int indent) {
-        String best = this.vertical(node, indent);
-        final Optional<String> flat = this.horizontal(node, indent);
-        if (flat.isPresent()
-            && new Penalty(flat.get(), this.weights).points()
-            < new Penalty(best, this.weights).points()) {
-            best = flat.get();
-        }
         final Optional<String> star = this.starred(node, indent);
-        if (star.isPresent()
-            && new Penalty(star.get(), this.weights).points()
-            < new Penalty(best, this.weights).points()) {
-            best = star.get();
+        final String result;
+        if (star.isPresent() && node.children.size() > 1) {
+            result = star.get();
+        } else {
+            String best = this.vertical(node, indent);
+            final Optional<String> flat = this.horizontal(node, indent);
+            if (flat.isPresent()
+                && new Penalty(flat.get(), this.weights).points()
+                < new Penalty(best, this.weights).points()) {
+                best = flat.get();
+            }
+            if (star.isPresent()
+                && new Penalty(star.get(), this.weights).points()
+                < new Penalty(best, this.weights).points()) {
+                best = star.get();
+            }
+            result = best;
         }
-        return best;
+        return result;
     }
 
     /**
@@ -326,34 +344,38 @@ final class Pretty {
 
     /**
      * Render an application whose last child is a tuple as a hybrid: the
-     * head glued to a trailing {@code *} on one line, with the tuple's
-     * elements laid out vertically beneath at one deeper indent.
+     * head carrying a trailing {@code *N} marker on one line, with every
+     * argument laid out vertically beneath at one deeper indent.
      *
-     * <p>The ordinary {@code seq *} idiom is a tuple applied as the last
+     * <p>The ordinary {@code seq *} idiom is a tuple applied as the sole
      * argument of an object. Rendered verbosely it becomes {@code seq} on
      * one line, a lone {@code *} on the next, and the elements one level
      * deeper still — a line taller and an indent wider than the source a
      * human writes. This keeps the {@code *} at the tail of the head's line
      * ({@code seq *}) and pulls the elements up one level, mirroring the
-     * hybrid inline-phi form (issues #5594, #5615). A trailing {@code *}
-     * absorbs exactly the indented siblings beneath it into the tuple, so
-     * this shape is the same tree as the verbose one, with no before-star
-     * ambiguity.</p>
+     * hybrid inline-phi form (issues #5594, #5615). When the tuple follows
+     * {@code N >= 1} leading positional arguments, the compact-tuple marker
+     * {@code *N} (§3.9) carries the count on the head's line
+     * ({@code sprintf *1}) and every argument — the leading ones and the
+     * tuple's elements alike — becomes an indented sibling (issue #5648).
+     * Either way the shape is the same tree as the verbose one, with no
+     * before-star ambiguity.</p>
      *
-     * <p>It applies only to a plain (non-formation, non-reversed)
-     * application whose sole child is a non-empty, unnamed star. The star
-     * must be the only child: a bare trailing {@code *} absorbs the
-     * indented siblings into the tuple, so the shape round-trips only when
-     * nothing else shares the head's line. A preceding argument
-     * ({@code sm.win32 "getenv" *}) would make the parser read a complete
-     * application with an empty tuple and reject the indented child, so
-     * {@link #tuply()} bars that case (issue #5622). The elements are always
-     * laid out vertically, so the genuinely ambiguous fully-horizontal
-     * {@code head * a b} — the before-star territory — is never produced
-     * here. The result is only a candidate: {@link #shaped} keeps it only
-     * when its penalty beats the plain vertical and horizontal renderings,
-     * so a short tuple that fits inline as {@code seq}, {@code * 1 2} on the
-     * next line is left alone.</p>
+     * <p>It applies to a plain (non-formation, non-reversed) application
+     * whose last child is a non-empty, unnamed star. When the star is the
+     * sole child ({@code N == 0}), the bare {@code *} absorbs the indented
+     * siblings into the tuple and the head must be a plain base, not a
+     * dotted method dispatch: after {@code "literal".printf *} the parser
+     * reads a complete application with an empty tuple and drops the
+     * indented element, so {@link #tuply()} bars that case (issues #5622,
+     * #5624). The {@code *N} marker ({@code N >= 1}) sits on the head line
+     * rather than being glued after arguments, so it round-trips after a
+     * dotted dispatch too ({@code string.sprintf *1}). The genuinely
+     * ambiguous before-star form {@code head args *} is never produced. The
+     * result is only a candidate: {@link #shaped} keeps it only when its
+     * penalty beats the plain vertical and horizontal renderings, so a short
+     * tuple that fits inline as {@code seq}, {@code * 1 2} on the next line
+     * is left alone.</p>
      *
      * @param node The node
      * @param indent The indentation level
@@ -362,9 +384,7 @@ final class Pretty {
     private Optional<String> starred(final Node node, final int indent) {
         Optional<String> result = Optional.empty();
         if (node.tuply()) {
-            result = Optional.of(
-                this.vertical(node.children.get(0).glued(node), indent)
-            );
+            result = Optional.of(this.vertical(node.glued(), indent));
         }
         return result;
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compact-tuple-marker.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compact-tuple-marker.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The compact-tuple marker "head *N" (N>=1, section 3.9) is the canonical
+# spelling of a tuple applied after N leading positional arguments: the "*N"
+# marker sits on the head line and every argument, the leading ones and the
+# tuple's elements alike, becomes an indented sibling. It is emitted even when
+# the verbose "* elem" child would inline onto fewer lines, and it round-trips
+# after a dotted method dispatch too (issue #5648, see also the parser's
+# compact-tuple-with-method.yaml). The marker never becomes the invalid
+# before-star form "head args *" removed by #5622.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+origin: |
+  [] > app
+    string.sprintf > msg
+      "Hello, %s and %s!"
+      * "Jeff" "Mary"
+
+printed: |
+  [] > app
+    string.sprintf *1 > msg
+      "Hello, %s and %s!"
+      "Jeff"
+      "Mary"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
@@ -43,9 +43,11 @@ printed: |
     if. > @
       plus.
         this
-          n.minus
+          n.minus *2
             "家"
             x
-            * "Hello, друг" 2.18 true
+            "Hello, друг"
+            2.18
+            true
         bar (n.plus "hello, 大家!")
     4.55 > x!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
@@ -27,7 +27,8 @@ printed: |
     ? >> list
     ? >> passed
     withouti > list3
-      concat
+      concat *1
         * 0 1
-        * 2 3
+        2
+        3
       0

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# A tuple applied after one or more leading positional arguments is the valid
+# compact-tuple case "head *N" (N>=1, section 3.9): the marker sits on the head
+# line and every argument, leading ones included, becomes an indented sibling.
+# Earlier (issue #5622) the printer bailed to the verbose "* elem" child to
+# avoid the invalid before-star form "sm.win32 "getenv" *", which the parser
+# reads as an empty tuple. The "*N" marker is a different, valid spelling that
+# round-trips after a dotted dispatch too, so it is emitted instead of the
+# verbose child (issue #5648).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -16,6 +24,6 @@ origin: |
 
 printed: |
   [] > main
-    sm.win32 > getenv
+    sm.win32 *1 > getenv
       "getenv"
-      * name
+      name


### PR DESCRIPTION
Fixes #5648.

## Problem

When an application applied a trailing tuple after one or more leading positional arguments — the valid compact-tuple case `head *N`, N≥1 — the printer never emitted the `*N` marker. It rendered the tuple as a verbose `* elem` child instead:

```
sprintf
  "Hello, %s and %s!"
  * "Jeff" "Mary"
```

instead of the canonical compact spelling (§3.9):

```
sprintf *1
  "Hello, %s and %s!"
  "Jeff"
  "Mary"
```

The trailing-star hybrid was gated by `Pretty.Node.tuply()`, which required `this.children.size() == 1`, so it only fired for the sole-child `seq *` idiom.

## Fix

- **`tuply()`** — generalized the `children.size() == 1` guard: the hybrid now fires whenever the *last* child is a gluable star, regardless of how many leading arguments precede it. Split into helpers `marked()` (head can carry a marker) and `absorbed(size)` to keep the boolean complexity within qulice limits.
- **`glued()`** — now builds `head *N` (N = number of leading arguments) and lays every argument — the leading ones and the tuple's elements — as indented siblings. `N == 0` keeps the bare `*` (the `seq *` idiom), matching the parser's default count.
- **`shaped()`** — the `*N` marker for N≥1 is the canonical spelling, so it is emitted whenever it applies rather than only when it wins the penalty vote (the verbose `* elem` child can inline onto fewer lines). The bare `*` (N==0) idiom stays a penalty-gated candidate, so a short tuple that fits inline as `seq`, `* 1 2` is still left alone.

Guards preserved:

- **Reversed dispatch / formation heads** cannot carry a marker → verbose `* elem` fall-back (a reversed compact-tuple head is not yet parseable).
- **Tuple-literal head** (`base == "*"`) is excluded — its elements are already tuple elements, and `* *N` would be a confusing self-application.
- **Before-star form** `head args *` (removed by #5622) is never produced. The dotted-dispatch restriction from #5622/#5624 now applies only to `N == 0` (the bare `*`); the `*N` marker sits on the head line, so it round-trips after a method dispatch too (`string.sprintf *1`, cf. the parser's `compact-tuple-with-method.yaml`).

## Tests

- New `compact-tuple-marker.yaml` covering the canonical `string.sprintf *1` case (dotted dispatch, tuple that would otherwise inline).
- Updated `trailing-star-after-args.yaml` (the #5622 case) to the new `sm.win32 *1` compaction.
- Updated `idiomatic.yaml` and `self-reference.yaml` where the generalized rule now compacts their trailing tuples.

All 110 `XmirTest` print-pack cases pass, including the `printsToParseableEo` idempotency check, and the 58 `MjPrintTest`/`MjFormatTest` cases (straight and reversed notation). Qulice passes on `eo-printer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYUSfEKzYNVXrs1S57DfvH)_