### PR TITLE
fix(#5733): align groovy-maven-plugin with Groovy 5, add JDK 26 to CI

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15-intel, macos-15]
-        java: [23]
+        java: [26]
     runs-on: ${{ matrix.os }}
     env:
       CONVERT_PATH: /tmp/antlr4-to-bnf-converter

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -445,9 +445,9 @@
         </executions>
         <dependencies>
           <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-xml</artifactId>
-            <version>3.0.25</version>
+            <version>5.0.7</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -432,9 +432,9 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-xml</artifactId>
-                <version>3.0.25</version>
+                <version>5.0.7</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -560,9 +560,9 @@
                 <version>0.37.1</version>
               </dependency>
               <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-xml</artifactId>
-                <version>3.0.25</version>
+                <version>5.0.7</version>
               </dependency>
               <dependency>
                 <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
Closes #5733.

## Problem

The `groovy-maven-plugin` executions pinned `org.codehaus.groovy:groovy-xml:3.0.25`, dragging the legacy Groovy 3 runtime onto the plugin classpath. Under JDK 26 the verify-phase `verify.groovy` crashes during semantic analysis with:

```
java.lang.IllegalArgumentException: Unsupported class file major version 70
```

thrown from `groovyjarjarasm.asm.ClassReader` via `AsmDecompiler`. Groovy 3.0.25 bundles an ASM that predates JDK 26 and cannot decompile its class files (major version 70). This is the same symptom as the already-fixed #1689 (Java 19, major version 63), recurring on a newer JDK.

## Changes

- Replace `org.codehaus.groovy:groovy-xml:3.0.25` with `org.apache.groovy:groovy-xml:5.0.7` in the `groovy-maven-plugin` executions, aligning with the Groovy 5 (`5.0.7`) used elsewhere in the project:
  - `eo-maven-plugin/pom.xml`
  - parent `pom.xml`
  - `eo-runtime/pom.xml` (same pattern, same failure — fixed for consistency so the JDK 26 build is green)
- Bump the `mvn` CI matrix from JDK 23 to JDK 26 in `.github/workflows/mvn.yml`.

The unrelated `org.codehaus.groovy:groovy-all` *exclusion* in `eo-maven-plugin/pom.xml` (on the `lints` dependency) is left untouched — it is intentionally excluding the old transitive runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoJL3ZF18pLmA7vGMcXxPH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoJL3ZF18pLmA7vGMcXxPH)_