### PR TITLE
Remove extra parenthesis in VerboseBytesAsString output

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -50,7 +50,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
                 break;
             case 8:
                 result = String.format(
-                    "[0x%s] = %s, or \"%s\")",
+                    "[0x%s] = %s, or \"%s\"",
                     this.toHex(),
                     new BytesOf(this.data).asNumber(),
                     this.escaped()


### PR DESCRIPTION
## Summary

Closes #5725 
This PR fixes a formatting issue in `VerboseBytesAsString` for 8-byte values.

The format string in the `case 8` branch contained an unmatched closing parenthesis:

```java
"[0x%s] = %s, or \"%s\")"
```

As a result, CLI output for numeric results included an extra `)` character. For example:

```text
[0x4028B0FB-A8826AA9-] = 12.34567, or "@(����j�")]
```

## Fix

Removed the stray closing parenthesis from the format string:

```java
"[0x%s] = %s, or \"%s\""
```

This produces correctly formatted output without the unmatched `)`.

## Example

Before:

```text
[0x4028B0FB-A8826AA9-] = 12.34567, or "@(����j�")]
```

After:

```text
[0x4028B0FB-A8826AA9-] = 12.34567, or "@(����j�"]
```
