### PR TITLE
Move `io.tee-input` to `input.tee` (#5501)

### DIFF
--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -3,7 +3,7 @@
 # provide a `read` object that takes the amount of bytes to read and
 # returns an input block - a dataizable portion of bytes that also has
 # its own `read` to fetch the next portion. See `input.dead`,
-# `input.as-bytes`, `input.length`, `bytes.to-input`, and `io.tee-input`.
+# `input.as-bytes`, `input.length`, `input.tee`, and `bytes.to-input`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -2,7 +2,6 @@
 
 +alias bytes.to-input
 +alias io.malloc-as-output
-+alias io.tee-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
@@ -34,7 +33,7 @@
         10
         seq * > [m]
           Q.input.length
-            io.tee-input
+            Q.input.tee
               bytes.to-input 01-02-03-04-05-06-07-08-09-10
               io.malloc-as-output m
           m

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -6,23 +6,24 @@
 #   5
 #   [m]
 #     read. > @
-#       tee-input
+#       tee
 #         bytes.to-input 01-02-03-04-05
-#         malloc-as-output m
+#         io.malloc-as-output m
 #       5
 # ```
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
 +alias bytes.to-input
++alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package input
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input output] > tee-input
+[input output] > tee
   [size] > read
     read. > @
       input-block
@@ -44,9 +45,9 @@
       malloc.of
         5
         read. > [mem]
-          tee-input
+          Q.input.tee
             bytes.to-input 01-02-03-04-05
-            malloc-as-output mem
+            io.malloc-as-output mem
           5
       01-02-03-04-05
 
@@ -58,9 +59,9 @@
           read.
             read.
               read.
-                tee-input
+                Q.input.tee
                   bytes.to-input 01-02-03-04-05
-                  malloc-as-output m
+                  io.malloc-as-output m
                 2
               2
             1
@@ -76,11 +77,11 @@
             5
             seq * > [m2] >>
               read.
-                tee-input
-                  tee-input
+                Q.input.tee
+                  Q.input.tee
                     bytes.to-input 01-02-03-04-05
-                    malloc-as-output m2
-                  malloc-as-output m1
+                    io.malloc-as-output m2
+                  io.malloc-as-output m1
                 5
               m1.write 5 2A-
               m1

--- a/eo-runtime/src/main/eo/io/copied.eo
+++ b/eo-runtime/src/main/eo/io/copied.eo
@@ -20,7 +20,7 @@
 
 [input output] > copied
   Q.input.length > @
-    tee-input
+    Q.input.tee
       input
       output
 

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -63,7 +63,7 @@ final class PhPackageTest {
                 "The %s attribute must be set to package object on dispatch",
                 Phi.RHO
             ),
-            pckg.take("tee-input").take(Phi.RHO),
+            pckg.take("copied").take(Phi.RHO),
             Matchers.equalTo(pckg)
         );
     }


### PR DESCRIPTION
Continues the io object reorganization from #5501 (follow-up to #5691), moving the tee input object out of the `io` package into the `input` package.

## Change

- `io/tee-input.eo` → `input/tee.eo` (object `tee-input` → `tee`, i.e. `input.tee`)

This matches the `input.tee X` naming in #5501 ("an input with a tee to the X output").

## Reference updates

- `io/copied.eo` — references the moved object via `Q.input.tee` (since `input`/`output` are void attribute names there, a bare `input.tee` would shadow).
- `input/length.eo` — dropped the `+alias io.tee-input`; its test now uses `Q.input.tee` (consistent with the adjacent `Q.input.length`).
- `input.eo` — doc comment now points at `input.tee` instead of `io.tee-input`.
- `PhPackageTest` — the `setsRhoToObject` case dispatched an `io` package member (previously `tee-input`); switched to `io.copied`, which stays in `io`.

The moved object reaches its former `io` sibling `malloc-as-output` via the `io.malloc-as-output` alias.

## Verification

Locally ran `mvn -pl eo-runtime test-compile` (EO format + lint + transpile, Java main + test compile: **BUILD SUCCESS**, 0 formatting issues) and the affected unit tests:

- `input.tee` (`EOteeTest`, 3), `io.copied` (`EOcopiedTest`, 6), `input.length` (`EOlengthTest`, 2), `input.as-bytes` (2) — pass
- `PhPackageTest` (13), `PhDefaultTest` (53) — pass

## Note

The remaining `io` objects (`copied`, `malloc-as-output`) stay in `io` for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA7VoXh5Dk4sokBnFb7MEL)_