### PR TITLE
Count printf specifiers carrying width, precision or flags

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -154,3 +154,21 @@
     printf *1
       "%f"
       0
+
+  eq. ++> formats-width-with-leading-spaces
+    "   42"
+    printf *1
+      "%5d"
+      42
+
+  eq. ++> formats-precision-to-two-decimals
+    "3.14"
+    printf *1
+      "%.2f"
+      3.1415
+
+  eq. ++> formats-left-justified-with-trailing-spaces
+    "x         "
+    printf *1
+      "%-10s"
+      "x"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -45,10 +45,11 @@ final class PrintfArgs {
      * character. Skipping the flags, width and precision keeps exactly one
      * argument counted per specifier such as {@code %5d}, {@code %.2f} or
      * {@code %-10s}, matching what {@code String.format} consumes on the
-     * formatting side.
+     * formatting side. Possessive quantifiers keep the scan linear in the
+     * length of the format string, with no backtracking.
      */
     private static final Pattern SPECIFIER = Pattern.compile(
-        "%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])"
+        "%(\\d++\\$)?+[-#+ 0,(]*+\\d*+(?:\\.\\d++)?+([a-zA-Z%])"
     );
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -39,6 +39,19 @@ final class PrintfArgs {
     private static final char PERCENT = '%';
 
     /**
+     * A single {@code printf} specifier. Group 1 is the optional {@code N$}
+     * positional index; an optional run of flags, an optional width and an
+     * optional {@code .precision} are then skipped; group 2 is the conversion
+     * character. Skipping the flags, width and precision keeps exactly one
+     * argument counted per specifier such as {@code %5d}, {@code %.2f} or
+     * {@code %-10s}, matching what {@code String.format} consumes on the
+     * formatting side.
+     */
+    private static final Pattern SPECIFIER = Pattern.compile(
+        "%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])"
+    );
+
+    /**
      * One past the largest {@code double} that still narrows to a valid
      * {@code long} without saturating: {@code 2^63}, exactly one ulp above
      * {@link Long#MAX_VALUE}. {@code (double) Long.MAX_VALUE} itself rounds
@@ -85,7 +98,7 @@ final class PrintfArgs {
 
     List<Object> formatted() {
         final List<Object> arguments = new ArrayList<>(0);
-        final Matcher matcher = Pattern.compile("%(\\d+\\$)?([a-zA-Z%])").matcher(this.format);
+        final Matcher matcher = PrintfArgs.SPECIFIER.matcher(this.format);
         long auto = 0L;
         while (matcher.find()) {
             final String positional = matcher.group(1);

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -120,4 +120,40 @@ final class PrintfArgsTest {
             Matchers.containsString("is unsupported")
         );
     }
+
+    @Test
+    void collectsArgumentForWidthSpecifier() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(42.0));
+        MatcherAssert.assertThat(
+            "a specifier with an explicit width, like %5d, must still collect its argument",
+            new PrintfArgs("%5d", 1L, tuple.take("at")).formatted(),
+            Matchers.equalTo(new ListOf<>(42L))
+        );
+    }
+
+    @Test
+    void collectsArgumentForPrecisionSpecifier() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(3.14159));
+        MatcherAssert.assertThat(
+            "a specifier with a precision, like %.2f, must still collect its argument",
+            new PrintfArgs("%.2f", 1L, tuple.take("at")).formatted(),
+            Matchers.equalTo(new ListOf<>(3.14159))
+        );
+    }
+
+    @Test
+    void collectsArgumentForFlaggedAndWidthSpecifier() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi("x"));
+        MatcherAssert.assertThat(
+            "a specifier with a flag and width, like %-10s, must still collect its argument",
+            new PrintfArgs("%-10s", 1L, tuple.take("at")).formatted(),
+            Matchers.equalTo(new ListOf<>("x"))
+        );
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -137,11 +137,11 @@ final class PrintfArgsTest {
     void collectsArgumentForPrecisionSpecifier() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(3.14159));
+        tuple.put("head", new Data.ToPhi(3.141_59));
         MatcherAssert.assertThat(
             "a specifier with a precision, like %.2f, must still collect its argument",
             new PrintfArgs("%.2f", 1L, tuple.take("at")).formatted(),
-            Matchers.equalTo(new ListOf<>(3.14159))
+            Matchers.equalTo(new ListOf<>(3.141_59))
         );
     }
 


### PR DESCRIPTION
## What & why

`EOprintf.lambda()` hands the format string to `String.format(Locale.US, ...)`, which honours width, precision and flags. But the argument collector `PrintfArgs.formatted()` enumerated specifiers with `Pattern.compile("%(\\d+\\$)?([a-zA-Z%])")`, matching only a bare conversion char (optionally positional). A specifier carrying flags, width or precision — `%5d`, `%.2f`, `%-10s`, `%05d`, `%+d`, `%,d` — was not matched, so **no argument was collected for it**, while the specifier itself stayed in the format. The argument list ended up shorter than the format demanded and a raw `java.util.MissingFormatArgumentException` escaped instead of a formatted value.

## Fix

Widen the collector regex to skip the flags/width/precision portion of the Java conversion grammar, keeping the conversion char as group 2 (option 1 in the issue):

```java
Pattern.compile("%(\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])")
```

One argument is now counted per real specifier and `String.format` performs the width/precision formatting it already supported. `group(2)` stays the conversion char, so no other code changed. Bare `%s`/`%d`/`%f`, positional `%1$s`/`%12$s`, and `%%` are unaffected. The pattern is compiled once into a documented `private static final` constant.

## Tests

- `PrintfArgsTest`: `formatted()` now collects exactly one argument for `%5d`, `%.2f` and `%-10s`.
- `printf.eo`: end-to-end `%5d` → `"   42"`, `%.2f` → `"3.14"`, `%-10s` → `"x         "`, each producing a defined string instead of a raw `MissingFormatArgumentException`.

Fixes #5630
