### PR TITLE
fix(#5631): guard null regex capture groups in matched-from-index

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -120,7 +120,8 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
         if (matcher.groupCount() > 0) {
             groups = new Phi[matcher.groupCount() + 1];
             for (int idx = 0; idx < groups.length; ++idx) {
-                groups[idx] = new Data.ToPhi(matcher.group(idx));
+                final String captured = matcher.group(idx);
+                groups[idx] = new Data.ToPhi(captured == null ? "" : captured);
             }
         } else {
             groups = new Phi[]{new Data.ToPhi(matcher.group())};

--- a/eo-runtime/src/test/java/org/eolang/EO_string/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/RegexAtomTest.java
@@ -110,6 +110,27 @@ final class RegexAtomTest {
     }
 
     @Test
+    void readsFromWhenOptionalGroupDoesNotParticipate() {
+        MatcherAssert.assertThat(
+            "match with a non-participating optional group must not crash when reading from",
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        new PhApplication(
+                            Phi.Φ.take("string.regex").copy(),
+                            "expression", new Data.ToPhi("/(a)(b)?/")
+                        ).take("compiled").take("match").copy(),
+                        "txt", new Data.ToPhi("a")
+                    ).take("matched-from-index").copy(),
+                    new Bind(RegexAtomTest.position(), new Data.ToPhi(1)),
+                    new Bind(RegexAtomTest.start(), new Data.ToPhi(0))
+                ).take("from")
+            ).asNumber(),
+            Matchers.equalTo(0.0)
+        );
+    }
+
+    @Test
     void rejectsStartIndexAfterTextEnd() {
         MatcherAssert.assertThat(
             String.format(

--- a/eo-runtime/src/test/java/org/eolang/EO_string/RegexAtomTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/RegexAtomTest.java
@@ -111,22 +111,26 @@ final class RegexAtomTest {
 
     @Test
     void readsFromWhenOptionalGroupDoesNotParticipate() {
+        final Phi matched = RegexAtomTest.optionalGroupMatch();
         MatcherAssert.assertThat(
             "match with a non-participating optional group must not crash when reading from",
+            new Dataized(matched.take("from")).asNumber(),
+            Matchers.equalTo(0.0)
+        );
+        MatcherAssert.assertThat(
+            "non-participating optional capture must be an empty string, not absent",
             new Dataized(
                 new PhApplication(
-                    new PhApplication(
-                        new PhApplication(
-                            Phi.Φ.take("string.regex").copy(),
-                            "expression", new Data.ToPhi("/(a)(b)?/")
-                        ).take("compiled").take("match").copy(),
-                        "txt", new Data.ToPhi("a")
-                    ).take("matched-from-index").copy(),
-                    new Bind(RegexAtomTest.position(), new Data.ToPhi(1)),
-                    new Bind(RegexAtomTest.start(), new Data.ToPhi(0))
-                ).take("from")
-            ).asNumber(),
-            Matchers.equalTo(0.0)
+                    matched.take("group").copy(),
+                    new Bind("index", new Data.ToPhi(2))
+                )
+            ).asString(),
+            Matchers.equalTo("")
+        );
+        MatcherAssert.assertThat(
+            "group slots must stay aligned with groupCount+1 even when a group does not participate",
+            new Dataized(matched.take("count")).asNumber(),
+            Matchers.equalTo(3.0)
         );
     }
 
@@ -142,6 +146,24 @@ final class RegexAtomTest {
                 Matchers.containsString(RegexAtomTest.start()),
                 Matchers.containsString("must be less than or equal to text length")
             )
+        );
+    }
+
+    /**
+     * Build matched-from-index for /(a)(b)?/ against "a".
+     * @return Matched block
+     */
+    private static Phi optionalGroupMatch() {
+        return new PhApplication(
+            new PhApplication(
+                new PhApplication(
+                    Phi.Φ.take("string.regex").copy(),
+                    "expression", new Data.ToPhi("/(a)(b)?/")
+                ).take("compiled").take("match").copy(),
+                "txt", new Data.ToPhi("a")
+            ).take("matched-from-index").copy(),
+            new Bind(RegexAtomTest.position(), new Data.ToPhi(1)),
+            new Bind(RegexAtomTest.start(), new Data.ToPhi(0))
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` when a regex match has a non-participating optional capturing group (e.g. `/(a)(b)?/` against `"a"`).
- In `EOregex$EOpattern$EOmatch$EOmatched_from_index.fill()`, map `Matcher.group(i) == null` to an empty string before wrapping with `Data.ToPhi`.
- Add regression test in `RegexAtomTest` that reads `.from` on such a match without crashing.

Fixes #5631.

## Test plan

- [x] `mvn -pl eo-runtime -am install -DskipTests` (Java 17)
- [x] `mvn -pl eo-runtime -Dtest=RegexAtomTest test` — **7/7 passed** (includes new `readsFromWhenOptionalGroupDoesNotParticipate`)

Made with [Cursor](https://cursor.com)