### PR TITLE
#5718: exclude quoted string literals from Penalty's code-structure scoring

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -73,6 +73,7 @@ import java.util.Map;
  *
  * @since 0.57.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class Penalty {
 
     /**
@@ -115,12 +116,13 @@ final class Penalty {
     int points() {
         int total = 0;
         for (final String line : this.code.split(String.valueOf('\n'), -1)) {
-            final int spaces = Penalty.spaces(line);
-            final int applied = Penalty.applied(line);
+            final String masked = Penalty.masked(line);
+            final int spaces = Penalty.spaces(masked);
+            final int applied = Penalty.applied(masked);
             total += this.indents(line) * this.weight(PenaltyKey.INDENT);
-            total += Penalty.brackets(line) * this.weight(PenaltyKey.BRACKET);
-            total += Penalty.phis(line) * this.weight(PenaltyKey.PHI);
-            total += Penalty.ifs(line) * this.weight(PenaltyKey.IF);
+            total += Penalty.brackets(masked) * this.weight(PenaltyKey.BRACKET);
+            total += Penalty.phis(masked) * this.weight(PenaltyKey.PHI);
+            total += Penalty.ifs(masked) * this.weight(PenaltyKey.IF);
             total += Math.max(0, line.length() - this.weight(PenaltyKey.WIDTH))
                 * this.weight(PenaltyKey.EXCESS);
             total += line.length() * this.weight(PenaltyKey.SYMBOL);
@@ -128,6 +130,45 @@ final class Penalty {
                 * this.weight(PenaltyKey.SPACE);
         }
         return total;
+    }
+
+    /**
+     * Replace the interior of every quoted string literal in a line with a
+     * neutral filler character, so that the structural scans below (spaces,
+     * brackets, phi attributes, suffix {@code if}, tokens) count only real
+     * EO syntax, not data sitting inside a string. The quote marks
+     * themselves are left in place; an escaped quote ({@code \"}) does not
+     * end the literal.
+     * @param line The line
+     * @return The line with string-literal interiors masked
+     */
+    private static String masked(final String line) {
+        final StringBuilder out = new StringBuilder(line.length());
+        boolean quoted = false;
+        boolean escaped = false;
+        for (int idx = 0; idx < line.length(); ++idx) {
+            final char chr = line.charAt(idx);
+            if (quoted) {
+                if (escaped) {
+                    escaped = false;
+                    out.append('x');
+                } else if (chr == '\\') {
+                    escaped = true;
+                    out.append('x');
+                } else if (chr == '"') {
+                    quoted = false;
+                    out.append(chr);
+                } else {
+                    out.append('x');
+                }
+            } else {
+                out.append(chr);
+                if (chr == '"') {
+                    quoted = true;
+                }
+            }
+        }
+        return out.toString();
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  * Test case for {@link Penalty}.
  * @since 0.57.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class PenaltyTest {
 
     @Test
@@ -149,6 +150,44 @@ final class PenaltyTest {
         MatcherAssert.assertThat(
             "Empty code should have zero penalty",
             new Penalty("").points(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void ignoresWordingDifferencesInsideStringLiteral() {
+        MatcherAssert.assertThat(
+            "A string literal's wording (spaces vs underscores) must not change the penalty",
+            new Penalty("\"three word string\" > x").points(),
+            Matchers.equalTo(new Penalty("\"three_word_string\" > x").points())
+        );
+    }
+
+    @Test
+    void ignoresParenthesesInsideStringLiteral() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.SYMBOL, 0);
+        weights.put(PenaltyKey.SPACE, 0);
+        weights.put(PenaltyKey.INDENT, 0);
+        MatcherAssert.assertThat(
+            "A parenthesis sitting inside a string literal is data, not code structure",
+            new Penalty(
+                "\"Unknown byte format (%x), can't recognize character\".printf",
+                weights
+            ).points(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void doesNotEndStringLiteralOnEscapedQuote() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.SYMBOL, 0);
+        weights.put(PenaltyKey.SPACE, 0);
+        weights.put(PenaltyKey.INDENT, 0);
+        MatcherAssert.assertThat(
+            "An escaped quote must not end the tracked string, leaving the bracket after it masked",
+            new Penalty("\"a\\\"(b)\" > x", weights).points(),
             Matchers.equalTo(0)
         );
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-star-tuples.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-star-tuples.yaml
@@ -26,8 +26,7 @@ printed: |
       "test"
     * > second
       bar
-      *
-        "foo bar"
+      * "foo bar"
       *
         1
         3

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -28,7 +28,6 @@
   eq. ++> tests-buffer-decorates-string-after-building
     length.
       with.
-        buffer
-          "Hi, "
+        buffer "Hi, "
         "Mark"
     8

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -91,8 +91,7 @@
 
   eq. ++> tests-concat-strings
     string
-      "hello ".as-bytes.concat
-        "world".as-bytes
+      "hello ".as-bytes.concat "world".as-bytes
     "hello world"
 
   eq. ++> tests-concat-with-empty
@@ -223,9 +222,7 @@
       3
     1F-EE-B5
 
-  eq. ++> tests-turns-bytes-into-a-string
-    "你好, друг!"
-    "你好, друг!"
+  "你好, друг!".eq "你好, друг!" ++> tests-turns-bytes-into-a-string
 
   CA-FE-BE-BE.size.eq 4 ++> tests-written-in-several-lines
 

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -127,5 +127,4 @@
               buffer.size
           output-block
 
-  console.write ++> tests-writes-to-console
-    "Hello, console-test!\n"
+  console.write "Hello, console-test!\n" ++> tests-writes-to-console

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -83,8 +83,7 @@
           target
   [mode scope cant-open] > open
     known.not.if > @
-      T
-        "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+      T "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
         existing.and exists.not
         cant-open
@@ -310,8 +309,7 @@
     seq * > @
       temp.open
         "w"
-        f.write > [f]
-          "Shrek is love"
+        f.write "Shrek is love" > [f]
       "Shrek is love".eq
         malloc.of
           13
@@ -420,16 +418,14 @@
     size.
       mktemp.tmpfile.open
         "w"
-        f.write > [f]
-          "Hello, world"
+        f.write "Hello, world" > [f]
     12
 
   ++> tests-writes-to-file-from-different-instances
     seq * > @
       temp.open
         "w"
-        f.write > [f]
-          "Shrek is love"
+        f.write "Shrek is love" > [f]
       open.
         file src
         "a"

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -218,8 +218,7 @@
     malloc.of > mem
       13
       seq * > [m]
-        m.put
-          "Hello, world!"
+        m.put "Hello, world!"
         m.put 42
 
   eq. ++> tests-malloc-read-over-a-limit-returns-fallback
@@ -271,9 +270,7 @@
         malloc.of > @
           12
           seq * > [m] >>
-            m.write
-              0
-              "Hello, "
+            m.write 0 "Hello, "
             m.write 7 "Jeff!"
             b.put
               (m.read 0 12).eq
@@ -365,8 +362,7 @@
 
   malloc.for --> on-overflow-string-malloc
     "Hello"
-    m.put > [m]
-      "Much longer string!"
+    m.put "Much longer string!" > [m]
 
   malloc.for --> on-reading-over-a-limit-without-fallback
     10

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -13,8 +13,7 @@
 [x y cant-mod] > mod
   if. > @
     divisor.eq 0
-    cant-mod
-      "cannot calculate mod by zero"
+    cant-mod "cannot calculate mod by zero"
     if.
       dividend.gt 0
       abs-mod

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -40,8 +40,7 @@
     recovered
       2.as-i64.div
         0.as-i64
-        T > [msg]
-          "cannot divide"
+        T "cannot divide" > [msg]
       42
     42
 

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -62,8 +62,7 @@
                 "WSACleanup"
                 *
             win32.failure
-          T
-            "Couldn't clean up the sockets subsystem"
+          T "Couldn't clean up the sockets subsystem"
           true
         "closesocket" > close
         "WSA error code %d".printf > message

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -54,5 +54,4 @@
               buffer.size
           output-block
 
-  stderr ++> tests-prints-to-stderr
-    "Hello, stderr-test!\n"
+  stderr "Hello, stderr-test!\n" ++> tests-prints-to-stderr

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -19,5 +19,4 @@
     console.write text
     true
 
-  stdout ++> tests-prints-to-console
-    "Hello, stdout-test!\n"
+  stdout "Hello, stdout-test!\n" ++> tests-prints-to-console

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -162,9 +162,7 @@
 
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
 
-  eq. ++> tests-calculates-length-of-spaces-only
-    " ".length
-    1
+  " ".length.eq 1 ++> tests-calculates-length-of-spaces-only
 
   (nan.eq "друг").not ++> tests-compares-string-with-nan
 
@@ -202,9 +200,7 @@
 
   "2026".is-digit ++> tests-package-detects-digits
 
-  ends-with. ++> tests-package-ends-with-suffix
-    "hello, world"
-    "world"
+  "hello, world".ends-with "world" ++> tests-package-ends-with-suffix
 
   eq. ++> tests-package-finds-index-of-character
     "hello".index-of "l"
@@ -216,23 +212,17 @@
     "ha".repeated 3
     "hahaha"
 
-  starts-with. ++> tests-package-starts-with-prefix
-    "hello, world"
-    "hello"
+  "hello, world".starts-with "hello" ++> tests-package-starts-with-prefix
 
   eq. ++> tests-package-takes-character-at-index
     "some".at 1
     "o"
 
-  eq. ++> tests-package-trims-surrounding-spaces
-    "  spaced  ".trimmed
-    "spaced"
+  "  spaced  ".trimmed.eq "spaced" ++> tests-package-trims-surrounding-spaces
 
   "hello".up-cased.eq "HELLO" ++> tests-package-up-cases-text
 
-  eq. ++> tests-preserves-indentation-in-text
-    "a\n b\n  c"
-    "a\n b\n  c"
+  "a\n b\n  c".eq "a\n b\n  c" ++> tests-preserves-indentation-in-text
 
   ++> tests-reads-the-length-with-n2-byte-characters
     and. > @
@@ -320,13 +310,9 @@
 
   "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
 
-  eq. ++> tests-supports-escape-sequences
-    "Hello, друг!\n"
-    "Hello, друг!\n"
+  "Hello, друг!\n".eq "Hello, друг!\n" ++> tests-supports-escape-sequences
 
-  eq. ++> tests-supports-escape-sequences-in-text
-    "Hello, друг!\n"
-    "Hello, друг!\n"
+  "Hello, друг!\n".eq "Hello, друг!\n" ++> tests-supports-escape-sequences-in-text
 
   "\n".eq "\n" ++> tests-supports-escape-sequences-line-break
 
@@ -336,9 +322,7 @@
 
   "e\ne\ne".eq 65-0A-65-0A-65 ++> tests-text-block-tree-lines
 
-  eq. ++> tests-text-block-with-margin
-    "z\n  y\n x"
-    7A-0A-20-20-79-0A-20-78
+  "z\n  y\n x".eq 7A-0A-20-20-79-0A-20-78 ++> tests-text-block-with-margin
 
   eq. ++> tests-turns-string-into-bytes
     "€ друг".as-bytes

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -40,8 +40,7 @@
 
   eq. ++> tests-reads-code-of-space
     32
-    as-ascii
-      " "
+    as-ascii " "
 
   eq. ++> tests-reads-code-of-uppercase-letter
     65

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -17,9 +17,7 @@
 [text cant-parse] > as-number
   if. > @
     not.
-      matches.
-        compiled.
-          regex "/^[+-]?\\d+(?:\\.\\d+)?$/"
+      (regex "/^[+-]?\\d+(?:\\.\\d+)?$/").compiled.matches
         text
     cant-parse
       "Can't convert text %s to number".printf

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -42,8 +42,4 @@
     "Hello, world!"
     "o, wo"
 
-  ++> tests-text-does-not-contain-substring
-    not. > @
-      contains
-        "Hello, world!"
-        "Hey"
+  (contains "Hello, world!" "Hey").not ++> tests-text-does-not-contain-substring

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -25,11 +25,7 @@
   txt.size > tlen!
   text > txt!
 
-  ++> tests-does-not-end-with-substring
-    not. > @
-      ends-with
-        "Hello world!"
-        "Hello"
+  (ends-with "Hello world!" "Hello").not ++> tests-does-not-end-with-substring
 
   ends-with ++> tests-ends-with-substring
     "Hello world!"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -41,12 +41,10 @@
             matched-from-index
               position.plus 1
               to
-          T
-            "Matched block does not exist, can't get next"
+          T "Matched block does not exist, can't get next"
         exists.if > text
           group 0
-          T
-            "Matched block does not exist, can't get text"
+          T "Matched block does not exist, can't get text"
       [position start] > matched-from-index /Q.string.regex.pattern.match.matched
       matched. > next
         matched-from-index 1 0
@@ -102,16 +100,13 @@
           second.group 2
           "2"
     next. > first
-      match.
-        compiled.
-          regex "/([a-z]+)([1-9]{1})/"
+      (regex "/([a-z]+)([1-9]{1})/").compiled.match
         "!hello1!world2"
     first.next > second
 
   matches. ++> tests-regex-ignores-comments-in-string
     compiled.
-      regex
-        "/(\\d) #ignore this comment/x"
+      regex "/(\\d) #ignore this comment/x"
     "4"
 
   matches. ++> tests-regex-matches-dotall-option

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -235,8 +235,7 @@
       accumulated
       found
     escaped ch > piece
-    T > unsupported-message
-      "Unsupported format specifier"
+    T "Unsupported format specifier" > unsupported-message
   tokenize > tokens
     0
     ""
@@ -257,9 +256,7 @@
   eq. ++> tests-scanf-with-complex-float
     1991.01
     head.
-      scanf
-        "this will be=%f"
-        "this will be=1991.01"
+      scanf "this will be=%f" "this will be=1991.01"
 
   eq. ++> tests-scanf-with-complex-int
     734987259

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -52,9 +52,7 @@
   eq. ++> tests-splits-and-returns-strings
     length.
       at.
-        split
-          "hello world!"
-          " "
+        split "hello world!" " "
         1
     6
 

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -23,11 +23,7 @@
   txt.size > tlen!
   text > txt!
 
-  ++> tests-does-not-start-with-substring
-    not. > @
-      starts-with
-        "Hello, world"
-        "world"
+  (starts-with "Hello, world" "world").not ++> tests-does-not-start-with-substring
 
   starts-with ++> tests-starts-with-substring
     "Hello, world"

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -48,18 +48,15 @@
   bts.size > len!
 
   eq. ++> tests-text-trimmed-left-many-spaces
-    trimmed-left
-      "     some"
+    trimmed-left "     some"
     "some"
 
   eq. ++> tests-text-trimmed-left-one-space
-    trimmed-left
-      " s"
+    trimmed-left " s"
     "s"
 
   eq. ++> tests-text-trimmed-left-only-spaces
-    trimmed-left
-      "     "
+    trimmed-left "     "
     ""
 
   eq. ++> tests-trimmed-left-empty-text
@@ -79,8 +76,7 @@
     "value"
 
   eq. ++> tests-trimmed-left-strips-mixed-ws
-    trimmed-left
-      " \t\n\f\rvalue"
+    trimmed-left " \t\n\f\rvalue"
     "value"
 
   eq. ++> tests-trimmed-left-strips-tab

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -46,18 +46,15 @@
   bts.size > len!
 
   eq. ++> tests-text-trimmed-right-many-spaces
-    trimmed-right
-      "some     "
+    trimmed-right "some     "
     "some"
 
   eq. ++> tests-text-trimmed-right-one-space
-    trimmed-right
-      "s "
+    trimmed-right "s "
     "s"
 
   eq. ++> tests-text-trimmed-right-only-spaces
-    trimmed-right
-      "     "
+    trimmed-right "     "
     ""
 
   eq. ++> tests-trimmed-right-empty-text
@@ -77,8 +74,7 @@
     "value"
 
   eq. ++> tests-trimmed-right-strips-mixed-ws
-    trimmed-right
-      "value \t\n\f\r"
+    trimmed-right "value \t\n\f\r"
     "value"
 
   eq. ++> tests-trimmed-right-strips-tab

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -24,28 +24,23 @@
     ""
 
   eq. ++> tests-text-trimmed-many-spaces
-    trimmed
-      "    some     "
+    trimmed "    some     "
     "some"
 
   eq. ++> tests-text-trimmed-one-space-both
-    trimmed
-      " some "
+    trimmed " some "
     "some"
 
   eq. ++> tests-text-trimmed-one-space-left
-    trimmed
-      " some"
+    trimmed " some"
     "some"
 
   eq. ++> tests-text-trimmed-one-space-right
-    trimmed
-      "some "
+    trimmed "some "
     "some"
 
   eq. ++> tests-text-trimmed-only-spaces
-    trimmed
-      "        "
+    trimmed "        "
     ""
 
   eq. ++> tests-trimmed-preserves-inner-content
@@ -53,11 +48,9 @@
     "no-whitespace"
 
   eq. ++> tests-trimmed-preserves-inner-whitespace
-    trimmed
-      "\t hello world \n"
+    trimmed "\t hello world \n"
     "hello world"
 
   eq. ++> tests-trimmed-strips-mixed-ws-both-sides
-    trimmed
-      " \t\n\f\rvalue \t\n\f\r"
+    trimmed " \t\n\f\rvalue \t\n\f\r"
     "value"

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -27,8 +27,7 @@
 [cases fallback] > switch
   if. > @
     cases.length.eq 0
-    fallback
-      "Switch cases are empty"
+    fallback "Switch cases are empty"
     if.
       true.eq found.match
       found.head
@@ -85,9 +84,7 @@
         *
           password.eq ""
           "empty password is not allowed"
-        *
-          false
-          "password is wrong"
+        * false "password is wrong"
       "password is correct!"
     "swordfish" > password
 

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -15,8 +15,7 @@
       or.
         0.gt index
         length.lte index
-      fallback
-        "Given index is out of tuple bounds"
+      fallback "Given index is out of tuple bounds"
       at-fast ^
     if. > [tup] > at-fast
       eq.
@@ -30,10 +29,8 @@
       length.plus idx
       idx
   tuple > empty
-    T
-      "Can't get tail from the empty tuple"
-    T
-      "Can't get head from the empty tuple"
+    T "Can't get tail from the empty tuple"
+    T "Can't get head from the empty tuple"
     0
   [other] > eq
     and. > @

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -12,8 +12,7 @@
 [sequence cant-max] > maximum
   if. > @
     is-empty lst
-    cant-max
-      "cannot get the maximum number from an empty sequence"
+    cant-max "cannot get the maximum number from an empty sequence"
     reduced
       lst
       ninf

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -12,8 +12,7 @@
 [sequence cant-min] > minimum
   if. > @
     is-empty lst
-    cant-min
-      "cannot get the minimum number from an empty sequence"
+    cant-min "cannot get the minimum number from an empty sequence"
     reduced
       lst
       pinf


### PR DESCRIPTION
Closes #5718.

`Penalty`'s helpers in `eo-printer/src/main/java/org/eolang/printer/Penalty.java` (`tokens()`, `applied()`, `brackets()`, `phis()`, `ifs()`, `spaces()`) scanned a line's raw characters with no notion of a quoted string literal. Data sitting inside a `"..."` string (spaces between words, a stray `(`/`)`, an `@`, or the substring `.if`) was counted exactly like real EO syntax, so a formation's flat-candidate score could be inflated purely by the wording of a string literal it contains, pushing `eo:format` toward a more vertical layout than the code's actual structure warranted.

Fix: added one shared `Penalty.masked(String)` helper that replaces the interior of quoted string literals with a neutral filler character (respecting `\"` escapes), and routed all six scoring methods through it instead of the raw line, so only genuine code structure is scored.

Second commit: fixing the scoring legitimately changes the canonical layout of 26 existing `eo-runtime` sources, since their formatting had been silently shaped by string-literal wording rather than actual structure. Regenerated them with `-Deo.autoFix` so `mvn clean install`'s canonical-format check keeps passing after this merges (without this, master's own build would immediately start failing its own format check, since Penalty would now compute different canonical output than what's currently committed).

Verified:
- `PenaltyTest`: 19/19 green.
- Full `eo-runtime` test suite after the reformat: 1730/1730 green.
- `mvn clean verify -PskipTests -Pqulice` (the exact CI gate), full repo: clean.
