### PR TITLE
Preserve name of recursive `>> name` formations in printer (#5681)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -16,30 +16,64 @@
   "@local" marker is deliberately KEPT on the void (#5581) so that
   "to-eo-tree" can print it back as a vertical "? &gt;&gt; name" line and
   preserve the void's anonymity (§9.2, R-9.2.3), rather than collapsing it
-  into a public "[name]" bracket param. A non-void "&gt;&gt;" handle (on an
-  anonymous formation) is left to the existing "inline-cactoos" pass, so its
-  @local marker is simply dropped.
+  into a public "[name]" bracket param.
+
+  A non-void "&gt;&gt;" handle sits on an anonymous formation. Usually the
+  "inline-cactoos" pass inlines that formation away, so its handle is
+  irrelevant and the "@local" marker is simply dropped. A self-referential
+  (recursive) formation is the exception: since #5677 "inline-cactoos"
+  correctly keeps it in place, so it reaches "to-eo-tree" and must carry a
+  readable name. Using the same self-reference test as that guard, such a
+  formation is treated like a handled void here — its "@local" is promoted
+  to the visible "@name", its self-references are rewritten back to the
+  handle, and the marker is KEPT so "to-eo-tree" prints "&gt;&gt; name"
+  rather than an anonymous "&gt;&gt;" bound to references to a synthetic
+  "vL_P" placeholder.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="void-handle" match="o[@local and @base=$eo:empty]" use="@name"/>
+  <xsl:variable name="auto" select="concat('a', $eo:cactoos)"/>
   <!--
-  References: rewrite each cactus segment that names a handled void
-  back into the readable handle.
+  A reference resolves to its own auto-name: given a base such as
+  "ξ.ρ.a🌵4-2", everything up to the cactus prefix is stripped, so the
+  resolved name is the trailing "a🌵4-2". Mirrors "inline-cactoos".
+  -->
+  <xsl:function name="eo:resolved-name" as="xs:string">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:sequence select="substring-after($base, substring-before($base, $auto))"/>
+  </xsl:function>
+  <!--
+  Whether the auto-named abstract "$target" transitively references its
+  own name "$name", i.e. its subtree holds a reference that resolves back
+  to "$name". Such an abstract is recursive and is never inlined by
+  "inline-cactoos" (#5677), so its handle must be restored here.
+  -->
+  <xsl:function name="eo:recursive" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+  </xsl:function>
+  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
+  <!--
+  References: rewrite each cactus segment that names a handled void or a
+  recursive formation back into the readable handle.
   -->
   <xsl:template match="@base">
     <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then key('void-handle', $seg)[1]/@local else $seg), '.')"/>
   </xsl:template>
-  <!-- Void declaration: promote the handle to the visible name. -->
-  <xsl:template match="o[@local and @base=$eo:empty]/@name">
+  <!--
+  Handled declaration (void or recursive formation): promote the handle
+  to the visible name.
+  -->
+  <xsl:template match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]/@name">
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
-  Keep the marker on voids so "to-eo-tree" restores the readable
-  "? &gt;&gt; name" handle; drop it on non-void formations, whose
-  handle is inlined away by the "inline-cactoos" pass.
+  Keep the marker on voids and on recursive formations so "to-eo-tree"
+  restores the readable "&gt;&gt; name" handle; drop it on the other
+  non-void formations, whose handle is inlined away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty)]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name))]/@local"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -315,6 +315,17 @@
           </xsl:choose>
           <xsl:value-of select="substring(@name, 2)"/>
         </xsl:when>
