### PR TITLE
#5810: keep based `&gt;&gt; name` handle and its arguments during auto-fix

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -40,17 +40,31 @@
   copy that self-reference back in and fire this template forever, so
   such a target is also left untouched (both the reference and the
   abstraction stay in place).
+
+  The inlined value keeps the target's obfuscated cactus `@name` only when
+  the name is still meaningful downstream: an abstract formation, whose name
+  `to-eo-tree` renders as the anonymous `[...] >>` marker (exactly what an
+  inlined anonymous formation should read as), and a dataized-const wrapper
+  (`.as-bytes` over `Φ.dataized`), whose name `dataized-to-const` later
+  promotes onto the abstract const node it rebuilds. A based `>> name` handle
+  whose value is a plain reference or application (`a >> b`, R-3.10.12) is
+  neither, so carrying its `@name` (or the `@local` handle it leaves behind)
+  over would turn the inline into a spurious named node that `to-eo-tree`
+  prints as its own `a >>` line, swallowing the surrounding argument; for
+  such a target the `@name` and `@local` are dropped and the value lands as
+  an anonymous argument (#5810).
   -->
   <xsl:template match="o[contains(@base, concat('.', $auto))]" priority="0">
     <xsl:variable name="name" select="eo:resolved-name(@base)"/>
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
+    <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized'))"/>
     <xsl:choose>
       <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name))">
         <xsl:element name="o">
           <xsl:if test="@as">
             <xsl:apply-templates select="@as"/>
           </xsl:if>
-          <xsl:apply-templates select="$target/@*"/>
+          <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
           <xsl:apply-templates select="$target/node()"/>
         </xsl:element>
       </xsl:when>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -107,8 +107,15 @@
   <!--
   Replace the first hosting reference with the merged binding, always keeping
   the reference's positional `@as`. A bare reference becomes the binding
-  inlined in place: the binding's other attributes and its children. A
-  single-segment dispatch `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
+  inlined in place: the binding's other attributes and its children. An
+  abstract formation keeps its obfuscated `@name`, which `to-eo-tree` renders
+  as the anonymous `[...] >>` marker; a based binding — a `>> name` handle
+  whose value is a plain reference such as `a >> b` (R-3.10.12) — drops its
+  `@name` (and the `@local` handle it leaves behind), since the bare reference
+  is unnamed and carrying the obfuscated name over would turn the inline into
+  a spurious named node that `to-eo-tree` prints as its own `a >>` line
+  instead of an anonymous argument (#5810). A single-segment dispatch
+  `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
   whose receiver is that inlined binding and whose arguments are the
   reference's own children — the equivalent inline for a dispatch use (#5782).
   The dispatch also keeps the reference's own `@name`, so a named use such as
@@ -121,7 +128,7 @@
       <xsl:when test="$seg = ''">
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
-          <xsl:apply-templates select="$binding/@*[name() != 'as']"/>
+          <xsl:apply-templates select="$binding/@*[name() != 'as' and (eo:abstract($binding) or (name() != 'name' and name() != 'local'))]"/>
           <xsl:apply-templates select="$binding/node()"/>
         </xsl:element>
       </xsl:when>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
@@ -12,7 +12,10 @@
 # file-local handle `>> auto` carries a cactus @name, so its binding is merged
 # onto the first bare `auto` reference (the `auto.gte`/`auto.neg` dispatches
 # cannot host it and stay references), while the real name `value` keeps both
-# its standalone binding and its bare reference.
+# its standalone binding and its bare reference. The merged binding is a based
+# value (not an abstract formation), so its obfuscated `@name` and `@local`
+# handle are dropped — the bare reference is unnamed and keeping them would
+# leave a spurious named `auto >>` node that `to-eo-tree` mis-prints (#5810).
 sheets:
   - /org/eolang/parser/parse/wrap-applications.xsl
   - /org/eolang/parser/parse/resolve-self.xsl
@@ -39,8 +42,9 @@ asserts:
   - /object/o[@name='abs' and not(o[starts-with(@name, 'a🌵')])]
   # It now lives at the first bare-reference site, inside the `if.` block,
   # keeping the reference's positional marker and gaining the binding's base
