### PR TITLE
eo-printer: deterministic formation attribute ordering (#5706)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -156,7 +156,25 @@
       <xsl:attribute name="data">
         <xsl:value-of select="if (eo:has-data(.)) then 'yes' else 'no'"/>
       </xsl:attribute>
-      <xsl:apply-templates select="o[not(eo:void(.)) or @local or @types]" mode="tree"/>
+      <!--
+      Formation attributes are emitted in a canonical order so that
+      textually-reordered but logically-identical bodies print the same
+      way (idempotent, diff-friendly output — #5706). The ordering is:
+      vertical void body lines first, then the decoratee (@name = φ),
+      then every other bound attribute alphabetically by name, and test
+      attributes last (also alphabetically). Two kinds of body keep
+      their source order untouched: application arguments (positional,
+      so their order carries meaning) and any body carrying a pipe
+      continuation ("| args", §3.14), whose "|" line must stay directly
+      below the named formation it applies to (R-3.14.7) — reordering
+      would strand it. In both cases the sort key collapses to a
+      constant, and since xsl:sort is stable the original order stands.
+      -->
+      <xsl:variable name="sortable" select="eo:abstract(.) and empty(o[@pipe])"/>
+      <xsl:apply-templates select="o[not(eo:void(.)) or @local or @types]" mode="tree">
+        <xsl:sort data-type="number" select="if (not($sortable)) then 0 else if (eo:void(.)) then 1 else if (@name = $eo:phi) then 2 else if (eo:test-attr(.)) then 4 else 3"/>
+        <xsl:sort select="if (not($sortable) or eo:void(.) or @name = $eo:phi) then '' else string(@name)"/>
+      </xsl:apply-templates>
     </line>
   </xsl:template>
   <!-- VOID WITH FILE-LOCAL HANDLE -->

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes.yaml
@@ -19,8 +19,8 @@ origin: |
 
 printed: |
   [] > main
-    EA-EA-EA-EA > xs
-    01- > one
-    "hello" > ys
     true > b1
     false > b2
+    01- > one
+    EA-EA-EA-EA > xs
+    "hello" > ys

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-in-const.yaml
@@ -20,5 +20,5 @@ printed: |
   [] > mktemp
     string > @
       [] >>!
-        getenv "TEMP" > temp!
         temp > @
+        getenv "TEMP" > temp!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
@@ -18,10 +18,10 @@ origin: |
 
 printed: |
   [a b c] > math
-    a.plus > weighted
-      b.times c
-    a.plus b > sum
     (a.plus b).div > mean
       c
     (a.gt b).and > sorted
       b.gt c
+    a.plus b > sum
+    a.plus > weighted
+      b.times c

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/idiomatic.yaml
@@ -39,8 +39,6 @@ printed: |
   +meta2 long tail
 
   [x x2 x3] > idiomatic
-    5 > iTest_me
-    [] > rr /Q.number
     if. > @
       plus.
         this
@@ -52,4 +50,6 @@ printed: |
             true
         bar
           n.plus "hello, 大家!"
+    5 > iTest_me
+    [] > rr /Q.number
     4.55 > x!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
@@ -41,9 +41,9 @@ printed: |
 
   [] > main
     [] > base
-      memory 0 > x
       x.write v > [self v] > f
       self.f self v > [self v] > g
+      memory 0 > x
     [] > derived
       base > @
       self.g self v > [self v] > f

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi.yaml
@@ -25,5 +25,5 @@ printed: |
 
   [] > examples
     a > [] > foo
-    ^.^.input-block > [size] > read
     true > [x] > nop
+    ^.^.input-block > [size] > read

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/just-float.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/just-float.yaml
@@ -17,6 +17,6 @@ origin: |
 
 printed: |
   [] > main
-    3.14 > pi
     [] > foo
       2.18 > e
+    3.14 > pi

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
@@ -18,9 +18,9 @@ origin: |
 
 printed: |
   [] > shapes
-    width.times height > [width height] > rectangle
     rectangle > area
       3
       4
+    width.times height > [width height] > rectangle
     (rectangle 3 4).plus > total
       rectangle 1 2

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-with-memory.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/seq-star-with-memory.yaml
@@ -20,9 +20,9 @@ origin: |
 
 printed: |
   [] > counter
-    memory 0 > state
     seq * > @
       state.write 0
       state.write
         state.as-int.plus 1
       state.as-int
+    memory 0 > state

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -18,55 +18,15 @@
   if > @
     01-
     00-
-  if > not
-    false
-    true
   if > [x] > and
     01-.eq x
     false
+  if > not
+    false
+    true
   if > [x] > or
     true
     01-.eq x
-
-  true.eq true ++> tests-compares-two-bools
-
-  true.as-bool ++> tests-true-as-bool
-
-  (true.eq 42).not ++> tests-compares-two-different-bool-types
-
-  and. ++> tests-compares-bool-to-bytes
-    true.eq 01-
-    false.eq 00-
-
-  and. ++> tests-compares-bool-to-bytes-reverse
-    01-.as-bytes.eq true
-    00-.as-bytes.eq false
-
-  eq. ++> tests-forks-on-true-condition
-    if.
-      5.eq 5
-      123
-      42
-    123
-
-  ++> tests-takes-parent-object
-    eq. > @
-      a 42
-      42
-    [x] > a
-      take > @
-      x > [] > take
-
-  ++> tests-takes-parent-through-attribute
-    [] > @
-      [] > @
-        x.eq 42 > [] > @
-    42 > x
-
-  --> when-applies-to-closed-object
-    closed true > @
-    x > [x] > a
-    a false > closed
 
   ++> tests-app-that-calls-func
     output.eq 2 > @
@@ -80,11 +40,50 @@
         1 > a
     app > output
 
+  and. ++> tests-compares-bool-to-bytes
+    true.eq 01-
+    false.eq 00-
+
+  and. ++> tests-compares-bool-to-bytes-reverse
+    01-.as-bytes.eq true
+    00-.as-bytes.eq false
+
+  and. ++> tests-compares-bool-to-string
+    true.eq "\u0001"
+    false.eq "\u0000"
+
+  true.eq true ++> tests-compares-two-bools
+
+  (true.eq 42).not ++> tests-compares-two-different-bool-types
+
+  ++> tests-compiles-correctly-with-long-duplicate-names
+    true > @
+    [] > long-object-name
+      [] > long-object-name
+        [] > long-object-name
+          [] > long-object-name
+            [] > long-object-name
+              42 > x
+
   ++> tests-extract-attribute-from-decoratee
     a.foo.eq 43 > @
-    [foo] > return
     return > [] > a
       42.plus 1
+    [foo] > return
+
+  eq. ++> tests-forks-on-false-condition
+    if.
+      5.eq 8
+      123
+      42
+    42
+
+  eq. ++> tests-forks-on-true-condition
+    if.
+      5.eq 5
+      123
+      42
+    123
 
   ++> tests-nesting-blah-test
     eq. > @
@@ -177,26 +176,27 @@
                                                                                   blah39 (x.plus 1) > @
                                                                                   x > [x] > blah39
 
-  ++> tests-compiles-correctly-with-long-duplicate-names
-    true > @
-    [] > long-object-name
-      [] > long-object-name
-        [] > long-object-name
-          [] > long-object-name
-            [] > long-object-name
-              42 > x
+  ++> tests-takes-parent-object
+    eq. > @
+      a 42
+      42
+    [x] > a
+      take > @
+      x > [] > take
 
-  true.not.eq false ++> tests-true-not-is-false
-
-  and. ++> tests-compares-bool-to-string
-    true.eq "\u0001"
-    false.eq "\u0000"
+  ++> tests-takes-parent-through-attribute
+    [] > @
+      [] > @
+        x.eq 42 > [] > @
+    42 > x
 
   (true.and false).not ++> tests-true-and-false-is-false
 
-  eq. ++> tests-forks-on-false-condition
-    if.
-      5.eq 8
-      123
-      42
-    42
+  true.as-bool ++> tests-true-as-bool
+
+  true.not.eq false ++> tests-true-not-is-false
+
+  --> when-applies-to-closed-object
+    closed true > @
+    x > [x] > a
+    a false > closed

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -13,10 +13,6 @@
     string
       buf.as-bytes.concat str.as-bytes
 
-  eq. ++> tests-buffer-decorates-string
-    buffer "Hello"
-    "Hello"
-
   eq. ++> tests-buffer-builds-simple-string
     with.
       with.
@@ -24,6 +20,10 @@
         ", "
       "Jeff"
     "Hello, Jeff"
+
+  eq. ++> tests-buffer-decorates-string
+    buffer "Hello"
+    "Hello"
 
   eq. ++> tests-buffer-decorates-string-after-building
     length.

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -23,74 +23,31 @@
 +unlint mandatory-package
 
 [@] > bytes
+  [b] > and /Q.bytes
+  [b] > concat /Q.bytes
   [b] > eq /Q.bool
+  [] > not /Q.bytes
+  [b] > or /Q.bytes
+  [x] > right /Q.bytes
   [] > size /Q.number
   [start len] > slice /Q.bytes
     ? > cant-slice /{Q.string}
-  [b] > and /Q.bytes
-  [b] > or /Q.bytes
-  [] > not /Q.bytes
-  [x] > right /Q.bytes
-  [b] > concat /Q.bytes
 
-  eq. ++> tests-takes-part-of-bytes
-    20-1F-EE-B5-90.slice
-      1
-      3
-    1F-EE-B5
+  eq. ++> tests-and-neg-bytes-as-number-with-leading-zeroes
+    as-number.
+      00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00
+    0
 
-  eq. ++> tests-size-of-part-is-correct
-    size.
-      20-1F-EE-B5-90-EE-BB.slice 2 3
-    3
+  eq. ++> tests-and-neg-bytes-as-number-without-leading-zeroes
+    as-number.
+      00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00
+    0
 
-  F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
-
-  eq. ++> tests-turns-bytes-into-a-string
-    "你好, друг!"
-    "你好, друг!"
-
-  ++> tests-right-with-zero
+  ++> tests-and-with-one-neg-one-plus
     not. > @
       eq.
-        0.as-bytes.right 2
-        -1.as-bytes
-
-  ++> tests-right-with-odd-neg
-    not. > @
-      eq.
-        -37.as-bytes.right 3
-        4.as-bytes
-
-  ++> tests-right-with-minus-one
-    not. > @
-      eq.
-        -1.as-bytes.right 4
-        0.as-bytes
-
-  ++> tests-right-with-even-neg
-    not. > @
-      eq.
-        -38.as-bytes.right 1
-        18.as-bytes
-
-  eq. ++> tests-right-with-even-plus
-    eq.
-      36.as-bytes.right 2
-      -10.as-bytes
-    false
-
-  ++> tests-right-with-odd-plus
-    not. > @
-      eq.
-        37.as-bytes.right 3
-        -5.as-bytes
-
-  ++> tests-and-with-zero
-    not. > @
-      eq.
-        0.as-bytes.and 32.as-bytes
-        -1.as-bytes
+        -7.as-bytes.and 7.as-bytes
+        -2.as-bytes
 
   ++> tests-and-with-two-neg
     not. > @
@@ -104,17 +61,88 @@
         5.as-bytes.and 10.as-bytes
         -1.as-bytes
 
-  ++> tests-and-with-one-neg-one-plus
+  ++> tests-and-with-zero
     not. > @
       eq.
-        -7.as-bytes.and 7.as-bytes
-        -2.as-bytes
+        0.as-bytes.and 32.as-bytes
+        -1.as-bytes
 
-  ++> tests-or-with-zero
+  eq. ++> tests-bitwise-works
+    as-number.
+      1.as-bytes.and 1.as-bytes
+    1
+
+  eq. ++> tests-bitwise-works-negative
+    as-number.
+      FF-FF-FF-FF-FF-FF-FF-81.as-bytes.or 00-00-00-00-00-00-00-7F.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  eq. ++> tests-concat-bools-as-bytes
+    true.as-bytes.concat false.as-bytes
+    01-00
+
+  eq. ++> tests-concat-empty
+    --.concat --
+    --
+
+  eq. ++> tests-concat-empty-with
+    --.concat 05-5E-78
+    05-5E-78
+
+  eq. ++> tests-concat-strings
+    string
+      "hello ".as-bytes.concat
+        "world".as-bytes
+    "hello world"
+
+  eq. ++> tests-concat-with-empty
+    05-5E-78.concat --
+    05-5E-78
+
+  ++> tests-concatenation-of-bytes
+    eq. > @
+      a.concat b
+      02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
+    02-EF-D4-05-5E-78-3A > a
+    12-33-C1-B5-5E-71-55 > b
+
+  ++> tests-conjunction-of-bytes
+    eq. > @
+      a.and b
+      02-23-C0-05-5E-70-10
+    02-EF-D4-05-5E-78-3A > a
+    12-33-C1-B5-5E-71-55 > b
+
+  F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
+
+  (-1.as-bytes.eq -1.as-bytes.not).not ++> tests-not-with-neg
+
+  (53.as-bytes.eq 53.as-bytes.not).not ++> tests-not-with-plus
+
+  (0.as-bytes.eq 0.as-bytes.not).not ++> tests-not-with-zero
+
+  eq. ++> tests-or-neg-bytes-as-number-with-zero
+    as-number.
+      -4294967296.as-bytes.or 0.as-bytes
+    -4294967296
+
+  eq. ++> tests-or-neg-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
+
+  eq. ++> tests-or-neg-bytes-with-one
+    FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
+    FF-FF-FF-FF-00-00-00-01
+
+  eq. ++> tests-or-neg-bytes-without-leading-zeroes
+    00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  ++> tests-or-with-one-neg-one-plus
     not. > @
       eq.
-        -11.as-bytes.or 0.as-bytes
-        10.as-bytes
+        -7.as-bytes.or 23.as-bytes
+        0.as-bytes
 
   ++> tests-or-with-two-neg
     not. > @
@@ -128,101 +156,11 @@
         5.as-bytes.or 14.as-bytes
         -16.as-bytes
 
-  ++> tests-or-with-one-neg-one-plus
+  ++> tests-or-with-zero
     not. > @
       eq.
-        -7.as-bytes.or 23.as-bytes
-        0.as-bytes
-
-  20-1F.and CA-FE-BE --> on-and-with-different-lengths
-
-  20-1F.or CA-FE-BE --> on-or-with-different-lengths
-
-  (0.as-bytes.eq 0.as-bytes.not).not ++> tests-not-with-zero
-
-  (-1.as-bytes.eq -1.as-bytes.not).not ++> tests-not-with-neg
-
-  (53.as-bytes.eq 53.as-bytes.not).not ++> tests-not-with-plus
-
-  ++> tests-conjunction-of-bytes
-    eq. > @
-      a.and b
-      02-23-C0-05-5E-70-10
-    02-EF-D4-05-5E-78-3A > a
-    12-33-C1-B5-5E-71-55 > b
-
-  CA-FE-BE-BE.size.eq 4 ++> tests-written-in-several-lines
-
-  eq. ++> tests-bitwise-works
-    as-number.
-      1.as-bytes.and 1.as-bytes
-    1
-
-  eq. ++> tests-bitwise-works-negative
-    as-number.
-      FF-FF-FF-FF-FF-FF-FF-81.as-bytes.or 00-00-00-00-00-00-00-7F.as-bytes
-    FF-FF-FF-FF-FF-FF-FF-FF
-
-  ++> tests-concatenation-of-bytes
-    eq. > @
-      a.concat b
-      02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
-    02-EF-D4-05-5E-78-3A > a
-    12-33-C1-B5-5E-71-55 > b
-
-  eq. ++> tests-concat-bools-as-bytes
-    true.as-bytes.concat false.as-bytes
-    01-00
-
-  eq. ++> tests-concat-with-empty
-    05-5E-78.concat --
-    05-5E-78
-
-  eq. ++> tests-concat-empty-with
-    --.concat 05-5E-78
-    05-5E-78
-
-  eq. ++> tests-concat-empty
-    --.concat --
-    --
-
-  eq. ++> tests-concat-strings
-    string
-      "hello ".as-bytes.concat
-        "world".as-bytes
-    "hello world"
-
-  eq. ++> tests-or-neg-bytes-with-leading-zeroes
-    00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-8E-EA-4C-B1
-
-  eq. ++> tests-and-neg-bytes-as-number-with-leading-zeroes
-    as-number.
-      00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00
-    0
-
-  eq. ++> tests-or-neg-bytes-without-leading-zeroes
-    00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-FF-FF-FF-FF
-
-  eq. ++> tests-and-neg-bytes-as-number-without-leading-zeroes
-    as-number.
-      00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00
-    0
-
-  eq. ++> tests-or-neg-bytes-as-number-with-zero
-    as-number.
-      -4294967296.as-bytes.or 0.as-bytes
-    -4294967296
-
-  eq. ++> tests-or-neg-bytes-with-one
-    FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
-    FF-FF-FF-FF-00-00-00-01
-
-  slice. --> on-out-of-bounds-slice
-    20-1F-EE-B5-90
-    3
-    10
+        -11.as-bytes.or 0.as-bytes
+        10.as-bytes
 
   eq. ++> tests-out-of-bounds-slice-returns-provided-fallback
     "recovered"
@@ -231,9 +169,71 @@
       10
       "recovered" > [msg]
 
+  ++> tests-right-with-even-neg
+    not. > @
+      eq.
+        -38.as-bytes.right 1
+        18.as-bytes
+
+  eq. ++> tests-right-with-even-plus
+    eq.
+      36.as-bytes.right 2
+      -10.as-bytes
+    false
+
+  ++> tests-right-with-minus-one
+    not. > @
+      eq.
+        -1.as-bytes.right 4
+        0.as-bytes
+
+  ++> tests-right-with-odd-neg
+    not. > @
+      eq.
+        -37.as-bytes.right 3
+        4.as-bytes
+
+  ++> tests-right-with-odd-plus
+    not. > @
+      eq.
+        37.as-bytes.right 3
+        -5.as-bytes
+
+  ++> tests-right-with-zero
+    not. > @
+      eq.
+        0.as-bytes.right 2
+        -1.as-bytes
+
+  eq. ++> tests-size-of-part-is-correct
+    size.
+      20-1F-EE-B5-90-EE-BB.slice 2 3
+    3
+
   eq. ++> tests-slice-with-overflowing-start-plus-len-returns-fallback
     "recovered"
     20-1F-EE-B5-90.slice
       2000000000
       2000000000
       "recovered" > [msg]
+
+  eq. ++> tests-takes-part-of-bytes
+    20-1F-EE-B5-90.slice
+      1
+      3
+    1F-EE-B5
+
+  eq. ++> tests-turns-bytes-into-a-string
+    "你好, друг!"
+    "你好, друг!"
+
+  CA-FE-BE-BE.size.eq 4 ++> tests-written-in-several-lines
+
+  20-1F.and CA-FE-BE --> on-and-with-different-lengths
+
+  20-1F.or CA-FE-BE --> on-or-with-different-lengths
+
+  slice. --> on-out-of-bounds-slice
+    20-1F-EE-B5-90
+    3
+    10

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -17,6 +17,6 @@
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * bts
 
-  01-01-01.as-i16 --> on-bytes-of-wrong-size-as-i16
-
   00-33.as-i16.as-bytes.eq 00-33 ++> tests-bytes-converts-to-i16-and-back
+
+  01-01-01.as-i16 --> on-bytes-of-wrong-size-as-i16

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -17,8 +17,8 @@
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * bts
 
-  01-01-01-01-01.as-i32 --> on-bytes-of-wrong-size-as-i32
-
   eq. ++> tests-bytes-converts-to-i32-and-back
     00-00-00-33.as-i32.as-bytes
     00-00-00-33
+
+  01-01-01-01-01.as-i32 --> on-bytes-of-wrong-size-as-i32

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -17,12 +17,9 @@
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * bts
 
-  01-01-01-01.as-i64 --> on-bytes-of-wrong-size-as-i64
-
-  eq. ++> tests-wrong-size-as-i64-returns-provided-fallback
-    "recovered"
-    01-01-01-01.as-i64
-      "recovered" > [msg]
+  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
+    not. > @
+      00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> tests-bytes-converts-to-i64
 
@@ -30,6 +27,9 @@
     00-00-00-00-00-00-00-33.as-i64.as-bytes
     00-00-00-00-00-00-00-33
 
-  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
-    not. > @
-      00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+  eq. ++> tests-wrong-size-as-i64-returns-provided-fallback
+    "recovered"
+    01-01-01-01.as-i64
+      "recovered" > [msg]
+
+  01-01-01-01.as-i64 --> on-bytes-of-wrong-size-as-i64

--- a/eo-runtime/src/main/eo/bytes/as-i8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i8.eo
@@ -17,6 +17,6 @@
       "Can't convert non 1 length bytes to i8, bytes are %x".printf
         * bts
 
-  01-01.as-i8 --> on-bytes-of-wrong-size-as-i8
-
   2A-.as-i8.as-bytes.eq 2A- ++> tests-bytes-converts-to-i8-and-back
+
+  01-01.as-i8 --> on-bytes-of-wrong-size-as-i8

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -26,9 +26,9 @@
             "Can't convert non 8 length bytes to a number, bytes are %x".printf
               * bts
 
-  01-01-01-01.as-number --> on-bytes-of-wrong-size-as-number
-
   eq. ++> tests-wrong-size-as-number-returns-provided-fallback
     "recovered"
     01-01-01-01.as-number
       "recovered" > [msg]
+
+  01-01-01-01.as-number --> on-bytes-of-wrong-size-as-number

--- a/eo-runtime/src/main/eo/bytes/as-u16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u16.eo
@@ -17,6 +17,6 @@
       "Can't convert non 2 length bytes to u16, bytes are %x".printf
         * bts
 
-  01-01-01.as-u16 --> on-bytes-of-wrong-size-as-u16
-
   00-33.as-u16.as-bytes.eq 00-33 ++> tests-bytes-converts-to-u16-and-back
+
+  01-01-01.as-u16 --> on-bytes-of-wrong-size-as-u16

--- a/eo-runtime/src/main/eo/bytes/as-u32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u32.eo
@@ -17,8 +17,8 @@
       "Can't convert non 4 length bytes to u32, bytes are %x".printf
         * bts
 
-  01-01-01-01-01.as-u32 --> on-bytes-of-wrong-size-as-u32
-
   eq. ++> tests-bytes-converts-to-u32-and-back
     00-00-00-33.as-u32.as-bytes
     00-00-00-33
+
+  01-01-01-01-01.as-u32 --> on-bytes-of-wrong-size-as-u32

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -17,13 +17,13 @@
       "Can't convert non 8 length bytes to u64, bytes are %x".printf
         * bts
 
-  01-01-01-01.as-u64 --> on-bytes-of-wrong-size-as-u64
+  eq. ++> tests-bytes-converts-to-u64-and-back
+    00-00-00-00-00-00-00-33.as-u64.as-bytes
+    00-00-00-00-00-00-00-33
 
   eq. ++> tests-wrong-size-as-u64-returns-provided-fallback
     "recovered"
     01-01-01-01.as-u64
       "recovered" > [msg]
 
-  eq. ++> tests-bytes-converts-to-u64-and-back
-    00-00-00-00-00-00-00-33.as-u64.as-bytes
-    00-00-00-00-00-00-00-33
+  01-01-01-01.as-u64 --> on-bytes-of-wrong-size-as-u64

--- a/eo-runtime/src/main/eo/bytes/as-u8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u8.eo
@@ -17,6 +17,6 @@
       "Can't convert non 1 length bytes to u8, bytes are %x".printf
         * bts
 
-  01-01.as-u8 --> on-bytes-of-wrong-size-as-u8
-
   2A-.as-u8.as-bytes.eq 2A- ++> tests-bytes-converts-to-u8-and-back
+
+  01-01.as-u8 --> on-bytes-of-wrong-size-as-u8

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -13,30 +13,6 @@
   ? >> x
   bts.right x.neg > @
 
-  ++> tests-left-zero
-    not. > @
-      eq.
-        0.as-bytes.left 1
-        -1.as-bytes
-
-  ++> tests-left-with-zero
-    not. > @
-      eq.
-        2.as-bytes.left 0
-        -3.as-bytes
-
-  ++> tests-left-with-odd-neg
-    not. > @
-      eq.
-        -17.as-bytes.left 1
-        33.as-bytes
-
-  eq. ++> tests-left-with-minus-one
-    eq.
-      -1.as-bytes.left 3
-      7.as-bytes
-    false
-
   eq. ++> tests-left-with-even-neg
     FF-FF-FF-FF-FF-FF-FF-EE.left 2
     00-00-00-00-00-00-00-47.not
@@ -47,8 +23,32 @@
         4.as-bytes.left 3
         -33.as-bytes
 
+  eq. ++> tests-left-with-minus-one
+    eq.
+      -1.as-bytes.left 3
+      7.as-bytes
+    false
+
+  ++> tests-left-with-odd-neg
+    not. > @
+      eq.
+        -17.as-bytes.left 1
+        33.as-bytes
+
   ++> tests-left-with-odd-plus
     not. > @
       eq.
         5.as-bytes.left 3
         -41.as-bytes
+
+  ++> tests-left-with-zero
+    not. > @
+      eq.
+        2.as-bytes.left 0
+        -3.as-bytes
+
+  ++> tests-left-zero
+    not. > @
+      eq.
+        0.as-bytes.left 1
+        -1.as-bytes

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -15,11 +15,25 @@
     b.and x.not
     b.not.and x
 
-  ++> tests-xor-with-zero
+  eq. ++> tests-one-xor-one-as-number
+    as-number.
+      1.as-bytes.xor 1.as-bytes
+    0
+
+  eq. ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
+    as-number.
+      00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  eq. ++> tests-xor-neg-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
+
+  ++> tests-xor-with-one-neg-one-plus
     not. > @
       eq.
-        0.as-bytes.xor 29.as-bytes
-        -30.as-bytes
+        -36.as-bytes.xor 43.as-bytes
+        8.as-bytes
 
   ++> tests-xor-with-two-neg
     not. > @
@@ -33,28 +47,14 @@
         53.as-bytes.xor 24.as-bytes
         -46.as-bytes
 
-  ++> tests-xor-with-one-neg-one-plus
+  ++> tests-xor-with-zero
     not. > @
       eq.
-        -36.as-bytes.xor 43.as-bytes
-        8.as-bytes
+        0.as-bytes.xor 29.as-bytes
+        -30.as-bytes
 
   eq. ++> tests-xor-works
     00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
     00-00-00-00-71-15-B3-4E
-
-  eq. ++> tests-one-xor-one-as-number
-    as-number.
-      1.as-bytes.xor 1.as-bytes
-    0
-
-  eq. ++> tests-xor-neg-bytes-with-leading-zeroes
-    00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-8E-EA-4C-B1
-
-  eq. ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
-    as-number.
-      00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-FF-FF-FF-FF
 
   20-1F.xor CA-FE-BE --> on-xor-with-different-lengths

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -28,21 +28,21 @@
 
 [id] > chunk
   get > @
-  read > get
-    0
-    size
-  [] > size /Q.number
-  [size] > resized /Q.chunk
   write > [source target length] > copy
     target
     read
       source
       length
-  [offset length] > read /Q.bytes
-    ? > cant-read /{Q.string}
-  [offset data] > write /Q.bool
+  read > get
+    0
+    size
   seq * > [object] > put
     write
       0
       object
     get
+  [offset length] > read /Q.bytes
+    ? > cant-read /{Q.string}
+  [size] > resized /Q.chunk
+  [] > size /Q.number
+  [offset data] > write /Q.bool

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -46,6 +46,14 @@
         mem
     01-02-03-04-05-06-07-08-09-A0
 
+  eq. ++> tests-makes-an-output-via-chunk-extension
+    malloc.of
+      3
+      seq * > [mem]
+        mem.to-output.write 01-02-03
+        mem
+    01-02-03
+
   eq. ++> writes-larger-data-than-provided-block
     malloc.of
       2
@@ -53,13 +61,5 @@
         write.
           to-output mem
           01-02-03
-        mem
-    01-02-03
-
-  eq. ++> tests-makes-an-output-via-chunk-extension
-    malloc.of
-      3
-      seq * > [mem]
-        mem.to-output.write 01-02-03
         mem
     01-02-03

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -12,6 +12,19 @@
 
 [file] > directory
   file > @
+  [] > deleted
+    ^.exists.if > @
+      seq *
+        rec-delete
+          (walk "**").at.^
+        ^
+      ^
+    if. > [tup] > rec-delete
+      tup.length.eq 0
+      true
+      seq *
+        tup.head.deleted
+        rec-delete tup.tail
   true > is-directory
   [] > made
     ^.exists.if > @
@@ -36,20 +49,9 @@
           ^.path
           posix.permissions
     created.code > outcome
-  [glob] > walk /Q.tuple
-  [] > deleted
-    ^.exists.if > @
-      seq *
-        rec-delete
-          (walk "**").at.^
-        ^
-      ^
-    if. > [tup] > rec-delete
-      tup.length.eq 0
-      true
-      seq *
-        tup.head.deleted
-        rec-delete tup.tail
+  T > [mode scope] > open
+    "The file %s is a directory, can't open for I/O operations".printf
+      * file
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -57,34 +59,7 @@
         "Directory %s does not exist, can't create temporary file".printf
           * file
     [] > touch /Q.string
-  T > [mode scope] > open
-    "The file %s is a directory, can't open for I/O operations".printf
-      * file
-
-  ++> tests-makes-new-directory
-    d.exists.and d.is-directory > @
-    (mktemp.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
-
-  ++> tests-deletes-empty-directory
-    not. > @
-      (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted.exists
-
-  mktemp.open --> on-opening-directory
-    "w"
-    true > [d]
-
-  ++> tests-deletes-directory-with-files-recursively
-    and. > @
-      and.
-        and.
-          first.exists.and second.exists
-          d.deleted.exists.not
-        first.exists.not
-      second.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
-    d.tmpfile > first
-    d.tmpfile > second
+  [glob] > walk /Q.tuple
 
   ++> tests-deletes-directory-with-file-and-dir
     and. > @
@@ -100,6 +75,27 @@
     made. > inner
       directory d.tmpfile.deleted
 
+  ++> tests-deletes-directory-with-files-recursively
+    and. > @
+      and.
+        and.
+          first.exists.and second.exists
+          d.deleted.exists.not
+        first.exists.not
+      second.exists.not
+    made. > d
+      directory mktemp.tmpfile.deleted
+    d.tmpfile > first
+    d.tmpfile > second
+
+  ++> tests-deletes-empty-directory
+    not. > @
+      (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted.exists
+
+  ++> tests-makes-new-directory
+    d.exists.and d.is-directory > @
+    (mktemp.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
+
   ++> tests-walks-recursively
     seq * > @
       (d.resolved "foo/bar").as-dir.made
@@ -109,6 +105,10 @@
       (d.as-dir.walk "**/*.txt").length.eq
         2
     (directory mktemp.tmpfile.deleted).made.as-path > d
+
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [d]
 
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -13,20 +13,30 @@
   path > @
   @. > as-path
     Q.path path
-  [cant-check] > is-directory
-    if. > @
-      info.code.eq 0
-      (info.output.mode.div 4096).floor.eq
-        4
-      cant-check
-    called. > info
+  [] > deleted
+    exists.if > @
+      if.
+        outcome.eq 0
+        ^
+        T
+          "Cant delete the file '%s': %s".printf
+            * path removed.output
+      ^
+    removed.code > outcome
+    called. > removed
       os.is-windows.if
         win32 *1
-          "_stat64"
+          win
           path
         posix *1
-          "stat"
+          unix
           path
+    is-directory.if > unix
+      "rmdir"
+      "unlink"
+    is-directory.if > win
+      "_rmdir"
+      "_unlink"
   eq. > [] > exists
     code.
       os.is-windows.if
@@ -39,65 +49,12 @@
           path
           0
     0
-  [] > touched
-    exists.if > @
-      ^
-      if.
-        descriptor.eq -1
-        T
-          "Cant touch the file '%s': %s".printf
-            * path created.output
-        seq *
-          closed
-          ^
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_creat"
-          path
-          win32.mode
-        posix *1
-          "creat"
-          path
-          posix.mode
-    created.code > descriptor
-    code. > closed
-      os.is-windows.if
-        win32 *1
-          "_close"
-          descriptor
-        posix *1
-          "close"
-          descriptor
-  [] > deleted
-    exists.if > @
-      if.
-        outcome.eq 0
-        ^
-        T
-          "Cant delete the file '%s': %s".printf
-            * path removed.output
-      ^
-    called. > removed
-      os.is-windows.if
-        win32 *1
-          win
-          path
-        posix *1
-          unix
-          path
-    removed.code > outcome
-    is-directory.if > win
-      "_rmdir"
-      "_unlink"
-    is-directory.if > unix
-      "rmdir"
-      "unlink"
-  [cant-measure] > size
+  [cant-check] > is-directory
     if. > @
       info.code.eq 0
-      info.output.size
-      cant-measure
+      (info.output.mode.div 4096).floor.eq
+        4
+      cant-check
     called. > info
       os.is-windows.if
         win32 *1
@@ -113,6 +70,7 @@
       T
         "Cant move the file '%s' to '%s': %s".printf
           * path target renamed.output
+    renamed.code > outcome
     called. > renamed
       os.is-windows.if
         win32 *1
@@ -123,7 +81,6 @@
           "rename"
           path
           target
-    renamed.code > outcome
   [mode scope cant-open] > open
     known.not.if > @
       T
@@ -137,18 +94,12 @@
           open-file
           ^
     mode > access!
-    (access.eq "r").as-bool.not > writable
-    (access.eq "w").as-bool.not.and > readable
-      (access.eq "a").as-bool.not
-    (access.eq "r").as-bool.or > existing
-      as-bool.
-        access.eq "r+"
-    (access.eq "w").as-bool.or > truncate
-      as-bool.
-        access.eq "w+"
     (access.eq "a").as-bool.or > appending
       as-bool.
         access.eq "a+"
+    (access.eq "r").as-bool.or > existing
+      as-bool.
+        access.eq "r+"
     or. > known
       existing.or truncate
       appending
@@ -157,15 +108,15 @@
         open-through
           []
             win32 > @
-            win32 "_open" > open
             win32 "_close" > close
+            win32 "_open" > open
             win32 "_read" > read
             win32 "_write" > write
         open-through
           []
             posix > @
-            posix "open" > open
             posix "close" > close
+            posix "open" > open
             posix "read" > read
             posix "write" > write
       [syscall] > open-through
@@ -181,20 +132,19 @@
               syscall.close
                 * descriptor
             true
-        called. > opened
-          syscall.open
-            * path flags syscall.mode
+        appending.if syscall.append 0 > append
+        existing.not.if syscall.creat 0 > creat
         opened.code > descriptor
-        plus. > flags
-          (direction.plus creat).plus trunc
-          append
         if. > direction
           readable.and writable
           syscall.rdwr
           writable.if syscall.wronly syscall.rdonly
-        existing.not.if syscall.creat 0 > creat
-        truncate.if syscall.trunc 0 > trunc
-        appending.if syscall.append 0 > append
+        plus. > flags
+          (direction.plus creat).plus trunc
+          append
+        called. > opened
+          syscall.open
+            * path flags syscall.mode
         [descriptor] > stream
           [size] > read
             (input-block --).read size > @
@@ -224,43 +174,179 @@
                     syscall.write
                       * descriptor buffer buffer.size
                   output-block
+        truncate.if syscall.trunc 0 > trunc
+    (access.eq "w").as-bool.not.and > readable
+      (access.eq "a").as-bool.not
+    (access.eq "w").as-bool.or > truncate
+      as-bool.
+        access.eq "w+"
+    (access.eq "r").as-bool.not > writable
+  [cant-measure] > size
+    if. > @
+      info.code.eq 0
+      info.output.size
+      cant-measure
+    called. > info
+      os.is-windows.if
+        win32 *1
+          "_stat64"
+          path
+        posix *1
+          "stat"
+          path
+  [] > touched
+    exists.if > @
+      ^
+      if.
+        descriptor.eq -1
+        T
+          "Cant touch the file '%s': %s".printf
+            * path created.output
+        seq *
+          closed
+          ^
+    code. > closed
+      os.is-windows.if
+        win32 *1
+          "_close"
+          descriptor
+        posix *1
+          "close"
+          descriptor
+    called. > created
+      os.is-windows.if
+        win32 *1
+          "_creat"
+          path
+          win32.mode
+        posix *1
+          "creat"
+          path
+          posix.mode
+    created.code > descriptor
 
-  (file ".").is-directory ++> tests-check-if-current-directory-is-directory
+  eq. ++> tests-appending-data-to-file
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        f.write "!" > [f]
+    13
 
   (file "absent.txt").exists.not ++> tests-check-if-absent-file-does-not-exist
 
-  ++> tests-returns-self-after-deleting
-    temp.deleted.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  ++> tests-returns-self-after-touching
-    temp.deleted.touched.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  mktemp.tmpfile.deleted.exists.not ++> tests-checks-file-does-not-exist-after-deleting
-
-  mktemp.tmpfile.deleted.touched.exists ++> tests-touches-a-file
-
-  mktemp.tmpfile.deleted.touched.size.eq ++> tests-measures-empty-file-after-touching
-    0
-
-  mktemp.tmpfile.deleted.size --> on-sizing-absent-file
-
-  mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
-
-  eq. ++> tests-sizing-absent-file-returns-fallback
-    -1
-    mktemp.tmpfile.deleted.size -1
+  (file ".").is-directory ++> tests-check-if-current-directory-is-directory
 
   mktemp.tmpfile.deleted.is-directory ++> tests-checking-absent-file-returns-fallback
     true
 
-  mktemp.tmpfile.deleted.touched.touched.exists ++> tests-does-not-fail-on-double-touching
+  mktemp.tmpfile.deleted.exists.not ++> tests-checks-file-does-not-exist-after-deleting
 
   mktemp.tmpfile.deleted.deleted.exists.not ++> tests-does-not-fail-on-double-deleting
 
-  --> an-error-on-touching-temp-file-in-absent-dir
-    (mktemp.as-path.resolved "foo").@.tmpfile > @
+  mktemp.tmpfile.deleted.touched.touched.exists ++> tests-does-not-fail-on-double-touching
+
+  eq. ++> tests-does-not-truncate-file-opened-for-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        true > [f]
+    12
+
+  eq. ++> tests-does-not-truncate-file-opened-for-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "r"
+        true > [f]
+    12
+
+  eq. ++> tests-does-not-truncate-file-opened-for-reading-or-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a+"
+        true > [f]
+    12
+
+  mktemp.tmpfile.deleted.touched.size.eq ++> tests-measures-empty-file-after-touching
+    0
+
+  ++> tests-moves-a-file
+    and. > @
+      exists.
+        temp.moved
+          "%s.dest".printf
+            * temp.path
+      temp.exists.not
+    mktemp.tmpfile > temp
+
+  ++> tests-reads-from-file
+    eq. > @
+      malloc.of
+        12
+        [m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [f]
+              "r"
+              m.put > [f] >>
+                f.read 12
+            m
+      "Hello, world"
+
+  ++> tests-reads-from-file-from-different-instances
+    seq * > @
+      temp.open
+        "w"
+        f.write > [f]
+          "Shrek is love"
+      "Shrek is love".eq
+        malloc.of
+          13
+          [m] >>
+            seq * > @
+              (file src).open
+                "r"
+                m.put > [f] >>
+                  f.read 13
+              m
+    temp.path > src
+    mktemp.tmpfile > temp
+
+  ++> tests-reads-from-file-sequentially
+    eq. > @
+      malloc.of
+        5
+        [m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [f]
+              "r"
+              m.put > [f] >>
+                (f.read 7).read 5
+            m
+      "world"
+
+  eq. ++> tests-recovers-from-opening-missing-file-through-fallback
+    "recovered"
+    mktemp.tmpfile.deleted.open
+      "r"
+      f > [f]
+      "recovered" > [reason]
 
   ++> tests-resolves-and-touches
     resolved.as-dir.made.tmpfile.exists.and > @
@@ -272,52 +358,24 @@
           "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
 
-  ++> tests-moves-a-file
-    and. > @
-      exists.
-        temp.moved
-          "%s.dest".printf
-            * temp.path
-      temp.exists.not
+  ++> tests-returns-self-after-deleting
+    temp.deleted.path.eq temp.path > @
     mktemp.tmpfile > temp
 
-  seq * --> on-opening-with-wrong-mode
-    mktemp.tmpfile.open
-      "x"
-      true > [f]
-    true
+  ++> tests-returns-self-after-touching
+    temp.deleted.touched.path.eq temp.path > @
+    mktemp.tmpfile > temp
 
-  mktemp.tmpfile.deleted.open --> on-reading-from-not-existed-file
-    "r"
-    f > [f]
+  eq. ++> tests-sizing-absent-file-returns-fallback
+    -1
+    mktemp.tmpfile.deleted.size -1
 
-  mktemp.tmpfile.deleted.open --> on-reading-or-writing-from-not-existed-file
-    "r+"
-    f > [f]
-
-  eq. ++> tests-recovers-from-opening-missing-file-through-fallback
-    "recovered"
-    mktemp.tmpfile.deleted.open
-      "r"
-      f > [f]
-      "recovered" > [reason]
-
-  ++> tests-touches-absent-file-on-opening-for-writing
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "w"
-        true > [f]
+  mktemp.tmpfile.deleted.touched.exists ++> tests-touches-a-file
 
   ++> tests-touches-absent-file-on-opening-for-appending
     exists. > @
       mktemp.tmpfile.deleted.open
         "a"
-        true > [f]
-
-  ++> tests-touches-absent-file-on-opening-for-writing-or-reading
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "w+"
         true > [f]
 
   ++> tests-touches-absent-file-on-opening-for-reading-or-appending
@@ -326,23 +384,17 @@
         "a+"
         true > [f]
 
-  eq. ++> tests-writes-data-to-file
-    size.
-      mktemp.tmpfile.open
+  ++> tests-touches-absent-file-on-opening-for-writing
+    exists. > @
+      mktemp.tmpfile.deleted.open
         "w"
-        f.write > [f]
-          "Hello, world"
-    12
+        true > [f]
 
-  eq. ++> tests-appending-data-to-file
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a"
-        f.write "!" > [f]
-    13
+  ++> tests-touches-absent-file-on-opening-for-writing-or-reading
+    exists. > @
+      mktemp.tmpfile.deleted.open
+        "w+"
+        true > [f]
 
   eq. ++> tests-truncates-file-opened-for-writing
     size.
@@ -364,82 +416,13 @@
         true > [f]
     0
 
-  eq. ++> tests-does-not-truncate-file-opened-for-appending
+  eq. ++> tests-writes-data-to-file
     size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a"
-        true > [f]
-    12
-
-  eq. ++> tests-does-not-truncate-file-opened-for-reading-or-appending
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a+"
-        true > [f]
-    12
-
-  eq. ++> tests-does-not-truncate-file-opened-for-reading
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "r"
-        true > [f]
-    12
-
-  mktemp.tmpfile.open --> on-writing-with-wrong-mode
-    "r"
-    f.write "Hello" > [f]
-
-  ++> tests-reads-from-file
-    eq. > @
-      malloc.of
-        12
-        [m]
-          seq * > @
-            open.
-              mktemp.tmpfile.open
-                "w"
-                f.write "Hello, world" > [f]
-              "r"
-              m.put > [f] >>
-                f.read 12
-            m
-      "Hello, world"
-
-  mktemp.tmpfile.open --> on-reading-negative-size-from-file
-    "r"
-    f.read -5 > [f]
-
-  mktemp.tmpfile.open --> on-reading-from-file-with-wrong-mode
-    "w"
-    f.read 12 > [f]
-
-  ++> tests-reads-from-file-from-different-instances
-    seq * > @
-      temp.open
+      mktemp.tmpfile.open
         "w"
         f.write > [f]
-          "Shrek is love"
-      "Shrek is love".eq
-        malloc.of
-          13
-          [m] >>
-            seq * > @
-              (file src).open
-                "r"
-                m.put > [f] >>
-                  f.read 13
-              m
-    temp.path > src
-    mktemp.tmpfile > temp
+          "Hello, world"
+    12
 
   ++> tests-writes-to-file-from-different-instances
     seq * > @
@@ -465,22 +448,6 @@
     temp.path > src
     mktemp.tmpfile > temp
 
-  ++> tests-reads-from-file-sequentially
-    eq. > @
-      malloc.of
-        5
-        [m]
-          seq * > @
-            open.
-              mktemp.tmpfile.open
-                "w"
-                f.write "Hello, world" > [f]
-              "r"
-              m.put > [f] >>
-                (f.read 7).read 5
-            m
-      "world"
-
   eq. ++> tests-writes-to-file-sequentially
     size.
       mktemp.tmpfile.open
@@ -489,3 +456,36 @@
           f.write "Hello, world"
           "!"
     13
+
+  --> an-error-on-touching-temp-file-in-absent-dir
+    (mktemp.as-path.resolved "foo").@.tmpfile > @
+
+  mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
+
+  seq * --> on-opening-with-wrong-mode
+    mktemp.tmpfile.open
+      "x"
+      true > [f]
+    true
+
+  mktemp.tmpfile.open --> on-reading-from-file-with-wrong-mode
+    "w"
+    f.read 12 > [f]
+
+  mktemp.tmpfile.deleted.open --> on-reading-from-not-existed-file
+    "r"
+    f > [f]
+
+  mktemp.tmpfile.open --> on-reading-negative-size-from-file
+    "r"
+    f.read -5 > [f]
+
+  mktemp.tmpfile.deleted.open --> on-reading-or-writing-from-not-existed-file
+    "r+"
+    f > [f]
+
+  mktemp.tmpfile.deleted.size --> on-sizing-absent-file
+
+  mktemp.tmpfile.open --> on-writing-with-wrong-mode
+    "r"
+    f.write "Hello" > [f]

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -11,9 +11,6 @@
 
 [as-bytes] > i16
   as-bytes > @
-  as-i32.as-i64 > as-i64
-  as-i64.as-number > as-number
-  times -1.as-i64.as-i32.as-i16 > neg
   [] > as-i32
     i32 > @
       prefix.concat as-bytes
@@ -23,33 +20,8 @@
         00-00
       00-00
       FF-FF
-  as-i32.lt x.as-i16.as-i32 > [x] > lt
-  as-i32.lte x.as-i16.as-i32 > [x] > lte
-  as-i32.gt x.as-i16.as-i32 > [x] > gt
-  as-i32.gte x.as-i16.as-i32 > [x] > gte
-  [x] > times
-    i16 right > @
-    (as-i32.times x.as-i16.as-i32).as-bytes.slice > right
-      2
-      2
-  [x] > plus
-    if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 right
-      plus.
-        i16 left
-        i16 right
-    as-bytes. > bts
-      as-i32.plus x.as-i16.as-i32
-    bts.slice > left
-      0
-      2
-    bts.slice > right
-      2
-      2
-  plus x.as-i16.neg > [x] > minus
+  as-i32.as-i64 > as-i64
+  as-i64.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -74,54 +46,106 @@
       2
     x.as-i16 > xval
     00-00 > zero
-
-  42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
-
-  eq. ++> tests-negative-i16-has-valid-bytes
-    -200.as-i64.as-i32.as-i16.as-bytes
-    FF-38
-
-  eq. ++> tests-i16-as-i32-widens-positive-with-zero-prefix
-    42.as-i64.as-i32.as-i16.as-i32.as-bytes
-    00-00-00-2A
+  as-i32.gt x.as-i16.as-i32 > [x] > gt
+  as-i32.gte x.as-i16.as-i32 > [x] > gte
+  as-i32.lt x.as-i16.as-i32 > [x] > lt
+  as-i32.lte x.as-i16.as-i32 > [x] > lte
+  plus x.as-i16.neg > [x] > minus
+  times -1.as-i64.as-i32.as-i16 > neg
+  [x] > plus
+    if. > @
+      or.
+        left.eq 00-00
+        left.eq FF-FF
+      i16 right
+      plus.
+        i16 left
+        i16 right
+    as-bytes. > bts
+      as-i32.plus x.as-i16.as-i32
+    bts.slice > left
+      0
+      2
+    bts.slice > right
+      2
+      2
+  [x] > times
+    i16 right > @
+    (as-i32.times x.as-i16.as-i32).as-bytes.slice > right
+      2
+      2
 
   eq. ++> tests-i16-as-i32-widens-negative-with-sign-extension
     -200.as-i64.as-i32.as-i16.as-i32.as-bytes
     FF-FF-FF-38
 
-  10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
+  eq. ++> tests-i16-as-i32-widens-positive-with-zero-prefix
+    42.as-i64.as-i32.as-i16.as-i32.as-bytes
+    00-00-00-2A
 
-  (10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16).not ++> tests-i16-less-equal
+  ++> tests-i16-div-by-i16-one
+    eq. > @
+      dividend.div 1.as-i64.as-i32.as-i16
+      dividend
+    -235.as-i64.as-i32.as-i16 > dividend
 
-  (10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16).not ++> tests-i16-less-false
+  eq. ++> tests-i16-div-by-zero-returns-provided-fallback
+    "recovered"
+    2.as-i64.as-i32.as-i16.div
+      0.as-i64.as-i32.as-i16
+      "recovered" > [msg]
+
+  lt. ++> tests-i16-div-less-than-i16-one
+    1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
+    1.as-i64.as-i32.as-i16
+
+  eq. ++> tests-i16-div-with-remainder
+    13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
+    -2.as-i64.as-i32.as-i16
+
+  (123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16).not ++> tests-i16-eq-false
+
+  123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
+
+  (0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16).not ++> tests-i16-greater-equal
+
+  (0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16).not ++> tests-i16-greater-false
 
   gt. ++> tests-i16-greater-true
     -200.as-i64.as-i32.as-i16
     -1000.as-i64.as-i32.as-i16
 
-  (0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16).not ++> tests-i16-greater-false
+  113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
 
-  (0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16).not ++> tests-i16-greater-equal
+  (0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16).not ++> tests-i16-gte-false
 
-  -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
+  -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
+
+  42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
+
+  (10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16).not ++> tests-i16-less-equal
+
+  (10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16).not ++> tests-i16-less-false
+
+  10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
 
   50.as-i64.as-i32.as-i16.lte 50.as-i64.as-i32.as-i16 ++> tests-i16-lte-equal
 
   (0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16).not ++> tests-i16-lte-false
 
-  -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
+  -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
 
-  113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
+  eq. ++> tests-i16-minus-with-overflow
+    -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
+    32767.as-i64.as-i32.as-i16
 
-  (0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16).not ++> tests-i16-gte-false
-
-  eq. ++> tests-i16-zero-eq-to-i16-zero
+  eq. ++> tests-i16-multiply-by-zero
+    1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
+
+  eq. ++> tests-i16-one-minus-i16-one
+    1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
-
-  123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
-
-  (123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16).not ++> tests-i16-eq-false
 
   eq. ++> tests-i16-one-plus-i16-one
     1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
@@ -131,50 +155,26 @@
     32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
     -32768.as-i64.as-i32.as-i16
 
-  eq. ++> tests-i16-one-minus-i16-one
-    1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-minus-with-overflow
-    -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-    32767.as-i64.as-i32.as-i16
-
-  div. --> on-division-i16-by-i16-zero
-    2.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-div-by-zero-returns-provided-fallback
-    "recovered"
-    2.as-i64.as-i32.as-i16.div
-      0.as-i64.as-i32.as-i16
-      "recovered" > [msg]
-
-  ++> tests-i16-div-by-i16-one
-    eq. > @
-      dividend.div 1.as-i64.as-i32.as-i16
-      dividend
-    -235.as-i64.as-i32.as-i16 > dividend
-
-  eq. ++> tests-i16-div-with-remainder
-    13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
-    -2.as-i64.as-i32.as-i16
-
-  lt. ++> tests-i16-div-less-than-i16-one
-    1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
-    1.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-multiply-by-zero
-    1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
   eq. ++> tests-i16-times-with-overflow
     32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
+
+  eq. ++> tests-i16-times-wraps-large-positive-product
+    300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
+    24464.as-i64.as-i32.as-i16
 
   eq. ++> tests-i16-times-wraps-modulo-2-pow-16
     256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
 
-  eq. ++> tests-i16-times-wraps-large-positive-product
-    300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
-    24464.as-i64.as-i32.as-i16
+  eq. ++> tests-i16-zero-eq-to-i16-zero
+    0.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  eq. ++> tests-negative-i16-has-valid-bytes
+    -200.as-i64.as-i32.as-i16.as-bytes
+    FF-38
+
+  div. --> on-division-i16-by-i16-zero
+    2.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -11,17 +11,6 @@
 
 [as-bytes] > i32
   as-bytes > @
-  as-i64.as-number > as-number
-  times -1.as-i64.as-i32 > neg
-  [] > as-i64
-    i64 > @
-      prefix.concat as-bytes
-    if. > prefix
-      eq.
-        as-bytes.and 80-00-00-00
-        00-00-00-00
-      00-00-00-00
-      FF-FF-FF-FF
   [cant-convert] > as-i16
     if. > @
       ^.eq left.as-i32
@@ -31,33 +20,16 @@
           * as-i64.as-number
     i16 > left
       as-bytes.slice 2 2
-  as-i64.lt x.as-i32.as-i64 > [x] > lt
-  as-i64.lte x.as-i32.as-i64 > [x] > lte
-  as-i64.gt x.as-i32.as-i64 > [x] > gt
-  as-i64.gte x.as-i32.as-i64 > [x] > gte
-  [x] > times
-    i32 right > @
-    (as-i64.times x.as-i32.as-i64).as-bytes.slice > right
-      4
-      4
-  [x] > plus
-    if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 right
-      plus.
-        i32 left
-        i32 right
-    as-bytes. > bts
-      as-i64.plus x.as-i32.as-i64
-    bts.slice > left
-      0
-      4
-    bts.slice > right
-      4
-      4
-  plus x.as-i32.neg > [x] > minus
+  [] > as-i64
+    i64 > @
+      prefix.concat as-bytes
+    if. > prefix
+      eq.
+        as-bytes.and 80-00-00-00
+        00-00-00-00
+      00-00-00-00
+      FF-FF-FF-FF
+  as-i64.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -82,62 +54,104 @@
       4
     x.as-i32 > xval
     00-00-00-00 > zero
-
-  42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
-
-  eq. ++> tests-negative-i32-has-valid-bytes
-    -200.as-i64.as-i32.as-bytes
-    FF-FF-FF-38
-
-  eq. ++> tests-i32-as-i64-widens-positive-with-zero-prefix
-    42.as-i64.as-i32.as-i64.as-bytes
-    00-00-00-00-00-00-00-2A
+  as-i64.gt x.as-i32.as-i64 > [x] > gt
+  as-i64.gte x.as-i32.as-i64 > [x] > gte
+  as-i64.lt x.as-i32.as-i64 > [x] > lt
+  as-i64.lte x.as-i32.as-i64 > [x] > lte
+  plus x.as-i32.neg > [x] > minus
+  times -1.as-i64.as-i32 > neg
+  [x] > plus
+    if. > @
+      or.
+        left.eq 00-00-00-00
+        left.eq FF-FF-FF-FF
+      i32 right
+      plus.
+        i32 left
+        i32 right
+    as-bytes. > bts
+      as-i64.plus x.as-i32.as-i64
+    bts.slice > left
+      0
+      4
+    bts.slice > right
+      4
+      4
+  [x] > times
+    i32 right > @
+    (as-i64.times x.as-i32.as-i64).as-bytes.slice > right
+      4
+      4
 
   eq. ++> tests-i32-as-i64-widens-negative-with-sign-extension
     -200.as-i64.as-i32.as-i64.as-bytes
     FF-FF-FF-FF-FF-FF-FF-38
 
-  eq. ++> tests-i32-to-i16-and-back
-    123.as-i64.as-i32
-    123.as-i64.as-i32.as-i16.as-i32
+  eq. ++> tests-i32-as-i64-widens-positive-with-zero-prefix
+    42.as-i64.as-i32.as-i64.as-bytes
+    00-00-00-00-00-00-00-2A
 
-  eq. ++> tests-negative-i32-to-i16-and-back
-    -123.as-i64.as-i32
-    -123.as-i64.as-i32.as-i16.as-i32
+  ++> tests-i32-div-by-i32-one
+    eq. > @
+      dividend.div 1.as-i64.as-i32
+      dividend
+    -235.as-i64.as-i32 > dividend
 
-  32768.as-i64.as-i32.as-i16 --> on-converting-i16-max-plus-one-to-i16
+  eq. ++> tests-i32-div-by-zero-returns-provided-fallback
+    "recovered"
+    2.as-i64.as-i32.div
+      0.as-i64.as-i32
+      "recovered" > [msg]
 
-  -32769.as-i64.as-i32.as-i16 --> on-converting-i16-min-minus-one-to-i16
+  lt. ++> tests-i32-div-less-than-i32-one
+    1.as-i64.as-i32.div 5.as-i64.as-i32
+    1.as-i64.as-i32
 
-  10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
+  eq. ++> tests-i32-div-with-remainder
+    13.as-i64.as-i32.div -5.as-i64.as-i32
+    -2.as-i64.as-i32
 
-  (10.as-i64.as-i32.lt 10.as-i64.as-i32).not ++> tests-i32-less-equal
+  (123.as-i64.as-i32.eq 42.as-i64.as-i32).not ++> tests-i32-eq-false
 
-  (10.as-i64.as-i32.lt -5.as-i64.as-i32).not ++> tests-i32-less-false
-
-  -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
-
-  (0.as-i64.as-i32.gt 100.as-i64.as-i32).not ++> tests-i32-greater-false
+  123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
 
   (0.as-i64.as-i32.gt 0.as-i64.as-i32).not ++> tests-i32-greater-equal
 
-  -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
+  (0.as-i64.as-i32.gt 100.as-i64.as-i32).not ++> tests-i32-greater-false
 
-  50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
-
-  (0.as-i64.as-i32.lte -10.as-i64.as-i32).not ++> tests-i32-lte-false
-
-  -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
+  -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
 
   113.as-i64.as-i32.gte 113.as-i64.as-i32 ++> tests-i32-gte-equal
 
   (0.as-i64.as-i32.gte 10.as-i64.as-i32).not ++> tests-i32-gte-false
 
-  0.as-i64.as-i32.eq 0.as-i64.as-i32 ++> tests-i32-zero-eq-to-i32-zero
+  -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
 
-  123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
+  42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
 
-  (123.as-i64.as-i32.eq 42.as-i64.as-i32).not ++> tests-i32-eq-false
+  (10.as-i64.as-i32.lt 10.as-i64.as-i32).not ++> tests-i32-less-equal
+
+  (10.as-i64.as-i32.lt -5.as-i64.as-i32).not ++> tests-i32-less-false
+
+  10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
+
+  50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
+
+  (0.as-i64.as-i32.lte -10.as-i64.as-i32).not ++> tests-i32-lte-false
+
+  -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
+
+  eq. ++> tests-i32-minus-with-overflow
+    -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
+    2147483647.as-i64.as-i32
+
+  eq. ++> tests-i32-multiply-by-zero
+    1000.as-i64.as-i32.times 0.as-i64.as-i32
+    0.as-i64.as-i32
+
+  eq. ++> tests-i32-one-minus-i32-one
+    1.as-i64.as-i32.minus 1.as-i64.as-i32
+    0.as-i64.as-i32
 
   eq. ++> tests-i32-one-plus-i32-one
     1.as-i64.as-i32.plus 1.as-i64.as-i32
@@ -147,55 +161,41 @@
     2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
     -2147483648.as-i64.as-i32
 
-  eq. ++> tests-i32-one-minus-i32-one
-    1.as-i64.as-i32.minus 1.as-i64.as-i32
+  eq. ++> tests-i32-times-with-overflow
+    2147483647.as-i64.as-i32.times 2.as-i64.as-i32
+    -2.as-i64.as-i32
+
+  eq. ++> tests-i32-times-wraps-large-positive-product
+    100000.as-i64.as-i32.times 100000.as-i64.as-i32
+    1410065408.as-i64.as-i32
+
+  eq. ++> tests-i32-times-wraps-modulo-2-pow-32
+    65536.as-i64.as-i32.times 65536.as-i64.as-i32
     0.as-i64.as-i32
 
-  eq. ++> tests-i32-minus-with-overflow
-    -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
-    2147483647.as-i64.as-i32
+  eq. ++> tests-i32-to-i16-and-back
+    123.as-i64.as-i32
+    123.as-i64.as-i32.as-i16.as-i32
 
-  2.as-i64.as-i32.div 0.as-i64.as-i32 --> on-division-i32-by-i32-zero
+  0.as-i64.as-i32.eq 0.as-i64.as-i32 ++> tests-i32-zero-eq-to-i32-zero
 
-  eq. ++> tests-i32-div-by-zero-returns-provided-fallback
-    "recovered"
-    2.as-i64.as-i32.div
-      0.as-i64.as-i32
-      "recovered" > [msg]
+  eq. ++> tests-negative-i32-has-valid-bytes
+    -200.as-i64.as-i32.as-bytes
+    FF-FF-FF-38
 
-  247483647.as-i64.as-i32.as-i16 --> on-converting-to-i16-if-out-of-bounds
+  eq. ++> tests-negative-i32-to-i16-and-back
+    -123.as-i64.as-i32
+    -123.as-i64.as-i32.as-i16.as-i32
 
   eq. ++> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
     "recovered"
     247483647.as-i64.as-i32.as-i16
       "recovered" > [msg]
 
-  ++> tests-i32-div-by-i32-one
-    eq. > @
-      dividend.div 1.as-i64.as-i32
-      dividend
-    -235.as-i64.as-i32 > dividend
+  32768.as-i64.as-i32.as-i16 --> on-converting-i16-max-plus-one-to-i16
 
-  eq. ++> tests-i32-div-with-remainder
-    13.as-i64.as-i32.div -5.as-i64.as-i32
-    -2.as-i64.as-i32
+  -32769.as-i64.as-i32.as-i16 --> on-converting-i16-min-minus-one-to-i16
 
-  lt. ++> tests-i32-div-less-than-i32-one
-    1.as-i64.as-i32.div 5.as-i64.as-i32
-    1.as-i64.as-i32
+  247483647.as-i64.as-i32.as-i16 --> on-converting-to-i16-if-out-of-bounds
 
-  eq. ++> tests-i32-multiply-by-zero
-    1000.as-i64.as-i32.times 0.as-i64.as-i32
-    0.as-i64.as-i32
-
-  eq. ++> tests-i32-times-with-overflow
-    2147483647.as-i64.as-i32.times 2.as-i64.as-i32
-    -2.as-i64.as-i32
-
-  eq. ++> tests-i32-times-wraps-modulo-2-pow-32
-    65536.as-i64.as-i32.times 65536.as-i64.as-i32
-    0.as-i64.as-i32
-
-  eq. ++> tests-i32-times-wraps-large-positive-product
-    100000.as-i64.as-i32.times 100000.as-i64.as-i32
-    1410065408.as-i64.as-i32
+  2.as-i64.as-i32.div 0.as-i64.as-i32 --> on-division-i32-by-i32-zero

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -14,7 +14,6 @@
 [as-bytes] > i64
   as-bytes > @
   as-i32.as-i16 > as-i16
-  times -1.as-i64 > neg
   [cant-convert] > as-i32
     if. > @
       ^.eq left.as-i64
@@ -25,6 +24,30 @@
     i32 > left
       as-bytes.slice 4 4
   [] > as-number /Q.number
+  [x] > div /Q.i64
+    ? > cant-divide /{Q.string}
+  [x] > gt
+    differ.if > @
+      positive
+      greater.and
+        not.
+          difference.as-bytes.eq zero
+    not. > differ
+      sign.eq
+        x.as-bytes.and mask
+    minus x > difference
+    eq. > greater
+      difference.as-bytes.and mask
+      zero
+    80-00-00-00-00-00-00-00 > mask
+    sign.eq zero > positive
+    as-bytes.and mask > sign
+    00-00-00-00-00-00-00-00 > zero
+  [x] > gte
+    or. > @
+      gt value
+      ^.eq value
+    x > value!
   gt. > [x] > lt
     i64 x.as-bytes
     ^
@@ -33,28 +56,13 @@
       lt value
       ^.eq value
     x > value!
-  [x] > gt
-    differ.if > @
-      positive
-      greater.and
-        not.
-          difference.as-bytes.eq zero
-    minus x > difference
-    00-00-00-00-00-00-00-00 > zero
-    80-00-00-00-00-00-00-00 > mask
-    as-bytes.and mask > sign
-    not. > differ
-      sign.eq
-        x.as-bytes.and mask
-    sign.eq zero > positive
-    eq. > greater
-      difference.as-bytes.and mask
-      zero
-  [x] > gte
-    or. > @
-      gt value
-      ^.eq value
+  [x] > minus
+    plus > @
+      neg.
+        i64 value
     x > value!
+  times -1.as-i64 > neg
+  [x] > plus /Q.i64
   [x] > times
     if. > [acc a b] > looped
       b.eq 00-00-00-00-00-00-00-00
@@ -72,16 +80,6 @@
       00-00-00-00-00-00-00-00
       as-bytes
       x.as-bytes
-  [x] > plus /Q.i64
-  [x] > minus
-    plus > @
-      neg.
-        i64 value
-    x > value!
-  [x] > div /Q.i64
-    ? > cant-divide /{Q.string}
-
-  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> tests-i64-has-valid-bytes
 
   ++> tests-i64-as-bytes-is-not-equal-to-number-bytes
     not. > @
@@ -89,46 +87,33 @@
         i64 234.as-bytes
         234.as-i64.as-bytes
 
-  234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> tests-i64-to-i32-and-back
+  ++> tests-i64-div-by-i64-one
+    eq. > @
+      dividend.div 1.as-i64
+      dividend
+    -235.as-i64 > dividend
 
-  -234.as-i64.eq -234.as-i64.as-i32.as-i64 ++> tests-negative-i64-to-i32-and-back
-
-  3147483647.as-i64.as-i32 --> on-converting-to-i32-if-out-of-bounds
-
-  eq. ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+  eq. ++> tests-i64-div-by-zero-returns-provided-fallback
     "recovered"
-    3147483647.as-i64.as-i32
+    2.as-i64.div
+      0.as-i64
       "recovered" > [msg]
 
-  eq. ++> tests-i64-i32-max-converts-without-error
-    2147483647.as-i64
-    2147483647.as-i64.as-i32.as-i64
+  lt. ++> tests-i64-div-less-than-i64-one
+    1.as-i64.div 5.as-i64
+    1.as-i64
 
-  eq. ++> tests-i64-i32-min-converts-without-error
-    -2147483648.as-i64
-    -2147483648.as-i64.as-i32.as-i64
+  eq. ++> tests-i64-div-with-remainder
+    13.as-i64.div -5.as-i64
+    -2.as-i64
 
-  2147483648.as-i64.as-i32 --> on-converting-i32-max-plus-one-to-i32
+  (123.@.eq 42.@).not ++> tests-i64-eq-false
 
-  -2147483649.as-i64.as-i32 --> on-converting-i32-min-minus-one-to-i32
-
-  10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
-
-  (10.as-i64.lt 10.as-i64).not ++> tests-i64-less-equal
-
-  (10.as-i64.lt -5.as-i64).not ++> tests-i64-less-false
-
-  -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
-
-  ++> tests-i64-less-with-large-difference
-    not. > @
-      5000000000000000000.as-i64.lt -5000000000000000000.as-i64
-
-  -200.as-i64.gt -1000.as-i64 ++> tests-i64-greater-true
-
-  (0.as-i64.gt 100.as-i64).not ++> tests-i64-greater-false
+  123.@.eq 123.@ ++> tests-i64-eq-true
 
   (0.as-i64.gt 0.as-i64).not ++> tests-i64-greater-equal
+
+  (0.as-i64.gt 100.as-i64).not ++> tests-i64-greater-false
 
   gt. ++> tests-i64-greater-max-over-min
     i64 7F-FF-FF-FF-FF-FF-FF-FF
@@ -144,65 +129,65 @@
     -5000000000000000000.as-i64
     -9000000000000000000.as-i64
 
-  -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
-
-  50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
-
-  (0.as-i64.lte -10.as-i64).not ++> tests-i64-lte-false
-
-  -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
+  -200.as-i64.gt -1000.as-i64 ++> tests-i64-greater-true
 
   113.as-i64.gte 113.as-i64 ++> tests-i64-gte-equal
 
   (0.as-i64.gte 10.as-i64).not ++> tests-i64-gte-false
 
-  0.@.eq 0.@ ++> tests-i64-zero-eq-to-i64-zero
+  -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
 
-  123.@.eq 123.@ ++> tests-i64-eq-true
+  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> tests-i64-has-valid-bytes
 
-  (123.@.eq 42.@).not ++> tests-i64-eq-false
+  eq. ++> tests-i64-i32-max-converts-without-error
+    2147483647.as-i64
+    2147483647.as-i64.as-i32.as-i64
 
-  eq. ++> tests-i64-one-plus-i64-one
-    1.as-i64.plus 1.as-i64
-    2.as-i64
+  eq. ++> tests-i64-i32-min-converts-without-error
+    -2147483648.as-i64
+    -2147483648.as-i64.as-i32.as-i64
 
-  eq. ++> tests-i64-one-minus-i64-one
-    1.as-i64.minus 1.as-i64
-    0.as-i64
+  -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
 
-  2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero
+  (10.as-i64.lt 10.as-i64).not ++> tests-i64-less-equal
 
-  eq. ++> tests-i64-div-by-zero-returns-provided-fallback
-    "recovered"
-    2.as-i64.div
-      0.as-i64
-      "recovered" > [msg]
+  (10.as-i64.lt -5.as-i64).not ++> tests-i64-less-false
 
-  ++> tests-i64-div-by-i64-one
-    eq. > @
-      dividend.div 1.as-i64
-      dividend
-    -235.as-i64 > dividend
+  10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
 
-  eq. ++> tests-i64-div-with-remainder
-    13.as-i64.div -5.as-i64
-    -2.as-i64
+  ++> tests-i64-less-with-large-difference
+    not. > @
+      5000000000000000000.as-i64.lt -5000000000000000000.as-i64
 
-  lt. ++> tests-i64-div-less-than-i64-one
-    1.as-i64.div 5.as-i64
-    1.as-i64
+  50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
+
+  (0.as-i64.lte -10.as-i64).not ++> tests-i64-lte-false
+
+  -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
 
   eq. ++> tests-i64-multiply-by-zero
     1000.as-i64.times 0.as-i64
     0.as-i64
 
-  eq. ++> tests-i64-times-of-two-negatives
-    -7.as-i64.times -6.as-i64
-    42.as-i64
+  eq. ++> tests-i64-one-minus-i64-one
+    1.as-i64.minus 1.as-i64
+    0.as-i64
+
+  eq. ++> tests-i64-one-plus-i64-one
+    1.as-i64.plus 1.as-i64
+    2.as-i64
+
+  eq. ++> tests-i64-times-keeps-low-bits-of-large-product
+    2147483647.as-i64.times 2147483647.as-i64
+    i64 3F-FF-FF-FF-00-00-00-01
 
   eq. ++> tests-i64-times-of-mixed-signs
     -7.as-i64.times 6.as-i64
     -42.as-i64
+
+  eq. ++> tests-i64-times-of-two-negatives
+    -7.as-i64.times -6.as-i64
+    42.as-i64
 
   eq. ++> tests-i64-times-wraps-modulo-2-pow-64
     times.
@@ -210,6 +195,21 @@
       4.as-i64
     0.as-i64
 
-  eq. ++> tests-i64-times-keeps-low-bits-of-large-product
-    2147483647.as-i64.times 2147483647.as-i64
-    i64 3F-FF-FF-FF-00-00-00-01
+  234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> tests-i64-to-i32-and-back
+
+  0.@.eq 0.@ ++> tests-i64-zero-eq-to-i64-zero
+
+  -234.as-i64.eq -234.as-i64.as-i32.as-i64 ++> tests-negative-i64-to-i32-and-back
+
+  eq. ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+    "recovered"
+    3147483647.as-i64.as-i32
+      "recovered" > [msg]
+
+  2147483648.as-i64.as-i32 --> on-converting-i32-max-plus-one-to-i32
+
+  -2147483649.as-i64.as-i32 --> on-converting-i32-min-minus-one-to-i32
+
+  3147483647.as-i64.as-i32 --> on-converting-to-i32-if-out-of-bounds
+
+  2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -12,8 +12,6 @@
 
 [as-bytes] > i8
   as-bytes > @
-  as-i16.as-number > as-number
-  times FF-.as-i8 > neg
   [] > as-i16
     i16 > @
       prefix.concat as-bytes
@@ -23,25 +21,7 @@
         00-
       00-
       FF-
-  as-i16.lt x.as-i8.as-i16 > [x] > lt
-  as-i16.lte x.as-i8.as-i16 > [x] > lte
-  as-i16.gt x.as-i8.as-i16 > [x] > gt
-  as-i16.gte x.as-i8.as-i16 > [x] > gte
-  [x] > times
-    i8 right > @
-    (as-i16.times x.as-i8.as-i16).as-bytes.slice > right
-      1
-      1
-  [x] > plus
-    i8 right > @
-    (as-i16.plus x.as-i8.as-i16).as-bytes.slice > right
-      1
-      1
-  [x] > minus
-    i8 right > @
-    (as-i16.minus x.as-i8.as-i16).as-bytes.slice > right
-      1
-      1
+  as-i16.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -54,40 +34,76 @@
       1
     x.as-i8 > xval
     00- > zero
-
-  2A-.as-i8.as-bytes.eq 2A- ++> tests-i8-has-valid-bytes
-
-  eq. ++> tests-negative-i8-has-valid-bytes
-    -56.as-i64.as-i32.as-i16.as-bytes.slice
+  as-i16.gt x.as-i8.as-i16 > [x] > gt
+  as-i16.gte x.as-i8.as-i16 > [x] > gte
+  as-i16.lt x.as-i8.as-i16 > [x] > lt
+  as-i16.lte x.as-i8.as-i16 > [x] > lte
+  [x] > minus
+    i8 right > @
+    (as-i16.minus x.as-i8.as-i16).as-bytes.slice > right
       1
       1
-    C8-
-
-  eq. ++> tests-i8-as-i16-widens-positive-with-zero-prefix
-    2A-.as-i8.as-i16.as-bytes
-    00-2A
+  times FF-.as-i8 > neg
+  [x] > plus
+    i8 right > @
+    (as-i16.plus x.as-i8.as-i16).as-bytes.slice > right
+      1
+      1
+  [x] > times
+    i8 right > @
+    (as-i16.times x.as-i8.as-i16).as-bytes.slice > right
+      1
+      1
 
   eq. ++> tests-i8-as-i16-widens-negative-with-sign-extension
     C8-.as-i8.as-i16.as-bytes
     FF-C8
 
-  C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
+  eq. ++> tests-i8-as-i16-widens-positive-with-zero-prefix
+    2A-.as-i8.as-i16.as-bytes
+    00-2A
 
-  0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
+  eq. ++> tests-i8-div-by-i8-one
+    C8-.as-i8.div 01-.as-i8
+    C8-.as-i8
 
-  (0A-.as-i8.lt 0A-.as-i8).not ++> tests-i8-less-equal
+  eq. ++> tests-i8-div-by-zero-returns-provided-fallback
+    "recovered"
+    02-.as-i8.div
+      00-.as-i8
+      "recovered" > [msg]
 
-  C8-.as-i8.lt 0A-.as-i8 ++> tests-i8-negative-less-than-positive
+  eq. ++> tests-i8-div-with-remainder
+    0D-.as-i8.div FB-.as-i8
+    FE-.as-i8
 
-  32-.as-i8.gt C8-.as-i8 ++> tests-i8-positive-greater-than-negative
-
-  32-.as-i8.lte 32-.as-i8 ++> tests-i8-lte-equal
-
-  32-.as-i8.gte 32-.as-i8 ++> tests-i8-gte-equal
+  (2A-.as-i8.eq 2B-.as-i8).not ++> tests-i8-eq-false
 
   2A-.as-i8.eq 2A-.as-i8 ++> tests-i8-eq-true
 
-  (2A-.as-i8.eq 2B-.as-i8).not ++> tests-i8-eq-false
+  32-.as-i8.gte 32-.as-i8 ++> tests-i8-gte-equal
+
+  2A-.as-i8.as-bytes.eq 2A- ++> tests-i8-has-valid-bytes
+
+  C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
+
+  (0A-.as-i8.lt 0A-.as-i8).not ++> tests-i8-less-equal
+
+  0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
+
+  32-.as-i8.lte 32-.as-i8 ++> tests-i8-lte-equal
+
+  eq. ++> tests-i8-minus-with-overflow
+    80-.as-i8.minus 01-.as-i8
+    7F-.as-i8
+
+  2A-.as-i8.neg.eq D6-.as-i8 ++> tests-i8-negation
+
+  C8-.as-i8.lt 0A-.as-i8 ++> tests-i8-negative-less-than-positive
+
+  eq. ++> tests-i8-one-minus-i8-one
+    01-.as-i8.minus 01-.as-i8
+    00-.as-i8
 
   eq. ++> tests-i8-one-plus-i8-one
     01-.as-i8.plus 01-.as-i8
@@ -97,15 +113,7 @@
     7F-.as-i8.plus 01-.as-i8
     80-.as-i8
 
-  2A-.as-i8.neg.eq D6-.as-i8 ++> tests-i8-negation
-
-  eq. ++> tests-i8-one-minus-i8-one
-    01-.as-i8.minus 01-.as-i8
-    00-.as-i8
-
-  eq. ++> tests-i8-minus-with-overflow
-    80-.as-i8.minus 01-.as-i8
-    7F-.as-i8
+  32-.as-i8.gt C8-.as-i8 ++> tests-i8-positive-greater-than-negative
 
   eq. ++> tests-i8-times
     06-.as-i8.times 07-.as-i8
@@ -115,18 +123,10 @@
     FF-.as-i8.times FF-.as-i8
     01-.as-i8
 
-  eq. ++> tests-i8-div-with-remainder
-    0D-.as-i8.div FB-.as-i8
-    FE-.as-i8
-
-  eq. ++> tests-i8-div-by-i8-one
-    C8-.as-i8.div 01-.as-i8
-    C8-.as-i8
+  eq. ++> tests-negative-i8-has-valid-bytes
+    -56.as-i64.as-i32.as-i16.as-bytes.slice
+      1
+      1
+    C8-
 
   02-.as-i8.div 00-.as-i8 --> on-division-i8-by-i8-zero
-
-  eq. ++> tests-i8-div-by-zero-returns-provided-fallback
-    "recovered"
-    02-.as-i8.div
-      00-.as-i8
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -34,13 +34,11 @@
         m
     01-02-03-04-05
 
-  eq. ++> tests-returns-correct-byte-count
-    malloc.of
-      10
-      Q.input.copied > [m]
-        bytes.as-input 01-02-03-04-05-06-07-08-09-10
-        m.to-output
-    10
+  eq. ++> tests-handles-dead-input
+    Q.input.copied
+      Q.input.dead
+      Q.output.dead
+    0
 
   eq. ++> tests-handles-empty-input
     malloc.of
@@ -52,14 +50,6 @@
         m
     --
 
-  eq. ++> tests-returns-zero-for-empty-input
-    malloc.of
-      0
-      Q.input.copied > [m]
-        bytes.as-input --
-        m.to-output
-    0
-
   eq. ++> tests-handles-large-data
     20
     malloc.of
@@ -68,8 +58,18 @@
         bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
         m.to-output
 
-  eq. ++> tests-handles-dead-input
-    Q.input.copied
-      Q.input.dead
-      Q.output.dead
+  eq. ++> tests-returns-correct-byte-count
+    malloc.of
+      10
+      Q.input.copied > [m]
+        bytes.as-input 01-02-03-04-05-06-07-08-09-10
+        m.to-output
+    10
+
+  eq. ++> tests-returns-zero-for-empty-input
+    malloc.of
+      0
+      Q.input.copied > [m]
+        bytes.as-input --
+        m.to-output
     0

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -76,43 +76,140 @@
     [] > @ /Q.bytes
     chunk > allocated
 
-  ++> tests-writes-into-memory-of
-    mem.eq 10 > @
-    malloc.of > mem
-      8
-      seq * > [m]
-        m.write 0 10
-        m
+  malloc.for ++> copies-and-resizes-to-target
+    0
+    seq * > [m]
+      m.copy
+        3
+        9
+        1
+      m.size.eq 10
 
-  ++> tests-puts-into-memory-for
-    mem.eq 10 > @
-    malloc.for > mem
-      0
-      m.put 10 > [m]
-
-  eq. ++> tests-returns-size-from-scope
+  eq. ++> tests-allocates-zero-bytes
+    0
     malloc.of
-      5
+      0
       m.size > [m]
-    5
 
-  ++> tests-malloc-scope-is-dataized-twice
-    2.eq > @
+  ++> tests-calculates-only-once
+    eq. > @
+      malloc.for 0 x
+      1
+    [m] > x
+      seq * > @
+        a.neg.neg.neg.neg.eq 42
+        m
+      seq * > [] > a
+        m.put
+          m.as-number.plus 1
+        42
+
+  ++> tests-constant-defends-against-side-effects
+    eq. > @
       malloc.for
+        7
+        [m] >>
+          m.put > @
+            num.times num
+          inc m > n!
+          number n > num
+      64
+    seq * > [x] > inc
+      x.put
+        x.as-number.plus 1
+      x.as-number
+
+  malloc.for ++> tests-copies-data-from-start-to-end
+    01-02-03-04-05-06
+    and. > [m]
+      m.copy
         0
-        [f]
-          seq > @
-            * second second
-          malloc.of > second
-            1
-            f.put > [s] >>
-              f.as-number.plus 1
+        3
+        3
+      m.get.eq 01-02-03-01-02-03
+
+  malloc.for ++> tests-copies-data-inside-itself
+    01-02-03-04-05
+    and. > [m]
+      m.copy
+        1
+        2
+        2
+      m.get.eq 01-02-02-03-05
+
+  ++> tests-malloc-allocates-right-size-block
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          10
+          b.put > [m] >>
+            m.size.eq 10
+
+  ++> tests-malloc-concacts-strings-with-offset
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          3
+          seq * > [m] >>
+            m.write 0 "XXX"
+            m.write 1 "Y"
+            b.put
+              (m.read 0 3).eq
+                "XYX"
+
+  ++> tests-malloc-decreases-block-size
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          01-02-03-04-05
+          b.put > [m] >>
+            and.
+              (m.resized 3).size.eq 3
+              m.get.eq 01-02-03
+
+  malloc.empty ++> tests-malloc-empty-is-empty
+    m.size.eq 0 > [m]
 
   eq. ++> tests-malloc-for-writes-first-init-value
     malloc.for
       42
       m > [m]
     42
+
+  malloc.of ++> tests-malloc-gives-id-to-allocated-block
+    1
+    m.put > [m]
+      m.id.gt 0
+
+  ++> tests-malloc-increases-block-size
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          01-02-03-04
+          b.put > [m] >>
+            and.
+              (m.resized 6).size.eq 6
+              m.get.eq 01-02-03-04-00-00
+
+  eq. ++> tests-malloc-is-strictly-sized-int
+    malloc.for
+      12248
+      m.put 2556 > [m]
+    2556
+
+  malloc.for ++> tests-malloc-is-strictly-typed-bool
+    false
+    m.put true > [m]
+
+  eq. ++> tests-malloc-is-strictly-typed-float
+    malloc.for
+      245.88
+      m.put 82.22 > [m]
+    82.22
 
   ++> tests-malloc-puts-over-the-previous-data
     eq. > @
@@ -125,6 +222,27 @@
           "Hello, world!"
         m.put 42
 
+  eq. ++> tests-malloc-read-over-a-limit-returns-fallback
+    01-02
+    malloc.of
+      1
+      m.read > [m]
+        0
+        10
+        01-02 > [ex]
+
+  ++> tests-malloc-reads-with-offset-and-length
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          10
+          seq * > [m] >>
+            m.write 2 "Hello"
+            b.put
+              (m.read 2 5).eq
+                "Hello"
+
   ++> tests-malloc-rewrites-and-increments-itself
     mem.eq 6 > @
     malloc.of > mem
@@ -134,62 +252,17 @@
         m.put
           m.as-number.plus 5
 
-  and. ++> tests-writes-into-two-malloc-objects
-    eq.
-      malloc.of
-        8
-        m.put 10 > [m]
-      10
-    eq.
-      malloc.of
-        8
-        m.put 20 > [m]
-      20
-
-  malloc.for --> on-overflow-boolean-malloc
-    false
-    m.put 8.612486788E7 > [m]
-
-  malloc.for --> on-overflow-string-malloc
-    "Hello"
-    m.put > [m]
-      "Much longer string!"
-
-  eq. ++> tests-malloc-is-strictly-sized-int
-    malloc.for
-      12248
-      m.put 2556 > [m]
-    2556
-
-  eq. ++> tests-malloc-is-strictly-typed-float
-    malloc.for
-      245.88
-      m.put 82.22 > [m]
-    82.22
-
-  eq. ++> tests-memory-is-strictly-sized-string
-    malloc.for
-      "Hello"
-      m.put "Prot" > [m]
-    "Proto"
-
-  malloc.for ++> tests-malloc-is-strictly-typed-bool
-    false
-    m.put true > [m]
-
-  malloc.of ++> tests-malloc-gives-id-to-allocated-block
-    1
-    m.put > [m]
-      m.id.gt 0
-
-  ++> tests-malloc-allocates-right-size-block
-    malloc.of > @
-      1
-      [b]
-        malloc.of > @
-          10
-          b.put > [m] >>
-            m.size.eq 10
+  ++> tests-malloc-scope-is-dataized-twice
+    2.eq > @
+      malloc.for
+        0
+        [f]
+          seq > @
+            * second second
+          malloc.of > second
+            1
+            f.put > [s] >>
+              f.as-number.plus 1
 
   ++> tests-malloc-writes-and-reads
     malloc.of > @
@@ -206,144 +279,17 @@
               (m.read 0 12).eq
                 "Hello, Jeff!"
 
-  ++> tests-malloc-concacts-strings-with-offset
-    malloc.of > @
-      1
-      [b]
-        malloc.of > @
-          3
-          seq * > [m] >>
-            m.write 0 "XXX"
-            m.write 1 "Y"
-            b.put
-              (m.read 0 3).eq
-                "XYX"
+  eq. ++> tests-memory-is-strictly-sized-string
+    malloc.for
+      "Hello"
+      m.put "Prot" > [m]
+    "Proto"
 
-  malloc.of ++> writes-beyond-offset-and-resizes
-    1
-    seq * > [m]
-      m.write 1 true
-      m.size.eq 2
-
-  ++> tests-malloc-reads-with-offset-and-length
-    malloc.of > @
-      1
-      [b]
-        malloc.of > @
-          10
-          seq * > [m] >>
-            m.write 2 "Hello"
-            b.put
-              (m.read 2 5).eq
-                "Hello"
-
-  eq. ++> tests-malloc-read-over-a-limit-returns-fallback
-    01-02
-    malloc.of
-      1
-      m.read > [m]
-        0
-        10
-        01-02 > [ex]
-
-  malloc.for --> on-reading-over-a-limit-without-fallback
-    10
-    m.read > [m]
+  ++> tests-puts-into-memory-for
+    mem.eq 10 > @
+    malloc.for > mem
       0
-      100
-
-  eq. ++> tests-allocates-zero-bytes
-    0
-    malloc.of
-      0
-      m.size > [m]
-
-  ++> tests-malloc-increases-block-size
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          01-02-03-04
-          b.put > [m] >>
-            and.
-              (m.resized 6).size.eq 6
-              m.get.eq 01-02-03-04-00-00
-
-  ++> tests-malloc-decreases-block-size
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          01-02-03-04-05
-          b.put > [m] >>
-            and.
-              (m.resized 3).size.eq 3
-              m.get.eq 01-02-03
-
-  malloc.of --> on-changing-size-to-negative
-    1
-    m.resized -1 > [m]
-
-  malloc.of --> on-changing-size-to-fractional
-    1
-    m.resized 1.5 > [m]
-
-  malloc.empty ++> tests-malloc-empty-is-empty
-    m.size.eq 0 > [m]
-
-  malloc.for ++> tests-copies-data-inside-itself
-    01-02-03-04-05
-    and. > [m]
-      m.copy
-        1
-        2
-        2
-      m.get.eq 01-02-02-03-05
-
-  malloc.for ++> tests-copies-data-from-start-to-end
-    01-02-03-04-05-06
-    and. > [m]
-      m.copy
-        0
-        3
-        3
-      m.get.eq 01-02-03-01-02-03
-
-  malloc.for --> on-copying-with-wrong-source
-    0
-    m.copy > [m]
-      9
-      1
-      1
-
-  malloc.for ++> copies-and-resizes-to-target
-    0
-    seq * > [m]
-      m.copy
-        3
-        9
-        1
-      m.size.eq 10
-
-  malloc.for --> on-copying-with-wrong-length
-    0
-    m.copy > [m]
-      3
-      1
-      9
-
-  ++> tests-calculates-only-once
-    eq. > @
-      malloc.for 0 x
-      1
-    [m] > x
-      seq * > @
-        a.neg.neg.neg.neg.eq 42
-        m
-      seq * > [] > a
-        m.put
-          m.as-number.plus 1
-        42
+      m.put 10 > [m]
 
   ++> tests-recursion-without-arguments
     eq. > @
@@ -359,17 +305,71 @@
         func n
       n
 
-  ++> tests-constant-defends-against-side-effects
-    eq. > @
-      malloc.for
-        7
-        [m] >>
-          m.put > @
-            num.times num
-          inc m > n!
-          number n > num
-      64
-    seq * > [x] > inc
-      x.put
-        x.as-number.plus 1
-      x.as-number
+  eq. ++> tests-returns-size-from-scope
+    malloc.of
+      5
+      m.size > [m]
+    5
+
+  ++> tests-writes-into-memory-of
+    mem.eq 10 > @
+    malloc.of > mem
+      8
+      seq * > [m]
+        m.write 0 10
+        m
+
+  and. ++> tests-writes-into-two-malloc-objects
+    eq.
+      malloc.of
+        8
+        m.put 10 > [m]
+      10
+    eq.
+      malloc.of
+        8
+        m.put 20 > [m]
+      20
+
+  malloc.of ++> writes-beyond-offset-and-resizes
+    1
+    seq * > [m]
+      m.write 1 true
+      m.size.eq 2
+
+  malloc.of --> on-changing-size-to-fractional
+    1
+    m.resized 1.5 > [m]
+
+  malloc.of --> on-changing-size-to-negative
+    1
+    m.resized -1 > [m]
+
+  malloc.for --> on-copying-with-wrong-length
+    0
+    m.copy > [m]
+      3
+      1
+      9
+
+  malloc.for --> on-copying-with-wrong-source
+    0
+    m.copy > [m]
+      9
+      1
+      1
+
+  malloc.for --> on-overflow-boolean-malloc
+    false
+    m.put 8.612486788E7 > [m]
+
+  malloc.for --> on-overflow-string-malloc
+    "Hello"
+    m.put > [m]
+      "Much longer string!"
+
+  malloc.for --> on-reading-over-a-limit-without-fallback
+    10
+    m.read > [m]
+      0
+      100

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -42,8 +42,6 @@
               ^.kbts > kbts
               tup.head.key > key
               tup.head.value > value
-      tuple.hash-code kbts > hash!
-      tup.head.key.as-bytes > kbts!
       if. > [ent] > has-key
         ent.length.eq 0
         false
@@ -52,6 +50,8 @@
             ent.head.kbts.eq kbts
           true
           has-key ent.tail
+      tuple.hash-code kbts > hash!
+      tup.head.key.as-bytes > kbts!
       @. > prev
         rec-rebuild tup.tail
   [key value] > entry
@@ -63,6 +63,11 @@
         rec-key-search entries
       tuple.hash-code kbts > hash!
       key.as-bytes > kbts!
+      [] > not-found
+        false > exists
+        cant-get > [cant-get] > get
+          "Object by hash code %d from given key does not exists".printf
+            * hash
       [tup] > rec-key-search
         if. > @
           tup.length.eq 0
@@ -78,11 +83,6 @@
               not-found
         @. > prev
           rec-key-search tup.tail
-      [] > not-found
-        false > exists
-        cant-get > [cant-get] > get
-          "Object by hash code %d from given key does not exists".printf
-            * hash
     (found key).exists > [key] > has
     tuple.mapped > keys
       entries
@@ -118,6 +118,107 @@
       tuple.hash-code kbts > hash!
       key.as-bytes > kbts!
 
+  ++> tests-adds-key-colliding-with-existing-one
+    and. > @
+      2.eq mp.size
+      2.eq
+        get.
+          mp.found "BB"
+    with. > mp
+      map *
+        map.entry "Aa" 1
+      "BB"
+      2
+
+  ++> tests-adds-new-pair-to-hash-map
+    and. > @
+      2.eq mp.size
+      mp.has "two"
+    with. > mp
+      map *
+        map.entry "one" 1
+      "two"
+      2
+
+  eq. ++> tests-does-not-change-map-without-non-existed-element
+    size.
+      without.
+        map *
+          map.entry "one" 1
+        "two"
+    1
+
+  ++> tests-does-not-find-element-by-key-in-hash-map
+    not. > @
+      exists.
+        found.
+          map *
+            map.entry "one" 1
+            map.entry "two" 2
+          "three"
+
+  ++> tests-does-not-have-absent-key-colliding-with-stored-one
+    not. > @
+      has.
+        map *
+          map.entry "Aa" 1
+        "BB"
+
+  ++> tests-does-not-have-element-by-key-in-hash-map
+    not. > @
+      has.
+        map *
+          map.entry "one" 1
+          map.entry "two" 2
+        "three"
+
+  eq. ++> tests-falls-back-for-absent-key-colliding-with-stored-one
+    "recovered"
+    get.
+      found.
+        map *
+          map.entry "Aa" 1
+        "BB"
+      "recovered" > [msg]
+
+  ++> tests-finds-element-by-key-in-map
+    2.eq found.get > @
+    mp.found "two" > found
+    map * > mp
+      map.entry "one" 1
+      map.entry "two" 2
+      map.entry "three" 3
+
+  ++> tests-finds-value-of-each-key-with-colliding-hash-codes
+    and. > @
+      1.eq first.get
+      2.eq second.get
+    mp.found "Aa" > first
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+    mp.found "BB" > second
+
+  has. ++> tests-has-element-with-key-in-hash-map
+    map *
+      map.entry "one" 1
+      map.entry "two" 2
+    "two"
+
+  ++> tests-keeps-both-keys-with-colliding-hash-codes
+    2.eq mp.size > @
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+
+  ++> tests-map-get-missing-returns-provided-fallback
+    "recovered".eq > @
+      get.
+        mp.found "absent"
+        "recovered" > [msg]
+    map * > mp
+      map.entry "one" 1
+
   ++> tests-map-rebuilds-itself
     2.eq mp.size > @
     map * > mp
@@ -141,6 +242,39 @@
                 m.as-number.plus 1
               1
 
+  ++> tests-removes-element-from-map-by-key
+    and. > @
+      1.eq mp.size
+      not.
+        mp.has "one"
+    without. > mp
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "one"
+
+  ++> tests-removes-only-the-given-key-of-colliding-ones
+    (mp.has "Aa").not.and > @
+      mp.has "BB"
+    without. > mp
+      map *
+        map.entry "Aa" 1
+        map.entry "BB" 2
+      "Aa"
+
+  ++> tests-replaces-value-if-pair-with-key-exists-in-map
+    and. > @
+      2.eq mp.size
+      3.eq
+        get.
+          mp.found "two"
+    with. > mp
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "two"
+      3
+
   eq. ++> tests-returns-list-of-keys
     keys.
       map *
@@ -162,140 +296,6 @@
       2
       3
       4
-
-  ++> tests-finds-element-by-key-in-map
-    2.eq found.get > @
-    mp.found "two" > found
-    map * > mp
-      map.entry "one" 1
-      map.entry "two" 2
-      map.entry "three" 3
-
-  ++> tests-does-not-find-element-by-key-in-hash-map
-    not. > @
-      exists.
-        found.
-          map *
-            map.entry "one" 1
-            map.entry "two" 2
-          "three"
-
-  has. ++> tests-has-element-with-key-in-hash-map
-    map *
-      map.entry "one" 1
-      map.entry "two" 2
-    "two"
-
-  ++> tests-does-not-have-element-by-key-in-hash-map
-    not. > @
-      has.
-        map *
-          map.entry "one" 1
-          map.entry "two" 2
-        "three"
-
-  eq. ++> tests-does-not-change-map-without-non-existed-element
-    size.
-      without.
-        map *
-          map.entry "one" 1
-        "two"
-    1
-
-  ++> tests-removes-element-from-map-by-key
-    and. > @
-      1.eq mp.size
-      not.
-        mp.has "one"
-    without. > mp
-      map *
-        map.entry "one" 1
-        map.entry "two" 2
-      "one"
-
-  ++> tests-adds-new-pair-to-hash-map
-    and. > @
-      2.eq mp.size
-      mp.has "two"
-    with. > mp
-      map *
-        map.entry "one" 1
-      "two"
-      2
-
-  ++> tests-replaces-value-if-pair-with-key-exists-in-map
-    and. > @
-      2.eq mp.size
-      3.eq
-        get.
-          mp.found "two"
-    with. > mp
-      map *
-        map.entry "one" 1
-        map.entry "two" 2
-      "two"
-      3
-
-  ++> tests-keeps-both-keys-with-colliding-hash-codes
-    2.eq mp.size > @
-    map * > mp
-      map.entry "Aa" 1
-      map.entry "BB" 2
-
-  ++> tests-finds-value-of-each-key-with-colliding-hash-codes
-    and. > @
-      1.eq first.get
-      2.eq second.get
-    mp.found "Aa" > first
-    map * > mp
-      map.entry "Aa" 1
-      map.entry "BB" 2
-    mp.found "BB" > second
-
-  ++> tests-does-not-have-absent-key-colliding-with-stored-one
-    not. > @
-      has.
-        map *
-          map.entry "Aa" 1
-        "BB"
-
-  eq. ++> tests-falls-back-for-absent-key-colliding-with-stored-one
-    "recovered"
-    get.
-      found.
-        map *
-          map.entry "Aa" 1
-        "BB"
-      "recovered" > [msg]
-
-  ++> tests-adds-key-colliding-with-existing-one
-    and. > @
-      2.eq mp.size
-      2.eq
-        get.
-          mp.found "BB"
-    with. > mp
-      map *
-        map.entry "Aa" 1
-      "BB"
-      2
-
-  ++> tests-removes-only-the-given-key-of-colliding-ones
-    (mp.has "Aa").not.and > @
-      mp.has "BB"
-    without. > mp
-      map *
-        map.entry "Aa" 1
-        map.entry "BB" 2
-      "Aa"
-
-  ++> tests-map-get-missing-returns-provided-fallback
-    "recovered".eq > @
-      get.
-        mp.found "absent"
-        "recovered" > [msg]
-    map * > mp
-      map.entry "one" 1
 
   --> on-map-get-missing-without-fallback
     get. > @

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -49,10 +49,10 @@
           getenv "TMPDIR" > tmpdir!
           getenv "USERPROFILE" > userprofile!
 
+  mktemp.tmpfile.exists ++> creates-tmpfile
+
   mktemp.exists ++> global-temp-dir-exists
 
   mktemp.is-directory ++> global-temp-dir-is-directory
 
   mktemp.path.eq mktemp.path ++> returns-the-same-tmpdir
-
-  mktemp.tmpfile.exists ++> creates-tmpfile

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -29,17 +29,23 @@
           negative.if
             magnitude.not.as-i64.plus 00-00-00-00-00-00-00-01.as-i64
             magnitude.as-i64
-    eq. > negative
-      as-bytes.and 80-00-00-00-00-00-00-00
-      80-00-00-00-00-00-00-00
     as-number. > exp
       as-i64.
         right.
           as-bytes.and 7F-F0-00-00-00-00-00-00
           52
+    if. > magnitude
+      exp.gte 1075
+      mantissa.left
+        exp.minus 1075
+      mantissa.right
+        1075.minus exp
     or. > mantissa
       as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF
       00-10-00-00-00-00-00-00
+    eq. > negative
+      as-bytes.and 80-00-00-00-00-00-00-00
+      80-00-00-00-00-00-00-00
     or. > overflow
       exp.eq 2047
       or.
@@ -49,12 +55,7 @@
           not.
             negative.and
               mantissa.eq 00-10-00-00-00-00-00-00
-    if. > magnitude
-      exp.gte 1075
-      mantissa.left
-        exp.minus 1075
-      mantissa.right
-        1075.minus exp
+  [x] > div /Q.number
   [x] > eq
     if. > @
       ^.is-nan.or
@@ -73,66 +74,36 @@
     0.as-bytes > pzero
     x > xbts!
   [x] > gt /Q.bool
-  [x] > times /Q.number
   [x] > plus /Q.number
-  [x] > div /Q.number
+  [x] > times /Q.number
 
-  eq. ++> tests-int-greater-true
-    -200.gt -1000
-    true
+  42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
 
-  eq. ++> tests-int-greater-false
-    not.
-      0.gt 100
-    true
+  42.as-bytes.eq 42 ++> tests-as-bytes-equals-to-int-backwards
 
-  eq. ++> tests-int-greater-equal
-    not.
-      0.gt 0
-    true
+  eq. ++> tests-as-i64-converts-fraction-below-one-to-zero
+    0.5.as-i64.as-bytes
+    00-00-00-00-00-00-00-00
 
-  eq. ++> tests-int-equal-to-nan-and-infinites-is-false
-    and.
-      and.
-        and.
-          and.
-            and.
-              (0.eq nan).eq false
-              (0.eq pinf).eq false
-            (0.eq ninf).eq false
-          (42.eq nan).eq false
-        eq.
-          42.eq pinf
-          false
-      eq.
-        42.eq ninf
-        false
-    true
+  eq. ++> tests-as-i64-converts-large-number-with-left-shift
+    1000000000000000000.as-i64.as-bytes
+    0D-E0-B6-B3-A7-64-00-00
 
-  eq. ++> tests-int-zero-eq-to-zero
-    0.eq 0
-    true
+  eq. ++> tests-as-i64-converts-long-min-boundary
+    -9.223372036854776e18.as-i64.as-bytes
+    80-00-00-00-00-00-00-00
 
-  eq. ++> tests-int-zero-eq-to-float-zero
-    0.eq 0
-    true
+  eq. ++> tests-as-i64-converts-negative-zero-to-zero
+    -0.as-i64.as-bytes
+    00-00-00-00-00-00-00-00
 
-  eq. ++> tests-int-eq-true
-    123.eq 123
-    true
+  eq. ++> tests-as-i64-truncates-negative-toward-zero
+    -3.7.as-i64.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FD
 
-  eq. ++> tests-int-eq-false
-    not.
-      123.eq 42
-    true
-
-  eq. ++> tests-one-plus-one
-    1.plus 1
-    2
-
-  eq. ++> tests-compares-two-different-number-types
-    68.eq "12345678"
-    false
+  eq. ++> tests-as-i64-truncates-positive-toward-zero
+    3.7.as-i64.as-bytes
+    00-00-00-00-00-00-00-03
 
   ++> tests-calculates-fibonacci-number-with-recursion
     eq. > @
@@ -159,10 +130,6 @@
           n
           1
           1
-      if. > [n] > small
-        n.eq 2
-        1
-        n
       if. > [n minus1 minus2] > rec
         n.eq 3
         minus1.plus minus2
@@ -170,62 +137,33 @@
           n.minus 1
           minus1.plus minus2
           minus1
+      if. > [n] > small
+        n.eq 2
+        1
+        n
 
-  seq * ++> tests-zero-division
-    2.div 0
-    true
-
-  ++> tests-division-by-one
-    eq. > @
-      dividend.div 1
-      dividend
-    -235 > dividend
+  eq. ++> tests-compares-two-different-number-types
+    68.eq "12345678"
+    false
 
   eq. ++> tests-div-for-dividend-greater-than-zero
     256.div 16
     16
+
+  lt. ++> tests-div-less-than-one
+    1.div 5
+    1
 
   eq. ++> tests-div-with-remainder
     floor.
       13.div -5
     -3
 
-  lt. ++> tests-div-less-than-one
-    1.div 5
-    1
-
-  42.as-bytes.eq 42 ++> tests-to-bytes-and-backwards
-
-  42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
-
-  42.as-bytes.eq 42 ++> tests-as-bytes-equals-to-int-backwards
-
-  eq. ++> tests-multiply-by-zero
-    1000.times 0
-    0
-
-  pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
-    1.div 0
-
-  pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
-
-  (pinf.eq ninf).not ++> tests-positive-infinity-not-eq-negative-infinity
-
-  (pinf.eq nan).not ++> tests-positive-infinity-not-eq-nan
-
-  (pinf.eq 42).not ++> tests-positive-infinity-not-eq-int
-
-  (pinf.eq 42.5).not ++> tests-positive-infinity-not-eq-float
-
-  (pinf.gt pinf).not ++> tests-positive-infinity-gt-positive-infinity
-
-  pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
-
-  (pinf.gt nan).not ++> tests-positive-infinity-not-gt-nan
-
-  pinf.gt 42 ++> tests-positive-infinity-gt-int
-
-  pinf.gt 42.5 ++> tests-positive-infinity-gt-float
+  ++> tests-division-by-one
+    eq. > @
+      dividend.div 1
+      dividend
+    -235 > dividend
 
   eq. ++> tests-float-equal-to-nan-and-infinites-is-false-highload
     and.
@@ -256,158 +194,189 @@
         false
     true
 
-  eq. ++> tests-positive-infinity-times-float-zero
-    as-bytes.
-      pinf.times 0
-    nan.as-bytes
+  eq. ++> tests-int-eq-false
+    not.
+      123.eq 42
+    true
 
-  eq. ++> tests-positive-infinity-times-neg-float-zero
-    as-bytes.
-      pinf.times -0
-    nan.as-bytes
+  eq. ++> tests-int-eq-true
+    123.eq 123
+    true
 
-  eq. ++> tests-positive-infinity-times-int-zero
-    as-bytes.
-      pinf.times 0
-    nan.as-bytes
+  eq. ++> tests-int-equal-to-nan-and-infinites-is-false
+    and.
+      and.
+        and.
+          and.
+            and.
+              (0.eq nan).eq false
+              (0.eq pinf).eq false
+            (0.eq ninf).eq false
+          (42.eq nan).eq false
+        eq.
+          42.eq pinf
+          false
+      eq.
+        42.eq ninf
+        false
+    true
 
-  eq. ++> tests-positive-infinity-times-nan
-    as-bytes.
-      pinf.times nan
-    nan.as-bytes
+  eq. ++> tests-int-greater-equal
+    not.
+      0.gt 0
+    true
 
-  eq. ++> tests-positive-infinity-times-negative-infinity
-    pinf.times ninf
+  eq. ++> tests-int-greater-false
+    not.
+      0.gt 100
+    true
+
+  eq. ++> tests-int-greater-true
+    -200.gt -1000
+    true
+
+  eq. ++> tests-int-zero-eq-to-float-zero
+    0.eq 0
+    true
+
+  eq. ++> tests-int-zero-eq-to-zero
+    0.eq 0
+    true
+
+  eq. ++> tests-multiply-by-zero
+    1000.times 0
+    0
+
+  nan.as-bytes.eq ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
+    as-bytes.
+      0.div 0
+
+  (nan.eq nan).not ++> tests-nan-not-eq-nan
+
+  (nan.eq 42).not ++> tests-nan-not-eq-number
+
+  eq. ++> tests-nan-not-gt-nan
+    nan.gt nan
+    false
+
+  eq. ++> tests-nan-not-gt-number
+    nan.gt 42
+    false
+
+  ninf.as-bytes.eq ++> tests-negative-infinity-as-bytes-is-valid
+    as-bytes.
+      -1.div 0
+
+  eq. ++> tests-negative-infinity-div-float-zero
+    ninf.div 0
     ninf
 
-  eq. ++> tests-positive-infinity-times-positive-infinity
-    pinf.times pinf
-    pinf
-
-  eq. ++> tests-positive-infinity-times-positive-float
-    pinf.times 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-times-positive-int
-    pinf.times 42
-    pinf
-
-  eq. ++> tests-positive-infinity-times-negative-float
-    pinf.times -42.5
+  eq. ++> tests-negative-infinity-div-int-zero
+    ninf.div 0
     ninf
 
-  eq. ++> tests-positive-infinity-times-negative-int
-    pinf.times -42
-    ninf
-
-  eq. ++> tests-positive-infinity-plus-nan
+  eq. ++> tests-negative-infinity-div-nan
     as-bytes.
-      pinf.plus nan
+      ninf.div nan
     nan.as-bytes
 
-  eq. ++> tests-positive-infinity-plus-negative-infinity
+  eq. ++> tests-negative-infinity-div-neg-float-zero
+    ninf.div -0
+    pinf
+
+  eq. ++> tests-negative-infinity-div-neg-int-zero
+    ninf.div -0
+    pinf
+
+  eq. ++> tests-negative-infinity-div-negative-float
+    ninf.div -42.5
+    pinf
+
+  eq. ++> tests-negative-infinity-div-negative-infinity
     as-bytes.
-      pinf.plus ninf
+      ninf.div ninf
     nan.as-bytes
 
-  eq. ++> tests-positive-infinity-plus-positive-infinity
-    pinf.plus pinf
+  eq. ++> tests-negative-infinity-div-negative-int
+    ninf.div -42
     pinf
 
-  eq. ++> tests-positive-infinity-plus-positive-float
-    pinf.plus 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-div-float-zero
-    pinf.div 0
-    pinf
-
-  eq. ++> tests-positive-infinity-div-neg-float-zero
-    pinf.div -0
+  eq. ++> tests-negative-infinity-div-positive-float
+    ninf.div 42.5
     ninf
 
-  eq. ++> tests-positive-infinity-div-int-zero
-    pinf.div 0
-    pinf
-
-  eq. ++> tests-positive-infinity-div-neg-int-zero
-    pinf.div -0
-    ninf
-
-  eq. ++> tests-positive-infinity-div-nan
+  eq. ++> tests-negative-infinity-div-positive-infinity
     as-bytes.
-      pinf.div nan
+      ninf.div pinf
     nan.as-bytes
 
-  eq. ++> tests-positive-infinity-div-negative-infinity
-    as-bytes.
-      pinf.div ninf
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-div-positive-infinity
-    as-bytes.
-      pinf.div pinf
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-div-positive-float
-    pinf.div 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-div-positive-int
-    pinf.div 42
-    pinf
-
-  eq. ++> tests-positive-infinity-div-negative-float
-    pinf.div -42.5
+  eq. ++> tests-negative-infinity-div-positive-int
+    ninf.div 42
     ninf
 
-  eq. ++> tests-positive-infinity-div-negative-int
-    pinf.div -42
-    ninf
+  ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
 
-  pinf.as-bytes.eq ++> tests-positive-infinity-as-bytes-is-valid
-    as-bytes.
-      1.div 0
+  (ninf.gt ninf).not ++> tests-negative-infinity-gt-negative-infinity
 
   ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
     -1.div 0
 
-  ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
-
-  (ninf.eq pinf).not ++> tests-negative-infinity-not-eq-positive-infinity
-
-  (ninf.eq nan).not ++> tests-negative-infinity-not-eq-nan
+  (ninf.eq 42.5).not ++> tests-negative-infinity-not-eq-float
 
   (ninf.eq 42).not ++> tests-negative-infinity-not-eq-int
 
-  (ninf.eq 42.5).not ++> tests-negative-infinity-not-eq-float
+  (ninf.eq nan).not ++> tests-negative-infinity-not-eq-nan
 
-  (ninf.gt ninf).not ++> tests-negative-infinity-gt-negative-infinity
+  (ninf.eq pinf).not ++> tests-negative-infinity-not-eq-positive-infinity
 
-  eq. ++> tests-negative-infinity-not-gt-positive-infinity
-    ninf.gt pinf
-    false
-
-  eq. ++> tests-negative-infinity-not-gt-nan
-    ninf.gt nan
+  eq. ++> tests-negative-infinity-not-gt-float
+    ninf.gt 42.5
     false
 
   eq. ++> tests-negative-infinity-not-gt-int
     ninf.gt 42
     false
 
-  eq. ++> tests-negative-infinity-not-gt-float
-    ninf.gt 42.5
+  eq. ++> tests-negative-infinity-not-gt-nan
+    ninf.gt nan
     false
+
+  eq. ++> tests-negative-infinity-not-gt-positive-infinity
+    ninf.gt pinf
+    false
+
+  eq. ++> tests-negative-infinity-plus-nan
+    as-bytes.
+      ninf.plus nan
+    nan.as-bytes
+
+  eq. ++> tests-negative-infinity-plus-negative-float
+    ninf.plus -42.5
+    ninf
+
+  ninf.eq ++> tests-negative-infinity-plus-negative-infinity
+    ninf.plus ninf
+
+  eq. ++> tests-negative-infinity-plus-negative-int
+    ninf.plus -42
+    ninf
+
+  eq. ++> tests-negative-infinity-plus-positive-float
+    ninf.plus 42.5
+    ninf
+
+  eq. ++> tests-negative-infinity-plus-positive-infinity
+    as-bytes.
+      ninf.plus pinf
+    nan.as-bytes
+
+  eq. ++> tests-negative-infinity-plus-positive-int
+    ninf.plus 42
+    ninf
 
   eq. ++> tests-negative-infinity-times-float-zero
     as-bytes.
       ninf.times 0
-    nan.as-bytes
-
-  eq. ++> tests-negative-infinity-times-neg-float-zero
-    as-bytes.
-      ninf.times -0
     nan.as-bytes
 
   eq. ++> tests-negative-infinity-times-int-zero
@@ -420,125 +389,206 @@
       ninf.times nan
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-times-positive-infinity
-    ninf.times pinf
-    ninf
-
-  eq. ++> tests-negative-infinity-times-negative-infinity
-    ninf.times ninf
-    pinf
-
-  eq. ++> tests-negative-infinity-times-positive-float
-    ninf.times 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-times-positive-int
-    ninf.times 42
-    ninf
+  eq. ++> tests-negative-infinity-times-neg-float-zero
+    as-bytes.
+      ninf.times -0
+    nan.as-bytes
 
   eq. ++> tests-negative-infinity-times-negative-float
     ninf.times -42.5
+    pinf
+
+  eq. ++> tests-negative-infinity-times-negative-infinity
+    ninf.times ninf
     pinf
 
   eq. ++> tests-negative-infinity-times-negative-int
     ninf.times -42
     pinf
 
-  eq. ++> tests-negative-infinity-plus-nan
+  eq. ++> tests-negative-infinity-times-positive-float
+    ninf.times 42.5
+    ninf
+
+  eq. ++> tests-negative-infinity-times-positive-infinity
+    ninf.times pinf
+    ninf
+
+  eq. ++> tests-negative-infinity-times-positive-int
+    ninf.times 42
+    ninf
+
+  eq. ++> tests-one-plus-one
+    1.plus 1
+    2
+
+  eq. ++> tests-out-of-range-as-i64-returns-provided-fallback
+    "recovered"
+    1.0e30.as-i64
+      "recovered" > [msg]
+
+  -17.9.abs.eq 17.9 ++> tests-package-absolute-of-negative
+
+  eq. ++> tests-package-modulo-of-two-numbers
+    7.mod 3
+    1
+
+  eq. ++> tests-package-power-via-number-namespace
+    number.power
+      2
+      5
+    32
+
+  eq. ++> tests-package-raises-to-power
+    2.power 4
+    16
+
+  lt. ++> tests-package-square-root-approximates
+    abs.
+      9.sqrt.minus 3
+    1.0E-9
+
+  pinf.as-bytes.eq ++> tests-positive-infinity-as-bytes-is-valid
     as-bytes.
-      ninf.plus nan
-    nan.as-bytes
+      1.div 0
 
-  eq. ++> tests-negative-infinity-plus-positive-infinity
-    as-bytes.
-      ninf.plus pinf
-    nan.as-bytes
-
-  ninf.eq ++> tests-negative-infinity-plus-negative-infinity
-    ninf.plus ninf
-
-  eq. ++> tests-negative-infinity-plus-positive-float
-    ninf.plus 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-plus-positive-int
-    ninf.plus 42
-    ninf
-
-  eq. ++> tests-negative-infinity-plus-negative-float
-    ninf.plus -42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-plus-negative-int
-    ninf.plus -42
-    ninf
-
-  eq. ++> tests-negative-infinity-div-float-zero
-    ninf.div 0
-    ninf
-
-  eq. ++> tests-negative-infinity-div-neg-float-zero
-    ninf.div -0
+  eq. ++> tests-positive-infinity-div-float-zero
+    pinf.div 0
     pinf
 
-  eq. ++> tests-negative-infinity-div-int-zero
-    ninf.div 0
-    ninf
-
-  eq. ++> tests-negative-infinity-div-neg-int-zero
-    ninf.div -0
+  eq. ++> tests-positive-infinity-div-int-zero
+    pinf.div 0
     pinf
 
-  eq. ++> tests-negative-infinity-div-nan
+  eq. ++> tests-positive-infinity-div-nan
     as-bytes.
-      ninf.div nan
+      pinf.div nan
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-div-positive-infinity
-    as-bytes.
-      ninf.div pinf
-    nan.as-bytes
-
-  eq. ++> tests-negative-infinity-div-negative-infinity
-    as-bytes.
-      ninf.div ninf
-    nan.as-bytes
-
-  eq. ++> tests-negative-infinity-div-positive-float
-    ninf.div 42.5
+  eq. ++> tests-positive-infinity-div-neg-float-zero
+    pinf.div -0
     ninf
 
-  eq. ++> tests-negative-infinity-div-positive-int
-    ninf.div 42
+  eq. ++> tests-positive-infinity-div-neg-int-zero
+    pinf.div -0
     ninf
 
-  eq. ++> tests-negative-infinity-div-negative-float
-    ninf.div -42.5
+  eq. ++> tests-positive-infinity-div-negative-float
+    pinf.div -42.5
+    ninf
+
+  eq. ++> tests-positive-infinity-div-negative-infinity
+    as-bytes.
+      pinf.div ninf
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-div-negative-int
+    pinf.div -42
+    ninf
+
+  eq. ++> tests-positive-infinity-div-positive-float
+    pinf.div 42.5
     pinf
 
-  eq. ++> tests-negative-infinity-div-negative-int
-    ninf.div -42
+  eq. ++> tests-positive-infinity-div-positive-infinity
+    as-bytes.
+      pinf.div pinf
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-div-positive-int
+    pinf.div 42
     pinf
 
-  ninf.as-bytes.eq ++> tests-negative-infinity-as-bytes-is-valid
+  pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
+
+  pinf.gt 42.5 ++> tests-positive-infinity-gt-float
+
+  pinf.gt 42 ++> tests-positive-infinity-gt-int
+
+  pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
+
+  (pinf.gt pinf).not ++> tests-positive-infinity-gt-positive-infinity
+
+  pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
+    1.div 0
+
+  (pinf.eq 42.5).not ++> tests-positive-infinity-not-eq-float
+
+  (pinf.eq 42).not ++> tests-positive-infinity-not-eq-int
+
+  (pinf.eq nan).not ++> tests-positive-infinity-not-eq-nan
+
+  (pinf.eq ninf).not ++> tests-positive-infinity-not-eq-negative-infinity
+
+  (pinf.gt nan).not ++> tests-positive-infinity-not-gt-nan
+
+  eq. ++> tests-positive-infinity-plus-nan
     as-bytes.
-      -1.div 0
+      pinf.plus nan
+    nan.as-bytes
 
-  (nan.eq 42).not ++> tests-nan-not-eq-number
-
-  (nan.eq nan).not ++> tests-nan-not-eq-nan
-
-  eq. ++> tests-nan-not-gt-number
-    nan.gt 42
-    false
-
-  eq. ++> tests-nan-not-gt-nan
-    nan.gt nan
-    false
-
-  nan.as-bytes.eq ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
+  eq. ++> tests-positive-infinity-plus-negative-infinity
     as-bytes.
-      0.div 0
+      pinf.plus ninf
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-plus-positive-float
+    pinf.plus 42.5
+    pinf
+
+  eq. ++> tests-positive-infinity-plus-positive-infinity
+    pinf.plus pinf
+    pinf
+
+  eq. ++> tests-positive-infinity-times-float-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-times-int-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-times-nan
+    as-bytes.
+      pinf.times nan
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-times-neg-float-zero
+    as-bytes.
+      pinf.times -0
+    nan.as-bytes
+
+  eq. ++> tests-positive-infinity-times-negative-float
+    pinf.times -42.5
+    ninf
+
+  eq. ++> tests-positive-infinity-times-negative-infinity
+    pinf.times ninf
+    ninf
+
+  eq. ++> tests-positive-infinity-times-negative-int
+    pinf.times -42
+    ninf
+
+  eq. ++> tests-positive-infinity-times-positive-float
+    pinf.times 42.5
+    pinf
+
+  eq. ++> tests-positive-infinity-times-positive-infinity
+    pinf.times pinf
+    pinf
+
+  eq. ++> tests-positive-infinity-times-positive-int
+    pinf.times 42
+    pinf
+
+  42.as-bytes.eq 42 ++> tests-to-bytes-and-backwards
+
+  seq * ++> tests-zero-division
+    2.div 0
+    true
 
   1.0e30.as-i64 --> on-converting-huge-number-to-i64
 
@@ -547,53 +597,3 @@
   nan.as-i64 --> on-converting-nan-to-i64
 
   pinf.as-i64 --> on-converting-positive-infinity-to-i64
-
-  eq. ++> tests-out-of-range-as-i64-returns-provided-fallback
-    "recovered"
-    1.0e30.as-i64
-      "recovered" > [msg]
-
-  eq. ++> tests-as-i64-truncates-positive-toward-zero
-    3.7.as-i64.as-bytes
-    00-00-00-00-00-00-00-03
-
-  eq. ++> tests-as-i64-truncates-negative-toward-zero
-    -3.7.as-i64.as-bytes
-    FF-FF-FF-FF-FF-FF-FF-FD
-
-  eq. ++> tests-as-i64-converts-fraction-below-one-to-zero
-    0.5.as-i64.as-bytes
-    00-00-00-00-00-00-00-00
-
-  eq. ++> tests-as-i64-converts-negative-zero-to-zero
-    -0.as-i64.as-bytes
-    00-00-00-00-00-00-00-00
-
-  eq. ++> tests-as-i64-converts-large-number-with-left-shift
-    1000000000000000000.as-i64.as-bytes
-    0D-E0-B6-B3-A7-64-00-00
-
-  eq. ++> tests-as-i64-converts-long-min-boundary
-    -9.223372036854776e18.as-i64.as-bytes
-    80-00-00-00-00-00-00-00
-
-  eq. ++> tests-package-raises-to-power
-    2.power 4
-    16
-
-  -17.9.abs.eq 17.9 ++> tests-package-absolute-of-negative
-
-  eq. ++> tests-package-modulo-of-two-numbers
-    7.mod 3
-    1
-
-  lt. ++> tests-package-square-root-approximates
-    abs.
-      9.sqrt.minus 3
-    1.0E-9
-
-  eq. ++> tests-package-power-via-number-namespace
-    number.power
-      2
-      5
-    32

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -14,22 +14,22 @@
     value.neg
   number num.as-bytes > value
 
-  eq. ++> tests-abs-int-positive
-    abs 3
-    3
-
-  eq. ++> tests-abs-int-negative
-    abs -3
-    3
-
-  eq. ++> tests-abs-zero
-    abs 0
-    0
+  eq. ++> tests-abs-float-negative
+    abs -17.9
+    17.9
 
   eq. ++> tests-abs-float-positive
     abs 13.5
     13.5
 
-  eq. ++> tests-abs-float-negative
-    abs -17.9
-    17.9
+  eq. ++> tests-abs-int-negative
+    abs -3
+    3
+
+  eq. ++> tests-abs-int-positive
+    abs 3
+    3
+
+  eq. ++> tests-abs-zero
+    abs 0
+    0

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,26 +15,17 @@
     pi.div 2
     arc-sine num
 
-  eq. ++> tests-arc-cosine-of-one-is-zero
-    arc-cosine 1
-    0
+  (arc-cosine 2).is-nan ++> tests-arc-cosine-above-one-is-nan
 
-  eq. ++> tests-arc-cosine-of-zero-is-pi-halves
-    arc-cosine 0
-    pi.div 2
+  (arc-cosine -2).is-nan ++> tests-arc-cosine-below-minus-one-is-nan
+
+  (arc-cosine nan).is-nan ++> tests-arc-cosine-of-nan-is-nan
+
+  (arc-cosine ninf).is-nan ++> tests-arc-cosine-of-negative-infinity-is-nan
 
   eq. ++> tests-arc-cosine-of-negative-one-is-pi
     arc-cosine -1
     pi
-
-  lt. ++> tests-arc-cosine-of-point-six
-    abs
-      minus.
-        times.
-          arc-cosine 0.6
-          1000
-        927.295
-    1
 
   lt. ++> tests-arc-cosine-of-negative-point-six
     abs
@@ -45,12 +36,21 @@
         2214.297
     1
 
-  (arc-cosine 2).is-nan ++> tests-arc-cosine-above-one-is-nan
+  eq. ++> tests-arc-cosine-of-one-is-zero
+    arc-cosine 1
+    0
 
-  (arc-cosine -2).is-nan ++> tests-arc-cosine-below-minus-one-is-nan
-
-  (arc-cosine nan).is-nan ++> tests-arc-cosine-of-nan-is-nan
+  lt. ++> tests-arc-cosine-of-point-six
+    abs
+      minus.
+        times.
+          arc-cosine 0.6
+          1000
+        927.295
+    1
 
   (arc-cosine pinf).is-nan ++> tests-arc-cosine-of-positive-infinity-is-nan
 
-  (arc-cosine ninf).is-nan ++> tests-arc-cosine-of-negative-infinity-is-nan
+  eq. ++> tests-arc-cosine-of-zero-is-pi-halves
+    arc-cosine 0
+    pi.div 2

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -17,11 +17,6 @@
     base.neg
     base
   number num.as-bytes > arg
-  abs arg > mag
-  sqrt > root
-    div.
-      1.minus mag
-      2
   if. > base
     mag.gt 0.5
     minus.
@@ -29,11 +24,14 @@
       2.times
         series root
     series mag
+  abs arg > mag
+  sqrt > root
+    div.
+      1.minus mag
+      2
   [point] > series
     point.times > @
       poly 1
-    point.times point > squared
-    30 > terms
     if. > [depth] > poly
       depth.gt terms
       1
@@ -49,30 +47,20 @@
               (depth.times 2).plus 1
           poly
             depth.plus 1
+    point.times point > squared
+    30 > terms
 
-  eq. ++> tests-arc-sine-of-zero-is-zero
-    arc-sine 0
-    0
+  (arc-sine 2).is-nan ++> tests-arc-sine-above-one-is-nan
 
-  lt. ++> tests-arc-sine-of-one-is-pi-halves
+  (arc-sine -2).is-nan ++> tests-arc-sine-below-minus-one-is-nan
+
+  lt. ++> tests-arc-sine-is-odd-function
     abs
-      minus.
-        times.
-          arc-sine 1
-          1000
-        times.
-          pi.div 2
-          1000
-    1
-
-  lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
-    abs
-      minus.
-        times.
-          arc-sine -1
-          1000
-        (pi.div 2).neg.times
-          1000
+      times.
+        plus.
+          arc-sine 0.6
+          arc-sine -0.6
+        1000
     1
 
   lt. ++> tests-arc-sine-of-half-is-pi-sixths
@@ -86,6 +74,8 @@
           1000
     1
 
+  (arc-sine nan).is-nan ++> tests-arc-sine-of-nan-is-nan
+
   lt. ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
     abs
       minus.
@@ -93,6 +83,29 @@
           arc-sine -0.5
           1000
         (pi.div 6).neg.times
+          1000
+    1
+
+  (arc-sine ninf).is-nan ++> tests-arc-sine-of-negative-infinity-is-nan
+
+  lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
+    abs
+      minus.
+        times.
+          arc-sine -1
+          1000
+        (pi.div 2).neg.times
+          1000
+    1
+
+  lt. ++> tests-arc-sine-of-one-is-pi-halves
+    abs
+      minus.
+        times.
+          arc-sine 1
+          1000
+        times.
+          pi.div 2
           1000
     1
 
@@ -105,21 +118,8 @@
         643.5
     1
 
-  lt. ++> tests-arc-sine-is-odd-function
-    abs
-      times.
-        plus.
-          arc-sine 0.6
-          arc-sine -0.6
-        1000
-    1
-
-  (arc-sine 2).is-nan ++> tests-arc-sine-above-one-is-nan
-
-  (arc-sine -2).is-nan ++> tests-arc-sine-below-minus-one-is-nan
-
-  (arc-sine nan).is-nan ++> tests-arc-sine-of-nan-is-nan
-
   (arc-sine pinf).is-nan ++> tests-arc-sine-of-positive-infinity-is-nan
 
-  (arc-sine ninf).is-nan ++> tests-arc-sine-of-negative-infinity-is-nan
+  eq. ++> tests-arc-sine-of-zero-is-zero
+    arc-sine 0
+    0

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -13,14 +13,19 @@
     num.plus
       pi.div 2
 
-  lt. ++> tests-cosine-of-zero-is-one
+  lt. ++> tests-cosine-is-even-function
     abs
-      minus.
-        times.
-          cosine 0
-          1000
+      times.
+        minus.
+          cosine
+            pi.div 3
+          cosine (pi.div 3).neg
         1000
     1
+
+  (cosine nan).is-nan ++> tests-cosine-of-nan-is-nan
+
+  (cosine ninf).is-nan ++> tests-cosine-of-negative-infinity-is-nan
 
   lt. ++> tests-cosine-of-pi-halves-is-zero
     abs
@@ -49,13 +54,23 @@
         500
     1
 
-  lt. ++> tests-cosine-is-even-function
+  (cosine pinf).is-nan ++> tests-cosine-of-positive-infinity-is-nan
+
+  lt. ++> tests-cosine-of-seventeen-radians
     abs
-      times.
-        minus.
-          cosine
-            pi.div 3
-          cosine (pi.div 3).neg
+      minus.
+        times.
+          cosine 17
+          1000
+        -275
+    1
+
+  lt. ++> tests-cosine-of-zero-is-one
+    abs
+      minus.
+        times.
+          cosine 0
+          1000
         1000
     1
 
@@ -69,18 +84,3 @@
           1000
         500
     1
-
-  lt. ++> tests-cosine-of-seventeen-radians
-    abs
-      minus.
-        times.
-          cosine 17
-          1000
-        -275
-    1
-
-  (cosine nan).is-nan ++> tests-cosine-of-nan-is-nan
-
-  (cosine pinf).is-nan ++> tests-cosine-of-positive-infinity-is-nan
-
-  (cosine ninf).is-nan ++> tests-cosine-of-negative-infinity-is-nan

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -14,15 +14,13 @@
     pi
   number num.as-bytes > value
 
-  eq. ++> tests-degrees-of-zero-is-zero
-    degrees 0
-    0
+  (degrees nan).is-nan ++> tests-degrees-of-nan-is-nan
 
-  lt. ++> tests-degrees-of-pi-is-half-turn
+  lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
     abs
       minus.
-        degrees pi
-        180
+        degrees pi.neg
+        -180
     1.0E-4
 
   lt. ++> tests-degrees-of-pi-halves-is-quarter-turn
@@ -33,6 +31,13 @@
         90
     1.0E-4
 
+  lt. ++> tests-degrees-of-pi-is-half-turn
+    abs
+      minus.
+        degrees pi
+        180
+    1.0E-4
+
   lt. ++> tests-degrees-of-two-pi-is-full-turn
     abs
       minus.
@@ -41,11 +46,6 @@
         360
     1.0E-4
 
-  lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
-    abs
-      minus.
-        degrees pi.neg
-        -180
-    1.0E-4
-
-  (degrees nan).is-nan ++> tests-degrees-of-nan-is-nan
+  eq. ++> tests-degrees-of-zero-is-zero
+    degrees 0
+    0

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -12,6 +12,14 @@
     e
     num
 
+  eq. ++> tests-exp-check-infinity-n1
+    exp pinf
+    pinf
+
+  eq. ++> tests-exp-check-infinity-n2
+    exp ninf
+    0
+
   lt. ++> tests-exp-check-n0
     abs
       e.minus
@@ -40,11 +48,3 @@
     1.0E-12
 
   (exp nan).is-nan ++> tests-exp-check-nan
-
-  eq. ++> tests-exp-check-infinity-n1
-    exp pinf
-    pinf
-
-  eq. ++> tests-exp-check-infinity-n2
-    exp ninf
-    0

--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -21,22 +21,22 @@
       trunc
   n.as-i64.as-number > trunc
 
-  3.7.floor.eq 3 ++> tests-floor-positive-fraction
-
   -3.7.floor.eq -4 ++> tests-floor-negative-fraction
 
   -0.1.floor.eq -1 ++> tests-floor-negative-small-fraction
 
   42.floor.eq 42 ++> tests-floor-of-integer
 
-  -5.floor.eq -5 ++> tests-floor-of-negative-integer
+  -1.0e20.floor.eq -1.0e20 ++> tests-floor-of-large-negative-integer
 
   1.0e20.floor.eq 1.0e20 ++> tests-floor-of-large-positive-integer
 
-  -1.0e20.floor.eq -1.0e20 ++> tests-floor-of-large-negative-integer
+  -5.floor.eq -5 ++> tests-floor-of-negative-integer
 
   0.floor.eq 0 ++> tests-floor-of-zero
 
-  pinf.floor.eq pinf ++> tests-positive-infinity-floor-is-equal-to-self
+  3.7.floor.eq 3 ++> tests-floor-positive-fraction
 
   ninf.floor.eq ninf ++> tests-negative-infinity-floor-is-equal-to-self
+
+  pinf.floor.eq pinf ++> tests-positive-infinity-floor-is-equal-to-self

--- a/eo-runtime/src/main/eo/number/gte.eo
+++ b/eo-runtime/src/main/eo/number/gte.eo
@@ -13,10 +13,6 @@
     n.eq value
   x > value!
 
-  eq. ++> tests-int-gte-true
-    -1000.gte -1100
-    true
-
   eq. ++> tests-int-gte-equal
     113.gte 113
     true
@@ -26,50 +22,54 @@
       0.gte 10
     true
 
-  eq. ++> tests-positive-infinity-gte-positive-infinity
-    pinf.gte pinf
+  eq. ++> tests-int-gte-true
+    -1000.gte -1100
     true
 
-  eq. ++> tests-positive-infinity-gte-negative-infinity
-    pinf.gte ninf
-    true
-
-  eq. ++> tests-positive-infinity-not-gte-nan
-    pinf.gte nan
-    false
-
-  eq. ++> tests-positive-infinity-gte-int
-    pinf.gte 42
-    true
-
-  eq. ++> tests-positive-infinity-gte-float
-    pinf.gte 42.5
-    true
-
-  eq. ++> tests-negative-infinity-gte-negative-infinity
-    ninf.gte ninf
-    true
-
-  eq. ++> tests-negative-infinity-not-gte-positive-infinity
-    ninf.gte pinf
-    false
-
-  eq. ++> tests-negative-infinity-not-gte-nan
-    ninf.gte nan
-    false
-
-  eq. ++> tests-negative-infinity-not-gte-int
-    ninf.gte 42
-    false
-
-  eq. ++> tests-negative-infinity-not-gte-float
-    ninf.gte 42.5
+  eq. ++> tests-nan-not-gte-nan
+    nan.gte nan
     false
 
   eq. ++> tests-nan-not-gte-number
     nan.gte 42
     false
 
-  eq. ++> tests-nan-not-gte-nan
-    nan.gte nan
+  eq. ++> tests-negative-infinity-gte-negative-infinity
+    ninf.gte ninf
+    true
+
+  eq. ++> tests-negative-infinity-not-gte-float
+    ninf.gte 42.5
+    false
+
+  eq. ++> tests-negative-infinity-not-gte-int
+    ninf.gte 42
+    false
+
+  eq. ++> tests-negative-infinity-not-gte-nan
+    ninf.gte nan
+    false
+
+  eq. ++> tests-negative-infinity-not-gte-positive-infinity
+    ninf.gte pinf
+    false
+
+  eq. ++> tests-positive-infinity-gte-float
+    pinf.gte 42.5
+    true
+
+  eq. ++> tests-positive-infinity-gte-int
+    pinf.gte 42
+    true
+
+  eq. ++> tests-positive-infinity-gte-negative-infinity
+    pinf.gte ninf
+    true
+
+  eq. ++> tests-positive-infinity-gte-positive-infinity
+    pinf.gte pinf
+    true
+
+  eq. ++> tests-positive-infinity-not-gte-nan
+    pinf.gte nan
     false

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -46,6 +46,28 @@
               a.plus b
         fun b
 
+  ++> tests-calculates-cube-integral
+    close-to > @
+      as-number.
+        integral
+          (x.times x).times x > [x]
+          1
+          10
+          100
+      2499.75
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
   ++> tests-calculates-lineal-integral
     close-to > @
       as-number.
@@ -77,28 +99,6 @@
           10
           100
       333
-      1.0E-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs
-            value.minus operand
-          err
-        0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
-
-  ++> tests-calculates-cube-integral
-    close-to > @
-      as-number.
-        integral
-          (x.times x).times x > [x]
-          1
-          10
-          100
-      2499.75
       1.0E-7
     [value operand err] > close-to
       lte. > @

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -14,12 +14,12 @@
         n.as-bytes.eq 7F-F0-00-00-00-00-00-00
         n.as-bytes.eq FF-F0-00-00-00-00-00-00
 
+  nan.is-finite.not ++> nan-is-not-finite
+
   32.is-finite ++> simple-number-is-finite
+
+  ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
 
   (number pinf.as-bytes).is-finite.not ++> tests-number-with-infinite-bytes-is-not-finite
 
   pinf.is-finite.not ++> tests-positive-infinity-is-not-finite
-
-  ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
-
-  nan.is-finite.not ++> nan-is-not-finite

--- a/eo-runtime/src/main/eo/number/is-integer.eo
+++ b/eo-runtime/src/main/eo/number/is-integer.eo
@@ -11,12 +11,12 @@
   n.is-finite.and > @
     n.eq n.floor
 
-  32.is-integer ++> int-number-is-integer
-
   32.5.is-integer.not ++> float-number-is-not-integer
 
-  pinf.is-integer.not ++> tests-positive-infinity-is-not-integer
+  32.is-integer ++> int-number-is-integer
+
+  nan.is-integer.not ++> nan-is-not-integer
 
   ninf.is-integer.not ++> tests-negative-infinity-is-not-integer
 
-  nan.is-integer.not ++> nan-is-not-integer
+  pinf.is-integer.not ++> tests-positive-infinity-is-not-integer

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -10,22 +10,11 @@
 [n] > is-nan
   n.as-bytes.eq 7F-F8-00-00-00-00-00-00 > @
 
-  42.5.is-nan.not ++> tests-simple-number-is-not-nan
+  nan.is-nan ++> nan-is-nan
 
-  (number nan.as-bytes).is-nan ++> tests-number-with-nan-bytes-is-nan
-
-  pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
-
-  ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
-
-  eq. ++> tests-nan-times-number-is-nan
+  eq. ++> tests-nan-div-nan-is-nan
     as-bytes.
-      nan.times 42
-    nan.as-bytes
-
-  eq. ++> tests-nan-times-nan-is-nan
-    as-bytes.
-      nan.times nan
+      nan.div nan
     nan.as-bytes
 
   eq. ++> tests-nan-div-number-is-nan
@@ -33,9 +22,23 @@
       nan.div 42
     nan.as-bytes
 
-  eq. ++> tests-nan-div-nan-is-nan
+  nan.floor.as-bytes.eq nan.as-bytes ++> tests-nan-floor-is-nan
+
+  eq. ++> tests-nan-minus-nan-is-nan
     as-bytes.
-      nan.div nan
+      nan.minus nan
+    nan.as-bytes
+
+  eq. ++> tests-nan-minus-number-is-nan
+    as-bytes.
+      nan.minus 42
+    nan.as-bytes
+
+  nan.@.as-bytes.eq nan.as-bytes ++> tests-nan-neg-is-nan
+
+  eq. ++> tests-nan-plus-nan-is-nan
+    as-bytes.
+      nan.plus nan
     nan.as-bytes
 
   eq. ++> tests-nan-plus-number-is-nan
@@ -43,23 +46,20 @@
       nan.plus 42
     nan.as-bytes
 
-  eq. ++> tests-nan-plus-nan-is-nan
+  eq. ++> tests-nan-times-nan-is-nan
     as-bytes.
-      nan.plus nan
+      nan.times nan
     nan.as-bytes
 
-  nan.@.as-bytes.eq nan.as-bytes ++> tests-nan-neg-is-nan
-
-  eq. ++> tests-nan-minus-number-is-nan
+  eq. ++> tests-nan-times-number-is-nan
     as-bytes.
-      nan.minus 42
+      nan.times 42
     nan.as-bytes
 
-  eq. ++> tests-nan-minus-nan-is-nan
-    as-bytes.
-      nan.minus nan
-    nan.as-bytes
+  ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
 
-  nan.floor.as-bytes.eq nan.as-bytes ++> tests-nan-floor-is-nan
+  (number nan.as-bytes).is-nan ++> tests-number-with-nan-bytes-is-nan
 
-  nan.is-nan ++> nan-is-nan
+  pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
+
+  42.5.is-nan.not ++> tests-simple-number-is-not-nan

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -23,7 +23,6 @@
         n.is-finite.if
           lnp n
           pinf
-  number num.as-bytes > n
   [p] > lnp
     if. > @
       p.gte e
@@ -43,11 +42,6 @@
       2.times > @
         t.times
           horner 0
-      div. > t
-        m.minus 1
-        m.plus 1
-      t.times t > squared
-      40 > terms
       if. > [k] > horner
         k.gt terms
         0
@@ -57,29 +51,12 @@
           squared.times
             horner
               k.plus 1
-
-  (ln -2.2).is-nan ++> tests-ln-of-negative-float-is-nan
-
-  eq. ++> tests-ln-of-zero-is-negative-infinity
-    ln 0
-    ninf
-
-  eq. ++> tests-ln-of-one-is-zero
-    ln 1
-    0
-
-  eq. ++> tests-ln-of-e-one-is-one
-    ln e
-    1
-
-  (ln -42).is-nan ++> tests-ln-of-negative-int-is-nan
-
-  lt. ++> tests-ln-of-twenty
-    abs
-      minus.
-        ln 20
-        2.995732273553991
-    1.0E-11
+      t.times t > squared
+      div. > t
+        m.minus 1
+        m.plus 1
+      40 > terms
+  number num.as-bytes > n
 
   lt. ++> tests-ln-fraction
     abs
@@ -88,14 +65,37 @@
         -0.6931471805599453
     1.0E-11
 
-  eq. ++> tests-ln-positive-infinity
-    ln pinf
-    pinf
-
-  (ln ninf).is-nan ++> tests-ln-negative-infinity
-
-  (ln nan).is-nan ++> tests-ln-nan
-
   lt. ++> tests-ln-monotonic
     ln 2
     ln 3
+
+  (ln nan).is-nan ++> tests-ln-nan
+
+  (ln ninf).is-nan ++> tests-ln-negative-infinity
+
+  eq. ++> tests-ln-of-e-one-is-one
+    ln e
+    1
+
+  (ln -2.2).is-nan ++> tests-ln-of-negative-float-is-nan
+
+  (ln -42).is-nan ++> tests-ln-of-negative-int-is-nan
+
+  eq. ++> tests-ln-of-one-is-zero
+    ln 1
+    0
+
+  lt. ++> tests-ln-of-twenty
+    abs
+      minus.
+        ln 20
+        2.995732273553991
+    1.0E-11
+
+  eq. ++> tests-ln-of-zero-is-negative-infinity
+    ln 0
+    ninf
+
+  eq. ++> tests-ln-positive-infinity
+    ln pinf
+    pinf

--- a/eo-runtime/src/main/eo/number/lt.eo
+++ b/eo-runtime/src/main/eo/number/lt.eo
@@ -13,8 +13,6 @@
       number value
   x > value!
 
-  10.lt 50 ++> tests-int-less-true
-
   eq. ++> tests-int-less-equal
     not.
       10.lt 10
@@ -25,25 +23,19 @@
       10.lt -5
     true
 
-  eq. ++> tests-positive-infinity-lt-positive-infinity
-    pinf.lt pinf
+  10.lt 50 ++> tests-int-less-true
+
+  eq. ++> tests-nan-not-lt-nan
+    nan.lt nan
     false
 
-  eq. ++> tests-positive-infinity-not-lt-negative-infinity
-    pinf.lt ninf
+  eq. ++> tests-nan-not-lt-number
+    nan.lt 42
     false
 
-  eq. ++> tests-positive-infinity-not-lt-nan
-    pinf.lt nan
-    false
+  ninf.lt 42.5 ++> tests-negative-infinity-lt-float
 
-  eq. ++> tests-positive-infinity-not-lt-int
-    pinf.lt 42
-    false
-
-  eq. ++> tests-positive-infinity-not-lt-float
-    pinf.lt 42.5
-    false
+  ninf.lt 42 ++> tests-negative-infinity-lt-int
 
   eq. ++> tests-negative-infinity-lt-negative-infinity
     ninf.lt ninf
@@ -57,14 +49,22 @@
     ninf.lt nan
     false
 
-  ninf.lt 42 ++> tests-negative-infinity-lt-int
-
-  ninf.lt 42.5 ++> tests-negative-infinity-lt-float
-
-  eq. ++> tests-nan-not-lt-number
-    nan.lt 42
+  eq. ++> tests-positive-infinity-lt-positive-infinity
+    pinf.lt pinf
     false
 
-  eq. ++> tests-nan-not-lt-nan
-    nan.lt nan
+  eq. ++> tests-positive-infinity-not-lt-float
+    pinf.lt 42.5
+    false
+
+  eq. ++> tests-positive-infinity-not-lt-int
+    pinf.lt 42
+    false
+
+  eq. ++> tests-positive-infinity-not-lt-nan
+    pinf.lt nan
+    false
+
+  eq. ++> tests-positive-infinity-not-lt-negative-infinity
+    pinf.lt ninf
     false

--- a/eo-runtime/src/main/eo/number/lte.eo
+++ b/eo-runtime/src/main/eo/number/lte.eo
@@ -13,10 +13,6 @@
     n.eq value
   x > value!
 
-  eq. ++> tests-int-leq-true
-    -200.lte -100
-    true
-
   eq. ++> tests-int-leq-equal
     50.lte 50
     true
@@ -26,25 +22,25 @@
       0.lte -10
     true
 
-  eq. ++> tests-positive-infinity-lte-positive-infinity
-    pinf.lte pinf
+  eq. ++> tests-int-leq-true
+    -200.lte -100
     true
 
-  eq. ++> tests-positive-infinity-not-lte-negative-infinity
-    pinf.lte ninf
+  eq. ++> tests-nan-not-lte-nan
+    nan.lte nan
     false
 
-  eq. ++> tests-positive-infinity-not-lte-nan
-    pinf.lte nan
+  eq. ++> tests-nan-not-lte-number
+    nan.lte 42
     false
 
-  eq. ++> tests-positive-infinity-not-lte-int
-    pinf.lte 42
-    false
+  eq. ++> tests-negative-infinity-lte-float
+    ninf.lte 42.5
+    true
 
-  eq. ++> tests-positive-infinity-not-lte-float
-    pinf.lte 42.5
-    false
+  eq. ++> tests-negative-infinity-lte-int
+    ninf.lte 42
+    true
 
   eq. ++> tests-negative-infinity-lte-negative-infinity
     ninf.lte ninf
@@ -58,18 +54,22 @@
     ninf.lte nan
     false
 
-  eq. ++> tests-negative-infinity-lte-int
-    ninf.lte 42
+  eq. ++> tests-positive-infinity-lte-positive-infinity
+    pinf.lte pinf
     true
 
-  eq. ++> tests-negative-infinity-lte-float
-    ninf.lte 42.5
-    true
-
-  eq. ++> tests-nan-not-lte-number
-    nan.lte 42
+  eq. ++> tests-positive-infinity-not-lte-float
+    pinf.lte 42.5
     false
 
-  eq. ++> tests-nan-not-lte-nan
-    nan.lte nan
+  eq. ++> tests-positive-infinity-not-lte-int
+    pinf.lte 42
+    false
+
+  eq. ++> tests-positive-infinity-not-lte-nan
+    pinf.lte nan
+    false
+
+  eq. ++> tests-positive-infinity-not-lte-negative-infinity
+    pinf.lte ninf
     false

--- a/eo-runtime/src/main/eo/number/minus.eo
+++ b/eo-runtime/src/main/eo/number/minus.eo
@@ -13,6 +13,36 @@
       number value
   x > value!
 
+  eq. ++> tests-negative-infinity-minus-nan
+    as-bytes.
+      ninf.minus nan
+    nan.as-bytes
+
+  eq. ++> tests-negative-infinity-minus-negative-float
+    ninf.minus -42.5
+    ninf
+
+  eq. ++> tests-negative-infinity-minus-negative-infinity
+    as-bytes.
+      ninf.minus ninf
+    nan.as-bytes
+
+  eq. ++> tests-negative-infinity-minus-negative-int
+    ninf.minus -42
+    ninf
+
+  eq. ++> tests-negative-infinity-minus-positive-float
+    ninf.minus 42.5
+    ninf
+
+  eq. ++> tests-negative-infinity-minus-positive-infinity
+    ninf.minus pinf
+    ninf
+
+  eq. ++> tests-negative-infinity-minus-positive-int
+    ninf.minus 42
+    ninf
+
   eq. ++> tests-one-minus-one
     1.minus 1
     0
@@ -22,57 +52,27 @@
       pinf.minus nan
     nan.as-bytes
 
-  eq. ++> tests-positive-infinity-minus-positive-infinity
-    as-bytes.
-      pinf.minus pinf
-    nan.as-bytes
+  eq. ++> tests-positive-infinity-minus-negative-float
+    pinf.minus -42.5
+    pinf
 
   eq. ++> tests-positive-infinity-minus-negative-infinity
     pinf.minus ninf
-    pinf
-
-  eq. ++> tests-positive-infinity-minus-positive-float
-    pinf.minus 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-minus-positive-int
-    pinf.minus 42
-    pinf
-
-  eq. ++> tests-positive-infinity-minus-negative-float
-    pinf.minus -42.5
     pinf
 
   eq. ++> tests-positive-infinity-minus-negative-int
     pinf.minus -42
     pinf
 
-  eq. ++> tests-negative-infinity-minus-nan
+  eq. ++> tests-positive-infinity-minus-positive-float
+    pinf.minus 42.5
+    pinf
+
+  eq. ++> tests-positive-infinity-minus-positive-infinity
     as-bytes.
-      ninf.minus nan
+      pinf.minus pinf
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-minus-negative-infinity
-    as-bytes.
-      ninf.minus ninf
-    nan.as-bytes
-
-  eq. ++> tests-negative-infinity-minus-positive-infinity
-    ninf.minus pinf
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-positive-float
-    ninf.minus 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-positive-int
-    ninf.minus 42
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-negative-float
-    ninf.minus -42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-negative-int
-    ninf.minus -42
-    ninf
+  eq. ++> tests-positive-infinity-minus-positive-int
+    pinf.minus 42
+    pinf

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -19,8 +19,6 @@
       dividend.gt 0
       abs-mod
       abs-mod.neg
-  number x.as-bytes > dividend
-  number y.as-bytes > divisor
   [] > abs-mod
     absx.minus > @
       absy.times
@@ -28,12 +26,43 @@
           absx.div absy
     abs dividend > absx
     abs divisor > absy
+  number x.as-bytes > dividend
+  number y.as-bytes > divisor
 
-  eq. ++> tests-mod-n1-n2
+  ++> tests-div-mod-compatibility
+    eq. > @
+      plus.
+        mod dividend divisor
+        divisor.times
+          (dividend.div divisor).as-i64.as-number
+      dividend
+    -13 > dividend
+    5 > divisor
+
+  eq. ++> tests-mod-by-zero-returns-provided-fallback
+    "recovered"
     mod
+      5
+      0
+      "recovered" > [msg]
+
+  eq. ++> tests-mod-dividend-by-one
+    mod
+      133
       1
-      2
-    1
+    0
+
+  eq. ++> tests-mod-dividend-less-than-divisor
+    mod
+      -1
+      5
+    -1
+
+  eq. ++> tests-mod-n0-n15-neg
+    mod
+      0
+      -15
+    0
 
   eq. ++> tests-mod-n0-n5
     mod
@@ -41,11 +70,11 @@
       5
     0
 
-  eq. ++> tests-mod-n0-n15-neg
+  eq. ++> tests-mod-n1-n2
     mod
-      0
-      -15
-    0
+      1
+      2
+    1
 
   eq. ++> tests-mod-n1-neg-n7
     mod
@@ -59,35 +88,6 @@
       -200
     16
 
-  ++> tests-div-mod-compatibility
-    eq. > @
-      plus.
-        mod dividend divisor
-        divisor.times
-          (dividend.div divisor).as-i64.as-number
-      dividend
-    -13 > dividend
-    5 > divisor
-
-  eq. ++> tests-mod-dividend-less-than-divisor
-    mod
-      -1
-      5
-    -1
-
-  eq. ++> tests-mod-dividend-by-one
-    mod
-      133
-      1
-    0
-
   mod --> on-mod-by-zero
     5
     0
-
-  eq. ++> tests-mod-by-zero-returns-provided-fallback
-    "recovered"
-    mod
-      5
-      0
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/number/neg.eo
+++ b/eo-runtime/src/main/eo/number/neg.eo
@@ -10,6 +10,6 @@
 [n] > neg
   n.times -1 > @
 
-  pinf.neg.eq ninf ++> tests-positive-infinity-neg-is-negative-infinity
-
   ninf.neg.eq pinf ++> tests-negative-infinity-neg-is-positive-infinity
+
+  pinf.neg.eq ninf ++> tests-positive-infinity-neg-is-negative-infinity

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -66,8 +66,30 @@
                 pinf
   number num.as-bytes > base
   number x.as-bytes > expo
-  expo.is-integer.and > odd
-    (expo.div 2).is-integer.not
+  [y] > expon
+    whole.times > @
+      fraction 1
+    20 > eterms
+    if. > [j] > fraction
+      j.gt eterms
+      1
+      1.plus
+        times.
+          r.div j
+          fraction
+            j.plus 1
+    floor. > k
+      y.plus 0.5
+    y.minus k > r
+    if. > whole
+      k.lt 0
+      1.div
+        ipow
+          e
+          abs k
+      ipow
+        e
+        abs k
   [b n] > ipow
     if. > @
       n.eq 0
@@ -83,40 +105,51 @@
     ipow > half
       b
       n.div 2
-  [y] > expon
-    whole.times > @
-      fraction 1
-    floor. > k
-      y.plus 0.5
-    y.minus k > r
-    20 > eterms
-    if. > whole
-      k.lt 0
-      1.div
-        ipow
-          e
-          abs k
-      ipow
-        e
-        abs k
-    if. > [j] > fraction
-      j.gt eterms
-      1
-      1.plus
-        times.
-          r.div j
-          fraction
-            j.plus 1
+  expo.is-integer.and > odd
+    (expo.div 2).is-integer.not
 
-  eq. ++> tests-power-of-two-to-four
-    power
-      2
-      4
+  (power 52 nan).is-nan ++> tests-power-any-to-nan-is-nan
+
+  eq. ++> tests-power-as-method-on-number
+    2.power 4
     16
 
-  eq. ++> tests-power-of-zero-exponent
+  eq. ++> tests-power-as-method-with-receiver-bound
+    3.power 2
+    9
+
+  lt. ++> tests-power-cube-root-of-twenty-seven
+    abs
+      minus.
+        power
+          27
+          1.div 3
+        3
+    1.0E-9
+
+  eq. ++> tests-power-float-to-zero-is-one
     power
-      2
+      42.5
+      0
+    1
+
+  eq. ++> tests-power-four-to-five
+    power
+      4
+      5
+    1024
+
+  eq. ++> tests-power-four-to-minus-three
+    power
+      4
+      -3
+    0.015625
+
+  (power -4 0.5).is-nan ++> tests-power-fractional-of-negative-is-nan
+
+  eq. ++> tests-power-int-to-zero-is-one
+    power
+      42
       0
     1
 
@@ -126,71 +159,9 @@
       -12341
     0
 
-  eq. ++> tests-power-of-three-squared
-    power
-      3
-      2
-    9
-
-  eq. ++> tests-power-of-zero-base
-    power
-      0
-      145
-    0
-
-  eq. ++> tests-power-zero-to-negative-odd
-    power
-      0
-      -567
-    pinf
-
-  (power nan nan).is-nan ++> tests-power-nan-to-nan-is-nan
-
   (power nan 42).is-nan ++> tests-power-nan-to-any-is-nan
 
-  (power 52 nan).is-nan ++> tests-power-any-to-nan-is-nan
-
-  eq. ++> tests-power-int-to-zero-is-one
-    power
-      42
-      0
-    1
-
-  eq. ++> tests-power-float-to-zero-is-one
-    power
-      42.5
-      0
-    1
-
-  eq. ++> tests-power-zero-to-negative-is-positive-infinity
-    power
-      0
-      -52
-    pinf
-
-  eq. ++> tests-power-zero-to-negative-infinity-is-positive-infinity
-    power
-      0
-      ninf
-    pinf
-
-  eq. ++> tests-power-positive-int-to-negative-infinity-is-zero
-    power
-      42
-      ninf
-    0
-
-  eq. ++> tests-power-positive-float-to-negative-infinity-is-zero
-    power
-      42.5
-      ninf
-    0
-
-  eq. ++> tests-power-negative-int-to-negative-infinity-is-zero
-    power
-      -42
-      ninf
-    0
+  (power nan nan).is-nan ++> tests-power-nan-to-nan-is-nan
 
   eq. ++> tests-power-negative-float-to-negative-infinity-is-zero
     power
@@ -198,11 +169,17 @@
       ninf
     0
 
-  eq. ++> tests-power-positive-infinity-to-negative-infinity-is-zero
+  eq. ++> tests-power-negative-float-to-positive-infinity-is-positive-infinity
     power
+      -4.2
       pinf
+    pinf
+
+  eq. ++> tests-power-negative-infinity-to-even-int-is-positive-infinity
+    power
       ninf
-    0
+      10
+    pinf
 
   eq. ++> tests-power-negative-infinity-to-negative-infinity-is-zero
     power
@@ -210,58 +187,22 @@
       ninf
     0
 
-  eq. ++> tests-power-positive-infinity-to-negative-int-is-zero
+  eq. ++> tests-power-negative-infinity-to-odd-int-is-negative-infinity
     power
-      pinf
+      ninf
+      9
+    ninf
+
+  eq. ++> tests-power-negative-infinity-to-positive-float-is-positive-infinity
+    power
+      ninf
+      9.9
+    pinf
+
+  eq. ++> tests-power-negative-int-to-negative-infinity-is-zero
+    power
       -42
-    0
-
-  eq. ++> tests-power-positive-infinity-to-negative-float-is-zero
-    power
-      pinf
-      -42.2
-    0
-
-  eq. ++> tests-power-two-to-minus-one
-    power
-      2
-      -1
-    0.5
-
-  eq. ++> tests-power-two-to-minus-two
-    power
-      2
-      -2
-    0.25
-
-  eq. ++> tests-power-two-to-minus-three
-    power
-      2
-      -3
-    0.125
-
-  eq. ++> tests-power-four-to-minus-three
-    power
-      4
-      -3
-    0.015625
-
-  eq. ++> tests-power-zero-to-positive-int-is-zero
-    power
-      0
-      4
-    0
-
-  eq. ++> tests-power-zero-to-positive-float-is-zero
-    power
-      0
-      4.2
-    0
-
-  eq. ++> tests-power-zero-to-positive-infinity-is-zero
-    power
-      0
-      pinf
+      ninf
     0
 
   eq. ++> tests-power-negative-int-to-positive-infinity-is-positive-infinity
@@ -270,17 +211,35 @@
       pinf
     pinf
 
-  eq. ++> tests-power-negative-float-to-positive-infinity-is-positive-infinity
+  eq. ++> tests-power-of-three-squared
     power
-      -4.2
-      pinf
-    pinf
+      3
+      2
+    9
 
-  eq. ++> tests-power-positive-int-to-positive-infinity-is-positive-infinity
+  eq. ++> tests-power-of-two-to-four
     power
-      42
-      pinf
-    pinf
+      2
+      4
+    16
+
+  eq. ++> tests-power-of-zero-base
+    power
+      0
+      145
+    0
+
+  eq. ++> tests-power-of-zero-exponent
+    power
+      2
+      0
+    1
+
+  eq. ++> tests-power-positive-float-to-negative-infinity-is-zero
+    power
+      42.5
+      ninf
+    0
 
   eq. ++> tests-power-positive-float-to-positive-infinity-is-positive-infinity
     power
@@ -288,11 +247,29 @@
       pinf
     pinf
 
-  eq. ++> tests-power-positive-infinity-to-positive-int-is-positive-infinity
+  eq. ++> tests-power-positive-float-to-positive-int
+    power
+      3.5
+      4
+    150.0625
+
+  eq. ++> tests-power-positive-infinity-to-negative-float-is-zero
     power
       pinf
-      42
-    pinf
+      -42.2
+    0
+
+  eq. ++> tests-power-positive-infinity-to-negative-infinity-is-zero
+    power
+      pinf
+      ninf
+    0
+
+  eq. ++> tests-power-positive-infinity-to-negative-int-is-zero
+    power
+      pinf
+      -42
+    0
 
   eq. ++> tests-power-positive-infinity-to-positive-float-is-positive-infinity
     power
@@ -306,41 +283,29 @@
       pinf
     pinf
 
-  eq. ++> tests-power-negative-infinity-to-positive-float-is-positive-infinity
+  eq. ++> tests-power-positive-infinity-to-positive-int-is-positive-infinity
     power
-      ninf
-      9.9
+      pinf
+      42
     pinf
 
-  eq. ++> tests-power-negative-infinity-to-even-int-is-positive-infinity
+  eq. ++> tests-power-positive-int-to-negative-infinity-is-zero
     power
+      42
       ninf
-      10
-    pinf
+    0
 
-  eq. ++> tests-power-negative-infinity-to-odd-int-is-negative-infinity
+  eq. ++> tests-power-positive-int-to-positive-infinity-is-positive-infinity
     power
-      ninf
-      9
-    ninf
+      42
+      pinf
+    pinf
 
   eq. ++> tests-power-positive-int-to-positive-int
     power
       2
       3
     8
-
-  eq. ++> tests-power-positive-float-to-positive-int
-    power
-      3.5
-      4
-    150.0625
-
-  eq. ++> tests-power-four-to-five
-    power
-      4
-      5
-    1024
 
   lt. ++> tests-power-square-root-of-nine
     abs
@@ -356,27 +321,62 @@
         1.4142135623730951
     1.0E-9
 
-  lt. ++> tests-power-cube-root-of-twenty-seven
-    abs
-      minus.
-        power
-          27
-          1.div 3
-        3
-    1.0E-9
+  eq. ++> tests-power-two-to-minus-one
+    power
+      2
+      -1
+    0.5
 
-  (power -4 0.5).is-nan ++> tests-power-fractional-of-negative-is-nan
+  eq. ++> tests-power-two-to-minus-three
+    power
+      2
+      -3
+    0.125
 
-  eq. ++> tests-power-as-method-on-number
-    2.power 4
-    16
-
-  eq. ++> tests-power-as-method-with-receiver-bound
-    3.power 2
-    9
+  eq. ++> tests-power-two-to-minus-two
+    power
+      2
+      -2
+    0.25
 
   eq. ++> tests-power-via-number-namespace
     power
       2
       4
     16
+
+  eq. ++> tests-power-zero-to-negative-infinity-is-positive-infinity
+    power
+      0
+      ninf
+    pinf
+
+  eq. ++> tests-power-zero-to-negative-is-positive-infinity
+    power
+      0
+      -52
+    pinf
+
+  eq. ++> tests-power-zero-to-negative-odd
+    power
+      0
+      -567
+    pinf
+
+  eq. ++> tests-power-zero-to-positive-float-is-zero
+    power
+      0
+      4.2
+    0
+
+  eq. ++> tests-power-zero-to-positive-infinity-is-zero
+    power
+      0
+      pinf
+    0
+
+  eq. ++> tests-power-zero-to-positive-int-is-zero
+    power
+      0
+      4
+    0

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -14,15 +14,27 @@
     180
   number num.as-bytes > value
 
-  eq. ++> tests-radians-of-zero-is-zero
-    radians 0
-    0
+  lt. ++> tests-radians-of-full-turn-is-two-pi
+    abs
+      minus.
+        radians 360
+        pi.times 2
+    1.0E-4
 
   lt. ++> tests-radians-of-half-turn-is-pi
     abs
       minus.
         radians 180
         pi
+    1.0E-4
+
+  (radians nan).is-nan ++> tests-radians-of-nan-is-nan
+
+  lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
+    abs
+      minus.
+        radians -180
+        pi.neg
     1.0E-4
 
   lt. ++> tests-radians-of-quarter-turn-is-pi-halves
@@ -32,18 +44,6 @@
         pi.div 2
     1.0E-4
 
-  lt. ++> tests-radians-of-full-turn-is-two-pi
-    abs
-      minus.
-        radians 360
-        pi.times 2
-    1.0E-4
-
-  lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
-    abs
-      minus.
-        radians -180
-        pi.neg
-    1.0E-4
-
-  (radians nan).is-nan ++> tests-radians-of-nan-is-nan
+  eq. ++> tests-radians-of-zero-is-zero
+    radians 0
+    0

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -10,26 +10,6 @@
 
 [seed] > random
   seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
-  random > next
-    as-number.
-      as-i64.
-        and.
-          as-bytes.
-            plus.
-              plus.
-                as-i64.
-                  left.
-                    and.
-                      as-bytes.
-                        ((seed.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
-                          25214903917.as-i64
-                      00-00-00-00-03-FF-FF-FF
-                    26
-                as-i64.
-                  (seed.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
-                    25214903917.as-i64
-              11.as-i64
-          00-0F-FF-FF-FF-FF-FF-FF
   [clock] > clocked
     random > @
       as-number.
@@ -51,16 +31,27 @@
     35 > shift1
     17 > shift3
     clock.as-bytes > tbytes
+  random > next
+    as-number.
+      as-i64.
+        and.
+          as-bytes.
+            plus.
+              plus.
+                as-i64.
+                  left.
+                    and.
+                      as-bytes.
+                        ((seed.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                          25214903917.as-i64
+                      00-00-00-00-03-FF-FF-FF
+                    26
+                as-i64.
+                  (seed.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                    25214903917.as-i64
+              11.as-i64
+          00-0F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
-
-  ++> tests-random-with-seed
-    not. > @
-      r.next.eq r.next.next
-    random 51 > r
-
-  eq. ++> tests-seeded-randoms-are-equal
-    (random 1654).next.next.next
-    (random 1654).next.next.next
 
   ++> tests-random-is-in-range
     and. > @
@@ -77,6 +68,15 @@
           rand.next.next.lt 0
     next. > rand
       random 123
+
+  ++> tests-random-with-seed
+    not. > @
+      r.next.eq r.next.next
+    random 51 > r
+
+  eq. ++> tests-seeded-randoms-are-equal
+    (random 1654).next.next.next
+    (random 1654).next.next.next
 
   ++> tests-two-random-numbers-not-equal
     not. > @

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -14,16 +14,6 @@
   reduced.times > @
     factor 1
   number num.as-bytes > arg
-  pi.times 2 > tau
-  arg.minus > reduced
-    times.
-      floor.
-        plus.
-          arg.div tau
-          0.5
-      tau
-  reduced.times reduced > squared
-  15 > terms
   if. > [depth] > factor
     depth.gt terms
     1
@@ -34,10 +24,39 @@
             (depth.times 2).plus 1
         factor
           depth.plus 1
+  arg.minus > reduced
+    times.
+      floor.
+        plus.
+          arg.div tau
+          0.5
+      tau
+  reduced.times reduced > squared
+  pi.times 2 > tau
+  15 > terms
 
-  eq. ++> tests-sine-of-zero-is-zero
-    sine 0
-    0
+  lt. ++> tests-sine-is-odd-function
+    abs
+      times.
+        plus.
+          sine
+            pi.div 3
+          sine (pi.div 3).neg
+        1000
+    1
+
+  (sine nan).is-nan ++> tests-sine-of-nan-is-nan
+
+  (sine ninf).is-nan ++> tests-sine-of-negative-infinity-is-nan
+
+  lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
+    abs
+      minus.
+        times.
+          sine (pi.div 2).neg
+          1000
+        -1000
+    1
 
   lt. ++> tests-sine-of-pi-halves-is-one
     abs
@@ -46,6 +65,13 @@
           sine
             pi.div 2
           1000
+        1000
+    1
+
+  lt. ++> tests-sine-of-pi-is-zero
+    abs
+      times.
+        sine pi
         1000
     1
 
@@ -59,20 +85,15 @@
         500
     1
 
-  lt. ++> tests-sine-of-pi-is-zero
-    abs
-      times.
-        sine pi
-        1000
-    1
+  (sine pinf).is-nan ++> tests-sine-of-positive-infinity-is-nan
 
-  lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
+  lt. ++> tests-sine-of-seventeen-radians
     abs
       minus.
         times.
-          sine (pi.div 2).neg
+          sine 17
           1000
-        -1000
+        -961
     1
 
   lt. ++> tests-sine-of-three-pi-halves-is-minus-one
@@ -85,16 +106,6 @@
         -1000
     1
 
-  lt. ++> tests-sine-is-odd-function
-    abs
-      times.
-        plus.
-          sine
-            pi.div 3
-          sine (pi.div 3).neg
-        1000
-    1
-
   lt. ++> tests-sine-of-two-pi-is-zero
     abs
       times.
@@ -102,6 +113,10 @@
           pi.times 2
         1000
     1
+
+  eq. ++> tests-sine-of-zero-is-zero
+    sine 0
+    0
 
   lt. ++> tests-sine-reduces-large-angle
     abs
@@ -113,18 +128,3 @@
           1000
         500
     1
-
-  lt. ++> tests-sine-of-seventeen-radians
-    abs
-      minus.
-        times.
-          sine 17
-          1000
-        -961
-    1
-
-  (sine nan).is-nan ++> tests-sine-of-nan-is-nan
-
-  (sine pinf).is-nan ++> tests-sine-of-positive-infinity-is-nan
-
-  (sine ninf).is-nan ++> tests-sine-of-negative-infinity-is-nan

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -18,19 +18,44 @@
       num
       0.5
 
-  eq. ++> tests-sqrt-zero
-    sqrt 0
-    0
+  lt. ++> tests-sqrt-check-float-input
+    abs
+      2.minus
+        sqrt 4
+    1.0E-11
 
-  eq. ++> tests-sqrt-one
-    sqrt 1
-    1
+  eq. ++> tests-sqrt-check-infinity-n1
+    sqrt pinf
+    pinf
+
+  (sqrt ninf).is-nan ++> tests-sqrt-check-infinity-n2
+
+  (sqrt nan).is-nan ++> tests-sqrt-check-nan-input
+
+  (sqrt -0.1).is-nan ++> tests-sqrt-check-negative-input
+
+  lt. ++> tests-sqrt-check-zero-input
+    abs
+      0.minus
+        sqrt 0
+    1.0E-11
 
   lt. ++> tests-sqrt-four
     abs
       minus.
         sqrt 4
         2
+    1.0E-9
+
+  eq. ++> tests-sqrt-one
+    sqrt 1
+    1
+
+  lt. ++> tests-sqrt-point-five
+    abs
+      minus.
+        sqrt 0.25
+        0.5
     1.0E-9
 
   lt. ++> tests-sqrt-two
@@ -40,31 +65,6 @@
         1.4142135623730951
     1.0E-9
 
-  lt. ++> tests-sqrt-point-five
-    abs
-      minus.
-        sqrt 0.25
-        0.5
-    1.0E-9
-
-  lt. ++> tests-sqrt-check-zero-input
-    abs
-      0.minus
-        sqrt 0
-    1.0E-11
-
-  (sqrt -0.1).is-nan ++> tests-sqrt-check-negative-input
-
-  lt. ++> tests-sqrt-check-float-input
-    abs
-      2.minus
-        sqrt 4
-    1.0E-11
-
-  (sqrt nan).is-nan ++> tests-sqrt-check-nan-input
-
-  eq. ++> tests-sqrt-check-infinity-n1
-    sqrt pinf
-    pinf
-
-  (sqrt ninf).is-nan ++> tests-sqrt-check-infinity-n2
+  eq. ++> tests-sqrt-zero
+    sqrt 0
+    0

--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -13,13 +13,6 @@
 
 [] > os
   name > @
-  [] > is-windows
-    and. > @
-      oname.size.gt 6
-      eq.
-        oname.slice 0 7
-        "Windows"
-    name > oname!
   as-bool. > is-linux
     matches.
       string.regex "/linux/i"
@@ -28,6 +21,13 @@
     matches.
       string.regex "/mac/i"
       name
+  [] > is-windows
+    and. > @
+      oname.size.gt 6
+      eq.
+        oname.slice 0 7
+        "Windows"
+    name > oname!
   [] > name /Q.string
 
   or. ++> tests-checks-os-family

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -20,9 +20,6 @@
       string uri.as-bytes
     posix
       string uri.as-bytes
-  os.is-windows.if > separator
-    win32.separator
-    posix.separator
   [paths] > joined
     normalized. > @
       os.is-windows.if
@@ -36,12 +33,52 @@
     directory > as-dir
       file uri
     file uri > as-file
+    [] > basename
+      string > @
+        if.
+          (pth.size.eq 0).or
+            idx.eq 0
+          pth
+          as-bytes.
+            txt.slice
+              idx
+              txt.length.minus
+                number idx
+      plus. > idx!
+        string.last-index-of txt separator
+        1
+      uri > pth!
+      string pth > txt
+    [] > dirname
+      string > @
+        if.
+          (pth.size.eq 0).or
+            len.eq -1
+          pth
+          (txt.slice 0 len).as-bytes
+      string.last-index-of txt separator > len!
+      uri > pth!
+      string pth > txt
+    [] > extname
+      if. > @
+        or.
+          base.size.eq 0
+          idx.eq -1
+        ""
+        string
+          as-bytes.
+            txt.slice
+              idx
+              txt.length.minus
+                number idx
+      basename > base!
+      string.last-index-of txt "." > idx!
+      string base > txt
     and. > is-absolute
       uri.length.gt 0
       eq.
         uri.as-bytes.slice 0 1
         separator
-    "/" > separator
     [] > normalized
       posix > @
         if.
@@ -95,47 +132,10 @@
               obts
               (uri.concat separator).concat obts
       other.as-bytes > obts
-    [] > basename
-      string > @
-        if.
-          (pth.size.eq 0).or
-            idx.eq 0
-          pth
-          as-bytes.
-            txt.slice
-              idx
-              txt.length.minus
-                number idx
-      plus. > idx!
-        string.last-index-of txt separator
-        1
-      uri > pth!
-      string pth > txt
-    [] > extname
-      if. > @
-        or.
-          base.size.eq 0
-          idx.eq -1
-        ""
-        string
-          as-bytes.
-            txt.slice
-              idx
-              txt.length.minus
-                number idx
-      basename > base!
-      string.last-index-of txt "." > idx!
-      string base > txt
-    [] > dirname
-      string > @
-        if.
-          (pth.size.eq 0).or
-            len.eq -1
-          pth
-          (txt.slice 0 len).as-bytes
-      string.last-index-of txt separator > len!
-      uri > pth!
-      string pth > txt
+    "/" > separator
+  os.is-windows.if > separator
+    win32.separator
+    posix.separator
   [uri] > win32
     validated > @
       string
@@ -147,7 +147,54 @@
       directory > as-dir
         file uri
       file uri > as-file
-      ^.separator > separator
+      [] > basename
+        string > @
+          if.
+            (pth.size.eq 0).or
+              idx.eq 0
+            pth
+            as-bytes.
+              txt.slice
+                idx
+                txt.length.minus
+                  number idx
+        plus. > idx!
+          string.last-index-of txt separator
+          1
+        uri > pth!
+        string pth > txt
+      [] > dirname
+        string > @
+          if.
+            (pth.size.eq 0).or
+              len.eq -1
+            pth
+            (txt.slice 0 len).as-bytes
+        string.last-index-of txt separator > len!
+        uri > pth!
+        string pth > txt
+      [] > extname
+        if. > @
+          (base.size.eq 0).or
+            idx.eq -1
+          ""
+          string
+            as-bytes.
+              txt.slice
+                idx
+                txt.length.minus
+                  number idx
+        basename > base!
+        string.last-index-of txt "." > idx!
+        string base > txt
+      [] > is-absolute
+        if. > @
+          ubts.size.eq 0
+          false
+          (is-root-relative ubts).or
+            (ubts.size.gt 1).and
+              is-drive-relative ubts
+        uri > ubts!
       [uri] > is-drive-relative
         as-bool. > @
           (string.regex "/^[a-zA-Z]:/").matches uri
@@ -156,26 +203,6 @@
           ubts.size.gt 0
           (ubts.slice 0 1).eq
             separator
-        uri > ubts!
-      [uri] > separated-correctly
-        if. > @
-          (string.index-of pth path.posix.separator).eq
-            -1
-          string ubts
-          string repl
-        string ubts > pth
-        string.replaced > repl!
-          pth
-          string.regex "/\\//"
-          separator
-        uri > ubts!
-      [] > is-absolute
-        if. > @
-          ubts.size.eq 0
-          false
-          (is-root-relative ubts).or
-            (ubts.size.gt 1).and
-              is-drive-relative ubts
         uri > ubts!
       [] > normalized
         validated > @
@@ -250,51 +277,19 @@
                   (ubts.concat separator).concat valid
         uri > ubts!
         separated-correctly other > valid!
-      [] > basename
-        string > @
-          if.
-            (pth.size.eq 0).or
-              idx.eq 0
-            pth
-            as-bytes.
-              txt.slice
-                idx
-                txt.length.minus
-                  number idx
-        plus. > idx!
-          string.last-index-of txt separator
-          1
-        uri > pth!
-        string pth > txt
-      [] > extname
+      [uri] > separated-correctly
         if. > @
-          (base.size.eq 0).or
-            idx.eq -1
-          ""
-          string
-            as-bytes.
-              txt.slice
-                idx
-                txt.length.minus
-                  number idx
-        basename > base!
-        string.last-index-of txt "." > idx!
-        string base > txt
-      [] > dirname
-        string > @
-          if.
-            (pth.size.eq 0).or
-              len.eq -1
-            pth
-            (txt.slice 0 len).as-bytes
-        string.last-index-of txt separator > len!
-        uri > pth!
-        string pth > txt
-
-  path.separator.eq ++> tests-determines-separator-depending-on-os
-    os.is-windows.if
-      path.win32.separator
-      path.posix.separator
+          (string.index-of pth path.posix.separator).eq
+            -1
+          string ubts
+          string repl
+        string ubts > pth
+        string.replaced > repl!
+          pth
+          string.regex "/\\//"
+          separator
+        uri > ubts!
+      ^.separator > separator
 
   and. ++> tests-detects-absolute-posix-path
     is-absolute.
@@ -307,6 +302,54 @@
         path.win32 "\\Windows\\Users"
     (path.win32 "temp\\var").is-absolute.not
 
+  path.separator.eq ++> tests-determines-separator-depending-on-os
+    os.is-windows.if
+      path.win32.separator
+      path.posix.separator
+
+  eq. ++> tests-does-not-take-extname-if-ends-with-separator
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          path.separator
+    ""
+
+  eq. ++> tests-does-not-take-extname-on-file-without-extension
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+    ""
+
+  eq. ++> tests-normalizes-absolute-win32-path-with-drive
+    normalized.
+      path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal"
+    "C:\\Users\\AppLocal"
+
+  eq. ++> tests-normalizes-absolute-win32-path-without-drive
+    normalized.
+      path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\"
+    "\\Windows\\App\\Local\\"
+
+  eq. ++> tests-normalizes-empty-posix-path-to-current-dir
+    normalized.
+      path.posix ""
+    "."
+
+  eq. ++> tests-normalizes-empty-win32-driveless-path-to-current-dir
+    normalized.
+      path.win32 ""
+    "."
+
+  eq. ++> tests-normalizes-path-to-root
+    normalized.
+      path.posix "/foo/bar/baz/../../../../"
+    "/"
+
   eq. ++> tests-normalizes-posix-path
     normalized.
       path.posix "/foo/bar/.//./baz//../x/"
@@ -317,35 +360,10 @@
       path.posix "../../foo/./bar/../x/../y"
     "../../foo/y"
 
-  eq. ++> tests-normalizes-empty-posix-path-to-current-dir
-    normalized.
-      path.posix ""
-    "."
-
-  eq. ++> tests-normalizes-path-to-root
-    normalized.
-      path.posix "/foo/bar/baz/../../../../"
-    "/"
-
-  eq. ++> tests-normalizes-absolute-win32-path-without-drive
-    normalized.
-      path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\"
-    "\\Windows\\App\\Local\\"
-
-  eq. ++> tests-normalizes-absolute-win32-path-with-drive
-    normalized.
-      path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal"
-    "C:\\Users\\AppLocal"
-
   eq. ++> tests-normalizes-relative-win32-path
     normalized.
       path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
     "..\\..\\foo\\x\\y\\"
-
-  eq. ++> tests-normalizes-empty-win32-driveless-path-to-current-dir
-    normalized.
-      path.win32 ""
-    "."
 
   eq. ++> tests-normalizes-win32-path-down-to-drive-with-separator
     normalized.
@@ -386,23 +404,11 @@
       "../www/html"
     "var/www/html"
 
-  eq. ++> tests-resolves-win32-relative-path-against-other-relative-path
+  eq. ++> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
     resolved.
-      path.win32 ".\\temp\\var"
-      ".\\..\\x"
-    "temp\\x"
-
-  eq. ++> tests-resolves-win32-relative-path-against-other-drive-relative-path
-    resolved.
-      path.win32 ".\\temp\\var"
-      "C:\\Windows\\Users"
-    "C:\\Windows\\Users"
-
-  eq. ++> tests-resolves-win32-relative-path-against-other-root-relative-path
-    resolved.
-      path.win32 ".\\temp\\var"
-      "\\Windows\\Users"
-    "\\Windows\\Users"
+      path.win32 "C:\\users\\local"
+      "D:\\local\\var"
+    "D:\\local\\var"
 
   eq. ++> tests-resolves-win32-drive-relative-path-against-other-relative-path
     resolved.
@@ -410,23 +416,29 @@
       ".\\var\\temp"
     "C:\\users\\local\\var\\temp"
 
-  eq. ++> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
-    resolved.
-      path.win32 "C:\\users\\local"
-      "D:\\local\\var"
-    "D:\\local\\var"
-
   eq. ++> tests-resolves-win32-drive-relative-path-against-other-root-relative-path
     resolved.
       path.win32 "C:\\users\\local"
       "\\local\\var"
     "C:\\local\\var"
 
-  eq. ++> tests-resolves-win32-root-relative-path-against-other-relative-path
+  eq. ++> tests-resolves-win32-relative-path-against-other-drive-relative-path
     resolved.
-      path.win32 "\\users\\local"
-      ".\\hello\\var"
-    "\\users\\local\\hello\\var"
+      path.win32 ".\\temp\\var"
+      "C:\\Windows\\Users"
+    "C:\\Windows\\Users"
+
+  eq. ++> tests-resolves-win32-relative-path-against-other-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      ".\\..\\x"
+    "temp\\x"
+
+  eq. ++> tests-resolves-win32-relative-path-against-other-root-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      "\\Windows\\Users"
+    "\\Windows\\Users"
 
   eq. ++> tests-resolves-win32-root-relative-path-against-other-drive-relative-path
     resolved.
@@ -434,21 +446,22 @@
       "D:\\hello\\var"
     "D:\\hello\\var"
 
+  eq. ++> tests-resolves-win32-root-relative-path-against-other-relative-path
+    resolved.
+      path.win32 "\\users\\local"
+      ".\\hello\\var"
+    "\\users\\local\\hello\\var"
+
   eq. ++> tests-resolves-win32-root-relative-path-against-other-root-relative-path
     resolved.
       path.win32 "\\users\\local"
       "\\hello\\var"
     "\\hello\\var"
 
-  eq. ++> tests-takes-valid-basename
+  eq. ++> tests-returns-base-with-backslash-in-path-on-posix
     basename.
-      path.joined
-        *
-          "var"
-          "www"
-          "html"
-          "hello.eo"
-    "hello.eo"
+      path.posix "/var/www/html/foo\\bar"
+    "foo\\bar"
 
   eq. ++> tests-returns-empty-basename-from-path-ended-with-separator
     basename.
@@ -460,52 +473,10 @@
           path.separator
     ""
 
-  eq. ++> tests-returns-base-with-backslash-in-path-on-posix
-    basename.
-      path.posix "/var/www/html/foo\\bar"
-    "foo\\bar"
-
   eq. ++> tests-returns-the-same-string-if-no-separator-is-found
     basename.
       path "Somebody"
     "Somebody"
-
-  eq. ++> tests-takes-file-extname
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          "hello.txt"
-    ".txt"
-
-  eq. ++> tests-does-not-take-extname-on-file-without-extension
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          "html"
-    ""
-
-  eq. ++> tests-does-not-take-extname-if-ends-with-separator
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          path.separator
-    ""
-
-  eq. ++> tests-returns-valid-dirname-from-file-path
-    dirname.
-      path.joined
-        *
-          "var"
-          "www"
-          "hello.txt"
-    path.joined
-      * "var" "www"
 
   eq. ++> tests-returns-valid-dirname-from-dir-path
     dirname.
@@ -514,6 +485,16 @@
           "var"
           "www"
           path.separator
+    path.joined
+      * "var" "www"
+
+  eq. ++> tests-returns-valid-dirname-from-file-path
+    dirname.
+      path.joined
+        *
+          "var"
+          "www"
+          "hello.txt"
     path.joined
       * "var" "www"
 
@@ -526,3 +507,22 @@
           "html"
     path.joined
       * "var" "www"
+
+  eq. ++> tests-takes-file-extname
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "hello.txt"
+    ".txt"
+
+  eq. ++> tests-takes-valid-basename
+    basename.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+          "hello.eo"
+    "hello.eo"

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -15,34 +15,23 @@
 
 [name args] > posix
   [] > @ /Q.return
-  2 > inet
-  -1 > none
-  6 > tcp
-  0 > rdonly
-  1 > wronly
-  2 > rdwr
-  os.is-macos.if > creat
-    512
-    64
-  os.is-macos.if > trunc
-    1024
-    512
   os.is-macos.if > append
     8
     1024
+  os.is-macos.if > creat
+    512
+    64
+  2 > inet
   420 > mode
+  -1 > none
   511 > permissions
-  1 > stream
-  0 > stdin
-  1 > stdout
-  2 > stderr
+  0 > rdonly
+  2 > rdwr
   [code output] > return
     output > @
     return > called
       code
       output
-  [seconds micros] > timeval
-  [mode size] > stat
   [family port address] > sockaddr-in
     00-00-00-00-00-00-00-00 > padding
     plus. > size
@@ -50,6 +39,35 @@
         family.size.plus port.size
         address.size
       padding.size
+  [mode size] > stat
+  2 > stderr
+  0 > stdin
+  1 > stdout
+  1 > stream
+  6 > tcp
+  [seconds micros] > timeval
+  os.is-macos.if > trunc
+    1024
+    512
+  1 > wronly
+
+  ++> tests-closes-posix-tcp-socket
+    os.is-windows.or > @
+      seq *
+        sd
+        not.
+          eq.
+            code.
+              posix *1
+                "close"
+                sd
+            -1
+    code. > sd
+      posix *1
+        "socket"
+        posix.inet
+        posix.stream
+        posix.tcp
 
   os.is-windows.or ++> tests-invokes-getpid-correctly
     gt.
@@ -82,24 +100,6 @@
             "close"
             sd
         sd.gt 0
-    code. > sd
-      posix *1
-        "socket"
-        posix.inet
-        posix.stream
-        posix.tcp
-
-  ++> tests-closes-posix-tcp-socket
-    os.is-windows.or > @
-      seq *
-        sd
-        not.
-          eq.
-            code.
-              posix *1
-                "close"
-                sd
-            -1
     code. > sd
       posix *1
         "socket"

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -43,6 +43,29 @@
       current.next
     acc
 
+  ++> tests-range-with-out-of-bounds
+    rng.eq > @
+      * 1 6
+    range > rng
+      []
+        b 1 > @
+        [num] > b
+          num > @
+          b > next
+            5.plus @
+      10
+
+  ++> tests-range-with-wrong-items-is-an-empty-array
+    tuple.is-empty rng > @
+    range > rng
+      []
+        y 10 > @
+        [num] > y
+          num > @
+          [] > next
+            42 > nothing
+      1
+
   ++> tests-simple-range-from-one-to-ten
     rng.eq > @
       *
@@ -83,26 +106,3 @@
           x > next
             0.5.plus @
       5
-
-  ++> tests-range-with-out-of-bounds
-    rng.eq > @
-      * 1 6
-    range > rng
-      []
-        b 1 > @
-        [num] > b
-          num > @
-          b > next
-            5.plus @
-      10
-
-  ++> tests-range-with-wrong-items-is-an-empty-array
-    tuple.is-empty rng > @
-    range > rng
-      []
-        y 10 > @
-        [num] > y
-          num > @
-          [] > next
-            42 > nothing
-      1

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -14,17 +14,17 @@
 
 [value alternative] > recovered /Q.bytes
 
-  eq. ++> tests-keeps-the-value-when-not-terminated
-    recovered
-      42
-      7
-    42
-
   eq. ++> tests-falls-back-to-alternative-when-terminated
     recovered
       2.as-i64.div 0.as-i64
       7
     7
+
+  eq. ++> tests-keeps-the-value-when-not-terminated
+    recovered
+      42
+      7
+    42
 
   eq. ++> tests-recovers-the-inner-recovery
     recovered

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -32,19 +32,17 @@
         steps.head
         steps.head
 
-  ++> tests-seq-single-dataization-float-less
-    malloc.of > @
+  eq. ++> tests-seq-calculates-and-returns
+    1
+    seq *
+      0
       1
-      [b]
-        malloc.for > @
-          0
-          b.put > [m] >>
-            lt.
-              seq *
-                m.put
-                  m.as-number.plus 1
-                m.as-number
-              1.1
+
+  eq. ++> tests-seq-calculates-and-returns-object
+    "Hello!"
+    seq *
+      0
+      "Hello!"
 
   ++> tests-seq-single-dataization-float-greater
     malloc.of > @
@@ -59,6 +57,52 @@
                   m.as-number.plus 1
                 m.as-number
               0.9
+
+  ++> tests-seq-single-dataization-float-less
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            lt.
+              seq *
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1.1
+
+  ++> tests-seq-single-dataization-int-equal-to-cache-problem-test
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            eq.
+              seq *
+                at.
+                  * 0 1
+                  m
+                m.put
+                  m.as-number.plus 1
+                m
+              1
+
+  ++> tests-seq-single-dataization-int-equal-to-test
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            eq.
+              seq *
+                m.put 0
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1
 
   ++> tests-seq-single-dataization-int-less
     malloc.of > @
@@ -132,47 +176,3 @@
       true
       true
       true
-
-  ++> tests-seq-single-dataization-int-equal-to-test
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          b.put > [m] >>
-            eq.
-              seq *
-                m.put 0
-                m.put
-                  m.as-number.plus 1
-                m.as-number
-              1
-
-  ++> tests-seq-single-dataization-int-equal-to-cache-problem-test
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          b.put > [m] >>
-            eq.
-              seq *
-                at.
-                  * 0 1
-                  m
-                m.put
-                  m.as-number.plus 1
-                m
-              1
-
-  eq. ++> tests-seq-calculates-and-returns
-    1
-    seq *
-      0
-      1
-
-  eq. ++> tests-seq-calculates-and-returns-object
-    "Hello!"
-    seq *
-      0
-      "Hello!"

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -17,21 +17,20 @@
         map.entry item true > [item]
   [mp] > initialized
     mp.keys > @
+    mp.has item > [item] > has
     mp.size > size
     set.initialized > [item] > with
       mp.with item true
     set.initialized > [item] > without
       mp.without item
-    mp.has item > [item] > has
 
-  eq. ++> tests-set-rebuilds-itself
-    set *
-      1
-      2
-      2
-    *
-      1
-      2
+  has. ++> tests-appends-new-item-to-set
+    with.
+      set *
+        1
+        2
+      3
+    3
 
   eq. ++> tests-does-not-append-existed-item-to-set
     size.
@@ -42,16 +41,17 @@
         1
     2
 
-  has. ++> tests-appends-new-item-to-set
-    with.
-      set *
-        1
-        2
-      3
-    3
-
   eq. ++> tests-empty-set-has-size-of-zero
     size.
       set
         *
     0
+
+  eq. ++> tests-set-rebuilds-itself
+    set *
+      1
+      2
+      2
+    *
+      1
+      2

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -55,18 +55,6 @@
     impl
       []
         raw > @
-        win32 > raw
-        "closesocket" > close
-        "WSA error code %d".printf > message
-          *
-            code.
-              win32
-                "WSAGetLastError"
-                *
-        code. > startup
-          win32 *1
-            "WSAStartup"
-            win32.version
         if. > cleanup
           eq.
             code.
@@ -77,10 +65,22 @@
           T
             "Couldn't clean up the sockets subsystem"
           true
+        "closesocket" > close
+        "WSA error code %d".printf > message
+          *
+            code.
+              win32
+                "WSAGetLastError"
+                *
+        win32 > raw
+        code. > startup
+          win32 *1
+            "WSAStartup"
+            win32.version
     impl
       []
         raw > @
-        posix > raw
+        true > cleanup
         "close" > close
         code. > message
           posix *1
@@ -89,18 +89,8 @@
               posix
                 "errno"
                 *
+        posix > raw
         0 > startup
-        true > cleanup
-  [port] > htons
-    as-i16. > @
-      or.
-        left.
-          bts.and 00-FF
-          8
-        and.
-          bts.right 8
-          00-FF
-    port.as-i16.as-bytes > bts
   [recv] > as-input
     [size] > read
       @. > @
@@ -123,53 +113,22 @@
         seq * > [buffer] > write
           send buffer
           output-block
+  [port] > htons
+    as-i16. > @
+      or.
+        left.
+          bts.and 00-FF
+          8
+        and.
+          bts.right 8
+          00-FF
+    port.as-i16.as-bytes > bts
   [sys] > impl
     code. > addr
       sys.raw *1
         "inet_addr"
         address
     addr.as-i32 > addrint
-    code. > sd
-      sys.raw *1
-        "socket"
-        sys.inet
-        sys.stream
-        sys.tcp
-    sys.sockaddr-in > sockaddr
-      sys.inet.as-i16
-      htons port
-      addrint
-    [sockfd] > scoped-socket
-      ^.^.as-input recv > as-input
-      ^.^.as-output send > as-output
-      [buffer cant-send] > send
-        if. > @
-          sent.eq -1
-          cant-send
-            "Failed to send a message through the socket #%d because %s".printf
-              * sockfd sys.message
-          sent
-        buffer > buff!
-        code. > sent
-          sys.raw *1
-            "send"
-            sockfd
-            buff
-            buff.size
-            0
-      [size cant-receive] > recv
-        if. > @
-          received.code.eq -1
-          cant-receive
-            "Failed to receive data from the socket #%d because %s".printf
-              * sockfd sys.message
-          received.output
-        called. > received
-          sys.raw *1
-            "recv"
-            sockfd
-            size
-            0
     [sockfd] > closed-socket
       if. > @
         closed.eq -1
@@ -181,32 +140,6 @@
         sys.raw *1
           sys.close
           sockfd
-    [scope cant] > safe-socket
-      if. > @
-        not.
-          sys.startup.eq 0
-        cant
-          "Couldn't start up the sockets subsystem because %s".printf
-            * sys.message
-        seq *
-          result
-          sys.cleanup
-          result
-      if. > result!
-        sd.eq -1
-        cant
-          "Couldn't create a socket because %s".printf
-            * sys.message
-        seq *
-          used
-          closed-socket sd
-          used
-      if. > used!
-        addr.eq sys.none
-        cant
-          "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
-            * address sys.message
-        scope
     [scope cant-connect] > connect
       safe-socket > @
         [] >>
@@ -271,3 +204,70 @@
               2048
           ^.^ > sock
         cant-listen
+    [scope cant] > safe-socket
+      if. > @
+        not.
+          sys.startup.eq 0
+        cant
+          "Couldn't start up the sockets subsystem because %s".printf
+            * sys.message
+        seq *
+          result
+          sys.cleanup
+          result
+      if. > result!
+        sd.eq -1
+        cant
+          "Couldn't create a socket because %s".printf
+            * sys.message
+        seq *
+          used
+          closed-socket sd
+          used
+      if. > used!
+        addr.eq sys.none
+        cant
+          "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
+            * address sys.message
+        scope
+    [sockfd] > scoped-socket
+      ^.^.as-input recv > as-input
+      ^.^.as-output send > as-output
+      [size cant-receive] > recv
+        if. > @
+          received.code.eq -1
+          cant-receive
+            "Failed to receive data from the socket #%d because %s".printf
+              * sockfd sys.message
+          received.output
+        called. > received
+          sys.raw *1
+            "recv"
+            sockfd
+            size
+            0
+      [buffer cant-send] > send
+        if. > @
+          sent.eq -1
+          cant-send
+            "Failed to send a message through the socket #%d because %s".printf
+              * sockfd sys.message
+          sent
+        buffer > buff!
+        code. > sent
+          sys.raw *1
+            "send"
+            sockfd
+            buff
+            buff.size
+            0
+    code. > sd
+      sys.raw *1
+        "socket"
+        sys.inet
+        sys.stream
+        sys.tcp
+    sys.sockaddr-in > sockaddr
+      sys.inet.as-i16
+      htons port
+      addrint

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -27,15 +27,6 @@
       size.eq 0
       0
       reclen 0 0
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    as-bytes.size > size
     if. > [index csize len] > inclen
       gt.
         index.plus csize
@@ -46,6 +37,14 @@
       reclen
         index.plus csize
         len.plus 1
+    80- > p1
+    E0- > p2
+    F0- > p3
+    F8- > p4
+    00- > r1
+    C0- > r2
+    p2 > r3
+    p3 > r4
     [index accum] > reclen
       if. > @
         index.eq size
@@ -66,6 +65,7 @@
                   "Unknown byte format (%x), can't recognize character".printf
                     * byte
       as-bytes.slice index 1 > byte
+    as-bytes.size > size
   [start len] > slice
     if. > @
       nstart.lt 0
@@ -98,19 +98,6 @@
       "Start index (%d) is out of string bounds".printf
         * nstart
     nstart.plus nlen > end
-    len > lbts!
-    number lbts > nlen
-    number sbts > nstart
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    start > sbts!
-    as-bytes.size > size
     if. > [index csize accum result cause] > increase
       gt.
         index.plus csize
@@ -123,6 +110,17 @@
         accum.plus 1
         result
         cause
+    len > lbts!
+    number lbts > nlen
+    number sbts > nstart
+    80- > p1
+    E0- > p2
+    F0- > p3
+    F8- > p4
+    00- > r1
+    C0- > r2
+    p2 > r3
+    p3 > r4
     [index accum result cause] > recidx
       if. > @
         accum.eq result
@@ -156,18 +154,82 @@
                     "Unknown byte format (%x), can't recognize character".printf
                       * byte
       as-bytes.slice index 1 > byte
+    start > sbts!
+    as-bytes.size > size
+
+  D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
 
   eq. ++> tests-calculates-length-of-spaces-only
     " ".length
     1
 
-  eq. ++> tests-turns-string-into-bytes
-    "€ друг".as-bytes
-    E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
+  (nan.eq "друг").not ++> tests-compares-string-with-nan
 
-  D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
+  (ninf.eq "друг").not ++> tests-compares-string-with-negative-infinity
 
-  "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
+  eq. ++> tests-compares-string-with-positive-infinity
+    pinf.eq "друг"
+    false
+
+  ("Hello".eq 42).not ++> tests-compares-two-different-string-types
+
+  ("Hello".eq "Good bye").not ++> tests-compares-two-different-strings
+
+  eq. ++> tests-compares-two-strings
+    "x".eq "x"
+    true
+
+  eq. ++> tests-no-slice-string
+    "no slice".slice
+      0
+      0
+    ""
+
+  "Ф".eq "Ф" ++> tests-one-symbol-string-compares
+
+  string.contains ++> tests-package-contains-via-string-namespace
+    "hello, world"
+    "world"
+
+  contains. ++> tests-package-contains-word-in-sentence
+    "hello, world, how are you?"
+    "how"
+
+  "eEo".is-alpha ++> tests-package-detects-alphabetic-text
+
+  "2026".is-digit ++> tests-package-detects-digits
+
+  ends-with. ++> tests-package-ends-with-suffix
+    "hello, world"
+    "world"
+
+  eq. ++> tests-package-finds-index-of-character
+    "hello".index-of "l"
+    2
+
+  "HELLO".low-cased.eq "hello" ++> tests-package-low-cases-text
+
+  eq. ++> tests-package-repeats-text
+    "ha".repeated 3
+    "hahaha"
+
+  starts-with. ++> tests-package-starts-with-prefix
+    "hello, world"
+    "hello"
+
+  eq. ++> tests-package-takes-character-at-index
+    "some".at 1
+    "o"
+
+  eq. ++> tests-package-trims-surrounding-spaces
+    "  spaced  ".trimmed
+    "spaced"
+
+  "hello".up-cased.eq "HELLO" ++> tests-package-up-cases-text
+
+  eq. ++> tests-preserves-indentation-in-text
+    "a\n b\n  c"
+    "a\n b\n  c"
 
   ++> tests-reads-the-length-with-n2-byte-characters
     and. > @
@@ -187,76 +249,8 @@
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
 
-  (string F0-9F-98).length --> on-taking-length-of-incomplete-n4-byte-character
-
-  ("Hello".eq 42).not ++> tests-compares-two-different-string-types
-
-  (nan.eq "друг").not ++> tests-compares-string-with-nan
-
-  eq. ++> tests-compares-string-with-positive-infinity
-    pinf.eq "друг"
-    false
-
-  (ninf.eq "друг").not ++> tests-compares-string-with-negative-infinity
-
-  "Abc".eq "Abc" ++> tests-text-block-one-line
-
-  "e\ne\ne".eq 65-0A-65-0A-65 ++> tests-text-block-tree-lines
-
-  eq. ++> tests-text-block-with-margin
-    "z\n  y\n x"
-    7A-0A-20-20-79-0A-20-78
-
-  ("Hello".eq "Good bye").not ++> tests-compares-two-different-strings
-
-  eq. ++> tests-supports-escape-sequences
-    "Hello, друг!\n"
-    "Hello, друг!\n"
-
-  eq. ++> tests-supports-escape-sequences-in-text
-    "Hello, друг!\n"
-    "Hello, друг!\n"
-
-  eq. ++> tests-preserves-indentation-in-text
-    "a\n b\n  c"
-    "a\n b\n  c"
-
-  eq. ++> tests-compares-two-strings
-    "x".eq "x"
-    true
-
-  "Ф".eq "Ф" ++> tests-one-symbol-string-compares
-
-  "\n".eq "\n" ++> tests-supports-escape-sequences-line-break
-
-  "Ф".eq "Ф" ++> tests-supports-escape-sequences-unicode
-
-  eq. ++> tests-slice-from-start
-    "hello".slice
-      0
-      1
-    "h"
-
-  eq. ++> tests-slice-in-the-middle
-    "hello".slice
-      2
-      3
-    "llo"
-
-  eq. ++> tests-slice-from-the-end
-    "hello".slice
-      4
-      1
-    "o"
-
   eq. ++> tests-slice-empty-string
     "".slice
-      0
-      0
-    ""
-
-  eq. ++> tests-no-slice-string
-    "no slice".slice
       0
       0
     ""
@@ -272,6 +266,30 @@
       0
       "Ф".length
     "Ф"
+
+  eq. ++> tests-slice-foreign-literals
+    "hello, 大家!".slice
+      7
+      1
+    "大"
+
+  eq. ++> tests-slice-from-start
+    "hello".slice
+      0
+      1
+    "h"
+
+  eq. ++> tests-slice-from-the-end
+    "hello".slice
+      4
+      1
+    "o"
+
+  eq. ++> tests-slice-in-the-middle
+    "hello".slice
+      2
+      3
+    "llo"
 
   eq. ++> tests-slice-with-n2-byte-characters
     "привет".slice
@@ -291,16 +309,37 @@
       8
     " 😀 and 😀"
 
-  eq. ++> tests-slice-foreign-literals
-    "hello, 大家!".slice
-      7
-      1
-    "大"
+  "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
 
-  slice. --> on-slicing-start-below-zero
-    "some string"
-    -1
-    1
+  eq. ++> tests-supports-escape-sequences
+    "Hello, друг!\n"
+    "Hello, друг!\n"
+
+  eq. ++> tests-supports-escape-sequences-in-text
+    "Hello, друг!\n"
+    "Hello, друг!\n"
+
+  "\n".eq "\n" ++> tests-supports-escape-sequences-line-break
+
+  "Ф".eq "Ф" ++> tests-supports-escape-sequences-unicode
+
+  "Abc".eq "Abc" ++> tests-text-block-one-line
+
+  "e\ne\ne".eq 65-0A-65-0A-65 ++> tests-text-block-tree-lines
+
+  eq. ++> tests-text-block-with-margin
+    "z\n  y\n x"
+    7A-0A-20-20-79-0A-20-78
+
+  eq. ++> tests-turns-string-into-bytes
+    "€ друг".as-bytes
+    E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
+
+  eq. ++> tests-unescapes-slashes
+    "x\\b\\f\\u\\r\\t\\n\\'"
+    78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+
+  "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> tests-unescapes-symbols
 
   slice. --> on-slicing-end-below-start
     "some string"
@@ -312,48 +351,9 @@
     7
     5
 
-  eq. ++> tests-unescapes-slashes
-    "x\\b\\f\\u\\r\\t\\n\\'"
-    78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+  slice. --> on-slicing-start-below-zero
+    "some string"
+    -1
+    1
 
-  "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> tests-unescapes-symbols
-
-  contains. ++> tests-package-contains-word-in-sentence
-    "hello, world, how are you?"
-    "how"
-
-  starts-with. ++> tests-package-starts-with-prefix
-    "hello, world"
-    "hello"
-
-  ends-with. ++> tests-package-ends-with-suffix
-    "hello, world"
-    "world"
-
-  "hello".up-cased.eq "HELLO" ++> tests-package-up-cases-text
-
-  "HELLO".low-cased.eq "hello" ++> tests-package-low-cases-text
-
-  eq. ++> tests-package-trims-surrounding-spaces
-    "  spaced  ".trimmed
-    "spaced"
-
-  eq. ++> tests-package-repeats-text
-    "ha".repeated 3
-    "hahaha"
-
-  eq. ++> tests-package-finds-index-of-character
-    "hello".index-of "l"
-    2
-
-  eq. ++> tests-package-takes-character-at-index
-    "some".at 1
-    "o"
-
-  "2026".is-digit ++> tests-package-detects-digits
-
-  "eEo".is-alpha ++> tests-package-detects-alphabetic-text
-
-  string.contains ++> tests-package-contains-via-string-namespace
-    "hello, world"
-    "world"
+  (string F0-9F-98).length --> on-taking-length-of-incomplete-n4-byte-character

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -14,9 +14,13 @@
     as-i16.
       00-.concat char.as-bytes
 
-  eq. ++> tests-reads-code-of-uppercase-letter
-    65
-    as-ascii "A"
+  eq. ++> tests-reads-code-of-last-lowercase-letter
+    122
+    as-ascii "z"
+
+  eq. ++> tests-reads-code-of-last-printable
+    126
+    as-ascii "~"
 
   eq. ++> tests-reads-code-of-last-uppercase-letter
     90
@@ -26,27 +30,23 @@
     97
     as-ascii "a"
 
-  eq. ++> tests-reads-code-of-last-lowercase-letter
-    122
-    as-ascii "z"
-
-  eq. ++> tests-reads-code-of-zero-digit
-    48
-    as-ascii "0"
-
   eq. ++> tests-reads-code-of-nine-digit
     57
     as-ascii "9"
+
+  eq. ++> tests-reads-code-of-punctuation
+    33
+    as-ascii "!"
 
   eq. ++> tests-reads-code-of-space
     32
     as-ascii
       " "
 
-  eq. ++> tests-reads-code-of-punctuation
-    33
-    as-ascii "!"
+  eq. ++> tests-reads-code-of-uppercase-letter
+    65
+    as-ascii "A"
 
-  eq. ++> tests-reads-code-of-last-printable
-    126
-    as-ascii "~"
+  eq. ++> tests-reads-code-of-zero-digit
+    48
+    as-ascii "0"

--- a/eo-runtime/src/main/eo/string/as-char.eo
+++ b/eo-runtime/src/main/eo/string/as-char.eo
@@ -13,10 +13,16 @@
     7
     1
 
-  eq. ++> tests-writes-byte-of-uppercase-letter
-    "A"
+  eq. ++> tests-round-trips-through-as-ascii
+    "!"
     string
-      as-char 65
+      as-char
+        as-ascii "!"
+
+  eq. ++> tests-writes-byte-of-last-printable
+    "~"
+    string
+      as-char 126
 
   eq. ++> tests-writes-byte-of-last-uppercase-letter
     "Z"
@@ -28,23 +34,17 @@
     string
       as-char 122
 
-  eq. ++> tests-writes-byte-of-zero-digit
-    "0"
-    string
-      as-char 48
-
   eq. ++> tests-writes-byte-of-space
     " "
     string
       as-char 32
 
-  eq. ++> tests-writes-byte-of-last-printable
-    "~"
+  eq. ++> tests-writes-byte-of-uppercase-letter
+    "A"
     string
-      as-char 126
+      as-char 65
 
-  eq. ++> tests-round-trips-through-as-ascii
-    "!"
+  eq. ++> tests-writes-byte-of-zero-digit
+    "0"
     string
-      as-char
-        as-ascii "!"
+      as-char 48

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -28,15 +28,15 @@
     floor. > q
       n.div 10
 
-  eq. ++> tests-writes-single-digit
-    "7"
+  eq. ++> tests-truncates-negative-fraction
+    "-7"
     string
-      as-decimal 7
+      as-decimal -7.89
 
-  eq. ++> tests-writes-zero
-    "0"
+  eq. ++> tests-truncates-positive-fraction
+    "42"
     string
-      as-decimal 0
+      as-decimal 42.987
 
   eq. ++> tests-writes-multi-digit-number
     "31415"
@@ -48,17 +48,17 @@
     string
       as-decimal -42
 
-  eq. ++> tests-truncates-positive-fraction
-    "42"
-    string
-      as-decimal 42.987
-
-  eq. ++> tests-truncates-negative-fraction
-    "-7"
-    string
-      as-decimal -7.89
-
   eq. ++> tests-writes-number-with-inner-zero
     "105"
     string
       as-decimal 105
+
+  eq. ++> tests-writes-single-digit
+    "7"
+    string
+      as-decimal 7
+
+  eq. ++> tests-writes-zero
+    "0"
+    string
+      as-decimal 0

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -16,14 +16,6 @@
       positive
         n.times -1
     positive n
-  if. > [p] > pow10
-    p.eq 0
-    1
-    times.
-      pow10
-        as-number.
-          p.minus 1
-      10
   [a] > positive
     concat. > @
       concat.
@@ -41,6 +33,14 @@
         a.times scale
         0.5
     pow10 places > scale
+  if. > [p] > pow10
+    p.eq 0
+    1
+    times.
+      pow10
+        as-number.
+          p.minus 1
+      10
   if. > [value count acc] > rec-pad
     count.eq 0
     acc
@@ -58,37 +58,37 @@
             48
         acc
 
-  eq. ++> tests-pads-with-trailing-zeros
-    "1.250000"
-    string
-      as-fixed 1.25 6
-
-  eq. ++> tests-writes-negative-value
-    "-2.500000"
-    string
-      as-fixed -2.5 6
-
-  eq. ++> tests-rounds-to-last-place
-    "0.123457"
-    string
-      as-fixed 0.123456789 6
-
   eq. ++> tests-carries-rounding-into-integer-part
     "1.000000"
     string
       as-fixed 0.9999999 6
-
-  eq. ++> tests-writes-zero
-    "0.000000"
-    string
-      as-fixed 0 6
 
   eq. ++> tests-honours-custom-places
     "3.14"
     string
       as-fixed 3.14159 2
 
+  eq. ++> tests-pads-with-trailing-zeros
+    "1.250000"
+    string
+      as-fixed 1.25 6
+
+  eq. ++> tests-rounds-to-last-place
+    "0.123457"
+    string
+      as-fixed 0.123456789 6
+
+  eq. ++> tests-writes-negative-value
+    "-2.500000"
+    string
+      as-fixed -2.5 6
+
   eq. ++> tests-writes-single-place
     "2.5"
     string
       as-fixed 2.5 1
+
+  eq. ++> tests-writes-zero
+    "0.000000"
+    string
+      as-fixed 0 6

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -20,11 +20,13 @@
     at.
       scanf "%f" text
 
+  eq. ++> tests-converts-float-text-to-number
+    3.14
+    as-number "3.14"
+
   eq. ++> tests-converts-text-to-number
     5
     as-number "5"
-
-  as-number "Hello" --> on-converting-text-to-number
 
   eq. ++> tests-non-numeric-text-returns-provided-fallback
     42
@@ -32,6 +34,4 @@
       "Hello"
       42 > [msg]
 
-  eq. ++> tests-converts-float-text-to-number
-    3.14
-    as-number "3.14"
+  as-number "Hello" --> on-converting-text-to-number

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -32,6 +32,12 @@
     idx
   text.length > len!
 
+  eq. ++> tests-returns-char-at-negative-index
+    "m"
+    at
+      "some"
+      -2
+
   eq. ++> tests-returns-first-char
     "s"
     at
@@ -44,19 +50,13 @@
       "some"
       2
 
-  eq. ++> tests-returns-char-at-negative-index
-    "m"
-    at
-      "some"
-      -2
-
-  at --> on-text-at-index-more-than-length
-    "some"
-    10
-
   eq. ++> tests-text-at-out-of-bounds-returns-provided-fallback
     "recovered"
     at
       "some"
       10
       "recovered" > [msg]
+
+  at --> on-text-at-index-more-than-length
+    "some"
+    10

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -17,10 +17,20 @@
     true
     x.and a > [a x]
 
-  contains-all *1 ++> tests-successful-contains-all
-    "abcdefghijk"
-    "abc"
-    "ghi"
+  contains-all ++> test-contains-all-without-substrings
+    "xyz"
+    *
+
+  contains-all ++> tests-contains-all-for-empty-text-and-without-substrings
+    ""
+    *
+
+  contains-all *1 ++> tests-contains-all-vert
+    "Hello, world!"
+    "ell"
+    " "
+    ","
+    "d!"
 
   ++> tests-not-contains-all
     not. > @
@@ -30,17 +40,7 @@
         "ty"
         "abc"
 
-  contains-all *1 ++> tests-contains-all-vert
-    "Hello, world!"
-    "ell"
-    " "
-    ","
-    "d!"
-
-  contains-all ++> test-contains-all-without-substrings
-    "xyz"
-    *
-
-  contains-all ++> tests-contains-all-for-empty-text-and-without-substrings
-    ""
-    *
+  contains-all *1 ++> tests-successful-contains-all
+    "abcdefghijk"
+    "abc"
+    "ghi"

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -18,26 +18,6 @@
     x.or a > [a x]
   text > txt!
 
-  contains-any *1 ++> tests-successful-contains-any
-    "Good morning"
-    "oo"
-    "goo"
-
-  ++> tests-not-contains-any
-    not. > @
-      contains-any *1
-        "xyzw"
-        "yx"
-        "zyx"
-        "wx"
-        "abc"
-
-  contains-any *1 ++> tests-contains-any-vert
-    "foo bar buzz"
-    "bar"
-    " "
-    "o"
-
   ++> test-contains-any-without-substrings
     not. > @
       contains-any
@@ -49,3 +29,23 @@
       contains-any
         ""
         *
+
+  contains-any *1 ++> tests-contains-any-vert
+    "foo bar buzz"
+    "bar"
+    " "
+    "o"
+
+  ++> tests-not-contains-any
+    not. > @
+      contains-any *1
+        "xyzw"
+        "yx"
+        "zyx"
+        "wx"
+        "abc"
+
+  contains-any *1 ++> tests-successful-contains-any
+    "Good morning"
+    "oo"
+    "goo"

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -20,10 +20,6 @@
   minus. > end!
     number tlen
     slen
-  sub.size > slen!
-  substring > sub!
-  txt.size > tlen!
-  text > txt!
   [idx] > rec-contains
     if. > @
       end.eq idx
@@ -37,6 +33,10 @@
         idx
         slen
       sub
+  sub.size > slen!
+  substring > sub!
+  txt.size > tlen!
+  text > txt!
 
   contains ++> tests-text-contains-substring
     "Hello, world!"

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -25,12 +25,12 @@
   txt.size > tlen!
   text > txt!
 
-  ends-with ++> tests-ends-with-substring
-    "Hello world!"
-    "world!"
-
   ++> tests-does-not-end-with-substring
     not. > @
       ends-with
         "Hello world!"
         "Hello"
+
+  ends-with ++> tests-ends-with-substring
+    "Hello world!"
+    "world!"

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -30,10 +30,6 @@
     number tlen
     slen
   rec-index-of 0 > found!
-  sub.size > slen!
-  substring > sub!
-  txt.size > tlen!
-  text > txt!
   [idx] > rec-index-of
     if. > @
       end.eq idx
@@ -48,6 +44,16 @@
         idx
         slen
       sub
+  sub.size > slen!
+  substring > sub!
+  txt.size > tlen!
+  text > txt!
+
+  eq. ++> tests-index-of-existed-substring-with-utf
+    3
+    index-of
+      "привет, друг!"
+      "в"
 
   eq. ++> tests-index-of-non-existed-substring-with-more-length
     -1
@@ -66,12 +72,6 @@
     index-of
       "привет, друг!"
       "x"
-
-  eq. ++> tests-index-of-existed-substring-with-utf
-    3
-    index-of
-      "привет, друг!"
-      "в"
 
   eq. ++> tests-returns-valid-index-of-substring
     6

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -15,6 +15,6 @@
 
   is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
 
-  (is-alpha "ab3d").not ++> tests-checks-if-text-with-number-is-not-alpha
-
   (is-alpha "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alpha
+
+  (is-alpha "ab3d").not ++> tests-checks-if-text-with-number-is-not-alpha

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -15,6 +15,6 @@
 
   is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
 
-  is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric
-
   (is-alphanumeric "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
+
+  is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,8 +12,8 @@
     regex "/^[\\x00-\\x7F]*$/"
     text
 
-  is-ascii "H311oW" ++> tests-checks-if-text-is-ascii
-
   (is-ascii "🌵").not ++> tests-checks-if-emoji-is-not-ascii
 
   is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
+
+  is-ascii "H311oW" ++> tests-checks-if-text-is-ascii

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,13 +13,13 @@
     regex "/^[0-9]+$/"
     text
 
-  is-digit "2026" ++> tests-checks-if-number-text-is-digit
+  (is-digit "").not ++> tests-checks-if-empty-text-is-not-digit
 
-  (is-digit "1a2").not ++> tests-checks-if-text-with-letter-is-not-digit
+  is-digit "2026" ++> tests-checks-if-number-text-is-digit
 
   is-digit "7" ++> tests-checks-if-single-digit-is-digit
 
-  (is-digit "").not ++> tests-checks-if-empty-text-is-not-digit
+  (is-digit "1a2").not ++> tests-checks-if-text-with-letter-is-not-digit
 
   (is-digit "12 34").not ++> tests-checks-if-text-with-space-is-not-digit
 

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -28,6 +28,15 @@
         acc
       tup.tail
 
+  eq. ++> tests-joined-many-strings
+    "hello-world-dear-friend"
+    joined *1
+      "-"
+      "hello"
+      "world"
+      "dear"
+      "friend"
+
   eq. ++> tests-joined-no-strings
     ""
     joined
@@ -39,12 +48,3 @@
     joined *1
       "-"
       "some"
-
-  eq. ++> tests-joined-many-strings
-    "hello-world-dear-friend"
-    joined *1
-      "-"
-      "hello"
-      "world"
-      "dear"
-      "friend"

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -30,10 +30,6 @@
     minus.
       number tlen
       slen
-  sub.size > slen!
-  substring > sub!
-  txt.size > tlen!
-  text > txt!
   [idx] > rec-index-of
     if. > @
       0.eq idx
@@ -48,6 +44,10 @@
         idx
         slen
       sub
+  sub.size > slen!
+  substring > sub!
+  txt.size > tlen!
+  text > txt!
 
   eq. ++> tests-finds-last-index-of-substring
     5
@@ -61,6 +61,12 @@
       "Hello"
       "Hello"
 
+  eq. ++> tests-last-index-of-existed-substring-with-utf
+    3
+    last-index-of
+      "привет, друг!"
+      "в"
+
   eq. ++> tests-last-index-of-non-existed-substring
     -1
     last-index-of
@@ -72,9 +78,3 @@
     last-index-of
       "привет, друг!"
       "x"
-
-  eq. ++> tests-last-index-of-existed-substring-with-utf
-    3
-    last-index-of
-      "привет, друг!"
-      "в"

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -26,7 +26,6 @@
           0
           0
           0
-  delimiter.size > size!
   [accum start current count] > rec-nsplit
     if. > @
       text.size.eq current
@@ -62,15 +61,15 @@
           text
           start
           current.minus start
+  delimiter.size > size!
 
-  eq. ++> tests-nsplit-with-limit-two
+  eq. ++> tests-nsplit-invalid-limit-returns-provided-fallback
+    "fallback"
     nsplit
-      "Cookie: a=1; b=2"
-      " "
-      2
-    *
-      "Cookie:"
-      "a=1; b=2"
+      "text"
+      "-"
+      0
+      "fallback" > [msg]
 
   eq. ++> tests-nsplit-with-dashes-limit-two
     nsplit
@@ -80,41 +79,6 @@
     *
       "a"
       "b-c-d"
-
-  eq. ++> tests-nsplit-with-limit-one
-    nsplit
-      "a-b-c"
-      "-"
-      1
-    * "a-b-c"
-
-  eq. ++> tests-nsplit-with-high-limit
-    nsplit
-      "a-b-c"
-      "-"
-      10
-    *
-      "a"
-      "b"
-      "c"
-
-  nsplit --> on-nsplit-with-limit-zero
-    "text"
-    "-"
-    0
-
-  nsplit --> on-nsplit-with-negative-limit
-    "text"
-    "-"
-    -1
-
-  eq. ++> tests-nsplit-invalid-limit-returns-provided-fallback
-    "fallback"
-    nsplit
-      "text"
-      "-"
-      0
-      "fallback" > [msg]
 
   eq. ++> tests-nsplit-with-empty-strings
     nsplit
@@ -126,6 +90,32 @@
       "a"
       "b-c"
 
+  eq. ++> tests-nsplit-with-high-limit
+    nsplit
+      "a-b-c"
+      "-"
+      10
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> tests-nsplit-with-limit-one
+    nsplit
+      "a-b-c"
+      "-"
+      1
+    * "a-b-c"
+
+  eq. ++> tests-nsplit-with-limit-two
+    nsplit
+      "Cookie: a=1; b=2"
+      " "
+      2
+    *
+      "Cookie:"
+      "a=1; b=2"
+
   eq. ++> tests-nsplit-with-multi-char-delimiter
     nsplit
       "a::b::c::d"
@@ -134,3 +124,13 @@
     *
       "a"
       "b::c::d"
+
+  nsplit --> on-nsplit-with-limit-zero
+    "text"
+    "-"
+    0
+
+  nsplit --> on-nsplit-with-negative-limit
+    "text"
+    "-"
+    -1

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -20,25 +20,62 @@
 
 [format args] > printf /Q.string
 
-  eq. ++> tests-prints-simple-string
-    "Hello, Jeffrey!"
+  eq. ++> formats-float-always-with-six-fraction-digits
+    "1.250000"
     printf *1
-      "Hello, %s!"
-      "Jeffrey"
+      "%f"
+      1.25
 
-  eq. ++> tests-prints-complex-string
-    "Привет 3.140000 Jeff X!"
+  eq. ++> formats-left-justified-with-trailing-spaces
+    "x         "
     printf *1
-      "Привет %f %s %s!"
-      3.14
+      "%-10s"
+      "x"
+
+  eq. ++> formats-numbered-substitution
+    "Hello, Jeff! Bye, Jeff!"
+    printf *1
+      "Hello, %s! Bye, %1$s!"
       "Jeff"
-      "X"
 
-  eq. ++> tests-prints-bytes-string
-    "40-45-00-00-00-00-00-00"
+  eq. ++> formats-numbered-substitution-with-multiple-args
+    "This is the first; This is the first as well; The second; and the 3"
     printf *1
-      "%x"
-      42.as-bytes
+      "This is the %s; This is the %1$s as well; The %s; and the %d"
+      "first"
+      "second"
+      3
+
+  eq. ++> formats-precision-to-two-decimals
+    "3.14"
+    printf *1
+      "%.2f"
+      3.1415
+
+  eq. ++> formats-width-with-leading-spaces
+    "   42"
+    printf *1
+      "%5d"
+      42
+
+  eq. ++> formats-with-ordered-numbered-substitutions
+    "first second second is after first"
+    printf *1
+      "%s %s %2$s is after %1$s"
+      "first"
+      "second"
+
+  eq. ++> formats-zero-float-with-six-fraction-digits
+    "0.000000"
+    printf *1
+      "%f"
+      0
+
+  eq. ++> rounds-float-carrying-into-integer-part
+    "1.000000"
+    printf *1
+      "%f"
+      0.9999999
 
   eq. ++> tests-formats-all-objects
     "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
@@ -50,25 +87,11 @@
       14
       false
 
-  printf *1 --> on-printf-with-arguments-that-does-not-match
-    "%s%s"
-    "Jeff"
-
   eq. ++> tests-printf-does-not-fail-if-arguments-more-than-formats
     "Hey"
     printf *1
       "%s"
       "Hey"
-      "Jeff"
-
-  printf --> on-printf-unsupported-format
-    "%o"
-    *
-
-  eq. ++> tests-printf-prints-percents
-    "%Jeff"
-    printf *1
-      "%%%s"
       "Jeff"
 
   ++> tests-printf-does-not-print-i64
@@ -85,47 +108,43 @@
       "%d"
       42.as-i64.as-number
 
-  eq. ++> formats-numbered-substitution
-    "Hello, Jeff! Bye, Jeff!"
+  eq. ++> tests-printf-prints-percents
+    "%Jeff"
     printf *1
-      "Hello, %s! Bye, %1$s!"
+      "%%%s"
       "Jeff"
 
-  printf *1 --> on-printf-with-oversized-positional-index
-    "%99999999999999999999$s"
-    "Jeff"
-
-  printf *1 --> on-printf-with-zero-positional-index
-    "%0$s"
-    "first"
-    "second"
-
-  eq. ++> formats-numbered-substitution-with-multiple-args
-    "This is the first; This is the first as well; The second; and the 3"
+  eq. ++> tests-prints-bytes-string
+    "40-45-00-00-00-00-00-00"
     printf *1
-      "This is the %s; This is the %1$s as well; The %s; and the %d"
-      "first"
-      "second"
-      3
+      "%x"
+      42.as-bytes
 
-  eq. ++> formats-with-ordered-numbered-substitutions
-    "first second second is after first"
+  eq. ++> tests-prints-complex-string
+    "Привет 3.140000 Jeff X!"
     printf *1
-      "%s %s %2$s is after %1$s"
-      "first"
-      "second"
+      "Привет %f %s %s!"
+      3.14
+      "Jeff"
+      "X"
 
-  eq. ++> truncates-positive-float-towards-zero-as-decimal
-    "42"
+  eq. ++> tests-prints-simple-string
+    "Hello, Jeffrey!"
     printf *1
-      "%d"
-      42.321
+      "Hello, %s!"
+      "Jeffrey"
 
   eq. ++> truncates-negative-float-towards-zero-as-decimal
     "-7"
     printf *1
       "%d"
       -7.89
+
+  eq. ++> truncates-positive-float-towards-zero-as-decimal
+    "42"
+    printf *1
+      "%d"
+      42.321
 
   eq. ++> truncates-rather-than-rounds-float-as-decimal
     "9"
@@ -137,38 +156,19 @@
     "%d"
     1.0e30
 
-  eq. ++> formats-float-always-with-six-fraction-digits
-    "1.250000"
-    printf *1
-      "%f"
-      1.25
+  printf --> on-printf-unsupported-format
+    "%o"
+    *
 
-  eq. ++> rounds-float-carrying-into-integer-part
-    "1.000000"
-    printf *1
-      "%f"
-      0.9999999
+  printf *1 --> on-printf-with-arguments-that-does-not-match
+    "%s%s"
+    "Jeff"
 
-  eq. ++> formats-zero-float-with-six-fraction-digits
-    "0.000000"
-    printf *1
-      "%f"
-      0
+  printf *1 --> on-printf-with-oversized-positional-index
+    "%99999999999999999999$s"
+    "Jeff"
 
-  eq. ++> formats-width-with-leading-spaces
-    "   42"
-    printf *1
-      "%5d"
-      42
-
-  eq. ++> formats-precision-to-two-decimals
-    "3.14"
-    printf *1
-      "%.2f"
-      3.1415
-
-  eq. ++> formats-left-justified-with-trailing-spaces
-    "x         "
-    printf *1
-      "%-10s"
-      "x"
+  printf *1 --> on-printf-with-zero-positional-index
+    "%0$s"
+    "first"
+    "second"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -30,14 +30,11 @@
     ? > cant-compile /{Q.string}
   [serialized] > pattern
     pattern serialized > compiled
-    (match txt).next.exists > [txt] > matches
     [txt] > match
-      matched. > next
-        matched-from-index 1 0
-      [position start] > matched-from-index /Q.string.regex.pattern.match.matched
       [position start from to groups] > matched
         groups.length > count
         start.gte 0 > exists
+        groups.at index > [index] > group
         $ > matched
         exists.if > next
           matched.
@@ -50,17 +47,21 @@
           group 0
           T
             "Matched block does not exist, can't get text"
-        groups.at index > [index] > group
-
-  matches. ++> tests-matches-regex-against-the-pattern
-    compiled.
-      regex "/[a-z]+/"
-    "hello"
+      [position start] > matched-from-index /Q.string.regex.pattern.match.matched
+      matched. > next
+        matched-from-index 1 0
+    (match txt).next.exists > [txt] > matches
 
   ++> tests-does-not-matches-regex-against-the-pattern
     not. > @
       (regex "/[a-z]+/").compiled.matches
         "123"
+
+  eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
+    "recovered"
+    compile.
+      regex "/[a-z/"
+      "recovered" > [msg]
 
   ++> tests-matched-sequence-has-right-border-indexes
     and. > @
@@ -72,6 +73,81 @@
       match.
         regex "/[a-z]+/"
         "!hello!"
+
+  matches. ++> tests-matches-regex-against-the-pattern
+    compiled.
+      regex "/[a-z]+/"
+    "hello"
+
+  eq. ++> tests-missing-slash-returns-provided-fallback
+    "no-slash"
+    compile.
+      regex "(.)+"
+      "no-slash" > [msg]
+
+  ++> tests-regex-contains-valid-groups-on-each-matched-block
+    and. > @
+      and.
+        and.
+          first.count.eq 3
+          (first.group 1).eq "hello"
+        eq.
+          first.group 2
+          "1"
+      and.
+        and.
+          second.count.eq 3
+          (second.group 1).eq "world"
+        eq.
+          second.group 2
+          "2"
+    next. > first
+      match.
+        compiled.
+          regex "/([a-z]+)([1-9]{1})/"
+        "!hello1!world2"
+    first.next > second
+
+  matches. ++> tests-regex-ignores-comments-in-string
+    compiled.
+      regex
+        "/(\\d) #ignore this comment/x"
+    "4"
+
+  matches. ++> tests-regex-matches-dotall-option
+    compiled.
+      regex "/(.*)/s"
+    "too \\n many \\n line \\n Feed\\n"
+
+  matches. ++> tests-regex-matches-entire-pattern
+    compiled.
+      regex "/[0-9]/\\d+/"
+    "2/75"
+
+  matches. ++> tests-regex-matches-with-case-insensitive-option
+    compiled.
+      regex "/(string)/i"
+    "StRiNg"
+
+  matches. ++> tests-regex-matches-with-multiline-option
+    compiled.
+      regex "/(^([0-9]+).*)/m"
+    "1 bottle of water on the wall. \\n1 bottle of water."
+
+  matches. ++> tests-regex-matches-with-regex-case-insensitive-and-caps
+    compiled.
+      regex "/(word)/i"
+    "WORD"
+
+  matches. ++> tests-regex-matches-with-regex-unix-lines
+    compiled.
+      regex "/(.+)/d"
+    "A\\r\\nB\\rC\\nD"
+
+  matches. ++> tests-regex-matches-with-unicode-case-and-insensitive
+    compiled.
+      regex "/(yildirim)/ui"
+    "Yıldırım"
 
   eq. ++> tests-regex-returns-valid-matched-string-sequence
     text.
@@ -96,17 +172,10 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  ((regex "/[a-z]+/").match "123").next.next --> on-getting-next-on-not-matched-block
+  (regex "/[a-z/").compile --> on-compiling-invalid-regex-without-fallback
 
   --> on-getting-from-position-on-not-matched-block
     from. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
-
-  --> on-getting-to-position-on-not-matched-block
-    to. > @
       next.
         match.
           regex "/[a-z]+/"
@@ -126,6 +195,8 @@
           regex "/[a-z]+/"
           "123"
 
+  ((regex "/[a-z]+/").match "123").next.next --> on-getting-next-on-not-matched-block
+
   group. --> on-getting-specified-group-on-not-matched-block
     next.
       match.
@@ -135,84 +206,13 @@
 
   ((regex "/[a-z]+/").match "123").next.text --> on-getting-text-on-not-matched-block
 
-  matches. ++> tests-regex-matches-dotall-option
-    compiled.
-      regex "/(.*)/s"
-    "too \\n many \\n line \\n Feed\\n"
-
-  matches. ++> tests-regex-matches-with-case-insensitive-option
-    compiled.
-      regex "/(string)/i"
-    "StRiNg"
-
-  matches. ++> tests-regex-matches-with-multiline-option
-    compiled.
-      regex "/(^([0-9]+).*)/m"
-    "1 bottle of water on the wall. \\n1 bottle of water."
-
-  matches. ++> tests-regex-matches-entire-pattern
-    compiled.
-      regex "/[0-9]/\\d+/"
-    "2/75"
-
-  matches. ++> tests-regex-matches-with-regex-unix-lines
-    compiled.
-      regex "/(.+)/d"
-    "A\\r\\nB\\rC\\nD"
-
-  matches. ++> tests-regex-matches-with-regex-case-insensitive-and-caps
-    compiled.
-      regex "/(word)/i"
-    "WORD"
-
-  matches. ++> tests-regex-ignores-comments-in-string
-    compiled.
-      regex
-        "/(\\d) #ignore this comment/x"
-    "4"
-
-  matches. ++> tests-regex-matches-with-unicode-case-and-insensitive
-    compiled.
-      regex "/(yildirim)/ui"
-    "Yıldırım"
-
-  (regex "(.)+").compiled --> on-missing-first-slash-in-regex
+  --> on-getting-to-position-on-not-matched-block
+    to. > @
+      next.
+        match.
+          regex "/[a-z]+/"
+          "123"
 
   (regex "/pattern").compiled --> on-missing-closing-slash-in-regex
 
-  eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
-    "recovered"
-    compile.
-      regex "/[a-z/"
-      "recovered" > [msg]
-
-  eq. ++> tests-missing-slash-returns-provided-fallback
-    "no-slash"
-    compile.
-      regex "(.)+"
-      "no-slash" > [msg]
-
-  (regex "/[a-z/").compile --> on-compiling-invalid-regex-without-fallback
-
-  ++> tests-regex-contains-valid-groups-on-each-matched-block
-    and. > @
-      and.
-        and.
-          first.count.eq 3
-          (first.group 1).eq "hello"
-        eq.
-          first.group 2
-          "1"
-      and.
-        and.
-          second.count.eq 3
-          (second.group 1).eq "world"
-        eq.
-          second.group 2
-          "2"
-    next. > first
-      match.
-        compiled.
-          regex "/([a-z]+)([1-9]{1})/"
-        "!hello1!world2"
-    first.next > second
+  (regex "(.)+").compiled --> on-missing-first-slash-in-regex

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -18,12 +18,6 @@
     string result
   times > amount!
   text > bts!
-  if. > result!
-    0.eq amount
-    --
-    rec-repeated
-      bts
-      1
   if. > [accum index] > rec-repeated
     amount.eq index
     accum
@@ -31,10 +25,18 @@
       accum.concat bts
       as-number.
         index.plus 1
+  if. > result!
+    0.eq amount
+    --
+    rec-repeated
+      bts
+      1
 
-  repeated --> on-text-repeating-less-than-zero-times
-    ""
-    -1
+  eq. ++> tests-text-repeated-five-times
+    "heyheyheyheyhey"
+    repeated
+      "hey"
+      5
 
   eq. ++> tests-text-repeated-negative-times-returns-provided-fallback
     "recovered"
@@ -49,8 +51,6 @@
       "some"
       0
 
-  eq. ++> tests-text-repeated-five-times
-    "heyheyheyheyhey"
-    repeated
-      "hey"
-      5
+  repeated --> on-text-repeating-less-than-zero-times
+    ""
+    -1

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -20,7 +20,6 @@
   text > bts!
   next. > matched
     target.match reinit
-  string bts > reinit
   block.exists.if > [block accum start] > rec-replaced
     rec-replaced
       block.next
@@ -36,6 +35,7 @@
         reinit.slice
           start
           reinit.length.minus start
+  string bts > reinit
 
   eq. ++> tests-does-not-replaces-if-regex-not-found
     replaced

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -19,10 +19,38 @@
 
 [format read] > scanf /Q.tuple
 
-  eq. ++> tests-scanf-with-string
-    "hello"
+  eq. ++> tests-scanf-complex-case
+    scanf
+      "Im%d %s old and this is! Let's calculate %f + %f= %f"
+      "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
+    *
+      18
+      "years"
+      9.999999999E7
+      0.01
+      100000000
+
+  eq. ++> tests-scanf-with-complex-float
+    1991.01
     head.
-      scanf "%s" "hello"
+      scanf
+        "this will be=%f"
+        "this will be=1991.01"
+
+  eq. ++> tests-scanf-with-complex-int
+    734987259
+    head.
+      scanf "!%d!" "!734987259!"
+
+  eq. ++> tests-scanf-with-complex-string
+    "test"
+    head.
+      scanf "some%sstring" "someteststring"
+
+  eq. ++> tests-scanf-with-float
+    0.24
+    head.
+      scanf "%f" "0.24"
 
   eq. ++> tests-scanf-with-int
     33
@@ -39,22 +67,21 @@
     head.
       scanf "%d" "+42"
 
-  eq. ++> tests-scanf-with-float
-    0.24
-    head.
-      scanf "%f" "0.24"
+  eq. ++> tests-scanf-with-printf
+    scanf
+      "%s is about %d?"
+      printf *1
+        "%s is about %d?"
+        "This"
+        8
+    *
+      "This"
+      8
 
-  scanf --> on-scanf-with-wrong-format
-    "%l"
-    "error"
-
-  scanf --> on-scanf-with-oversized-int
-    "%d"
-    "99999999999999999999"
-
-  scanf --> on-scanf-with-dangling-percent
-    "hello%"
+  eq. ++> tests-scanf-with-string
     "hello"
+    head.
+      scanf "%s" "hello"
 
   eq. ++> tests-scanf-with-string-int-float
     scanf
@@ -70,41 +97,14 @@
     head.
       scanf "%s!" "hello!"
 
-  eq. ++> tests-scanf-with-complex-string
-    "test"
-    head.
-      scanf "some%sstring" "someteststring"
+  scanf --> on-scanf-with-dangling-percent
+    "hello%"
+    "hello"
 
-  eq. ++> tests-scanf-with-complex-int
-    734987259
-    head.
-      scanf "!%d!" "!734987259!"
+  scanf --> on-scanf-with-oversized-int
+    "%d"
+    "99999999999999999999"
 
-  eq. ++> tests-scanf-with-complex-float
-    1991.01
-    head.
-      scanf
-        "this will be=%f"
-        "this will be=1991.01"
-
-  eq. ++> tests-scanf-with-printf
-    scanf
-      "%s is about %d?"
-      printf *1
-        "%s is about %d?"
-        "This"
-        8
-    *
-      "This"
-      8
-
-  eq. ++> tests-scanf-complex-case
-    scanf
-      "Im%d %s old and this is! Let's calculate %f + %f= %f"
-      "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
-    *
-      18
-      "years"
-      9.999999999E7
-      0.01
-      100000000
+  scanf --> on-scanf-with-wrong-format
+    "%l"
+    "error"

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -17,7 +17,6 @@
       0
   text > bts!
   delimiter > delim!
-  delim.size > size!
   bts.size > len!
   [accum start current] > rec-split
     if. > @
@@ -48,11 +47,30 @@
           bts
           start
           current.minus start
+  delim.size > size!
+
+  eq. ++> tests-splits-and-returns-strings
+    length.
+      at.
+        split
+          "hello world!"
+          " "
+        1
+    6
 
   eq. ++> tests-splits-text-by-dash
     split
       "a-b-c"
       "-"
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> tests-splits-text-by-multi-char-delimiter
+    split
+      "a::b::c"
+      "::"
     *
       "a"
       "b"
@@ -67,21 +85,3 @@
       "a"
       "b"
       ""
-
-  eq. ++> tests-splits-and-returns-strings
-    length.
-      at.
-        split
-          "hello world!"
-          " "
-        1
-    6
-
-  eq. ++> tests-splits-text-by-multi-char-delimiter
-    split
-      "a::b::c"
-      "::"
-    *
-      "a"
-      "b"
-      "c"

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -23,12 +23,12 @@
   txt.size > tlen!
   text > txt!
 
-  starts-with ++> tests-starts-with-substring
-    "Hello, world"
-    "Hello"
-
   ++> tests-does-not-start-with-substring
     not. > @
       starts-with
         "Hello, world"
         "world"
+
+  starts-with ++> tests-starts-with-substring
+    "Hello, world"
+    "Hello"

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -22,8 +22,6 @@
           number len
           idx
   text > bts!
-  first-non-ws-index 0 > idx!
-  bts.size > len!
   [index] > first-non-ws-index
     if. > @
       len.eq index
@@ -36,6 +34,7 @@
     bts.slice > char!
       index
       1
+  first-non-ws-index 0 > idx!
   or. > [c] > is-ws
     c.eq 20-
     or.
@@ -46,43 +45,44 @@
           c.eq 0B-
           (c.eq 0C-).or
             c.eq 0D-
-
-  eq. ++> tests-trimmed-left-empty-text
-    trimmed-left ""
-    ""
-
-  eq. ++> tests-text-trimmed-left-one-space
-    trimmed-left
-      " s"
-    "s"
+  bts.size > len!
 
   eq. ++> tests-text-trimmed-left-many-spaces
     trimmed-left
       "     some"
     "some"
 
+  eq. ++> tests-text-trimmed-left-one-space
+    trimmed-left
+      " s"
+    "s"
+
   eq. ++> tests-text-trimmed-left-only-spaces
     trimmed-left
       "     "
     ""
 
-  eq. ++> tests-trimmed-left-strips-tab
-    trimmed-left "\tvalue"
-    "value"
+  eq. ++> tests-trimmed-left-empty-text
+    trimmed-left ""
+    ""
 
-  eq. ++> tests-trimmed-left-strips-lf
-    trimmed-left "\nvalue"
+  eq. ++> tests-trimmed-left-strips-cr
+    trimmed-left "\rvalue"
     "value"
 
   eq. ++> tests-trimmed-left-strips-ff
     trimmed-left "\fvalue"
     "value"
 
-  eq. ++> tests-trimmed-left-strips-cr
-    trimmed-left "\rvalue"
+  eq. ++> tests-trimmed-left-strips-lf
+    trimmed-left "\nvalue"
     "value"
 
   eq. ++> tests-trimmed-left-strips-mixed-ws
     trimmed-left
       " \t\n\f\rvalue"
+    "value"
+
+  eq. ++> tests-trimmed-left-strips-tab
+    trimmed-left "\tvalue"
     "value"

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -21,7 +21,6 @@
         first-non-ws-index
           (number len).plus -1
   text > bts!
-  bts.size > len!
   [index] > first-non-ws-index
     if. > @
       -1.eq index
@@ -44,43 +43,44 @@
           c.eq 0B-
           (c.eq 0C-).or
             c.eq 0D-
-
-  eq. ++> tests-trimmed-right-empty-text
-    trimmed-right ""
-    ""
-
-  eq. ++> tests-text-trimmed-right-one-space
-    trimmed-right
-      "s "
-    "s"
+  bts.size > len!
 
   eq. ++> tests-text-trimmed-right-many-spaces
     trimmed-right
       "some     "
     "some"
 
+  eq. ++> tests-text-trimmed-right-one-space
+    trimmed-right
+      "s "
+    "s"
+
   eq. ++> tests-text-trimmed-right-only-spaces
     trimmed-right
       "     "
     ""
 
-  eq. ++> tests-trimmed-right-strips-tab
-    trimmed-right "value\t"
-    "value"
+  eq. ++> tests-trimmed-right-empty-text
+    trimmed-right ""
+    ""
 
-  eq. ++> tests-trimmed-right-strips-lf
-    trimmed-right "value\n"
+  eq. ++> tests-trimmed-right-strips-cr
+    trimmed-right "value\r"
     "value"
 
   eq. ++> tests-trimmed-right-strips-ff
     trimmed-right "value\f"
     "value"
 
-  eq. ++> tests-trimmed-right-strips-cr
-    trimmed-right "value\r"
+  eq. ++> tests-trimmed-right-strips-lf
+    trimmed-right "value\n"
     "value"
 
   eq. ++> tests-trimmed-right-strips-mixed-ws
     trimmed-right
       "value \t\n\f\r"
+    "value"
+
+  eq. ++> tests-trimmed-right-strips-tab
+    trimmed-right "value\t"
     "value"

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -19,6 +19,20 @@
     trimmed-left
       trimmed-right text
 
+  eq. ++> tests-text-trimmed-empty
+    trimmed ""
+    ""
+
+  eq. ++> tests-text-trimmed-many-spaces
+    trimmed
+      "    some     "
+    "some"
+
+  eq. ++> tests-text-trimmed-one-space-both
+    trimmed
+      " some "
+    "some"
+
   eq. ++> tests-text-trimmed-one-space-left
     trimmed
       " some"
@@ -29,29 +43,10 @@
       "some "
     "some"
 
-  eq. ++> tests-text-trimmed-one-space-both
-    trimmed
-      " some "
-    "some"
-
-  eq. ++> tests-text-trimmed-many-spaces
-    trimmed
-      "    some     "
-    "some"
-
-  eq. ++> tests-text-trimmed-empty
-    trimmed ""
-    ""
-
   eq. ++> tests-text-trimmed-only-spaces
     trimmed
       "        "
     ""
-
-  eq. ++> tests-trimmed-strips-mixed-ws-both-sides
-    trimmed
-      " \t\n\f\rvalue \t\n\f\r"
-    "value"
 
   eq. ++> tests-trimmed-preserves-inner-content
     trimmed "no-whitespace"
@@ -61,3 +56,8 @@
     trimmed
       "\t hello world \n"
     "hello world"
+
+  eq. ++> tests-trimmed-strips-mixed-ws-both-sides
+    trimmed
+      " \t\n\f\rvalue \t\n\f\r"
+    "value"

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -47,45 +47,6 @@
     @. > previous
       rec-case tup.tail
 
-  eq. ++> tests-switch-simple-case
-    switch *
-      * false "1"
-      * true "2"
-    "2"
-
-  ++> tests-switch-strings-case
-    eq. > @
-      switch *
-        *
-          password.eq "swordfish"
-          "password is correct!"
-        *
-          password.eq ""
-          "empty password is not allowed"
-        *
-          false
-          "password is wrong"
-      "password is correct!"
-    "swordfish" > password
-
-  eq. ++> tests-switch-with-several-true-cases
-    switch *
-      * true "TRUE1"
-      * false "FALSE"
-      * true "TRUE2"
-    "TRUE1"
-
-  switch * ++> tests-switch-with-all-false-cases
-    *
-      false
-      "false1"
-    *
-      false
-      "false2"
-
-  switch --> on-empty-switch
-    *
-
   eq. ++> tests-empty-switch-returns-provided-fallback
     "recovered"
     switch
@@ -108,3 +69,42 @@
     false > c1
     "1".eq "2" > c2
     true > c3
+
+  eq. ++> tests-switch-simple-case
+    switch *
+      * false "1"
+      * true "2"
+    "2"
+
+  ++> tests-switch-strings-case
+    eq. > @
+      switch *
+        *
+          password.eq "swordfish"
+          "password is correct!"
+        *
+          password.eq ""
+          "empty password is not allowed"
+        *
+          false
+          "password is wrong"
+      "password is correct!"
+    "swordfish" > password
+
+  switch * ++> tests-switch-with-all-false-cases
+    *
+      false
+      "false1"
+    *
+      false
+      "false2"
+
+  eq. ++> tests-switch-with-several-true-cases
+    switch *
+      * true "TRUE1"
+      * false "FALSE"
+      * true "TRUE2"
+    "TRUE1"
+
+  switch --> on-empty-switch
+    *

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -10,12 +10,6 @@
 +unlint mandatory-package
 
 [tail head length] > tuple
-  tuple > empty
-    T
-      "Can't get tail from the empty tuple"
-    T
-      "Can't get head from the empty tuple"
-    0
   [i fallback] > at
     if. > @
       or.
@@ -24,22 +18,23 @@
       fallback
         "Given index is out of tuple bounds"
       at-fast ^
-    i > idx!
-    if. > index!
-      0.gt idx
-      length.plus idx
-      idx
     if. > [tup] > at-fast
       eq.
         tup.length.plus -1
         index
       tup.head
       at-fast tup.tail
-  tuple > [x] > with
-    ^
-    x
-    as-number.
-      length.plus 1
+    i > idx!
+    if. > index!
+      0.gt idx
+      length.plus idx
+      idx
+  tuple > empty
+    T
+      "Can't get tail from the empty tuple"
+    T
+      "Can't get head from the empty tuple"
+    0
   [other] > eq
     and. > @
       length.eq other.length
@@ -50,14 +45,39 @@
       and.
         first.head.eq second.head
         receq first.tail second.tail
+  tuple > [x] > with
+    ^
+    x
+    as-number.
+      length.plus 1
 
-  eq. ++> tests-makes-tuple-through-special-syntax
-    length.
-      * 1 2
-    2
+  ++> tests-at-fast-with-first-element
+    eq. > @
+      at-fast.
+        arr.at 0
+        arr
+      100
+    * > arr
+      100
+      101
+      102
 
-  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-through-special-syntax
-    0
+  ++> tests-at-fast-with-last-element
+    eq. > @
+      at-fast.
+        arr.at 2
+        arr
+      102
+    * > arr
+      100
+      101
+      102
+
+  ++> tests-creates-empty-tuple-with-number
+    eq. > @
+      a.at 0
+      3
+    tuple.empty.with 3 > a
 
   ++> tests-empty-tuple-length
     eq. > @
@@ -67,6 +87,21 @@
             *
       0
     [elements] > arr
+
+  ++> tests-gets-lengths-of-empty-tuple
+    a.length.eq 0 > @
+    * > a
+
+  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-through-special-syntax
+    0
+
+  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-without-additional-obj
+    0
+
+  eq. ++> tests-makes-tuple-through-special-syntax
+    length.
+      * 1 2
+    2
 
   ++> tests-non-empty-tuple-length-test
     eq. > @
@@ -80,6 +115,59 @@
             "e"
       5
     [elements] > arr
+
+  eq. ++> tests-out-of-bounds-at-returns-provided-fallback
+    "recovered"
+    at.
+      *
+        1
+        2
+        3
+        4
+      20
+      "recovered" > [msg]
+
+  eq. ++> tests-package-tuple-concatenates-with-another
+    concat.
+      * 0 1
+      * 2 3
+    *
+      0
+      1
+      2
+      3
+
+  contains. ++> tests-package-tuple-contains-element
+    *
+      1
+      2
+      3
+    2
+
+  tuple.contains ++> tests-package-tuple-contains-via-tuple-namespace
+    *
+      1
+      2
+      3
+    2
+
+  ++> tests-package-tuple-does-not-contain-element
+    not. > @
+      contains.
+        *
+          1
+          2
+          3
+        5
+
+  eq. ++> tests-package-tuple-index-of-element
+    index-of.
+      *
+        10
+        20
+        30
+      20
+    1
 
   ++> tests-tuple-as-a-bound-attribute-size-0
     tup.length.eq 0 > @
@@ -103,43 +191,33 @@
       1
       2
 
-  ++> tests-tuple-with
+  ++> tests-tuple-empty-fluent-with-indented-keyword
     and. > @
       and.
-        and.
-          (arr.at 0).eq 1
-          (arr.at 1).eq 2
         eq.
-          arr.at 2
-          3
+          arr.at 0
+          1
+        eq.
+          arr.at 1
+          2
       eq.
-        arr.at 3
-        "with"
-    with. > arr
-      *
-        1
-        2
+        arr.at 2
         3
-      "with"
+    with. > arr
+      with.
+        tuple.empty.with 1
+        2
+      3
 
-  at. --> on-wrong-tuple-at
+  eq. ++> tests-tuple-equality
     *
       1
       2
       3
-      4
-    20
-
-  eq. ++> tests-out-of-bounds-at-returns-provided-fallback
-    "recovered"
-    at.
-      *
-        1
-        2
-        3
-        4
-      20
-      "recovered" > [msg]
+    *
+      1
+      2
+      3
 
   ++> tests-tuple-fluent-with
     and. > @
@@ -177,103 +255,15 @@
         2
       3
 
-  ++> tests-gets-lengths-of-empty-tuple
-    a.length.eq 0 > @
-    * > a
-
-  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-without-additional-obj
-    0
-
-  tuple.empty.head --> on-getting-head-from-empty-tuple
-
-  tuple.empty.tail --> on-getting-tail-from-empty-tuple
-
-  ++> tests-creates-empty-tuple-with-number
-    eq. > @
-      a.at 0
-      3
-    tuple.empty.with 3 > a
-
-  ++> tests-at-fast-with-first-element
-    eq. > @
-      at-fast.
-        arr.at 0
-        arr
-      100
-    * > arr
-      100
-      101
-      102
-
-  ++> tests-at-fast-with-last-element
-    eq. > @
-      at-fast.
-        arr.at 2
-        arr
-      102
-    * > arr
-      100
-      101
-      102
-
-  ++> tests-tuple-empty-fluent-with-indented-keyword
-    and. > @
-      and.
-        eq.
-          arr.at 0
-          1
-        eq.
-          arr.at 1
-          2
-      eq.
-        arr.at 2
-        3
-    with. > arr
-      with.
-        tuple.empty.with 1
-        2
-      3
-
-  ++> tests-tuple-with-negative-index-gets-last
-    eq. > @
-      arr.at -1
-      4
-    * > arr
-      0
-      1
-      2
-      3
-      4
-
-  ++> tests-tuple-with-negative-index-gets-first
-    eq. > @
-      arr.at -5
-      0
-    * > arr
-      0
-      1
-      2
-      3
-      4
-
-  --> on-out-of-tuple-bounds-with-negative-index
-    arr.at -6 > @
-    * > arr
-      0
-      1
-      2
-      3
-      4
-
-  eq. ++> tests-tuple-equality
+  eq. ++> tests-tuple-nested-equality
     *
-      1
-      2
-      3
+      * 0 1
+      * 4 0
+      * 7 3
     *
-      1
-      2
-      3
+      * 0 1
+      * 4 0
+      * 7 3
 
   ++> tests-tuple-not-equality
     not. > @
@@ -287,54 +277,64 @@
           2
           1
 
-  eq. ++> tests-tuple-nested-equality
-    *
-      * 0 1
-      * 4 0
-      * 7 3
-    *
-      * 0 1
-      * 4 0
-      * 7 3
-
-  contains. ++> tests-package-tuple-contains-element
-    *
-      1
-      2
-      3
-    2
-
-  ++> tests-package-tuple-does-not-contain-element
-    not. > @
-      contains.
-        *
-          1
-          2
+  ++> tests-tuple-with
+    and. > @
+      and.
+        and.
+          (arr.at 0).eq 1
+          (arr.at 1).eq 2
+        eq.
+          arr.at 2
           3
-        5
-
-  eq. ++> tests-package-tuple-index-of-element
-    index-of.
+      eq.
+        arr.at 3
+        "with"
+    with. > arr
       *
-        10
-        20
-        30
-      20
-    1
+        1
+        2
+        3
+      "with"
 
-  eq. ++> tests-package-tuple-concatenates-with-another
-    concat.
-      * 0 1
-      * 2 3
-    *
+  ++> tests-tuple-with-negative-index-gets-first
+    eq. > @
+      arr.at -5
+      0
+    * > arr
       0
       1
       2
       3
+      4
 
-  tuple.contains ++> tests-package-tuple-contains-via-tuple-namespace
+  ++> tests-tuple-with-negative-index-gets-last
+    eq. > @
+      arr.at -1
+      4
+    * > arr
+      0
+      1
+      2
+      3
+      4
+
+  tuple.empty.head --> on-getting-head-from-empty-tuple
+
+  tuple.empty.tail --> on-getting-tail-from-empty-tuple
+
+  --> on-out-of-tuple-bounds-with-negative-index
+    arr.at -6 > @
+    * > arr
+      0
+      1
+      2
+      3
+      4
+
+  at. --> on-wrong-tuple-at
     *
       1
       2
       3
-    2
+      4
+    20

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -23,6 +23,22 @@
   index > idx!
   list.length.minus idx > start!
 
+  eq. ++> tests-large-index-in-back
+    back
+      *
+        1
+        2
+        3
+        4
+        5
+      10
+    *
+      1
+      2
+      3
+      4
+      5
+
   eq. ++> tests-simple-back
     back
       *
@@ -45,19 +61,3 @@
         4
         5
       0
-
-  eq. ++> tests-large-index-in-back
-    back
-      *
-        1
-        2
-        3
-        4
-        5
-      10
-    *
-      1
-      2
-      3
-      4
-      5

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -14,14 +14,6 @@
     -1.eq
       index-of list element
 
-  contains ++> tests-list-contains-string
-    *
-      "qwerty"
-      "asdfgh"
-      3
-      "qwerty"
-    "qwerty"
-
   contains ++> tests-list-contains-number
     *
       "qwerty"
@@ -29,6 +21,14 @@
       3
       "qwerty"
     3
+
+  contains ++> tests-list-contains-string
+    *
+      "qwerty"
+      "asdfgh"
+      3
+      "qwerty"
+    "qwerty"
 
   ++> tests-list-does-not-contain
     not. > @

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -16,20 +16,18 @@
     list
     func item > [item index] >>
 
-  ++> tests-iterates-with-each
-    eq. > @
-      malloc.for
-        0
-        [m]
-          each > @
-            * 1 2 3
-            m.put > [i] >>
-              m.as-number.plus i
-      6
-
   each ++> tests-each-empty-list
     *
     false > [x]
+
+  eq. ++> tests-each-returns-last-func-result
+    each
+      *
+        1
+        2
+        3
+      x > [x]
+    3
 
   ++> tests-each-single-element
     eq. > @
@@ -42,15 +40,6 @@
               m.as-number.plus i
       7
 
-  eq. ++> tests-each-returns-last-func-result
-    each
-      *
-        1
-        2
-        3
-      x > [x]
-    3
-
   ++> tests-each-sums-more-numbers
     eq. > @
       malloc.for
@@ -61,3 +50,14 @@
             m.put > [i] >>
               m.as-number.plus i
       60
+
+  ++> tests-iterates-with-each
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            * 1 2 3
+            m.put > [i] >>
+              m.as-number.plus i
+      6

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -18,6 +18,15 @@
     list
     func item > [item index] >>
 
+  eq. ++> tests-filtered-with-bools
+    filtered
+      *
+        true
+        false
+        true
+      v.not > [v]
+    * false
+
   eq. ++> tests-simple-filtered
     filtered
       *
@@ -31,12 +40,3 @@
       3
       4
       5
-
-  eq. ++> tests-filtered-with-bools
-    filtered
-      *
-        true
-        false
-        true
-      v.not > [v]
-    * false

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -31,37 +31,6 @@
     tup
     rechead tup.tail
 
-  eq. ++> tests-simple-front
-    front
-      *
-        1
-        2
-        3
-        4
-        5
-      1
-    * 1
-
-  is-empty ++> tests-list-front-with-zero-index
-    front
-      *
-        1
-        2
-        3
-      0
-
-  eq. ++> tests-list-front-with-length-index
-    front
-      *
-        1
-        2
-        3
-      3
-    *
-      1
-      2
-      3
-
   eq. ++> tests-complex-front
     front
       *
@@ -73,15 +42,6 @@
     *
       "foo"
       2.2
-
-  eq. ++> tests-front-with-negative
-    front
-      *
-        1
-        2
-        3
-      -1
-    * 3
 
   eq. ++> tests-complex-front-with-negative
     front
@@ -95,3 +55,43 @@
       2.2
       00-01
       "bar"
+
+  eq. ++> tests-front-with-negative
+    front
+      *
+        1
+        2
+        3
+      -1
+    * 3
+
+  eq. ++> tests-list-front-with-length-index
+    front
+      *
+        1
+        2
+        3
+      3
+    *
+      1
+      2
+      3
+
+  is-empty ++> tests-list-front-with-zero-index
+    front
+      *
+        1
+        2
+        3
+      0
+
+  eq. ++> tests-simple-front
+    front
+      *
+        1
+        2
+        3
+        4
+        5
+      1
+    * 1

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -26,24 +26,6 @@
         next
     recidx tup.tail > next!
 
-  eq. ++> tests-returns-index-of
-    1
-    index-of
-      *
-        1
-        2
-        3
-      2
-
-  eq. ++> tests-returns-first-index-of-element
-    0
-    index-of
-      *
-        -1
-        2
-        -1
-      -1
-
   eq. ++> tests-does-not-find-index-of
     -1
     index-of
@@ -61,3 +43,21 @@
         "qwerty"
         3
       "qwerty"
+
+  eq. ++> tests-returns-first-index-of-element
+    0
+    index-of
+      *
+        -1
+        2
+        -1
+      -1
+
+  eq. ++> tests-returns-index-of
+    1
+    index-of
+      *
+        1
+        2
+        3
+      2

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -11,14 +11,20 @@
   ? >> list
   0.eq list.length > @
 
+  is-empty ++> list-should-be-empty
+    *
+
   ++> tests-list-should-not-be-empty
     not. > @
       is-empty *
         1
         2
 
-  is-empty ++> list-should-be-empty
-    *
+  ++> tests-list-should-not-be-empty-with-one-anon-object
+    not. > @
+      is-empty xs
+    * > xs
+      [f]
 
   ++> tests-list-should-not-be-empty-with-three-objects
     not. > @
@@ -27,9 +33,3 @@
       [x]
       [y]
       [z]
-
-  ++> tests-list-should-not-be-empty-with-one-anon-object
-    not. > @
-      is-empty xs
-    * > xs
-      [f]

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -23,20 +23,6 @@
         max
   sequence > lst
 
-  maximum --> on-taking-maximum-from-empty-sequence
-    *
-
-  eq. ++> tests-maximum-of-empty-returns-provided-fallback
-    "recovered"
-    maximum
-      *
-      "recovered" > [msg]
-
-  eq. ++> tests-maximum-of-one-item-array
-    maximum
-      * 42
-    42
-
   eq. ++> tests-maximum-of-array-is-first
     maximum *
       25
@@ -57,3 +43,17 @@
       -2
       25
     25
+
+  eq. ++> tests-maximum-of-empty-returns-provided-fallback
+    "recovered"
+    maximum
+      *
+      "recovered" > [msg]
+
+  eq. ++> tests-maximum-of-one-item-array
+    maximum
+      * 42
+    42
+
+  maximum --> on-taking-maximum-from-empty-sequence
+    *

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -23,20 +23,6 @@
         min
   sequence > lst
 
-  minimum --> on-taking-minimum-from-empty-sequence
-    *
-
-  eq. ++> tests-minimum-of-empty-returns-provided-fallback
-    "recovered"
-    minimum
-      *
-      "recovered" > [msg]
-
-  eq. ++> tests-minimum-of-one-item-array
-    minimum
-      * 42
-    42
-
   eq. ++> tests-minimum-of-array-is-first
     minimum *
       -2
@@ -57,3 +43,17 @@
       25
       -2
     -2
+
+  eq. ++> tests-minimum-of-empty-returns-provided-fallback
+    "recovered"
+    minimum
+      *
+      "recovered" > [msg]
+
+  eq. ++> tests-minimum-of-one-item-array
+    minimum
+      * 42
+    42
+
+  minimum --> on-taking-minimum-from-empty-sequence
+    *

--- a/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
+++ b/eo-runtime/src/main/eo/tuple/range-of-numbers.eo
@@ -26,26 +26,6 @@
     T
       "Some of the arguments are not integers"
 
-  eq. ++> tests-simple-range-of-numbers-from-one-to-ten
-    range-of-numbers
-      1
-      10
-    *
-      1
-      2
-      3
-      4
-      5
-      6
-      7
-      8
-      9
-
-  is-empty ++> tests-range-of-numbers-from-ten-to-ten-is-empty
-    range-of-numbers
-      10
-      10
-
   is-empty ++> tests-range-of-descending-numbers-is-empty
     range-of-numbers
       10
@@ -62,6 +42,30 @@
       -2
       -1
 
+  is-empty ++> tests-range-of-numbers-from-ten-to-ten-is-empty
+    range-of-numbers
+      10
+      10
+
+  eq. ++> tests-simple-range-of-numbers-from-one-to-ten
+    range-of-numbers
+      1
+      10
+    *
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      9
+
+  range-of-numbers --> on-range-of-not-numbers
+    1.5
+    5.2
+
   range-of-numbers --> on-range-of-numbers-with-non-number-start
     1.2
     3
@@ -69,7 +73,3 @@
   range-of-numbers --> on-range-of-numbers-with-not-number-end
     1
     2.5
-
-  range-of-numbers --> on-range-of-not-numbers
-    1.5
-    5.2

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -29,16 +29,15 @@
       tup.head
       tup.tail.length
 
-  ++> tests-reduce-list-with-index
-    6.eq > @
+  ++> tests-list-reducedi-bools-array
+    not. > @
       reducedi
-        * 1 1
-        0
-        x.plus > [a x i] >>
-          a.plus
-            at.
-              * 2 2
-              i
+        *
+          true
+          true
+          false
+        true
+        x.and a > [a x i]
 
   eq. ++> tests-list-reducedi-long-int-array
     reducedi
@@ -92,16 +91,6 @@
       x.plus a > [a x i]
     1
 
-  ++> tests-list-reducedi-bools-array
-    not. > @
-      reducedi
-        *
-          true
-          true
-          false
-        true
-        x.and a > [a x i]
-
   ++> tests-list-reducedi-nested-functions
     eq. > @
       reducedi
@@ -115,3 +104,14 @@
             acc.minus x
       10.plus
         0.minus 500
+
+  ++> tests-reduce-list-with-index
+    6.eq > @
+      reducedi
+        * 1 1
+        0
+        x.plus > [a x i] >>
+          a.plus
+            at.
+              * 2 2
+              i

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -15,6 +15,17 @@
     shift
     list.length
 
+  eq. ++> tests-shifted-with-shift-greater-than-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      6
+    *
+
   eq. ++> tests-shifted-with-shift-less-than-length
     shifted
       *
@@ -28,14 +39,3 @@
       3
       4
       5
-
-  eq. ++> tests-shifted-with-shift-greater-than-length
-    shifted
-      *
-        8
-        2
-        3
-        4
-        5
-      6
-    *

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -63,22 +63,29 @@
       4
       5
 
-  eq. ++> tests-slice-with-negative-start
+  eq. ++> tests-slice-with-end-gt-length
     slice
       *
-        8
-        76
-        -3
-        0
-        3
-        8
-        -12
-      -4
-      6
+        "foo"
+        "bar"
+        "buzz"
+      1
+      10
     *
-      0
-      3
-      8
+      "bar"
+      "buzz"
+
+  eq. ++> tests-slice-with-end-lt-negative-length
+    slice
+      *
+        "A"
+        "b"
+        "C"
+        "d"
+        "E"
+      2
+      -9
+    *
 
   eq. ++> tests-slice-with-negative-end
     slice
@@ -98,6 +105,23 @@
       "xyz"
       82.42
 
+  eq. ++> tests-slice-with-negative-start
+    slice
+      *
+        8
+        76
+        -3
+        0
+        3
+        8
+        -12
+      -4
+      6
+    *
+      0
+      3
+      8
+
   eq. ++> tests-slice-with-negative-start-and-end
     slice
       *
@@ -113,53 +137,17 @@
       0
       0
 
-  eq. ++> tests-slice-with-end-gt-length
+  eq. ++> tests-slice-with-negative-start-gte-end
     slice
       *
-        "foo"
-        "bar"
-        "buzz"
-      1
-      10
-    *
-      "bar"
-      "buzz"
-
-  eq. ++> tests-slice-with-start-lt-negative-length
-    slice
-      *
-        9
-        99
-        999
-        9999
-      -10
-      3
-    *
-      9
-      99
-      999
-
-  eq. ++> tests-slice-with-end-lt-negative-length
-    slice
-      *
-        "A"
+        "f"
+        1
         "b"
-        "C"
-        "d"
-        "E"
-      2
-      -9
-    *
-
-  eq. ++> tests-slice-with-start-gte-end-both-positive
-    slice
-      *
+        2
+        "b"
         3
-        "-5"
-        0
-        "foo"
-      2
-      0
+      -1
+      3
     *
 
   eq. ++> tests-slice-with-start-gte-end-both-negative
@@ -176,17 +164,15 @@
       -5
     *
 
-  eq. ++> tests-slice-with-negative-start-gte-end
+  eq. ++> tests-slice-with-start-gte-end-both-positive
     slice
       *
-        "f"
-        1
-        "b"
-        2
-        "b"
         3
-      -1
-      3
+        "-5"
+        0
+        "foo"
+      2
+      0
     *
 
   eq. ++> tests-slice-with-start-gte-negative-end
@@ -201,3 +187,17 @@
       4
       -5
     *
+
+  eq. ++> tests-slice-with-start-lt-negative-length
+    slice
+      *
+        9
+        99
+        999
+        9999
+      -10
+      3
+    *
+      9
+      99
+      999

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -19,24 +19,6 @@
       list
       list.length.minus index
 
-  eq. ++> tests-simple-insert
-    withi
-      *
-        1
-        2
-        3
-        4
-        5
-      3
-      "hello"
-    *
-      1
-      2
-      3
-      "hello"
-      4
-      5
-
   eq. ++> tests-insert-with-zero-index
     withi
       *
@@ -52,5 +34,23 @@
       1
       2
       3
+      4
+      5
+
+  eq. ++> tests-simple-insert
+    withi
+      *
+        1
+        2
+        3
+        4
+        5
+      3
+      "hello"
+    *
+      1
+      2
+      3
+      "hello"
       4
       5

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -12,28 +12,9 @@
 
 [as-bytes] > u16
   as-bytes > @
-  as-i32.as-number > as-number
   i32 > [] > as-i32
     00-00.concat as-bytes
-  as-i32.lt x.as-u16.as-i32 > [x] > lt
-  as-i32.lte x.as-u16.as-i32 > [x] > lte
-  as-i32.gt x.as-u16.as-i32 > [x] > gt
-  as-i32.gte x.as-u16.as-i32 > [x] > gte
-  [x] > times
-    u16 right > @
-    (as-i32.times x.as-u16.as-i32).as-bytes.slice > right
-      2
-      2
-  [x] > plus
-    u16 right > @
-    (as-i32.plus x.as-u16.as-i32).as-bytes.slice > right
-      2
-      2
-  [x] > minus
-    u16 right > @
-    (as-i32.minus x.as-u16.as-i32).as-bytes.slice > right
-      2
-      2
+  as-i32.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -46,8 +27,25 @@
       2
     x.as-u16 > xval
     00-00 > zero
-
-  00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
+  as-i32.gt x.as-u16.as-i32 > [x] > gt
+  as-i32.gte x.as-u16.as-i32 > [x] > gte
+  as-i32.lt x.as-u16.as-i32 > [x] > lt
+  as-i32.lte x.as-u16.as-i32 > [x] > lte
+  [x] > minus
+    u16 right > @
+    (as-i32.minus x.as-u16.as-i32).as-bytes.slice > right
+      2
+      2
+  [x] > plus
+    u16 right > @
+    (as-i32.plus x.as-u16.as-i32).as-bytes.slice > right
+      2
+      2
+  [x] > times
+    u16 right > @
+    (as-i32.times x.as-u16.as-i32).as-bytes.slice > right
+      2
+      2
 
   eq. ++> tests-u16-as-i32-widens-with-zero-prefix
     FF-FF.as-u16.as-i32.as-bytes
@@ -55,33 +53,39 @@
 
   FF-FF.as-u16.as-number.eq 65535 ++> tests-u16-as-number-is-unsigned
 
-  00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
+  eq. ++> tests-u16-div-by-u16-one
+    FF-FF.as-u16.div 00-01.as-u16
+    FF-FF.as-u16
 
-  (00-0A.as-u16.lt 00-0A.as-u16).not ++> tests-u16-less-equal
+  eq. ++> tests-u16-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-02.as-u16.div
+      00-00.as-u16
+      "recovered" > [msg]
+
+  eq. ++> tests-u16-div-is-unsigned
+    FF-FF.as-u16.div 00-02.as-u16
+    7F-FF.as-u16
+
+  (00-2A.as-u16.eq 00-2B.as-u16).not ++> tests-u16-eq-false
+
+  00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
 
   FF-FF.as-u16.gt 00-01.as-u16 ++> tests-u16-greater-treats-high-bit-as-magnitude
-
-  (FF-FF.as-u16.lt 00-01.as-u16).not ++> tests-u16-high-bit-not-less-than-one
-
-  00-00.as-u16.lt FF-FF.as-u16 ++> tests-u16-zero-less-than-max
-
-  00-32.as-u16.lte 00-32.as-u16 ++> tests-u16-lte-equal
 
   00-32.as-u16.gte 00-32.as-u16 ++> tests-u16-gte-equal
 
   (00-00.as-u16.gte 00-0A.as-u16).not ++> tests-u16-gte-false
 
-  00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
+  00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
 
-  (00-2A.as-u16.eq 00-2B.as-u16).not ++> tests-u16-eq-false
+  (FF-FF.as-u16.lt 00-01.as-u16).not ++> tests-u16-high-bit-not-less-than-one
 
-  eq. ++> tests-u16-one-plus-u16-one
-    00-01.as-u16.plus 00-01.as-u16
-    00-02.as-u16
+  (00-0A.as-u16.lt 00-0A.as-u16).not ++> tests-u16-less-equal
 
-  eq. ++> tests-u16-plus-with-overflow
-    FF-FF.as-u16.plus 00-01.as-u16
-    00-00.as-u16
+  00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
+
+  00-32.as-u16.lte 00-32.as-u16 ++> tests-u16-lte-equal
 
   eq. ++> tests-u16-minus
     00-05.as-u16.minus 00-03.as-u16
@@ -91,6 +95,14 @@
     00-00.as-u16.minus 00-01.as-u16
     FF-FF.as-u16
 
+  eq. ++> tests-u16-one-plus-u16-one
+    00-01.as-u16.plus 00-01.as-u16
+    00-02.as-u16
+
+  eq. ++> tests-u16-plus-with-overflow
+    FF-FF.as-u16.plus 00-01.as-u16
+    00-00.as-u16
+
   eq. ++> tests-u16-times
     00-06.as-u16.times 00-07.as-u16
     00-2A.as-u16
@@ -99,18 +111,6 @@
     01-00.as-u16.times 01-00.as-u16
     00-00.as-u16
 
-  eq. ++> tests-u16-div-is-unsigned
-    FF-FF.as-u16.div 00-02.as-u16
-    7F-FF.as-u16
-
-  eq. ++> tests-u16-div-by-u16-one
-    FF-FF.as-u16.div 00-01.as-u16
-    FF-FF.as-u16
+  00-00.as-u16.lt FF-FF.as-u16 ++> tests-u16-zero-less-than-max
 
   00-02.as-u16.div 00-00.as-u16 --> on-division-u16-by-u16-zero
-
-  eq. ++> tests-u16-div-by-zero-returns-provided-fallback
-    "recovered"
-    00-02.as-u16.div
-      00-00.as-u16
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -12,28 +12,9 @@
 
 [as-bytes] > u32
   as-bytes > @
-  as-i64.as-number > as-number
   i64 > [] > as-i64
     00-00-00-00.concat as-bytes
-  as-i64.lt x.as-u32.as-i64 > [x] > lt
-  as-i64.lte x.as-u32.as-i64 > [x] > lte
-  as-i64.gt x.as-u32.as-i64 > [x] > gt
-  as-i64.gte x.as-u32.as-i64 > [x] > gte
-  [x] > times
-    u32 right > @
-    (as-i64.times x.as-u32.as-i64).as-bytes.slice > right
-      4
-      4
-  [x] > plus
-    u32 right > @
-    (as-i64.plus x.as-u32.as-i64).as-bytes.slice > right
-      4
-      4
-  [x] > minus
-    u32 right > @
-    (as-i64.minus x.as-u32.as-i64).as-bytes.slice > right
-      4
-      4
+  as-i64.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -46,8 +27,25 @@
       4
     x.as-u32 > xval
     00-00-00-00 > zero
-
-  00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
+  as-i64.gt x.as-u32.as-i64 > [x] > gt
+  as-i64.gte x.as-u32.as-i64 > [x] > gte
+  as-i64.lt x.as-u32.as-i64 > [x] > lt
+  as-i64.lte x.as-u32.as-i64 > [x] > lte
+  [x] > minus
+    u32 right > @
+    (as-i64.minus x.as-u32.as-i64).as-bytes.slice > right
+      4
+      4
+  [x] > plus
+    u32 right > @
+    (as-i64.plus x.as-u32.as-i64).as-bytes.slice > right
+      4
+      4
+  [x] > times
+    u32 right > @
+    (as-i64.times x.as-u32.as-i64).as-bytes.slice > right
+      4
+      4
 
   eq. ++> tests-u32-as-i64-widens-with-zero-prefix
     FF-FF-FF-FF.as-u32.as-i64.as-bytes
@@ -55,37 +53,43 @@
 
   FF-FF-FF-FF.as-u32.as-number.eq 4294967295 ++> tests-u32-as-number-is-unsigned
 
-  00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
+  eq. ++> tests-u32-div-by-u32-one
+    FF-FF-FF-FF.as-u32.div 00-00-00-01.as-u32
+    FF-FF-FF-FF.as-u32
 
-  (00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32).not ++> tests-u32-less-equal
+  eq. ++> tests-u32-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-00-00-02.as-u32.div
+      00-00-00-00.as-u32
+      "recovered" > [msg]
+
+  eq. ++> tests-u32-div-is-unsigned
+    FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
+    7F-FF-FF-FF.as-u32
+
+  (00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32).not ++> tests-u32-eq-false
+
+  00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
 
   gt. ++> tests-u32-greater-treats-high-bit-as-magnitude
     FF-FF-FF-FF.as-u32
     00-00-00-01.as-u32
 
-  ++> tests-u32-high-bit-not-less-than-one
-    not. > @
-      FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
-
-  00-00-00-00.as-u32.lt FF-FF-FF-FF.as-u32 ++> tests-u32-zero-less-than-max
-
-  00-00-00-32.as-u32.lte 00-00-00-32.as-u32 ++> tests-u32-lte-equal
-
   00-00-00-32.as-u32.gte 00-00-00-32.as-u32 ++> tests-u32-gte-equal
 
   (00-00-00-00.as-u32.gte 00-00-00-0A.as-u32).not ++> tests-u32-gte-false
 
-  00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
+  00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
 
-  (00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32).not ++> tests-u32-eq-false
+  ++> tests-u32-high-bit-not-less-than-one
+    not. > @
+      FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
 
-  eq. ++> tests-u32-one-plus-u32-one
-    00-00-00-01.as-u32.plus 00-00-00-01.as-u32
-    00-00-00-02.as-u32
+  (00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32).not ++> tests-u32-less-equal
 
-  eq. ++> tests-u32-plus-with-overflow
-    FF-FF-FF-FF.as-u32.plus 00-00-00-01.as-u32
-    00-00-00-00.as-u32
+  00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
+
+  00-00-00-32.as-u32.lte 00-00-00-32.as-u32 ++> tests-u32-lte-equal
 
   eq. ++> tests-u32-minus
     00-00-00-05.as-u32.minus 00-00-00-03.as-u32
@@ -95,6 +99,14 @@
     00-00-00-00.as-u32.minus 00-00-00-01.as-u32
     FF-FF-FF-FF.as-u32
 
+  eq. ++> tests-u32-one-plus-u32-one
+    00-00-00-01.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-02.as-u32
+
+  eq. ++> tests-u32-plus-with-overflow
+    FF-FF-FF-FF.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-00.as-u32
+
   eq. ++> tests-u32-times
     00-00-00-06.as-u32.times 00-00-00-07.as-u32
     00-00-00-2A.as-u32
@@ -103,18 +115,6 @@
     00-01-00-00.as-u32.times 00-01-00-00.as-u32
     00-00-00-00.as-u32
 
-  eq. ++> tests-u32-div-is-unsigned
-    FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
-    7F-FF-FF-FF.as-u32
-
-  eq. ++> tests-u32-div-by-u32-one
-    FF-FF-FF-FF.as-u32.div 00-00-00-01.as-u32
-    FF-FF-FF-FF.as-u32
+  00-00-00-00.as-u32.lt FF-FF-FF-FF.as-u32 ++> tests-u32-zero-less-than-max
 
   00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> on-division-u32-by-u32-zero
-
-  eq. ++> tests-u32-div-by-zero-returns-provided-fallback
-    "recovered"
-    00-00-00-02.as-u32.div
-      00-00-00-00.as-u32
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -14,7 +14,6 @@
 
 [as-bytes] > u64
   as-bytes > @
-  as-bytes.xor 80-00-00-00-00-00-00-00 > flip
   plus. > [] > as-number
     as-number.
       i64 as-bytes
@@ -24,33 +23,6 @@
         80-00-00-00-00-00-00-00
       1.8446744073709552e19
       0
-  lt. > [x] > lt
-    i64 flip
-    i64 x.as-u64.flip
-  lte. > [x] > lte
-    i64 flip
-    i64 x.as-u64.flip
-  gt. > [x] > gt
-    i64 flip
-    i64 x.as-u64.flip
-  gte. > [x] > gte
-    i64 flip
-    i64 x.as-u64.flip
-  [x] > plus
-    u64 sum.as-bytes > @
-    plus. > sum
-      i64 as-bytes
-      i64 x.as-u64.as-bytes
-  [x] > minus
-    u64 diff.as-bytes > @
-    minus. > diff
-      i64 as-bytes
-      i64 x.as-u64.as-bytes
-  [x] > times
-    u64 product.as-bytes > @
-    times. > product
-      i64 as-bytes
-      i64 x.as-u64.as-bytes
   [x cant-divide] > div
     if. > @
       d.as-bytes.eq 00-00-00-00-00-00-00-00
@@ -67,6 +39,13 @@
           u64 00-00-00-00-00-00-00-00
         final
     x.as-u64 > d
+    if. > final
+      rem.gte d
+      q0plus1
+      u64 q0
+    times. > prod
+      u64 q0
+      d
     left. > q0
       as-bytes.
         div.
@@ -74,95 +53,62 @@
             as-bytes.right 1
           i64 d.as-bytes
       1
-    times. > prod
-      u64 q0
-      d
-    minus prod > rem
     plus. > q0plus1
       u64 q0
       u64 00-00-00-00-00-00-00-01
-    if. > final
-      rem.gte d
-      q0plus1
-      u64 q0
-
-  eq. ++> tests-u64-has-valid-bytes
-    00-00-00-00-00-00-00-2A.as-u64.as-bytes
-    00-00-00-00-00-00-00-2A
-
-  00-00-00-00-00-00-00-2A.as-u64.as-number.eq 42 ++> tests-u64-as-number-small
+    minus prod > rem
+  as-bytes.xor 80-00-00-00-00-00-00-00 > flip
+  gt. > [x] > gt
+    i64 flip
+    i64 x.as-u64.flip
+  gte. > [x] > gte
+    i64 flip
+    i64 x.as-u64.flip
+  lt. > [x] > lt
+    i64 flip
+    i64 x.as-u64.flip
+  lte. > [x] > lte
+    i64 flip
+    i64 x.as-u64.flip
+  [x] > minus
+    u64 diff.as-bytes > @
+    minus. > diff
+      i64 as-bytes
+      i64 x.as-u64.as-bytes
+  [x] > plus
+    u64 sum.as-bytes > @
+    plus. > sum
+      i64 as-bytes
+      i64 x.as-u64.as-bytes
+  [x] > times
+    u64 product.as-bytes > @
+    times. > product
+      i64 as-bytes
+      i64 x.as-u64.as-bytes
 
   gt. ++> tests-u64-as-number-is-unsigned
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
     0
 
-  lt. ++> tests-u64-less-true
-    00-00-00-00-00-00-00-0A.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  ++> tests-u64-less-equal
-    not. > @
-      00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
-
-  gt. ++> tests-u64-greater-treats-high-bit-as-magnitude
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
-    00-00-00-00-00-00-00-01.as-u64
-
-  ++> tests-u64-high-bit-not-less-than-one
-    not. > @
-      FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
-
-  lt. ++> tests-u64-zero-less-than-max
-    00-00-00-00-00-00-00-00.as-u64
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
-
-  lte. ++> tests-u64-lte-equal
-    00-00-00-00-00-00-00-32.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  gte. ++> tests-u64-gte-equal
-    00-00-00-00-00-00-00-32.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  ++> tests-u64-gte-false
-    not. > @
-      00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
-
-  eq. ++> tests-u64-eq-true
-    00-00-00-00-00-00-00-2A.as-u64
-    00-00-00-00-00-00-00-2A.as-u64
-
-  eq. ++> tests-u64-one-plus-u64-one
-    00-00-00-00-00-00-00-01.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
-    00-00-00-00-00-00-00-02.as-u64
-
-  eq. ++> tests-u64-plus-with-overflow
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
-    00-00-00-00-00-00-00-00.as-u64
-
-  eq. ++> tests-u64-minus
-    00-00-00-00-00-00-00-05.as-u64.minus 00-00-00-00-00-00-00-03.as-u64
-    00-00-00-00-00-00-00-02.as-u64
-
-  eq. ++> tests-u64-minus-with-underflow
-    00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
-
-  eq. ++> tests-u64-times
-    00-00-00-00-00-00-00-06.as-u64.times 00-00-00-00-00-00-00-07.as-u64
-    00-00-00-00-00-00-00-2A.as-u64
-
-  eq. ++> tests-u64-times-wraps-modulo-2-pow-64
-    00-00-00-01-00-00-00-00.as-u64.times 00-00-00-01-00-00-00-00.as-u64
-    00-00-00-00-00-00-00-00.as-u64
-
-  eq. ++> tests-u64-div-is-unsigned
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
-    7F-FF-FF-FF-FF-FF-FF-FF.as-u64
+  00-00-00-00-00-00-00-2A.as-u64.as-number.eq 42 ++> tests-u64-as-number-small
 
   eq. ++> tests-u64-div-by-large-divisor
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 80-00-00-00-00-00-00-00.as-u64
     00-00-00-00-00-00-00-01.as-u64
+
+  eq. ++> tests-u64-div-by-u64-one
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-01.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> tests-u64-div-by-zero-returns-provided-fallback
+    "recovered"
+    00-00-00-00-00-00-00-02.as-u64.div
+      00-00-00-00-00-00-00-00.as-u64
+      "recovered" > [msg]
+
+  eq. ++> tests-u64-div-is-unsigned
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
+    7F-FF-FF-FF-FF-FF-FF-FF.as-u64
 
   eq. ++> tests-u64-div-small-not-reaching-large-divisor
     00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64
@@ -172,16 +118,70 @@
     00-00-00-00-00-00-00-2A.as-u64.div 00-00-00-00-00-00-00-05.as-u64
     00-00-00-00-00-00-00-08.as-u64
 
-  eq. ++> tests-u64-div-by-u64-one
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-01.as-u64
+  eq. ++> tests-u64-eq-true
+    00-00-00-00-00-00-00-2A.as-u64
+    00-00-00-00-00-00-00-2A.as-u64
+
+  gt. ++> tests-u64-greater-treats-high-bit-as-magnitude
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+    00-00-00-00-00-00-00-01.as-u64
+
+  gte. ++> tests-u64-gte-equal
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  ++> tests-u64-gte-false
+    not. > @
+      00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
+
+  eq. ++> tests-u64-has-valid-bytes
+    00-00-00-00-00-00-00-2A.as-u64.as-bytes
+    00-00-00-00-00-00-00-2A
+
+  ++> tests-u64-high-bit-not-less-than-one
+    not. > @
+      FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
+
+  ++> tests-u64-less-equal
+    not. > @
+      00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
+
+  lt. ++> tests-u64-less-true
+    00-00-00-00-00-00-00-0A.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lte. ++> tests-u64-lte-equal
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  eq. ++> tests-u64-minus
+    00-00-00-00-00-00-00-05.as-u64.minus 00-00-00-00-00-00-00-03.as-u64
+    00-00-00-00-00-00-00-02.as-u64
+
+  eq. ++> tests-u64-minus-with-underflow
+    00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> tests-u64-one-plus-u64-one
+    00-00-00-00-00-00-00-01.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
+    00-00-00-00-00-00-00-02.as-u64
+
+  eq. ++> tests-u64-plus-with-overflow
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  eq. ++> tests-u64-times
+    00-00-00-00-00-00-00-06.as-u64.times 00-00-00-00-00-00-00-07.as-u64
+    00-00-00-00-00-00-00-2A.as-u64
+
+  eq. ++> tests-u64-times-wraps-modulo-2-pow-64
+    00-00-00-01-00-00-00-00.as-u64.times 00-00-00-01-00-00-00-00.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  lt. ++> tests-u64-zero-less-than-max
+    00-00-00-00-00-00-00-00.as-u64
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64
 
   div. --> on-division-u64-by-u64-zero
     00-00-00-00-00-00-00-02.as-u64
     00-00-00-00-00-00-00-00.as-u64
-
-  eq. ++> tests-u64-div-by-zero-returns-provided-fallback
-    "recovered"
-    00-00-00-00-00-00-00-02.as-u64.div
-      00-00-00-00-00-00-00-00.as-u64
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -12,28 +12,9 @@
 
 [as-bytes] > u8
   as-bytes > @
-  as-i16.as-number > as-number
   i16 > [] > as-i16
     00-.concat as-bytes
-  as-i16.lt x.as-u8.as-i16 > [x] > lt
-  as-i16.lte x.as-u8.as-i16 > [x] > lte
-  as-i16.gt x.as-u8.as-i16 > [x] > gt
-  as-i16.gte x.as-u8.as-i16 > [x] > gte
-  [x] > times
-    u8 right > @
-    (as-i16.times x.as-u8.as-i16).as-bytes.slice > right
-      1
-      1
-  [x] > plus
-    u8 right > @
-    (as-i16.plus x.as-u8.as-i16).as-bytes.slice > right
-      1
-      1
-  [x] > minus
-    u8 right > @
-    (as-i16.minus x.as-u8.as-i16).as-bytes.slice > right
-      1
-      1
+  as-i16.as-number > as-number
   [x cant-divide] > div
     if. > @
       xval.eq zero
@@ -46,42 +27,65 @@
       1
     x.as-u8 > xval
     00- > zero
-
-  2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
+  as-i16.gt x.as-u8.as-i16 > [x] > gt
+  as-i16.gte x.as-u8.as-i16 > [x] > gte
+  as-i16.lt x.as-u8.as-i16 > [x] > lt
+  as-i16.lte x.as-u8.as-i16 > [x] > lte
+  [x] > minus
+    u8 right > @
+    (as-i16.minus x.as-u8.as-i16).as-bytes.slice > right
+      1
+      1
+  [x] > plus
+    u8 right > @
+    (as-i16.plus x.as-u8.as-i16).as-bytes.slice > right
+      1
+      1
+  [x] > times
+    u8 right > @
+    (as-i16.times x.as-u8.as-i16).as-bytes.slice > right
+      1
+      1
 
   FF-.as-u8.as-i16.as-bytes.eq 00-FF ++> tests-u8-as-i16-widens-with-zero-prefix
 
-  255.as-i64.as-i32.as-i16.eq FF-.as-u8.as-i16 ++> tests-u8-max-byte-is-unsigned
-
   FF-.as-u8.as-number.eq 255 ++> tests-u8-as-number-is-unsigned
 
-  0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
+  eq. ++> tests-u8-div-by-u8-one
+    FF-.as-u8.div 01-.as-u8
+    FF-.as-u8
 
-  (0A-.as-u8.lt 0A-.as-u8).not ++> tests-u8-less-equal
+  eq. ++> tests-u8-div-by-zero-returns-provided-fallback
+    "recovered"
+    02-.as-u8.div
+      00-.as-u8
+      "recovered" > [msg]
+
+  eq. ++> tests-u8-div-is-unsigned
+    C8-.as-u8.div 03-.as-u8
+    42-.as-u8
+
+  (2A-.as-u8.eq 2B-.as-u8).not ++> tests-u8-eq-false
+
+  2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
 
   FF-.as-u8.gt 01-.as-u8 ++> tests-u8-greater-treats-high-bit-as-magnitude
-
-  (FF-.as-u8.lt 01-.as-u8).not ++> tests-u8-high-bit-not-less-than-one
-
-  00-.as-u8.lt FF-.as-u8 ++> tests-u8-zero-less-than-max
-
-  32-.as-u8.lte 32-.as-u8 ++> tests-u8-lte-equal
 
   32-.as-u8.gte 32-.as-u8 ++> tests-u8-gte-equal
 
   (00-.as-u8.gte 0A-.as-u8).not ++> tests-u8-gte-false
 
-  2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
+  2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
 
-  (2A-.as-u8.eq 2B-.as-u8).not ++> tests-u8-eq-false
+  (FF-.as-u8.lt 01-.as-u8).not ++> tests-u8-high-bit-not-less-than-one
 
-  eq. ++> tests-u8-one-plus-u8-one
-    01-.as-u8.plus 01-.as-u8
-    02-.as-u8
+  (0A-.as-u8.lt 0A-.as-u8).not ++> tests-u8-less-equal
 
-  eq. ++> tests-u8-plus-with-overflow
-    FF-.as-u8.plus 01-.as-u8
-    00-.as-u8
+  0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
+
+  32-.as-u8.lte 32-.as-u8 ++> tests-u8-lte-equal
+
+  255.as-i64.as-i32.as-i16.eq FF-.as-u8.as-i16 ++> tests-u8-max-byte-is-unsigned
 
   eq. ++> tests-u8-minus
     05-.as-u8.minus 03-.as-u8
@@ -91,30 +95,26 @@
     00-.as-u8.minus 01-.as-u8
     FF-.as-u8
 
+  eq. ++> tests-u8-one-plus-u8-one
+    01-.as-u8.plus 01-.as-u8
+    02-.as-u8
+
+  eq. ++> tests-u8-plus-with-overflow
+    FF-.as-u8.plus 01-.as-u8
+    00-.as-u8
+
   eq. ++> tests-u8-times
     06-.as-u8.times 07-.as-u8
     2A-.as-u8
-
-  eq. ++> tests-u8-times-wraps-modulo-2-pow-8
-    10-.as-u8.times 10-.as-u8
-    00-.as-u8
 
   eq. ++> tests-u8-times-wraps-large-product
     FF-.as-u8.times FF-.as-u8
     01-.as-u8
 
-  eq. ++> tests-u8-div-is-unsigned
-    C8-.as-u8.div 03-.as-u8
-    42-.as-u8
+  eq. ++> tests-u8-times-wraps-modulo-2-pow-8
+    10-.as-u8.times 10-.as-u8
+    00-.as-u8
 
-  eq. ++> tests-u8-div-by-u8-one
-    FF-.as-u8.div 01-.as-u8
-    FF-.as-u8
+  00-.as-u8.lt FF-.as-u8 ++> tests-u8-zero-less-than-max
 
   02-.as-u8.div 00-.as-u8 --> on-division-u8-by-u8-zero
-
-  eq. ++> tests-u8-div-by-zero-returns-provided-fallback
-    "recovered"
-    02-.as-u8.div
-      00-.as-u8
-      "recovered" > [msg]

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -47,57 +47,28 @@
       current
     body index > current
 
-  ++> tests-while-dataizes-only-first-cycle
-    0.eq > @
-      malloc.for
-        42
-        [m]
-          while > @
-            i.eq 0 > [i]
-            m.put i > [i] >>
-
-  ++> tests-simple-while-with-false-first
-    not. > @
-      while
-        false > [i]
-        true > [i]
-
-  ++> tests-simple-bool-expression-via-malloc-in-while
-    eq. > @
-      malloc.for
-        true
-        [m]
-          while > @
-            m > [i] >>
-            m.put false > [i] >>
-      false
-
-  ++> tests-last-while-dataization-object
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            2.gt m > [i] >>
-            m.put > [i] >>
-              m.as-number.plus 1
-      3
-
-  ++> tests-last-while-dataization-object-with-false-condition
-    not. > @
-      while
-        1.gt 2 > [i]
-        true > [i]
-
-  ++> tests-while-simple-iteration
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            i.lt 10 > [i]
-            m.put i > [i] >>
-      9
+  ++> tests-iterating-tuple-with-while-using-external-iterator
+    data.eq arr.length > @
+    * > arr
+      1
+      1
+      1
+      1
+    malloc.for > data
+      0
+      [acc] >>
+        malloc.for > @
+          0
+          [iter] >>
+            while > @
+              max.gt iter > [i] >>
+              seq * > [i] >>
+                acc.put
+                  acc.as-number.plus
+                    arr.at iter
+                iter.put
+                  iter.as-number.plus 1
+    arr.length.plus -1 > max
 
   ++> tests-iterating-tuple-with-while-using-internal-iterator
     data.eq arr.length > @
@@ -124,29 +95,6 @@
                     acc.as-number.plus (arr.at i)
                   iter.put
                     iter.as-number.plus 1
-    arr.length.plus -1 > max
-
-  ++> tests-iterating-tuple-with-while-using-external-iterator
-    data.eq arr.length > @
-    * > arr
-      1
-      1
-      1
-      1
-    malloc.for > data
-      0
-      [acc] >>
-        malloc.for > @
-          0
-          [iter] >>
-            while > @
-              max.gt iter > [i] >>
-              seq * > [i] >>
-                acc.put
-                  acc.as-number.plus
-                    arr.at iter
-                iter.put
-                  iter.as-number.plus 1
     arr.length.plus -1 > max
 
   ++> tests-iterating-tuple-with-while-without-body-multiple
@@ -197,3 +145,55 @@
                 true > [i]
               acc
     arr.length > max
+
+  ++> tests-last-while-dataization-object
+    eq. > @
+      malloc.for
+        0
+        [m]
+          while > @
+            2.gt m > [i] >>
+            m.put > [i] >>
+              m.as-number.plus 1
+      3
+
+  ++> tests-last-while-dataization-object-with-false-condition
+    not. > @
+      while
+        1.gt 2 > [i]
+        true > [i]
+
+  ++> tests-simple-bool-expression-via-malloc-in-while
+    eq. > @
+      malloc.for
+        true
+        [m]
+          while > @
+            m > [i] >>
+            m.put false > [i] >>
+      false
+
+  ++> tests-simple-while-with-false-first
+    not. > @
+      while
+        false > [i]
+        true > [i]
+
+  ++> tests-while-dataizes-only-first-cycle
+    0.eq > @
+      malloc.for
+        42
+        [m]
+          while > @
+            i.eq 0 > [i]
+            m.put i > [i] >>
+
+  ++> tests-while-simple-iteration
+    eq. > @
+      malloc.for
+        0
+        [m]
+          while > @
+            i.lt 10 > [i]
+            m.put i > [i] >>
+      9

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -20,30 +20,20 @@
 
 [name args] > win32
   [] > @ /Q.return
-  2 > inet
-  -1 > none
-  -1 > invalid
-  6 > tcp
-  32768 > rdonly
-  32769 > wronly
-  32770 > rdwr
-  256 > creat
-  512 > trunc
   8 > append
-  384 > mode
-  1 > stream
+  256 > creat
   -1 > failure
-  0 > stdin
-  1 > stdout
-  2 > stderr
-  02-02 > version
+  2 > inet
+  -1 > invalid
+  384 > mode
+  -1 > none
+  32768 > rdonly
+  32770 > rdwr
   [code output] > return
     output > @
     return > called
       code
       output
-  [time millitm] > timeb
-  [mode size] > stat64
   [family port address] > sockaddr-in
     00-00-00-00-00-00-00-00 > padding
     plus. > size
@@ -51,6 +41,16 @@
         family.size.plus port.size
         address.size
       padding.size
+  [mode size] > stat64
+  2 > stderr
+  0 > stdin
+  1 > stdout
+  1 > stream
+  6 > tcp
+  [time millitm] > timeb
+  512 > trunc
+  02-02 > version
+  32769 > wronly
 
   os.is-windows.not.or ++> tests-returns-valid-win32-inet-addr-for-localhost
     eq.


### PR DESCRIPTION
Fixes #5706.

## Problem

`eo-printer` emitted formation attributes in source order rather than a canonical one, producing order-dependent diffs, non-idempotent formatting, and undermining the cross-module format-verification effort.

## Change

Added `<xsl:sort>` keys to the formation-body `<xsl:apply-templates>` in `eo-printer/.../print/to-eo-tree.xsl`. Formation attributes now print in a canonical, stable order:

1. Vertical void body lines (`? >> name`, `? > name /{…}`) first
2. The decoratee (`@name = φ`, i.e. `… > @`)
3. All other bound attributes, alphabetically by name
4. Test attributes (`++>` / `-->`) last, alphabetically by name

Two kinds of body deliberately keep their **source order** (the sort key collapses to a constant and `xsl:sort` is stable):

- **Application arguments** — positional, so their order carries meaning. Only abstract formations are reordered.
- **Bodies containing a pipe continuation** (`| args`, §3.14) — the `|` line must stay directly below the named formation it applies to (R-3.14.7); reordering would strand it and break re-parsing.

## Reformatting existing sources

Because `eo-runtime` runs the `format` goal in check mode during its build, its `.eo` sources must match the canonical layout. Reformatted all 109 divergent runtime `.eo` files via `eo:format -Deo.autoFix=true` (pure attribute reordering — insertions equal deletions).

## Verification

- `XmirTest` green (134 tests): both `printsToEo` and the `printsToParseableEo` idempotency/round-trip check pass. Updated the 9 affected printer test packs.
- `MjPrintTest` (64) and `MjFormatTest` (5) unchanged and green.
- `mvn -pl eo-runtime compile` succeeds — reformatted sources parse, pass the format check, transpile, and compile.
- A second `format` check pass reports zero divergence, confirming idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CktVBV56MhWdxcoaZP1haj)_