### PR TITLE
fix(#5725): remove unmatched parenthesis from verbose bytes

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -50,7 +50,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
                 break;
             case 8:
                 result = String.format(
-                    "[0x%s] = %s, or \"%s\")",
+                    "[0x%s] = %s, or \"%s\"",
                     this.toHex(),
                     new BytesOf(this.data).asNumber(),
                     this.escaped()

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,6 +18,19 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @since 0.1
  */
 final class VerboseBytesAsStringTest {
+
+    @Test
+    void representsEightByteValueWithoutUnmatchedParenthesis() {
+        MatcherAssert.assertThat(
+            "Eight-byte output must not contain an unmatched parenthesis",
+            new VerboseBytesAsString(
+                ByteBuffer.allocate(Double.BYTES).putDouble(12.345_67D).array()
+            ).get(),
+            Matchers.equalTo(
+                "[0x4028B0FB-A8826AA9-] = 12.34567, or \"@(\\ufffd\\ufffd\\ufffd\\ufffdj\\ufffd\""
+            )
+        );
+    }
 
     @ParameterizedTest
     @MethodSource("getTestSources")


### PR DESCRIPTION
## Summary

- remove the unmatched closing parenthesis from 8-byte verbose output
- add an exact-output regression test for an 8-byte double value

Fixes #5725.

## Test plan

- `mvn -pl eo-runtime -Dtest=VerboseBytesAsStringTest test` — 7 tests passed
- `mvn -pl eo-runtime test` — 1,722 tests passed, 0 failures, 0 errors, 16 skipped
- `mvn clean install -Pqulice` — attempted with Java 17 and Java 21; Java 17 is rejected by Qulice's Java 21 prerequisite, while Java 21 reaches unrelated repository failures in `eo-maven-plugin/MjPrintTest` (JucsProvider/JUnit 6 incompatibility) and later generated-class validation
- Java 21 Qulice static checking reported no violations in the changed test after formatting

The implementation and test diff were reviewed locally.