### PR TITLE
#5808, #5809: keep the drive and drive-relative ".." in win32 path normalization

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -215,6 +215,8 @@
             2
             ubts.size.plus -2
           ubts
+        as-bool. > driveless-rooted
+          ^.is-root-relative driveless
         as-bool. > is-drive-relative
           ^.is-drive-relative ubts
         as-bool. > is-root-relative
@@ -222,7 +224,9 @@
         as-bytes. > normalized
           if.
             driveless.size.eq 0
-            "."
+            is-drive-relative.if
+              uri.slice 0 2
+              "."
             concat.
               concat.
                 is-drive-relative.if
@@ -244,8 +248,7 @@
                 (accum.length.gt 0).and
                   (accum.head.eq "..").not
                 accum.tail
-                if.
-                  is-root-relative.not.and is-drive-relative.not
+                driveless-rooted.not.if
                   accum.with segment
                   accum
               if.
@@ -364,6 +367,16 @@
     normalized.
       path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
     "..\\..\\foo\\x\\y\\"
+
+  eq. ++> tests-normalizes-win32-drive-only-path-keeps-drive
+    normalized.
+      path.win32 "C:"
+    "C:"
+
+  eq. ++> tests-normalizes-win32-drive-relative-path-keeps-leading-dotdot
+    normalized.
+      path.win32 "C:..\\foo"
+    "C:..\\foo"
 
   eq. ++> tests-normalizes-win32-path-down-to-drive-with-separator
     normalized.


### PR DESCRIPTION
Fixes #5808. Fixes #5809.

Two related empty/collapse gaps in `win32` normalization:

**#5808** — a drive-only path (`C:`) has an empty `driveless` part, and the `driveless.size.eq 0` branch returned `"."`, dropping the drive letter (while `C:.` and `C:foo` kept it). Fix: return the drive prefix for a drive-relative path, `"."` only for a truly empty (non-drive) path.

- `path.win32 "C:" .normalized` -> `"C:"` (was `"."`)
- `path.win32 "" .normalized` -> `"."` (unchanged)

**#5809** — a leading `..` was dropped for *any* drive-relative path, but an unrooted `C:..\foo` is relative in its path portion (the current directory on C: is unknown), so the `..` must be preserved — just like the driveless `..\foo`. Fix: gate the drop on whether the **driveless** part is rooted (starts with the separator) rather than on the mere presence of a drive letter.

- `path.win32 "C:..\foo" .normalized` -> `"C:..\foo"` (was `"C:foo"`)
- `path.win32 "C:\.." .normalized` -> `"C:\"` (unchanged, rooted drive)
- `path.win32 "..\foo" .normalized` -> `"..\foo"` (unchanged)

Added regression tests for both cases.

(The posix branch has a related empty-collapse gap fixed in #5801.)