### PR TITLE
#5715: reformat scanf.eo to the current canonical attribute order

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -19,11 +19,147 @@
   extracted > @
     pattern
     specifiers
-  tokenize > tokens
-    0
-    ""
-    *
-    false
+  [ch] > escaped
+    metachar.if > @
+      escaped-char
+      ch
+    chained *1 > escaped-char
+      "\\"
+      ch
+    metachars.contains ch > metachar
+    * > metachars
+      "\\"
+      "^"
+      "$"
+      "."
+      "|"
+      "?"
+      "*"
+      "+"
+      "("
+      ")"
+      "["
+      "]"
+      "{"
+      "}"
+      "/"
+  [pattern specifiers] > extracted
+    convert > @
+      1
+      *
+    [text] > as-float
+      negative.if negated magnitude > @
+      index-of unsigned "." > dot
+      div. > fraction
+        fold-digits
+          slice
+            unsigned
+            dot.plus 1
+            places
+        10.power places
+      not. > has-fraction
+        dot.eq -1
+      has-fraction.if with-fraction whole > magnitude
+      magnitude.times -1 > negated
+      eq. > negative
+        slice
+          text
+          0
+          1
+        "-"
+      unsigned.length.minus > places
+        dot.plus 1
+      negative.or > signed-prefix
+        eq.
+          slice text 0 1
+          "+"
+      signed-prefix.if > unsigned
+        slice
+          text
+          1
+          text.length.minus 1
+        text
+      fold-digits unsigned > whole
+      plus. > with-fraction
+        fold-digits
+          slice unsigned 0 dot
+        fraction
+    [text] > as-integer
+      if. > @
+        digits.length.gt 19
+        overflow
+        signed
+      signed-prefix.if > digits
+        slice
+          text
+          1
+          text.length.minus 1
+        text
+      fold-digits digits > folded
+      folded.times -1 > negated
+      eq. > negative
+        slice
+          text
+          0
+          1
+        "-"
+      overflow-message > overflow
+      T > overflow-message
+        "The number doesn't fit into long range for the '%d' conversion"
+      negative.if negated folded > signed
+      negative.or > signed-prefix
+        eq.
+          slice text 0 1
+          "+"
+    [group acc] > convert
+      matched.exists.not.if > @
+        *
+        next-group
+      convert > next
+        group.plus 1
+        acc.with
+          converted
+            specifiers.at
+              group.minus 1
+              T
+            matched.group group
+      if. > next-group
+        group.gt specifiers.length
+        acc
+        next
+    [spec text] > converted
+      if. > @
+        spec.eq "s"
+        text
+        as-number-value
+      as-float text > as-float-value
+      as-integer text > as-integer-value
+      if. > as-number-value
+        spec.eq "d"
+        as-integer-value
+        as-float-value
+    [text] > fold-digits
+      rec 0 0 > @
+      [index acc] > rec
+        if. > @
+          index.eq text.length
+          acc
+          next
+        rec > next
+          index.plus 1
+          (acc.times 10).plus
+            minus.
+              as-ascii
+                slice text index 1
+              48
+    match. > found
+      regex wrapped
+      read
+    found.next > matched
+    chained *1 > wrapped
+      "/"
+      pattern
+      "/"
   tokens.at > pattern
     0
     T
@@ -39,12 +175,6 @@
       format
       pos
       1
-    escaped ch > piece
-    pending.if *1 > ended
-      dangling
-      accumulated
-      found
-    dangling-message > dangling
     pending.if > continued
       if.
         ch.eq "%"
@@ -97,151 +227,21 @@
             piece
           found
           false
+    dangling-message > dangling
     T > dangling-message
       "The format string ends with a dangling percent and no specifier after it"
+    pending.if *1 > ended
+      dangling
+      accumulated
+      found
+    escaped ch > piece
     T > unsupported-message
       "Unsupported format specifier"
