### PR TITLE
#5782: host a moniker on a single-segment method dispatch

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -62,11 +62,17 @@
     </xsl:choose>
   </xsl:template>
   <!--
-  Drop an inlined auto-named abstract; keep cactus-named voids and
-  keep self-referential (recursive) abstracts, which are never inlined.
+  Drop an inlined auto-named abstract; keep cactus-named voids, keep
+  self-referential (recursive) abstracts, which are never inlined, and keep
+  a binding that a surviving method dispatch still reaches through its name.
+  Such a dispatch reference (`ξ.<name>.<seg>`) is not inlined above — its
+  receiver is buried in a dotted base — so dropping the binding would strand
+  the reference on a synthetic "vL_P" placeholder. Keeping it lets
+  "merge-monikers" host the binding as the receiver of a reversed dispatch
+  instead (#5782).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -81,6 +87,19 @@
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+  </xsl:function>
+  <!--
+  Whether a reference in the auto-named binding's owner reaches it through a
+  method dispatch `ξ.<name>.<seg>` — its base carries the binding's name
+  followed by a further segment. Such a reference is not inlined (its receiver
+  is not a bare cactus name), so the binding is kept for "merge-monikers"
+  rather than dropped (#5782). The binding's own subtree is excluded so a
+  helper that merely dispatches on itself is not mistaken for an external use.
+  -->
+  <xsl:function name="eo:dispatched" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="exists($target/..//o[contains(@base, concat($name, '.')) and not(ancestor-or-self::o[. is $target])])"/>
   </xsl:function>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -35,15 +35,34 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
-  The single attribute name a bare `ξ.<name>` reference resolves to, or the
-  empty string for anything that is not a hostable bare reference. A named
-  node (its `@name` would be clobbered by the binding), a trailing path,
-  arguments, or a non-`ξ` base all disqualify it.
+  The single attribute name a hostable `ξ.<name>` reference resolves to, or
+  the empty string for anything that is not hostable. Two shapes host a
+  binding: a bare reference `ξ.<name>` (no trailing path, no arguments) and a
+  single trailing dispatch segment `ξ.<name>.<seg>`, a reversed dispatch
+  spelled forward whose receiver `<name>` can be inlined exactly as the bare
+  case is, only as a reversed dispatch's receiver rather than a plain one
+  (#5782). Both resolve to `<name>`. A named node (its `@name` would be
+  clobbered by the binding), a multi-segment path, or a non-`ξ` base all
+  disqualify it.
   -->
   <xsl:function name="eo:resolved-ref" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="tail" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, concat($eo:xi, '.')) and not(contains($tail, '.')) and not($ref/o)) then $tail else ''"/>
+    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, concat($eo:xi, '.')) and not(contains($tail, '.')) and not($ref/o)) then $tail else if (eo:dispatch-seg($ref) != '') then substring-before($tail, '.') else ''"/>
+  </xsl:function>
+  <!--
+  The trailing dispatch segment of a hostable single-segment dispatch
+  reference `ξ.<name>.<seg>` — the receiver name `<name>` carries no further
+  dot, so exactly one dispatch segment `<seg>` trails it — or the empty string
+  for a bare reference, a named node, a non-`ξ` base, or a multi-segment chain
+  such as `ξ.a.b.c` (which would need deeply nested reversed dispatches and is
+  deliberately left expanded, #5782). Unlike a bare reference, a dispatch may
+  carry arguments: it inlines to a reversed dispatch that keeps them.
+  -->
+  <xsl:function name="eo:dispatch-seg" as="xs:string">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="tail" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
+    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, concat($eo:xi, '.')) and contains($tail, '.') and substring-before($tail, '.') != '' and not(contains(substring-after($tail, '.'), '.'))) then substring-after($tail, '.') else ''"/>
   </xsl:function>
   <!--
   Whether `$attr` is a formation attribute eligible to become a moniker:
@@ -58,14 +77,18 @@
     <xsl:sequence select="exists($attr/@name) and starts-with($attr/@name, concat('a', $eo:cactoos)) and exists($attr/@base) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
