### PR TITLE
fix(#5630): count one printf argument per specifier with width/precision

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -162,3 +162,24 @@
       printf
         "%f"
         * 0.0
+
+  ++> formats-float-with-precision
+    eq. > @
+      "3.14"
+      printf
+        "%.2f"
+        * 3.14159
+
+  ++> formats-integer-with-width
+    eq. > @
+      "   42"
+      printf
+        "%5d"
+        * 42
+
+  ++> formats-string-left-justified-with-width
+    eq. > @
+      "x         "
+      printf
+        "%-10s"
+        * "x"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -85,7 +85,9 @@ final class PrintfArgs {
 
     List<Object> formatted() {
         final List<Object> arguments = new ArrayList<>(0);
-        final Matcher matcher = Pattern.compile("%(\\d+\\$)?([a-zA-Z%])").matcher(this.format);
+        final Matcher matcher = Pattern.compile(
+            "%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])"
+        ).matcher(this.format);
         long auto = 0L;
         while (matcher.find()) {
             final String positional = matcher.group(1);

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -86,7 +86,7 @@ final class PrintfArgs {
     List<Object> formatted() {
         final List<Object> arguments = new ArrayList<>(0);
         final Matcher matcher = Pattern.compile(
-            "%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])"
+            "%(\\d+\\$)?[-#+ 0,(]*+\\d*+(?:\\.\\d+)?+([a-zA-Z%])"
         ).matcher(this.format);
         long auto = 0L;
         while (matcher.find()) {

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -106,6 +106,18 @@ final class PrintfArgsTest {
     }
 
     @Test
+    void countsOneArgumentPerSpecifierWithWidthAndPrecision() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(3.14159));
+        MatcherAssert.assertThat(
+            "a specifier carrying precision must still consume exactly one argument",
+            new PrintfArgs("%.2f", 1L, tuple.take("at")).formatted(),
+            Matchers.equalTo(new ListOf<>(3.14159))
+        );
+    }
+
+    @Test
     void reportsUnsupportedFormatMessageInsteadOfDoubleFormatting() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -109,11 +109,11 @@ final class PrintfArgsTest {
     void countsOneArgumentPerSpecifierWithWidthAndPrecision() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(3.14159));
+        tuple.put("head", new Data.ToPhi(3.141_59));
         MatcherAssert.assertThat(
             "a specifier carrying precision must still consume exactly one argument",
             new PrintfArgs("%.2f", 1L, tuple.take("at")).formatted(),
-            Matchers.equalTo(new ListOf<>(3.14159))
+            Matchers.equalTo(new ListOf<>(3.141_59))
         );
     }
 


### PR DESCRIPTION
Closes #5630

## What
`PrintfArgs.formatted()` enumerated format specifiers with `Pattern.compile("%(\\d+\\$)?([a-zA-Z%])")`, which matches only a bare conversion char (optionally positional). A specifier carrying flags, width or precision — `%5d`, `%.2f`, `%-10s`, `%05d`, `%+d`, `%,d` — was not matched, so no argument got collected for it while the specifier stayed in the format handed to `String.format`. The argument list ended up shorter than the format demanded, so a raw `java.util.MissingFormatArgumentException` escaped instead of a proper result.

## Fix
Widen the collector regex to skip the flags/width/precision portion of the conversion grammar while keeping the conversion char as capture group 2:

```java
Pattern.compile("%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])")
```

One argument is now counted per real specifier, and `String.format` performs the actual width/precision formatting (already worked once the argument was supplied).

## Tests
- `PrintfArgsTest#countsOneArgumentPerSpecifierWithWidthAndPrecision` — reproduces the bug directly against `PrintfArgs` (fails on `master`, passes with the fix).
- `printf.eo`: `formats-float-with-precision` (`%.2f`), `formats-integer-with-width` (`%5d`), `formats-string-left-justified-with-width` (`%-10s`) — end-to-end regression via `printf`.

```
mvn -pl eo-runtime test -Dtest=PrintfArgsTest,EOprintfTest
Tests run: 7, Failures: 0, Errors: 0 -- PrintfArgsTest
Tests run: 25, Failures: 0, Errors: 0 -- EOprintfTest
```