### PR TITLE
bug(#5794): print anonymous dispatched formations via reversed dispatch

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -15,13 +15,15 @@
   binding line) parse to one and the same object graph. This pass turns
   the expanded spelling back into the moniker.
 
-  For each formation, an eligible named bound attribute (see
-  `eo:moniker-binding`) is merged onto the first bare `ξ.<name>` reference
-  reachable through no intervening formation (so the name still binds to
-  the same formation). A method-dispatch use such as `value.gte`, a
-  reference carrying arguments, or a reference that is itself a named
-  attribute (such as `temp > @`) cannot host the binding and stays a
-  reference; when no bare reference exists, the binding is left in place.
+  For each formation, an eligible bound attribute (see `eo:moniker-binding`)
+  is merged onto the first hostable reference reachable through no intervening
+  formation (so the name still binds to the same formation). A bare `ξ.<name>`
+  reference must be unnamed, but a single-segment dispatch `ξ.<name>.<seg>`
+  (#5782) may also host onto a named reference (such as `q. > @`), since the
+  reversed dispatch keeps the reference's own `@name` (#5794); a bare
+  reference carrying arguments or a multi-segment path cannot host the binding
+  and stays a reference. When no hostable reference exists, the binding is
+  left in place.
 
   A binding with several hostable references still becomes a moniker,
   landing on the first one in document order (#5739). This deliberately
@@ -41,9 +43,9 @@
   single trailing dispatch segment `ξ.<name>.<seg>`, a reversed dispatch
   spelled forward whose receiver `<name>` can be inlined exactly as the bare
   case is, only as a reversed dispatch's receiver rather than a plain one
-  (#5782). Both resolve to `<name>`. A named node (its `@name` would be
-  clobbered by the binding), a multi-segment path, or a non-`ξ` base all
-  disqualify it.
+  (#5782). Both resolve to `<name>`. A multi-segment path or a non-`ξ` base
+  disqualify it, as does a named node for the bare case only — a bare inline
+  would clobber the reference's `@name`, but a dispatch keeps it (#5794).
   -->
   <xsl:function name="eo:resolved-ref" as="xs:string">
     <xsl:param name="ref" as="element()"/>
@@ -54,27 +56,28 @@
   The trailing dispatch segment of a hostable single-segment dispatch
   reference `ξ.<name>.<seg>` — the receiver name `<name>` carries no further
   dot, so exactly one dispatch segment `<seg>` trails it — or the empty string
-  for a bare reference, a named node, a non-`ξ` base, or a multi-segment chain
-  such as `ξ.a.b.c` (which would need deeply nested reversed dispatches and is
+  for a bare reference, a non-`ξ` base, or a multi-segment chain such as
+  `ξ.a.b.c` (which would need deeply nested reversed dispatches and is
   deliberately left expanded, #5782). Unlike a bare reference, a dispatch may
-  carry arguments: it inlines to a reversed dispatch that keeps them.
+  carry arguments and may be a named node: it inlines to a reversed dispatch
+  that keeps both (#5794).
   -->
   <xsl:function name="eo:dispatch-seg" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="tail" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, concat($eo:xi, '.')) and contains($tail, '.') and substring-before($tail, '.') != '' and not(contains(substring-after($tail, '.'), '.'))) then substring-after($tail, '.') else ''"/>
+    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, concat($eo:xi, '.')) and contains($tail, '.') and substring-before($tail, '.') != '' and not(contains(substring-after($tail, '.'), '.'))) then substring-after($tail, '.') else ''"/>
   </xsl:function>
   <!--
   Whether `$attr` is a formation attribute eligible to become a moniker:
-  auto-named with the cactus prefix (`a🌵`, §9.2), bound (has a base), and
-  neither void, `φ`, a test, nor already floated with a pipe (`|`). Only
-  the compiler's obfuscated names are merged; a real, author-chosen name
-  such as `value` reads best on its own `... > name` line and stays
-  standalone (#5738).
+  auto-named with the cactus prefix (`a🌵`, §9.2), either bound (has a base)
+  or an abstract formation (#5794), and neither void, `φ`, a test, nor already
+  floated with a pipe (`|`). Only the compiler's obfuscated names are merged;
+  a real, author-chosen name such as `value` reads best on its own
+  `... > name` line and stays standalone (#5738).
   -->
   <xsl:function name="eo:moniker-binding" as="xs:boolean">
     <xsl:param name="attr" as="element()"/>
-    <xsl:sequence select="exists($attr/@name) and starts-with($attr/@name, concat('a', $eo:cactoos)) and exists($attr/@base) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
+    <xsl:sequence select="exists($attr/@name) and starts-with($attr/@name, concat('a', $eo:cactoos)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
   The references, in document order, that can host the binding `$attr`: a bare
@@ -108,6 +111,8 @@
   single-segment dispatch `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
   whose receiver is that inlined binding and whose arguments are the
   reference's own children — the equivalent inline for a dispatch use (#5782).
+  The dispatch also keeps the reference's own `@name`, so a named use such as
+  `q. > @` over an anonymous formation round-trips (#5794).
   -->
   <xsl:template match="o[exists(eo:hosted-binding(.))]" priority="1">
     <xsl:variable name="binding" select="eo:hosted-binding(.)"/>
@@ -123,6 +128,7 @@
       <xsl:otherwise>
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
+          <xsl:apply-templates select="@name"/>
           <xsl:attribute name="base" select="concat('.', $seg)"/>
           <xsl:element name="o">
             <xsl:apply-templates select="$binding/@*[name() != 'as']"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-formation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-formation.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An anonymous auto-named ("a🌵…") abstract formation, reached only through a
+# single-segment method dispatch whose result is bound to a named attribute
+# ("q. > @"). Two extensions let "merge-monikers" host it as a moniker (#5794):
+# an abstract formation (not just a based binding) is now an eligible
+# "eo:moniker-binding", and a single-segment dispatch may host onto a named
+# reference — the reversed dispatch keeps the reference's own "@name". So the
+# formation is inlined as the receiver of the reversed dispatch "q." (base
+# ".q", still named "φ"), keeping its "5" argument, and the standalone binding
+# with its forward "ξ.a🌵….q" reference disappears. Without the fix the binding
+# reached the printer standalone and its reference dangled on a synthetic
+# "vL_P" placeholder.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+  - /org/eolang/printer/print/merge-monikers.xsl
+asserts:
+  # The obfuscated formation is no longer a standalone attribute of "bar".
+  - /object/o[@name='bar' and not(o[starts-with(@name, 'a🌵')])]
+  # No forward "ξ.a🌵….q" reference survives: the dispatch was un-rolled.
+  - /object[count(//o[starts-with(@base, 'ξ.a🌵')])=0]
+  # The dispatch is now a reversed "q." (base '.q') that keeps its own "@name"
+  # ("φ", i.e. "> @"); its receiver is the inlined anonymous formation.
+  - /object/o[@name='bar']/o[@name='φ' and @base='.q']/o[starts-with(@name, 'a🌵') and not(@base)]
+  # The reversed dispatch keeps its own "5" argument after the receiver.
+  - /object/o[@name='bar']/o[@base='.q']/o[starts-with(@name, 'a🌵')]/following-sibling::o[@as='α0' and @base='Φ.number']
+  # The formation's "$"-recursion stays a bare "ξ".
+  - /object/o[@name='bar']/o[@base='.q']/o[starts-with(@name, 'a🌵')]/o[@name='φ' and @base='ξ']
+input: |
+  +package foo
+
+  [] > bar
+    q. > @
+      [n] >>
+        $ (n.minus 1) > @
+      5

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-auto-named-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-auto-named-handle.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An anonymous, file-local recursive formation the parser auto-names "a🌵…"
+# with no "&gt;&gt; name" handle, reached from the outside through a method
+# dispatch bound to a named attribute ("q. &gt; @"). "inline-cactoos" keeps
+# such a self-referential formation in place (#5677). Before #5794
+# "merge-monikers" ignored it — it hosts only based bindings, and never onto a
+# named reference — so it reached the printer standalone and "to-eo-tree"
+# printed the declaration anonymously ("[n] &gt;&gt;") while rewriting the
+# surviving cactus name to a synthetic "vL_P" on the reference, leaving it
+# dangling. Now "merge-monikers" also hosts an abstract formation, and hosts a
+# single-segment dispatch onto a named reference (keeping the "&gt; @"), so the
+# formation is inlined back as the anonymous receiver of the reversed dispatch
+# "q. &gt; @" — no dangling reference — with its "$"-application decoratee in
+# the canonical compact form ("$ &gt; [n] &gt;&gt;"), re-parsing to the same graph.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package foo
+
+  [] > bar
+    q. > @
+      [n] >>
+        $ (n.minus 1) > @
+      5
+
+printed: |
+  +package foo
+
+  [] > bar
+    q. > @
+      $ > [n] >>
+        n.minus 1
+      5


### PR DESCRIPTION
Closes #5794.

## Problem

An anonymous, file-local recursive formation — one the parser auto-names `a🌵…` with no `>> name` handle — reached from the outside only through a method dispatch bound to a named attribute (`q. > @`) printed lossily. This program on `master`:

```
+package foo

[] > bar
  q. > @
    [n] >>
      $ (n.minus 1) > @
    5
```

became:

```
+package foo

[] > bar
  v5_4.q 5 > @
  $ > [n] >>
    n.minus 1
```

`v5_4` named no binding, so the reference dangled and the file no longer re-parsed to the same graph.

## Root cause

`merge-monikers` already inlines a dispatched cactus binding as the receiver of a reversed dispatch (#5782), which is exactly the spelling this program uses (`q. > @`). But it skipped this case on two counts:

1. `eo:moniker-binding` required a `@base`, so it hosted only **based** bindings — never an **abstract formation**.
2. Hostability rejected **named** references, so a dispatch bound to `> @` stayed expanded.

With neither pass handling it, the formation reached `to-eo-tree` standalone: its cactus name was rewritten to a synthetic `vL_P` on the reference while the declaration printed anonymously — the two disagreed and the reference dangled.

## Fix (`merge-monikers.xsl`)

Both restrictions are lifted:

- An **abstract formation** is now an eligible `eo:moniker-binding` (not just a based binding).
- A **single-segment dispatch may host onto a named reference**, and the reversed dispatch keeps the reference's own `@name`.

So the anonymous formation is inlined back as the receiver of the reversed dispatch `q. > @`, its `5` argument preserved, and no dangling reference remains. The formation stays anonymous (`>>`) — its `$`-application decoratee is laid out in the printer's canonical compact form:

```
+package foo

[] > bar
  q. > @
    $ > [n] >>
      n.minus 1
    5
```

This re-parses to the same graph and reprints to itself. The `moniker-dispatch` case (#5782, unnamed dispatch onto a based binding) is unaffected — an absent `@name` is preserved as absent.

## Tests

- `recursive-auto-named-handle.yaml` — end-to-end EO print-pack: the reported program prints with the formation kept inline in the reversed dispatch (no dangling `vL_P`) and round-trips (`printsToEo` + `printsToParseableEo`).
- `merge-monikers-formation.yaml` — XSL-level pack asserting `merge-monikers` hosts the abstract formation onto the named dispatch, keeps `@name` and the argument, and leaves no forward `ξ.a🌵….q` reference.

All 181 `eo-printer` tests pass (`mvn -pl eo-printer test`), including the existing `merge-monikers`, `merge-monikers-dispatch`, `recursive-local-handle`, and `auto-named-abstract` packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)