-  The bare `ξ.<name>` references, in document order, that can host the
-  binding `$attr`: a bare reference whose nearest formation ancestor is the
-  binding's own owner and that does not sit inside the binding itself.
+  The references, in document order, that can host the binding `$attr`: a bare
+  `ξ.<name>` reference or a single-segment dispatch `ξ.<name>.<seg>` (#5782)
+  whose nearest formation ancestor is the binding's own owner and that does
+  not sit inside the binding itself. Bare references are listed first, so a
+  binding with both spellings still folds into the shorter bare inline and a
+  dispatch hosts only when no bare reference is available.
   -->
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
-    <xsl:sequence select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
+    <xsl:variable name="refs" select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
+    <xsl:sequence select="($refs[eo:dispatch-seg(.) = ''], $refs[eo:dispatch-seg(.) != ''])"/>
   </xsl:function>
   <!--
   The binding that a reference `$ref` should be replaced with, or the empty
@@ -79,17 +102,36 @@
     <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
-  Replace the first hosting reference with the merged binding: keep the
-  reference's positional `@as`, take the binding's other attributes and its
-  children.
+  Replace the first hosting reference with the merged binding, always keeping
+  the reference's positional `@as`. A bare reference becomes the binding
+  inlined in place: the binding's other attributes and its children. A
+  single-segment dispatch `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
+  whose receiver is that inlined binding and whose arguments are the
+  reference's own children — the equivalent inline for a dispatch use (#5782).
   -->
   <xsl:template match="o[exists(eo:hosted-binding(.))]" priority="1">
     <xsl:variable name="binding" select="eo:hosted-binding(.)"/>
-    <xsl:element name="o">
-      <xsl:apply-templates select="@as"/>
-      <xsl:apply-templates select="$binding/@*[name() != 'as']"/>
-      <xsl:apply-templates select="$binding/node()"/>
-    </xsl:element>
+    <xsl:variable name="seg" select="eo:dispatch-seg(.)"/>
+    <xsl:choose>
+      <xsl:when test="$seg = ''">
+        <xsl:element name="o">
+          <xsl:apply-templates select="@as"/>
+          <xsl:apply-templates select="$binding/@*[name() != 'as']"/>
+          <xsl:apply-templates select="$binding/node()"/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:element name="o">
+          <xsl:apply-templates select="@as"/>
+          <xsl:attribute name="base" select="concat('.', $seg)"/>
+          <xsl:element name="o">
+            <xsl:apply-templates select="$binding/@*[name() != 'as']"/>
+            <xsl:apply-templates select="$binding/node()"/>
+          </xsl:element>
+          <xsl:apply-templates select="o"/>
+        </xsl:element>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!--
   Drop the standalone binding once it has been merged onto a reference.

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-dispatch.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A reversed dispatch is a prefix method dispatch: `auto.gte 0` and
+# `gte. auto 0` parse to the same graph, so a file-local `>>` handle that is
+# used only through a single-segment method dispatch (`auto.gte`, never a bare
+# `auto`) can still become a moniker (#5782). The binding is inlined as the
+# receiver of a reversed dispatch `gte.` rather than as a plain bare
+# reference, keeping the dispatch's own argument. Only one trailing segment is
+# hostable this way; a multi-segment chain stays expanded. Here the obfuscated
+# `number num.as-bytes >> auto` handle is merged onto its lone `auto.gte 0`
+# use, which becomes `gte.` over the inlined block.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+  - /org/eolang/printer/print/merge-monikers.xsl
+asserts:
+  # The obfuscated (cactus-named) binding is no longer a direct attribute of
+  # the formation: it has been merged onto its only, method-dispatch use.
+  - /object/o[@name='abs' and not(o[starts-with(@name, 'a🌵')])]
+  # No forward `ξ.a🌵….gte` reference survives: the dispatch was un-rolled.
+  - /object[count(//o[starts-with(@base, 'ξ.a🌵')])=0]
+  # The dispatch is now a reversed `gte.` (base '.gte') whose receiver is the
+  # inlined block, carrying the binding's base and child and its `@local`
+  # handle so the readable name still prints.
+  - /object/o[@name='abs']/o[@name='φ' and @base='.if']/o[@base='.gte']/o[starts-with(@name, 'a🌵') and @local='auto' and @base='Φ.number']/o[@base='ξ.num.as-bytes']
+  # The reversed dispatch keeps its own positional argument after the receiver.
+  - /object/o[@name='abs']/o[@name='φ']/o[@base='.gte']/o[starts-with(@name, 'a🌵')]/following-sibling::o[@as='α0']
+input: |
+  +package number
+
+  [num] > abs
+    if. > @
+      auto.gte 0
+      num
+      num
+    number num.as-bytes >> auto

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-dispatch.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A "moniker" — a named binding written at its use site — is merged back only
+# for the compiler's auto-generated, obfuscated names (the `a🌵` cactus prefix,
+# §9.2). Here the obfuscated file-local handle `number num.as-bytes >> auto` is
+# used only through a single method dispatch, `auto.gte 0`, and never through a
+# bare `auto`. A reversed dispatch is prefix method dispatch, so `auto.gte 0`
+# and `gte. auto 0` denote the same graph; the block can therefore be inlined
+# as the receiver of a reversed dispatch exactly as a bare reference is inlined
+# as a plain receiver (#5782). The printer drops the standalone `>> auto`
+# binding and rewrites `auto.gte 0` into `gte.` over the inlined block, keeping
+# the dispatch's `0` argument. Without the fix the handle had no bare
+# reference to land on, so `inline-cactoos` stranded the dispatch on a synthetic
+# `v_` placeholder instead. Only one trailing segment is hostable this way; a
+# multi-segment chain would need nested reversed dispatches and stays expanded.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package number
+
+  [num] > abs
+    if. > @
+      auto.gte 0
+      num
+      num
+    number num.as-bytes >> auto
+
+printed: |
+  +package number
+
+  [num] > abs
+    if. > @
+      gte.
+        number num.as-bytes >>
+        0
+      num
+      num


### PR DESCRIPTION
Closes #5782.

## Problem

The printer's `merge-monikers` pass merged an obfuscated `>>`-handle binding onto a **bare** reference but never onto a **method-dispatch** reference, so two structurally identical blocks printed asymmetrically. A delegation spelled `input-block` folded the block in as a moniker, while the parallel `output-block.write buffer` left the block expanded — a difference driven only by how the decorator happened to spell the call.

The gate in `eo:resolved-ref` yielded a hostable name only when the base after `ξ.` had no trailing dot, so `ξ.input-block` passed but `ξ.output-block.write` was rejected.

## Fix

A reversed dispatch is a prefix method dispatch: `x.write buf` and `write. x buf` parse to the same graph. So the block can be inlined as the **receiver of a reversed dispatch**, exactly as the bare case is inlined as a plain receiver.

**`merge-monikers.xsl`**
- `eo:resolved-ref` / `eo:moniker-refs` now also accept a reference carrying a **single** trailing dispatch segment (`ξ.<name>.<seg>`), with arguments allowed.
- A new `eo:dispatch-seg` helper extracts that trailing segment.
- The replacement template gains a branch that emits a reversed dispatch `<seg>.` whose receiver is the inlined block and whose arguments are the reference's own children, instead of a bare inline.
- A multi-segment chain (`a.b.c.d 1`) would need deeply nested reversed dispatches and is deliberately left expanded.
- Bare references are hosted first, so a binding with both spellings still folds into the shorter bare inline and existing behaviour is unchanged.

**`inline-cactoos.xsl`** (needed so the binding actually reaches `merge-monikers` in the full pipeline)
- `inline-cactoos` runs before `merge-monikers` and used to unconditionally drop an auto-named `>>`-handle binding unless it was recursive. A handle used only through a dispatch (`auto.gte 0`, never a bare `auto`) had no bare reference to inline, so it was dropped and the dispatch stranded on a synthetic `v_` placeholder — never reaching `merge-monikers`.
- It now also keeps a binding that a surviving method dispatch (`ξ.<name>.<seg>`) still reaches through its name (via the new `eo:dispatched` helper), so the binding lives on for `merge-monikers` to host.

## Tests

- `eo-packs/print/merge-monikers-dispatch.yaml` — unit pack asserting, at the XMIR level, that a handle used only through `auto.gte 0` merges into a reversed `gte.` over the inlined block.
- `print-packs/yaml/moniker-dispatch.yaml` — **end-to-end** pack proving the printed rendering: `auto.gte 0` over a `number num.as-bytes >> auto` handle prints as a `gte.` reversed dispatch with the block inlined as its receiver, and reprints to itself.

Full `XmirTest` suite passes (**144 tests**), including the unchanged `merge-monikers.yaml` pack (confirming bare-reference priority is preserved) and no regressions in the other print packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)