-  [ch] > escaped
-    metachar.if > @
-      escaped-char
-      ch
-    metachars.contains ch > metachar
-    chained *1 > escaped-char
-      "\\"
-      ch
-    * > metachars
-      "\\"
-      "^"
-      "$"
-      "."
-      "|"
-      "?"
-      "*"
-      "+"
-      "("
-      ")"
-      "["
-      "]"
-      "{"
-      "}"
-      "/"
-  [pattern specifiers] > extracted
-    convert > @
-      1
-      *
-    chained *1 > wrapped
-      "/"
-      pattern
-      "/"
-    match. > found
-      regex wrapped
-      read
-    found.next > matched
-    [group acc] > convert
-      matched.exists.not.if > @
-        *
-        next-group
-      if. > next-group
-        group.gt specifiers.length
-        acc
-        next
-      convert > next
-        group.plus 1
-        acc.with
-          converted
-            specifiers.at
-              group.minus 1
-              T
-            matched.group group
-    [spec text] > converted
-      if. > @
-        spec.eq "s"
-        text
-        as-number-value
-      if. > as-number-value
-        spec.eq "d"
-        as-integer-value
-        as-float-value
-      as-integer text > as-integer-value
-      as-float text > as-float-value
-    [text] > as-integer
-      if. > @
-        digits.length.gt 19
-        overflow
-        signed
-      overflow-message > overflow
-      negative.if negated folded > signed
-      folded.times -1 > negated
-      eq. > negative
-        slice
-          text
-          0
-          1
-        "-"
-      negative.or > signed-prefix
-        eq.
-          slice text 0 1
-          "+"
-      signed-prefix.if > digits
-        slice
-          text
-          1
-          text.length.minus 1
-        text
-      fold-digits digits > folded
-      T > overflow-message
-        "The number doesn't fit into long range for the '%d' conversion"
-    [text] > as-float
-      negative.if negated magnitude > @
-      magnitude.times -1 > negated
-      eq. > negative
-        slice
-          text
-          0
-          1
-        "-"
-      negative.or > signed-prefix
-        eq.
-          slice text 0 1
-          "+"
-      signed-prefix.if > unsigned
-        slice
-          text
-          1
-          text.length.minus 1
-        text
-      index-of unsigned "." > dot
-      has-fraction.if with-fraction whole > magnitude
-      not. > has-fraction
-        dot.eq -1
-      fold-digits unsigned > whole
-      plus. > with-fraction
-        fold-digits
-          slice unsigned 0 dot
-        fraction
-      unsigned.length.minus > places
-        dot.plus 1
-      div. > fraction
-        fold-digits
-          slice
-            unsigned
-            dot.plus 1
-            places
-        10.power places
-    [text] > fold-digits
-      rec 0 0 > @
-      [index acc] > rec
-        if. > @
-          index.eq text.length
-          acc
-          next
-        rec > next
-          index.plus 1
-          (acc.times 10).plus
-            minus.
-              as-ascii
-                slice text index 1
-              48
+  tokenize > tokens
+    0
+    ""
+    *
+    false
 
   eq. ++> tests-scanf-complex-case
     scanf


### PR DESCRIPTION
Closes #5715.

`scanf.eo` (added by #5488/#5711) was formatted with `-Deo.autoFix` under the canonical-order rules in effect at the time. While that PR was open, the fix for #5706 ("eo-printer: emit formation attributes in canonical order", commit `507977b79d`) merged into master, changing what canonical order means. There was no textual conflict when #5711 merged, since master's prior `scanf.eo` was a one-line native-atom stub, so the merge simply took the new file as-is. Result: `scanf.eo` on master now fails the `format` goal, breaking `mvn clean install` for everyone, since `MjFormat` fails the build hard when a source is not canonical.

Ran `-Deo.autoFix` once to bring `scanf.eo` in line with the current canonical order. No behavior change, pure reformat.

Verified:
- `mvn -pl eo-runtime process-sources` (format check, no autoFix) now passes with 0 violations, down from 1.
- `EOscanfTest`: 15/15 green, unchanged.
- `mvn clean verify -PskipTests -Pqulice` (the exact command CI's `qulice` job runs): clean.