+        <xsl:when test="@local">
+          <!--
+          A non-void formation declared with a file-local handle
+          ("&gt;&gt; name", R-3.10.12): a recursive helper kept in place by
+          "inline-cactoos" (#5677) whose "@local" marker "restore-local-names"
+          preserves (#5681). It is printed with its readable handle under the
+          double-arrow, not as an anonymous "&gt;&gt;".
+          -->
+          <xsl:text> &gt;&gt; </xsl:text>
+          <xsl:value-of select="@local"/>
+        </xsl:when>
         <xsl:when test="starts-with(@name, concat('a', $eo:cactoos))">
           <xsl:text> &gt;&gt;</xsl:text>
         </xsl:when>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-recursive-local-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-recursive-local-name.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A recursive helper declared with a file-local handle ("? >> rec", whose
+# body calls "rec" again) compiles to an auto-named abstract that references
+# its own name. Since #5677 the "inline-cactoos" pass keeps it in place, so
+# it reaches the printer and its name must survive. "restore-local-names"
+# treats such a self-referential formation like a handled void (#5681): it
+# promotes the "@local" handle to the visible "@name", rewrites the
+# self-references back to the handle, and keeps the "@local" marker so
+# "to-eo-tree" can print "&gt;&gt; name" instead of an anonymous
+# "&gt;&gt;" bound to synthetic "vL_P" references.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The self-referential formation keeps its readable handle: its cactus
+  # @name is promoted to the handle and the @local marker is preserved.
+  - /object/o[@name='foo']/o[@name='reclast' and @local='reclast' and not(@base)]
+  # Its self-reference is rewritten back to the handle, not a cactus name.
+  - /object/o[@name='foo']/o[@name='reclast']//o[contains(@base, 'reclast')]
+  # The outer reference to it is rewritten to the handle as well.
+  - /object/o[@name='foo']/o[contains(@base, 'reclast')]/o[contains(@base, 'list')]
+  # No synthetic cactus name for the formation survives anywhere.
+  - /object[not(.//o[contains(@name, '🌵') and @local='reclast'])]
+input: |
+  [] > foo
+    reclast > @
+      list
+    if. > [tup] >> reclast
+      tup.length.eq 0
+      -1
+      reclast tup.tail

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A recursive helper named with a file-local handle ("&gt;&gt; name",
+# R-3.10.12) whose body calls itself. Since #5677 the "inline-cactoos" pass
+# correctly keeps such a self-referential formation in place instead of
+# inlining it away, so it reaches the printer and its name must survive.
+# "restore-local-names" promotes the "@local" handle back to the visible
+# name and rewrites the self-references to it, and "to-eo-tree" prints the
+# handle under a double-arrow. Without the fix (#5681) the name is dropped:
+# the formation prints as an anonymous "[tup] &gt;&gt;" and its
+# self-references as the synthetic "v6_2" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package tuple
+
+  [] > last-index-of
+    ? >> list
+    ? >> wanted
+    reclast list > @
+    [tup] >> reclast
+      if. > @
+        tup.length.eq 0
+        -1
+        if.
+          tup.head.eq wanted
+          tup.tail.length
+          reclast tup.tail
+
+printed: |
+  +package tuple
+
+  [] > last-index-of
+    ? >> list
+    ? >> wanted
+    reclast list > @
+    if. > [tup] >> reclast
+      tup.length.eq 0
+      -1
+      if.
+        tup.head.eq wanted
+        tup.tail.length
+        reclast tup.tail


### PR DESCRIPTION
Fixes #5681.

## Problem

In the printer train, `restore-local-names.xsl` dropped the `@local` handle marker on every non-void `>>` formation, and its `void-handle` key matched voids only (`@base=∅`), so references to such a formation were never rewritten back to the readable handle. That was harmless while `inline-cactoos.xsl` always inlined the formation away, but the #5677 guard now correctly keeps a self-referential (recursive) formation in place.

Such a formation therefore reached `to-eo-tree.xsl` with its user name gone: the definition printed as an anonymous `[t] >>` and its self-references as the synthetic cactus placeholder `v15_2`. The result was also non-idempotent — `eo:format` never converged.

## Fix

- **`restore-local-names.xsl`**: stop treating a non-void `>>` handle as always-inlined. When the formation references itself — using the same self-reference test the #5677 guard added to `inline-cactoos.xsl` — it is now treated like a handled void: its `@local` is promoted to the visible `@name`, the `void-handle` key is extended to rewrite its self-references back to the handle, and the `@local` marker is kept instead of being dropped.
- **`to-eo-tree.xsl`**: a non-void formation carrying an `@local` handle is now printed with its readable name under a double-arrow (`>> name`) rather than as an anonymous `>>`.

## Tests

- `print-packs/yaml/recursive-local-handle.yaml` — end-to-end round-trip: a recursive helper declared with `[tup] >> reclast` now formats to `if. > [tup] >> reclast` (was `if. > [tup] >>` with `v6_2` references), and the printed form re-prints to itself (idempotent).
- `eo-packs/print/restore-recursive-local-name.yaml` — focused XSL-level assertions on `restore-local-names.xsl`: the handle is promoted to `@name`, the marker is kept, and both the self-reference and the outer reference are rewritten to the readable handle.

All 160 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WSJjXij3WwQ1dG7fYdjif

---
_Generated by [Claude Code](https://claude.ai/code/session_016WSJjXij3WwQ1dG7fYdjif)_