### PR TITLE
#5633: surface the real out-of-bounds cause from string.slice

### DIFF
--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -77,11 +77,14 @@
         T
           "Length to slice must be >= 0, but was %d".printf
             * nlen
-        if.
-          nlen.eq 0
-          ""
-          string
-            as-bytes.slice bstart blen
+        seq *
+          bstart
+          blen
+          if.
+            nlen.eq 0
+            ""
+            string
+              as-bytes.slice bstart blen
     minus. > blen
       recidx
         number bstart
@@ -248,6 +251,12 @@
       str.length.eq 11
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
+
+  eq. ++> tests-slice-at-end-with-zero-length
+    "hello".slice
+      5
+      0
+    ""
 
   eq. ++> tests-slice-empty-string
     "".slice

--- a/eo-runtime/src/test/java/org/eolang/EO_string/StringSliceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/StringSliceTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (4 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD
+
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.ExAbstract;
+import org.eolang.PhApplication;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@code string.slice} out-of-bounds behavior.
+ * @since 0.57.4
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class StringSliceTest {
+
+    @Test
+    void takesLegalSlice() {
+        MatcherAssert.assertThat(
+            "a valid slice is taken correctly",
+            new Dataized(
+                StringSliceTest.slice("hello", 2, 3)
+            ).asString(),
+            Matchers.equalTo("llo")
+        );
+    }
+
+    @Test
+    void surfacesOutOfBoundsCauseForLength() {
+        MatcherAssert.assertThat(
+            "the real out-of-bounds cause must reach the caller, not the 'must be a number' mask",
+            new UncheckedText(
+                new TextOf(
+                    Assertions.assertThrows(
+                        ExAbstract.class,
+                        () -> new Dataized(
+                            StringSliceTest.slice("hello", 2, 10)
+                        ).asString(),
+                        "an out-of-range length must terminate with the reason"
+                    )
+                )
+            ).asString(),
+            Matchers.containsString("out of string bounds")
+        );
+    }
+
+    @Test
+    void surfacesOutOfBoundsCauseForStart() {
+        MatcherAssert.assertThat(
+            "the real out-of-bounds start cause must reach the caller, not the 'must be a number' mask",
+            new UncheckedText(
+                new TextOf(
+                    Assertions.assertThrows(
+                        ExAbstract.class,
+                        () -> new Dataized(
+                            StringSliceTest.slice("hello", 10, 1)
+                        ).asString(),
+                        "an out-of-range start must terminate with the reason"
+                    )
+                )
+            ).asString(),
+            Matchers.containsString("Start index (10) is out of string bounds")
+        );
+    }
+
+    @Test
+    void throwsWhenStartPastEndWithZeroLength() {
+        MatcherAssert.assertThat(
+            "an out-of-range start must be rejected even when the length is zero",
+            new UncheckedText(
+                new TextOf(
+                    Assertions.assertThrows(
+                        ExAbstract.class,
+                        () -> new Dataized(
+                            StringSliceTest.slice("hello", 10, 0)
+                        ).asString(),
+                        "a zero length must not silently ignore an out-of-range start"
+                    )
+                )
+            ).asString(),
+            Matchers.containsString("Start index (10) is out of string bounds")
+        );
+    }
+
+    /**
+     * Build {@code text.slice(start, len)} as a {@link Phi}.
+     * @param text The string to slice
+     * @param start The start index
+     * @param len The length to slice
+     * @return The slice application
+     */
+    private static Phi slice(final String text, final int start, final int len) {
+        return new PhApplication(
+            new PhApplication(
+                new Data.ToPhi(text).take("slice").copy(),
+                "start",
+                new Data.ToPhi(start)
+            ),
+            "len",
+            new Data.ToPhi(len)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #5633.

`string.slice` mishandled out-of-range indices in two related ways.

**1. The real "out of string bounds" cause was masked into a false "must be a number" error.** For an out-of-range slice, the byte-offset helpers `bstart`/`blen` already raise the intended message via a bottom (⊥). That ⊥ then flowed as `bstart`/`blen` into `as-bytes.slice`, whose `Expect` chain ends in `.otherwise("must be a number")`. As detailed by @morphqdd on the issue, `Expect`'s `applyOtherwise` catches the inner `ExThat` (which *does* carry the real "out of string bounds" message) and rethrows `ExOtherwise(String.format("%s %s", subject, "must be a number"), ex)` — the `ex` is passed but never becomes the cause (no placeholder, no `initCause`), so the real message is lost. The caller saw `the 'len'/'start' attribute must be a number` for a perfectly valid number, and the two carefully-written "out of string bounds" messages were unreachable.

**2. A zero length silently ignored an out-of-range start.** The `nlen.eq 0 → ""` shortcut returned before the start upper-bound check (`bstart`) was ever forced, so e.g. `slice "hello" 10 0` returned `""` with no error.

## Fix

Both `bstart` and `blen` are now forced via `seq` **before** `as-bytes.slice` is reached:

```
seq *
  bstart
  blen
  if.
    nlen.eq 0
    ""
    string
      as-bytes.slice bstart blen
```

Their ⊥ therefore surfaces directly as the object's own `@` result with the correct message, never entering the `Expect` chain that would rewrite it, and the start upper bound is now checked regardless of the length. This keeps the fix contained to `string.eo` and leaves the shared `Expect.java` masking (the broader #5478 angle @morphqdd is tackling in #5484) untouched.

| call | before | after |
| --- | --- | --- |
| `slice "hello" 2 3` | `"llo"` | `"llo"` (unchanged) |
| `slice "hello" 2 10` | `the 'len' attribute must be a number` | `Start index + length to slice (12) is out of string bounds` |
| `slice "hello" 10 1` | `the 'start' attribute must be a number` | `Start index (10) is out of string bounds` |
| `slice "hello" 10 0` | `""` (no error) | `Start index (10) is out of string bounds` |

## Tests

Both bugs change behavior from "returns a value" to "terminates with the right message", which the EO example DSL cannot discriminate (a `-->` negative example only asserts that dataization throws, and `asBool` on the pre-fix `""`/wrong-⊥ throws anyway). Added `StringSliceTest` (hand-written, in `org.eolang.EO_string`, modeled on `EObytesEOsliceTest`/`RegexAtomTest`) that asserts the **surfaced message** for the out-of-range start and length cases and that the zero-length case now terminates — verified these three fail against the pre-fix implementation (`must be a number` / nothing thrown) and pass with the fix. Also added an EO regression example for the valid `start == length, len == 0` edge (`slice "hello" 5 0 → ""`). Full `eo-runtime` suite green apart from the pre-existing `EOsocketTest.refusesConnectionViaSyscall` Windows/TEST-NET artifact (also fails on unmodified master). No new lint warnings.