### PR TITLE
#5632: require the whole text to be a number in string.as-number

### DIFF
--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -1,6 +1,11 @@
 # Returns the original `text` as `number`.
 # If the text is not numeric, the `cant-parse` fallback is returned,
 # or the bottom object when unbound.
+# The whole `text` must be the number: `scanf` matches its `%f` pattern
+# unanchored (via `find`), so on its own it would accept any text that
+# merely contains a number-shaped substring, e.g. `"$100"` or `"12.34.56"`.
+# The text is therefore validated against the anchored equivalent of that
+# same `%f` token, so that only a text that is entirely a number is parsed.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -11,27 +16,56 @@
 
 [text cant-parse] > as-number
   if. > @
-    scanned.length.eq 0
+    not.
+      matches.
+        compiled.
+          regex "/^[+-]?\\d+(?:\\.\\d+)?$/"
+        text
     cant-parse
       "Can't convert text %s to number".printf
         * text
-    scanned.head
-  ^. > scanned
-    at.
-      scanf "%f" text
+    (scanf "%f" text).at.^.head
 
   eq. ++> tests-converts-float-text-to-number
     3.14
     as-number "3.14"
 
+  eq. ++> tests-converts-negative-text-to-number
+    -42
+    as-number "-42"
+
   eq. ++> tests-converts-text-to-number
     5
     as-number "5"
+
+  eq. ++> tests-currency-prefixed-text-returns-provided-fallback
+    42
+    as-number
+      "$100"
+      42 > [msg]
+
+  eq. ++> tests-embedded-number-text-returns-provided-fallback
+    42
+    as-number
+      "abc5"
+      42 > [msg]
+
+  eq. ++> tests-multiple-dots-text-returns-provided-fallback
+    42
+    as-number
+      "12.34.56"
+      42 > [msg]
 
   eq. ++> tests-non-numeric-text-returns-provided-fallback
     42
     as-number
       "Hello"
+      42 > [msg]
+
+  eq. ++> tests-space-separated-numbers-text-returns-provided-fallback
+    42
+    as-number
+      "1 2 3"
       42 > [msg]
 
   as-number "Hello" --> on-converting-text-to-number


### PR DESCRIPTION
Fixes #5632.

`string.as-number` delegated parsing to `scanf`, whose `%f` pattern (`([+-]?\d+(?:\.\d+)?)`) is matched **unanchored** (via `find`), and the only guard was `scanned.length.eq 0` — i.e. "was anything found at all". Any text that merely *contained* a number-shaped substring was therefore accepted and a number returned, contradicting the object's own docstring contract:

| text | before | after |
| --- | --- | --- |
| `"abc5"` | `5.0` | `cant-parse` |
| `"12.34.56"` | `12.34` | `cant-parse` |
| `"$100"` | `100.0` | `cant-parse` |
| `"1 2 3"` | `1.0` | `cant-parse` |
| `"5"`, `"3.14"`, `"-42"` | parsed | parsed (unchanged) |

Per the issue's suggested resolution (option 1), the anchoring is applied at `as-number`'s call site, not in `scanf` (which must stay unanchored for its general substring-scanning use). The text is validated against the anchored equivalent of the same `%f` token, `^[+-]?\d+(?:\.\d+)?$`, so only a text that is entirely a number is parsed; otherwise the `cant-parse` fallback (or `⊥` when unbound) is returned.

Added tests covering `"abc5"`, `"12.34.56"`, `"$100"`, `"1 2 3"` (each must fall back) and a negative-signed number; verified they fail against the old implementation and pass with the fix. Full `eo-runtime` suite is green (the only failure is the pre-existing `EOsocketTest.refusesConnectionViaSyscall` Windows/TEST-NET artifact, which also fails on unmodified master). No new lint warnings.