### PR TITLE
#5810: reformat const file-local `&gt;&gt; name!` handle without mangling it

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -367,6 +367,11 @@ final class Suffix {
     /**
      * Parse a {@code >>} (auto) suffix, optionally carrying a trailing
      * file-local handle ({@code >> name}, §3.10) kept as the label.
+     *
+     * <p>The optional {@code !} const marker (§3.10) may sit either right
+     * after {@code >>} on an anonymous handle ({@code >>!}) or right after a
+     * named handle ({@code >> name!}), mirroring the {@code > name!} spelling
+     * of a plain named binding. Only one marker is accepted.</p>
      * @param tail Tail substring
      * @param after Index immediately after {@code >>}
      * @param span Source span
@@ -399,6 +404,10 @@ final class Suffix {
                 );
             }
             rest = end;
+        }
+        if (!cnst && rest < tail.length() && tail.charAt(rest) == '!') {
+            cnst = true;
+            rest = rest + 1;
         }
         final int trailing = Suffix.skipSpace(tail, rest);
         if (trailing < tail.length() && tail.charAt(trailing) == '/') {

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -372,6 +372,7 @@ final class Suffix {
      * after {@code >>} on an anonymous handle ({@code >>!}) or right after a
      * named handle ({@code >> name!}), mirroring the {@code > name!} spelling
      * of a plain named binding. Only one marker is accepted.</p>
+     *
      * @param tail Tail substring
      * @param after Index immediately after {@code >>}
      * @param span Source span
@@ -389,22 +390,8 @@ final class Suffix {
             idx = idx + 1;
         }
         final int begin = Suffix.skipSpace(tail, idx);
-        String handle = "";
-        int rest = begin;
-        if (begin < tail.length() && !Suffix.endsName(tail.charAt(begin))) {
-            int end = begin;
-            while (end < tail.length() && !Suffix.endsName(tail.charAt(end))) {
-                end = end + 1;
-            }
-            handle = tail.substring(begin, end);
-            if (handle.codePoints().anyMatch(cp -> cp == 0x1F335)) {
-                throw new ParseError(
-                    span.line(), home + begin,
-                    "cactus emoji is reserved for auto-names; not allowed in identifiers"
-                );
-            }
-            rest = end;
-        }
+        final String handle = Suffix.handle(tail, begin, span, home);
+        int rest = begin + handle.length();
         if (!cnst && rest < tail.length() && tail.charAt(rest) == '!') {
             cnst = true;
             rest = rest + 1;
@@ -418,6 +405,33 @@ final class Suffix {
         }
         Suffix.endsClean(tail, trailing, span, home);
         return new Suffix.Parsed(Form.AUTO, handle, "", cnst);
+    }
+
+    /**
+     * Read a file-local handle name starting at {@code begin}, running up to
+     * the next name terminator; the empty string when no handle is present.
+     * @param tail Tail substring
+     * @param begin Index where the handle name may start
+     * @param span Source span
+     * @param home Source column where tail begins
+     * @return The handle, or the empty string when absent
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private static String handle(
+        final String tail, final int begin, final Span span, final int home
+    ) {
+        int end = begin;
+        while (end < tail.length() && !Suffix.endsName(tail.charAt(end))) {
+            end = end + 1;
+        }
+        final String handle = tail.substring(begin, end);
+        if (handle.codePoints().anyMatch(cp -> cp == 0x1F335)) {
+            throw new ParseError(
+                span.line(), home + begin,
+                "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
+        return handle;
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -239,6 +239,16 @@ final class SuffixTest {
     }
 
     @Test
+    void combinesHandleWithTrailingConst() {
+        final Suffix suffix = new Suffix(" >> fibo!", new Span("[] >> fibo!", 1), 2);
+        MatcherAssert.assertThat(
+            "`>> fibo!` must report both the handle and a trailing const marker, like `> name!`",
+            suffix.constant() && "fibo".equals(suffix.handle()),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void rejectsTrailingGarbageAfterPlusGreaterSuffix() {
         final Span span = new Span("[] +> foo garbage", 1);
         Assertions.assertThrows(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-local-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-local-handle.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A named file-local handle may carry the `!` const marker (`>> name!`), just
+# as a plain named binding does (`> name!`) and an anonymous handle does
+# (`>>!`). The parser lowers the const to a `.as-bytes` over `Φ.dataized`
+# wrapper and keeps the handle on the dataized value (#5817).
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.as-bytes' and @name='a🌵3-2']/o[@base='Φ.dataized']/o[@base='ξ.a' and @local='b']
+  - //o[@base='ξ.a🌵3-2']
+input: |
+  [a] > foo
+    42.plus b > x
+    a >> b!

--- a/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
@@ -5,7 +5,18 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="dataized-to-const" version="2.0">
   <!--
-  Performs the reverse operation of "/org/eolang/parser/const-to-dataized.xsl"
+  Performs the reverse operation of "/org/eolang/parser/const-to-dataized.xsl":
+  a `.as-bytes` over `Φ.dataized` wrapper is rebuilt as its dataized argument
+  carrying `@const`.
+
+  The wrapper's name is promoted onto the rebuilt node only when it is
+  meaningful there: a real author name (`f > some!`) prints as the named const
+  binding, and an abstract formation keeps its obfuscated cactus name so
+  `to-eo-tree` renders the anonymous `[...] >>!` marker. A cactus name on a
+  based value — a const file-local handle such as `a >> b!` folded onto its
+  use site — is dropped, so the value lands as an anonymous const reference
+  `a!` rather than a spurious `a >>!` line that keeps the obfuscated name and
+  swallows the surrounding argument (#5810).
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -15,7 +26,9 @@
       <xsl:when test="exists($argument)">
         <xsl:element name="o">
           <xsl:apply-templates select="$argument/@*[name()!='as']"/>
-          <xsl:attribute name="name" select="@name"/>
+          <xsl:if test="@name and (eo:abstract($argument) or not(starts-with(@name, concat('a', $eo:cactoos))))">
+            <xsl:attribute name="name" select="@name"/>
+          </xsl:if>
           <xsl:attribute name="const"/>
           <xsl:for-each select="$argument/o">
             <xsl:apply-templates select="."/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-local-handle.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle whose value is a plain reference (`a >> b!`,
+# R-3.10.12). The parser lowers the const to a `.as-bytes` over `Φ.dataized`
+# wrapper carrying the obfuscated cactus name, and resolves the `b` use to the
+# cactus name. `inline-cactoos` folds the single-use wrapper onto its bare
+# reference and `dataized-to-const` rebuilds the `@const`. Because the value is
+# a based reference (not an abstract formation), its obfuscated `@name` is
+# dropped rather than promoted onto the rebuilt node: the value lands as the
+# anonymous argument `a`, not a spurious named `a >>!` line that swallows the
+# `.plus` argument (#5810). An inline anonymous const reference (`a!`) is not
+# valid EO, so the const marker does not survive the fold, exactly as the
+# non-const handle folds to a bare `a` — the printed form re-parses to itself.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    42.plus b > x
+    a >> b!
+
+printed: |
+  [a] > foo
+    42.plus a > x


### PR DESCRIPTION
Follow-up to #5810, for the const case. Reported the parser half as #5817.

## Problem

Auto-fixing a const file-local handle mangles it. Given:

```
[a] > foo
  42.plus b > x
  a >> b!
```

there were two coupled defects:

1. **Parser** (#5817): `a >> b!` didn't even parse — `[3:8] error: 'trailing garbage after name suffix'`.
2. **Printer**: once it parses, the printer emitted `42.plus > x` / `a >>!`, losing the `.plus` argument (the same shape as the original #5810 bug).

## Fix

**Parser — `Suffix.auto` (`eo-parser/.../Suffix.java`).** The `>>` parser looked for the `!` const marker only *immediately after* `>>` (so `>>!` and `>> name` worked, but `>> name!` did not). The `> name!` parser already reads the name first and then the marker; this mirrors that by accepting a trailing `!` after the handle. The handle-reading loop already stops at `!` (a name terminator), so the marker sits exactly where the new check looks. `>>!` and `>> name` are unchanged.

**Printer — `dataized-to-const.xsl`.** A const handle is lowered to a `.as-bytes` over `Φ.dataized` wrapper carrying the obfuscated cactus name; `inline-cactoos` folds the single-use wrapper onto its bare reference and `dataized-to-const` rebuilds the `@const`. It *always* promoted the wrapper's name onto the rebuilt node — but for a based value that's an obfuscated cactus name, leaving a spurious named node that `to-eo-tree` prints as its own `a >>!` line. Now the name is promoted only when it's meaningful: a real author name (`f > some!`) or an abstract formation (`[...] >>!`); a cactus name on a based value is dropped, so the value lands as an anonymous argument.

## Result

```
[a] > foo
  42.plus a > x
```

Valid EO, re-parses to itself. An inline anonymous const reference (`a!`) is not valid EO, so — as with the non-const handle that folds to a bare `a` in #5810 — the const marker does not survive the fold.

## Changes

- `eo-parser/.../Suffix.java` — accept the `!` const marker after a named `>>` handle.
- `eo-parser/.../SuffixTest.java` — `>> fibo!` unit test.
- `eo-parser/.../eo-syntax/const-local-handle.yaml` — parse pack for `>> name!`.
- `eo-printer/.../dataized-to-const.xsl` — drop a cactus name on a based const value.
- `eo-printer/.../print-packs/yaml/const-local-handle.yaml` — round-trip print pack.

All 1499 `eo-parser` and 185 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fHmUx3xd8UbGUS5iJtgvh)_