### PR TITLE
#5780: scope-guard file-local handle resolution

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -3,22 +3,44 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" id="resolve-local-names" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" exclude-result-prefixes="xs eo" id="resolve-local-names" version="2.0">
   <!--
   The "&gt;&gt; foo" file-local handle (§3.10 / §9.2): the parser emits the
-  anonymous object with its cactus @name plus a "@local='foo'" marker. We
-  build the per-file "handle -&gt; cactus-name" table and rewrite every @base
-  equal to a handle into that (reserved) cactus name; a handle declared more
-  than once is an error. The "@local" marker is deliberately kept on the
-  declaring object so that later passes (in particular the printer, see
-  #5563) can recover the readable handle from the otherwise-synthetic cactus
-  name instead of printing a placeholder like "vL_P".
+  anonymous object with its cactus @name plus a "@local='foo'" marker. A
+  handle is an attribute of the formation that declares it, so we rewrite a
+  @base equal to a handle name into that (reserved) cactus name; a handle
+  declared more than once is an error. The "@local" marker is deliberately
+  kept on the declaring object so that later passes (in particular the
+  printer, see #5563) can recover the readable handle from the otherwise-
+  synthetic cactus name instead of printing a placeholder like "vL_P".
+
+  The rewrite is guarded by lexical scope (#5780). A reference binds to a
+  handle only when the formation that declares the handle is the nearest
+  enclosing scope of the reference that declares the name at all - so a
+  nearer "&gt; foo" attribute (or "&gt;&gt; foo" handle) of the same name
+  shadows a handle in a more distant scope, and a file-local handle no longer
+  hijacks a same-named public attribute in an unrelated sibling formation.
+  This mirrors how "build-fqns" later resolves a name to the nearest
+  enclosing formation that owns an attribute of that name.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="handle" match="o[@local]" use="@local"/>
-  <xsl:template match="o[@base and key('handle', @base)]">
+  <!--
+  The file-local handle that captures the given reference, or the empty
+  sequence when the reference resolves to something else (a public attribute
+  or a global). The nearest enclosing formation (an "o" without "@base") that
+  declares the referenced name - as a public attribute "@name" or as a handle
+  "@local" - is the reference's scope; the reference binds to a handle only
+  when that scope's declaration is itself a handle.
+  -->
+  <xsl:function name="eo:captor" as="element()?">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="name" as="xs:string" select="$ref/@base"/>
+    <xsl:variable name="scope" as="element()?" select="($ref/ancestor::o[not(@base)][o[@name=$name or @local=$name]])[last()]"/>
+    <xsl:sequence select="$scope/o[@local=$name][1]"/>
+  </xsl:function>
+  <xsl:template match="o[@base and exists(eo:captor(.))]">
     <xsl:copy>
-      <xsl:attribute name="base" select="key('handle', @base)[1]/@name"/>
+      <xsl:attribute name="base" select="eo:captor(.)/@name"/>
       <xsl:apply-templates select="@* except @base"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-sibling-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-sibling-scope.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  # the file-local handle keeps its "@local" marker and gets a cactus name
+  - //o[@local='blk' and @name]
+  # only the handle's own body reference is rewritten to the cactus name
+  - /object[count(//o[@base=//o[@local='blk']/@name])=1]
+  # the sibling formation's own "> blk" reference is NOT hijacked by the handle
+  - //o[@base='blk']
+input: |
+  [] > top
+    os.pick > @
+      []
+        [] >> blk
+          blk > @
+      []
+        [] > blk
+          blk.foo > @


### PR DESCRIPTION
Closes #5780.

## Problem

`eo-parser/.../parse/resolve-local-names.xsl` rewrote **every** `@base` equal to a `>> foo` file-local handle name into that handle's cactus `@name`, file-wide, with no regard for lexical scope. When a handle name also named a public `> foo` attribute in an *unrelated sibling* formation, the handle hijacked that formation's own references. The later rooting pass (`build-fqns`) then could not find the cactus name in the reference's own scope and prefixed it with `Φ`, producing a dangling global reference (e.g. `Couldn't find object 'Φ.input-block'` at runtime, and `Q.input-block` in the printer's canonical output).

Minimal case — the second `blk.foo`, which has its own `> blk` sibling, was bound to the *first* formation's `>> blk` handle instead of `ξ.ρ.blk`:

```
[] > top
  os.pick > @
    []
      [] >> blk
        blk > @
    []
      [] > blk
        blk.foo > @
```

## Fix

A `>> foo` handle is an attribute of the formation that declares it, so a reference should bind to it only within that formation's lexical scope. The pass now binds a reference to a handle **only when the handle's declaring formation is the nearest enclosing scope of the reference that declares the name at all** — so a nearer `> foo` attribute (or `>> foo` handle) of the same name shadows a handle in a more distant scope, and a file-local handle no longer hijacks a same-named public attribute in a sibling formation. This mirrors how `build-fqns` resolves a name to the nearest enclosing formation that owns an attribute of that name.

Self-reference (recursion) via `>> foo` is unaffected: the reference lives inside the handle's declaring formation, which remains its nearest declaring scope.

## Tests

- Added `resolve-local-names-sibling-scope.yaml` reproducing the bug: the handle's own reference is rewritten to the cactus name while the sibling formation's `blk.foo` keeps its `blk` base. Verified this pack **fails** on the pre-fix stylesheet and passes after.
- Full `eo-parser` suite green (1496 tests), including the existing `resolve-local-names`, `resolve-local-names-duplicate`, and `void-local-handle` packs (the last confirms a handle is still reachable from a sibling reference in the *same* scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NN1yNHLfj7w5hcbEyKtkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NN1yNHLfj7w5hcbEyKtkJ)_