### PR TITLE
fix(#5739): merge monikers onto the first of several references

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -25,8 +25,10 @@ import org.eolang.printer.Xmir;
  *
  * <p>This goal walks through all registered {@code .eo} sources (see
  * {@link MjRegister}), reformats every one of them in memory by parsing
- * it to XMIR and printing it back with {@link Xmir#toEO()}, and compares
- * the result against what is on disk. In its default "check" mode, it
+ * it to XMIR and printing it back with {@link Xmir#toEO()} until the text
+ * stops changing (the moniker merge of #5739 is not a single-pass
+ * fixpoint, so the canonical form is the fixpoint of parse-and-print), and
+ * compares that against what is on disk. In its default "check" mode, it
  * prints a colored unified {@link Diff} for every file that diverges from
  * the canonical form and fails the build. When {@link #autoFix} is turned
  * on (via the {@code eo.autoFix} property), it overwrites the divergent
@@ -41,6 +43,19 @@ import org.eolang.printer.Xmir;
     threadSafe = true
 )
 public final class MjFormat extends MjSafe {
+
+    /**
+     * The most parse-and-print passes taken to settle the moniker layout
+     * before giving up.
+     *
+     * <p>Merging a moniker onto its first bare reference (#5739) is not a
+     * single-pass fixpoint: the canonical attribute ordering of #5706 can
+     * move which reference is "first", so one print may shift a moniker and
+     * a further print settle it. The structural form is therefore reached by
+     * iterating parse-and-print until it stops changing; this cap keeps a
+     * pathological non-converging source from looping forever.</p>
+     */
+    private static final int SETTLE = 8;
 
     /**
      * Overwrite divergent sources with their canonical form instead of
@@ -105,9 +120,7 @@ public final class MjFormat extends MjSafe {
      */
     private boolean reformat(final Path source) throws IOException {
         final String actual = new UncheckedText(new TextOf(source)).asString();
-        final String canonical = new Xmir(
-            new EoSyntax(actual).parsed(), this.weights()
-        ).toEO();
+        final String canonical = this.canonical(actual);
         final Diff diff = new Diff(actual, canonical);
         final boolean diverged = !diff.same();
         if (diverged && this.autoFix) {
@@ -122,6 +135,37 @@ public final class MjFormat extends MjSafe {
             );
         }
         return diverged;
+    }
+
+    /**
+     * The canonical form of a source.
+     *
+     * <p>A binding with several bare references merges onto whichever is
+     * "first" in the canonically ordered body (#5706, #5739), and that
+     * choice can move on the next pass, so a single parse-and-print is not
+     * always a fixpoint. The moniker's home is decided by the structure
+     * alone (attribute order and the XSL merge), not by the layout weights,
+     * so this settles it at the default, always-reparseable layout — a
+     * custom {@link #step} would emit indentation the parser cannot read
+     * back — and then lays the settled structure out once with the
+     * configured weights. The settling is bounded by {@link #SETTLE}; a
+     * source that has not settled by then is laid out as-is and reported
+     * divergent, so it fails loudly instead of looping.</p>
+     *
+     * @param source The current text of the {@code .eo} file
+     * @return The canonical text
+     * @throws IOException If fails to parse the source
+     */
+    private String canonical(final String source) throws IOException {
+        String structure = source;
+        for (int pass = 0; pass < MjFormat.SETTLE; ++pass) {
+            final String next = new Xmir(new EoSyntax(structure).parsed()).toEO();
+            if (next.equals(structure)) {
+                break;
+            }
+            structure = next;
+        }
+        return new Xmir(new EoSyntax(structure).parsed(), this.weights()).toEO();
     }
 
     /**

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -15,20 +15,22 @@
   binding line) parse to one and the same object graph. This pass turns
   the expanded spelling back into the moniker.
 
-  For each formation, a named bound attribute that is neither void, `φ`,
-  a test, nor pipe-floated is merged onto its bare `ξ.<name>` reference
+  For each formation, an eligible named bound attribute (see
+  `eo:moniker-binding`) is merged onto the first bare `ξ.<name>` reference
   reachable through no intervening formation (so the name still binds to
   the same formation). A method-dispatch use such as `value.gte`, a
   reference carrying arguments, or a reference that is itself a named
   attribute (such as `temp > @`) cannot host the binding and stays a
-  reference.
+  reference; when no bare reference exists, the binding is left in place.
 
-  Only a binding with exactly one hostable reference is merged. With two
-  or more, the choice of a host would not survive the print/parse round
-  trip: canonical attribute ordering (#5706) reorders the sibling bindings
-  a reference sits inside, so "the first reference" flips between passes
-  and the printer stops converging. Such a binding, and one with no bare
-  reference at all, is left in place.
+  A binding with several hostable references still becomes a moniker,
+  landing on the first one in document order (#5739). This deliberately
+  gives up the print/parse fixpoint that a single-reference-only merge
+  (#5707) guaranteed: canonical attribute ordering (#5706) can reorder the
+  sibling bindings a reference sits inside, so "the first reference" may
+  shift between passes and the printed moniker may move with it. Since only
+  the compiler's obfuscated names are merged (#5738), this shift stays
+  hidden inside auto-generated plumbing and never moves an author's name.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -56,9 +58,9 @@
     <xsl:sequence select="exists($attr/@name) and starts-with($attr/@name, concat('a', $eo:cactoos)) and exists($attr/@base) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
-  The bare `ξ.<name>` references that can host the binding `$attr`: a bare
-  reference whose nearest formation ancestor is the binding's own owner and
-  that does not sit inside the binding itself.
+  The bare `ξ.<name>` references, in document order, that can host the
+  binding `$attr`: a bare reference whose nearest formation ancestor is the
+  binding's own owner and that does not sit inside the binding itself.
   -->
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
@@ -68,13 +70,13 @@
   <!--
   The binding that a reference `$ref` should be replaced with, or the empty
   sequence when `$ref` hosts no binding (not a bare reference, no eligible
-  binding, or a binding with anything other than this single reference).
+  binding, or not the first hosting reference).
   -->
   <xsl:function name="eo:hosted-binding" as="element()*">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
     <xsl:variable name="binding" select="$owner/o[@name = eo:resolved-ref($ref) and eo:moniker-binding(.)][1]"/>
-    <xsl:sequence select="if (exists($binding) and (count(eo:moniker-refs($binding)) = 1) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
   Replace the first hosting reference with the merged binding: keep the
@@ -92,7 +94,7 @@
   <!--
   Drop the standalone binding once it has been merged onto a reference.
   -->
-  <xsl:template match="o[eo:moniker-binding(.) and count(eo:moniker-refs(.)) = 1]" priority="1"/>
+  <xsl:template match="o[eo:moniker-binding(.) and exists(eo:moniker-refs(.))]" priority="1"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -53,6 +53,10 @@ final class XmirTest {
     void printsToParseableEo(final String pack) throws IOException {
         final Xtory xtory = new XtSticky(new XtYaml(pack));
         Assumptions.assumeTrue(xtory.map().get("skip") == null);
+        Assumptions.assumeTrue(
+            !Boolean.FALSE.equals(xtory.map().get("reprints")),
+            "'reprints: false' packs need not reprint to themselves (#5739)"
+        );
         final String printed = (String) xtory.map().get("printed");
         MatcherAssert.assertThat(
             String.format(


### PR DESCRIPTION
Closes #5739. Rebased onto latest `master` (after #5738 merged).

## What

`merge-monikers.xsl` merged a binding only when it had exactly one hostable reference (the `count(eo:moniker-refs(...)) = 1` guard added in #5707). This drops that guard and restores the pre-#5707 behaviour: an eligible binding with several hostable references still becomes a moniker, landing on the **first** reference in document order (`eo:moniker-refs($binding)[1] is $ref`).

Eligibility is left exactly as #5738 defined it — only the compiler's obfuscated `a🌵` names are merged, so an author's chosen name is never moved.

## The accepted trade-off

The print stops being a single-pass fixpoint: #5706's canonical attribute sort can move which reference is "first" between passes, so re-printing may shift the moniker. The two assertions that relied on the single-pass fixpoint are relaxed to land together with the XSL change:

- **`eo-printer` — `printsToParseableEo`**: now honours a per-pack `reprints: false` flag for packs whose printed form is not expected to reprint to itself.
- **`eo-maven-plugin` — the `.eo` format check (`MjFormat`)**: computes the canonical form as the *fixpoint* of parse-and-print instead of asserting a single pass is already one. The moniker's home is decided by structure alone (attribute order + the XSL merge), not by the layout weights, so it settles at the always-reparseable default layout and then lays the settled structure out once with the configured weights (a custom `step` would otherwise emit indentation the parser cannot read back).

## Scope note (post-#5738)

Now that #5738 restricts merging to obfuscated names, **no eligible (bound, obfuscated) binding in `eo-runtime` currently has more than one hostable reference** — the multi-reference case is a no-op on today's sources (verified: zero `.eo` files change). The guard removal restores the general behaviour the issue asks for, and the relaxations above are kept as future-proofing for when such a binding does arise. No `eo-runtime` sources are reformatted.

## Testing

- `eo-printer`: full module suite — 173 tests, 0 failures.
- `eo-maven-plugin`: `MjFormatTest` — 5 tests, 0 failures.

Relates to #5738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwV3xFsXu8FzAPKc3xdHp1