### PR TITLE
fix(eo-runtime): return fallback when no switch case evaluates to true (#5726)

### DIFF
--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -14,7 +14,9 @@
 #       "this value will be skipped"
 # ```
 #
-# This object returns the value of the first true statement.
+# This object returns the value of the first true statement,
+# or invokes `fallback` with a descriptive message when `cases`
+# is empty or when every case condition is false.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -46,7 +48,8 @@
                 rec-case tup.tail
             | cases
       found.head
-      true
+      fallback
+        "No switch case matched"
 
   switch * ++> can-return-true-when-all-cases-are-false
     *
@@ -94,6 +97,14 @@
       "password is correct!"
     "swordfish" > password
 
+  eq. ++> can-switch-on-all-false-cases-with-fallback
+    "fallback"
+    switch
+      *
+        * false "false1"
+        * false "false2"
+      "fallback" > [message]
+
   eq. ++> can-switch-on-the-first-of-several-true-cases
     switch *
       * true "TRUE1"
@@ -106,6 +117,14 @@
     switch
       *
       "recovered" > [message]
+
+  switch * --> stops-on-all-false-cases-without-fallback
+    *
+      false
+      "false1"
+    *
+      false
+      "false2"
 
   switch --> stops-on-an-empty-switch
     *

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -51,14 +51,6 @@
       fallback
         "No switch case matched"
 
-  switch * ++> can-return-true-when-all-cases-are-false
-    *
-      false
-      "false1"
-    *
-      false
-      "false2"
-
   ++> can-switch-on-a-complex-case
     eq. > @
       switch *

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -82,6 +82,14 @@
       * true "2"
     "2"
 
+  eq. ++> can-switch-on-all-false-cases-with-fallback
+    "fallback"
+    switch
+      *
+        * false "false1"
+        * false "false2"
+      "fallback" > [message]
+
   ++> can-switch-on-strings
     eq. > @
       switch *
@@ -96,14 +104,6 @@
           "password is wrong"
       "password is correct!"
     "swordfish" > password
-
-  eq. ++> can-switch-on-all-false-cases-with-fallback
-    "fallback"
-    switch
-      *
-        * false "false1"
-        * false "false2"
-      "fallback" > [message]
 
   eq. ++> can-switch-on-the-first-of-several-true-cases
     switch *


### PR DESCRIPTION
Closes #5726

### What was changed
In `eo-runtime/src/main/eo/switch.eo`, updated `switch` logic so that when no case evaluates to true in a non-empty `cases` array, it returns `fallback` instead of returning literal `true`.

Updated documentation and unit tests in `switch.eo`:
- Added test verifying `switch` returns `fallback` when all cases evaluate to `false`.
- Added test verifying `switch` without `fallback` fails when all cases evaluate to `false`.