### PR TITLE
Exempt name-binding spaces from `Penalty.spaces()` base term

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -36,12 +36,13 @@ import java.util.Map;
  *   column costs {@link PenaltyKey#EXCESS} point;</li>
  *   <li>every symbol in the block costs {@link PenaltyKey#SYMBOL}
  *   point;</li>
- *   <li>every space on a line past the leading indentation costs
- *   {@link PenaltyKey#SPACE} points, and the genuine argument-applying
- *   spaces among them (name bindings such as {@code >} do not count) pay
- *   an extra super-linear surcharge: r such spaces cost r squared, rather
- *   than r, times the weight, so longer applications grow super-linearly
- *   more expensive while name bindings are left alone.</li>
+ *   <li>every argument-applying space on a line past the leading
+ *   indentation costs {@link PenaltyKey#SPACE} points (name bindings such
+ *   as {@code >} do not count and cost nothing), and those genuine
+ *   argument-applying spaces additionally pay an extra super-linear
+ *   surcharge: r such spaces cost r squared, rather than r, times the
+ *   weight, so longer applications grow super-linearly more expensive
+ *   while name bindings are left alone.</li>
  * </ul>
  *
  * <p>All of these weights, together with the indentation
@@ -51,22 +52,24 @@ import java.util.Map;
  * default.</p>
  *
  * <p>For example, with the default weights this snippet has a penalty of
- * 99 (five indents at two points each, one explicit {@code @} at fifteen,
- * 39 symbols, plus five application spaces at seven points each — all name
- * bindings, so no surcharge):</p>
+ * 71 (five indents at two points each, one explicit {@code @} at fifteen,
+ * 39 symbols, plus one application space at seven points — the four
+ * spaces around the {@code >} markers only bind names, so they are exempt
+ * and there is no surcharge):</p>
  *
  * <pre> [] &gt; foo
  *   gt. &gt; @
  *     42
  *     bar.hello 88</pre>
  *
- * <p>This one, rendering the same object on a single line, scores 106:
- * one opening parenthesis at nineteen points, 31 symbols, and six
- * application spaces at seven points (42) of which two genuinely apply
- * arguments — {@code 42.gt} to {@code (bar.hello 88)}, and
- * {@code bar.hello} to {@code 88} — so those two pay the surcharge that
- * takes them from 2 to 2 squared, i.e. 4, times the weight (an extra
- * 14). The super-linear charge is what pushes the printer away from a
+ * <p>This one, rendering the same object on a single line, scores 78:
+ * one opening parenthesis at nineteen points, 31 symbols, and two
+ * application spaces at seven points (14) — {@code 42.gt} to
+ * {@code (bar.hello 88)}, and {@code bar.hello} to {@code 88} — which,
+ * since both genuinely apply arguments, pay the surcharge that takes them
+ * from 2 to 2 squared, i.e. 4, times the weight (an extra 14). The four
+ * spaces around the {@code >} markers only bind names, so they are exempt.
+ * The super-linear charge is what pushes the printer away from a
  * sprawling application:</p>
  *
  * <pre> 42.gt (bar.hello 88) &gt; [] &gt; foo</pre>
@@ -153,7 +156,16 @@ final class Penalty {
     }
 
     /**
-     * Count the spaces in a line beyond the leading indentation.
+     * Count the spaces in a line beyond the leading indentation, excluding
+     * the spaces that surround a name-binding marker.
+     *
+     * <p>A space sitting next to a {@code >} (so {@code >}, {@code >>},
+     * {@code ++>} or {@code -->}) binds a name rather than applying an
+     * argument, so it is skipped here — matching the exemption that
+     * {@link #applied(String)} and {@link #binding(String)} already make. This keeps
+     * the base {@link PenaltyKey#SPACE} term and the super-linear surcharge in
+     * {@link #points()} in agreement about what counts as an application.</p>
+     *
      * @param line The line
      * @return The number of spaces
      */
@@ -164,7 +176,9 @@ final class Penalty {
         }
         int total = 0;
         for (int idx = lead; idx < line.length(); ++idx) {
-            if (line.charAt(idx) == ' ') {
+            if (line.charAt(idx) == ' '
+                && !(idx > 0 && line.charAt(idx - 1) == '>')
+                && !(idx + 1 < line.length() && line.charAt(idx + 1) == '>')) {
                 ++total;
             }
         }

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -52,9 +52,9 @@ public enum PenaltyKey {
     SYMBOL(1),
 
     /**
-     * Points charged for each space on a line beyond the leading
-     * indentation. The genuine argument-applying spaces among them (name
-     * bindings such as {@code >} do not count) additionally pay a
+     * Points charged for each argument-applying space on a line beyond the
+     * leading indentation. Name bindings such as {@code >} do not count and
+     * cost nothing. The genuine argument-applying spaces additionally pay a
      * super-linear surcharge at this same weight, so {@code r} of them cost
      * {@code r} squared, rather than {@code r}, times the weight and longer
      * applications grow super-linearly more expensive.

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -145,6 +145,17 @@ final class PenaltyTest {
     }
 
     @Test
+    void exemptsNameBindingSpacesFromBaseTerm() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.SYMBOL, 0);
+        MatcherAssert.assertThat(
+            "The spaces around a name-binding > should cost nothing in the base term",
+            new Penalty("foo > bar", weights).points(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
     void chargesNothingForEmptyCode() {
         MatcherAssert.assertThat(
             "Empty code should have zero penalty",


### PR DESCRIPTION
Fixes #5687.

## Problem

`Penalty.spaces()` counted every space past the leading indentation, including the spaces that surround a name-binding marker (`>`, `>>`, `++>`, `-->`). Those spaces fed the base `SPACE` term in `Penalty.points()`.

This disagreed with the companion `applied()` helper (and its documentation), which deliberately exempts binding spaces from the super-linear surcharge because "name bindings such as `>` do not count" as applications. So the two halves of the same space penalty defined a binding space differently: the surcharge exempted it, the base term charged it.

## Fix

- `spaces()` now skips a space when the adjacent character is `>` (i.e. `line.charAt(idx - 1) == '>'` or `line.charAt(idx + 1) == '>'`), mirroring the exemption that `applied()` and `binding()` already apply. A space that only binds a name now costs nothing in the base term as well as the surcharge.
- Updated the class-level Javadoc worked examples (now 71 and 78 points) and the `SPACE` key doc so the base term and the surcharge agree on what counts as an application.
- Added `exemptsNameBindingSpacesFromBaseTerm` to `PenaltyTest`.

This is a consistency fix to the penalty model. It does not change existing printer output (e.g. `last-index-of.eo`), since tie candidates lose the same binding-space cost. All 163 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J54kneU6bNbCBJADQDAhAq)_