### PR TITLE
#5821: support `!` const marker on inline arguments

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -187,6 +187,9 @@ final class Emissions {
             if (value.binding() != null) {
                 emit.slot(Emissions.bindingTag(value.binding()));
             }
+            if (value.constant()) {
+                emit.constant();
+            }
             emit.close();
         } else {
             Emissions.openValue(emit, null, value, line);
@@ -202,6 +205,9 @@ final class Emissions {
             emit.method(last.fragile());
             if (value.binding() != null) {
                 emit.slot(Emissions.bindingTag(value.binding()));
+            }
+            if (value.constant()) {
+                emit.constant();
             }
             emit.close();
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -574,8 +574,15 @@ final class Tokens {
             } else {
                 tie = null;
             }
+            final boolean cnst;
+            if (!this.atEnd() && this.current() == '!') {
+                this.cursor = this.cursor + 1;
+                cnst = true;
+            } else {
+                cnst = false;
+            }
             args.add(
-                new Value(bare.kind(), bare.raw(), bare.pos(), this.cursor, tie, tail)
+                new Value(bare.kind(), bare.raw(), bare.pos(), this.cursor, tie, tail, cnst)
             );
         }
         return args;

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -67,6 +67,14 @@ final class Value {
     private final List<MethodChain> chain;
 
     /**
+     * True when the value carries a trailing {@code !} const marker
+     * (R-9.4) as an inline argument — e.g. {@code 42.plus a!}. Only
+     * set for horizontal arguments; a line head's const marker is a
+     * name-suffix concern handled by {@link Suffix}.
+     */
+    private final boolean constant;
+
+    /**
      * Ctor — no binding, no chain.
      * @param tag Kind
      * @param text Raw text
@@ -75,7 +83,7 @@ final class Value {
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     Value(final Kind tag, final String text, final int column, final int after) {
-        this(tag, text, column, after, null, Value.NO_CHAIN);
+        this(tag, text, column, after, null, Value.NO_CHAIN, false);
     }
 
     /**
@@ -90,7 +98,7 @@ final class Value {
     Value(
         final Kind tag, final String text, final int column, final int after, final String tie
     ) {
-        this(tag, text, column, after, tie, Value.NO_CHAIN);
+        this(tag, text, column, after, tie, Value.NO_CHAIN, false);
     }
 
     /**
@@ -101,11 +109,12 @@ final class Value {
      * @param after Index past the value
      * @param tie Optional inline-binding label or N
      * @param links Method-dispatch chain on this value (empty for a bare value)
+     * @param cnst Whether a trailing {@code !} const marker is present
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     Value(
         final Kind tag, final String text, final int column, final int after,
-        final String tie, final List<MethodChain> links
+        final String tie, final List<MethodChain> links, final boolean cnst
     ) {
         this.kind = tag;
         this.raw = text;
@@ -113,6 +122,7 @@ final class Value {
         this.end = after;
         this.binding = tie;
         this.chain = links;
+        this.constant = cnst;
     }
 
     /**
@@ -164,6 +174,15 @@ final class Value {
      */
     List<MethodChain> chain() {
         return this.chain;
+    }
+
+    /**
+     * Whether this value carries a trailing {@code !} const marker as
+     * an inline argument (R-9.4).
+     * @return Const flag
+     */
+    boolean constant() {
+        return this.constant;
     }
 
     /**

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
@@ -8,6 +8,9 @@
   Replace @const with dataized.as-bytes
   1. a > b!     => (dataized a).as-bytes > b
   2. x.y z > m! => (dataized (x.y z)).as-bytes > m
+  3. 42.plus a! => a nameless const argument; the wrapper gets a cactus
+  auto-name (as AutoName does in Java) so vars-float-up floats it up and
+  leaves a proper reference, not an empty name that fails to round-trip.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -37,9 +40,25 @@
   </xsl:function>
   <!-- Template -->
   <xsl:template match="o[@const]">
+    <!--
+    The name to carry onto the floated .as-bytes wrapper. A const on a
+    named binding (a > b!) already has one; a const on an anonymous
+    inline argument (42.plus a!) has none, so we synthesise a cactus
+    auto-name from the source coordinates (mirrors AutoName in Java).
+    -->
+    <xsl:variable name="cname">
+      <xsl:choose>
+        <xsl:when test="@name and @name != ''">
+          <xsl:value-of select="@name"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat('a🌵', @line, '-', @pos)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:element name="o">
       <xsl:attribute name="base" select="'.as-bytes'"/>
-      <xsl:attribute name="name" select="@name"/>
+      <xsl:attribute name="name" select="$cname"/>
       <xsl:attribute name="line" select="@line"/>
       <xsl:attribute name="pos" select="@pos + 8"/>
       <xsl:element name="o">
@@ -52,7 +71,7 @@
           </xsl:for-each>
           <xsl:if test="eo:abstract(.)">
             <xsl:attribute name="name">
-              <xsl:value-of select="eo:unique-name(@name, ./parent::o, 0)"/>
+              <xsl:value-of select="eo:unique-name($cname, ./parent::o, 0)"/>
             </xsl:attribute>
           </xsl:if>
           <xsl:for-each select="o">

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-inline-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-inline-argument.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.as-bytes' and @name='a🌵2-10']/o[@base='Φ.dataized']/o[@base='ξ.a']
+  - //o[@base='.plus']/o[@base='ξ.a🌵2-10']
+input: |
+  [a] > foo
+    42.plus a! > x

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -157,9 +157,12 @@ final class Pretty {
         } else {
             String best = this.vertical(node, indent);
             final Optional<String> flat = this.horizontal(node, indent);
+            final boolean inline =
+                node.children.stream().anyMatch(child -> "!".equals(child.tail));
             if (flat.isPresent()
-                && new Penalty(flat.get(), this.weights).points()
-                <= new Penalty(best, this.weights).points()) {
+                && (inline
+                || new Penalty(flat.get(), this.weights).points()
+                <= new Penalty(best, this.weights).points())) {
                 best = flat.get();
             }
             if (star.isPresent()
@@ -459,21 +462,36 @@ final class Pretty {
      * its own name suffix), or empty if it can't be inlined safely. A
      * data-receiver dispatch is inlined in its suffix shape ({@code
      * 5.plus 3}), never the reversed one.
+     *
+     * <p>A name suffix in the tail ({@code > name}, {@code >>}) has no inline
+     * spelling and blocks inlining. The lone {@code !} const marker of an
+     * anonymous inline const argument (#5821) is the exception: it does have
+     * one — the value with a trailing {@code !} ({@code a!}) — so it inlines
+     * and the {@code !} is appended.</p>
+     *
      * @param given The node
      * @return The inlined content, or empty
      */
     private static Optional<String> flat(final Node given) {
         final Optional<String> result;
         final Node node = Pretty.suffixed(given).orElse(given);
+        final boolean cnst = "!".equals(node.tail);
+        final String mark;
+        if (cnst) {
+            mark = "!";
+        } else {
+            mark = "";
+        }
         if (node.reversed && node.children.size() <= 1) {
             result = Optional.empty();
-        } else if (node.abstractt || !node.tail.isEmpty() || "*".equals(node.base)) {
+        } else if (node.abstractt || !node.tail.isEmpty() && !cnst
+            || "*".equals(node.base)) {
             result = Optional.empty();
         } else if (node.children.isEmpty()) {
-            result = Optional.of(node.base);
+            result = Optional.of(node.base.concat(mark));
         } else {
             result = Pretty.inlined(node.children)
-                .map(args -> String.join(" ", node.base, args));
+                .map(args -> String.join(" ", node.base, args).concat(mark));
         }
         return result;
     }

--- a/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/dataized-to-const.xsl
@@ -15,7 +15,20 @@
       <xsl:when test="exists($argument)">
         <xsl:element name="o">
           <xsl:apply-templates select="$argument/@*[name()!='as']"/>
-          <xsl:attribute name="name" select="@name"/>
+          <!--
+          Named const (a > b!) keeps its name; an anonymous inline const
+          argument (42.plus a!) folds in without one and reads as `a!`.
+          -->
+          <xsl:if test="@name and @name != ''">
+            <xsl:attribute name="name" select="@name"/>
+          </xsl:if>
+          <!--
+          Carry the wrapper's positional slot (@as) so a const argument
+          beside others (42.plus a! b) keeps its place in the sequence.
+          -->
+          <xsl:if test="@as">
+            <xsl:attribute name="as" select="@as"/>
+          </xsl:if>
           <xsl:attribute name="const"/>
           <xsl:for-each select="$argument/o">
             <xsl:apply-templates select="."/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -43,21 +43,23 @@
 
   The inlined value keeps the target's obfuscated cactus `@name` only when
   the name is still meaningful downstream: an abstract formation, whose name
-  `to-eo-tree` renders as the anonymous `[...] >>` marker (exactly what an
-  inlined anonymous formation should read as), and a dataized-const wrapper
-  (`.as-bytes` over `Φ.dataized`), whose name `dataized-to-const` later
-  promotes onto the abstract const node it rebuilds. A based `>> name` handle
-  whose value is a plain reference or application (`a >> b`, R-3.10.12) is
-  neither, so carrying its `@name` (or the `@local` handle it leaves behind)
-  over would turn the inline into a spurious named node that `to-eo-tree`
-  prints as its own `a >>` line, swallowing the surrounding argument; for
-  such a target the `@name` and `@local` are dropped and the value lands as
-  an anonymous argument (#5810).
+  `to-eo-tree` renders as the anonymous `[...] >>` marker, and a dataized-const
+  wrapper (`.as-bytes` over `Φ.dataized`) over an abstract value, whose name
+  `dataized-to-const` later promotes onto the abstract const node it rebuilds.
+  A based `>> name` handle whose value is a plain reference or application
+  (`a >> b`, R-3.10.12) is neither, so carrying its `@name` (or the `@local`
+  handle) over would turn the inline into a spurious named node that
+  `to-eo-tree` prints as its own `a >>` line, swallowing the surrounding
+  argument; for such a target `@name` and `@local` are dropped and the value
+  lands as an anonymous argument (#5810). A dataized-const wrapper over a
+  non-abstract value is the anonymous inline const argument (`42.plus a!`,
+  #5821): its cactus name is likewise dropped so the folded value reads inline
+  as `a!`, not as a vertical `a >>!` line.
   -->
   <xsl:template match="o[contains(@base, concat('.', $auto))]" priority="0">
     <xsl:variable name="name" select="eo:resolved-name(@base)"/>
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
-    <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized'))"/>
+    <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
     <xsl:choose>
       <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name))">
         <xsl:element name="o">

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -405,9 +405,6 @@
           </xsl:choose>
         </xsl:otherwise>
       </xsl:choose>
-      <xsl:if test="@const">
-        <xsl:text>!</xsl:text>
-      </xsl:if>
       <xsl:if test="eo:atom(.)">
         <!--
         A multi-segment signature (e.g. "Φ.malloc.of.allocated") stays
@@ -418,6 +415,14 @@
         -->
         <xsl:value-of select="concat(' /', eo:signature(string(./o[@name=$eo:lambda]/@atom)))"/>
       </xsl:if>
+    </xsl:if>
+    <!--
+    The `!` const marker, for a named binding (`... > name!`, `[] >>!`)
+    and for an anonymous inline const argument (`42.plus a!`, #5821) that
+    carries `@const` with no `@name`.
+    -->
+    <xsl:if test="@const">
+      <xsl:text>!</xsl:text>
     </xsl:if>
   </xsl:template>
   <!-- DATA -->

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-argument-among-others.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-argument-among-others.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const inline argument sitting beside a plain one must stay on one line:
+# a bare `a!` on its own vertical line does not parse, so the penalty vote
+# that would otherwise split the arguments is overridden (#5821).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a b] > foo
+    42.plus a! b > x
+
+printed: |
+  [a b] > foo
+    42.plus a! b > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-argument.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    42.plus a! > x
+
+printed: |
+  [a] > foo
+    42.plus a! > x


### PR DESCRIPTION
Closes #5821.

Allows the `!` const marker (R-9.4) on an **inline argument**, so a const value can be passed positionally without first floating it onto its own `... > name!` line:

```
[a] > foo
  42.plus a! > x
```

Previously this failed to parse with `[2:11] error: 'trailing garbage after expression'`.

## Parser

- `Tokens.readArgs` reads a trailing `!` after the argument value (and optional inline binding).
- `Value` carries a `constant` flag; `Emissions.emitArg` emits `@const` on the argument's `<o>`.
- `const-to-dataized.xsl` synthesises a cactus auto-name (the same `a🌵<line>-<pos>` shape as `AutoName`) for a `@const` node that has no name. `vars-float-up` can then float the `(dataized …).as-bytes` wrapper up to the enclosing formation and leave a proper reference behind, instead of the empty `name=""` / `base="ξ."` that did not round-trip.

## Printer

- `inline-cactoos.xsl` drops the cactus name when folding a dataized-const wrapper over a **non-abstract** value, so the folded value reads inline (a formation still keeps its name and prints `[…] >>!`).
- `dataized-to-const.xsl` rebuilds an anonymous const node (no `@name`) and carries the wrapper's positional `@as`, so a const argument beside a plain one keeps its slot.
- `to-eo-tree.xsl` renders `!` on an unnamed const node.
- `Pretty` keeps a const argument on one line — a bare `a!` on its own line has no valid vertical spelling, so the penalty vote that would otherwise split the arguments is overridden.

## Tests

- Parser `eo-syntax` pack `const-inline-argument.yaml` for `42.plus a!`.
- Printer print-packs proving the inline round-trip (`const-inline-argument.yaml`) and that a const argument beside a plain one stays on one line (`const-inline-argument-among-others.yaml`).

All existing parser (1497) and printer (183) tests continue to pass.

## Note on the motivating round-trip

The issue also mentions a print-pack proving `a >> b!` reprints to `42.plus a! > x`. That relies on parsing the const file-local handle `>> b!`, which is #5817 and has not landed yet (`>> b!` currently errors with `trailing garbage after name suffix`). The printer fold path added here already handles that anonymous-const case via the same `inline-cactoos` change, so it will produce the desired output once #5817 lands; the print-pack for it can be added then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015jisBPZBvXQDXLkj9n91QF)_