### PR TITLE
Bind a nested file-local handle's self-reference

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -21,7 +21,10 @@
   shadows a handle in a more distant scope, and a file-local handle no longer
   hijacks a same-named public attribute in an unrelated sibling formation.
   This mirrors how "build-fqns" later resolves a name to the nearest
-  enclosing formation that owns an attribute of that name.
+  enclosing formation that owns an attribute of that name. A handle written
+  nested inside an application (a moniker with arguments, §3.14) still binds
+  its own body's self-reference (#5788), before "vars-float-up" hoists it into
+  a proper attribute position.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
@@ -30,13 +33,19 @@
   or a global). The nearest enclosing formation (an "o" without "@base") that
   declares the referenced name - as a public attribute "@name" or as a handle
   "@local" - is the reference's scope; the reference binds to a handle only
-  when that scope's declaration is itself a handle.
+  when that scope's declaration is itself a handle. When no enclosing formation
+  declares the name at all, a self-referential handle still captures its own
+  body (#5788): a "&gt;&gt; foo" formation written nested inside an application
+  (a moniker with arguments) is not a direct attribute of any enclosing
+  formation yet, so the ordinary scope search misses it, but its body's
+  reference to "foo" is the handle's own recursion and binds to the nearest
+  enclosing handle of that name.
   -->
   <xsl:function name="eo:captor" as="element()?">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="name" as="xs:string" select="$ref/@base"/>
     <xsl:variable name="scope" as="element()?" select="($ref/ancestor::o[not(@base)][o[@name=$name or @local=$name]])[last()]"/>
-    <xsl:sequence select="$scope/o[@local=$name][1]"/>
+    <xsl:sequence select="if (exists($scope)) then $scope/o[@local=$name][1] else ($ref/ancestor::o[@local=$name])[last()]"/>
   </xsl:function>
   <xsl:template match="o[@base and exists(eo:captor(.))]">
     <xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-nested-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-nested-handle.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  # the recursive handle keeps its "@local" marker and gets a cactus name
+  - //o[@local='r' and @name]
+  # the handle's own body reference binds to the handle, not to a global,
+  # even though the handle is written nested inside an application (#5788)
+  - /object[count(//o[@base=//o[@local='r']/@name])=1]
+input: |
+  [list index] > front
+    if. > @
+      index.eq 0
+      list
+      if. > [t] >> r
+        t.length.eq index
+        t
+        r t.tail
+      | list


### PR DESCRIPTION
When a `>> foo` file-local handle is written nested inside an application (the moniker-with-arguments spelling, §3.14), `resolve-local-names` failed to bind the handle's own body reference to it. The handle is not yet a direct attribute of any enclosing formation at that point in the pipeline, so the `#5780` scope guard found no scope and let the self-reference root at a dangling global `Φ.foo`. This pass now captures such a self-reference to the nearest enclosing handle of the same name whenever the ordinary scope search comes up empty.

The visible effect is in `eo-printer`: the moniker spelling used to parse to a different object graph than the equivalent expanded spelling, so a recursive `[t] >> r` formation no longer looked recursive on the round trip. `inline-cactoos` then inlined it and dropped its `| args` pipe, and `restore-local-names` dropped the `>> r` handle, so the `moniker-with-arguments` pack could not reprint to itself. With the fix both spellings parse identically and the pack round-trips losslessly.

Added a focused parser pack that pins the capture, and the full `eo-parser` (1497) and `eo-printer` (182) suites are green. Closes #5788.