### PR TITLE
#5807: resolving a path against an empty component no longer crashes

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -127,10 +127,12 @@
         posix
           string
             if.
-              (obts.slice 0 1).eq
-                separator
-              obts
-              (uri.concat separator).concat obts
+              obts.size.eq 0
+              uri
+              if.
+                (obts.slice 0 1).eq separator
+                obts
+                (uri.concat separator).concat obts
       other.as-bytes > obts
     "/" > separator
   os.is-windows.if > separator
@@ -391,6 +393,12 @@
       path.posix "/var/temp"
       "./www/html"
     "/var/temp/www/html"
+
+  eq. ++> tests-resolves-posix-path-against-empty-other
+    resolved.
+      path.posix "/a/b"
+      ""
+    "/a/b"
 
   eq. ++> tests-resolves-posix-relative-path-against-other-absolute-path
     resolved.


### PR DESCRIPTION
Fixes #5807.

`resolved` inspected the first byte of `other` (`obts.slice 0 1`) to decide whether it is absolute, but sliced without a length guard, so resolving against an empty component threw an out-of-bounds `ExFailure` instead of resolving. Joining/resolving against an empty string is a normal operation and must not crash (Node `path.resolve('/a/b','')` -> `/a/b`).

Fix: guard the empty `other` and return the base path (normalized). Now:

- `path.posix "/a/b" .resolved ""` -> `"/a/b"` (was a crash)
- `path.posix "/a/b" .resolved "x"` -> `"/a/b/x"` (unchanged)

Added a regression test for resolving against an empty component.