### PR TITLE
#5804: parse a bracketed IPv6 host in the uri object

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -45,6 +45,14 @@
       0
       hash-idx
     rest
+  string.index-of > bracket-end-idx
+    host-port
+    "]"
+  bracket-end-idx.plus 1 > bracket-start
+  host-port.slice > bracket-tail
+    bracket-start
+    host-port.length.minus
+      number bracket-start
   has-fragment.if > fragment
     rest.slice
       hash-idx.plus 1
@@ -57,6 +65,9 @@
     "//"
   not. > has-authority-path
     authority-path-idx.eq -1
+  string.starts-with > has-bracket-host
+    host-port
+    "["
   not. > has-fragment
     hash-idx.eq -1
   not. > has-port
@@ -100,9 +111,14 @@
         number
           port-colon-idx.plus 1
     ""
-  string.index-of > port-colon-idx
-    host-port
-    ":"
+  has-bracket-host.if > port-colon-idx
+    if.
+      rel-colon.eq -1
+      -1
+      rel-colon.plus bracket-start
+    string.index-of
+      host-port
+      ":"
   has-query.if > query
     before-fragment.slice
       question-idx.plus 1
@@ -113,6 +129,9 @@
   string.index-of > question-idx
     before-fragment
     "?"
+  string.index-of > rel-colon
+    bracket-tail
+    ":"
   text.slice > rest
     scheme-colon.plus 1
     text.length.minus
@@ -132,6 +151,21 @@
   string.index-of > userinfo-at-idx
     authority
     "@"
+
+  eq. ++> tests-parses-bracketed-ipv6-host-with-port
+    host.
+      uri "http://[::1]:8080/p"
+    "[::1]"
+
+  eq. ++> tests-parses-bracketed-ipv6-host-without-port
+    host.
+      uri "http://[2001:db8::1]/p"
+    "[2001:db8::1]"
+
+  eq. ++> tests-parses-bracketed-ipv6-port
+    port.
+      uri "http://[::1]:8080/p"
+    "8080"
 
   eq. ++> tests-parses-empty-host-of-triple-slash-uri
     host.


### PR DESCRIPTION
Fixes #5804.

The port separator was taken as the *first* `:` in the authority. For a bracketed IPv6 literal (`[::1]:8080`) that colon sits inside the address, so `host` became `"["` and `port` became the leftover `":1]:8080"` — a silently wrong result for a valid RFC 3986 host.

Fix: when the host part starts with `[`, locate the port `:` **after** the closing `]`; plain `host:port` parsing is unchanged (`host`, `port` and `has-port` all derive from that index). Now:

- `uri "http://[::1]:8080/p" .host` -> `"[::1]"` (was `"["`)
- `uri "http://[::1]:8080/p" .port` -> `"8080"`
- `uri "http://[2001:db8::1]/p" .host` -> `"[2001:db8::1]"`
- `uri "pgsql://localhost:899" .host` / `.port` -> `"localhost"` / `"899"` (unchanged)

Added regression tests for the bracketed IPv6 host, with and without a port.