### PR TITLE
#5802: dirname of a root-anchored single component is the root

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -55,7 +55,10 @@
           (pth.size.eq 0).or
             len.eq -1
           pth
-          (txt.slice 0 len).as-bytes
+          if.
+            len.eq 0
+            separator
+            (txt.slice 0 len).as-bytes
       string.last-index-of txt separator > len!
       uri > pth!
       string pth > txt
@@ -169,7 +172,10 @@
             (pth.size.eq 0).or
               len.eq -1
             pth
-            (txt.slice 0 len).as-bytes
+            if.
+              len.eq 0
+              separator
+              (txt.slice 0 len).as-bytes
         string.last-index-of txt separator > len!
         uri > pth!
         string pth > txt
@@ -472,6 +478,16 @@
           "html"
           path.separator
     ""
+
+  eq. ++> tests-returns-root-dirname-of-posix-single-component
+    dirname.
+      path.posix "/foo"
+    "/"
+
+  eq. ++> tests-returns-root-dirname-of-win32-root-relative
+    dirname.
+      path.win32 "\\foo"
+    "\\"
 
   eq. ++> tests-returns-the-same-string-if-no-separator-is-found
     basename.


### PR DESCRIPTION
Fixes #5802.

For an absolute path with a single component (e.g. `/foo`), the only separator is at index 0, so `dirname` sliced `txt[0:0]` and returned `""` — losing the fact that the parent is the root directory. A `dirname` that drops the root can no longer be combined with `basename` to reconstruct the path.

Fix: when the last separator is at index 0 (`len.eq 0`), return the separator (the root) instead of the empty prefix, in both the posix and win32 `dirname`. Now:

- `path.posix "/foo" .dirname` -> `"/"` (was `""`)
- `path.win32 "\foo" .dirname` -> `"\"` (was `""`)
- `path.posix "/var/www" .dirname` -> `"/var"` (unchanged)

Added regression tests for the posix and win32 root cases.