### PR TITLE
Fix #5696: printer emits canonical `[@]` for void φ decoratee params

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -283,7 +283,17 @@
         <xsl:if test="position()&gt;1">
           <xsl:text> </xsl:text>
         </xsl:if>
-        <xsl:value-of select="@name"/>
+        <xsl:choose>
+          <xsl:when test="@name = $eo:phi">
+            <xsl:value-of select="'@'"/>
+          </xsl:when>
+          <xsl:when test="@name = $eo:rho">
+            <xsl:value-of select="'^'"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="@name"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
       <xsl:text>]</xsl:text>
     </xsl:if>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-phi-param.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-phi-param.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package org.eolang
+
+  [@] > input
+
+printed: |
+  +package org.eolang
+
+  [@] > input

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -22,7 +22,7 @@
 +unlint redundant-object
 +unlint mandatory-package
 
-[φ] > bytes
+[@] > bytes
   [b] > eq /bool
   [] > size /number
   [start len] > slice /bytes

--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -13,4 +13,4 @@
 +unlint mandatory-package
 +unlint unit-test-missing
 
-[φ] > input
+[@] > input

--- a/eo-runtime/src/main/eo/output.eo
+++ b/eo-runtime/src/main/eo/output.eo
@@ -12,4 +12,4 @@
 +unlint mandatory-package
 +unlint unit-test-missing
 
-[φ] > output
+[@] > output


### PR DESCRIPTION
Closes #5696.

## Problem

The void-parameter head template in `to-eo-tree.xsl:286` emitted the internal decoratee name `φ` verbatim (`<xsl:value-of select="@name"/>`), with no `φ → @` translation. As a result `eo:format` rewrote a hand-written `[@] > input` back into `[φ] > input`, and `mvn clean test -rf :eo-runtime` failed the `format` goal on `input.eo` and `output.eo`, demanding the non-idiomatic `[φ]` form.

This contradicted the rest of the same stylesheet, which treats `@` as the canonical surface form of `φ` (the header comment at line 20, the bound-name tail at line 350, and `eo:translate-path`).

## Fix

- In the void-parameter loop, translate the name the way the tail already does: emit `@` when the name is `φ` and, symmetrically, `^` when it is `ρ`, falling back to the raw name otherwise.
- Update `eo-runtime/src/main/eo/input.eo`, `output.eo`, and `bytes.eo` to the now-canonical `[@]` head (previously `[φ]`). These produce identical XMIR — the parser maps `@` back to `φ` — so this is a purely cosmetic, canonicalizing change.
- Add print-pack `void-phi-param.yaml` locking in the `[@]` round-trip.

## Verification

`XmirTest` (all 130 print-packs, covering both `printsToEo` and `printsToParseableEo` round-trips) passes, including the new pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D2bUT2FAJBpFJRRWorvRw

---
_Generated by [Claude Code](https://claude.ai/code/session_015D2bUT2FAJBpFJRRWorvRw)_