### PR TITLE
Fold only-phi hybrid past nested anonymous-object arguments

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -124,17 +124,25 @@ final class Node {
      * Whether this node carries no name suffix anywhere in its subtree.
      *
      * <p>A line is "named" when its {@code tail} holds a {@code > name},
-     * {@code > [params]} or {@code >>} suffix. This walks the node and all
-     * its descendants, so a named line nested below the top level — inside
-     * a tuple, a dispatch, or an application — is caught too. It decides
-     * whether a decoratee's whole subtree is safe to fold into a compact
-     * only-phi formation, which binds nothing but its {@code φ} decoratee
-     * (issue #5604).</p>
+     * {@code > [params] > name} or {@code >>} suffix — a named or auto-named
+     * attribute. This walks the node and all its descendants, so a named line
+     * nested below the top level — inside a tuple, a dispatch, or an
+     * application — is caught too. It decides whether a decoratee's whole
+     * subtree is safe to fold into a compact only-phi formation, which binds
+     * nothing but its {@code φ} decoratee (issue #5604).</p>
+     *
+     * <p>A bare {@code > @} suffix is not a name: it marks the {@code φ}
+     * decoratee, which is exactly what an only-phi formation binds, so a
+     * nested anonymous object (an argument such as {@code m > [m]}, whose
+     * subtree carries an inner {@code m > @}) is legal and must not withhold
+     * the fold. Only a genuine named or auto-named attribute ({@code > name},
+     * {@code >>}) does, since those cannot be attributes of an only-phi
+     * formation.</p>
      *
      * @return True when neither this node nor any descendant is named
      */
     boolean nameless() {
-        return this.tail.isEmpty()
+        return (this.tail.isEmpty() || " > @".equals(this.tail))
             && this.children.stream().allMatch(Node::nameless);
     }
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-anonymous-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-anonymous-argument.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The "tests-malloc-for-writes-first-init-value" test attribute from
+# malloc.eo: its phi (the reversed "eq.") applies regular arguments, one of
+# which is an anonymous formation "m > [m]" nested inside "malloc.for". The
+# only-phi fold used to be withheld because the recursive "nameless" guard
+# treated the anonymous object's inner " > @" phi decoratee as a name. A phi
+# decoratee is exactly what an only-phi formation binds, so a nested anonymous
+# object is a legal argument: the cheaper hybrid ("eq. ++> ...") must be built.
+# Auto-named attributes (">>") still withhold it (see hybrid-phi-named-argument).
+penalties:
+  INDENT: 2
+  BRACKET: 19
+  PHI: 15
+  IF: 50
+  EXCESS: 3
+  SYMBOL: 1
+  SPACE: 7
+  WIDTH: 80
+  STEP: 2
+origin: |
+  +package org.eolang
+
+  [] > foo
+
+    ++> tests-malloc-for-writes-first-init-value
+      eq. > @
+        malloc.for
+          42
+          m > [m]
+        42
+
+printed: |
+  +package org.eolang
+
+  [] > foo
+
+    eq. ++> tests-malloc-for-writes-first-init-value
+      malloc.for
+        42
+        m > [m]
+      42

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-compact-tuple.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-compact-tuple.yaml
@@ -19,9 +19,8 @@ origin: |
           m
 
 printed: |
-  [] > foo
-    malloc.of > @
-      5
-      seq * > [m]
-        m.write 0 10
-        m
+  malloc.of > [] > foo
+    5
+    seq * > [m]
+      m.write 0 10
+      m

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -224,16 +224,16 @@
     3
     10
 
-  ++> tests-out-of-bounds-slice-returns-provided-fallback
-    "recovered".eq > @
-      20-1F-EE-B5-90.slice
-        3
-        10
-        "recovered" > [msg]
+  eq. ++> tests-out-of-bounds-slice-returns-provided-fallback
+    "recovered"
+    20-1F-EE-B5-90.slice
+      3
+      10
+      "recovered" > [msg]
 
-  ++> tests-slice-with-overflowing-start-plus-len-returns-fallback
-    "recovered".eq > @
-      20-1F-EE-B5-90.slice
-        2000000000
-        2000000000
-        "recovered" > [msg]
+  eq. ++> tests-slice-with-overflowing-start-plus-len-returns-fallback
+    "recovered"
+    20-1F-EE-B5-90.slice
+      2000000000
+      2000000000
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -19,10 +19,10 @@
 
   01-01-01-01.as-i64 --> on-bytes-of-wrong-size-as-i64
 
-  ++> tests-wrong-size-as-i64-returns-provided-fallback
-    "recovered".eq > @
-      01-01-01-01.as-i64
-        "recovered" > [msg]
+  eq. ++> tests-wrong-size-as-i64-returns-provided-fallback
+    "recovered"
+    01-01-01-01.as-i64
+      "recovered" > [msg]
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> tests-bytes-converts-to-i64
 

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -28,7 +28,7 @@
 
   01-01-01-01.as-number --> on-bytes-of-wrong-size-as-number
 
-  ++> tests-wrong-size-as-number-returns-provided-fallback
-    "recovered".eq > @
-      01-01-01-01.as-number
-        "recovered" > [msg]
+  eq. ++> tests-wrong-size-as-number-returns-provided-fallback
+    "recovered"
+    01-01-01-01.as-number
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -19,10 +19,10 @@
 
   01-01-01-01.as-u64 --> on-bytes-of-wrong-size-as-u64
 
-  ++> tests-wrong-size-as-u64-returns-provided-fallback
-    "recovered".eq > @
-      01-01-01-01.as-u64
-        "recovered" > [msg]
+  eq. ++> tests-wrong-size-as-u64-returns-provided-fallback
+    "recovered"
+    01-01-01-01.as-u64
+      "recovered" > [msg]
 
   eq. ++> tests-bytes-converts-to-u64-and-back
     00-00-00-00-00-00-00-33.as-u64.as-bytes

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -69,10 +69,9 @@
     not. > @
       (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted.exists
 
-  --> on-opening-directory
-    mktemp.open > @
-      "w"
-      true > [d]
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [d]
 
   ++> tests-deletes-directory-with-files-recursively
     and. > @

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -281,29 +281,26 @@
       temp.exists.not
     mktemp.tmpfile > temp
 
-  --> on-opening-with-wrong-mode
-    seq * > @
-      mktemp.tmpfile.open
-        "x"
-        true > [f]
-      true
+  seq * --> on-opening-with-wrong-mode
+    mktemp.tmpfile.open
+      "x"
+      true > [f]
+    true
 
-  --> on-reading-from-not-existed-file
-    mktemp.tmpfile.deleted.open > @
+  mktemp.tmpfile.deleted.open --> on-reading-from-not-existed-file
+    "r"
+    f > [f]
+
+  mktemp.tmpfile.deleted.open --> on-reading-or-writing-from-not-existed-file
+    "r+"
+    f > [f]
+
+  eq. ++> tests-recovers-from-opening-missing-file-through-fallback
+    "recovered"
+    mktemp.tmpfile.deleted.open
       "r"
       f > [f]
-
-  --> on-reading-or-writing-from-not-existed-file
-    mktemp.tmpfile.deleted.open > @
-      "r+"
-      f > [f]
-
-  ++> tests-recovers-from-opening-missing-file-through-fallback
-    "recovered".eq > @
-      mktemp.tmpfile.deleted.open
-        "r"
-        f > [f]
-        "recovered" > [reason]
+      "recovered" > [reason]
 
   ++> tests-touches-absent-file-on-opening-for-writing
     exists. > @
@@ -329,84 +326,77 @@
         "a+"
         true > [f]
 
-  ++> tests-writes-data-to-file
-    eq. > @
-      size.
+  eq. ++> tests-writes-data-to-file
+    size.
+      mktemp.tmpfile.open
+        "w"
+        f.write > [f]
+          "Hello, world"
+    12
+
+  eq. ++> tests-appending-data-to-file
+    size.
+      open.
         mktemp.tmpfile.open
           "w"
           f.write "Hello, world" > [f]
-      12
+        "a"
+        f.write "!" > [f]
+    13
 
-  ++> tests-appending-data-to-file
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
-          "a"
-          f.write "!" > [f]
-      13
-
-  ++> tests-truncates-file-opened-for-writing
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
+  eq. ++> tests-truncates-file-opened-for-writing
+    size.
+      open.
+        mktemp.tmpfile.open
           "w"
-          true > [f]
-      0
+          f.write "Hello, world" > [f]
+        "w"
+        true > [f]
+    0
 
-  ++> tests-truncates-file-opened-for-writing-or-reading
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
-          "w+"
-          true > [f]
-      0
+  eq. ++> tests-truncates-file-opened-for-writing-or-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "w+"
+        true > [f]
+    0
 
-  ++> tests-does-not-truncate-file-opened-for-appending
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
-          "a"
-          true > [f]
-      12
+  eq. ++> tests-does-not-truncate-file-opened-for-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        true > [f]
+    12
 
-  ++> tests-does-not-truncate-file-opened-for-reading-or-appending
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
-          "a+"
-          true > [f]
-      12
+  eq. ++> tests-does-not-truncate-file-opened-for-reading-or-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a+"
+        true > [f]
+    12
 
-  ++> tests-does-not-truncate-file-opened-for-reading
-    eq. > @
-      size.
-        open.
-          mktemp.tmpfile.open
-            "w"
-            f.write "Hello, world" > [f]
-          "r"
-          true > [f]
-      12
+  eq. ++> tests-does-not-truncate-file-opened-for-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "r"
+        true > [f]
+    12
 
-  --> on-writing-with-wrong-mode
-    mktemp.tmpfile.open > @
-      "r"
-      f.write "Hello" > [f]
+  mktemp.tmpfile.open --> on-writing-with-wrong-mode
+    "r"
+    f.write "Hello" > [f]
 
   ++> tests-reads-from-file
     eq. > @
@@ -424,15 +414,13 @@
             m
       "Hello, world"
 
-  --> on-reading-negative-size-from-file
-    mktemp.tmpfile.open > @
-      "r"
-      f.read -5 > [f]
+  mktemp.tmpfile.open --> on-reading-negative-size-from-file
+    "r"
+    f.read -5 > [f]
 
-  --> on-reading-from-file-with-wrong-mode
-    mktemp.tmpfile.open > @
-      "w"
-      f.read 12 > [f]
+  mktemp.tmpfile.open --> on-reading-from-file-with-wrong-mode
+    "w"
+    f.read 12 > [f]
 
   ++> tests-reads-from-file-from-different-instances
     seq * > @
@@ -493,12 +481,11 @@
             m
       "world"
 
-  ++> tests-writes-to-file-sequentially
-    eq. > @
-      size.
-        mktemp.tmpfile.open
-          "a+"
-          write. > [f]
-            f.write "Hello, world"
-            "!"
-      13
+  eq. ++> tests-writes-to-file-sequentially
+    size.
+      mktemp.tmpfile.open
+        "a+"
+        write. > [f]
+          f.write "Hello, world"
+          "!"
+    13

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -143,11 +143,11 @@
     2.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
 
-  ++> tests-i16-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      2.as-i64.as-i32.as-i16.div
-        0.as-i64.as-i32.as-i16
-        "recovered" > [msg]
+  eq. ++> tests-i16-div-by-zero-returns-provided-fallback
+    "recovered"
+    2.as-i64.as-i32.as-i16.div
+      0.as-i64.as-i32.as-i16
+      "recovered" > [msg]
 
   ++> tests-i16-div-by-i16-one
     eq. > @

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -157,18 +157,18 @@
 
   2.as-i64.as-i32.div 0.as-i64.as-i32 --> on-division-i32-by-i32-zero
 
-  ++> tests-i32-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      2.as-i64.as-i32.div
-        0.as-i64.as-i32
-        "recovered" > [msg]
+  eq. ++> tests-i32-div-by-zero-returns-provided-fallback
+    "recovered"
+    2.as-i64.as-i32.div
+      0.as-i64.as-i32
+      "recovered" > [msg]
 
   247483647.as-i64.as-i32.as-i16 --> on-converting-to-i16-if-out-of-bounds
 
-  ++> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
-    "recovered".eq > @
-      247483647.as-i64.as-i32.as-i16
-        "recovered" > [msg]
+  eq. ++> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
+    "recovered"
+    247483647.as-i64.as-i32.as-i16
+      "recovered" > [msg]
 
   ++> tests-i32-div-by-i32-one
     eq. > @

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -95,10 +95,10 @@
 
   3147483647.as-i64.as-i32 --> on-converting-to-i32-if-out-of-bounds
 
-  ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
-    "recovered".eq > @
-      3147483647.as-i64.as-i32
-        "recovered" > [msg]
+  eq. ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+    "recovered"
+    3147483647.as-i64.as-i32
+      "recovered" > [msg]
 
   eq. ++> tests-i64-i32-max-converts-without-error
     2147483647.as-i64
@@ -172,11 +172,11 @@
 
   2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero
 
-  ++> tests-i64-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      2.as-i64.div
-        0.as-i64
-        "recovered" > [msg]
+  eq. ++> tests-i64-div-by-zero-returns-provided-fallback
+    "recovered"
+    2.as-i64.div
+      0.as-i64
+      "recovered" > [msg]
 
   ++> tests-i64-div-by-i64-one
     eq. > @

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -125,8 +125,8 @@
 
   02-.as-i8.div 00-.as-i8 --> on-division-i8-by-i8-zero
 
-  ++> tests-i8-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      02-.as-i8.div
-        00-.as-i8
-        "recovered" > [msg]
+  eq. ++> tests-i8-div-by-zero-returns-provided-fallback
+    "recovered"
+    02-.as-i8.div
+      00-.as-i8
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -25,53 +25,49 @@
       input
       output
 
-  ++> tests-copies-all-bytes-and-returns-length
-    eq. > @
-      malloc.of
-        5
-        seq * > [m]
-          Q.input.copied
-            bytes.to-input 01-02-03-04-05
-            io.malloc-as-output m
-          m
-      01-02-03-04-05
-
-  ++> tests-returns-correct-byte-count
-    eq. > @
-      malloc.of
-        10
-        Q.input.copied > [m]
-          bytes.to-input 01-02-03-04-05-06-07-08-09-10
+  eq. ++> tests-copies-all-bytes-and-returns-length
+    malloc.of
+      5
+      seq * > [m]
+        Q.input.copied
+          bytes.to-input 01-02-03-04-05
           io.malloc-as-output m
+        m
+    01-02-03-04-05
+
+  eq. ++> tests-returns-correct-byte-count
+    malloc.of
       10
+      Q.input.copied > [m]
+        bytes.to-input 01-02-03-04-05-06-07-08-09-10
+        io.malloc-as-output m
+    10
 
-  ++> tests-handles-empty-input
-    eq. > @
-      malloc.of
-        0
-        seq * > [m]
-          Q.input.copied
-            bytes.to-input --
-            io.malloc-as-output m
-          m
-      --
-
-  ++> tests-returns-zero-for-empty-input
-    eq. > @
-      malloc.of
-        0
-        Q.input.copied > [m]
+  eq. ++> tests-handles-empty-input
+    malloc.of
+      0
+      seq * > [m]
+        Q.input.copied
           bytes.to-input --
           io.malloc-as-output m
-      0
+        m
+    --
 
-  ++> tests-handles-large-data
-    20.eq > @
-      malloc.of
-        20
-        Q.input.copied > [m]
-          bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
-          io.malloc-as-output m
+  eq. ++> tests-returns-zero-for-empty-input
+    malloc.of
+      0
+      Q.input.copied > [m]
+        bytes.to-input --
+        io.malloc-as-output m
+    0
+
+  eq. ++> tests-handles-large-data
+    20
+    malloc.of
+      20
+      Q.input.copied > [m]
+        bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+        io.malloc-as-output m
 
   eq. ++> tests-handles-dead-input
     Q.input.copied

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -27,14 +27,13 @@
       bytes.to-input 01-02-03-04-05-06-07-08-09-10
     10
 
-  ++> tests-copies-all-bytes-to-output-and-returns-length
-    eq. > @
-      malloc.of
-        10
-        seq * > [m]
-          Q.input.length
-            Q.input.tee
-              bytes.to-input 01-02-03-04-05-06-07-08-09-10
-              io.malloc-as-output m
-          m
-      01-02-03-04-05-06-07-08-09-10
+  eq. ++> tests-copies-all-bytes-to-output-and-returns-length
+    malloc.of
+      10
+      seq * > [m]
+        Q.input.length
+          Q.input.tee
+            bytes.to-input 01-02-03-04-05-06-07-08-09-10
+            io.malloc-as-output m
+        m
+    01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -40,33 +40,31 @@
         (input.read size).read.^ > chunk
         (output.write chunk).write.^ > written
 
-  ++> tests-reads-from-bytes-and-writes-to-memory
-    eq. > @
-      malloc.of
+  eq. ++> tests-reads-from-bytes-and-writes-to-memory
+    malloc.of
+      5
+      read. > [mem]
+        Q.input.tee
+          bytes.to-input 01-02-03-04-05
+          io.malloc-as-output mem
         5
-        read. > [mem]
-          Q.input.tee
-            bytes.to-input 01-02-03-04-05
-            io.malloc-as-output mem
-          5
-      01-02-03-04-05
+    01-02-03-04-05
 
-  ++> tests-reads-from-bytes-and-writes-to-memory-by-portions
-    eq. > @
-      malloc.of
-        5
-        seq * > [m]
+  eq. ++> tests-reads-from-bytes-and-writes-to-memory-by-portions
+    malloc.of
+      5
+      seq * > [m]
+        read.
           read.
             read.
-              read.
-                Q.input.tee
-                  bytes.to-input 01-02-03-04-05
-                  io.malloc-as-output m
-                2
+              Q.input.tee
+                bytes.to-input 01-02-03-04-05
+                io.malloc-as-output m
               2
-            1
-          m
-      01-02-03-04-05
+            2
+          1
+        m
+    01-02-03-04-05
 
   ++> tests-reads-from-bytes-and-writes-to-two-memory-blocks
     eq. > @

--- a/eo-runtime/src/main/eo/io/malloc-as-output.eo
+++ b/eo-runtime/src/main/eo/io/malloc-as-output.eo
@@ -37,24 +37,24 @@
         output-block
           offset.plus buffer.size
 
-  ++> tests-makes-an-output-from-malloc-and-writes
-    eq. > @
-      malloc.of
-        10
-        seq * > [mem]
+  eq. ++> tests-makes-an-output-from-malloc-and-writes
+    malloc.of
+      10
+      seq * > [mem]
+        write.
           write.
-            write.
-              (malloc-as-output mem).write 01-02-03
-              04-05-06-07
-            08-09-A0
-          mem
-      01-02-03-04-05-06-07-08-09-A0
+            (malloc-as-output mem).write 01-02-03
+            04-05-06-07
+          08-09-A0
+        mem
+    01-02-03-04-05-06-07-08-09-A0
 
-  ++> writes-larger-data-than-provided-block
-    eq. > @
-      malloc.of
-        2
-        seq * > [mem]
-          (malloc-as-output mem).write 01-02-03
-          mem
-      01-02-03
+  eq. ++> writes-larger-data-than-provided-block
+    malloc.of
+      2
+      seq * > [mem]
+        write.
+          malloc-as-output mem
+          01-02-03
+        mem
+    01-02-03

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -103,12 +103,11 @@
       0
       m.put 10 > [m]
 
-  ++> tests-returns-size-from-scope
-    eq. > @
-      malloc.of
-        5
-        m.size > [m]
+  eq. ++> tests-returns-size-from-scope
+    malloc.of
       5
+      m.size > [m]
+    5
 
   ++> tests-malloc-scope-is-dataized-twice
     2.eq > @
@@ -122,12 +121,11 @@
             f.put > [s] >>
               f.as-number.plus 1
 
-  ++> tests-malloc-for-writes-first-init-value
-    eq. > @
-      malloc.for
-        42
-        m > [m]
+  eq. ++> tests-malloc-for-writes-first-init-value
+    malloc.for
       42
+      m > [m]
+    42
 
   ++> tests-malloc-puts-over-the-previous-data
     eq. > @
@@ -149,61 +147,53 @@
         m.put
           m.as-number.plus 5
 
-  ++> tests-writes-into-two-malloc-objects
-    and. > @
-      eq.
-        malloc.of
-          8
-          m.put 10 > [m]
-        10
-      eq.
-        malloc.of
-          8
-          m.put 20 > [m]
-        20
+  and. ++> tests-writes-into-two-malloc-objects
+    eq.
+      malloc.of
+        8
+        m.put 10 > [m]
+      10
+    eq.
+      malloc.of
+        8
+        m.put 20 > [m]
+      20
 
-  --> on-overflow-boolean-malloc
-    malloc.for > @
-      false
-      m.put 8.612486788E7 > [m]
+  malloc.for --> on-overflow-boolean-malloc
+    false
+    m.put 8.612486788E7 > [m]
 
-  --> on-overflow-string-malloc
-    malloc.for > @
+  malloc.for --> on-overflow-string-malloc
+    "Hello"
+    m.put > [m]
+      "Much longer string!"
+
+  eq. ++> tests-malloc-is-strictly-sized-int
+    malloc.for
+      12248
+      m.put 2556 > [m]
+    2556
+
+  eq. ++> tests-malloc-is-strictly-typed-float
+    malloc.for
+      245.88
+      m.put 82.22 > [m]
+    82.22
+
+  eq. ++> tests-memory-is-strictly-sized-string
+    malloc.for
       "Hello"
-      m.put > [m]
-        "Much longer string!"
+      m.put "Prot" > [m]
+    "Proto"
 
-  ++> tests-malloc-is-strictly-sized-int
-    eq. > @
-      malloc.for
-        12248
-        m.put 2556 > [m]
-      2556
+  malloc.for ++> tests-malloc-is-strictly-typed-bool
+    false
+    m.put true > [m]
 
-  ++> tests-malloc-is-strictly-typed-float
-    eq. > @
-      malloc.for
-        245.88
-        m.put 82.22 > [m]
-      82.22
-
-  ++> tests-memory-is-strictly-sized-string
-    eq. > @
-      malloc.for
-        "Hello"
-        m.put "Prot" > [m]
-      "Proto"
-
-  ++> tests-malloc-is-strictly-typed-bool
-    malloc.for > @
-      false
-      m.put true > [m]
-
-  ++> tests-malloc-gives-id-to-allocated-block
-    malloc.of > @
-      1
-      m.put > [m]
-        m.id.gt 0
+  malloc.of ++> tests-malloc-gives-id-to-allocated-block
+    1
+    m.put > [m]
+      m.id.gt 0
 
   ++> tests-malloc-allocates-right-size-block
     malloc.of > @
@@ -242,12 +232,11 @@
               (m.read 0 3).eq
                 "XYX"
 
-  ++> writes-beyond-offset-and-resizes
-    malloc.of > @
-      1
-      seq * > [m]
-        m.write 1 true
-        m.size.eq 2
+  malloc.of ++> writes-beyond-offset-and-resizes
+    1
+    seq * > [m]
+      m.write 1 true
+      m.size.eq 2
 
   ++> tests-malloc-reads-with-offset-and-length
     malloc.of > @
@@ -261,26 +250,26 @@
               (m.read 2 5).eq
                 "Hello"
 
-  ++> tests-malloc-read-over-a-limit-returns-fallback
-    01-02.eq > @
-      malloc.of
-        1
-        [m]
-          m.read > @
-            0
-            10
-            01-02 > [ex]
-
-  --> on-reading-over-a-limit-without-fallback
-    malloc.for > @
-      10
-      m.read 0 100 > [m]
-
-  ++> tests-allocates-zero-bytes
-    0.eq > @
-      malloc.of
+  eq. ++> tests-malloc-read-over-a-limit-returns-fallback
+    01-02
+    malloc.of
+      1
+      m.read > [m]
         0
-        m.size > [m]
+        10
+        01-02 > [ex]
+
+  malloc.for --> on-reading-over-a-limit-without-fallback
+    10
+    m.read > [m]
+      0
+      100
+
+  eq. ++> tests-allocates-zero-bytes
+    0
+    malloc.of
+      0
+      m.size > [m]
 
   ++> tests-malloc-increases-block-size
     malloc.of > @
@@ -304,65 +293,57 @@
               (m.resized 3).size.eq 3
               m.get.eq 01-02-03
 
-  --> on-changing-size-to-negative
-    malloc.of > @
-      1
-      m.resized -1 > [m]
+  malloc.of --> on-changing-size-to-negative
+    1
+    m.resized -1 > [m]
 
-  --> on-changing-size-to-fractional
-    malloc.of > @
-      1
-      m.resized 1.5 > [m]
+  malloc.of --> on-changing-size-to-fractional
+    1
+    m.resized 1.5 > [m]
 
-  ++> tests-malloc-empty-is-empty
-    malloc.empty > @
-      m.size.eq 0 > [m]
+  malloc.empty ++> tests-malloc-empty-is-empty
+    m.size.eq 0 > [m]
 
-  ++> tests-copies-data-inside-itself
-    malloc.for > @
-      01-02-03-04-05
-      and. > [m]
-        m.copy
-          1
-          2
-          2
-        m.get.eq 01-02-02-03-05
-
-  ++> tests-copies-data-from-start-to-end
-    malloc.for > @
-      01-02-03-04-05-06
-      and. > [m]
-        m.copy
-          0
-          3
-          3
-        m.get.eq 01-02-03-01-02-03
-
-  --> on-copying-with-wrong-source
-    malloc.for > @
-      0
-      m.copy > [m]
-        9
+  malloc.for ++> tests-copies-data-inside-itself
+    01-02-03-04-05
+    and. > [m]
+      m.copy
         1
-        1
+        2
+        2
+      m.get.eq 01-02-02-03-05
 
-  ++> copies-and-resizes-to-target
-    malloc.for > @
-      0
-      seq * > [m]
-        m.copy
-          3
-          9
-          1
-        m.size.eq 10
-
-  --> on-copying-with-wrong-length
-    malloc.for > @
-      0
-      m.copy > [m]
+  malloc.for ++> tests-copies-data-from-start-to-end
+    01-02-03-04-05-06
+    and. > [m]
+      m.copy
+        0
         3
-        1
+        3
+      m.get.eq 01-02-03-01-02-03
+
+  malloc.for --> on-copying-with-wrong-source
+    0
+    m.copy > [m]
+      9
+      1
+      1
+
+  malloc.for ++> copies-and-resizes-to-target
+    0
+    seq * > [m]
+      m.copy
+        3
         9
+        1
+      m.size.eq 10
+
+  malloc.for --> on-copying-with-wrong-length
+    0
+    m.copy > [m]
+      3
+      1
+      9
 
   ++> tests-calculates-only-once
     eq. > @

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -259,14 +259,14 @@
           map.entry "Aa" 1
         "BB"
 
-  ++> tests-falls-back-for-absent-key-colliding-with-stored-one
-    "recovered".eq > @
-      get.
-        found.
-          map *
-            map.entry "Aa" 1
-          "BB"
-        "recovered" > [msg]
+  eq. ++> tests-falls-back-for-absent-key-colliding-with-stored-one
+    "recovered"
+    get.
+      found.
+        map *
+          map.entry "Aa" 1
+        "BB"
+      "recovered" > [msg]
 
   ++> tests-adds-key-colliding-with-existing-one
     and. > @

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -548,10 +548,10 @@
 
   pinf.as-i64 --> on-converting-positive-infinity-to-i64
 
-  ++> tests-out-of-range-as-i64-returns-provided-fallback
-    "recovered".eq > @
-      1.0e30.as-i64
-        "recovered" > [msg]
+  eq. ++> tests-out-of-range-as-i64-returns-provided-fallback
+    "recovered"
+    1.0e30.as-i64
+      "recovered" > [msg]
 
   eq. ++> tests-as-i64-truncates-positive-toward-zero
     3.7.as-i64.as-bytes

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -85,9 +85,9 @@
     5
     0
 
-  ++> tests-mod-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      mod
-        5
-        0
-        "recovered" > [msg]
+  eq. ++> tests-mod-by-zero-returns-provided-fallback
+    "recovered"
+    mod
+      5
+      0
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -34,14 +34,14 @@
       42
     42
 
-  ++> tests-recovers-when-a-provided-fallback-terminates
-    eq. > @
-      recovered
-        2.as-i64.div
-          0.as-i64
-          T "cannot divide" > [msg]
-        42
+  eq. ++> tests-recovers-when-a-provided-fallback-terminates
+    recovered
+      2.as-i64.div
+        0.as-i64
+        T > [msg]
+          "cannot divide"
       42
+    42
 
   recovered --> when-both-are-terminated
     2.as-i64.div 0.as-i64

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -26,11 +26,11 @@
 
   as-number "Hello" --> on-converting-text-to-number
 
-  ++> tests-non-numeric-text-returns-provided-fallback
-    42.eq > @
-      as-number
-        "Hello"
-        42 > [msg]
+  eq. ++> tests-non-numeric-text-returns-provided-fallback
+    42
+    as-number
+      "Hello"
+      42 > [msg]
 
   eq. ++> tests-converts-float-text-to-number
     3.14

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -54,9 +54,9 @@
     "some"
     10
 
-  ++> tests-text-at-out-of-bounds-returns-provided-fallback
-    "recovered".eq > @
-      at
-        "some"
-        10
-        "recovered" > [msg]
+  eq. ++> tests-text-at-out-of-bounds-returns-provided-fallback
+    "recovered"
+    at
+      "some"
+      10
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -108,13 +108,13 @@
     "-"
     -1
 
-  ++> tests-nsplit-invalid-limit-returns-provided-fallback
-    "fallback".eq > @
-      nsplit
-        "text"
-        "-"
-        0
-        "fallback" > [msg]
+  eq. ++> tests-nsplit-invalid-limit-returns-provided-fallback
+    "fallback"
+    nsplit
+      "text"
+      "-"
+      0
+      "fallback" > [msg]
 
   eq. ++> tests-nsplit-with-empty-strings
     nsplit

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -180,17 +180,17 @@
 
   (regex "/pattern").compiled --> on-missing-closing-slash-in-regex
 
-  ++> tests-invalid-regex-syntax-returns-provided-fallback
-    "recovered".eq > @
-      compile.
-        regex "/[a-z/"
-        "recovered" > [msg]
+  eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
+    "recovered"
+    compile.
+      regex "/[a-z/"
+      "recovered" > [msg]
 
-  ++> tests-missing-slash-returns-provided-fallback
-    "no-slash".eq > @
-      compile.
-        regex "(.)+"
-        "no-slash" > [msg]
+  eq. ++> tests-missing-slash-returns-provided-fallback
+    "no-slash"
+    compile.
+      regex "(.)+"
+      "no-slash" > [msg]
 
   (regex "/[a-z/").compile --> on-compiling-invalid-regex-without-fallback
 

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -36,12 +36,12 @@
     ""
     -1
 
-  ++> tests-text-repeated-negative-times-returns-provided-fallback
-    "recovered".eq > @
-      repeated
-        "x"
-        -1
-        "recovered" > [msg]
+  eq. ++> tests-text-repeated-negative-times-returns-provided-fallback
+    "recovered"
+    repeated
+      "x"
+      -1
+      "recovered" > [msg]
 
   eq. ++> tests-text-repeated-zero-times-is-empty
     ""

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -86,11 +86,11 @@
   switch --> on-empty-switch
     *
 
-  ++> tests-empty-switch-returns-provided-fallback
-    "recovered".eq > @
-      switch
-        *
-        "recovered" > [msg]
+  eq. ++> tests-empty-switch-returns-provided-fallback
+    "recovered"
+    switch
+      *
+      "recovered" > [msg]
 
   ++> tests-switch-complex-case
     eq. > @

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -130,16 +130,16 @@
       4
     20
 
-  ++> tests-out-of-bounds-at-returns-provided-fallback
-    "recovered".eq > @
-      at.
-        *
-          1
-          2
-          3
-          4
-        20
-        "recovered" > [msg]
+  eq. ++> tests-out-of-bounds-at-returns-provided-fallback
+    "recovered"
+    at.
+      *
+        1
+        2
+        3
+        4
+      20
+      "recovered" > [msg]
 
   ++> tests-tuple-fluent-with
     and. > @

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -27,10 +27,9 @@
               m.as-number.plus i
       6
 
-  ++> tests-each-empty-list
-    each > @
-      *
-      false > [x]
+  each ++> tests-each-empty-list
+    *
+    false > [x]
 
   ++> tests-each-single-element
     eq. > @
@@ -43,15 +42,14 @@
               m.as-number.plus i
       7
 
-  ++> tests-each-returns-last-func-result
-    eq. > @
-      each
-        *
-          1
-          2
-          3
-        x > [x]
-      3
+  eq. ++> tests-each-returns-last-func-result
+    each
+      *
+        1
+        2
+        3
+      x > [x]
+    3
 
   ++> tests-each-sums-more-numbers
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -18,27 +18,25 @@
     list
     func item > [item index] >>
 
-  ++> tests-simple-filtered
-    eq. > @
-      filtered
-        *
-          3
-          1
-          4
-          2
-          5
-        v.gt 2 > [v]
+  eq. ++> tests-simple-filtered
+    filtered
       *
         3
+        1
         4
+        2
         5
+      v.gt 2 > [v]
+    *
+      3
+      4
+      5
 
-  ++> tests-filtered-with-bools
-    eq. > @
-      filtered
-        *
-          true
-          false
-          true
-        v.not > [v]
-      * false
+  eq. ++> tests-filtered-with-bools
+    filtered
+      *
+        true
+        false
+        true
+      v.not > [v]
+    * false

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -26,51 +26,50 @@
     recfilter tup.tail > next
   | list > @
 
-  ++> tests-filteredi-with-lt
-    eq. > @
-      filteredi
-        *
-          3
-          1
-          4
-          2
-          5
-        v.lt 3 > [v i]
-      * 1 2
+  eq. ++> tests-filteredi-with-lt
+    filteredi
+      *
+        3
+        1
+        4
+        2
+        5
+      v.lt 3 > [v i]
+    *
+      1
+      2
 
-  ++> tests-filteredi-with-string-length
-    eq. > @
-      filteredi
-        *
-          "Hello"
-          "Name"
-          "EO"
-          "List"
-        v.length.gt 4 > [v i]
-      * "Hello"
+  eq. ++> tests-filteredi-with-string-length
+    filteredi
+      *
+        "Hello"
+        "Name"
+        "EO"
+        "List"
+      v.length.gt 4 > [v i]
+    * "Hello"
 
-  ++> tests-filteredi-with-empty-list
-    is-empty > @
-      filteredi
-        *
-        v.lt 3 > [v i]
+  is-empty ++> tests-filteredi-with-empty-list
+    filteredi
+      *
+      v.lt 3 > [v i]
 
-  ++> tests-filteredi-by-index
-    eq. > @
-      filteredi
-        *
-          3
-          1
-          4
-        i.gt 0 > [v i]
-      * 1 4
+  eq. ++> tests-filteredi-by-index
+    filteredi
+      *
+        3
+        1
+        4
+      i.gt 0 > [v i]
+    *
+      1
+      4
 
-  ++> tests-filteredi-with-bools
-    eq. > @
-      filteredi
-        *
-          true
-          false
-          true
-        v.not > [v i]
-      * false
+  eq. ++> tests-filteredi-with-bools
+    filteredi
+      *
+        true
+        false
+        true
+      v.not > [v i]
+    * false

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -16,15 +16,14 @@
     list
     func item > [item idx] >>
 
-  ++> tests-simple-list-mapping
-    eq. > @
-      mapped
-        *
-          1
-          2
-          3
-        x.times 2 > [x]
+  eq. ++> tests-simple-list-mapping
+    mapped
       *
+        1
         2
-        4
-        6
+        3
+      x.times 2 > [x]
+    *
+      2
+      4
+      6

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -19,17 +19,16 @@
     accum.with > [accum item idx] >>
       func item idx
 
-  ++> tests-list-mappedi-should-work
-    eq. > @
-      mappedi
-        *
-          1
-          2
-          3
-          4
-        i.times x > [x i]
+  eq. ++> tests-list-mappedi-should-work
+    mappedi
       *
-        0
+        1
         2
-        6
-        12
+        3
+        4
+      i.times x > [x i]
+    *
+      0
+      2
+      6
+      12

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -26,11 +26,11 @@
   maximum --> on-taking-maximum-from-empty-sequence
     *
 
-  ++> tests-maximum-of-empty-returns-provided-fallback
-    "recovered".eq > @
-      maximum
-        *
-        "recovered" > [msg]
+  eq. ++> tests-maximum-of-empty-returns-provided-fallback
+    "recovered"
+    maximum
+      *
+      "recovered" > [msg]
 
   eq. ++> tests-maximum-of-one-item-array
     maximum

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -26,11 +26,11 @@
   minimum --> on-taking-minimum-from-empty-sequence
     *
 
-  ++> tests-minimum-of-empty-returns-provided-fallback
-    "recovered".eq > @
-      minimum
-        *
-        "recovered" > [msg]
+  eq. ++> tests-minimum-of-empty-returns-provided-fallback
+    "recovered"
+    minimum
+      *
+      "recovered" > [msg]
 
   eq. ++> tests-minimum-of-one-item-array
     minimum

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -21,24 +21,22 @@
       accum
       item
 
-  ++> tests-list-reduce-without-index
-    eq. > @
-      reduced
-        *
-          1
-          2
-          3
-          4
-        -1
-        a.times x > [a x]
-      -24
+  eq. ++> tests-list-reduce-without-index
+    reduced
+      *
+        1
+        2
+        3
+        4
+      -1
+      a.times x > [a x]
+    -24
 
-  ++> tests-list-reduced-printing
-    eq. > @
-      reduced
-        * 0 1
-        ""
-        acc.concat > [acc item]
-          "%d".printf
-            * item
-      "01"
+  eq. ++> tests-list-reduced-printing
+    reduced
+      * 0 1
+      ""
+      acc.concat > [acc item]
+        "%d".printf
+          * item
+    "01"

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -40,58 +40,57 @@
               * 2 2
               i
 
-  ++> tests-list-reducedi-long-int-array
-    eq. > @
-      reducedi
-        *
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          0
-          1
+  eq. ++> tests-list-reducedi-long-int-array
+    reducedi
+      *
         0
-        x.plus a > [a x i]
-      1
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        1
+      0
+      x.plus a > [a x i]
+    1
 
   ++> tests-list-reducedi-bools-array
     not. > @

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -109,8 +109,8 @@
 
   00-02.as-u16.div 00-00.as-u16 --> on-division-u16-by-u16-zero
 
-  ++> tests-u16-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      00-02.as-u16.div
-        00-00.as-u16
-        "recovered" > [msg]
+  eq. ++> tests-u16-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-02.as-u16.div
+      00-00.as-u16
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -113,8 +113,8 @@
 
   00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> on-division-u32-by-u32-zero
 
-  ++> tests-u32-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      00-00-00-02.as-u32.div
-        00-00-00-00.as-u32
-        "recovered" > [msg]
+  eq. ++> tests-u32-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-00-00-02.as-u32.div
+      00-00-00-00.as-u32
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -180,8 +180,8 @@
     00-00-00-00-00-00-00-02.as-u64
     00-00-00-00-00-00-00-00.as-u64
 
-  ++> tests-u64-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      00-00-00-00-00-00-00-02.as-u64.div
-        00-00-00-00-00-00-00-00.as-u64
-        "recovered" > [msg]
+  eq. ++> tests-u64-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-00-00-00-00-00-00-02.as-u64.div
+      00-00-00-00-00-00-00-00.as-u64
+      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -113,8 +113,8 @@
 
   02-.as-u8.div 00-.as-u8 --> on-division-u8-by-u8-zero
 
-  ++> tests-u8-div-by-zero-returns-provided-fallback
-    "recovered".eq > @
-      02-.as-u8.div
-        00-.as-u8
-        "recovered" > [msg]
+  eq. ++> tests-u8-div-by-zero-returns-provided-fallback
+    "recovered"
+    02-.as-u8.div
+      00-.as-u8
+      "recovered" > [msg]


### PR DESCRIPTION
Follow-up to #5700 / PR #5702, addressing a case spotted in `malloc.eo`.

## Problem

`Xmir.toEO()` kept the verbose ` > @` layout here:

```
++> tests-malloc-for-writes-first-init-value
  eq. > @
    malloc.for
      42
      m > [m]
    42
```

instead of the strictly cheaper hybrid:

```
eq. ++> tests-malloc-for-writes-first-init-value
  malloc.for
    42
    m > [m]
  42
```

The cause is `Node.nameless()`, the recursive guard that decides whether an only-φ formation may collapse into the compact inline-φ hybrid. It rejected **any** non-empty tail in the decoratee's subtree, which over-blocked a nested anonymous object like `m > [m]` (an anonymous formation whose φ is `m`) because its inner ` > @` φ decoratee reads as a "name".

## Fix

A ` > @` suffix marks the **φ decoratee** — exactly what an only-φ formation binds — never a named or auto-named attribute. So a nested anonymous object is a legal argument and must not withhold the fold. `nameless()` now treats a bare ` > @` tail as safe; genuine named/auto-named attributes (`> name`, `>>`) still block it, so the `#5598`/`#5604` guards (`[sum] >>`, `[left] >>`, `[a x i] >>`) are unchanged.

Verified the hybrid is valid, semantically identical EO: it parses without errors and round-trips (`printsToParseableEo`), i.e. it renders the same XMIR as the verbose form.

## Tests & formatting

- Added `hybrid-phi-anonymous-argument.yaml` (the malloc case from the report).
- Updated `inline-phi-compact-tuple.yaml`, whose canonical layout now legitimately uses the hybrid (the anonymous `seq * > [m]` argument no longer blocks the outer fold).
- Full `eo-printer` suite (172 tests) green.
- Reformatted 39 `eo-runtime` `.eo` sources to their new canonical layout (required by the `format` goal). Semantics-preserving and idempotent: a second `format` pass reports *"All 151 EO source(s) are formatted canonically."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuhgdsjotvaC6rWu39HDjm)_