### PR TITLE
Preserve `|` pipe applications in printer (#5684)

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -33,10 +33,13 @@ import java.util.List;
  *
  * <p>Emission (R-3.14.7): the line emits a base-less {@code <o pipe=''>}
  * with the args as children; the {@code wrap-applications} reshape sets
- * {@code @base} from the preceding sibling's {@code @name} and drops
- * {@code @pipe}, so downstream passes treat it as a hand-written
- * application of the predecessor by name. The predecessor object stays in
- * place.</p>
+ * {@code @base} from the preceding sibling's {@code @name}, so downstream
+ * passes treat it as a hand-written application of the predecessor by
+ * name. The predecessor object stays in place. The {@code @pipe} marker
+ * itself is retained (not dropped) so the printer can round-trip the
+ * compact {@code | args > name} line rather than expand it into a
+ * two-line vertical application (#5684); it is a cosmetic hint that
+ * downstream passes and the compiler ignore.</p>
  *
  * @since 0.1
  */

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -156,6 +156,21 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="pipe" type="xs:string">
+      <xs:annotation>
+        <xs:appinfo>The marker of a pipe-application continuation line "| args &gt; name" (§3.14)</xs:appinfo>
+        <xs:documentation>
+          A cosmetic marker kept on the application node that a "|" pipe line
+          (R-3.14.7) parses into. The "wrap-applications" pass sets the node's
+          "base" to the preceding sibling's name so the semantics match a
+          hand-written application, but retains this marker so the printer can
+          round-trip the compact "| args &gt; name" continuation line instead
+          of expanding it into a two-line vertical application (#5684).
+          Downstream passes and the compiler read "base" and ignore this
+          marker.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="loc" type="locator"/>
     <xs:attribute name="atom" type="fqn">
       <xs:annotation>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
@@ -13,12 +13,19 @@
   <o base="Φ.number">5</o>
   </o>
 
-  We rewrite the @pipe node into an ordinary application whose @base
-  refers to the preceding sibling by its @name, and drop @pipe. The
-  preceding sibling (the formation, or a previous pipe) is left in
-  place, so `| 5 > foo5` after `[x] > foo` is identical in XMIR to
-  `foo 5 > foo5`. Chained pipes read the previous pipe's @name the same
-  way, building left-associated applications.
+  We rewrite the @pipe node into an application whose @base refers to
+  the preceding sibling by its @name. The preceding sibling (the
+  formation, or a previous pipe) is left in place, so `| 5 > foo5`
+  after `[x] > foo` is semantically identical to `foo 5 > foo5`.
+  Chained pipes read the previous pipe's @name the same way, building
+  left-associated applications.
+
+  The @pipe marker is KEPT on the application (it used to be dropped
+  here) so that the printer can round-trip the compact `| args > name`
+  continuation line instead of expanding it into a two-line vertical
+  application (#5684). It is a cosmetic hint only: downstream passes and
+  the compiler read @base for semantics and ignore @pipe, exactly as
+  they ignore the @local handle preserved for the same reason (#5681).
 
   When the pipe sits inside an argument block (its parent has a @base,
   so its siblings are collected as positional arguments), leaving the
@@ -34,7 +41,7 @@
       <xsl:attribute name="base">
         <xsl:value-of select="preceding-sibling::o[1]/@name"/>
       </xsl:attribute>
-      <xsl:apply-templates select="@* except @pipe"/>
+      <xsl:apply-templates select="@*"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/wrap-applications.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/wrap-applications.yaml
@@ -6,10 +6,9 @@ sheets:
   - /org/eolang/parser/parse/wrap-applications.xsl
 asserts:
   - /object[not(errors)]
-  - /object[not(//o[@pipe])]
-  - //o[@base='foo' and @name='foo5' and count(o)=1]
+  - //o[@base='foo' and @name='foo5' and @pipe='' and count(o)=1]
   - //o[@base='foo' and @name='foo5']/o[@base='Φ.number']
-  - //o[@name='foo' and not(@base)]
+  - //o[@name='foo' and not(@base) and not(@pipe)]
 input: |
   [] > app
     [x] > foo

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -190,6 +190,21 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+  <!-- PIPE APPLICATION (§3.14) -->
+  <!--
+  A "| args &gt; name" continuation line (R-3.14.7). The parser rewrote
+  it into an application of its same-indent predecessor, pointing @base
+  at that predecessor's name but keeping the @pipe marker (#5684). We
+  restore the compact "|" head only when that predecessor is still the
+  immediately preceding sibling, so the emitted pipe has a valid target
+  directly above it — the base then reads "ξ.&lt;name&gt;" (or the bare
+  "&lt;name&gt;" if reference resolution has not rooted it). When the
+  predecessor has floated away (#5526) the guard fails and the node
+  prints as an ordinary application, which round-trips just as safely.
+  -->
+  <xsl:template match="o[@pipe and (@base = concat($eo:xi, '.', preceding-sibling::o[1]/@name) or @base = preceding-sibling::o[1]/@name)]" mode="head" priority="2">
+    <xsl:text>|</xsl:text>
+  </xsl:template>
   <!-- BASED -->
   <xsl:template match="o[@base and not(eo:has-data(.))]" mode="head">
     <!--

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-floated.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-floated.yaml
@@ -11,11 +11,12 @@ penalties:
   SPACE: 7
 origin: |
   [] > app
-    [x] > foo
-      x.plus x > @
-    | 5 > foo5
-
+    and > result
+      [x] > bar
+        x > @
+      | 5 > baz
 printed: |
   [] > app
-    x.plus x > [x] > foo
-    | 5 > foo5
+    and baz > result
+    x > [x] > bar
+    | 5 > baz

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive.yaml
@@ -11,11 +11,10 @@ penalties:
   SPACE: 7
 origin: |
   [] > app
-    [x] > foo
-      x.plus x > @
-    | 5 > foo5
-
+    [t] >> rec
+      rec t > @
+    | list > @
 printed: |
   [] > app
-    x.plus x > [x] > foo
-    | 5 > foo5
+    rec t > [t] >> rec
+    | list > @


### PR DESCRIPTION
Fixes #5684.

## Problem

The printer never emitted the `|` pipe-application syntax (spec §3.14); it always expanded a pipe line into a two-line vertical application. Because both forms parse to identical XMIR, the compact author-written `|` was **write-only** — destroyed on the first `eo:format`.

The root cause: `wrap-applications.xsl` dropped the `@pipe` marker at parse time, rewriting the line into an ordinary application, so no trace of the pipe reached `to-eo-tree.xsl`, which had no pipe-emission branch.

## Fix

Mirrors the direction of #5681 (preserving compact `>> name` formations):

1. **`wrap-applications.xsl`** — retain the `@pipe` marker on the application node instead of stripping it. `@base` is still set from the preceding sibling's `@name` for semantics; `@pipe` is a cosmetic hint that downstream passes and the compiler ignore.
2. **`XMIR.xsd`** — declare the `pipe` attribute so the canonical XMIR validates.
3. **`to-eo-tree.xsl`** — add a head branch that emits `|` for a pipe node, **only when its predecessor is still the immediately preceding sibling** (`@base` matches `ξ.<name>` / `<name>`). When the predecessor has floated away (#5526) the guard fails and the node prints as an ordinary application, which round-trips just as safely.

## Tests

- Updated `wrap-applications.yaml` (parser pack) to assert `@pipe` is now retained.
- Updated `pipe-named.yaml` (printer pack): `| 5 > foo5` is now preserved instead of expanded to `foo 5 > foo5`.
- Added `pipe-recursive.yaml` — the issue's `>> name` recursive-formation + `| list > @` scenario.
- Added `pipe-floated.yaml` — pipe inside an argument block (#5526 float-up) still round-trips compactly.

All new packs also pass the printer's `printsToParseableEo` round-trip check (printed EO re-parses to the same EO). Full `eo-parser` (1482) and `eo-printer` (162) suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdSramPXm1rBhwrqeHkJt6)_