### PR TITLE
Reorganize io input/output objects into `input`/`output` packages (#5501)

### DIFF
--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -1,0 +1,16 @@
+# Input is an abstract source of bytes that can be read sequentially.
+# Any input decorates the object bound to its `@` attribute, which must
+# provide a `read` object that takes the amount of bytes to read and
+# returns an input block - a dataizable portion of bytes that also has
+# its own `read` to fetch the next portion. See `input.dead`,
+# `input.as-bytes`, `input.length`, `bytes.to-input`, and `io.tee-input`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint unit-test-missing
+
+[φ] > input

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -2,35 +2,35 @@
 #
 # Example usage:
 # ```
-# input-as-bytes > bts
+# as-bytes > bts
 #   bytes.to-input 01-02-03-04-05
 # ```
 # After dataization, `bts` equals `01-02-03-04-05`.
 
 +alias bytes.to-input
++alias io.copied
++alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package input
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > input-as-bytes
+[input] > as-bytes
   malloc.of > @
     0
     seq * > [m] >>
-      copied
+      io.copied
         input
-        malloc-as-output m
+        io.malloc-as-output m
       m
 
   ++> tests-bytes-to-input-and-back
     eq. > @
-      input-as-bytes
+      Q.input.as-bytes
         bytes.to-input bts
       bts
     01-02-03-04-05-06-07-08 > bts
 
-  eq. ++> tests-returns-empty-bytes-from-dead-input
-    input-as-bytes dead-input
-    --
+  (Q.input.as-bytes dead).eq -- ++> tests-returns-empty-bytes-from-dead-input

--- a/eo-runtime/src/main/eo/input/dead.eo
+++ b/eo-runtime/src/main/eo/input/dead.eo
@@ -3,12 +3,12 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package input
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > dead-input
+[] > dead
   [size] > read
     input-block > @
     [] > input-block
@@ -21,4 +21,4 @@
       eq.
         i1.read 10
         --
-    dead-input.read 10 > i1
+    dead.read 10 > i1

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -1,14 +1,16 @@
 # Reads all the bytes from provided `input` and returns its length.
 
 +alias bytes.to-input
++alias io.malloc-as-output
++alias io.tee-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package input
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > input-length
+[input] > length
   rec-read > @
     input
     0
@@ -22,7 +24,7 @@
     (input.read 4096).read.^ > chunk
 
   eq. ++> tests-reads-all-bytes-and-returns-length
-    input-length
+    Q.input.length
       bytes.to-input 01-02-03-04-05-06-07-08-09-10
     10
 
@@ -31,9 +33,9 @@
       malloc.of
         10
         seq * > [m]
-          input-length
-            tee-input
+          Q.input.length
+            io.tee-input
               bytes.to-input 01-02-03-04-05-06-07-08-09-10
-              malloc-as-output m
+              io.malloc-as-output m
           m
       01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/main/eo/io/copied.eo
+++ b/eo-runtime/src/main/eo/io/copied.eo
@@ -19,7 +19,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [input output] > copied
-  input-length > @
+  Q.input.length > @
     tee-input
       input
       output
@@ -73,4 +73,4 @@
           bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
           malloc-as-output m
 
-  (copied dead-input dead-output).eq 0 ++> tests-handles-dead-input
+  (copied Q.input.dead Q.output.dead).eq 0 ++> tests-handles-dead-input

--- a/eo-runtime/src/main/eo/output.eo
+++ b/eo-runtime/src/main/eo/output.eo
@@ -1,0 +1,15 @@
+# Output is an abstract destination of bytes that can be written sequentially.
+# Any output decorates the object bound to its `@` attribute, which must
+# provide a `write` object that takes the bytes to write and returns an
+# output block ready to write the next portion. See `output.dead` and
+# `io.malloc-as-output`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint unit-test-missing
+
+[φ] > output

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -2,16 +2,16 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package output
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > dead-output
+[] > dead
   [buffer] > write
     output-block > @
     [] > output-block
       true > @
       output-block > [buffer] > write
 
-  dead-output.write 01-02-03 ++> writes-bytes-to-nowhere
+  dead.write 01-02-03 ++> writes-bytes-to-nowhere

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -396,7 +396,7 @@ public class PhDefault implements Phi, Cloneable {
      * When there's no such object, the terminated
      * computation stays terminated. When the object exists but has no free
      * positional attribute to receive the bound object (for example a nullary
-     * object like {@code io.dead-input}), a clear error is raised instead of the
+     * object like {@code input.dead}), a clear error is raised instead of the
      * low-level "attribute is already set / no attributes here" message.</p>
      *
      * @param name The name of the absent attribute

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -39,7 +39,7 @@ final class PhDefaultTest {
             "Implicit dispatch to a nullary extension must explain the real problem",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PhDefault("Φ.io").take("dead-input"),
+                () -> new PhDefault("Φ.input").take("dead"),
                 "Applying a receiver to a nullary extension must be rejected"
             ).getMessage(),
             Matchers.containsString("takes no arguments")

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -63,7 +63,7 @@ final class PhPackageTest {
                 "The %s attribute must be set to package object on dispatch",
                 Phi.RHO
             ),
-            pckg.take("dead-input").take(Phi.RHO),
+            pckg.take("tee-input").take(Phi.RHO),
             Matchers.equalTo(pckg)
         );
     }


### PR DESCRIPTION
Implements one part of #5501 — the naming/classification reorganization for input/output objects in `eo-runtime`.

## Changes

Introduces the root `input` and `output` structure objects and moves the input/output supplementary objects out of the `io` package into dedicated `input` and `output` packages:

- **New** `eo-runtime/src/main/eo/input.eo` and `output.eo` — abstract structure objects (`[@] > input`, `[@] > output`)
- `io/dead-input.eo` → `input/dead.eo` (`input.dead`)
- `io/dead-output.eo` → `output/dead.eo` (`output.dead`)
- `io/input-as-bytes.eo` → `input/as-bytes.eo` (`input.as-bytes`)
- `io/input-length.eo` → `input/length.eo` (`input.length`)

The remaining `io` objects (`copied`, `malloc-as-output`, `tee-input`) stay in `io` for now.

## Reference updates

- `io/copied.eo` — now references the moved objects via their fully-qualified names (`Q.input.length`, `Q.input.dead`, `Q.output.dead`), since `input`/`output` are also void attribute names in `copied`.
- The moved objects reference their former `io` siblings via `io.copied` / `io.malloc-as-output` / `io.tee-input` aliases.
- Java tests that referenced the moved objects by name updated: `PhDefaultTest` (`Φ.input`/`dead`), `PhPackageTest` (`tee-input`), plus a doc comment in `PhDefault.java`.

## Verification

Locally ran `mvn -pl eo-runtime test-compile` (EO format + lint + transpile, Java main + test compile: **BUILD SUCCESS**) and the affected unit tests:

- `input.dead`, `output.dead`, `input.as-bytes`, `input.length` object tests — pass
- `EOcopiedTest`, `PhDefaultTest`, `PhPackageTest` — pass

## Note

The shape of the base `input`/`output` objects (`[@]`) was chosen per discussion; #5501 itself notes their exact semantics are still open (see @maxonfjvipon's comment). Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA7VoXh5Dk4sokBnFb7MEL)_