### PR TITLE
Rename bytes.to-input object to bytes.as-input

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -3,7 +3,7 @@
 # via `as-bytes`.
 # Here's how you can read portions of bytes from the input:
 # ```
-# to-input > i
+# as-input > i
 #   01-02-03-04-05-06-07-08-F5-F6
 # seq > @
 #   *
@@ -28,7 +28,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[bts] > to-input
+[bts] > as-input
   [size] > read
     @. > @
       read.
@@ -65,7 +65,7 @@
         i3.read 2
         --
     read. > i1
-      to-input 01-02-03-04-05-06-07-08-F5-F6
+      as-input 01-02-03-04-05-06-07-08-F5-F6
       4
     i1.read 4 > i2
     i2.read 4 > i3

--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -3,7 +3,7 @@
 # provide a `read` object that takes the amount of bytes to read and
 # returns an input block - a dataizable portion of bytes that also has
 # its own `read` to fetch the next portion. See `input.dead`,
-# `input.as-bytes`, `input.length`, `input.tee`, and `bytes.to-input`.
+# `input.as-bytes`, `input.length`, `input.tee`, and `bytes.as-input`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -3,11 +3,11 @@
 # Example usage:
 # ```
 # as-bytes > bts
-#   bytes.to-input 01-02-03-04-05
+#   bytes.as-input 01-02-03-04-05
 # ```
 # After dataization, `bts` equals `01-02-03-04-05`.
 
-+alias bytes.to-input
++alias bytes.as-input
 +alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -25,10 +25,10 @@
         io.malloc-as-output m
       m
 
-  ++> tests-bytes-to-input-and-back
+  ++> tests-bytes-as-input-and-back
     eq. > @
       Q.input.as-bytes
-        bytes.to-input bts
+        bytes.as-input bts
       bts
     01-02-03-04-05-06-07-08 > bts
 

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -4,13 +4,13 @@
 # Example usage:
 # ```
 # copied > total-bytes
-#   bytes.to-input 01-02-03-04-05
+#   bytes.as-input 01-02-03-04-05
 #   io.malloc-as-output memory
 # ```
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
-+alias bytes.to-input
++alias bytes.as-input
 +alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -30,7 +30,7 @@
       5
       seq * > [m]
         Q.input.copied
-          bytes.to-input 01-02-03-04-05
+          bytes.as-input 01-02-03-04-05
           io.malloc-as-output m
         m
     01-02-03-04-05
@@ -39,7 +39,7 @@
     malloc.of
       10
       Q.input.copied > [m]
-        bytes.to-input 01-02-03-04-05-06-07-08-09-10
+        bytes.as-input 01-02-03-04-05-06-07-08-09-10
         io.malloc-as-output m
     10
 
@@ -48,7 +48,7 @@
       0
       seq * > [m]
         Q.input.copied
-          bytes.to-input --
+          bytes.as-input --
           io.malloc-as-output m
         m
     --
@@ -57,7 +57,7 @@
     malloc.of
       0
       Q.input.copied > [m]
-        bytes.to-input --
+        bytes.as-input --
         io.malloc-as-output m
     0
 
@@ -66,7 +66,7 @@
     malloc.of
       20
       Q.input.copied > [m]
-        bytes.to-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+        bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
         io.malloc-as-output m
 
   eq. ++> tests-handles-dead-input

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -1,6 +1,6 @@
 # Reads all the bytes from provided `input` and returns its length.
 
-+alias bytes.to-input
++alias bytes.as-input
 +alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -24,7 +24,7 @@
 
   eq. ++> tests-reads-all-bytes-and-returns-length
     Q.input.length
-      bytes.to-input 01-02-03-04-05-06-07-08-09-10
+      bytes.as-input 01-02-03-04-05-06-07-08-09-10
     10
 
   eq. ++> tests-copies-all-bytes-to-output-and-returns-length
@@ -33,7 +33,7 @@
       seq * > [m]
         Q.input.length
           Q.input.tee
-            bytes.to-input 01-02-03-04-05-06-07-08-09-10
+            bytes.as-input 01-02-03-04-05-06-07-08-09-10
             io.malloc-as-output m
         m
     01-02-03-04-05-06-07-08-09-10

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -7,14 +7,14 @@
 #   [m]
 #     read. > @
 #       tee
-#         bytes.to-input 01-02-03-04-05
+#         bytes.as-input 01-02-03-04-05
 #         io.malloc-as-output m
 #       5
 # ```
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
-+alias bytes.to-input
++alias bytes.as-input
 +alias io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -45,7 +45,7 @@
       5
       read. > [mem]
         Q.input.tee
-          bytes.to-input 01-02-03-04-05
+          bytes.as-input 01-02-03-04-05
           io.malloc-as-output mem
         5
     01-02-03-04-05
@@ -58,7 +58,7 @@
           read.
             read.
               Q.input.tee
-                bytes.to-input 01-02-03-04-05
+                bytes.as-input 01-02-03-04-05
                 io.malloc-as-output m
               2
             2
@@ -77,7 +77,7 @@
               read.
                 Q.input.tee
                   Q.input.tee
-                    bytes.to-input 01-02-03-04-05
+                    bytes.as-input 01-02-03-04-05
                     io.malloc-as-output m2
                   io.malloc-as-output m1
                 5


### PR DESCRIPTION
Renames the `bytes.to-input` object to `bytes.as-input` for naming consistency with the other `as-*` converters under `bytes/` (`as-bytes`, `as-i64`, `as-number`, etc.).

## Changes

- Renamed file `eo-runtime/src/main/eo/bytes/to-input.eo` → `eo-runtime/src/main/eo/bytes/as-input.eo` (via `git mv`, preserving history).
- Renamed the object definition `[bts] > to-input` → `[bts] > as-input`, and updated the in-object doc example and test.
- Updated all references and `+alias bytes.to-input` declarations to `bytes.as-input` in:
  - `eo-runtime/src/main/eo/input.eo`
  - `eo-runtime/src/main/eo/input/as-bytes.eo` (also renamed test `tests-bytes-to-input-and-back` → `tests-bytes-as-input-and-back`)
  - `eo-runtime/src/main/eo/input/copied.eo`
  - `eo-runtime/src/main/eo/input/length.eo`
  - `eo-runtime/src/main/eo/input/tee.eo`

No remaining references to `to-input` exist in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J83sQtMdqAWdKevjAmJrT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01J83sQtMdqAWdKevjAmJrT6)_