### PR TITLE
Apply recursive objects via the pipe

### DIFF
--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -11,9 +11,6 @@
 
 [] > array
   ? >> bts
-  slice-byte > @
-    *
-    0
   bts > data!
   data.size > len!
   if. > [tup index] > slice-byte
@@ -24,6 +21,9 @@
       as-number.
         index.plus 1
     tup
+  | > @
+    *
+    0
 
   eq. ++> tests-converts-bytes-to-array
     array 20-1F-EE-B5-FF

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -54,10 +54,6 @@
       ^.eq value
     x > value!
   [x] > times
-    looped > @
-      00-00-00-00-00-00-00-00
-      as-bytes
-      x.as-bytes
     if. > [acc a b] > looped
       b.eq 00-00-00-00-00-00-00-00
       i64 acc
@@ -70,6 +66,10 @@
           acc
         a.left 1
         b.right 1
+    | > @
+      00-00-00-00-00-00-00-00
+      as-bytes
+      x.as-bytes
   [x] > plus /i64
   [x] > minus
     plus > @

--- a/eo-runtime/src/main/eo/io/input-length.eo
+++ b/eo-runtime/src/main/eo/io/input-length.eo
@@ -9,9 +9,6 @@
 +spdx SPDX-License-Identifier: MIT
 
 [input] > input-length
-  rec-read > @
-    input
-    0
   [input length] > rec-read
     if. > @
       chunk.size.eq 0
@@ -20,6 +17,9 @@
         chunk
         length.plus chunk.size
     (input.read 4096).read.^ > chunk
+  | > @
+    input
+    0
 
   eq. ++> tests-reads-all-bytes-and-returns-length
     input-length

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -23,10 +23,6 @@
 [] > stdin
   all-lines > @
   [] > all-lines
-    rec-read > @
-      next-line
-      --
-      true
     eol > separator!
     if. > [line buffer first] > rec-read
       line.length.eq 0
@@ -37,6 +33,10 @@
           buffer.concat line
           (buffer.concat separator).concat line
         false
+    | > @
+      next-line
+      --
+      true
   [] > next-line
     if. > @
       first.as-bytes.size.eq 0

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -9,9 +9,13 @@
 +spdx SPDX-License-Identifier: MIT
 
 [bts] > as-hex
-  rec-hex > @
-    0
-    --
+  [h] > hex-digit
+    if. > @
+      h.lt 10
+      as-char
+        h.plus 48
+      as-char
+        h.plus 55
   [index acc] > rec-hex
     if. > @
       index.eq bts.size
@@ -32,13 +36,9 @@
       hex-digit
         bval.minus
           (bval.div 16).floor.times 16
-  [h] > hex-digit
-    if. > @
-      h.lt 10
-      as-char
-        h.plus 48
-      as-char
-        h.plus 55
+  | > @
+    0
+    --
 
   ++> tests-writes-single-byte
     "41".eq > @

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -15,7 +15,6 @@
 [] > filteredi
   ? >> list
   ? >> func
-  recfilter list > @
   [tup] > recfilter
     if. > @
       tup.length.eq 0
@@ -25,6 +24,7 @@
         next.with tup.head
         next
     recfilter tup.tail > next
+  | list > @
 
   ++> tests-filteredi-with-lt
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/hash-code.eo
+++ b/eo-runtime/src/main/eo/tuple/hash-code.eo
@@ -13,9 +13,6 @@
 
 [] > hash-code
   ? >> input
-  rec-hash-code > @
-    0
-    0
   input.as-bytes > bts!
   bts.size > size!
   if. > [acc index] > rec-hash-code
@@ -29,6 +26,9 @@
             bts.slice index 1
       as-number.
         index.plus 1
+  | > @
+    0
+    0
 
   and. ++> tests-hash-code-bools-is-number
     (hash-code true).as-bytes.size.eq

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -11,14 +11,14 @@
 [] > last-index-of
   ? >> list
   ? >> wanted
-  reclast list > @
-  if. > [tup] > reclast
-    tup.length.eq 0
+  if. > [t] > rec
+    t.length.eq 0
     -1
     if.
-      tup.head.eq wanted
-      tup.tail.length
-      reclast tup.tail
+      t.head.eq wanted
+      t.tail.length
+      rec t.tail
+  | list > @
 
   eq. ++> tests-finds-last-index-of
     1


### PR DESCRIPTION
This picks up where the manual fix to `tuple/last-index-of.eo` left off. That file used to name a recursive helper, apply it at the top, then define it below. It now defines the inline object first and applies it with the `|` pipe. I swept the rest of the runtime for the same shape and found six more helpers doing it the old way: `recfilter` in `filteredi`, `rec-hash-code` in `hash-code`, `slice-byte` in `array`, `rec-read` in `input-length`, `rec-hex` in `as-hex`, `looped` in `i64.times`, and `rec-read` in `stdin.all-lines`.

The point is readability: the helper reads top-to-bottom as a definition, and the pipe supplies its arguments right after, instead of the call sitting above a definition you have not read yet. Single-argument pipes stay on one line; multi-argument ones use the canonical vertical form the printer expects. In `as-hex` I moved `hex-digit` above `rec-hex` so the pipe follows its named predecessor.

I ran a clean `eo-runtime` build with `-Deo.autoFix`: 1706 tests pass, and every source is canonically formatted.

Closes #5674