### PR TITLE
Move `io.copied` to `input.copied` (#5501)

### DIFF
--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -8,7 +8,6 @@
 # After dataization, `bts` equals `01-02-03-04-05`.
 
 +alias bytes.to-input
-+alias io.copied
 +alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -21,7 +20,7 @@
   malloc.of > @
     0
     seq * > [m] >>
-      io.copied
+      Q.input.copied
         input
         io.malloc-as-output m
       m

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -5,15 +5,16 @@
 # ```
 # copied > total-bytes
 #   bytes.to-input 01-02-03-04-05
-#   malloc-as-output memory
+#   io.malloc-as-output memory
 # ```
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
 +alias bytes.to-input
++alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package io
++package input
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -29,9 +30,9 @@
       malloc.of
         5
         seq * > [m]
-          copied
+          Q.input.copied
             bytes.to-input 01-02-03-04-05
-            malloc-as-output m
+            io.malloc-as-output m
           m
       01-02-03-04-05
 
@@ -39,9 +40,9 @@
     eq. > @
       malloc.of
         10
-        copied > [m]
+        Q.input.copied > [m]
           bytes.to-input 01-02-03-04-05-06-07-08-09-10
-          malloc-as-output m
+          io.malloc-as-output m
       10
 
   ++> tests-handles-empty-input
@@ -49,9 +50,9 @@
       malloc.of
         0
         seq * > [m]
-          copied
+          Q.input.copied
             bytes.to-input --
-            malloc-as-output m
+            io.malloc-as-output m
           m
       --
 
@@ -60,17 +61,17 @@
       malloc.of
         0
         [m]
-          copied > @
+          Q.input.copied > @
             bytes.to-input --
-            malloc-as-output m
+            io.malloc-as-output m
       0
 
   ++> tests-handles-large-data
     20.eq > @
       malloc.of
         20
-        copied > [m]
+        Q.input.copied > [m]
           bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
-          malloc-as-output m
+          io.malloc-as-output m
 
-  (copied Q.input.dead Q.output.dead).eq 0 ++> tests-handles-dead-input
+  (Q.input.copied Q.input.dead Q.output.dead).eq 0 ++> tests-handles-dead-input

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -63,7 +63,7 @@ final class PhPackageTest {
                 "The %s attribute must be set to package object on dispatch",
                 Phi.RHO
             ),
-            pckg.take("copied").take(Phi.RHO),
+            pckg.take("malloc-as-output").take(Phi.RHO),
             Matchers.equalTo(pckg)
         );
     }


### PR DESCRIPTION
Continues the io object reorganization from #5501 (follow-up to #5691 and #5693), moving the copied object out of the `io` package into the `input` package.

## Change

- `io/copied.eo` → `input/copied.eo` (object `copied` → `input.copied`)

## Reference updates

- `input/as-bytes.eo` — references the moved object via `Q.input.copied` (dropped the now-unneeded `+alias io.copied`), consistent with the `Q.input.*` forms the formatter canonicalizes to in this package.
- `PhPackageTest` — the `setsRhoToObject` case dispatched an `io` package member (previously `copied`); switched to `malloc-as-output`, the sole object remaining in `io`.
- The moved object reaches `malloc-as-output` via the `io.malloc-as-output` alias.

## Verification

Locally ran `mvn -pl eo-runtime test-compile` (EO format + lint + transpile, Java main + test compile: **BUILD SUCCESS**, 0 formatting issues) and the affected unit tests:

- `input.copied` (`EOcopiedTest`, 6), `input.as-bytes` (2), `input.length` (2), `input.tee` (3) — pass
- `PhPackageTest` (13), `PhDefaultTest` (53) — pass

## Note

After this move, `io` contains only `malloc-as-output`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA7VoXh5Dk4sokBnFb7MEL)_