### PR TITLE
fix(#5657): treat throwing-test marker `--&gt;` as a name binding

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -179,8 +179,9 @@ final class Penalty {
      * make up an application's length.
      *
      * <p>Only the spaces that apply an argument to an object count. A space
-     * that sits next to a name-binding marker ({@code >}, {@code >>} or
-     * {@code ++>}) binds a name rather than applying an argument, and the
+     * that sits next to a name-binding marker ({@code >}, {@code >>},
+     * {@code ++>} or {@code -->}) binds a name rather than applying an
+     * argument, and the
      * spaces between the void attributes inside a formation's {@code [..]}
      * head are not applications either; neither is counted. So
      * {@code foo > [] > bar} has no application spaces, while
@@ -238,10 +239,11 @@ final class Penalty {
     /**
      * Is this token a name-binding marker rather than an applied argument?
      * @param token The token
-     * @return TRUE for {@code >}, {@code >>} and {@code ++>}
+     * @return TRUE for {@code >}, {@code >>}, {@code ++>} and {@code -->}
      */
     private static boolean binding(final String token) {
-        return ">".equals(token) || ">>".equals(token) || "++>".equals(token);
+        return ">".equals(token) || ">>".equals(token)
+            || "++>".equals(token) || "-->".equals(token);
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -111,6 +111,20 @@ final class PenaltyTest {
     }
 
     @Test
+    void treatsThrowingTestMarkerAsBinding() {
+        final Map<PenaltyKey, Integer> weights =
+            Collections.singletonMap(PenaltyKey.SYMBOL, 0);
+        MatcherAssert.assertThat(
+            "The throwing-test marker should bind a name like ++>, not apply arguments",
+            new Penalty("foo --> name", weights).points(),
+            Matchers.allOf(
+                Matchers.equalTo(new Penalty("foo ++> name", weights).points()),
+                Matchers.lessThan(new Penalty("foo bar name", weights).points())
+            )
+        );
+    }
+
+    @Test
     void chargesNothingForEmptyCode() {
         MatcherAssert.assertThat(
             "Empty code should have zero penalty",

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
@@ -24,5 +24,4 @@ printed: |
 
   [x] > dataized /bytes
 
-    --> on-something
-      x.eq x > @
+    x.eq x --> on-something

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -130,11 +130,9 @@
         -7.as-bytes.or 23.as-bytes
         0.as-bytes
 
-  --> on-and-with-different-lengths
-    20-1F.and CA-FE-BE > @
+  20-1F.and CA-FE-BE --> on-and-with-different-lengths
 
-  --> on-or-with-different-lengths
-    20-1F.or CA-FE-BE > @
+  20-1F.or CA-FE-BE --> on-or-with-different-lengths
 
   (0.as-bytes.eq 0.as-bytes.not).not ++> tests-not-with-zero
 
@@ -206,10 +204,7 @@
     FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
     FF-FF-FF-FF-00-00-00-01
 
-  --> on-out-of-bounds-slice
-    20-1F-EE-B5-90.slice > @
-      3
-      10
+  20-1F-EE-B5-90.slice 3 10 --> on-out-of-bounds-slice
 
   ++> tests-out-of-bounds-slice-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -54,5 +54,4 @@
       00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
     FF-FF-FF-FF-FF-FF-FF-FF
 
-  --> on-xor-with-different-lengths
-    20-1F.xor CA-FE-BE > @
+  20-1F.xor CA-FE-BE --> on-xor-with-different-lengths

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -114,7 +114,4 @@
         2
     (directory mktemp.tmpfile.deleted).made.as-path > d
 
-  --> on-walking-absent-directory
-    walk. > @
-      directory mktemp.tmpfile.deleted
-      "**"
+  (directory mktemp.tmpfile.deleted).walk "**" --> on-walking-absent-directory

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -156,8 +156,7 @@
     -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
     2147483647.as-i64.as-i32
 
-  --> on-division-i32-by-i32-zero
-    2.as-i64.as-i32.div 0.as-i64.as-i32 > @
+  2.as-i64.as-i32.div 0.as-i64.as-i32 --> on-division-i32-by-i32-zero
 
   ++> tests-i32-div-by-zero-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -167,8 +167,7 @@
 
   (1.as-i64.minus 1.as-i64).eq 0.as-i64 ++> tests-i64-one-minus-i64-one
 
-  --> on-division-i64-by-i64-zero
-    2.as-i64.div 0.as-i64 > @
+  2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero
 
   ++> tests-i64-div-by-zero-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -76,10 +76,7 @@
       mod 133 1
       0
 
-  --> on-mod-by-zero
-    mod > @
-      5
-      0
+  mod 5 0 --> on-mod-by-zero
 
   ++> tests-mod-by-zero-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -190,9 +190,7 @@
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
 
-  --> on-taking-length-of-incomplete-n4-byte-character
-    length. > @
-      string F0-9F-98
+  (string F0-9F-98).length --> on-taking-length-of-incomplete-n4-byte-character
 
   ("Hello".eq 42).not ++> tests-compares-two-different-string-types
 

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -22,8 +22,7 @@
 
   5.eq (as-number "5") ++> tests-converts-text-to-number
 
-  --> on-converting-text-to-number
-    as-number "Hello" > @
+  as-number "Hello" --> on-converting-text-to-number
 
   ++> tests-non-numeric-text-returns-provided-fallback
     42.eq > @

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -44,10 +44,7 @@
     "m".eq > @
       at "some" -2
 
-  --> on-text-at-index-more-than-length
-    at > @
-      "some"
-      10
+  at "some" 10 --> on-text-at-index-more-than-length
 
   ++> tests-text-at-out-of-bounds-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -98,17 +98,9 @@
       "b"
       "c"
 
-  --> on-nsplit-with-limit-zero
-    nsplit > @
-      "text"
-      "-"
-      0
+  nsplit "text" "-" 0 --> on-nsplit-with-limit-zero
 
-  --> on-nsplit-with-negative-limit
-    nsplit > @
-      "text"
-      "-"
-      -1
+  nsplit "text" "-" -1 --> on-nsplit-with-negative-limit
 
   ++> tests-nsplit-invalid-limit-returns-provided-fallback
     "fallback".eq > @

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -50,10 +50,9 @@
       14
       false
 
-  --> on-printf-with-arguments-that-does-not-match
-    printf *1 > @
-      "%s%s"
-      "Jeff"
+  printf *1 --> on-printf-with-arguments-that-does-not-match
+    "%s%s"
+    "Jeff"
 
   eq. ++> tests-printf-does-not-fail-if-arguments-more-than-formats
     "Hey"
@@ -92,10 +91,9 @@
       "Hello, %s! Bye, %1$s!"
       "Jeff"
 
-  --> on-printf-with-oversized-positional-index
-    printf *1 > @
-      "%99999999999999999999$s"
-      "Jeff"
+  printf *1 --> on-printf-with-oversized-positional-index
+    "%99999999999999999999$s"
+    "Jeff"
 
   printf *1 --> on-printf-with-zero-positional-index
     "%0$s"
@@ -135,10 +133,9 @@
       "%d"
       9.99
 
-  --> on-formatting-huge-number-as-decimal
-    printf *1 > @
-      "%d"
-      1.0e30
+  printf *1 --> on-formatting-huge-number-as-decimal
+    "%d"
+    1.0e30
 
   eq. ++> formats-float-always-with-six-fraction-digits
     "1.250000"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -96,12 +96,7 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  --> on-getting-next-on-not-matched-block
-    next. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  ((regex "/[a-z]+/").match "123").next.next --> on-getting-next-on-not-matched-block
 
   --> on-getting-from-position-on-not-matched-block
     from. > @
@@ -138,12 +133,7 @@
         "123"
     1
 
-  --> on-getting-text-on-not-matched-block
-    text. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  ((regex "/[a-z]+/").match "123").next.text --> on-getting-text-on-not-matched-block
 
   matches. ++> tests-regex-matches-dotall-option
     compiled.
@@ -186,13 +176,9 @@
       regex "/(yildirim)/ui"
     "Yıldırım"
 
-  --> on-missing-first-slash-in-regex
-    compiled. > @
-      regex "(.)+"
+  (regex "(.)+").compiled --> on-missing-first-slash-in-regex
 
-  --> on-missing-closing-slash-in-regex
-    compiled. > @
-      regex "/pattern"
+  (regex "/pattern").compiled --> on-missing-closing-slash-in-regex
 
   ++> tests-invalid-regex-syntax-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -32,10 +32,7 @@
       as-number.
         index.plus 1
 
-  --> on-text-repeating-less-than-zero-times
-    repeated > @
-      ""
-      -1
+  repeated "" -1 --> on-text-repeating-less-than-zero-times
 
   ++> tests-text-repeated-negative-times-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -29,20 +29,11 @@
 
   0.24.eq (scanf "%f" "0.24").head ++> tests-scanf-with-float
 
-  --> on-scanf-with-wrong-format
-    scanf > @
-      "%l"
-      "error"
+  scanf "%l" "error" --> on-scanf-with-wrong-format
 
-  --> on-scanf-with-oversized-int
-    scanf > @
-      "%d"
-      "99999999999999999999"
+  scanf "%d" "99999999999999999999" --> on-scanf-with-oversized-int
 
-  --> on-scanf-with-dangling-percent
-    scanf > @
-      "hello%"
-      "hello"
+  scanf "hello%" "hello" --> on-scanf-with-dangling-percent
 
   eq. ++> tests-scanf-with-string-int-float
     scanf

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -62,17 +62,8 @@
       -2
       -1
 
-  --> on-range-of-numbers-with-non-number-start
-    range-of-numbers > @
-      1.2
-      3
+  range-of-numbers 1.2 3 --> on-range-of-numbers-with-non-number-start
 
-  --> on-range-of-numbers-with-not-number-end
-    range-of-numbers > @
-      1
-      2.5
+  range-of-numbers 1 2.5 --> on-range-of-numbers-with-not-number-end
 
-  --> on-range-of-not-numbers
-    range-of-numbers > @
-      1.5
-      5.2
+  range-of-numbers 1.5 5.2 --> on-range-of-not-numbers


### PR DESCRIPTION
Fixes #5657.

## Problem

`Penalty.binding()` recognised `>`, `>>` and `++>` as name-binding markers but omitted the throwing-test marker `-->`. Because of that, the two spaces flanking `-->` were counted as argument applications and paid the super-linear `SPACE` surcharge added in #5653. The phi-free shorthand (e.g. `mod 5 0 --> on-mod-by-zero`) therefore scored far higher than its `++>` twin (131 vs 61, against a verbose form of 88), so the layout search rejected it and kept the verbose

```
--> on-mod-by-zero
  mod > @
    5
    0
```

with an explicit `@` — exactly the shape the PHI penalty (#5655) steers away from. This is the untreated twin of #5567 (which fixed the same collapse for `++>`).

## Fix

- **`Penalty.binding()`**: add `"-->".equals(token)` to the disjunction so the throwing-test marker is treated as a name binding, like `++>`. Javadoc updated accordingly.
- **`throws-test-attribute.yaml`**: restore the collapsed golden `x.eq x --> on-something` (it was the regression #5653 introduced for `-->`).
- **`PenaltyTest`**: add `treatsThrowingTestMarkerAsBinding`, asserting `foo --> name` is charged like `foo ++> name` and cheaper than the application `foo bar name`.
- **eo-runtime `.eo` sources**: reformat the 15 files whose `-->` tests now render canonically in the compact shorthand, so the format-check gate stays green.

## Verification

- `eo-printer` `PenaltyTest` (10) and `XmirTest` (114 print-pack goldens) pass.
- `mvn process-sources` on `eo-runtime` (format check, autoFix off) reports "All 139 EO source(s) are formatted canonically", BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjwDHuWPVtWq2kv4VrCFyD)_