### PR TITLE
#5650: keep compact suffix for compound-receiver method chains

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -88,14 +88,37 @@ final class MjFormatTest {
                 new FakeMaven(temp)
                     .with("autoFix", true)
                     .with("step", 4)
-                    .withProgram(MjFormatTest.canonical(new HelloWorld().asString()))
+                    .withProgram(MjFormatTest.canonical(MjFormatTest.nested()))
                     .execute(MjFormat.class)
                     .result()
                     .get("foo/x/main.eo")
             ).asString(),
             Matchers.containsString(
-                String.valueOf('\n').concat("        org.eolang.io.stdout")
+                String.valueOf('\n').concat("        x > first")
             )
+        );
+    }
+
+    /**
+     * A program that stays multi-line whatever the layout weights are.
+     *
+     * <p>A nested formation with two bindings never collapses onto a single
+     * line — an only-phi formation binds nothing but its {@code φ} decoratee —
+     * so its deepest lines sit two indentation levels in and expose the
+     * configured {@code step}, unlike a compact one-liner such as
+     * {@code (stdout "Hello!" x).print > [x] > main}.</p>
+     *
+     * @return The EO program source
+     */
+    private static String nested() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[x] > main",
+            "  [] > inner",
+            "    x > first",
+            "    x > second"
         );
     }
 

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -101,13 +101,18 @@ final class Pretty {
      * Lay out a node as a (possibly multi-line) block at the given
      * indentation, picking the rendering with the lowest penalty.
      *
-     * <p>When the node is a reversed dispatch on a lone data receiver
-     * ({@code plus. 5 3}), its equivalent suffix shape ({@code 5.plus 3})
-     * is laid out too and the lower-penalty one is kept — the same
-     * penalty comparison that already decides inline versus vertical. The
-     * suffix shape is never longer and its vertical form has one fewer
-     * child line, so it can only tie or win; a tie (both fit the width)
-     * resolves to the suffix, the shorter and more readable form.</p>
+     * <p>When the node is a reversed dispatch whose receiver has a one-line
+     * inline form ({@code plus. 5 3}, {@code div. (a.plus b) c},
+     * {@code ^. read. (input.read 4096)}), its equivalent suffix shape
+     * ({@code 5.plus 3}, {@code (a.plus b).div c},
+     * {@code (input.read 4096).read.^}) is laid out too and the lower-penalty
+     * one is kept — the same penalty comparison that already decides inline
+     * versus vertical. A lone-data or plain-chain receiver glues bare and its
+     * suffix can only tie or win, so a tie (both fit the width) resolves to
+     * the suffix, the shorter form; a compound receiver pays a {@code BRACKET}
+     * for its parentheses, so its suffix is kept only when the saved
+     * indentation and repeated base characters outweigh that one bracket
+     * (#5650).</p>
      *
      * @param node The node
      * @param indent The indentation level
@@ -166,17 +171,30 @@ final class Pretty {
     }
 
     /**
-     * The suffix shape of a reversed dispatch on a lone data receiver, if
-     * this node is one.
+     * The suffix shape of a reversed dispatch, if this node is one whose
+     * receiver has a one-line inline form.
      *
-     * <p>A data-receiver dispatch is stored as a reversed head
-     * ({@code plus.}) whose first child is the data literal receiver, since
-     * a literal cannot fold into a dotted {@code @base} the way a named
-     * receiver does. This rebuilds it in suffix position — the receiver
-     * glued to the method ({@code 5.plus}) with the remaining arguments
-     * kept as children — so both shapes can be weighed against each other.
-     * A compound receiver (one with children of its own) has no suffix
-     * form and yields empty, leaving the reversed head untouched.</p>
+     * <p>A dispatch is stored as a reversed head ({@code plus.},
+     * {@code div.}) whose first child is the receiver whenever the receiver
+     * cannot fold into a dotted {@code @base} the way a named identifier does:
+     * a data literal ({@code 5}, {@code "x"}, {@code 01-}) or a compound
+     * expression ({@code input.read 4096}, {@code a.plus b}). This rebuilds it
+     * in suffix position — the receiver glued to the method with the remaining
+     * arguments kept as children — so both shapes can be weighed against each
+     * other in {@link #layout}.</p>
+     *
+     * <p>The receiver is inlined through {@link #flat} and glued to the
+     * method as {@code receiver.method}. A receiver that itself applies
+     * arguments ({@code input.read 4096}, {@code a.plus b}) is wrapped in
+     * parentheses ({@code (input.read 4096).read}, {@code (a.plus b).div c}),
+     * exactly as {@link #inlined} wraps such an argument; a receiver that is a
+     * single token or a plain dispatch chain ({@code 5}, {@code 01-.as-bool},
+     * {@code (input.read 4096).read}) is glued bare, since redundant
+     * parentheses around a single token fail to parse (#5591). The parenthesis
+     * cost is modelled by {@code BRACKET}, so {@link #layout} keeps the suffix
+     * shape only when it beats the reversed vertical form on penalty; a
+     * receiver with no one-line inline form yields empty and leaves the
+     * reversed head untouched (#5650).</p>
      *
      * @param node The node
      * @return The suffix-shaped node, or empty if it doesn't apply
@@ -185,19 +203,24 @@ final class Pretty {
         Optional<Node> result = Optional.empty();
         if (node.reversed && !node.children.isEmpty()) {
             final Node receiver = node.children.get(0);
-            if (receiver.data && receiver.children.isEmpty()
-                && receiver.tail.isEmpty()) {
-                result = Optional.of(
-                    new Node(
+            result = Pretty.flat(receiver).map(
+                inline -> {
+                    final String glued;
+                    if (Pretty.suffixed(receiver).orElse(receiver).children.isEmpty()) {
+                        glued = inline;
+                    } else {
+                        glued = "(".concat(inline).concat(")");
+                    }
+                    return new Node(
                         String.join(
-                            ".", receiver.base,
+                            ".", glued,
                             node.base.substring(0, node.base.length() - 1)
                         ),
                         node.tail, node.abstractt, node.test, false, false,
                         node.children.subList(1, node.children.size())
-                    )
-                );
-            }
+                    );
+                }
+            );
         }
         return result;
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# A reversed dispatch ("and.") over two compound comparison receivers packs
+# back into suffix position ("(true.eq 01-).and (false.eq 00-)") when that
+# beats the reversed shape on penalty: the two parenthesized comparisons cost
+# the same either way, so the shorter suffix form wins and the whole formation
+# collapses through the inline-phi form onto one line (#5650).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -14,4 +19,4 @@ origin: |
       true.eq 01-
       false.eq 00-
 printed: |
-  and. (true.eq 01-) (false.eq 00-) > [] > compares-bool-to-bytes
+  (true.eq 01-).and (false.eq 00-) > [] > compares-bool-to-bytes

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A method chain on a compound receiver keeps the compact one-liner a human
+# wrote ("(input.read 4096).read.^") instead of being de-compacted into a
+# three-line nested reversed dispatch. The dispatch is stored reversed because
+# neither the outer "^" receiver "(input.read 4096).read" nor the inner "read"
+# receiver "input.read 4096" folds into a dotted base; the printer rebuilds
+# each in suffix position, wrapping only the receiver that applies arguments
+# ("input.read 4096") in parentheses, and keeps the suffix shape because its
+# single bracket beats the extra indentation and repeated base characters of
+# the reversed vertical form (#5650).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+origin: |
+  [input] > input-length
+    (input.read 4096).read.^ > chunk
+
+printed: |
+  [input] > input-length
+    (input.read 4096).read.^ > chunk

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
@@ -3,8 +3,12 @@
 ---
 # yamllint disable rule:line-length
 # Mixed method-dispatch chains. A named receiver folds into the suffix form
-# (a.plus b), but a compound receiver cannot, so its dispatch stays reversed
-# (div. (a.plus b) c, and. over its two comparisons).
+# (a.plus b). A compound receiver is also folded into a parenthesized suffix
+# ((a.plus b).div c) whenever that beats the reversed shape on penalty (#5650):
+# div's single bracket costs the same either way, so the shorter suffix wins,
+# but "and." over two parenthesized comparisons pays two brackets, which the
+# reversed vertical form (two short child lines) undercuts, so it stays
+# reversed.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -23,7 +27,7 @@ printed: |
     a.plus > weighted
       b.times c
     a.plus b > sum
-    div. (a.plus b) c > mean
+    (a.plus b).div c > mean
     and. > sorted
       a.gt b
       b.gt c

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
@@ -31,5 +31,5 @@ printed: |
   [] > cosine
 
     lt. ++> tests-cosine-of-pi-thirds-is-half
-      abs (minus. (times. (cosine (pi.div 3)) 1000) 500)
+      abs (((cosine (pi.div 3)).times 1000).minus 500)
       1

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
@@ -3,9 +3,10 @@
 ---
 # yamllint disable rule:line-length
 # A chain of nested "if." dispatches written vertically packs back onto a
-# single line when it fits: the inner if. inlines in parentheses as an
-# argument of the outer one, and the whole expression collapses through the
-# inline-phi form into the formation's head.
+# single line when it fits: each dispatch folds its compound comparison
+# receiver into suffix position ("(x.lt 0).if ..."), the inner one inlines in
+# parentheses as an argument of the outer, and the whole expression collapses
+# through the inline-phi form into the formation's head (#5650).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -23,4 +24,4 @@ origin: |
         "positive"
 
 printed: |
-  if. (x.lt 0) "negative" (if. (x.eq 0) "zero" "positive") > [x] > classify
+  (x.lt 0).if "negative" ((x.eq 0).if "zero" "positive") > [x] > classify

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# When a reversed dispatch ("eq.") inlines its arguments, an argument that is
-# itself a data-receiver dispatch ("01-.as-bool") is a single token: it has a
-# receiver child but takes no arguments of its own. It must inline bare, never
-# wrapped as "(01-.as-bool)", which would produce EO that fails to parse with
-# "redundant parentheses around a single token" (#5591). Only an argument that
-# actually applies arguments (and therefore contains a space, like "5.plus 3")
-# gets parenthesized.
+# When a reversed dispatch ("eq.") folds into suffix position, its receiver
+# ("01-.as-bool") — itself a data-receiver dispatch — is a single token: it has
+# a receiver child but takes no arguments of its own. It must glue bare
+# ("01-.as-bool.eq"), never wrapped as "(01-.as-bool)", which would produce EO
+# that fails to parse with "redundant parentheses around a single token"
+# (#5591). Only a receiver or argument that actually applies arguments (and
+# therefore contains a space, like "5.plus 3") gets parenthesized. The compact
+# suffix chain wins on penalty and the only-phi formation collapses onto one
+# line (#5650).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -23,6 +25,4 @@ origin: |
         00-.as-bool
 
 printed: |
-  [] > app
-    not. > @
-      eq. 01-.as-bool 00-.as-bool
+  (01-.as-bool.eq 00-.as-bool).not > [] > app

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
@@ -24,8 +24,7 @@ printed: |
   [] > foo
     seq * > @
       bar.deleted
-      if.
-        outcome.eq 0
+      (outcome.eq 0).if
         ^
         T
           "Cant delete '%s': %s".printf

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -41,4 +41,4 @@ printed: |
     if. > [tup] > reclast
       tup.length.eq 0
       -1
-      if. (tup.head.eq wanted) tup.tail.length (reclast tup.tail)
+      (tup.head.eq wanted).if tup.tail.length (reclast tup.tail)


### PR DESCRIPTION
Closes #5650.

## Problem

The `format` goal de-compacted a method chain on a compound receiver. In `eo-runtime/src/main/eo/io/input-length.eo:20` the hand-written source

```
(input.read 4096).read.^ > chunk
```

was rewritten into a three-line nested reversed dispatch:

```
^. > chunk
  read.
    input.read 4096
```

Same tree, so no correctness loss, but the compact one-liner a human wrote was lost — and it scores *better* under the printer's own penalty function.

## Root cause

Candidate generation, not penalty. `Pretty.suffixed()` only rebuilt the glued suffix shape `receiver.method` when the receiver was a lone data literal (the `5.plus` case). A compound receiver (one with children of its own, like `input.read 4096`) yielded empty, so the parenthesized suffix `(input.read 4096).read.^` was never built and `layout()` only ever weighed the reversed vertical form.

## Fix

Generalize `suffixed()` so any reversed dispatch whose receiver has a one-line inline form is rebuilt in suffix position:

- the receiver is inlined through `flat()` and glued to the method as `receiver.method`;
- it is wrapped in parentheses only when it applies arguments of its own (reusing the same rule as `inlined()`), so a single token such as `01-.as-bool` stays bare and never triggers *"redundant parentheses around a single token"* (#5591);
- the parenthesis cost is already modelled by `BRACKET`, so the existing penalty comparison in `layout()` keeps the suffix shape only when it beats the reversed vertical form. A receiver that does not fit inline, or a chain that is genuinely uglier with the paren, is rejected on penalty rather than never being considered.

The reported case now round-trips as the compact `(input.read 4096).read.^ > chunk`.

## Tests

- Refreshed the seven print-packs whose canonical layout is now more compact (e.g. `div. (a.plus b) c` → `(a.plus b).div c`, `if. (x.lt 0) ...` → `(x.lt 0).if ...`). The idempotency check (`printsToParseableEo`) still passes for all of them.
- Added `compound-receiver-suffix.yaml`, a dedicated pack for the exact `(input.read 4096).read.^` scenario.
- Updated `MjFormatTest.appliesCustomIndentationStep` to use a nested formation, since the hello-world fixture now legitimately collapses to the one-liner `(stdout "Hello!" x).print > [x] > main` and no longer exercises deep indentation.

All `eo-printer` (134) and `eo-maven-plugin` `MjFormatTest`/`MjPrintTest` (58) tests pass, and `qulice` (0.27.6, as CI runs it) is green for both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGEf5FcqoecvBVVtqWQPre

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGEf5FcqoecvBVVtqWQPre)_