-  # and child (the `@local` handle is preserved so the readable name prints).
-  - /object/o[@name='abs']/o[@name='φ' and @base='.if']/o[starts-with(@name, 'a🌵') and @local='auto' and @base='Φ.number' and @as='α0']/o[@base='ξ.num.as-bytes']
+  # and child, but as an anonymous value: the based binding's obfuscated
+  # `@name` and its `@local` handle are dropped (#5810).
+  - /object/o[@name='abs']/o[@name='φ' and @base='.if']/o[not(@name) and not(@local) and @base='Φ.number' and @as='α0']/o[@base='ξ.num.as-bytes']
   # The method-dispatch use of the cactus name stays a reference.
   - /object/o[@name='abs']/o[@name='φ']/o[starts-with(@base, 'ξ.a🌵') and ends-with(@base, '.gte')]
   # The real name `value` is NOT merged: its standalone binding stays a direct

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
@@ -15,7 +15,7 @@
 # its standalone binding and its bare reference. The merged binding is a based
 # value (not an abstract formation), so its obfuscated `@name` and `@local`
 # handle are dropped — the bare reference is unnamed and keeping them would
-# leave a spurious named `auto >>` node that `to-eo-tree` mis-prints (#5810).
+# leave a spurious named `auto >>` node that `to-eo-tree` misprints (#5810).
 sheets:
   - /org/eolang/parser/parse/wrap-applications.xsl
   - /org/eolang/parser/parse/resolve-self.xsl

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-local-handle.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A file-local `>> name` handle (R-3.10.12) whose value is a plain reference,
+# not a formation, such as `a >> b`. The parser stores it as an obfuscated
+# cactus binding (`a🌵…`) carrying the handle in `@local` and a `ξ.a` base,
+# and resolves every `b` use to the cactus name. Unlike the recursive-handle
+# and auto-named cases, a based binding is neither void nor an abstract
+# formation, so `restore-local-names` drops its `@local`, and `inline-cactoos`
+# folds the single-use cactus binding back onto its bare `b` reference. The
+# inlined value must land as the anonymous reference `a`, not a spurious
+# named `a >>` node that keeps the obfuscated `@name`: `to-eo-tree` prints
+# such a node as its own `a >>` line, swallowing both the handle and the
+# surrounding `.plus` argument (#5810).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    42.plus b > @
+    a >> b
+
+printed: |
+  42.plus a > [a] > foo


### PR DESCRIPTION
Fixes #5810.

## Problem

Running the printer in auto-fix mode over a file-local `>> ` handle whose value is a plain reference mangled it. Given:

```
[a] > foo
  42.plus b > @
  a >> b
```

`Xmir.toEO` emitted:

```
[a] > foo
  42.plus > @
    a >>
```

— the handle `b` and the `.plus` argument were both lost.

## Root cause

The parser stores `a >> b` as an obfuscated cactus binding (`a🌵…`) carrying the handle in `@local` and a `ξ.a` base, and resolves every `b` reference to the cactus name. Unlike a `? >> name` void or an anonymous `>>` formation, a based binding is neither void nor abstract, so `restore-local-names` drops its `@local` and the binding survives into the folding passes as a single-use cactus binding.

In the full print pipeline the fold is done by **`inline-cactoos`** (which runs before `merge-monikers`); `merge-monikers` exhibits the same latent bug in isolation. Both copied the binding's obfuscated cactus `@name` onto the inlined value. Because the hosting reference is unnamed, this produced a spurious *named* node, which `to-eo-tree` prints as its own `a >>` line instead of as `.plus`'s argument.

> Note: the issue pins the fix to `merge-monikers`, but in the assembled pipeline `inline-cactoos` folds the binding first, so the fix had to be applied there too (and consistently in both sheets).

## Fix

Drop the cactus `@name` (and the `@local` handle it leaves behind) when the inlined value is *not* something whose name is still meaningful downstream:

- an **abstract formation** keeps its name so `to-eo-tree` can render the anonymous `[...] >>` marker;
- a **dataized-const wrapper** (`.as-bytes` over `Φ.dataized`) keeps its name so `dataized-to-const` can promote it onto the abstract const node it rebuilds;
- every other **based value** lands as an anonymous argument.

Result:

```
42.plus a > [a] > foo
```

## Changes

- `eo-printer/.../inline-cactoos.xsl` — drop `@name`/`@local` for based inlined values, with an exception for abstract formations and dataized-const wrappers.
- `eo-printer/.../merge-monikers.xsl` — same exclusion in the bare-reference branch (keeps `@name` for abstract formations).
- `eo-printer/.../print-packs/yaml/based-local-handle.yaml` — new print-pack reproducing the issue (reprints to a fixpoint).
- `eo-printer/.../eo-packs/print/merge-monikers.yaml` — updated the merged-node assertion to expect the anonymous value.

All 184 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fHmUx3xd8UbGUS5iJtgvh)_