### PR TITLE
#5800: format goal INFO report now includes elapsed time

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -101,7 +101,9 @@ public final class MjFormat extends MjSafe {
     private Integer step;
 
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void exec() throws IOException {
+        final long start = System.currentTimeMillis();
         final Collection<TjForeign> sources = this.scopedTojos().withSources();
         final Collection<Path> divergent = new LinkedList<>();
         for (final TjForeign tojo : sources) {
@@ -109,7 +111,7 @@ public final class MjFormat extends MjSafe {
                 divergent.add(tojo.source());
             }
         }
-        this.report(sources.size(), divergent);
+        this.report(sources.size(), divergent, System.currentTimeMillis() - start);
     }
 
     /**
@@ -201,13 +203,18 @@ public final class MjFormat extends MjSafe {
      * Report the outcome, failing the build if needed.
      * @param total The number of registered sources
      * @param divergent The sources that diverged from the canonical form
+     * @param millis The elapsed time, in milliseconds
      */
-    private void report(final int total, final Collection<Path> divergent) {
+    private void report(final int total, final Collection<Path> divergent, final long millis) {
         if (divergent.isEmpty()) {
-            Logger.info(this, "All %d EO source(s) are formatted canonically", total);
+            Logger.info(
+                this, "All %d EO source(s) are formatted canonically in %[ms]s", total, millis
+            );
         } else if (this.autoFix) {
             Logger.info(
-                this, "Reformatted %d of %d EO source(s)", divergent.size(), total
+                this,
+                "Reformatted %d of %d EO source(s) in %[ms]s",
+                divergent.size(), total, millis
             );
         } else {
             throw new IllegalStateException(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -208,12 +208,14 @@ public final class MjFormat extends MjSafe {
     private void report(final int total, final Collection<Path> divergent, final long millis) {
         if (divergent.isEmpty()) {
             Logger.info(
-                this, "All %d EO source(s) are formatted canonically in %[ms]s", total, millis
+                this,
+                "All %d EO source(s) are formatted canonically, took %[ms]s to check",
+                total, millis
             );
         } else if (this.autoFix) {
             Logger.info(
                 this,
-                "Reformatted %d of %d EO source(s) in %[ms]s",
+                "Reformatted %d of %d EO source(s), took %[ms]s",
                 divergent.size(), total, millis
             );
         } else {


### PR DESCRIPTION
Closes #5800

The `format` goal's INFO report showed only counts, never how long it took, unlike every other goal (which surfaces its duration via the `Timed` decorator or via `MjSafe`'s DEBUG-level timing).

`MjFormat.exec()` now captures the elapsed time and passes it into `report()`, which appends ` in %[ms]s` to both the "all canonical" and "reformatted N of M" messages, reusing the same `%[ms]s` idiom already used by `Timed`.
