### PR TITLE
#5653: scale the per-space penalty super-linearly by application length

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -4,7 +4,9 @@
  */
 package org.eolang.printer;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,9 +29,12 @@ import java.util.Map;
  *   column costs {@link PenaltyKey#EXCESS} point;</li>
  *   <li>every symbol in the block costs {@link PenaltyKey#SYMBOL}
  *   point;</li>
- *   <li>every space that applies an argument — one past the leading
- *   indentation of a line — costs {@link PenaltyKey#APPLICATION}
- *   points.</li>
+ *   <li>every space on a line past the leading indentation costs
+ *   {@link PenaltyKey#SPACE} points, and the genuine argument-applying
+ *   spaces among them (name bindings such as {@code >} do not count) pay
+ *   an extra super-linear surcharge: r such spaces cost r squared, rather
+ *   than r, times the weight, so longer applications grow super-linearly
+ *   more expensive while name bindings are left alone.</li>
  * </ul>
  *
  * <p>All of these weights, together with the indentation
@@ -40,16 +45,22 @@ import java.util.Map;
  *
  * <p>For example, with the default weights this snippet has a penalty of
  * 89 (five indents at three points each, 39 symbols, plus five
- * application spaces at seven points each):</p>
+ * application spaces at seven points each — all name bindings, so no
+ * surcharge):</p>
  *
  * <pre> [] &gt; foo
  *   gt. &gt; @
  *     42
  *     bar.hello 88</pre>
  *
- * <p>While this one, rendering the same object differently, scores
- * only 88 (one opening parenthesis at fifteen points, 31 symbols, plus
- * six application spaces at seven points each):</p>
+ * <p>This one, rendering the same object on a single line, scores 106:
+ * one opening parenthesis at nineteen points, 31 symbols, and six
+ * application spaces at seven points (42) of which two genuinely apply
+ * arguments — {@code 42.gt} to {@code (bar.hello 88)}, and
+ * {@code bar.hello} to {@code 88} — so those two pay the surcharge that
+ * takes them from 2 to 2 squared, i.e. 4, times the weight (an extra
+ * 14). The super-linear charge is what pushes the printer away from a
+ * sprawling application:</p>
  *
  * <pre> 42.gt (bar.hello 88) &gt; [] &gt; foo</pre>
  *
@@ -98,11 +109,14 @@ final class Penalty {
         int total = 0;
         for (final String line : this.code.split(String.valueOf('\n'), -1)) {
             final int opened = Penalty.brackets(line);
+            final int spaces = Penalty.spaces(line);
+            final int applied = Penalty.applied(line);
             total += this.indents(line) * this.weight(PenaltyKey.INDENT);
             total += opened * (opened + 1) / 2 * this.weight(PenaltyKey.BRACKET);
             total += this.overflow(line) * this.weight(PenaltyKey.EXCESS);
             total += line.length() * this.weight(PenaltyKey.SYMBOL);
-            total += Penalty.applications(line) * this.weight(PenaltyKey.APPLICATION);
+            total += (spaces + applied * (applied - 1))
+                * this.weight(PenaltyKey.SPACE);
         }
         return total;
     }
@@ -139,12 +153,11 @@ final class Penalty {
     }
 
     /**
-     * Count application spaces in a line: every space beyond the leading
-     * indentation.
+     * Count the spaces in a line beyond the leading indentation.
      * @param line The line
-     * @return The number of application spaces
+     * @return The number of spaces
      */
-    private static int applications(final String line) {
+    private static int spaces(final String line) {
         int lead = 0;
         while (lead < line.length() && line.charAt(lead) == ' ') {
             ++lead;
@@ -156,6 +169,76 @@ final class Penalty {
             }
         }
         return total;
+    }
+
+    /**
+     * Count the genuine argument-applying spaces in a line — the ones that
+     * make up an application's length.
+     *
+     * <p>Only the spaces that apply an argument to an object count. A space
+     * that sits next to a name-binding marker ({@code >}, {@code >>} or
+     * {@code ++>}) binds a name rather than applying an argument, and the
+     * spaces between the void attributes inside a formation's {@code [..]}
+     * head are not applications either; neither is counted. So
+     * {@code foo > [] > bar} has no application spaces, while
+     * {@code foo bar 42 44} has three. This count drives the super-linear
+     * surcharge in {@link #points()}, so longer applications grow more
+     * expensive while name bindings are left alone.</p>
+     *
+     * @param line The line
+     * @return The number of argument-applying spaces
+     */
+    private static int applied(final String line) {
+        int lead = 0;
+        while (lead < line.length() && line.charAt(lead) == ' ') {
+            ++lead;
+        }
+        final String[] tokens = Penalty.tokens(line.substring(lead));
+        int total = 0;
+        for (int idx = 0; idx + 1 < tokens.length; ++idx) {
+            if (!Penalty.binding(tokens[idx]) && !Penalty.binding(tokens[idx + 1])) {
+                ++total;
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Split a line's content into space-separated tokens, keeping the void
+     * attributes inside a formation's {@code [..]} head together as one
+     * token so their separators are not mistaken for applications.
+     * @param text The line content, past the leading indentation
+     * @return The tokens
+     */
+    private static String[] tokens(final String text) {
+        final List<String> out = new ArrayList<>(0);
+        final StringBuilder token = new StringBuilder(0);
+        int square = 0;
+        for (int idx = 0; idx < text.length(); ++idx) {
+            final char chr = text.charAt(idx);
+            if (chr == '[') {
+                ++square;
+            } else if (chr == ']') {
+                --square;
+            }
+            if (chr == ' ' && square == 0) {
+                out.add(token.toString());
+                token.setLength(0);
+            } else {
+                token.append(chr);
+            }
+        }
+        out.add(token.toString());
+        return out.toArray(new String[0]);
+    }
+
+    /**
+     * Is this token a name-binding marker rather than an applied argument?
+     * @param token The token
+     * @return TRUE for {@code >}, {@code >>} and {@code ++>}
+     */
+    private static boolean binding(final String token) {
+        return ">".equals(token) || ">>".equals(token) || "++>".equals(token);
     }
 
     /**

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -41,10 +41,14 @@ public enum PenaltyKey {
     SYMBOL(1),
 
     /**
-     * Points charged for each space that applies an argument — every
-     * space on a line beyond its leading indentation.
+     * Points charged for each space on a line beyond the leading
+     * indentation. The genuine argument-applying spaces among them (name
+     * bindings such as {@code >} do not count) additionally pay a
+     * super-linear surcharge at this same weight, so {@code r} of them cost
+     * {@code r} squared, rather than {@code r}, times the weight and longer
+     * applications grow super-linearly more expensive.
      */
-    APPLICATION(7),
+    SPACE(7),
 
     /**
      * The column after which characters start being charged.

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyOverridesTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyOverridesTest.java
@@ -31,7 +31,7 @@ final class PenaltyOverridesTest {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.BRACKET, 100);
         weights.put(PenaltyKey.SYMBOL, 0);
-        weights.put(PenaltyKey.APPLICATION, 0);
+        weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "A single parenthesis should cost the overridden weight",
             new Penalty("42.gt (bar.hello 88) > [] > foo", weights).points(),
@@ -44,7 +44,7 @@ final class PenaltyOverridesTest {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.STEP, 4);
         weights.put(PenaltyKey.SYMBOL, 0);
-        weights.put(PenaltyKey.APPLICATION, 0);
+        weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "Two levels of four-space indentation should cost six points",
             new Penalty(
@@ -72,7 +72,7 @@ final class PenaltyOverridesTest {
     @Test
     void honoursOverriddenApplicationWeight() {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
-        weights.put(PenaltyKey.APPLICATION, 100);
+        weights.put(PenaltyKey.SPACE, 100);
         weights.put(PenaltyKey.SYMBOL, 0);
         MatcherAssert.assertThat(
             "A single application space should cost the overridden weight",

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -21,7 +21,7 @@ final class PenaltyTest {
     void chargesForIndentation() {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.SYMBOL, 0);
-        weights.put(PenaltyKey.APPLICATION, 0);
+        weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "Five levels of indentation should cost fifteen points",
             new Penalty(
@@ -42,7 +42,7 @@ final class PenaltyTest {
     void chargesProgressivelyForParentheses() {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.SYMBOL, 0);
-        weights.put(PenaltyKey.APPLICATION, 0);
+        weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "Two parentheses on one line should cost three bracket-weights",
             new Penalty("f (a) (b)", weights).points(),
@@ -67,7 +67,7 @@ final class PenaltyTest {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.INDENT, 0);
         weights.put(PenaltyKey.BRACKET, 0);
-        weights.put(PenaltyKey.APPLICATION, 0);
+        weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "Every symbol in the block should cost one point",
             new Penalty("42.gt (bar.hello 88) > [] > foo", weights).points(),
@@ -78,12 +78,23 @@ final class PenaltyTest {
     @Test
     void chargesForApplications() {
         MatcherAssert.assertThat(
-            "Each non-indentation space should cost seven points",
+            "Four application spaces should cost four squared times seven points",
             new Penalty(
                 "foo 4 5 6 7",
                 Collections.singletonMap(PenaltyKey.SYMBOL, 0)
             ).points(),
-            Matchers.equalTo(28)
+            Matchers.equalTo(112)
+        );
+    }
+
+    @Test
+    void chargesApplicationsSuperLinearly() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.SYMBOL, 0);
+        MatcherAssert.assertThat(
+            "Doubling the applied arguments should more than double the charge",
+            new Penalty("foo a b c d", weights).points(),
+            Matchers.greaterThan(2 * new Penalty("foo a b", weights).points())
         );
     }
 
@@ -99,7 +110,7 @@ final class PenaltyTest {
     @Test
     void prefersHorizontalOverDeepVertical() {
         final Map<PenaltyKey, Integer> weights =
-            Collections.singletonMap(PenaltyKey.APPLICATION, 0);
+            Collections.singletonMap(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             "The flatter rendering should score lower than the deeply nested one",
             new Penalty("nan.plus negative-infinity > x", weights).points(),

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/aliases.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/aliases.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package sandbox
   +alias sm.os

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/auto-named-abstract.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/auto-named-abstract.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > y
     x > first

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/backslash.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/backslash.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     regex "/^[\\x00-\\x7F]*$/" > rgx

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term-phi.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term-phi.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     T > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     T > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     EA-EA-EA-EA > xs

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/cactus-void.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > compares-bool-to-bytes
     and. > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-auto-named.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-auto-named.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > y
     x > first

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > mktemp
     string > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/data-receiver-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/data-receiver-dispatch.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [foo] > app
     5.plus 3 > a

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dataized.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dataized.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > foo
     [] > f

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dataless.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dataless.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package sandbox
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [a b c] > math
     a.plus (b.times c) > weighted
@@ -21,6 +21,7 @@ printed: |
     a.plus > weighted
       b.times c
     a.plus b > sum
-    (a.plus b).div c > mean
+    (a.plus b).div > mean
+      c
     (a.gt b).and > sorted
       b.gt c

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/emoji.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/emoji.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     "🌵" > cactoos

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-bytes.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   -- > empty
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-string.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-string.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     Q.io.stdout > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-tuples.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-tuples.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     * > empty

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-deep-named-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-deep-named-argument.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-formation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-formation.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 
@@ -27,5 +27,8 @@ printed: |
     index.eq acc
     acc
     plus.
-      * 1 2 3
+      *
+        1
+        2
+        3
       0

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-named-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-named-argument.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-test.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-test.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 
@@ -27,5 +27,8 @@ printed: |
 
     is-empty ++> tests-list-front-with-zero-index
       tuple.front
-        * 1 2 3
+        *
+          1
+          2
+          3
         0

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +meta1
   +meta2 short
@@ -50,5 +50,6 @@ printed: |
             "Hello, друг"
             2.18
             true
-        bar (n.plus "hello, 大家!")
+        bar
+          n.plus "hello, 大家!"
     4.55 > x!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package sandbox
   +alias stdout org.eolang.io.stdout

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-compact-tuple.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-compact-tuple.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > foo
     malloc.of > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
@@ -28,5 +28,8 @@ printed: |
 
     lt. ++> tests-cosine-of-pi-thirds-is-half
       abs
-        ((cosine (pi.div 3)).times 1000).minus 500
+        minus.
+          (cosine (pi.div 3)).times
+            1000
+          500
       1

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-wide.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-wide.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/just-float.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/just-float.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     3.14 > pi

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multiline-string.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multiline-string.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     Q.io.stdout > @
@@ -18,4 +18,6 @@ origin: |
       """
 
 printed: |
-  io.stdout "Hello\nit's me" > [] > app
+  [] > app
+    io.stdout > @
+      "Hello\nit's me"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > shapes
     [width height] > rectangle
@@ -19,6 +19,10 @@ origin: |
 printed: |
   [] > shapes
     width.times height > [width height] > rectangle
-    rectangle 3 4 > area
+    rectangle > area
+      3
+      4
     (rectangle 3 4).plus > total
-      rectangle 1 2
+      rectangle
+        1
+        2

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [x] > classify
     if. > @
@@ -23,4 +23,6 @@ printed: |
   [x] > classify
     (x.lt 0).if > @
       "negative"
-      (x.eq 0).if "zero" "positive"
+      (x.eq 0).if
+        "zero"
+        "positive"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-parent.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-parent.yaml
@@ -7,7 +7,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-star-tuples.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-star-tuples.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > foo
     * abc 4.3 "test" > first
@@ -20,12 +20,25 @@ origin: |
 
 printed: |
   [] > foo
-    * abc 4.3 "test" > first
+    * > first
+      abc
+      4.3
+      "test"
     * > second
       bar
-      * "foo bar"
-      * 1 3 4
+      *
+        "foo bar"
+      *
+        1
+        3
+        4
     * > third
-      * 4 5 6 6
-      test
-        * 5 6 6
+      *
+        4
+        5
+        6
+        6
+      test *
+        5
+        6
+        6

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-in-argument-block.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-in-argument-block.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > foo
     bar > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     [x] > foo

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
@@ -7,7 +7,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     not. > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/self-reference.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package tuple
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > foo
     seq > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-with-memory.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-with-memory.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > counter
     memory 0 > state

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/stars-tuples.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/stars-tuples.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     * 1 "Hello" x > array
@@ -25,8 +25,17 @@ origin: |
 
 printed: |
   [] > main
-    * 1 "Hello" x > array
+    * > array
+      1
+      "Hello"
+      x
     * > xs
-      * 1 2
-      * 3 4
-      * 5 6
+      *
+        1
+        2
+      *
+        3
+        4
+      *
+        5
+        6

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/string-with-double-spaces.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/string-with-double-spaces.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   """
    z

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 
@@ -24,4 +24,5 @@ printed: |
 
   [x] > dataized /bytes
 
-    x.eq x --> on-something
+    --> on-something
+      x.eq x > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > app
     Q.io.stdout > @
@@ -19,4 +19,6 @@ origin: |
 printed: |
   [] > app
     io.stdout > @
-      string.sprintf "result is %d\n" (-1.times 228)
+      string.sprintf
+        "result is %d\n"
+        -1.times 228

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-args.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > main
     sm.win32 > getenv

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/trailing-star-after-dispatch.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [nstart nlen code] > main
     "Start index + length to slice (%d) is out of string bounds".printf > long

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/tuple-of-applications.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/tuple-of-applications.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   [] > pairs
     * (pair "a" 1) (pair "b" 2) > items
@@ -19,8 +19,12 @@ origin: |
 printed: |
   [] > pairs
     * > items
-      pair "a" 1
-      pair "b" 2
+      pair
+        "a"
+        1
+      pair
+        "b"
+        2
     [k v] > pair
       k > key
       v > value

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package tuple
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-type-annotation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-type-annotation.yaml
@@ -8,7 +8,7 @@ penalties:
   EXCESS: 1
   WIDTH: 80
   STEP: 2
-  APPLICATION: 7
+  SPACE: 7
 origin: |
   +package org.eolang
 


### PR DESCRIPTION
Closes #5653. Stacked on top of `5577` (PR #5579), where the penalty printer lives — this is not yet on `master`.

## What changed

The penalty-based printer charged its per-space weight **flatly**, once per space on a line, so every argument cost the same constant increment regardless of how long the application already was — and the cost vanished once arguments wrapped vertically. Nothing pushed the printer (or the author) away from a sprawling application.

Now the **genuine argument-applying spaces** on a line pay a super-linear surcharge: `r` such spaces cost `r²`, rather than `r`, times the weight. Longer applications therefore grow super-linearly more expensive and the printer favours shorter ones — for the three arguments in `foo bar 42 44` the weight is effectively multiplied by 3.

Spaces that merely **bind a name** (`>`, `>>`, `++>`) or separate the void attributes inside a formation's `[..]` head are not applications, so they keep their flat per-space charge and are left untouched. In particular `foo > [] > bar` (all name bindings, zero applications) renders exactly as before.

### Rename `APPLICATION` → `SPACE`

The weight is charged for **every** space on a line, not only for argument applications (name bindings and string-internal spaces are charged too, at the flat rate), so `PenaltyKey.APPLICATION` is renamed to `PenaltyKey.SPACE` for accuracy. Only the genuine argument-applying spaces additionally carry the super-linear surcharge.

- `Penalty.java` — flat per-space base charge kept (`spaces()`); new `applied()` (with `tokens()`/`binding()` helpers) counts only genuine argument-applying spaces; `points()` adds the `r² − r` surcharge. Docs/examples updated.
- `PenaltyKey.java` — `APPLICATION` → `SPACE`, doc updated.
- `PenaltyTest.java` / `PenaltyOverridesTest.java` — updated to `SPACE`; `chargesForApplications` now expects `4²·7 = 112`; new `chargesApplicationsSuperLinearly` test.
- Print-pack weight blocks renamed `APPLICATION:` → `SPACE:` (51 packs), and 13 goldens regenerated for genuine multi-argument-application cases.

Scoped to `eo-printer` only. Reformatting the eo-runtime `.eo` sources is a separate concern and is intentionally **not** included here.

## Verification

- `eo-printer`: 127 tests pass (`XmirTest` 114, `PenaltyTest` 8, `PenaltyOverridesTest` 5), including the `printsToParseableEo` idempotency/parseability check.
- Verified `foo > [] > bar` round-trips unchanged.
- qulice: my changed files produce no violations.

Note: `MjPrintTest` shows failures on this branch, but they pre-exist on `origin/5577` independently of this change (clean `5577` has more of them); the maven print-packs are stale on the base branch, so I left them untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL51NxsYxxo34h6s7iVByZ