### PR TITLE
#5774: drop spurious minus sign for negative values that render as zero

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -11,9 +11,8 @@
 [n] > as-decimal
   if. > @
     n.lt 0
-    "-".as-bytes.concat
-      digits
-        n.times -1
+    negative
+      n.times -1
     digits n
   [n] > digits
     if. > @
@@ -27,6 +26,21 @@
             48
     floor. > q
       n.div 10
+  if. > [m] > negative
+    m.floor.eq 0
+    digits m
+    "-".as-bytes.concat
+      digits m
+
+  eq. ++> tests-negative-below-one-drops-sign
+    "0"
+    string
+      as-decimal -0.9
+
+  eq. ++> tests-negative-truncating-to-zero-drops-sign
+    "0"
+    string
+      as-decimal -0.5
 
   eq. ++> tests-truncates-negative-fraction
     "-7"

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -12,9 +12,8 @@
 [n places] > as-fixed
   if. > @
     n.lt 0
-    "-".as-bytes.concat
-      positive
-        n.times -1
+    signed
+      n.times -1
     positive n
   [a] > positive
     concat. > @
@@ -57,6 +56,17 @@
                 (value.div 10).floor.times 10
             48
         acc
+  if. > [a] > signed
+    eq.
+      floor.
+        plus.
+          a.times
+            pow10 places
+          0.5
+      0
+    positive a
+    "-".as-bytes.concat
+      positive a
 
   eq. ++> tests-carries-rounding-into-integer-part
     "1.000000"
@@ -67,6 +77,16 @@
     "3.14"
     string
       as-fixed 3.14159 2
+
+  eq. ++> tests-negative-rounding-to-zero-drops-sign
+    "0.00"
+    string
+      as-fixed -1.0E-4 2
+
+  eq. ++> tests-negative-tiny-rounding-to-zero-drops-sign
+    "0.00"
+    string
+      as-fixed -0.001 2
 
   eq. ++> tests-pads-with-trailing-zeros
     "1.250000"


### PR DESCRIPTION
## What

`string.as-decimal` and `string.as-fixed` chose the output sign from `n.lt 0`
on the **original** argument, before the magnitude was truncated/rounded down
to zero. So a small negative value whose rendered magnitude is all zeros was
still written with a leading `-`:

- `as-decimal -0.5` produced `"-0"` (expected `"0"`)
- `as-fixed -0.0001 2` produced `"-0.00"` (expected `"0.00"`)

A signed zero misrepresents the value and is a well-known display defect in
fixed-point output (money, reports). `printf "%d"` on the same input already
yields `"0"`.

## Fix

Decide the sign from the magnitude that is actually rendered, not from the raw
input:

- `as-decimal`: the negative branch delegates to a `negative` helper that omits
  the `-` when the truncated integer magnitude (`m.floor`) is zero.
- `as-fixed`: the negative branch delegates to a `signed` helper that omits the
  `-` when the value rounded to `places` (`floor(|n| * 10^places + 0.5)`) is
  zero.

Non-zero negatives keep their sign; positives are unchanged.

## Verification

Built `eo-runtime` from source and ran its test suite. Added EO test objects
covering the defect, alongside the existing controls:

| call | before | after |
| --- | --- | --- |
| `as-decimal -0.5` | `"-0"` | `"0"` |
| `as-decimal -0.9` | `"-0"` | `"0"` |
| `as-decimal -7.89` | `"-7"` | `"-7"` (control) |
| `as-fixed -0.0001 2` | `"-0.00"` | `"0.00"` |
| `as-fixed -0.001 2` | `"-0.00"` | `"0.00"` |
| `as-fixed -2.5 6` | `"-2.500000"` | `"-2.500000"` (control) |

Fixes #5774
