### PR TITLE
#5774: drop spurious minus sign for negative values that render as zero

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -14,11 +14,6 @@
     signed
       n.times -1
     digits n
-  if. > [magnitude] > signed
-    magnitude.lt 1
-    digits magnitude
-    "-".as-bytes.concat
-      digits magnitude
   [n] > digits
     if. > @
       n.lt 10
@@ -30,6 +25,11 @@
         as-char
           (n.minus (q.times 10)).floor.plus
             48
+  if. > [magnitude] > signed
+    magnitude.lt 1
+    digits magnitude
+    "-".as-bytes.concat
+      digits magnitude
 
   eq. ++> tests-keeps-sign-on-negative-value-after-truncation
     "-1"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -32,6 +32,16 @@
     string
       as-decimal -7.89
 
+  eq. ++> tests-truncates-negative-fraction-below-one-to-zero-without-sign
+    "0"
+    string
+      as-decimal -0.5
+
+  eq. ++> tests-keeps-sign-on-negative-value-after-truncation
+    "-1"
+    string
+      as-decimal -1.5
+
   eq. ++> tests-truncates-positive-fraction
     "42"
     string

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -14,12 +14,11 @@
     signed
       n.times -1
     digits n
-  [magnitude] > signed
-    if. > @
-      magnitude.lt 1
+  if. > [magnitude] > signed
+    magnitude.lt 1
+    digits magnitude
+    "-".as-bytes.concat
       digits magnitude
-      "-".as-bytes.concat
-        digits magnitude
   [n] > digits
     if. > @
       n.lt 10
@@ -32,6 +31,11 @@
           (n.minus (q.times 10)).floor.plus
             48
 
+  eq. ++> tests-keeps-sign-on-negative-value-after-truncation
+    "-1"
+    string
+      as-decimal -1.5
+
   eq. ++> tests-truncates-negative-fraction
     "-7"
     string
@@ -41,11 +45,6 @@
     "0"
     string
       as-decimal -0.5
-
-  eq. ++> tests-keeps-sign-on-negative-value-after-truncation
-    "-1"
-    string
-      as-decimal -1.5
 
   eq. ++> tests-truncates-positive-fraction
     "42"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -11,10 +11,15 @@
 [n] > as-decimal
   if. > @
     n.lt 0
-    "-".as-bytes.concat
-      digits
-        n.times -1
+    signed
+      n.times -1
     digits n
+  [magnitude] > signed
+    if. > @
+      magnitude.lt 1
+      digits magnitude
+      "-".as-bytes.concat
+        digits magnitude
   [n] > digits
     if. > @
       n.lt 10

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -77,6 +77,16 @@
     string
       as-fixed 0.123456789 6
 
+  eq. ++> tests-rounds-negative-fraction-to-zero-without-sign
+    "0.00"
+    string
+      as-fixed -0.0001 2
+
+  eq. ++> tests-keeps-sign-on-negative-rounded-value
+    "-0.40"
+    string
+      as-fixed -0.4 2
+
   eq. ++> tests-writes-negative-value
     "-2.500000"
     string

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -12,9 +12,8 @@
 [n places] > as-fixed
   if. > @
     n.lt 0
-    "-".as-bytes.concat
-      positive
-        n.times -1
+    signed
+      n.times -1
     positive n
   [a] > positive
     concat. > @
@@ -27,11 +26,7 @@
           ip.times scale
         places
         --
-    floor. > m
-      plus.
-        a.times scale
-        0.5
-    pow10 places > scale
+    rounded a > m
   if. > [p] > pow10
     p.eq 0
     1
@@ -56,6 +51,19 @@
                 (value.div 10).floor.times 10
             48
         acc
+  [a] > rounded
+    floor.
+      plus.
+        a.times scale
+        0.5
+  pow10 places > scale
+  [magnitude] > signed
+    if. > @
+      scaled.eq 0
+      positive magnitude
+      "-".as-bytes.concat
+        positive magnitude
+    rounded magnitude > scaled
 
   eq. ++> tests-carries-rounding-into-integer-part
     "1.000000"

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -52,7 +52,7 @@
             48
         acc
   [a] > rounded
-    floor.
+    floor. > @
       plus.
         a.times scale
         0.5
@@ -75,25 +75,25 @@
     string
       as-fixed 3.14159 2
 
+  eq. ++> tests-keeps-sign-on-negative-rounded-value
+    "-0.40"
+    string
+      as-fixed -0.4 2
+
   eq. ++> tests-pads-with-trailing-zeros
     "1.250000"
     string
       as-fixed 1.25 6
 
+  eq. ++> tests-rounds-negative-fraction-to-zero-without-sign
+    "0.00"
+    string
+      as-fixed -1.0E-4 2
+
   eq. ++> tests-rounds-to-last-place
     "0.123457"
     string
       as-fixed 0.123456789 6
-
-  eq. ++> tests-rounds-negative-fraction-to-zero-without-sign
-    "0.00"
-    string
-      as-fixed -0.0001 2
-
-  eq. ++> tests-keeps-sign-on-negative-rounded-value
-    "-0.40"
-    string
-      as-fixed -0.4 2
 
   eq. ++> tests-writes-negative-value
     "-2.500000"


### PR DESCRIPTION
## Summary

- Prevent `string.as-decimal` from emitting a minus sign when truncation renders a negative value as zero.
- Prevent `string.as-fixed` from emitting a minus sign when rounding renders a negative value as zero.
- Add regression coverage for signed-zero and non-zero negative controls.

Fixes #5774.

## Validation

- `git diff --check` passed.
- `mvn -pl :eo-runtime test -ntp` was attempted on the clean PR branch but exceeded the 5-minute local timeout.