### PR TITLE
fix(#5722): make redundant-parens detection quote-aware in Tokens

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -239,12 +239,7 @@ final class Tokens {
             );
         }
         final String inside = this.body.substring(start + 1, this.cursor - 1);
-        if (!inside.isEmpty()
-            && inside.indexOf(' ') < 0
-            && inside.indexOf('(') < 0
-            && inside.indexOf(')') < 0
-            && inside.indexOf('[') < 0
-            && inside.indexOf(']') < 0) {
+        if (Tokens.singleToken(inside)) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + start,
                 String.format(
@@ -639,6 +634,47 @@ final class Tokens {
      */
     String body() {
         return this.body;
+    }
+
+    /**
+     * Whether a paren group's content wraps a single, atomic token, which
+     * makes the surrounding parentheses redundant.
+     *
+     * <p>The scan tracks quote state (toggled on an unescaped {@code "}) so
+     * that spaces, parentheses and brackets living <em>inside</em> a string
+     * literal don't fool it into thinking the group holds more than one token.
+     * A quoted string is always a single token regardless of its contents, so
+     * {@code ("hello")}, {@code ("hello world")} and {@code ("a(b)c")} are all
+     * treated the same way — consistently redundant.</p>
+     *
+     * @param inside The text between the parentheses, exclusive
+     * @return True if the parentheses wrap exactly one token
+     */
+    private static boolean singleToken(final String inside) {
+        boolean single = !inside.isEmpty();
+        boolean quoted = false;
+        int idx = 0;
+        while (idx < inside.length()) {
+            final char glyph = inside.charAt(idx);
+            if (quoted) {
+                if (glyph == '\\' && idx + 1 < inside.length()) {
+                    idx = idx + 1;
+                } else if (glyph == '"') {
+                    quoted = false;
+                }
+            } else if (glyph == '"') {
+                quoted = true;
+            } else if (glyph == ' '
+                || glyph == '('
+                || glyph == ')'
+                || glyph == '['
+                || glyph == ']') {
+                single = false;
+                break;
+            }
+            idx = idx + 1;
+        }
+        return single;
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -454,6 +454,39 @@ final class TokensTest {
     }
 
     @Test
+    void rejectsRedundantParensAroundSingleStringLiteral() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Tokens(
+                "(\"hello world\")", new Span("(\"hello world\")", 1)
+            ).readGroup(),
+            "a single string-literal argument in parens must be flagged as redundant regardless of inner spaces"
+        );
+    }
+
+    @Test
+    void rejectsRedundantParensAroundStringLiteralWithBrackets() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Tokens(
+                "(\"a(b)[c]\")", new Span("(\"a(b)[c]\")", 1)
+            ).readGroup(),
+            "brackets and parens inside a string literal must not defeat the redundant-parens check"
+        );
+    }
+
+    @Test
+    void acceptsParensAroundMultipleStringLiterals() {
+        MatcherAssert.assertThat(
+            "readGroup must keep parens that genuinely wrap more than one token",
+            new Tokens(
+                "(\"a\" \"b\")", new Span("(\"a\" \"b\")", 1)
+            ).readGroup().raw(),
+            Matchers.equalTo("(\"a\" \"b\")")
+        );
+    }
+
+    @Test
     void rejectsUnterminatedParenGroup() {
         Assertions.assertThrows(
             ParseError.class,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/redundant-parentheses/string-literal.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:6] error: 'redundant parentheses around a single token — `("hello world")` should be written as `"hello world"`'
+input: |
+  1.add ("hello world") > x


### PR DESCRIPTION
Closes #5722.

## Problem

`Tokens.readGroup()` decides whether a parenthesized group is "redundant around a single token" by scanning the raw substring between the parens for a space or for `(`, `)`, `[`, `]`. That scan has no notion of quoted-string content, so it is fooled by characters inside a string literal:

```
1.add ("hello")        -> redundant parentheses error
1.add ("hello world")  -> accepted silently
```

Both are the same case — a parenthesized single string-literal argument — but only the single-word one was flagged. Same asymmetry for `("a(b)c")` and `("a[b]c")`. (Same class of bug as the `Penalty.java` fix in #5718.)

## Fix

`readGroup()`'s single-token detection now tracks quote state (toggled on an unescaped `"`) while scanning, neutralizing spaces/parens/brackets that live inside a string literal. A parenthesized single string literal is therefore treated consistently — always redundant — regardless of its contents.

## Tests

- `TokensTest`: `("hello world")` and `("a(b)[c]")` are now rejected as redundant; `("a" "b")` (genuinely two tokens) is still accepted.
- New end-to-end typo-pack `redundant-parentheses/string-literal.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)