### PR TITLE
fix(eo-printer): preserve argument applied to a data literal (#5721)

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.printer;
 
+import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StEnvelope;
@@ -16,7 +17,6 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import org.eolang.parser.StXnav;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * This {@link Shift} turns hex data inside XMIR.
@@ -100,14 +100,7 @@ final class StUnhex extends StEnvelope {
      */
     private static void inline(final Xnav xnav, final String text) {
         final Node parent = xnav.node();
-        final NodeList children = parent.getChildNodes();
-        int elements = 0;
-        for (int idx = 0; idx < children.getLength(); ++idx) {
-            if (children.item(idx).getNodeType() == Node.ELEMENT_NODE) {
-                elements = elements + 1;
-            }
-        }
-        if (elements > 1) {
+        if (xnav.elements(Filter.withName("o")).count() > 1L) {
             parent.replaceChild(
                 parent.getOwnerDocument().createTextNode(text),
                 xnav.element("o").node()

--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.printer;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StEnvelope;
 import com.yegor256.xsline.StSequence;
@@ -14,6 +15,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.eolang.parser.StXnav;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * This {@link Shift} turns hex data inside XMIR.
@@ -40,9 +43,7 @@ final class StUnhex extends StEnvelope {
         StUnhex.class.getSimpleName(),
         new StXnav(
             StUnhex.BYTES,
-            xnav -> xnav.node().setTextContent(
-                xnav.element("o").text().orElse("")
-            )
+            xnav -> StUnhex.inline(xnav, xnav.element("o").text().orElse(""))
         ),
         new StXnav(
             StUnhex.elements("number"),
@@ -53,7 +54,7 @@ final class StUnhex extends StEnvelope {
                 if (buffer.remaining() == Double.BYTES) {
                     final double number = buffer.getDouble();
                     if (!Double.isNaN(number) && !Double.isInfinite(number)) {
-                        xnav.node().setTextContent(StUnhex.number(number));
+                        StUnhex.inline(xnav, StUnhex.number(number));
                     }
                 }
             }
@@ -65,8 +66,8 @@ final class StUnhex extends StEnvelope {
                     StUnhex.undash(xnav.element("o").text().orElse(""))
                 ).array()
             ).ifPresent(
-                decoded -> xnav.node().setTextContent(
-                    String.format("\"%s\"", StUnhex.escape(decoded))
+                decoded -> StUnhex.inline(
+                    xnav, String.format("\"%s\"", StUnhex.escape(decoded))
                 )
             )
         )
@@ -85,6 +86,35 @@ final class StUnhex extends StEnvelope {
      */
     StUnhex(final Shift origin) {
         super(origin);
+    }
+
+    /**
+     * Replace a data literal's byte-payload child with a text node holding its
+     * readable EO form, leaving any sibling intact. A bare data literal can be
+     * the head of an application (for example {@code 42 5}), in which case its
+     * {@code <o>} wrapper holds the applied argument alongside the byte payload.
+     * Calling {@code setTextContent} on the wrapper would drop that argument, so
+     * only the first child (the payload) is replaced (#5721).
+     * @param xnav Navigator positioned at the literal wrapper {@code <o>}
+     * @param text The readable replacement text
+     */
+    private static void inline(final Xnav xnav, final String text) {
+        final Node parent = xnav.node();
+        final NodeList children = parent.getChildNodes();
+        int elements = 0;
+        for (int idx = 0; idx < children.getLength(); ++idx) {
+            if (children.item(idx).getNodeType() == Node.ELEMENT_NODE) {
+                elements = elements + 1;
+            }
+        }
+        if (elements > 1) {
+            parent.replaceChild(
+                parent.getOwnerDocument().createTextNode(text),
+                xnav.element("o").node()
+            );
+        } else {
+            parent.setTextContent(text);
+        }
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -40,6 +40,39 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
+    void keepsArgumentAppliedToDataLiteral(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must keep an argument applied to a data literal, but it didn't",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<p><o base='Φ.number'>",
+                        "<o base='Φ.bytes'><o>43-70-2E-4F-30-46-73-2E</o></o>",
+                        "<o base='arg'/>",
+                        "</o></p>"
+                    )
+                )
+            ),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("//o[@base='Φ.number']/o[@base='arg']"),
+                Matchers.anyOf(
+                    XhtmlMatchers.hasXPath(
+                        "//o[@base='Φ.number' and text()='72872276393407200']"
+                    ),
+                    XhtmlMatchers.hasXPath(
+                        "//o[@base='Φ.number' and text()='7.28722763934072e16']"
+                    )
+                )
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
     void convertsMaxIntFromHexToEo(final Shift shift, final String type) {
         MatcherAssert.assertThat(
             String.format("StUnhex by %s must skip unhexing max integer number", type),


### PR DESCRIPTION
Closes #5721.

## Problem

`StUnhex` converts a data literal's hex payload to readable EO by calling
`setTextContent` on the literal's wrapper `<o>` element. In the DOM,
`setTextContent` deletes **all** of the element's children and replaces
them with a single text node.

The XPath guards only require that the literal's first child is its own byte
payload; they never require it to be the *only* child. A bare data literal
can legitimately be the head of an application in parser-accepted EO (for
example `42 5 > x`), where the wrapper's second child is the applied
argument. `setTextContent` wiped that argument out, so the printer silently
turned `42 5 > x` into `42 > x` (and likewise for `"str" 5`, `01-02 5`,
and compact-tuple arguments).

## Fix

Add `inline()`, which replaces only the byte-payload child (the first `<o>`)
with a text node, leaving any sibling argument in place. For the common
single-child case the result is identical to before; when an argument is
present it now survives.

## Tests

Added `keepsArgumentAppliedToDataLiteral`, which unhexes a number literal
carrying a sibling argument and asserts both the converted number and the
argument survive. Verified it fails without the fix; the full eo-printer
suite (174 tests, incl. 137 end-to-end `XmirTest`) is green.