### PR TITLE
#5806: integrate exactly n subsections regardless of step

### DIFF
--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -14,25 +14,23 @@
     malloc.of
       8
       [sum] >>
-        malloc.for > @
-          a
-          [left] >>
-            seq * > @
-              while
-                if. > [i] >>
-                  (left.as-number.plus step).lt right
-                  seq *
-                    sum.put
-                      sum.as-number.plus
-                        subsection left.as-number (left.as-number.plus step)
-                    left.put (left.as-number.plus step)
-                    true
-                  false
-                true > [i]
-              sum
-            b > right
-            as-number. > step
-              (right.minus left).div n
+        seq * > @
+          while
+            if. > [i] >>
+              i.lt n
+              seq *
+                sum.put
+                  sum.as-number.plus
+                    subsection
+                      a.plus (i.times step)
+                      a.plus
+                        (i.plus 1).times step
+                true
+              false
+            true > [i]
+          sum
+        as-number. > step
+          (b.minus a).div n
   times. > [a b] > subsection
     div.
       b.minus a
@@ -99,6 +97,50 @@
           10
           100
       333
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> tests-integral-with-evenly-dividing-step
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          0
+          10
+          10
+      50
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> tests-integral-with-single-partition
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          0
+          1
+          1
+      0.5
       1.0E-7
     [value operand err] > close-to
       lte. > @


### PR DESCRIPTION
Fixes #5806.

The Simpson-rule loop advanced a running position and continued only while `position + step` was **strictly** less than `b`. When the step `(b-a)/n` divides evenly (an integer or power-of-two step), the position lands exactly on `b` and the strict `<` skips the final subsection — `integral (x>[x]) 0 10 10` gave `40.5` instead of `50`, and `n=1` integrated nothing (`0`). The shipped tests only passed because their steps (`0.6`, `0.09`) are not exactly representable, so accumulation error sneaked the last interval in.

Fix: drive the loop by a **count** from `0` to `n-1` and derive each interval directly as `[a + i*step, a + (i+1)*step]`. The number of subsections is now always `n`, independent of floating-point accumulation. Now:

- `integral (x>[x]) 0 10 10 .as-number` -> `50` (was `40.5`)
- `integral (x>[x]) 0 1 1 .as-number` -> `0.5` (was `0`)
- the existing cube / linear / quadratic tests still pass unchanged

Added regression tests for the evenly-dividing-step and single-partition cases.