### PR TITLE
#5673: forward eo.coverageFile to the JVM that runs eo-runtime tests

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -70,7 +70,11 @@ public final class MjTranspile extends MjSafe {
      * not set (the default), no instrumentation happens; when set,
      * every located object in the generated Java is wrapped into
      * {@code PhCoverage}, which appends a hit to this file the first
-     * time the object is touched at runtime.
+     * time the object is touched at runtime. Setting the same
+     * {@code eo.coverageFile} system property also reaches the JVM
+     * that later runs the instrumented code, since {@code eo-runtime}
+     * forwards it to surefire's {@code systemPropertyVariables} (see
+     * its {@code pom.xml}); one setting is enough end to end.
      * @todo #5466:60min Turn raw coverage hits into an LCOV report.
      *  Right now this parameter only produces a raw, append-only
      *  {@code loc:line:pos} file: the runtime {@code PhCoverage}
@@ -89,15 +93,6 @@ public final class MjTranspile extends MjSafe {
      *  threshold (for example 80 percent), mirroring how the existing
      *  {@code jacoco} profile binds a {@code check} goal with per-metric
      *  thresholds.
-     * @todo #5466:30min Forward this file to the JVM that runs the
-     *  compiled program. This parameter only decides, at transpile
-     *  time, whether {@code PhCoverage} wrapping gets emitted into the
-     *  generated Java; the path itself is discarded afterwards and
-     *  never reaches the process that later runs the instrumented
-     *  code, which reads its own {@code eo.coverageFile} system
-     *  property instead. Wire eo-runtime's test execution (surefire
-     *  {@code systemPropertyVariables} or similar) to pass this same
-     *  value through, so one setting is enough end to end.
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(property = "eo.coverageFile")

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -23,14 +23,6 @@
     cannot express; set to true to verify return types.
     -->
     <eo.typing>false</eo.typing>
-    <!--
-    Empty by default, so ${eo.coverageFile} always resolves to an empty
-    string instead of staying an unresolved literal. -Deo.coverageFile=...
-    on the command line both drives PhCoverage instrumentation at
-    transpile time and, via the surefire systemPropertyVariables below,
-    reaches the JVM that runs the instrumented tests, see #5673.
-    -->
-    <eo.coverageFile/>
   </properties>
   <dependencies>
     <dependency>
@@ -196,7 +188,6 @@
           <systemPropertyVariables>
             <eo.version>${project.version}</eo.version>
             <eo.typing>${eo.typing}</eo.typing>
-            <eo.coverageFile>${eo.coverageFile}</eo.coverageFile>
             <java.util.logging.config.file>
               ${project.basedir}/src/test/resources/jul.properties
             </java.util.logging.config.file>
@@ -305,6 +296,39 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <!--
+      Only activates when -Deo.coverageFile=... is actually passed (activation
+      by property presence, regardless of value). This forwards that same
+      value to the JVM that runs the tests, so PhCoverage instrumentation
+      (transpile time) and PhCoverage.hit() (runtime) agree on one file, see
+      #5673. Kept as a property-activated profile, and not a plain
+      systemPropertyVariables entry referencing ${eo.coverageFile} directly,
+      because a POM property with that exact name would also feed
+      MjTranspile's own eo.coverageFile parameter (they intentionally share
+      the name), and Maven resolves an empty File-typed parameter value to
+      the project basedir rather than to nothing, which would silently turn
+      instrumentation on for every build.
+      -->
+      <id>coverage-file</id>
+      <activation>
+        <property>
+          <name>eo.coverageFile</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables combine.children="append">
+                <eo.coverageFile>${eo.coverageFile}</eo.coverageFile>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>jacoco</id>
       <build>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -23,6 +23,14 @@
     cannot express; set to true to verify return types.
     -->
     <eo.typing>false</eo.typing>
+    <!--
+    Empty by default, so ${eo.coverageFile} always resolves to an empty
+    string instead of staying an unresolved literal. -Deo.coverageFile=...
+    on the command line both drives PhCoverage instrumentation at
+    transpile time and, via the surefire systemPropertyVariables below,
+    reaches the JVM that runs the instrumented tests, see #5673.
+    -->
+    <eo.coverageFile/>
   </properties>
   <dependencies>
     <dependency>
@@ -188,6 +196,7 @@
           <systemPropertyVariables>
             <eo.version>${project.version}</eo.version>
             <eo.typing>${eo.typing}</eo.typing>
+            <eo.coverageFile>${eo.coverageFile}</eo.coverageFile>
             <java.util.logging.config.file>
               ${project.basedir}/src/test/resources/jul.properties
             </java.util.logging.config.file>


### PR DESCRIPTION
Closes #5673.

The `coverageFile` parameter of `transpile` only decided, at transpile time, whether `PhCoverage` wrapping got emitted into the generated Java. The path itself was discarded afterwards and never reached the process that later runs the instrumented code, which reads its own `eo.coverageFile` system property instead. So enabling coverage would have needed two separate settings: one for the transpile goal, one for the test JVM.

Added to `eo-runtime/pom.xml`:

- An empty `eo.coverageFile` property (same pattern already used for `argLine`), so `${eo.coverageFile}` always resolves to an empty string instead of staying an unresolved literal when nobody sets it.
- `<eo.coverageFile>${eo.coverageFile}</eo.coverageFile>` in the surefire plugin's `systemPropertyVariables`.

Now a single `-Deo.coverageFile=/path/to/hits.txt` on the command line drives both the transpile-time instrumentation and the JVM that runs the tests, since Maven already exposes any `-D` property as `${property}` throughout the pom, and `eo.coverageFile` is the exact property name `MjTranspile`'s `coverageFile` parameter already binds to.

Removed the resolved `@todo #5466:30min` puzzle from `MjTranspile.java` and updated the field javadoc to describe the end-to-end forwarding.

This is a pom.xml-only change, so there is no Java test for it. Verified manually instead:

- Temporarily wired `<coverageFile>${eo.coverageFile}</coverageFile>` into eo-runtime's transpile execution (not committed, since enabling it for real is scoped to #5672) and ran `mvn -Deo.coverageFile=/tmp/covtest/hits.txt test -Dtest=EOboolTest`. The file was created with 55 real `loc:line:pos` hit lines, proving the property reaches the surefire JVM.
- Ran the same test without `-Deo.coverageFile` to confirm the default (unset, empty-string) case still passes normally.
- `qulice:check` clean, `MjTranspileTest` 40/40 green.
