### PR TITLE
fix(eo-parser): ignore quoted content in redundant-paren check (#5722)

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -239,12 +239,7 @@ final class Tokens {
             );
         }
         final String inside = this.body.substring(start + 1, this.cursor - 1);
-        if (!inside.isEmpty()
-            && inside.indexOf(' ') < 0
-            && inside.indexOf('(') < 0
-            && inside.indexOf(')') < 0
-            && inside.indexOf('[') < 0
-            && inside.indexOf(']') < 0) {
+        if (!inside.isEmpty() && Tokens.singleToken(inside)) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + start,
                 String.format(
@@ -639,6 +634,40 @@ final class Tokens {
      */
     String body() {
         return this.body;
+    }
+
+    /**
+     * Whether the content of a paren group is a single token — it holds no
+     * token separator ({@code ' '}, {@code '('}, {@code ')'}, {@code '['} or
+     * {@code ']'}) outside of a quoted string literal. Characters inside
+     * double quotes are ignored, since a string literal is always one atomic
+     * token regardless of what it contains.
+     * @param inside Content between the parentheses
+     * @return True if the content is a single token
+     */
+    private static boolean singleToken(final String inside) {
+        boolean single = true;
+        int idx = 0;
+        while (idx < inside.length()) {
+            final char glyph = inside.charAt(idx);
+            if (glyph == '"') {
+                idx = idx + 1;
+                while (idx < inside.length() && inside.charAt(idx) != '"') {
+                    if (inside.charAt(idx) == '\\' && idx + 1 < inside.length()) {
+                        idx = idx + 1;
+                    }
+                    idx = idx + 1;
+                }
+                idx = idx + 1;
+            } else if (glyph == ' ' || glyph == '(' || glyph == ')'
+                || glyph == '[' || glyph == ']') {
+                single = false;
+                break;
+            } else {
+                idx = idx + 1;
+            }
+        }
+        return single;
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal-with-braces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal-with-braces.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:6] error: 'redundant parentheses around a single token — `("a(b)c")` should be written as `"a(b)c"`'
+  1.add ("a(b)c") > x
+        ^
+input: |
+  1.add ("a(b)c") > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal-with-space.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal-with-space.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:6] error: 'redundant parentheses around a single token — `("hello world")` should be written as `"hello world"`'
+  1.add ("hello world") > x
+        ^
+input: |
+  1.add ("hello world") > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:6] error: 'redundant parentheses around a single token — `("hello")` should be written as `"hello"`'
+  1.add ("hello") > x
+        ^
+input: |
+  1.add ("hello") > x


### PR DESCRIPTION
Closes #5722.

## Problem

`Tokens.readGroup()` decided whether a parenthesized group wraps a single
token by scanning the raw substring between the parens for a space or a
`(`/`)`/`[`/`]`. That scan had no notion of quoted strings, so it was fooled
by string content:

```
1.add ("hello") > x         → redundant-parentheses error
1.add ("hello world") > x   → silently accepted
```

Both are the same case — a parenthesized single string-literal argument —
but only the single-word one was flagged. The same asymmetry hit
`("a(b)c")` / `("a[b]c")`. This is the same class of bug fixed for
`Penalty.java` in #5718.

## Fix

Replaced the naive `indexOf` checks with `singleToken()`, which scans the
group content while tracking quote state — skipping characters inside
double quotes exactly as the surrounding group scanner already does — and
reports a single token only when no separator appears **outside** a string
literal. A parenthesized single string literal is now flagged consistently
regardless of what characters appear inside its quotes.

## Tests

Added three `eo-typos/redundant-parentheses` packs: a plain quoted string,
a quoted string containing a space (the previously-accepted regression
case), and one containing brackets. `EoSyntaxTest#checksTypoPacks` green
(77/77).