### PR TITLE
Penalize suffix `foo.if` dispatch to keep `if` in prefix form

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * {@link Pretty} to choose, among all possible renderings of the same
  * object, the one that reads best.</p>
  *
- * <p>The score is a sum of three components, computed over all lines:</p>
+ * <p>The score is a sum of several components, computed over all lines:</p>
  *
  * <ul>
  *   <li>every level of indentation on a line costs
@@ -27,6 +27,9 @@ import java.util.Map;
  *   nesting hurts readability more;</li>
  *   <li>every explicit phi attribute {@code @} costs
  *   {@link PenaltyKey#PHI} points;</li>
+ *   <li>every {@code if} dispatched in suffix position ({@code foo.if})
+ *   costs {@link PenaltyKey#IF} points, so the printer keeps {@code if}
+ *   in prefix form ({@code if. foo});</li>
  *   <li>every character sitting past the {@link PenaltyKey#WIDTH}-th
  *   column costs {@link PenaltyKey#EXCESS} point.</li>
  * </ul>
@@ -98,6 +101,7 @@ final class Penalty {
             total += this.indents(line) * this.weight(PenaltyKey.INDENT);
             total += Penalty.brackets(line) * this.weight(PenaltyKey.BRACKET);
             total += Penalty.phis(line) * this.weight(PenaltyKey.PHI);
+            total += Penalty.ifs(line) * this.weight(PenaltyKey.IF);
             total += this.overflow(line) * this.weight(PenaltyKey.EXCESS);
         }
         return total;
@@ -175,5 +179,40 @@ final class Penalty {
             }
         }
         return count;
+    }
+
+    /**
+     * Count {@code if} attributes dispatched in suffix position
+     * ({@code foo.if}) in a line.
+     *
+     * <p>Only the suffix form {@code .if}, taken as a whole word (followed by
+     * a non-identifier character or the end of the line), is counted. The
+     * prefix form {@code if.} never begins with a dot, so it stays free, and
+     * longer names such as {@code .iffy} are left untouched.</p>
+     *
+     * @param line The line
+     * @return The number of suffix {@code if} attributes
+     */
+    private static int ifs(final String line) {
+        int count = 0;
+        final String needle = ".if";
+        int idx = line.indexOf(needle);
+        while (idx >= 0) {
+            final int after = idx + needle.length();
+            if (after >= line.length() || !Penalty.identifier(line.charAt(after))) {
+                ++count;
+            }
+            idx = line.indexOf(needle, idx + 1);
+        }
+        return count;
+    }
+
+    /**
+     * Is this character allowed inside an EO identifier?
+     * @param chr The character
+     * @return TRUE if it continues an identifier
+     */
+    private static boolean identifier(final char chr) {
+        return Character.isLetterOrDigit(chr) || chr == '-' || chr == '_';
     }
 }

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -15,7 +15,7 @@ package org.eolang.printer;
  * one aesthetic is no longer baked into the tool.</p>
  *
  * @since 0.57.0
- * @checkstyle MagicNumberCheck (40 lines)
+ * @checkstyle MagicNumberCheck (50 lines)
  */
 public enum PenaltyKey {
 
@@ -33,6 +33,12 @@ public enum PenaltyKey {
      * Points charged for each explicit phi attribute {@code @} on a line.
      */
     PHI(15),
+
+    /**
+     * Points charged for each {@code if} emitted as a suffix attribute
+     * ({@code foo.if}), to keep {@code if} in prefix form ({@code if. foo}).
+     */
+    IF(50),
 
     /**
      * Points charged for each character past {@link #WIDTH}.

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -36,43 +36,21 @@ final class PenaltyTest {
         );
     }
 
-    @Test
-    void chargesForPhi() {
-        MatcherAssert.assertThat(
-            "Two explicit phi attributes on one line should cost thirty points",
-            new Penalty("@.eq @").points(),
-            Matchers.equalTo(30)
-        );
-    }
-
-    @Test
-    void chargesForSuffixIf() {
-        MatcherAssert.assertThat(
-            "A suffix if dispatch should cost fifty points",
-            new Penalty("foo.if a b c").points(),
-            Matchers.equalTo(50)
-        );
-    }
-
-    @Test
-    void chargesNothingForPrefixIf() {
-        MatcherAssert.assertThat(
-            "A prefix if dispatch should be free",
-            new Penalty("if. foo a b c").points(),
-            Matchers.equalTo(0)
-        );
-    }
-
     @ParameterizedTest
     @CsvSource({
+        "'@.eq @', 30",
+        "'foo.if a b c', 50",
+        "'if. foo a b c', 0",
         "'foo.iffy a b', 0",
-        "'foo.if a b', 50",
         "'foo.if', 50",
         "'x.if.gt y', 50"
     })
-    void chargesForSuffixIfAsWholeWord(final String code, final int points) {
+    void chargesForLineAttributes(final String code, final int points) {
         MatcherAssert.assertThat(
-            String.format("The if suffix in %s should cost %d points", code, points),
+            String.format(
+                "The line attributes in %s should cost %d points, phi and suffix if charged",
+                code, points
+            ),
             new Penalty(code).points(),
             Matchers.equalTo(points)
         );

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -45,6 +45,39 @@ final class PenaltyTest {
         );
     }
 
+    @Test
+    void chargesForSuffixIf() {
+        MatcherAssert.assertThat(
+            "A suffix if dispatch should cost fifty points",
+            new Penalty("foo.if a b c").points(),
+            Matchers.equalTo(50)
+        );
+    }
+
+    @Test
+    void chargesNothingForPrefixIf() {
+        MatcherAssert.assertThat(
+            "A prefix if dispatch should be free",
+            new Penalty("if. foo a b c").points(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'foo.iffy a b', 0",
+        "'foo.if a b', 50",
+        "'foo.if', 50",
+        "'x.if.gt y', 50"
+    })
+    void chargesForSuffixIfAsWholeWord(final String code, final int points) {
+        MatcherAssert.assertThat(
+            String.format("The if suffix in %s should cost %d points", code, points),
+            new Penalty(code).points(),
+            Matchers.equalTo(points)
+        );
+    }
+
     @ParameterizedTest
     @CsvSource({
         "'42.gt (bar.hello 88) > [] > foo', 7",

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
@@ -6,11 +6,14 @@
 # single line when it fits: each dispatch folds its compound comparison
 # receiver into suffix position ("(x.lt 0).if ..."), the inner one inlines in
 # parentheses as an argument of the outer, and the whole expression collapses
-# through the inline-phi form into the formation's head (#5650).
+# through the inline-phi form into the formation's head (#5650). The suffix
+# "if" penalty (#5665) is disabled here (IF: 0) so the suffix fold is still
+# chosen and the collapse can be demonstrated.
 penalties:
   INDENT: 3
   BRACKET: 7
   EXCESS: 1
+  IF: 0
   WIDTH: 80
   STEP: 2
 origin: |

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
@@ -2,18 +2,16 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# A chain of nested "if." dispatches written vertically packs back onto a
-# single line when it fits: each dispatch folds its compound comparison
-# receiver into suffix position ("(x.lt 0).if ..."), the inner one inlines in
-# parentheses as an argument of the outer, and the whole expression collapses
-# through the inline-phi form into the formation's head (#5650). The suffix
-# "if" penalty (#5665) is disabled here (IF: 0) so the suffix fold is still
-# chosen and the collapse can be demonstrated.
+# A chain of nested "if" dispatches stays in prefix form ("if. ..."): even
+# though the compound comparison receivers could fold into suffix position and
+# collapse the whole expression onto a single line (#5650), the suffix "if"
+# penalty (#5665) makes prefix notation cheaper, so "if" is never dispatched
+# after its object. The inner "if" still inlines its arguments on one line, but
+# in prefix form.
 penalties:
   INDENT: 3
   BRACKET: 7
   EXCESS: 1
-  IF: 0
   WIDTH: 80
   STEP: 2
 origin: |
@@ -27,4 +25,8 @@ origin: |
         "positive"
 
 printed: |
-  (x.lt 0).if "negative" ((x.eq 0).if "zero" "positive") > [x] > classify
+  [x] > classify
+    if. > @
+      x.lt 0
+      "negative"
+      if. (x.eq 0) "zero" "positive"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-idiom.yaml
@@ -24,7 +24,8 @@ printed: |
   seq > [] > foo
     *
       bar.deleted
-      (outcome.eq 0).if
+      if.
+        outcome.eq 0
         ^
         T
           "Cant delete '%s': %s".printf

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -41,4 +41,4 @@ printed: |
     if. > [tup] > reclast
       tup.length.eq 0
       -1
-      (tup.head.eq wanted).if tup.tail.length (reclast tup.tail)
+      if. (tup.head.eq wanted) tup.tail.length (reclast tup.tail)


### PR DESCRIPTION
Closes #5665.

The pretty-printer scored suffix dispatch (`foo.if a b c`) and prefix dispatch (`if. foo a b c`) of the `if` attribute identically, because `Penalty.points()` had no term distinguishing them. Purely for aesthetics, `if` reads best in prefix form.

## Changes

- **`PenaltyKey.java`**: added an `IF(50)` key alongside `PHI(15)`, and bumped the `@checkstyle MagicNumberCheck` line hint.
- **`Penalty.java`**: added one accumulation line in `points()` — `total += Penalty.ifs(line) * this.weight(PenaltyKey.IF);` — backed by a new static `ifs(String line)` counter that tallies `if` as a whole-word suffix attribute (`.if` followed by a non-identifier character or line end), mirroring the existing `phis(String line)` counter. A small `identifier(char)` helper defines identifier-continuation characters. Class javadoc updated to describe the new component.
- **`PenaltyTest.java`**: added tests covering the suffix penalty (`foo.if` → 50), the free prefix form (`if. foo` → 0), and whole-word matching (`foo.iffy` → 0, `x.if.gt` → 50).

With this term, `foo.if a b c` costs 50 points while `if. foo a b c` costs zero, so the layout search always keeps `if` in prefix notation. The prefix form `if.` never contains `.if`, so it stays free.

## How to test

```
mvn -pl eo-printer test -Dtest=PenaltyTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McMpo6svFGFYVv4rj5rrH5)_