### PR TITLE
#5710: fix inverted comparison in FpIfTargetOlder.isAfter()

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FpIfTargetOlder.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FpIfTargetOlder.java
@@ -30,7 +30,7 @@ public final class FpIfTargetOlder extends FpEnvelope {
             new FpFork(
                 (source, target) -> {
                     final Path dest = destination.apply(target);
-                    final boolean older = FpIfTargetOlder.isAfter(dest, source);
+                    final boolean older = FpIfTargetOlder.isOlder(dest, source);
                     if (older) {
                         Logger.debug(
                             FpIfTargetOlder.class,
@@ -59,8 +59,8 @@ public final class FpIfTargetOlder extends FpEnvelope {
      * @return True if first path is older that second path
      * @throws IOException If fails to compare files
      */
-    private static boolean isAfter(final Path first, final Path second) throws IOException {
-        return Files.getLastModifiedTime(first).toInstant().isAfter(
+    private static boolean isOlder(final Path first, final Path second) throws IOException {
+        return Files.getLastModifiedTime(first).toInstant().isBefore(
             Files.getLastModifiedTime(second).toInstant()
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfTargetOlderTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FpIfTargetOlderTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link FpIfTargetOlder}.
+ * @since 0.58
+ */
+final class FpIfTargetOlderTest {
+
+    @Test
+    void choosesTheFirstFootprintWhenTargetIsOlder(@TempDir final Path tmp) throws IOException {
+        final Path source = tmp.resolve("source");
+        final Path target = tmp.resolve("target");
+        FpIfTargetOlderTest.touch(source, Instant.now());
+        FpIfTargetOlderTest.touch(target, Instant.now().minusSeconds(60));
+        Assertions.assertEquals(
+            source,
+            new FpIfTargetOlder(
+                t -> t,
+                (src, tgt) -> source,
+                (src, tgt) -> target
+            ).apply(source, target),
+            "Should choose the first footprint when the target is older than the source"
+        );
+    }
+
+    @Test
+    void choosesTheSecondFootprintWhenTargetIsNewer(@TempDir final Path tmp) throws IOException {
+        final Path source = tmp.resolve("source");
+        final Path target = tmp.resolve("target");
+        FpIfTargetOlderTest.touch(source, Instant.now().minusSeconds(60));
+        FpIfTargetOlderTest.touch(target, Instant.now());
+        Assertions.assertEquals(
+            target,
+            new FpIfTargetOlder(
+                t -> t,
+                (src, tgt) -> source,
+                (src, tgt) -> target
+            ).apply(source, target),
+            "Should choose the second footprint when the target is newer than the source"
+        );
+    }
+
+    /**
+     * Create a file with the given last modified time.
+     * @param path Path to the file
+     * @param mtime Last modified time to set
+     * @throws IOException If fails to create or touch the file
+     */
+    private static void touch(final Path path, final Instant mtime) throws IOException {
+        new Saved("", path).value();
+        Files.setLastModifiedTime(path, FileTime.from(mtime));
+    }
+}


### PR DESCRIPTION
Closes #5710.

`FpIfTargetOlder.isAfter(dest, source)` returned `first.mtime.isAfter(second.mtime)`, true when the target is newer than the source. Its own Javadoc says the opposite: "Returns true if first given path is older in terms of last modified time." The result was stored in a variable named `older` and fed into `FpFork`, where `true` picks the first, rebuild-oriented footprint. Because the comparison was inverted, a genuinely stale target made `older` false, so the wrong footprint got chosen, and the debug log even printed "is newer than source" for a target that was actually older.

Renamed the method to `isOlder` and swapped `isAfter` for `isBefore`, so it now actually returns true when the target is older, matching both its own Javadoc and the `older` variable name at the call site. This also matches the naming convention of the sibling `FpIfTargetExists` (a boolean method named after the condition it computes).

Added `FpIfTargetOlderTest` with two cases, both using files with controlled last-modified times:
- target older than source: expects the first (rebuild) footprint.
- target newer than source: expects the second footprint.

Verified the test actually catches the bug: temporarily reverted the fix, confirmed both new tests fail (with results exactly swapped), then restored the fix and confirmed both pass.

The class had no callers in `src/main` and no test class before this, which is presumably why the inversion went unnoticed; it will misbehave the moment something wires it into the caching pipeline.

Verified: `qulice:check` clean (including jtcop), full `eo-maven-plugin` test suite passes with no new failures. The 9 `MjPrintTest` failures on this branch are pre-existing on unmodified master too (confirmed via `git stash` and rerunning on master), unrelated to this change.
