### PR TITLE
Guard inline-cactoos against self-referential abstracts (#5677)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="inline-cactoos" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" id="inline-cactoos" version="2.0">
   <!--
   Converts such EO code:
   [] > foo
@@ -22,15 +22,30 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:variable name="auto" select="concat('a', $eo:cactoos)"/>
   <!--
+  A reference resolves to its own auto-name: given a base such as
+  `ξ.ρ.a🌵4-2`, everything up to the cactus prefix is stripped, so the
+  resolved name is the trailing `a🌵4-2`. This mirrors the `$name`
+  computation in the inlining template below.
+  -->
+  <xsl:function name="eo:resolved-name" as="xs:string">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:sequence select="substring-after($base, substring-before($base, $auto))"/>
+  </xsl:function>
+  <!--
   Inline a reference to an auto-named abstract. A `? >> name` void
   (R-3.4.7 / R-3.10.12) also has a cactus name, so a reference that
-  resolves to a void (or to nothing) is left untouched.
+  resolves to a void (or to nothing) is left untouched. A recursive
+  helper (`? >> rec` whose body calls `rec` again) compiles to an
+  auto-named abstract that references its own name; inlining it would
+  copy that self-reference back in and fire this template forever, so
+  such a target is also left untouched (both the reference and the
+  abstraction stay in place).
   -->
   <xsl:template match="o[contains(@base, concat('.', $auto))]" priority="0">
-    <xsl:variable name="name" select="substring-after(@base, substring-before(@base, $auto))"/>
+    <xsl:variable name="name" select="eo:resolved-name(@base)"/>
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:choose>
-      <xsl:when test="exists($target) and not(eo:void($target))">
+      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name))">
         <xsl:element name="o">
           <xsl:if test="@as">
             <xsl:apply-templates select="@as"/>
@@ -46,10 +61,27 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-  <!-- Drop an inlined auto-named abstract; keep cactus-named voids. -->
+  <!--
+  Drop an inlined auto-named abstract; keep cactus-named voids and
+  keep self-referential (recursive) abstracts, which are never inlined.
+  -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <!-- Nothing here -->
+    <xsl:if test="eo:recursive(., @name)">
+      <xsl:copy>
+        <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:if>
   </xsl:template>
+  <!--
+  Whether the auto-named abstract `$target` transitively references its
+  own name `$name`, i.e. its subtree holds a reference that resolves
+  back to `$name`. Such an abstract is recursive and must not be inlined.
+  -->
+  <xsl:function name="eo:recursive" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+  </xsl:function>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-recursive.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-recursive.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A recursive helper declared with a cactus name (`? >> rec`, whose body
+# calls `rec` again) compiles to an auto-named abstract that references its
+# own name. Inlining it used to copy that self-reference back in and fire
+# the "inline-cactoos" template forever (see issue #5677). The guard leaves
+# both the reference and the self-referential abstraction in place instead.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The self-referential abstraction is not dropped: it keeps its cactus
+  # name and its file-local handle.
+  - /object/o[@name='foo']/o[@name='a🌵4-2' and @local='reclast' and not(@base)]
+  # The self-reference inside its body is left intact (the recursion stays).
+  - /object/o[@name='foo']/o[@name='a🌵4-2']//o[contains(@base, 'a🌵4-2')]
+  # The outer reference to it is not inlined: it is still a reference (carries
+  # a cactus @base) and still holds its own `list` argument, rather than being
+  # replaced by a copy of the abstraction's body.
+  - /object/o[@name='foo']/o[contains(@base, 'a🌵4-2')]/o[contains(@base, 'list')]
+input: |
+  [] > foo
+    reclast > @
+      list
+    if. > [tup] >> reclast
+      tup.length.eq 0
+      -1
+      reclast tup.tail


### PR DESCRIPTION
Closes #5677.

## Problem

The `inline-cactoos` printer pass (`eo-printer/.../print/inline-cactoos.xsl`) inlined a reference to a cactus-named (`a🌵…`) abstraction by unconditionally copying the target's body. When that abstraction referenced itself — a recursive helper written as `? >> rec` whose body calls `rec` again — the copied body still held the self-reference, so the same template fired on it again, without bound. Saxon aborted with:

```
Too many nested apply-templates calls. Possible infinite recursion.
```

and the `format` goal (`MjFormat`) failed the whole build. A recursive helper is legal EO, so the printer should not crash on it. The defect was specific to the cactus-named (`>>`) variant; the same recursion written with a plain name (`> rec`) prints fine.

## Fix

Guard the `o[contains(@base, concat('.', $auto))]` inlining template so it inlines only when the target does **not** transitively reference its own name. When the target's subtree contains a reference that resolves back to `$name`, the template now falls through to the copy branch and leaves the reference in place. The companion "drop the inlined abstract" template is likewise guarded so a self-referential abstraction is kept rather than removed. Both the reference and the abstraction therefore stay in place instead of being expanded.

The self-reference check is factored into two small `eo:` functions (`eo:resolved-name`, `eo:recursive`), and the existing `$name` computation now reuses `eo:resolved-name` so the reference-resolution logic lives in one place.

## Test

Added `eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-recursive.yaml`, an XMIR-level pack that runs the full parser pipeline followed by `inline-cactoos` on a recursive `? >> reclast` helper and asserts that the abstraction, its self-reference, and the outer reference are all left in place (no infinite recursion). All 119 `XmirTest` packs and the full `eo-printer` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvUCazUDqTkQ3WiBtr68HU)_