### PR TITLE
#5801: a relative path that normalizes away becomes "."

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -84,7 +84,10 @@
         if.
           normalized.eq "//"
           "/"
-          string normalized
+          if.
+            normalized.size.eq 0
+            "."
+            string normalized
       ^.is-absolute.as-bool > is-absolute
       as-bytes. > normalized
         if.
@@ -354,6 +357,11 @@
     normalized.
       path.posix "/foo/bar/.//./baz//../x/"
     "/foo/bar/x/"
+
+  eq. ++> tests-normalizes-posix-path-collapsing-to-current-dir
+    normalized.
+      path.posix "foo/.."
+    "."
 
   eq. ++> tests-normalizes-posix-relative-path
     normalized.


### PR DESCRIPTION
Fixes #5801.

When the `..`/`.` segment reduction cancels everything (e.g. `foo/..`, `.`, `a/b/../..`), the joined path is empty and, for a relative path, `normalized` returned `""` — a falsy, meaningless path. An empty *input* is already special-cased to `"."`, so a path that *reduces* to empty must produce the same current-directory marker.

Fix: map an empty normalized result to `"."` in the posix wrapper that already post-processes `"//"` -> `"/"`. Now:

- `path.posix "foo/.." .normalized` -> `"."` (was `""`)
- `path.posix "." .normalized` -> `"."`
- `path.posix "/foo/bar/../.." .normalized` -> `"/"` (unchanged)

Added a regression test for the collapsing relative path.

(The win32 branch has related empty/collapse gaps tracked separately in #5808 and #5809.)