### PR TITLE
#5719: make MjSafe.exitError always fail the build regardless of unrollExitError

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -683,10 +683,17 @@ abstract class MjSafe extends AbstractMojo {
      */
     private void exitError(final String msg, final Throwable exp)
         throws MojoFailureException {
-        if (!this.unrollExitError) {
-            return;
+        if (this.unrollExitError) {
+            this.logCauses(exp);
         }
-        final MojoFailureException out = new MojoFailureException(msg, exp);
+        throw new MojoFailureException(msg, exp);
+    }
+
+    /**
+     * Log the deduplicated cause chain of the given exception.
+     * @param exp Original problem
+     */
+    private void logCauses(final Throwable exp) {
         final List<String> causes = MjSafe.causes(exp);
         for (int pos = 0; pos < causes.size(); ++pos) {
             final String cause = causes.get(pos);
@@ -714,7 +721,6 @@ abstract class MjSafe extends AbstractMojo {
         for (final String cause : new LinkedHashSet<>(causes)) {
             Logger.error(this, cause);
         }
-        throw out;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjSafeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjSafeTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link MjSafe}.
+ * @since 0.1
+ */
+final class MjSafeTest {
+
+    @Test
+    void failsBuildWhenUnrollExitErrorIsTrue() {
+        final MjSafeTest.Failing mojo = new MjSafeTest.Failing();
+        mojo.unrollExitError = true;
+        Assertions.assertThrows(
+            MojoFailureException.class,
+            mojo::execute,
+            "Build must fail when the wrapped Mojo throws and unrollExitError is true"
+        );
+    }
+
+    @Test
+    void failsBuildWhenUnrollExitErrorIsFalse() {
+        final MjSafeTest.Failing mojo = new MjSafeTest.Failing();
+        mojo.unrollExitError = false;
+        Assertions.assertThrows(
+            MojoFailureException.class,
+            mojo::execute,
+            "Build must still fail when the wrapped Mojo throws, even if unrollExitError is false"
+        );
+    }
+
+    /**
+     * The mojo whose exec() always fails.
+     * @since 0.1
+     */
+    @Mojo(name = "failing", defaultPhase = LifecyclePhase.VALIDATE)
+    private static final class Failing extends MjSafe {
+
+        @Override
+        public void exec() throws IOException {
+            throw new IOException("intentional failure for MjSafeTest");
+        }
+    }
+}


### PR DESCRIPTION
Closes #5719.

`MjSafe.exitError()` used to just `return` without throwing anything when `eo.unrollExitError` was `false`, so a real exception from the Mojo's work was silently swallowed and Maven reported the build as successful. This contradicted the parameter's own Javadoc, which describes it only as controlling whether the exception is logged in detail, not whether the build fails.

Fix: `exitError()` now always throws `MojoFailureException`. The `unrollExitError` flag only gates the detailed cause-chain logging, which is now extracted into a separate `logCauses` helper (needed to keep the method's cognitive complexity under PMD's threshold once the early return was removed).

Added `MjSafeTest.java` with a minimal `Failing` Mojo whose `exec()` always throws:
- `unrollExitError=true`: throws `MojoFailureException` with the cause chain logged.
- `unrollExitError=false`: this is the actual regression test for the bug. Still throws `MojoFailureException`, just without the detailed log.

Verified the regression test is real by temporarily reverting the fix and re-running: the `unrollExitError=false` test fails against the old code (nothing thrown), passes with the fix.

Verified:
- `MjSafeTest`: 2/2 green.
- `mvn clean verify -PskipTests -Pqulice` (the exact command CI runs): clean.
