### PR TITLE
Move bytes-as-input to bytes package as to-input

### DIFF
--- a/eo-runtime/src/main/eo/bytes/to-input.eo
+++ b/eo-runtime/src/main/eo/bytes/to-input.eo
@@ -3,7 +3,7 @@
 # via `as-bytes`.
 # Here's how you can read portions of bytes from the input:
 # ```
-# bytes-as-input > i
+# to-input > i
 #   01-02-03-04-05-06-07-08-F5-F6
 # seq > @
 #   *
@@ -23,12 +23,12 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package bytes
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts] > bytes-as-input
+[bts] > to-input
   [size] > read
     @. > @
       read.
@@ -65,7 +65,7 @@
         i3.read 2
         --
     read. > i1
-      bytes-as-input 01-02-03-04-05-06-07-08-F5-F6
+      to-input 01-02-03-04-05-06-07-08-F5-F6
       4
     i1.read 4 > i2
     i2.read 4 > i3

--- a/eo-runtime/src/main/eo/io/copied.eo
+++ b/eo-runtime/src/main/eo/io/copied.eo
@@ -4,12 +4,13 @@
 # Example usage:
 # ```
 # copied > total-bytes
-#   bytes-as-input 01-02-03-04-05
+#   bytes.to-input 01-02-03-04-05
 #   malloc-as-output memory
 # ```
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
++alias bytes.to-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
@@ -29,7 +30,7 @@
         5
         seq * > [m]
           copied
-            bytes-as-input 01-02-03-04-05
+            bytes.to-input 01-02-03-04-05
             malloc-as-output m
           m
       01-02-03-04-05
@@ -39,7 +40,7 @@
       malloc.of
         10
         copied > [m]
-          bytes-as-input 01-02-03-04-05-06-07-08-09-10
+          bytes.to-input 01-02-03-04-05-06-07-08-09-10
           malloc-as-output m
       10
 
@@ -49,7 +50,7 @@
         0
         seq * > [m]
           copied
-            bytes-as-input --
+            bytes.to-input --
             malloc-as-output m
           m
       --
@@ -60,7 +61,7 @@
         0
         [m]
           copied > @
-            bytes-as-input --
+            bytes.to-input --
             malloc-as-output m
       0
 
@@ -69,7 +70,7 @@
       malloc.of
         20
         copied > [m]
-          bytes-as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+          bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
           malloc-as-output m
 
   ++> tests-handles-dead-input

--- a/eo-runtime/src/main/eo/io/input-as-bytes.eo
+++ b/eo-runtime/src/main/eo/io/input-as-bytes.eo
@@ -3,10 +3,11 @@
 # Example usage:
 # ```
 # input-as-bytes > bts
-#   bytes-as-input 01-02-03-04-05
+#   bytes.to-input 01-02-03-04-05
 # ```
 # After dataization, `bts` equals `01-02-03-04-05`.
 
++alias bytes.to-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
@@ -26,7 +27,7 @@
   ++> tests-bytes-to-input-and-back
     eq. > @
       input-as-bytes
-        bytes-as-input bts
+        bytes.to-input bts
       bts
     01-02-03-04-05-06-07-08 > bts
 

--- a/eo-runtime/src/main/eo/io/input-length.eo
+++ b/eo-runtime/src/main/eo/io/input-length.eo
@@ -1,5 +1,6 @@
 # Reads all the bytes from provided `input` and returns its length.
 
++alias bytes.to-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
@@ -22,7 +23,7 @@
 
   eq. ++> tests-reads-all-bytes-and-returns-length
     input-length
-      bytes-as-input 01-02-03-04-05-06-07-08-09-10
+      bytes.to-input 01-02-03-04-05-06-07-08-09-10
     10
 
   ++> tests-copies-all-bytes-to-output-and-returns-length
@@ -32,7 +33,7 @@
         seq * > [m]
           input-length
             tee-input
-              bytes-as-input 01-02-03-04-05-06-07-08-09-10
+              bytes.to-input 01-02-03-04-05-06-07-08-09-10
               malloc-as-output m
           m
       01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/main/eo/io/tee-input.eo
+++ b/eo-runtime/src/main/eo/io/tee-input.eo
@@ -7,13 +7,14 @@
 #   [m]
 #     read. > @
 #       tee-input
-#         bytes-as-input 01-02-03-04-05
+#         bytes.to-input 01-02-03-04-05
 #         malloc-as-output m
 #       5
 # ```
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
++alias bytes.to-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
@@ -44,7 +45,7 @@
         5
         read. > [mem]
           tee-input
-            bytes-as-input 01-02-03-04-05
+            bytes.to-input 01-02-03-04-05
             malloc-as-output mem
           5
       01-02-03-04-05
@@ -58,7 +59,7 @@
             read.
               read.
                 tee-input
-                  bytes-as-input 01-02-03-04-05
+                  bytes.to-input 01-02-03-04-05
                   malloc-as-output m
                 2
               2
@@ -77,7 +78,7 @@
               read.
                 tee-input
                   tee-input
-                    bytes-as-input 01-02-03-04-05
+                    bytes.to-input 01-02-03-04-05
                     malloc-as-output m2
                   malloc-as-output m1
                 5


### PR DESCRIPTION
A small step toward the uniform naming convention proposed in #5501.

## What changed

- Moved `eo-runtime/src/main/eo/io/bytes-as-input.eo` → `eo-runtime/src/main/eo/bytes/to-input.eo`.
- Renamed the object from `bytes-as-input` (in package `io`) to `to-input` (in package `bytes`).
- Updated the callers in the `io` package to reference it via `+alias bytes.to-input`:
  - `io/copied.eo`
  - `io/input-as-bytes.eo`
  - `io/input-length.eo`
  - `io/tee-input.eo`
- Updated docstring usage examples accordingly.

## Why

Per #5501, supplementary type-mapping objects should live alongside their target type and drop the redundant source-type prefix. `bytes-as-input` maps bytes into an `input`, so it belongs in the `bytes` package as `to-input`, referenced as `bytes.to-input` — matching the existing pattern where e.g. `string/regex.eo` (`+package string`) is consumed via `+alias string.regex`.

Refs #5501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014svxMDGjM8PbbiWQEuy72F)_