### PR TITLE
Fix #5700: prefer cheaper inline-phi hybrid even when the one-liner fits width

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -53,11 +53,6 @@ final class Pretty {
     private final String tab;
 
     /**
-     * The column past which a line overflows, the {@code WIDTH} weight.
-     */
-    private final int width;
-
-    /**
      * Ctor, using the default penalty weights.
      * @param element The {@code <eo>} element
      */
@@ -76,9 +71,6 @@ final class Pretty {
         this.weights = config;
         this.tab = " ".repeat(
             config.getOrDefault(PenaltyKey.STEP, PenaltyKey.STEP.fallback())
-        );
-        this.width = config.getOrDefault(
-            PenaltyKey.WIDTH, PenaltyKey.WIDTH.fallback()
         );
     }
 
@@ -305,13 +297,16 @@ final class Pretty {
      * plus vertical-args layout and saving one line and one indent level
      * over the verbose shape (issue #5594); when those arguments are a lone
      * tuple the star is glued onto the head line too ({@link #hybrid}). The
-     * flat one-liner is kept while it fits the {@code WIDTH} limit, but once
-     * it overflows (or cannot be built) the hybrid is used instead, rather
-     * than gating the hybrid behind the one-liner's absence and falling back
-     * to the verbose shape when the one-liner overflows (issue #5635). Either
-     * way the result is only a candidate — the penalty/width check in
-     * {@link #shaped} keeps it only when it beats the plain vertical
-     * rendering. A formation decoratee
+     * flat one-liner and the hybrid are both built and the lower-penalty of
+     * the two is returned, rather than discriminating between them by whether
+     * the one-liner fits the {@code WIDTH} limit: the hybrid drops the
+     * {@code @} (saving its {@code PHI} charge) and lifts the arguments one
+     * indent level, so it is often cheaper even when the one-liner fits, and a
+     * width check would hide it whenever the one-liner did not overflow (issue
+     * #5700, the residual case #5635 left open). When the one-liner cannot be
+     * built at all, the hybrid is used unconditionally. Either way the result
+     * is only a candidate — the penalty check in {@link #shaped} keeps it only
+     * when it beats the plain vertical rendering. A formation decoratee
      * (its bindings are vertical, not arguments) and a receiver-only
      * reversed dispatch ({@code not.} with just its receiver, mirroring the
      * rejection in {@link #flat}) have no hybrid form, so they yield empty
@@ -359,11 +354,16 @@ final class Pretty {
                 && !(decoratee.reversed && decoratee.children.size() <= 1);
             final boolean unnamed = decoratee.children.stream()
                 .allMatch(Node::nameless);
-            if (applied && unnamed
-                && flat.map(line -> line.length() > this.width).orElse(true)) {
-                result = Optional.of(
-                    this.vertical(decoratee.hybrid(marker), indent)
-                );
+            if (applied && unnamed) {
+                final String hybrid = this.vertical(decoratee.hybrid(marker), indent);
+                if (flat.map(
+                    line -> new Penalty(hybrid, this.weights).points()
+                        < new Penalty(line, this.weights).points()
+                ).orElse(true)) {
+                    result = Optional.of(hybrid);
+                } else {
+                    result = flat;
+                }
             } else {
                 result = flat;
             }

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -356,14 +356,12 @@ final class Pretty {
                 .allMatch(Node::nameless);
             if (applied && unnamed) {
                 final String hybrid = this.vertical(decoratee.hybrid(marker), indent);
-                if (flat.map(
-                    line -> new Penalty(hybrid, this.weights).points()
-                        < new Penalty(line, this.weights).points()
-                ).orElse(true)) {
-                    result = Optional.of(hybrid);
-                } else {
-                    result = flat;
-                }
+                result = Optional.of(
+                    flat.filter(
+                        line -> new Penalty(line, this.weights).points()
+                            <= new Penalty(hybrid, this.weights).points()
+                    ).orElse(hybrid)
+                );
             } else {
                 result = flat;
             }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compares-bool-to-bytes.yaml
@@ -15,6 +15,6 @@ origin: |
       true.eq 01-
       false.eq 00-
 printed: |
-  [] > compares-bool-to-bytes
-    (true.eq 01-).and > @
-      false.eq 00-
+  and. > [] > compares-bool-to-bytes
+    true.eq 01-
+    false.eq 00-

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-string.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/empty-string.yaml
@@ -15,4 +15,5 @@ origin: |
       Q.string.sprintf ""
 
 printed: |
-  io.stdout (string.sprintf "") > [] > app
+  io.stdout > [] > app
+    string.sprintf ""

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-hybrid-under-width.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-hybrid-under-width.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The only-phi "copy" formation from malloc.eo: its phi applies regular
+# arguments and its flat one-liner
+# "write target (read source length) > [source target length] > copy" fits
+# under 80 columns, yet the compact hybrid is strictly cheaper — it drops the
+# "@" (saving the PHI charge), sheds the bracket the one-liner needs around
+# "(read source length)", and lifts the arguments one indent level. The printer
+# must therefore hand the hybrid to the penalty vote even when the one-liner
+# fits the width, not only when it overflows (issue #5700, the residual case
+# #5635 left open). These are the default weights the issue reasons about.
+penalties:
+  INDENT: 2
+  BRACKET: 19
+  PHI: 15
+  IF: 50
+  EXCESS: 3
+  SYMBOL: 1
+  SPACE: 7
+  WIDTH: 80
+  STEP: 2
+origin: |
+  +package org.eolang
+
+  [] > examples
+    [id] > allocated
+      [source target length] > copy
+        write > @
+          target
+          read source length
+
+printed: |
+  +package org.eolang
+
+  [] > examples
+    [id] > allocated
+      write > [source target length] > copy
+        target
+        read source length

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multiline-string.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multiline-string.yaml
@@ -18,4 +18,5 @@ origin: |
       """
 
 printed: |
-  io.stdout "Hello\nit's me" > [] > app
+  io.stdout > [] > app
+    "Hello\nit's me"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-if-inline.yaml
@@ -8,7 +8,9 @@
 # penalty (#5665) makes prefix notation cheaper, so "if" is never dispatched
 # after its object. The inner "if" keeps its arguments on separate lines too,
 # since the per-symbol and per-space penalties make a single inline line dearer
-# than the vertical layout.
+# than the vertical layout. The outer only-phi formation still collapses to the
+# cheaper inline-phi hybrid ("if. > [x] > classify"), which drops the "@" and
+# lifts the branches one indent level (#5700).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -27,11 +29,10 @@ origin: |
         "positive"
 
 printed: |
-  [x] > classify
-    if. > @
-      x.lt 0
-      "negative"
-      if.
-        x.eq 0
-        "zero"
-        "positive"
+  if. > [x] > classify
+    x.lt 0
+    "negative"
+    if.
+      x.eq 0
+      "zero"
+      "positive"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/times.yaml
@@ -17,8 +17,7 @@ origin: |
         -1.times 228
 
 printed: |
-  [] > app
-    io.stdout > @
-      string.sprintf
-        "result is %d\n"
-        -1.times 228
+  io.stdout > [] > app
+    string.sprintf
+      "result is %d\n"
+      -1.times 228

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -21,14 +21,12 @@
   if > not
     false
     true
-  [x] > and
-    if > @
-      01-.eq x
-      false
-  [x] > or
-    if > @
-      true
-      01-.eq x
+  if > [x] > and
+    01-.eq x
+    false
+  if > [x] > or
+    true
+    01-.eq x
 
   true.eq true ++> tests-compares-two-bools
 
@@ -36,22 +34,20 @@
 
   (true.eq 42).not ++> tests-compares-two-different-bool-types
 
-  ++> tests-compares-bool-to-bytes
-    and. > @
-      true.eq 01-
-      false.eq 00-
+  and. ++> tests-compares-bool-to-bytes
+    true.eq 01-
+    false.eq 00-
 
   and. ++> tests-compares-bool-to-bytes-reverse
     01-.as-bytes.eq true
     00-.as-bytes.eq false
 
-  ++> tests-forks-on-true-condition
-    eq. > @
-      if.
-        5.eq 5
-        123
-        42
+  eq. ++> tests-forks-on-true-condition
+    if.
+      5.eq 5
       123
+      42
+    123
 
   ++> tests-takes-parent-object
     eq. > @
@@ -87,7 +83,8 @@
   ++> tests-extract-attribute-from-decoratee
     a.foo.eq 43 > @
     [foo] > return
-    return (42.plus 1) > [] > a
+    return > [] > a
+      42.plus 1
 
   ++> tests-nesting-blah-test
     eq. > @
@@ -191,17 +188,15 @@
 
   true.not.eq false ++> tests-true-not-is-false
 
-  ++> tests-compares-bool-to-string
-    and. > @
-      true.eq "\u0001"
-      false.eq "\u0000"
+  and. ++> tests-compares-bool-to-string
+    true.eq "\u0001"
+    false.eq "\u0000"
 
   (true.and false).not ++> tests-true-and-false-is-false
 
-  ++> tests-forks-on-false-condition
-    eq. > @
-      if.
-        5.eq 8
-        123
-        42
+  eq. ++> tests-forks-on-false-condition
+    if.
+      5.eq 8
+      123
       42
+    42

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -9,12 +9,13 @@
 
 [buf] > buffer
   buf > @
-  [str] > with
-    buffer > @
-      string
-        buf.as-bytes.concat str.as-bytes
+  buffer > [str] > with
+    string
+      buf.as-bytes.concat str.as-bytes
 
-  (buffer "Hello").eq "Hello" ++> tests-buffer-decorates-string
+  eq. ++> tests-buffer-decorates-string
+    buffer "Hello"
+    "Hello"
 
   eq. ++> tests-buffer-builds-simple-string
     with.

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -33,15 +33,22 @@
   [x] > right /bytes
   [b] > concat /bytes
 
-  (20-1F-EE-B5-90.slice 1 3).eq 1F-EE-B5 ++> tests-takes-part-of-bytes
+  eq. ++> tests-takes-part-of-bytes
+    20-1F-EE-B5-90.slice
+      1
+      3
+    1F-EE-B5
 
-  (20-1F-EE-B5-90-EE-BB.slice 2 3).size.eq 3 ++> tests-size-of-part-is-correct
+  eq. ++> tests-size-of-part-is-correct
+    size.
+      20-1F-EE-B5-90-EE-BB.slice 2 3
+    3
 
   F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
 
-  ++> tests-turns-bytes-into-a-string
-    "你好, друг!".eq > @
-      "你好, друг!"
+  eq. ++> tests-turns-bytes-into-a-string
+    "你好, друг!"
+    "你好, друг!"
 
   ++> tests-right-with-zero
     not. > @
@@ -146,7 +153,10 @@
 
   CA-FE-BE-BE.size.eq 4 ++> tests-written-in-several-lines
 
-  (1.as-bytes.and 1.as-bytes).as-number.eq 1 ++> tests-bitwise-works
+  eq. ++> tests-bitwise-works
+    as-number.
+      1.as-bytes.and 1.as-bytes
+    1
 
   eq. ++> tests-bitwise-works-negative
     as-number.
@@ -160,13 +170,21 @@
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  (true.as-bytes.concat false.as-bytes).eq 01-00 ++> tests-concat-bools-as-bytes
+  eq. ++> tests-concat-bools-as-bytes
+    true.as-bytes.concat false.as-bytes
+    01-00
 
-  (05-5E-78.concat --).eq 05-5E-78 ++> tests-concat-with-empty
+  eq. ++> tests-concat-with-empty
+    05-5E-78.concat --
+    05-5E-78
 
-  (--.concat 05-5E-78).eq 05-5E-78 ++> tests-concat-empty-with
+  eq. ++> tests-concat-empty-with
+    --.concat 05-5E-78
+    05-5E-78
 
-  (--.concat --).eq -- ++> tests-concat-empty
+  eq. ++> tests-concat-empty
+    --.concat --
+    --
 
   eq. ++> tests-concat-strings
     string
@@ -201,7 +219,10 @@
     FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
     FF-FF-FF-FF-00-00-00-01
 
-  20-1F-EE-B5-90.slice 3 10 --> on-out-of-bounds-slice
+  slice. --> on-out-of-bounds-slice
+    20-1F-EE-B5-90
+    3
+    10
 
   ++> tests-out-of-bounds-slice-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -31,12 +31,11 @@
         -17.as-bytes.left 1
         33.as-bytes
 
-  ++> tests-left-with-minus-one
-    eq. > @
-      eq.
-        -1.as-bytes.left 3
-        7.as-bytes
-      false
+  eq. ++> tests-left-with-minus-one
+    eq.
+      -1.as-bytes.left 3
+      7.as-bytes
+    false
 
   eq. ++> tests-left-with-even-neg
     FF-FF-FF-FF-FF-FF-FF-EE.left 2

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -43,7 +43,10 @@
     00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
     00-00-00-00-71-15-B3-4E
 
-  (1.as-bytes.xor 1.as-bytes).as-number.eq 0 ++> tests-one-xor-one-as-number
+  eq. ++> tests-one-xor-one-as-number
+    as-number.
+      1.as-bytes.xor 1.as-bytes
+    0
 
   eq. ++> tests-xor-neg-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -127,4 +127,5 @@
               buffer.size
           output-block
 
-  console.write "Hello, console-test!\n" ++> tests-writes-to-console
+  console.write ++> tests-writes-to-console
+    "Hello, console-test!\n"

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -51,7 +51,8 @@
             cached.as-bool
             m
           func > cached!
-          m.put (m.as-number.plus 1) > [] > func
+          m.put > [] > func
+            m.as-number.plus 1
       1
 
   ++> tests-dataizes-as-bytes-behaves-as-exclamationed

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -111,4 +111,6 @@
         2
     (directory mktemp.tmpfile.deleted).made.as-path > d
 
-  (directory mktemp.tmpfile.deleted).walk "**" --> on-walking-absent-directory
+  walk. --> on-walking-absent-directory
+    directory mktemp.tmpfile.deleted
+    "**"

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -419,7 +419,8 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put (f.read 12) > [f] >>
+              m.put > [f] >>
+                f.read 12
             m
       "Hello, world"
 
@@ -437,7 +438,8 @@
     seq * > @
       temp.open
         "w"
-        f.write "Shrek is love" > [f]
+        f.write > [f]
+          "Shrek is love"
       "Shrek is love".eq
         malloc.of
           13
@@ -445,7 +447,8 @@
             seq * > @
               (file src).open
                 "r"
-                m.put (f.read 13) > [f] >>
+                m.put > [f] >>
+                  f.read 13
               m
     temp.path > src
     mktemp.tmpfile > temp
@@ -454,7 +457,8 @@
     seq * > @
       temp.open
         "w"
-        f.write "Shrek is love" > [f]
+        f.write > [f]
+          "Shrek is love"
       open.
         file src
         "a"
@@ -466,7 +470,8 @@
             seq * > @
               (file src).open
                 "r"
-                m.put (f.read 14) > [f] >>
+                m.put > [f] >>
+                  f.read 14
               m
         "Shrek is love!"
     temp.path > src
@@ -483,7 +488,8 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put ((f.read 7).read 5) > [f] >>
+              m.put > [f] >>
+                (f.read 7).read 5
             m
       "world"
 
@@ -492,5 +498,7 @@
       size.
         mktemp.tmpfile.open
           "a+"
-          (f.write "Hello, world").write "!" > [f]
+          write. > [f]
+            f.write "Hello, world"
+            "!"
       13

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -109,9 +109,7 @@
 
   (0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16).not ++> tests-i16-lte-false
 
-  gte. ++> tests-i16-gte-true
-    -1000.as-i64.as-i32.as-i16
-    -1100.as-i64.as-i32.as-i16
+  -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
 
   113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
 

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -25,7 +25,9 @@
     i32 > left
       as-bytes.slice 4 4
   [] > as-number /number
-  (i64 x.as-bytes).gt ^ > [x] > lt
+  gt. > [x] > lt
+    i64 x.as-bytes
+    ^
   [x] > lte
     or. > @
       lt value
@@ -89,9 +91,7 @@
 
   234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> tests-i64-to-i32-and-back
 
-  eq. ++> tests-negative-i64-to-i32-and-back
-    -234.as-i64
-    -234.as-i64.as-i32.as-i64
+  -234.as-i64.eq -234.as-i64.as-i32.as-i64 ++> tests-negative-i64-to-i32-and-back
 
   3147483647.as-i64.as-i32 --> on-converting-to-i32-if-out-of-bounds
 
@@ -162,9 +162,13 @@
 
   (123.@.eq 42.@).not ++> tests-i64-eq-false
 
-  (1.as-i64.plus 1.as-i64).eq 2.as-i64 ++> tests-i64-one-plus-i64-one
+  eq. ++> tests-i64-one-plus-i64-one
+    1.as-i64.plus 1.as-i64
+    2.as-i64
 
-  (1.as-i64.minus 1.as-i64).eq 0.as-i64 ++> tests-i64-one-minus-i64-one
+  eq. ++> tests-i64-one-minus-i64-one
+    1.as-i64.minus 1.as-i64
+    0.as-i64
 
   2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero
 
@@ -180,15 +184,25 @@
       dividend
     -235.as-i64 > dividend
 
-  (13.as-i64.div -5.as-i64).eq -2.as-i64 ++> tests-i64-div-with-remainder
+  eq. ++> tests-i64-div-with-remainder
+    13.as-i64.div -5.as-i64
+    -2.as-i64
 
-  (1.as-i64.div 5.as-i64).lt 1.as-i64 ++> tests-i64-div-less-than-i64-one
+  lt. ++> tests-i64-div-less-than-i64-one
+    1.as-i64.div 5.as-i64
+    1.as-i64
 
-  (1000.as-i64.times 0.as-i64).eq 0.as-i64 ++> tests-i64-multiply-by-zero
+  eq. ++> tests-i64-multiply-by-zero
+    1000.as-i64.times 0.as-i64
+    0.as-i64
 
-  (-7.as-i64.times -6.as-i64).eq 42.as-i64 ++> tests-i64-times-of-two-negatives
+  eq. ++> tests-i64-times-of-two-negatives
+    -7.as-i64.times -6.as-i64
+    42.as-i64
 
-  (-7.as-i64.times 6.as-i64).eq -42.as-i64 ++> tests-i64-times-of-mixed-signs
+  eq. ++> tests-i64-times-of-mixed-signs
+    -7.as-i64.times 6.as-i64
+    -42.as-i64
 
   eq. ++> tests-i64-times-wraps-modulo-2-pow-64
     times.

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -89,23 +89,39 @@
 
   (2A-.as-i8.eq 2B-.as-i8).not ++> tests-i8-eq-false
 
-  (01-.as-i8.plus 01-.as-i8).eq 02-.as-i8 ++> tests-i8-one-plus-i8-one
+  eq. ++> tests-i8-one-plus-i8-one
+    01-.as-i8.plus 01-.as-i8
+    02-.as-i8
 
-  (7F-.as-i8.plus 01-.as-i8).eq 80-.as-i8 ++> tests-i8-plus-with-overflow
+  eq. ++> tests-i8-plus-with-overflow
+    7F-.as-i8.plus 01-.as-i8
+    80-.as-i8
 
   2A-.as-i8.neg.eq D6-.as-i8 ++> tests-i8-negation
 
-  (01-.as-i8.minus 01-.as-i8).eq 00-.as-i8 ++> tests-i8-one-minus-i8-one
+  eq. ++> tests-i8-one-minus-i8-one
+    01-.as-i8.minus 01-.as-i8
+    00-.as-i8
 
-  (80-.as-i8.minus 01-.as-i8).eq 7F-.as-i8 ++> tests-i8-minus-with-overflow
+  eq. ++> tests-i8-minus-with-overflow
+    80-.as-i8.minus 01-.as-i8
+    7F-.as-i8
 
-  (06-.as-i8.times 07-.as-i8).eq 2A-.as-i8 ++> tests-i8-times
+  eq. ++> tests-i8-times
+    06-.as-i8.times 07-.as-i8
+    2A-.as-i8
 
-  (FF-.as-i8.times FF-.as-i8).eq 01-.as-i8 ++> tests-i8-times-of-two-negatives
+  eq. ++> tests-i8-times-of-two-negatives
+    FF-.as-i8.times FF-.as-i8
+    01-.as-i8
 
-  (0D-.as-i8.div FB-.as-i8).eq FE-.as-i8 ++> tests-i8-div-with-remainder
+  eq. ++> tests-i8-div-with-remainder
+    0D-.as-i8.div FB-.as-i8
+    FE-.as-i8
 
-  (C8-.as-i8.div 01-.as-i8).eq C8-.as-i8 ++> tests-i8-div-by-i8-one
+  eq. ++> tests-i8-div-by-i8-one
+    C8-.as-i8.div 01-.as-i8
+    C8-.as-i8
 
   02-.as-i8.div 00-.as-i8 --> on-division-i8-by-i8-zero
 

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -32,4 +32,6 @@
       bts
     01-02-03-04-05-06-07-08 > bts
 
-  (Q.input.as-bytes dead).eq -- ++> tests-returns-empty-bytes-from-dead-input
+  eq. ++> tests-returns-empty-bytes-from-dead-input
+    Q.input.as-bytes dead
+    --

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -60,10 +60,9 @@
     eq. > @
       malloc.of
         0
-        [m]
-          Q.input.copied > @
-            bytes.to-input --
-            io.malloc-as-output m
+        Q.input.copied > [m]
+          bytes.to-input --
+          io.malloc-as-output m
       0
 
   ++> tests-handles-large-data
@@ -74,4 +73,8 @@
           bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
           io.malloc-as-output m
 
-  (Q.input.copied Q.input.dead Q.output.dead).eq 0 ++> tests-handles-dead-input
+  eq. ++> tests-handles-dead-input
+    Q.input.copied
+      Q.input.dead
+      Q.output.dead
+    0

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -62,7 +62,9 @@
 +unlint mandatory-package
 
 [] > malloc
-  malloc.of 0 scope > [scope] > empty
+  malloc.of > [scope] > empty
+    0
+    scope
   [object scope] > for
     malloc.of > @
       bts.size
@@ -77,10 +79,9 @@
       read 0 size > get
       [] > size /number
       [size] > resized /Q.malloc.of.allocated
-      [source target length] > copy
-        write > @
-          target
-          read source length
+      write > [source target length] > copy
+        target
+        read source length
       [offset length] > read /bytes
         ? > cant-read /{string}
       [offset data] > write /bool
@@ -118,7 +119,8 @@
             * second second
           malloc.of > second
             1
-            f.put (f.as-number.plus 1) > [s] >>
+            f.put > [s] >>
+              f.as-number.plus 1
 
   ++> tests-malloc-for-writes-first-init-value
     eq. > @
@@ -168,7 +170,8 @@
   --> on-overflow-string-malloc
     malloc.for > @
       "Hello"
-      m.put "Much longer string!" > [m]
+      m.put > [m]
+        "Much longer string!"
 
   ++> tests-malloc-is-strictly-sized-int
     eq. > @
@@ -199,7 +202,8 @@
   ++> tests-malloc-gives-id-to-allocated-block
     malloc.of > @
       1
-      m.put (m.id.gt 0) > [m]
+      m.put > [m]
+        m.id.gt 0
 
   ++> tests-malloc-allocates-right-size-block
     malloc.of > @
@@ -207,7 +211,8 @@
       [b]
         malloc.of > @
           10
-          b.put (m.size.eq 10) > [m] >>
+          b.put > [m] >>
+            m.size.eq 10
 
   ++> tests-malloc-writes-and-reads
     malloc.of > @
@@ -294,11 +299,10 @@
       [b]
         malloc.for > @
           01-02-03-04-05
-          [m] >>
-            b.put > @
-              and.
-                (m.resized 3).size.eq 3
-                m.get.eq 01-02-03
+          b.put > [m] >>
+            and.
+              (m.resized 3).size.eq 3
+              m.get.eq 01-02-03
 
   --> on-changing-size-to-negative
     malloc.of > @
@@ -317,23 +321,30 @@
   ++> tests-copies-data-inside-itself
     malloc.for > @
       01-02-03-04-05
-      [m]
-        and. > @
-          m.copy 1 2 2
-          m.get.eq 01-02-02-03-05
+      and. > [m]
+        m.copy
+          1
+          2
+          2
+        m.get.eq 01-02-02-03-05
 
   ++> tests-copies-data-from-start-to-end
     malloc.for > @
       01-02-03-04-05-06
-      [m]
-        and. > @
-          m.copy 0 3 3
-          m.get.eq 01-02-03-01-02-03
+      and. > [m]
+        m.copy
+          0
+          3
+          3
+        m.get.eq 01-02-03-01-02-03
 
   --> on-copying-with-wrong-source
     malloc.for > @
       0
-      m.copy 9 1 1 > [m]
+      m.copy > [m]
+        9
+        1
+        1
 
   ++> copies-and-resizes-to-target
     malloc.for > @
@@ -348,7 +359,10 @@
   --> on-copying-with-wrong-length
     malloc.for > @
       0
-      m.copy 3 1 9 > [m]
+      m.copy > [m]
+        3
+        1
+        9
 
   ++> tests-calculates-only-once
     eq. > @

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -77,11 +77,19 @@
   [x] > plus /number
   [x] > div /number
 
-  (-200.gt -1000).eq true ++> tests-int-greater-true
+  eq. ++> tests-int-greater-true
+    -200.gt -1000
+    true
 
-  (0.gt 100).not.eq true ++> tests-int-greater-false
+  eq. ++> tests-int-greater-false
+    not.
+      0.gt 100
+    true
 
-  (0.gt 0).not.eq true ++> tests-int-greater-equal
+  eq. ++> tests-int-greater-equal
+    not.
+      0.gt 0
+    true
 
   eq. ++> tests-int-equal-to-nan-and-infinites-is-false
     and.
@@ -101,31 +109,43 @@
         false
     true
 
-  (0.eq 0).eq true ++> tests-int-zero-eq-to-zero
+  eq. ++> tests-int-zero-eq-to-zero
+    0.eq 0
+    true
 
-  (0.eq 0).eq true ++> tests-int-zero-eq-to-float-zero
+  eq. ++> tests-int-zero-eq-to-float-zero
+    0.eq 0
+    true
 
-  (123.eq 123).eq true ++> tests-int-eq-true
+  eq. ++> tests-int-eq-true
+    123.eq 123
+    true
 
-  (123.eq 42).not.eq true ++> tests-int-eq-false
+  eq. ++> tests-int-eq-false
+    not.
+      123.eq 42
+    true
 
-  (1.plus 1).eq 2 ++> tests-one-plus-one
+  eq. ++> tests-one-plus-one
+    1.plus 1
+    2
 
-  (68.eq "12345678").eq false ++> tests-compares-two-different-number-types
+  eq. ++> tests-compares-two-different-number-types
+    68.eq "12345678"
+    false
 
   ++> tests-calculates-fibonacci-number-with-recursion
     eq. > @
       fibo 4
       3
-    [n] > fibo
-      if. > @
-        n.lt 3
-        1
-        plus.
-          fibo
-            n.minus 1
-          fibo
-            n.minus 2
+    if. > [n] > fibo
+      n.lt 3
+      1
+      plus.
+        fibo
+          n.minus 1
+        fibo
+          n.minus 2
 
   ++> tests-calculates-fibonacci-number-with-tail
     eq. > @
@@ -139,11 +159,10 @@
           n
           1
           1
-      [n] > small
-        if. > @
-          n.eq 2
-          1
-          n
+      if. > [n] > small
+        n.eq 2
+        1
+        n
       if. > [n minus1 minus2] > rec
         n.eq 3
         minus1.plus minus2
@@ -162,11 +181,18 @@
       dividend
     -235 > dividend
 
-  (256.div 16).eq 16 ++> tests-div-for-dividend-greater-than-zero
+  eq. ++> tests-div-for-dividend-greater-than-zero
+    256.div 16
+    16
 
-  (13.div -5).floor.eq -3 ++> tests-div-with-remainder
+  eq. ++> tests-div-with-remainder
+    floor.
+      13.div -5
+    -3
 
-  (1.div 5).lt 1 ++> tests-div-less-than-one
+  lt. ++> tests-div-less-than-one
+    1.div 5
+    1
 
   42.as-bytes.eq 42 ++> tests-to-bytes-and-backwards
 
@@ -174,9 +200,12 @@
 
   42.as-bytes.eq 42 ++> tests-as-bytes-equals-to-int-backwards
 
-  (1000.times 0).eq 0 ++> tests-multiply-by-zero
+  eq. ++> tests-multiply-by-zero
+    1000.times 0
+    0
 
-  pinf.eq (1.div 0) ++> tests-positive-infinity-is-equal-to-one-div-zero
+  pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
+    1.div 0
 
   pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
 
@@ -247,38 +276,68 @@
       pinf.times nan
     nan.as-bytes
 
-  (pinf.times ninf).eq ninf ++> tests-positive-infinity-times-negative-infinity
+  eq. ++> tests-positive-infinity-times-negative-infinity
+    pinf.times ninf
+    ninf
 
-  (pinf.times pinf).eq pinf ++> tests-positive-infinity-times-positive-infinity
+  eq. ++> tests-positive-infinity-times-positive-infinity
+    pinf.times pinf
+    pinf
 
-  (pinf.times 42.5).eq pinf ++> tests-positive-infinity-times-positive-float
+  eq. ++> tests-positive-infinity-times-positive-float
+    pinf.times 42.5
+    pinf
 
-  (pinf.times 42).eq pinf ++> tests-positive-infinity-times-positive-int
+  eq. ++> tests-positive-infinity-times-positive-int
+    pinf.times 42
+    pinf
 
-  (pinf.times -42.5).eq ninf ++> tests-positive-infinity-times-negative-float
+  eq. ++> tests-positive-infinity-times-negative-float
+    pinf.times -42.5
+    ninf
 
-  (pinf.times -42).eq ninf ++> tests-positive-infinity-times-negative-int
+  eq. ++> tests-positive-infinity-times-negative-int
+    pinf.times -42
+    ninf
 
-  (pinf.plus nan).as-bytes.eq nan.as-bytes ++> tests-positive-infinity-plus-nan
+  eq. ++> tests-positive-infinity-plus-nan
+    as-bytes.
+      pinf.plus nan
+    nan.as-bytes
 
   eq. ++> tests-positive-infinity-plus-negative-infinity
     as-bytes.
       pinf.plus ninf
     nan.as-bytes
 
-  (pinf.plus pinf).eq pinf ++> tests-positive-infinity-plus-positive-infinity
+  eq. ++> tests-positive-infinity-plus-positive-infinity
+    pinf.plus pinf
+    pinf
 
-  (pinf.plus 42.5).eq pinf ++> tests-positive-infinity-plus-positive-float
+  eq. ++> tests-positive-infinity-plus-positive-float
+    pinf.plus 42.5
+    pinf
 
-  (pinf.div 0).eq pinf ++> tests-positive-infinity-div-float-zero
+  eq. ++> tests-positive-infinity-div-float-zero
+    pinf.div 0
+    pinf
 
-  (pinf.div -0).eq ninf ++> tests-positive-infinity-div-neg-float-zero
+  eq. ++> tests-positive-infinity-div-neg-float-zero
+    pinf.div -0
+    ninf
 
-  (pinf.div 0).eq pinf ++> tests-positive-infinity-div-int-zero
+  eq. ++> tests-positive-infinity-div-int-zero
+    pinf.div 0
+    pinf
 
-  (pinf.div -0).eq ninf ++> tests-positive-infinity-div-neg-int-zero
+  eq. ++> tests-positive-infinity-div-neg-int-zero
+    pinf.div -0
+    ninf
 
-  (pinf.div nan).as-bytes.eq nan.as-bytes ++> tests-positive-infinity-div-nan
+  eq. ++> tests-positive-infinity-div-nan
+    as-bytes.
+      pinf.div nan
+    nan.as-bytes
 
   eq. ++> tests-positive-infinity-div-negative-infinity
     as-bytes.
@@ -290,19 +349,28 @@
       pinf.div pinf
     nan.as-bytes
 
-  (pinf.div 42.5).eq pinf ++> tests-positive-infinity-div-positive-float
+  eq. ++> tests-positive-infinity-div-positive-float
+    pinf.div 42.5
+    pinf
 
-  (pinf.div 42).eq pinf ++> tests-positive-infinity-div-positive-int
+  eq. ++> tests-positive-infinity-div-positive-int
+    pinf.div 42
+    pinf
 
-  (pinf.div -42.5).eq ninf ++> tests-positive-infinity-div-negative-float
+  eq. ++> tests-positive-infinity-div-negative-float
+    pinf.div -42.5
+    ninf
 
-  (pinf.div -42).eq ninf ++> tests-positive-infinity-div-negative-int
+  eq. ++> tests-positive-infinity-div-negative-int
+    pinf.div -42
+    ninf
 
   pinf.as-bytes.eq ++> tests-positive-infinity-as-bytes-is-valid
     as-bytes.
       1.div 0
 
-  ninf.eq (-1.div 0) ++> tests-negative-infinity-is-equal-to-one-div-zero
+  ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
+    -1.div 0
 
   ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
 
@@ -316,13 +384,21 @@
 
   (ninf.gt ninf).not ++> tests-negative-infinity-gt-negative-infinity
 
-  (ninf.gt pinf).eq false ++> tests-negative-infinity-not-gt-positive-infinity
+  eq. ++> tests-negative-infinity-not-gt-positive-infinity
+    ninf.gt pinf
+    false
 
-  (ninf.gt nan).eq false ++> tests-negative-infinity-not-gt-nan
+  eq. ++> tests-negative-infinity-not-gt-nan
+    ninf.gt nan
+    false
 
-  (ninf.gt 42).eq false ++> tests-negative-infinity-not-gt-int
+  eq. ++> tests-negative-infinity-not-gt-int
+    ninf.gt 42
+    false
 
-  (ninf.gt 42.5).eq false ++> tests-negative-infinity-not-gt-float
+  eq. ++> tests-negative-infinity-not-gt-float
+    ninf.gt 42.5
+    false
 
   eq. ++> tests-negative-infinity-times-float-zero
     as-bytes.
@@ -344,44 +420,79 @@
       ninf.times nan
     nan.as-bytes
 
-  (ninf.times pinf).eq ninf ++> tests-negative-infinity-times-positive-infinity
+  eq. ++> tests-negative-infinity-times-positive-infinity
+    ninf.times pinf
+    ninf
 
-  (ninf.times ninf).eq pinf ++> tests-negative-infinity-times-negative-infinity
+  eq. ++> tests-negative-infinity-times-negative-infinity
+    ninf.times ninf
+    pinf
 
-  (ninf.times 42.5).eq ninf ++> tests-negative-infinity-times-positive-float
+  eq. ++> tests-negative-infinity-times-positive-float
+    ninf.times 42.5
+    ninf
 
-  (ninf.times 42).eq ninf ++> tests-negative-infinity-times-positive-int
+  eq. ++> tests-negative-infinity-times-positive-int
+    ninf.times 42
+    ninf
 
-  (ninf.times -42.5).eq pinf ++> tests-negative-infinity-times-negative-float
+  eq. ++> tests-negative-infinity-times-negative-float
+    ninf.times -42.5
+    pinf
 
-  (ninf.times -42).eq pinf ++> tests-negative-infinity-times-negative-int
+  eq. ++> tests-negative-infinity-times-negative-int
+    ninf.times -42
+    pinf
 
-  (ninf.plus nan).as-bytes.eq nan.as-bytes ++> tests-negative-infinity-plus-nan
+  eq. ++> tests-negative-infinity-plus-nan
+    as-bytes.
+      ninf.plus nan
+    nan.as-bytes
 
   eq. ++> tests-negative-infinity-plus-positive-infinity
     as-bytes.
       ninf.plus pinf
     nan.as-bytes
 
-  ninf.eq (ninf.plus ninf) ++> tests-negative-infinity-plus-negative-infinity
+  ninf.eq ++> tests-negative-infinity-plus-negative-infinity
+    ninf.plus ninf
 
-  (ninf.plus 42.5).eq ninf ++> tests-negative-infinity-plus-positive-float
+  eq. ++> tests-negative-infinity-plus-positive-float
+    ninf.plus 42.5
+    ninf
 
-  (ninf.plus 42).eq ninf ++> tests-negative-infinity-plus-positive-int
+  eq. ++> tests-negative-infinity-plus-positive-int
+    ninf.plus 42
+    ninf
 
-  (ninf.plus -42.5).eq ninf ++> tests-negative-infinity-plus-negative-float
+  eq. ++> tests-negative-infinity-plus-negative-float
+    ninf.plus -42.5
+    ninf
 
-  (ninf.plus -42).eq ninf ++> tests-negative-infinity-plus-negative-int
+  eq. ++> tests-negative-infinity-plus-negative-int
+    ninf.plus -42
+    ninf
 
-  (ninf.div 0).eq ninf ++> tests-negative-infinity-div-float-zero
+  eq. ++> tests-negative-infinity-div-float-zero
+    ninf.div 0
+    ninf
 
-  (ninf.div -0).eq pinf ++> tests-negative-infinity-div-neg-float-zero
+  eq. ++> tests-negative-infinity-div-neg-float-zero
+    ninf.div -0
+    pinf
 
-  (ninf.div 0).eq ninf ++> tests-negative-infinity-div-int-zero
+  eq. ++> tests-negative-infinity-div-int-zero
+    ninf.div 0
+    ninf
 
-  (ninf.div -0).eq pinf ++> tests-negative-infinity-div-neg-int-zero
+  eq. ++> tests-negative-infinity-div-neg-int-zero
+    ninf.div -0
+    pinf
 
-  (ninf.div nan).as-bytes.eq nan.as-bytes ++> tests-negative-infinity-div-nan
+  eq. ++> tests-negative-infinity-div-nan
+    as-bytes.
+      ninf.div nan
+    nan.as-bytes
 
   eq. ++> tests-negative-infinity-div-positive-infinity
     as-bytes.
@@ -393,13 +504,21 @@
       ninf.div ninf
     nan.as-bytes
 
-  (ninf.div 42.5).eq ninf ++> tests-negative-infinity-div-positive-float
+  eq. ++> tests-negative-infinity-div-positive-float
+    ninf.div 42.5
+    ninf
 
-  (ninf.div 42).eq ninf ++> tests-negative-infinity-div-positive-int
+  eq. ++> tests-negative-infinity-div-positive-int
+    ninf.div 42
+    ninf
 
-  (ninf.div -42.5).eq pinf ++> tests-negative-infinity-div-negative-float
+  eq. ++> tests-negative-infinity-div-negative-float
+    ninf.div -42.5
+    pinf
 
-  (ninf.div -42).eq pinf ++> tests-negative-infinity-div-negative-int
+  eq. ++> tests-negative-infinity-div-negative-int
+    ninf.div -42
+    pinf
 
   ninf.as-bytes.eq ++> tests-negative-infinity-as-bytes-is-valid
     as-bytes.
@@ -409,9 +528,13 @@
 
   (nan.eq nan).not ++> tests-nan-not-eq-nan
 
-  (nan.gt 42).eq false ++> tests-nan-not-gt-number
+  eq. ++> tests-nan-not-gt-number
+    nan.gt 42
+    false
 
-  (nan.gt nan).eq false ++> tests-nan-not-gt-nan
+  eq. ++> tests-nan-not-gt-nan
+    nan.gt nan
+    false
 
   nan.as-bytes.eq ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
     as-bytes.
@@ -454,12 +577,23 @@
     -9.223372036854776e18.as-i64.as-bytes
     80-00-00-00-00-00-00-00
 
-  (2.power 4).eq 16 ++> tests-package-raises-to-power
+  eq. ++> tests-package-raises-to-power
+    2.power 4
+    16
 
   -17.9.abs.eq 17.9 ++> tests-package-absolute-of-negative
 
-  (7.mod 3).eq 1 ++> tests-package-modulo-of-two-numbers
+  eq. ++> tests-package-modulo-of-two-numbers
+    7.mod 3
+    1
 
-  (9.sqrt.minus 3).abs.lt 1.0E-9 ++> tests-package-square-root-approximates
+  lt. ++> tests-package-square-root-approximates
+    abs.
+      9.sqrt.minus 3
+    1.0E-9
 
-  (number.power 2 5).eq 32 ++> tests-package-power-via-number-namespace
+  eq. ++> tests-package-power-via-number-namespace
+    number.power
+      2
+      5
+    32

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -14,12 +14,22 @@
     value.neg
   number num.as-bytes > value
 
-  (abs 3).eq 3 ++> tests-abs-int-positive
+  eq. ++> tests-abs-int-positive
+    abs 3
+    3
 
-  (abs -3).eq 3 ++> tests-abs-int-negative
+  eq. ++> tests-abs-int-negative
+    abs -3
+    3
 
-  (abs 0).eq 0 ++> tests-abs-zero
+  eq. ++> tests-abs-zero
+    abs 0
+    0
 
-  (abs 13.5).eq 13.5 ++> tests-abs-float-positive
+  eq. ++> tests-abs-float-positive
+    abs 13.5
+    13.5
 
-  (abs -17.9).eq 17.9 ++> tests-abs-float-negative
+  eq. ++> tests-abs-float-negative
+    abs -17.9
+    17.9

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,14 +15,17 @@
     pi.div 2
     arc-sine num
 
-  (arc-cosine 1).eq 0 ++> tests-arc-cosine-of-one-is-zero
+  eq. ++> tests-arc-cosine-of-one-is-zero
+    arc-cosine 1
+    0
 
-  ++> tests-arc-cosine-of-zero-is-pi-halves
-    eq. > @
-      arc-cosine 0
-      pi.div 2
+  eq. ++> tests-arc-cosine-of-zero-is-pi-halves
+    arc-cosine 0
+    pi.div 2
 
-  (arc-cosine -1).eq pi ++> tests-arc-cosine-of-negative-one-is-pi
+  eq. ++> tests-arc-cosine-of-negative-one-is-pi
+    arc-cosine -1
+    pi
 
   lt. ++> tests-arc-cosine-of-point-six
     abs

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -50,7 +50,9 @@
           poly
             depth.plus 1
 
-  (arc-sine 0).eq 0 ++> tests-arc-sine-of-zero-is-zero
+  eq. ++> tests-arc-sine-of-zero-is-zero
+    arc-sine 0
+    0
 
   lt. ++> tests-arc-sine-of-one-is-pi-halves
     abs

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -14,15 +14,16 @@
     pi
   number num.as-bytes > value
 
-  (degrees 0).eq 0 ++> tests-degrees-of-zero-is-zero
+  eq. ++> tests-degrees-of-zero-is-zero
+    degrees 0
+    0
 
-  ++> tests-degrees-of-pi-is-half-turn
-    lt. > @
-      abs
-        minus.
-          degrees pi
-          180
-      1.0E-4
+  lt. ++> tests-degrees-of-pi-is-half-turn
+    abs
+      minus.
+        degrees pi
+        180
+    1.0E-4
 
   lt. ++> tests-degrees-of-pi-halves-is-quarter-turn
     abs

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -12,39 +12,39 @@
     e
     num
 
-  ++> tests-exp-check-n0
-    lt. > @
-      abs
-        e.minus
-          exp 1
-      1.0E-8
+  lt. ++> tests-exp-check-n0
+    abs
+      e.minus
+        exp 1
+    1.0E-8
 
-  ++> tests-exp-check-n1
-    lt. > @
-      abs
-        minus.
-          1.div e
-          exp -1
-      1.0E-8
+  lt. ++> tests-exp-check-n1
+    abs
+      minus.
+        1.div e
+        exp -1
+    1.0E-8
 
-  ++> tests-exp-check-n2
-    lt. > @
-      abs
-        minus.
-          power e 5
-          exp 5
-      1.0E-7
+  lt. ++> tests-exp-check-n2
+    abs
+      minus.
+        power e 5
+        exp 5
+    1.0E-7
 
-  ++> tests-exp-check-n3
-    lt. > @
-      abs
-        minus.
-          power e -10
-          exp -10
-      1.0E-12
+  lt. ++> tests-exp-check-n3
+    abs
+      minus.
+        power e -10
+        exp -10
+    1.0E-12
 
   (exp nan).is-nan ++> tests-exp-check-nan
 
-  (exp pinf).eq pinf ++> tests-exp-check-infinity-n1
+  eq. ++> tests-exp-check-infinity-n1
+    exp pinf
+    pinf
 
-  (exp ninf).eq 0 ++> tests-exp-check-infinity-n2
+  eq. ++> tests-exp-check-infinity-n2
+    exp ninf
+    0

--- a/eo-runtime/src/main/eo/number/gte.eo
+++ b/eo-runtime/src/main/eo/number/gte.eo
@@ -13,32 +13,63 @@
     n.eq value
   x > value!
 
-  (-1000.gte -1100).eq true ++> tests-int-gte-true
+  eq. ++> tests-int-gte-true
+    -1000.gte -1100
+    true
 
-  (113.gte 113).eq true ++> tests-int-gte-equal
+  eq. ++> tests-int-gte-equal
+    113.gte 113
+    true
 
-  (0.gte 10).not.eq true ++> tests-int-gte-false
+  eq. ++> tests-int-gte-false
+    not.
+      0.gte 10
+    true
 
-  (pinf.gte pinf).eq true ++> tests-positive-infinity-gte-positive-infinity
+  eq. ++> tests-positive-infinity-gte-positive-infinity
+    pinf.gte pinf
+    true
 
-  (pinf.gte ninf).eq true ++> tests-positive-infinity-gte-negative-infinity
+  eq. ++> tests-positive-infinity-gte-negative-infinity
+    pinf.gte ninf
+    true
 
-  (pinf.gte nan).eq false ++> tests-positive-infinity-not-gte-nan
+  eq. ++> tests-positive-infinity-not-gte-nan
+    pinf.gte nan
+    false
 
-  (pinf.gte 42).eq true ++> tests-positive-infinity-gte-int
+  eq. ++> tests-positive-infinity-gte-int
+    pinf.gte 42
+    true
 
-  (pinf.gte 42.5).eq true ++> tests-positive-infinity-gte-float
+  eq. ++> tests-positive-infinity-gte-float
+    pinf.gte 42.5
+    true
 
-  (ninf.gte ninf).eq true ++> tests-negative-infinity-gte-negative-infinity
+  eq. ++> tests-negative-infinity-gte-negative-infinity
+    ninf.gte ninf
+    true
 
-  (ninf.gte pinf).eq false ++> tests-negative-infinity-not-gte-positive-infinity
+  eq. ++> tests-negative-infinity-not-gte-positive-infinity
+    ninf.gte pinf
+    false
 
-  (ninf.gte nan).eq false ++> tests-negative-infinity-not-gte-nan
+  eq. ++> tests-negative-infinity-not-gte-nan
+    ninf.gte nan
+    false
 
-  (ninf.gte 42).eq false ++> tests-negative-infinity-not-gte-int
+  eq. ++> tests-negative-infinity-not-gte-int
+    ninf.gte 42
+    false
 
-  (ninf.gte 42.5).eq false ++> tests-negative-infinity-not-gte-float
+  eq. ++> tests-negative-infinity-not-gte-float
+    ninf.gte 42.5
+    false
 
-  (nan.gte 42).eq false ++> tests-nan-not-gte-number
+  eq. ++> tests-nan-not-gte-number
+    nan.gte 42
+    false
 
-  (nan.gte nan).eq false ++> tests-nan-not-gte-nan
+  eq. ++> tests-nan-not-gte-nan
+    nan.gte nan
+    false

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -63,11 +63,10 @@
             value.minus operand
           err
         0
-      [value] > abs
-        if. > @
-          value.gte 0
-          value
-          value.neg
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
 
   ++> tests-calculates-quadratic-integral
     close-to > @
@@ -86,11 +85,10 @@
             value.minus operand
           err
         0
-      [value] > abs
-        if. > @
-          value.gte 0
-          value
-          value.neg
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
 
   ++> tests-calculates-cube-integral
     close-to > @
@@ -109,8 +107,7 @@
             value.minus operand
           err
         0
-      [value] > abs
-        if. > @
-          value.gte 0
-          value
-          value.neg
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -18,23 +18,47 @@
 
   ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
 
-  (nan.times 42).as-bytes.eq nan.as-bytes ++> tests-nan-times-number-is-nan
+  eq. ++> tests-nan-times-number-is-nan
+    as-bytes.
+      nan.times 42
+    nan.as-bytes
 
-  (nan.times nan).as-bytes.eq nan.as-bytes ++> tests-nan-times-nan-is-nan
+  eq. ++> tests-nan-times-nan-is-nan
+    as-bytes.
+      nan.times nan
+    nan.as-bytes
 
-  (nan.div 42).as-bytes.eq nan.as-bytes ++> tests-nan-div-number-is-nan
+  eq. ++> tests-nan-div-number-is-nan
+    as-bytes.
+      nan.div 42
+    nan.as-bytes
 
-  (nan.div nan).as-bytes.eq nan.as-bytes ++> tests-nan-div-nan-is-nan
+  eq. ++> tests-nan-div-nan-is-nan
+    as-bytes.
+      nan.div nan
+    nan.as-bytes
 
-  (nan.plus 42).as-bytes.eq nan.as-bytes ++> tests-nan-plus-number-is-nan
+  eq. ++> tests-nan-plus-number-is-nan
+    as-bytes.
+      nan.plus 42
+    nan.as-bytes
 
-  (nan.plus nan).as-bytes.eq nan.as-bytes ++> tests-nan-plus-nan-is-nan
+  eq. ++> tests-nan-plus-nan-is-nan
+    as-bytes.
+      nan.plus nan
+    nan.as-bytes
 
   nan.@.as-bytes.eq nan.as-bytes ++> tests-nan-neg-is-nan
 
-  (nan.minus 42).as-bytes.eq nan.as-bytes ++> tests-nan-minus-number-is-nan
+  eq. ++> tests-nan-minus-number-is-nan
+    as-bytes.
+      nan.minus 42
+    nan.as-bytes
 
-  (nan.minus nan).as-bytes.eq nan.as-bytes ++> tests-nan-minus-nan-is-nan
+  eq. ++> tests-nan-minus-nan-is-nan
+    as-bytes.
+      nan.minus nan
+    nan.as-bytes
 
   nan.floor.as-bytes.eq nan.as-bytes ++> tests-nan-floor-is-nan
 

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -60,37 +60,42 @@
 
   (ln -2.2).is-nan ++> tests-ln-of-negative-float-is-nan
 
-  (ln 0).eq ninf ++> tests-ln-of-zero-is-negative-infinity
+  eq. ++> tests-ln-of-zero-is-negative-infinity
+    ln 0
+    ninf
 
-  (ln 1).eq 0 ++> tests-ln-of-one-is-zero
+  eq. ++> tests-ln-of-one-is-zero
+    ln 1
+    0
 
-  (ln e).eq 1 ++> tests-ln-of-e-one-is-one
+  eq. ++> tests-ln-of-e-one-is-one
+    ln e
+    1
 
   (ln -42).is-nan ++> tests-ln-of-negative-int-is-nan
 
-  ++> tests-ln-of-twenty
-    lt. > @
-      abs
-        minus.
-          ln 20
-          2.995732273553991
-      1.0E-11
+  lt. ++> tests-ln-of-twenty
+    abs
+      minus.
+        ln 20
+        2.995732273553991
+    1.0E-11
 
-  ++> tests-ln-fraction
-    lt. > @
-      abs
-        minus.
-          ln 0.5
-          -0.6931471805599453
-      1.0E-11
+  lt. ++> tests-ln-fraction
+    abs
+      minus.
+        ln 0.5
+        -0.6931471805599453
+    1.0E-11
 
-  (ln pinf).eq pinf ++> tests-ln-positive-infinity
+  eq. ++> tests-ln-positive-infinity
+    ln pinf
+    pinf
 
   (ln ninf).is-nan ++> tests-ln-negative-infinity
 
   (ln nan).is-nan ++> tests-ln-nan
 
-  ++> tests-ln-monotonic
-    lt. > @
-      ln 2
-      ln 3
+  lt. ++> tests-ln-monotonic
+    ln 2
+    ln 3

--- a/eo-runtime/src/main/eo/number/lt.eo
+++ b/eo-runtime/src/main/eo/number/lt.eo
@@ -15,30 +15,56 @@
 
   10.lt 50 ++> tests-int-less-true
 
-  (10.lt 10).not.eq true ++> tests-int-less-equal
+  eq. ++> tests-int-less-equal
+    not.
+      10.lt 10
+    true
 
-  (10.lt -5).not.eq true ++> tests-int-less-false
+  eq. ++> tests-int-less-false
+    not.
+      10.lt -5
+    true
 
-  (pinf.lt pinf).eq false ++> tests-positive-infinity-lt-positive-infinity
+  eq. ++> tests-positive-infinity-lt-positive-infinity
+    pinf.lt pinf
+    false
 
-  (pinf.lt ninf).eq false ++> tests-positive-infinity-not-lt-negative-infinity
+  eq. ++> tests-positive-infinity-not-lt-negative-infinity
+    pinf.lt ninf
+    false
 
-  (pinf.lt nan).eq false ++> tests-positive-infinity-not-lt-nan
+  eq. ++> tests-positive-infinity-not-lt-nan
+    pinf.lt nan
+    false
 
-  (pinf.lt 42).eq false ++> tests-positive-infinity-not-lt-int
+  eq. ++> tests-positive-infinity-not-lt-int
+    pinf.lt 42
+    false
 
-  (pinf.lt 42.5).eq false ++> tests-positive-infinity-not-lt-float
+  eq. ++> tests-positive-infinity-not-lt-float
+    pinf.lt 42.5
+    false
 
-  (ninf.lt ninf).eq false ++> tests-negative-infinity-lt-negative-infinity
+  eq. ++> tests-negative-infinity-lt-negative-infinity
+    ninf.lt ninf
+    false
 
-  (ninf.lt pinf).eq true ++> tests-negative-infinity-lt-positive-infinity
+  eq. ++> tests-negative-infinity-lt-positive-infinity
+    ninf.lt pinf
+    true
 
-  (ninf.lt nan).eq false ++> tests-negative-infinity-not-lt-nan
+  eq. ++> tests-negative-infinity-not-lt-nan
+    ninf.lt nan
+    false
 
   ninf.lt 42 ++> tests-negative-infinity-lt-int
 
   ninf.lt 42.5 ++> tests-negative-infinity-lt-float
 
-  (nan.lt 42).eq false ++> tests-nan-not-lt-number
+  eq. ++> tests-nan-not-lt-number
+    nan.lt 42
+    false
 
-  (nan.lt nan).eq false ++> tests-nan-not-lt-nan
+  eq. ++> tests-nan-not-lt-nan
+    nan.lt nan
+    false

--- a/eo-runtime/src/main/eo/number/lte.eo
+++ b/eo-runtime/src/main/eo/number/lte.eo
@@ -13,32 +13,63 @@
     n.eq value
   x > value!
 
-  (-200.lte -100).eq true ++> tests-int-leq-true
+  eq. ++> tests-int-leq-true
+    -200.lte -100
+    true
 
-  (50.lte 50).eq true ++> tests-int-leq-equal
+  eq. ++> tests-int-leq-equal
+    50.lte 50
+    true
 
-  (0.lte -10).not.eq true ++> tests-int-leq-false
+  eq. ++> tests-int-leq-false
+    not.
+      0.lte -10
+    true
 
-  (pinf.lte pinf).eq true ++> tests-positive-infinity-lte-positive-infinity
+  eq. ++> tests-positive-infinity-lte-positive-infinity
+    pinf.lte pinf
+    true
 
-  (pinf.lte ninf).eq false ++> tests-positive-infinity-not-lte-negative-infinity
+  eq. ++> tests-positive-infinity-not-lte-negative-infinity
+    pinf.lte ninf
+    false
 
-  (pinf.lte nan).eq false ++> tests-positive-infinity-not-lte-nan
+  eq. ++> tests-positive-infinity-not-lte-nan
+    pinf.lte nan
+    false
 
-  (pinf.lte 42).eq false ++> tests-positive-infinity-not-lte-int
+  eq. ++> tests-positive-infinity-not-lte-int
+    pinf.lte 42
+    false
 
-  (pinf.lte 42.5).eq false ++> tests-positive-infinity-not-lte-float
+  eq. ++> tests-positive-infinity-not-lte-float
+    pinf.lte 42.5
+    false
 
-  (ninf.lte ninf).eq true ++> tests-negative-infinity-lte-negative-infinity
+  eq. ++> tests-negative-infinity-lte-negative-infinity
+    ninf.lte ninf
+    true
 
-  (ninf.lte pinf).eq true ++> tests-negative-infinity-lte-positive-infinity
+  eq. ++> tests-negative-infinity-lte-positive-infinity
+    ninf.lte pinf
+    true
 
-  (ninf.lte nan).eq false ++> tests-negative-infinity-not-lte-nan
+  eq. ++> tests-negative-infinity-not-lte-nan
+    ninf.lte nan
+    false
 
-  (ninf.lte 42).eq true ++> tests-negative-infinity-lte-int
+  eq. ++> tests-negative-infinity-lte-int
+    ninf.lte 42
+    true
 
-  (ninf.lte 42.5).eq true ++> tests-negative-infinity-lte-float
+  eq. ++> tests-negative-infinity-lte-float
+    ninf.lte 42.5
+    true
 
-  (nan.lte 42).eq false ++> tests-nan-not-lte-number
+  eq. ++> tests-nan-not-lte-number
+    nan.lte 42
+    false
 
-  (nan.lte nan).eq false ++> tests-nan-not-lte-nan
+  eq. ++> tests-nan-not-lte-nan
+    nan.lte nan
+    false

--- a/eo-runtime/src/main/eo/number/minus.eo
+++ b/eo-runtime/src/main/eo/number/minus.eo
@@ -13,7 +13,9 @@
       number value
   x > value!
 
-  (1.minus 1).eq 0 ++> tests-one-minus-one
+  eq. ++> tests-one-minus-one
+    1.minus 1
+    0
 
   eq. ++> tests-positive-infinity-minus-nan
     as-bytes.
@@ -25,15 +27,25 @@
       pinf.minus pinf
     nan.as-bytes
 
-  (pinf.minus ninf).eq pinf ++> tests-positive-infinity-minus-negative-infinity
+  eq. ++> tests-positive-infinity-minus-negative-infinity
+    pinf.minus ninf
+    pinf
 
-  (pinf.minus 42.5).eq pinf ++> tests-positive-infinity-minus-positive-float
+  eq. ++> tests-positive-infinity-minus-positive-float
+    pinf.minus 42.5
+    pinf
 
-  (pinf.minus 42).eq pinf ++> tests-positive-infinity-minus-positive-int
+  eq. ++> tests-positive-infinity-minus-positive-int
+    pinf.minus 42
+    pinf
 
-  (pinf.minus -42.5).eq pinf ++> tests-positive-infinity-minus-negative-float
+  eq. ++> tests-positive-infinity-minus-negative-float
+    pinf.minus -42.5
+    pinf
 
-  (pinf.minus -42).eq pinf ++> tests-positive-infinity-minus-negative-int
+  eq. ++> tests-positive-infinity-minus-negative-int
+    pinf.minus -42
+    pinf
 
   eq. ++> tests-negative-infinity-minus-nan
     as-bytes.
@@ -45,12 +57,22 @@
       ninf.minus ninf
     nan.as-bytes
 
-  (ninf.minus pinf).eq ninf ++> tests-negative-infinity-minus-positive-infinity
+  eq. ++> tests-negative-infinity-minus-positive-infinity
+    ninf.minus pinf
+    ninf
 
-  (ninf.minus 42.5).eq ninf ++> tests-negative-infinity-minus-positive-float
+  eq. ++> tests-negative-infinity-minus-positive-float
+    ninf.minus 42.5
+    ninf
 
-  (ninf.minus 42).eq ninf ++> tests-negative-infinity-minus-positive-int
+  eq. ++> tests-negative-infinity-minus-positive-int
+    ninf.minus 42
+    ninf
 
-  (ninf.minus -42.5).eq ninf ++> tests-negative-infinity-minus-negative-float
+  eq. ++> tests-negative-infinity-minus-negative-float
+    ninf.minus -42.5
+    ninf
 
-  (ninf.minus -42).eq ninf ++> tests-negative-infinity-minus-negative-int
+  eq. ++> tests-negative-infinity-minus-negative-int
+    ninf.minus -42
+    ninf

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -29,15 +29,35 @@
     abs dividend > absx
     abs divisor > absy
 
-  (mod 1 2).eq 1 ++> tests-mod-n1-n2
+  eq. ++> tests-mod-n1-n2
+    mod
+      1
+      2
+    1
 
-  (mod 0 5).eq 0 ++> tests-mod-n0-n5
+  eq. ++> tests-mod-n0-n5
+    mod
+      0
+      5
+    0
 
-  (mod 0 -15).eq 0 ++> tests-mod-n0-n15-neg
+  eq. ++> tests-mod-n0-n15-neg
+    mod
+      0
+      -15
+    0
 
-  (mod -1 7).eq -1 ++> tests-mod-n1-neg-n7
+  eq. ++> tests-mod-n1-neg-n7
+    mod
+      -1
+      7
+    -1
 
-  (mod 16 -200).eq 16 ++> tests-mod-n16-n200-neg
+  eq. ++> tests-mod-n16-n200-neg
+    mod
+      16
+      -200
+    16
 
   ++> tests-div-mod-compatibility
     eq. > @
@@ -49,11 +69,21 @@
     -13 > dividend
     5 > divisor
 
-  (mod -1 5).eq -1 ++> tests-mod-dividend-less-than-divisor
+  eq. ++> tests-mod-dividend-less-than-divisor
+    mod
+      -1
+      5
+    -1
 
-  (mod 133 1).eq 0 ++> tests-mod-dividend-by-one
+  eq. ++> tests-mod-dividend-by-one
+    mod
+      133
+      1
+    0
 
-  mod 5 0 --> on-mod-by-zero
+  mod --> on-mod-by-zero
+    5
+    0
 
   ++> tests-mod-by-zero-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -108,17 +108,41 @@
           fraction
             j.plus 1
 
-  (power 2 4).eq 16 ++> tests-power-of-two-to-four
+  eq. ++> tests-power-of-two-to-four
+    power
+      2
+      4
+    16
 
-  (power 2 0).eq 1 ++> tests-power-of-zero-exponent
+  eq. ++> tests-power-of-zero-exponent
+    power
+      2
+      0
+    1
 
-  (power 984782 -12341).eq 0 ++> tests-power-large-negative-exponent
+  eq. ++> tests-power-large-negative-exponent
+    power
+      984782
+      -12341
+    0
 
-  (power 3 2).eq 9 ++> tests-power-of-three-squared
+  eq. ++> tests-power-of-three-squared
+    power
+      3
+      2
+    9
 
-  (power 0 145).eq 0 ++> tests-power-of-zero-base
+  eq. ++> tests-power-of-zero-base
+    power
+      0
+      145
+    0
 
-  (power 0 -567).eq pinf ++> tests-power-zero-to-negative-odd
+  eq. ++> tests-power-zero-to-negative-odd
+    power
+      0
+      -567
+    pinf
 
   (power nan nan).is-nan ++> tests-power-nan-to-nan-is-nan
 
@@ -126,11 +150,23 @@
 
   (power 52 nan).is-nan ++> tests-power-any-to-nan-is-nan
 
-  (power 42 0).eq 1 ++> tests-power-int-to-zero-is-one
+  eq. ++> tests-power-int-to-zero-is-one
+    power
+      42
+      0
+    1
 
-  (power 42.5 0).eq 1 ++> tests-power-float-to-zero-is-one
+  eq. ++> tests-power-float-to-zero-is-one
+    power
+      42.5
+      0
+    1
 
-  (power 0 -52).eq pinf ++> tests-power-zero-to-negative-is-positive-infinity
+  eq. ++> tests-power-zero-to-negative-is-positive-infinity
+    power
+      0
+      -52
+    pinf
 
   eq. ++> tests-power-zero-to-negative-infinity-is-positive-infinity
     power
@@ -138,7 +174,11 @@
       ninf
     pinf
 
-  (power 42 ninf).eq 0 ++> tests-power-positive-int-to-negative-infinity-is-zero
+  eq. ++> tests-power-positive-int-to-negative-infinity-is-zero
+    power
+      42
+      ninf
+    0
 
   eq. ++> tests-power-positive-float-to-negative-infinity-is-zero
     power
@@ -182,19 +222,47 @@
       -42.2
     0
 
-  (power 2 -1).eq 0.5 ++> tests-power-two-to-minus-one
+  eq. ++> tests-power-two-to-minus-one
+    power
+      2
+      -1
+    0.5
 
-  (power 2 -2).eq 0.25 ++> tests-power-two-to-minus-two
+  eq. ++> tests-power-two-to-minus-two
+    power
+      2
+      -2
+    0.25
 
-  (power 2 -3).eq 0.125 ++> tests-power-two-to-minus-three
+  eq. ++> tests-power-two-to-minus-three
+    power
+      2
+      -3
+    0.125
 
-  (power 4 -3).eq 0.015625 ++> tests-power-four-to-minus-three
+  eq. ++> tests-power-four-to-minus-three
+    power
+      4
+      -3
+    0.015625
 
-  (power 0 4).eq 0 ++> tests-power-zero-to-positive-int-is-zero
+  eq. ++> tests-power-zero-to-positive-int-is-zero
+    power
+      0
+      4
+    0
 
-  (power 0 4.2).eq 0 ++> tests-power-zero-to-positive-float-is-zero
+  eq. ++> tests-power-zero-to-positive-float-is-zero
+    power
+      0
+      4.2
+    0
 
-  (power 0 pinf).eq 0 ++> tests-power-zero-to-positive-infinity-is-zero
+  eq. ++> tests-power-zero-to-positive-infinity-is-zero
+    power
+      0
+      pinf
+    0
 
   eq. ++> tests-power-negative-int-to-positive-infinity-is-positive-infinity
     power
@@ -256,19 +324,30 @@
       9
     ninf
 
-  (power 2 3).eq 8 ++> tests-power-positive-int-to-positive-int
+  eq. ++> tests-power-positive-int-to-positive-int
+    power
+      2
+      3
+    8
 
-  (power 3.5 4).eq 150.0625 ++> tests-power-positive-float-to-positive-int
+  eq. ++> tests-power-positive-float-to-positive-int
+    power
+      3.5
+      4
+    150.0625
 
-  (power 4 5).eq 1024 ++> tests-power-four-to-five
+  eq. ++> tests-power-four-to-five
+    power
+      4
+      5
+    1024
 
-  ++> tests-power-square-root-of-nine
-    lt. > @
-      abs
-        minus.
-          power 9 0.5
-          3
-      1.0E-9
+  lt. ++> tests-power-square-root-of-nine
+    abs
+      minus.
+        power 9 0.5
+        3
+    1.0E-9
 
   lt. ++> tests-power-square-root-of-two
     abs
@@ -288,8 +367,16 @@
 
   (power -4 0.5).is-nan ++> tests-power-fractional-of-negative-is-nan
 
-  (2.power 4).eq 16 ++> tests-power-as-method-on-number
+  eq. ++> tests-power-as-method-on-number
+    2.power 4
+    16
 
-  (3.power 2).eq 9 ++> tests-power-as-method-with-receiver-bound
+  eq. ++> tests-power-as-method-with-receiver-bound
+    3.power 2
+    9
 
-  (power 2 4).eq 16 ++> tests-power-via-number-namespace
+  eq. ++> tests-power-via-number-namespace
+    power
+      2
+      4
+    16

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -14,15 +14,16 @@
     180
   number num.as-bytes > value
 
-  (radians 0).eq 0 ++> tests-radians-of-zero-is-zero
+  eq. ++> tests-radians-of-zero-is-zero
+    radians 0
+    0
 
-  ++> tests-radians-of-half-turn-is-pi
-    lt. > @
-      abs
-        minus.
-          radians 180
-          pi
-      1.0E-4
+  lt. ++> tests-radians-of-half-turn-is-pi
+    abs
+      minus.
+        radians 180
+        pi
+    1.0E-4
 
   lt. ++> tests-radians-of-quarter-turn-is-pi-halves
     abs

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -35,7 +35,9 @@
         factor
           depth.plus 1
 
-  (sine 0).eq 0 ++> tests-sine-of-zero-is-zero
+  eq. ++> tests-sine-of-zero-is-zero
+    sine 0
+    0
 
   lt. ++> tests-sine-of-pi-halves-is-one
     abs
@@ -57,13 +59,12 @@
         500
     1
 
-  ++> tests-sine-of-pi-is-zero
-    lt. > @
-      abs
-        times.
-          sine pi
-          1000
-      1
+  lt. ++> tests-sine-of-pi-is-zero
+    abs
+      times.
+        sine pi
+        1000
+    1
 
   lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
     abs
@@ -94,14 +95,13 @@
         1000
     1
 
-  ++> tests-sine-of-two-pi-is-zero
-    lt. > @
-      abs
-        times.
-          sine
-            pi.times 2
-          1000
-      1
+  lt. ++> tests-sine-of-two-pi-is-zero
+    abs
+      times.
+        sine
+          pi.times 2
+        1000
+    1
 
   lt. ++> tests-sine-reduces-large-angle
     abs

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -18,52 +18,53 @@
       num
       0.5
 
-  (sqrt 0).eq 0 ++> tests-sqrt-zero
+  eq. ++> tests-sqrt-zero
+    sqrt 0
+    0
 
-  (sqrt 1).eq 1 ++> tests-sqrt-one
+  eq. ++> tests-sqrt-one
+    sqrt 1
+    1
 
-  ++> tests-sqrt-four
-    lt. > @
-      abs
-        minus.
-          sqrt 4
-          2
-      1.0E-9
+  lt. ++> tests-sqrt-four
+    abs
+      minus.
+        sqrt 4
+        2
+    1.0E-9
 
-  ++> tests-sqrt-two
-    lt. > @
-      abs
-        minus.
-          sqrt 2
-          1.4142135623730951
-      1.0E-9
+  lt. ++> tests-sqrt-two
+    abs
+      minus.
+        sqrt 2
+        1.4142135623730951
+    1.0E-9
 
-  ++> tests-sqrt-point-five
-    lt. > @
-      abs
-        minus.
-          sqrt 0.25
-          0.5
-      1.0E-9
+  lt. ++> tests-sqrt-point-five
+    abs
+      minus.
+        sqrt 0.25
+        0.5
+    1.0E-9
 
-  ++> tests-sqrt-check-zero-input
-    lt. > @
-      abs
-        0.minus
-          sqrt 0
-      1.0E-11
+  lt. ++> tests-sqrt-check-zero-input
+    abs
+      0.minus
+        sqrt 0
+    1.0E-11
 
   (sqrt -0.1).is-nan ++> tests-sqrt-check-negative-input
 
-  ++> tests-sqrt-check-float-input
-    lt. > @
-      abs
-        2.minus
-          sqrt 4
-      1.0E-11
+  lt. ++> tests-sqrt-check-float-input
+    abs
+      2.minus
+        sqrt 4
+    1.0E-11
 
   (sqrt nan).is-nan ++> tests-sqrt-check-nan-input
 
-  (sqrt pinf).eq pinf ++> tests-sqrt-check-infinity-n1
+  eq. ++> tests-sqrt-check-infinity-n1
+    sqrt pinf
+    pinf
 
   (sqrt ninf).is-nan ++> tests-sqrt-check-infinity-n2

--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -30,4 +30,6 @@
       name
   [] > name /string
 
-  (os.is-windows.or os.is-macos).or os.is-linux ++> tests-checks-os-family
+  or. ++> tests-checks-os-family
+    os.is-windows.or os.is-macos
+    os.is-linux

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -14,7 +14,11 @@
 
 [value alternative] > recovered /bytes
 
-  (recovered 42 7).eq 42 ++> tests-keeps-the-value-when-not-terminated
+  eq. ++> tests-keeps-the-value-when-not-terminated
+    recovered
+      42
+      7
+    42
 
   eq. ++> tests-falls-back-to-alternative-when-terminated
     recovered

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -18,10 +18,10 @@
   [mp] > initialized
     mp.keys > @
     mp.size > size
-    [item] > with
-      set.initialized > @
-        mp.with item true
-    set.initialized (mp.without item) > [item] > without
+    set.initialized > [item] > with
+      mp.with item true
+    set.initialized > [item] > without
+      mp.without item
     mp.has item > [item] > has
 
   eq. ++> tests-set-rebuilds-itself

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -54,4 +54,5 @@
               buffer.size
           output-block
 
-  stderr "Hello, stderr-test!\n" ++> tests-prints-to-stderr
+  stderr ++> tests-prints-to-stderr
+    "Hello, stderr-test!\n"

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -19,4 +19,5 @@
     console.write text
     true
 
-  stdout "Hello, stdout-test!\n" ++> tests-prints-to-console
+  stdout ++> tests-prints-to-console
+    "Hello, stdout-test!\n"

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -157,7 +157,9 @@
                       * byte
       as-bytes.slice index 1 > byte
 
-  " ".length.eq 1 ++> tests-calculates-length-of-spaces-only
+  eq. ++> tests-calculates-length-of-spaces-only
+    " ".length
+    1
 
   eq. ++> tests-turns-string-into-bytes
     "€ друг".as-bytes
@@ -191,7 +193,9 @@
 
   (nan.eq "друг").not ++> tests-compares-string-with-nan
 
-  (pinf.eq "друг").eq false ++> tests-compares-string-with-positive-infinity
+  eq. ++> tests-compares-string-with-positive-infinity
+    pinf.eq "друг"
+    false
 
   (ninf.eq "друг").not ++> tests-compares-string-with-negative-infinity
 
@@ -199,25 +203,27 @@
 
   "e\ne\ne".eq 65-0A-65-0A-65 ++> tests-text-block-tree-lines
 
-  ++> tests-text-block-with-margin
-    "z\n  y\n x".eq > @
-      7A-0A-20-20-79-0A-20-78
+  eq. ++> tests-text-block-with-margin
+    "z\n  y\n x"
+    7A-0A-20-20-79-0A-20-78
 
   ("Hello".eq "Good bye").not ++> tests-compares-two-different-strings
 
-  ++> tests-supports-escape-sequences
-    "Hello, друг!\n".eq > @
-      "Hello, друг!\n"
+  eq. ++> tests-supports-escape-sequences
+    "Hello, друг!\n"
+    "Hello, друг!\n"
 
   eq. ++> tests-supports-escape-sequences-in-text
     "Hello, друг!\n"
     "Hello, друг!\n"
 
-  ++> tests-preserves-indentation-in-text
-    "a\n b\n  c".eq > @
-      "a\n b\n  c"
+  eq. ++> tests-preserves-indentation-in-text
+    "a\n b\n  c"
+    "a\n b\n  c"
 
-  ("x".eq "x").eq true ++> tests-compares-two-strings
+  eq. ++> tests-compares-two-strings
+    "x".eq "x"
+    true
 
   "Ф".eq "Ф" ++> tests-one-symbol-string-compares
 
@@ -225,33 +231,59 @@
 
   "Ф".eq "Ф" ++> tests-supports-escape-sequences-unicode
 
-  ("hello".slice 0 1).eq "h" ++> tests-slice-from-start
+  eq. ++> tests-slice-from-start
+    "hello".slice
+      0
+      1
+    "h"
 
-  ("hello".slice 2 3).eq "llo" ++> tests-slice-in-the-middle
+  eq. ++> tests-slice-in-the-middle
+    "hello".slice
+      2
+      3
+    "llo"
 
-  ("hello".slice 4 1).eq "o" ++> tests-slice-from-the-end
+  eq. ++> tests-slice-from-the-end
+    "hello".slice
+      4
+      1
+    "o"
 
-  ("".slice 0 0).eq "" ++> tests-slice-empty-string
+  eq. ++> tests-slice-empty-string
+    "".slice
+      0
+      0
+    ""
 
-  ++> tests-no-slice-string
-    eq. > @
-      "no slice".slice
-        0
-        0
-      ""
+  eq. ++> tests-no-slice-string
+    "no slice".slice
+      0
+      0
+    ""
 
-  ("\n".slice 0 "\n".length).eq "\n" ++> tests-slice-escape-sequences-line-break
+  eq. ++> tests-slice-escape-sequences-line-break
+    "\n".slice
+      0
+      "\n".length
+    "\n"
 
-  ("Ф".slice 0 "Ф".length).eq "Ф" ++> tests-slice-escape-sequences-unicode
+  eq. ++> tests-slice-escape-sequences-unicode
+    "Ф".slice
+      0
+      "Ф".length
+    "Ф"
 
-  ("привет".slice 1 2).eq "ри" ++> tests-slice-with-n2-byte-characters
+  eq. ++> tests-slice-with-n2-byte-characters
+    "привет".slice
+      1
+      2
+    "ри"
 
-  ++> tests-slice-with-n3-byte-characters
-    eq. > @
-      "The अ is अ".slice
-        1
-        6
-      "he अ i"
+  eq. ++> tests-slice-with-n3-byte-characters
+    "The अ is अ".slice
+      1
+      6
+    "he अ i"
 
   eq. ++> tests-slice-with-n4-byte-characters
     "One 😀 and 😀 another".slice
@@ -259,27 +291,26 @@
       8
     " 😀 and 😀"
 
-  ++> tests-slice-foreign-literals
-    eq. > @
-      "hello, 大家!".slice
-        7
-        1
-      "大"
-
-  --> on-slicing-start-below-zero
-    "some string".slice > @
-      -1
-      1
-
-  --> on-slicing-end-below-start
-    "some string".slice > @
-      2
-      -1
-
-  --> on-slicing-end-greater-actual
-    "some string".slice > @
+  eq. ++> tests-slice-foreign-literals
+    "hello, 大家!".slice
       7
-      5
+      1
+    "大"
+
+  slice. --> on-slicing-start-below-zero
+    "some string"
+    -1
+    1
+
+  slice. --> on-slicing-end-below-start
+    "some string"
+    2
+    -1
+
+  slice. --> on-slicing-end-greater-actual
+    "some string"
+    7
+    5
 
   eq. ++> tests-unescapes-slashes
     "x\\b\\f\\u\\r\\t\\n\\'"
@@ -291,23 +322,33 @@
     "hello, world, how are you?"
     "how"
 
-  "hello, world".starts-with "hello" ++> tests-package-starts-with-prefix
+  starts-with. ++> tests-package-starts-with-prefix
+    "hello, world"
+    "hello"
 
-  "hello, world".ends-with "world" ++> tests-package-ends-with-suffix
+  ends-with. ++> tests-package-ends-with-suffix
+    "hello, world"
+    "world"
 
   "hello".up-cased.eq "HELLO" ++> tests-package-up-cases-text
 
   "HELLO".low-cased.eq "hello" ++> tests-package-low-cases-text
 
-  ++> tests-package-trims-surrounding-spaces
-    "  spaced  ".trimmed.eq > @
-      "spaced"
+  eq. ++> tests-package-trims-surrounding-spaces
+    "  spaced  ".trimmed
+    "spaced"
 
-  ("ha".repeated 3).eq "hahaha" ++> tests-package-repeats-text
+  eq. ++> tests-package-repeats-text
+    "ha".repeated 3
+    "hahaha"
 
-  ("hello".index-of "l").eq 2 ++> tests-package-finds-index-of-character
+  eq. ++> tests-package-finds-index-of-character
+    "hello".index-of "l"
+    2
 
-  ("some".at 1).eq "o" ++> tests-package-takes-character-at-index
+  eq. ++> tests-package-takes-character-at-index
+    "some".at 1
+    "o"
 
   "2026".is-digit ++> tests-package-detects-digits
 

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -14,23 +14,39 @@
     as-i16.
       00-.concat char.as-bytes
 
-  65.eq (as-ascii "A") ++> tests-reads-code-of-uppercase-letter
+  eq. ++> tests-reads-code-of-uppercase-letter
+    65
+    as-ascii "A"
 
-  90.eq (as-ascii "Z") ++> tests-reads-code-of-last-uppercase-letter
+  eq. ++> tests-reads-code-of-last-uppercase-letter
+    90
+    as-ascii "Z"
 
-  97.eq (as-ascii "a") ++> tests-reads-code-of-lowercase-letter
+  eq. ++> tests-reads-code-of-lowercase-letter
+    97
+    as-ascii "a"
 
-  122.eq (as-ascii "z") ++> tests-reads-code-of-last-lowercase-letter
+  eq. ++> tests-reads-code-of-last-lowercase-letter
+    122
+    as-ascii "z"
 
-  48.eq (as-ascii "0") ++> tests-reads-code-of-zero-digit
+  eq. ++> tests-reads-code-of-zero-digit
+    48
+    as-ascii "0"
 
-  57.eq (as-ascii "9") ++> tests-reads-code-of-nine-digit
+  eq. ++> tests-reads-code-of-nine-digit
+    57
+    as-ascii "9"
 
-  ++> tests-reads-code-of-space
-    32.eq > @
-      as-ascii
-        " "
+  eq. ++> tests-reads-code-of-space
+    32
+    as-ascii
+      " "
 
-  33.eq (as-ascii "!") ++> tests-reads-code-of-punctuation
+  eq. ++> tests-reads-code-of-punctuation
+    33
+    as-ascii "!"
 
-  126.eq (as-ascii "~") ++> tests-reads-code-of-last-printable
+  eq. ++> tests-reads-code-of-last-printable
+    126
+    as-ascii "~"

--- a/eo-runtime/src/main/eo/string/as-char.eo
+++ b/eo-runtime/src/main/eo/string/as-char.eo
@@ -13,35 +13,35 @@
     7
     1
 
-  ++> tests-writes-byte-of-uppercase-letter
-    "A".eq > @
-      string
-        as-char 65
+  eq. ++> tests-writes-byte-of-uppercase-letter
+    "A"
+    string
+      as-char 65
 
-  ++> tests-writes-byte-of-last-uppercase-letter
-    "Z".eq > @
-      string
-        as-char 90
+  eq. ++> tests-writes-byte-of-last-uppercase-letter
+    "Z"
+    string
+      as-char 90
 
-  ++> tests-writes-byte-of-lowercase-letter
-    "z".eq > @
-      string
-        as-char 122
+  eq. ++> tests-writes-byte-of-lowercase-letter
+    "z"
+    string
+      as-char 122
 
-  ++> tests-writes-byte-of-zero-digit
-    "0".eq > @
-      string
-        as-char 48
+  eq. ++> tests-writes-byte-of-zero-digit
+    "0"
+    string
+      as-char 48
 
-  ++> tests-writes-byte-of-space
-    " ".eq > @
-      string
-        as-char 32
+  eq. ++> tests-writes-byte-of-space
+    " "
+    string
+      as-char 32
 
-  ++> tests-writes-byte-of-last-printable
-    "~".eq > @
-      string
-        as-char 126
+  eq. ++> tests-writes-byte-of-last-printable
+    "~"
+    string
+      as-char 126
 
   eq. ++> tests-round-trips-through-as-ascii
     "!"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -28,37 +28,37 @@
     floor. > q
       n.div 10
 
-  ++> tests-writes-single-digit
-    "7".eq > @
-      string
-        as-decimal 7
+  eq. ++> tests-writes-single-digit
+    "7"
+    string
+      as-decimal 7
 
-  ++> tests-writes-zero
-    "0".eq > @
-      string
-        as-decimal 0
+  eq. ++> tests-writes-zero
+    "0"
+    string
+      as-decimal 0
 
-  ++> tests-writes-multi-digit-number
-    "31415".eq > @
-      string
-        as-decimal 31415
+  eq. ++> tests-writes-multi-digit-number
+    "31415"
+    string
+      as-decimal 31415
 
-  ++> tests-writes-negative-number
-    "-42".eq > @
-      string
-        as-decimal -42
+  eq. ++> tests-writes-negative-number
+    "-42"
+    string
+      as-decimal -42
 
-  ++> tests-truncates-positive-fraction
-    "42".eq > @
-      string
-        as-decimal 42.987
+  eq. ++> tests-truncates-positive-fraction
+    "42"
+    string
+      as-decimal 42.987
 
-  ++> tests-truncates-negative-fraction
-    "-7".eq > @
-      string
-        as-decimal -7.89
+  eq. ++> tests-truncates-negative-fraction
+    "-7"
+    string
+      as-decimal -7.89
 
-  ++> tests-writes-number-with-inner-zero
-    "105".eq > @
-      string
-        as-decimal 105
+  eq. ++> tests-writes-number-with-inner-zero
+    "105"
+    string
+      as-decimal 105

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -16,14 +16,14 @@
       positive
         n.times -1
     positive n
-  [p] > pow10
-    if. > @
-      p.eq 0
-      1
-      times.
-        pow10
-          (p.minus 1).as-number
-        10
+  if. > [p] > pow10
+    p.eq 0
+    1
+    times.
+      pow10
+        as-number.
+          p.minus 1
+      10
   [a] > positive
     concat. > @
       concat.
@@ -58,37 +58,37 @@
             48
         acc
 
-  ++> tests-pads-with-trailing-zeros
-    "1.250000".eq > @
-      string
-        as-fixed 1.25 6
+  eq. ++> tests-pads-with-trailing-zeros
+    "1.250000"
+    string
+      as-fixed 1.25 6
 
-  ++> tests-writes-negative-value
-    "-2.500000".eq > @
-      string
-        as-fixed -2.5 6
+  eq. ++> tests-writes-negative-value
+    "-2.500000"
+    string
+      as-fixed -2.5 6
 
-  ++> tests-rounds-to-last-place
-    "0.123457".eq > @
-      string
-        as-fixed 0.123456789 6
+  eq. ++> tests-rounds-to-last-place
+    "0.123457"
+    string
+      as-fixed 0.123456789 6
 
   eq. ++> tests-carries-rounding-into-integer-part
     "1.000000"
     string
       as-fixed 0.9999999 6
 
-  ++> tests-writes-zero
-    "0.000000".eq > @
-      string
-        as-fixed 0 6
+  eq. ++> tests-writes-zero
+    "0.000000"
+    string
+      as-fixed 0 6
 
-  ++> tests-honours-custom-places
-    "3.14".eq > @
-      string
-        as-fixed 3.14159 2
+  eq. ++> tests-honours-custom-places
+    "3.14"
+    string
+      as-fixed 3.14159 2
 
-  ++> tests-writes-single-place
-    "2.5".eq > @
-      string
-        as-fixed 2.5 1
+  eq. ++> tests-writes-single-place
+    "2.5"
+    string
+      as-fixed 2.5 1

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -9,13 +9,12 @@
 +spdx SPDX-License-Identifier: MIT
 
 [bts] > as-hex
-  [h] > hex-digit
-    if. > @
-      h.lt 10
-      as-char
-        h.plus 48
-      as-char
-        h.plus 55
+  if. > [h] > hex-digit
+    h.lt 10
+    as-char
+      h.plus 48
+    as-char
+      h.plus 55
   [index acc] > rec-hex
     if. > @
       index.eq bts.size
@@ -40,10 +39,10 @@
     0
     --
 
-  ++> tests-writes-single-byte
-    "41".eq > @
-      string
-        as-hex "A".as-bytes
+  eq. ++> tests-writes-single-byte
+    "41"
+    string
+      as-hex "A".as-bytes
 
   eq. ++> tests-joins-bytes-with-hyphens
     "4A-65-66-66"
@@ -60,7 +59,7 @@
     string
       as-hex 42.as-bytes
 
-  ++> tests-writes-empty-bytes
-    "".eq > @
-      string
-        as-hex --
+  eq. ++> tests-writes-empty-bytes
+    ""
+    string
+      as-hex --

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -20,7 +20,9 @@
     at.
       scanf "%f" text
 
-  5.eq (as-number "5") ++> tests-converts-text-to-number
+  eq. ++> tests-converts-text-to-number
+    5
+    as-number "5"
 
   as-number "Hello" --> on-converting-text-to-number
 
@@ -30,4 +32,6 @@
         "Hello"
         42 > [msg]
 
-  3.14.eq (as-number "3.14") ++> tests-converts-float-text-to-number
+  eq. ++> tests-converts-float-text-to-number
+    3.14
+    as-number "3.14"

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -32,19 +32,27 @@
     idx
   text.length > len!
 
-  ++> tests-returns-first-char
-    "s".eq > @
-      at "some" 0
+  eq. ++> tests-returns-first-char
+    "s"
+    at
+      "some"
+      0
 
-  ++> tests-returns-third-char
-    "m".eq > @
-      at "some" 2
+  eq. ++> tests-returns-third-char
+    "m"
+    at
+      "some"
+      2
 
-  ++> tests-returns-char-at-negative-index
-    "m".eq > @
-      at "some" -2
+  eq. ++> tests-returns-char-at-negative-index
+    "m"
+    at
+      "some"
+      -2
 
-  at "some" 10 --> on-text-at-index-more-than-length
+  at --> on-text-at-index-more-than-length
+    "some"
+    10
 
   ++> tests-text-at-out-of-bounds-returns-provided-fallback
     "recovered".eq > @

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -38,10 +38,9 @@
         slen
       sub
 
-  ++> tests-text-contains-substring
-    contains > @
-      "Hello, world!"
-      "o, wo"
+  contains ++> tests-text-contains-substring
+    "Hello, world!"
+    "o, wo"
 
   ++> tests-text-does-not-contain-substring
     not. > @

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -25,10 +25,9 @@
   txt.size > tlen!
   text > txt!
 
-  ++> tests-ends-with-substring
-    ends-with > @
-      "Hello world!"
-      "world!"
+  ends-with ++> tests-ends-with-substring
+    "Hello world!"
+    "world!"
 
   ++> tests-does-not-end-with-substring
     not. > @

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -30,7 +30,9 @@
   as-ascii "Z" > maxcode
   as-ascii "A" > mincode
 
-  "hello".eq (low-cased "HELLO") ++> tests-converts-text-to-lower-case
+  eq. ++> tests-converts-text-to-lower-case
+    "hello"
+    low-cased "HELLO"
 
   eq. ++> tests-converts-text-with-low-letters-to-lower-case
     "hello"

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -98,9 +98,15 @@
       "b"
       "c"
 
-  nsplit "text" "-" 0 --> on-nsplit-with-limit-zero
+  nsplit --> on-nsplit-with-limit-zero
+    "text"
+    "-"
+    0
 
-  nsplit "text" "-" -1 --> on-nsplit-with-negative-limit
+  nsplit --> on-nsplit-with-negative-limit
+    "text"
+    "-"
+    -1
 
   ++> tests-nsplit-invalid-limit-returns-provided-fallback
     "fallback".eq > @

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -32,7 +32,9 @@
       as-number.
         index.plus 1
 
-  repeated "" -1 --> on-text-repeating-less-than-zero-times
+  repeated --> on-text-repeating-less-than-zero-times
+    ""
+    -1
 
   ++> tests-text-repeated-negative-times-returns-provided-fallback
     "recovered".eq > @
@@ -41,10 +43,14 @@
         -1
         "recovered" > [msg]
 
-  ++> tests-text-repeated-zero-times-is-empty
-    "".eq > @
-      repeated "some" 0
+  eq. ++> tests-text-repeated-zero-times-is-empty
+    ""
+    repeated
+      "some"
+      0
 
-  ++> tests-text-repeated-five-times
-    "heyheyheyheyhey".eq > @
-      repeated "hey" 5
+  eq. ++> tests-text-repeated-five-times
+    "heyheyheyheyhey"
+    repeated
+      "hey"
+      5

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -19,21 +19,42 @@
 
 [format read] > scanf /tuple
 
-  "hello".eq (scanf "%s" "hello").head ++> tests-scanf-with-string
+  eq. ++> tests-scanf-with-string
+    "hello"
+    head.
+      scanf "%s" "hello"
 
-  33.eq (scanf "%d" "33").head ++> tests-scanf-with-int
+  eq. ++> tests-scanf-with-int
+    33
+    head.
+      scanf "%d" "33"
 
-  -42.eq (scanf "%d" "-42").head ++> tests-scanf-with-negative-int
+  eq. ++> tests-scanf-with-negative-int
+    -42
+    head.
+      scanf "%d" "-42"
 
-  42.eq (scanf "%d" "+42").head ++> tests-scanf-with-positive-signed-int
+  eq. ++> tests-scanf-with-positive-signed-int
+    42
+    head.
+      scanf "%d" "+42"
 
-  0.24.eq (scanf "%f" "0.24").head ++> tests-scanf-with-float
+  eq. ++> tests-scanf-with-float
+    0.24
+    head.
+      scanf "%f" "0.24"
 
-  scanf "%l" "error" --> on-scanf-with-wrong-format
+  scanf --> on-scanf-with-wrong-format
+    "%l"
+    "error"
 
-  scanf "%d" "99999999999999999999" --> on-scanf-with-oversized-int
+  scanf --> on-scanf-with-oversized-int
+    "%d"
+    "99999999999999999999"
 
-  scanf "hello%" "hello" --> on-scanf-with-dangling-percent
+  scanf --> on-scanf-with-dangling-percent
+    "hello%"
+    "hello"
 
   eq. ++> tests-scanf-with-string-int-float
     scanf
@@ -44,7 +65,10 @@
       33
       0.24
 
-  "hello".eq (scanf "%s!" "hello!").head ++> tests-scanf-with-string-with-ending
+  eq. ++> tests-scanf-with-string-with-ending
+    "hello"
+    head.
+      scanf "%s!" "hello!"
 
   eq. ++> tests-scanf-with-complex-string
     "test"

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -14,10 +14,9 @@
     start
     len
 
-  ++> tests-text-slices-the-origin-string
-    eq. > @
-      slice
-        "Hello, world!"
-        7
-        5
-      "world"
+  eq. ++> tests-text-slices-the-origin-string
+    slice
+      "Hello, world!"
+      7
+      5
+    "world"

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -23,10 +23,9 @@
   txt.size > tlen!
   text > txt!
 
-  ++> tests-starts-with-substring
-    starts-with > @
-      "Hello, world"
-      "Hello"
+  starts-with ++> tests-starts-with-substring
+    "Hello, world"
+    "Hello"
 
   ++> tests-does-not-start-with-substring
     not. > @

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -47,33 +47,40 @@
           (c.eq 0C-).or
             c.eq 0D-
 
-  (trimmed-left "").eq "" ++> tests-trimmed-left-empty-text
+  eq. ++> tests-trimmed-left-empty-text
+    trimmed-left ""
+    ""
 
-  ++> tests-text-trimmed-left-one-space
-    eq. > @
-      trimmed-left
-        " s"
-      "s"
+  eq. ++> tests-text-trimmed-left-one-space
+    trimmed-left
+      " s"
+    "s"
 
-  ++> tests-text-trimmed-left-many-spaces
-    eq. > @
-      trimmed-left
-        "     some"
-      "some"
+  eq. ++> tests-text-trimmed-left-many-spaces
+    trimmed-left
+      "     some"
+    "some"
 
-  ++> tests-text-trimmed-left-only-spaces
-    eq. > @
-      trimmed-left
-        "     "
-      ""
+  eq. ++> tests-text-trimmed-left-only-spaces
+    trimmed-left
+      "     "
+    ""
 
-  (trimmed-left "\tvalue").eq "value" ++> tests-trimmed-left-strips-tab
+  eq. ++> tests-trimmed-left-strips-tab
+    trimmed-left "\tvalue"
+    "value"
 
-  (trimmed-left "\nvalue").eq "value" ++> tests-trimmed-left-strips-lf
+  eq. ++> tests-trimmed-left-strips-lf
+    trimmed-left "\nvalue"
+    "value"
 
-  (trimmed-left "\fvalue").eq "value" ++> tests-trimmed-left-strips-ff
+  eq. ++> tests-trimmed-left-strips-ff
+    trimmed-left "\fvalue"
+    "value"
 
-  (trimmed-left "\rvalue").eq "value" ++> tests-trimmed-left-strips-cr
+  eq. ++> tests-trimmed-left-strips-cr
+    trimmed-left "\rvalue"
+    "value"
 
   eq. ++> tests-trimmed-left-strips-mixed-ws
     trimmed-left

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -45,33 +45,40 @@
           (c.eq 0C-).or
             c.eq 0D-
 
-  (trimmed-right "").eq "" ++> tests-trimmed-right-empty-text
+  eq. ++> tests-trimmed-right-empty-text
+    trimmed-right ""
+    ""
 
-  ++> tests-text-trimmed-right-one-space
-    eq. > @
-      trimmed-right
-        "s "
-      "s"
+  eq. ++> tests-text-trimmed-right-one-space
+    trimmed-right
+      "s "
+    "s"
 
-  ++> tests-text-trimmed-right-many-spaces
-    eq. > @
-      trimmed-right
-        "some     "
-      "some"
+  eq. ++> tests-text-trimmed-right-many-spaces
+    trimmed-right
+      "some     "
+    "some"
 
-  ++> tests-text-trimmed-right-only-spaces
-    eq. > @
-      trimmed-right
-        "     "
-      ""
+  eq. ++> tests-text-trimmed-right-only-spaces
+    trimmed-right
+      "     "
+    ""
 
-  (trimmed-right "value\t").eq "value" ++> tests-trimmed-right-strips-tab
+  eq. ++> tests-trimmed-right-strips-tab
+    trimmed-right "value\t"
+    "value"
 
-  (trimmed-right "value\n").eq "value" ++> tests-trimmed-right-strips-lf
+  eq. ++> tests-trimmed-right-strips-lf
+    trimmed-right "value\n"
+    "value"
 
-  (trimmed-right "value\f").eq "value" ++> tests-trimmed-right-strips-ff
+  eq. ++> tests-trimmed-right-strips-ff
+    trimmed-right "value\f"
+    "value"
 
-  (trimmed-right "value\r").eq "value" ++> tests-trimmed-right-strips-cr
+  eq. ++> tests-trimmed-right-strips-cr
+    trimmed-right "value\r"
+    "value"
 
   eq. ++> tests-trimmed-right-strips-mixed-ws
     trimmed-right

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -19,37 +19,34 @@
     trimmed-left
       trimmed-right text
 
-  ++> tests-text-trimmed-one-space-left
-    eq. > @
-      trimmed
-        " some"
-      "some"
+  eq. ++> tests-text-trimmed-one-space-left
+    trimmed
+      " some"
+    "some"
 
-  ++> tests-text-trimmed-one-space-right
-    eq. > @
-      trimmed
-        "some "
-      "some"
+  eq. ++> tests-text-trimmed-one-space-right
+    trimmed
+      "some "
+    "some"
 
-  ++> tests-text-trimmed-one-space-both
-    eq. > @
-      trimmed
-        " some "
-      "some"
+  eq. ++> tests-text-trimmed-one-space-both
+    trimmed
+      " some "
+    "some"
 
-  ++> tests-text-trimmed-many-spaces
-    eq. > @
-      trimmed
-        "    some     "
-      "some"
+  eq. ++> tests-text-trimmed-many-spaces
+    trimmed
+      "    some     "
+    "some"
 
-  (trimmed "").eq "" ++> tests-text-trimmed-empty
+  eq. ++> tests-text-trimmed-empty
+    trimmed ""
+    ""
 
-  ++> tests-text-trimmed-only-spaces
-    eq. > @
-      trimmed
-        "        "
-      ""
+  eq. ++> tests-text-trimmed-only-spaces
+    trimmed
+      "        "
+    ""
 
   eq. ++> tests-trimmed-strips-mixed-ws-both-sides
     trimmed

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -30,7 +30,9 @@
   as-ascii "z" > maxcode!
   as-ascii "a" > mincode!
 
-  "HELLO".eq (up-cased "hello") ++> tests-converts-text-to-upper-case
+  eq. ++> tests-converts-text-to-upper-case
+    "HELLO"
+    up-cased "hello"
 
   eq. ++> tests-converts-text-with-upper-letters-to-upper-case
     "HELLO"

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -35,12 +35,11 @@
         index
       tup.head
       at-fast tup.tail
-  [x] > with
-    tuple > @
-      ^
-      x
-      as-number.
-        length.plus 1
+  tuple > [x] > with
+    ^
+    x
+    as-number.
+      length.plus 1
   [other] > eq
     and. > @
       length.eq other.length

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -16,11 +16,10 @@
     reducedi
       list
       *
-      [accum item idx] >>
-        if. > @
-          idx.gte start
-          accum.with item
-          accum
+      if. > [accum item idx] >>
+        idx.gte start
+        accum.with item
+        accum
   index > idx!
   list.length.minus idx > start!
 

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -13,7 +13,9 @@
   reducedi > @
     passed
     list
-    with accum item > [accum item index]
+    with > [accum item index]
+      accum
+      item
 
   ++> tests-concatenates-lists
     and. > @

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -23,7 +23,8 @@
         [m]
           each > @
             * 1 2 3
-            m.put (m.as-number.plus i) > [i] >>
+            m.put > [i] >>
+              m.as-number.plus i
       6
 
   ++> tests-each-empty-list
@@ -38,7 +39,8 @@
         [m]
           each > @
             * 7
-            m.put (m.as-number.plus i) > [i] >>
+            m.put > [i] >>
+              m.as-number.plus i
       7
 
   ++> tests-each-returns-last-func-result
@@ -58,5 +60,6 @@
         [m]
           each > @
             * 10 20 30
-            m.put (m.as-number.plus i) > [i] >>
+            m.put > [i] >>
+              m.as-number.plus i
       60

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -28,5 +28,6 @@
         [m]
           eachi > @
             * 1 2 3
-            m.put ((m.as-number.plus item).plus index) > [item index] >>
+            m.put > [item index] >>
+              (m.as-number.plus item).plus index
       9

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -26,11 +26,10 @@
         list
         rechead list
   index > idx!
-  [tup] > rechead
-    if. > @
-      tup.length.eq idx
-      tup
-      rechead tup.tail
+  if. > [tup] > rechead
+    tup.length.eq idx
+    tup
+    rechead tup.tail
 
   eq. ++> tests-simple-front
     front

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -16,9 +16,8 @@
   reducedi > @
     list
     *
-    [accum item idx] >>
-      accum.with > @
-        func item idx
+    accum.with > [accum item idx] >>
+      func item idx
 
   ++> tests-list-mappedi-should-work
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -17,11 +17,10 @@
     reduced
       lst
       ninf
-      [max item]
-        if. > @
-          item.as-number.gt max
-          item
-          max
+      if. > [max item]
+        item.as-number.gt max
+        item
+        max
   sequence > lst
 
   maximum --> on-taking-maximum-from-empty-sequence

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -17,11 +17,10 @@
     reduced
       lst
       pinf
-      [min item]
-        if. > @
-          min.gt item.as-number
-          item
-          min
+      if. > [min item]
+        min.gt item.as-number
+        item
+        min
   sequence > lst
 
   minimum --> on-taking-minimum-from-empty-sequence

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -62,8 +62,14 @@
       -2
       -1
 
-  range-of-numbers 1.2 3 --> on-range-of-numbers-with-non-number-start
+  range-of-numbers --> on-range-of-numbers-with-non-number-start
+    1.2
+    3
 
-  range-of-numbers 1 2.5 --> on-range-of-numbers-with-not-number-end
+  range-of-numbers --> on-range-of-numbers-with-not-number-end
+    1
+    2.5
 
-  range-of-numbers 1.5 5.2 --> on-range-of-not-numbers
+  range-of-numbers --> on-range-of-not-numbers
+    1.5
+    5.2

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -17,7 +17,9 @@
   reducedi > @
     list
     start
-    func accum item > [accum item idx] >>
+    func > [accum item idx] >>
+      accum
+      item
 
   ++> tests-list-reduce-without-index
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -110,10 +110,9 @@
         0
         [acc x i]
           check x > @
-          [el] > check
-            if. > @
-              x.lt 100
-              acc.plus x
-              acc.minus x
+          if. > [el] > check
+            x.lt 100
+            acc.plus x
+            acc.minus x
       10.plus
         0.minus 500

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -13,11 +13,10 @@
   reduced > @
     list
     *
-    [accum item] >>
-      if. > @
-        element.eq item
-        accum
-        accum.with item
+    if. > [accum item] >>
+      element.eq item
+      accum
+      accum.with item
 
   eq. ++> tests-list-without
     without

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -13,11 +13,10 @@
   reducedi > @
     list
     *
-    [accum item idx] >>
-      if. > @
-        i.eq idx
-        accum
-        accum.with item
+    if. > [accum item idx] >>
+      i.eq idx
+      accum
+      accum.with item
 
   eq. ++> tests-list-withouti
     withouti
@@ -37,7 +36,9 @@
         "text"
         "f"
       * "text" "f"
-    withouti a 0 > [a] > foo
+    withouti > [a] > foo
+      a
+      0
 
   eq. ++> tests-list-withouti-nested-array
     withouti

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -13,9 +13,8 @@
 [as-bytes] > u16
   as-bytes > @
   as-i32.as-number > as-number
-  [] > as-i32
-    i32 > @
-      00-00.concat as-bytes
+  i32 > [] > as-i32
+    00-00.concat as-bytes
   as-i32.lt x.as-u16.as-i32 > [x] > lt
   as-i32.lte x.as-u16.as-i32 > [x] > lte
   as-i32.gt x.as-u16.as-i32 > [x] > gt
@@ -60,9 +59,7 @@
 
   (00-0A.as-u16.lt 00-0A.as-u16).not ++> tests-u16-less-equal
 
-  gt. ++> tests-u16-greater-treats-high-bit-as-magnitude
-    FF-FF.as-u16
-    00-01.as-u16
+  FF-FF.as-u16.gt 00-01.as-u16 ++> tests-u16-greater-treats-high-bit-as-magnitude
 
   (FF-FF.as-u16.lt 00-01.as-u16).not ++> tests-u16-high-bit-not-less-than-one
 
@@ -86,21 +83,29 @@
     FF-FF.as-u16.plus 00-01.as-u16
     00-00.as-u16
 
-  (00-05.as-u16.minus 00-03.as-u16).eq 00-02.as-u16 ++> tests-u16-minus
+  eq. ++> tests-u16-minus
+    00-05.as-u16.minus 00-03.as-u16
+    00-02.as-u16
 
   eq. ++> tests-u16-minus-with-underflow
     00-00.as-u16.minus 00-01.as-u16
     FF-FF.as-u16
 
-  (00-06.as-u16.times 00-07.as-u16).eq 00-2A.as-u16 ++> tests-u16-times
+  eq. ++> tests-u16-times
+    00-06.as-u16.times 00-07.as-u16
+    00-2A.as-u16
 
   eq. ++> tests-u16-times-wraps-modulo-2-pow-16
     01-00.as-u16.times 01-00.as-u16
     00-00.as-u16
 
-  (FF-FF.as-u16.div 00-02.as-u16).eq 7F-FF.as-u16 ++> tests-u16-div-is-unsigned
+  eq. ++> tests-u16-div-is-unsigned
+    FF-FF.as-u16.div 00-02.as-u16
+    7F-FF.as-u16
 
-  (FF-FF.as-u16.div 00-01.as-u16).eq FF-FF.as-u16 ++> tests-u16-div-by-u16-one
+  eq. ++> tests-u16-div-by-u16-one
+    FF-FF.as-u16.div 00-01.as-u16
+    FF-FF.as-u16
 
   00-02.as-u16.div 00-00.as-u16 --> on-division-u16-by-u16-zero
 

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -13,9 +13,8 @@
 [as-bytes] > u32
   as-bytes > @
   as-i64.as-number > as-number
-  [] > as-i64
-    i64 > @
-      00-00-00-00.concat as-bytes
+  i64 > [] > as-i64
+    00-00-00-00.concat as-bytes
   as-i64.lt x.as-u32.as-i64 > [x] > lt
   as-i64.lte x.as-u32.as-i64 > [x] > lte
   as-i64.gt x.as-u32.as-i64 > [x] > gt

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -24,22 +24,18 @@
         80-00-00-00-00-00-00-00
       1.8446744073709552e19
       0
-  [x] > lt
-    lt. > @
-      i64 flip
-      i64 x.as-u64.flip
-  [x] > lte
-    lte. > @
-      i64 flip
-      i64 x.as-u64.flip
-  [x] > gt
-    gt. > @
-      i64 flip
-      i64 x.as-u64.flip
-  [x] > gte
-    gte. > @
-      i64 flip
-      i64 x.as-u64.flip
+  lt. > [x] > lt
+    i64 flip
+    i64 x.as-u64.flip
+  lte. > [x] > lte
+    i64 flip
+    i64 x.as-u64.flip
+  gt. > [x] > gt
+    i64 flip
+    i64 x.as-u64.flip
+  gte. > [x] > gte
+    i64 flip
+    i64 x.as-u64.flip
   [x] > plus
     u64 sum.as-bytes > @
     plus. > sum

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -13,9 +13,8 @@
 [as-bytes] > u8
   as-bytes > @
   as-i16.as-number > as-number
-  [] > as-i16
-    i16 > @
-      00-.concat as-bytes
+  i16 > [] > as-i16
+    00-.concat as-bytes
   as-i16.lt x.as-u8.as-i16 > [x] > lt
   as-i16.lte x.as-u8.as-i16 > [x] > lte
   as-i16.gt x.as-u8.as-i16 > [x] > gt
@@ -76,15 +75,25 @@
 
   (2A-.as-u8.eq 2B-.as-u8).not ++> tests-u8-eq-false
 
-  (01-.as-u8.plus 01-.as-u8).eq 02-.as-u8 ++> tests-u8-one-plus-u8-one
+  eq. ++> tests-u8-one-plus-u8-one
+    01-.as-u8.plus 01-.as-u8
+    02-.as-u8
 
-  (FF-.as-u8.plus 01-.as-u8).eq 00-.as-u8 ++> tests-u8-plus-with-overflow
+  eq. ++> tests-u8-plus-with-overflow
+    FF-.as-u8.plus 01-.as-u8
+    00-.as-u8
 
-  (05-.as-u8.minus 03-.as-u8).eq 02-.as-u8 ++> tests-u8-minus
+  eq. ++> tests-u8-minus
+    05-.as-u8.minus 03-.as-u8
+    02-.as-u8
 
-  (00-.as-u8.minus 01-.as-u8).eq FF-.as-u8 ++> tests-u8-minus-with-underflow
+  eq. ++> tests-u8-minus-with-underflow
+    00-.as-u8.minus 01-.as-u8
+    FF-.as-u8
 
-  (06-.as-u8.times 07-.as-u8).eq 2A-.as-u8 ++> tests-u8-times
+  eq. ++> tests-u8-times
+    06-.as-u8.times 07-.as-u8
+    2A-.as-u8
 
   eq. ++> tests-u8-times-wraps-modulo-2-pow-8
     10-.as-u8.times 10-.as-u8
@@ -94,9 +103,13 @@
     FF-.as-u8.times FF-.as-u8
     01-.as-u8
 
-  (C8-.as-u8.div 03-.as-u8).eq 42-.as-u8 ++> tests-u8-div-is-unsigned
+  eq. ++> tests-u8-div-is-unsigned
+    C8-.as-u8.div 03-.as-u8
+    42-.as-u8
 
-  (FF-.as-u8.div 01-.as-u8).eq FF-.as-u8 ++> tests-u8-div-by-u8-one
+  eq. ++> tests-u8-div-by-u8-one
+    FF-.as-u8.div 01-.as-u8
+    FF-.as-u8
 
   02-.as-u8.div 00-.as-u8 --> on-division-u8-by-u8-zero
 

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -79,7 +79,8 @@
         [m]
           while > @
             2.gt m > [i] >>
-            m.put (m.as-number.plus 1) > [i] >>
+            m.put > [i] >>
+              m.as-number.plus 1
       3
 
   ++> tests-last-while-dataization-object-with-false-condition


### PR DESCRIPTION
Fixes #5700.

## Problem

`Pretty.phi()` gated the hybrid inline-phi collapse behind a width check
(`flat.map(line -> line.length() > this.width)`), so an only-φ formation whose
φ applies regular arguments kept the verbose ` > @` / flat one-liner shape
whenever the one-liner fit under 80 columns — even when the strictly cheaper
hybrid (`decoratee > [params] > name` with the arguments beneath) beat it on
penalty. In `eo-runtime/src/main/eo/malloc.eo` the `copy` object was the
reported manifestation. This is the residual case #5635 left open: its fix used
a width check where its own text prescribed a penalty comparison.

## Fix

In `Pretty.phi()`, when the decoratee applies unnamed arguments
(`applied && unnamed`), build **both** the flat one-liner and the hybrid
(`decoratee.hybrid(marker)`) and return the lower-penalty of the two; when the
one-liner cannot be built, use the hybrid unconditionally (unchanged). The
hybrid drops the `@` (saving its `PHI` charge) and lifts the arguments one
indent level, so the penalty vote in `shaped()` can now prefer it whenever it
beats **both** the one-liner and the verbose shape — not only when the one-liner
overflows the width limit.

The `width` field of `Pretty` became unused and was removed; overflow is
already priced in by the `EXCESS` weight inside `Penalty`.

## Tests & formatting

- Added `inline-phi-hybrid-under-width.yaml` — the malloc `copy` case from the
  issue, pinned to the default weights the issue reasons about.
- Updated the print-packs whose canonical layout now legitimately uses the
  cheaper hybrid: `compares-bool-to-bytes`, `empty-string`, `multiline-string`,
  `nested-if-inline`, `times`. All packs still round-trip
  (`printsToParseableEo`), and the full `eo-printer` suite (168 tests) is green.
- Reformatted the `eo-runtime` `.eo` sources to their new canonical layout.
  This is required because the `format` goal fails the build on any file that
  diverges from `Xmir.toEO()`. The reformatting is semantics-preserving (same
  XMIR — only a different candidate among equivalent renderings) and idempotent:
  a second `format` pass reports *"All 151 EO source(s) are formatted
  canonically"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuhgdsjotvaC6rWu39HDjm)_