### PR TITLE
#5634: compare map keys by bytes, not only by hash code

### DIFF
--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -1,8 +1,14 @@
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.
 # The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
+# Two keys are the same only when their hash codes and their raw bytes are equal.
+# A hash code alone is not enough, since `tuple.hash-code` is a `31 * acc + byte`
+# polynomial and therefore has collisions, e.g. `"Aa"` and `"BB"` both hash to 2112.
+# Comparing hash codes only would make such distinct keys overwrite each other.
+# Every key is dataized to bytes exactly once, when the map is built, and the
+# hash code is derived from those bytes rather than from the key itself,
+# so that keys with side effects are never evaluated more than once.
 
-+alias tuple.contains
 +alias tuple.filtered
 +alias tuple.hash-code
 +alias tuple.mapped
@@ -21,26 +27,31 @@
       if.
         pairs.length.eq 0
         *
-        entries.
+        @.
           rec-rebuild pairs
-    [entries hashes] > couple
     [tup] > rec-rebuild
       if. > @
         tup.length.eq 0
-        couple
-          *
-          *
+        *
         if.
-          tuple.contains prev.hashes hash
+          has-key prev
           prev
-          couple
-            prev.entries.with
-              [] >>
-                ^.hash > hash
-                tup.head.key > key
-                tup.head.value > value
-            prev.hashes.with hash
-      tuple.hash-code tup.head.key > hash!
+          prev.with
+            [] >>
+              ^.hash > hash
+              ^.kbts > kbts
+              tup.head.key > key
+              tup.head.value > value
+      tuple.hash-code kbts > hash!
+      tup.head.key.as-bytes > kbts!
+      if. > [ent] > has-key
+        ent.length.eq 0
+        false
+        if.
+          (ent.head.hash.eq hash).and
+            ent.head.kbts.eq kbts
+          true
+          has-key ent.tail
       @. > prev
         rec-rebuild tup.tail
   [key value] > entry
@@ -50,7 +61,8 @@
         size.eq 0
         not-found
         rec-key-search entries
-      tuple.hash-code key > hash!
+      tuple.hash-code kbts > hash!
+      key.as-bytes > kbts!
       [tup] > rec-key-search
         if. > @
           tup.length.eq 0
@@ -58,7 +70,8 @@
           prev.exists.if
             prev
             if.
-              tup.head.hash.eq hash
+              (tup.head.hash.eq hash).and
+                tup.head.kbts.eq kbts
               [] >>
                 true > exists
                 tup.head.value > [cant-get] > get
@@ -83,18 +96,27 @@
         with.
           tuple.filtered
             entries
-            (hash.eq entry.hash).not > [entry] >>
+            [entry] >>
+              not. > @
+                (hash.eq entry.hash).and
+                  kbts.eq entry.kbts
           [] >>
             ^.hash > hash
+            ^.kbts > kbts
             ^.key > key
             ^.value > value
-      tuple.hash-code key > hash!
+      tuple.hash-code kbts > hash!
+      key.as-bytes > kbts!
     [key] > without
       map.initialized > @
         tuple.filtered
           entries
-          (hash.eq entry.hash).not > [entry] >>
-      tuple.hash-code key > hash!
+          [entry] >>
+            not. > @
+              (hash.eq entry.hash).and
+                kbts.eq entry.kbts
+      tuple.hash-code kbts > hash!
+      key.as-bytes > kbts!
 
   ++> tests-map-rebuilds-itself
     2.eq mp.size > @
@@ -213,6 +235,59 @@
         map.entry "two" 2
       "two"
       3
+
+  ++> tests-keeps-both-keys-with-colliding-hash-codes
+    2.eq mp.size > @
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+
+  ++> tests-finds-value-of-each-key-with-colliding-hash-codes
+    and. > @
+      1.eq first.get
+      2.eq second.get
+    mp.found "Aa" > first
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+    mp.found "BB" > second
+
+  ++> tests-does-not-have-absent-key-colliding-with-stored-one
+    not. > @
+      has.
+        map *
+          map.entry "Aa" 1
+        "BB"
+
+  ++> tests-falls-back-for-absent-key-colliding-with-stored-one
+    "recovered".eq > @
+      get.
+        found.
+          map *
+            map.entry "Aa" 1
+          "BB"
+        "recovered" > [msg]
+
+  ++> tests-adds-key-colliding-with-existing-one
+    and. > @
+      2.eq mp.size
+      2.eq
+        get.
+          mp.found "BB"
+    with. > mp
+      map *
+        map.entry "Aa" 1
+      "BB"
+      2
+
+  ++> tests-removes-only-the-given-key-of-colliding-ones
+    (mp.has "Aa").not.and > @
+      mp.has "BB"
+    without. > mp
+      map *
+        map.entry "Aa" 1
+        map.entry "BB" 2
+      "Aa"
 
   ++> tests-map-get-missing-returns-provided-fallback
     "recovered".eq > @


### PR DESCRIPTION
Closes #5634.

`map` identified entries by their **hash code alone and never compared the actual keys**, in `rec-rebuild` (dedup on rebuild), `found`/`rec-key-search` (lookup), `with` and `without` (filtering). `tuple.hash-code` is a `31 * acc + byte` polynomial, so collisions are trivial to hit: `"Aa"` and `"BB"` both hash to `31*65 + 97 == 31*66 + 66 == 2112`. Two distinct keys that collide were therefore treated as one key — one entry was silently dropped when the map was built, and looking up the other key returned the wrong value while reporting `exists` as `true`.

Every key comparison now also compares the raw bytes of the key, so a hash match only narrows the candidates and byte equality confirms the hit.

The tricky part is that `tests-map-rebuilds-itself-only-once` requires each key to be dataized exactly once, so simply calling `key.as-bytes` at every comparison would have broken that guarantee. Instead each key is dataized to bytes once, when the map is built, the bytes are stored in the entry next to the hash code, and the hash code is now derived from those bytes rather than from the key object. Since `bytes.as-bytes` returns the very same chain of bytes, `tuple.hash-code` no longer touches the key, and the total number of key dataizations is unchanged.

The `hashes` tuple and the `couple` object are gone: duplicates are now detected by scanning the accumulated entries directly, so the `tuple.contains` alias is no longer needed either.

`set` is built on top of `map` (`mp.with`/`without`/`has`/`keys`), so it inherited the same defect and is fixed by this change as well.

Six examples were added to `map.eo`. Verified locally that all six fail against the current `master` logic and pass with this change:

| example | on `master` | with this change |
| --- | --- | --- |
| `tests-keeps-both-keys-with-colliding-hash-codes` | `size` is 1 | `size` is 2 |
| `tests-finds-value-of-each-key-with-colliding-hash-codes` | `"BB"` yields `1` | `"Aa"` yields `1`, `"BB"` yields `2` |
| `tests-does-not-have-absent-key-colliding-with-stored-one` | `has "BB"` is `true` | `false` |
| `tests-falls-back-for-absent-key-colliding-with-stored-one` | returns `"Aa"`'s value | returns the fallback |
| `tests-adds-key-colliding-with-existing-one` | `with` replaces instead of adding | both keys kept |
| `tests-removes-only-the-given-key-of-colliding-ones` | `without "Aa"` drops `"BB"` too | only `"Aa"` removed |

`EOmapTest` is 20/20 green and the full `eo-runtime` suite is 1628 tests with no new failures. The only failure, `EOsocketTest.refusesConnectionViaSyscall`, reproduces identically on an unmodified `master` on this machine and is unrelated to this change. The change introduces no new lint warnings: the two reported for `map.eo` are present on `master` as well.
