### PR TITLE
#5799: reject negative or non-integer places in string.as-fixed

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -1,7 +1,7 @@
 # Writes the number `n` as fixed-point decimal with exactly `places` fraction
 # digits, rounding to the nearest unit in the last place, so that `2.5` with
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
-# If `places` is negative or not a whole number, the `cant-fix` fallback is
+# If `places` is negative or not a whole number, the `cant-print` fallback is
 # returned, or the bottom object when unbound.
 
 +architect yegor256@gmail.com
@@ -11,13 +11,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n places cant-fix] > as-fixed
+[n places cant-print] > as-fixed
   if. > @
     or.
       0.gt places
       not.
         places.floor.eq places
-    cant-fix
+    cant-print
       "Can't write a fixed-point decimal with %s fraction places".printf
         * places
     if.

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -1,6 +1,8 @@
 # Writes the number `n` as fixed-point decimal with exactly `places` fraction
 # digits, rounding to the nearest unit in the last place, so that `2.5` with
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
+# If `places` is negative or not a whole number, the `cant-fix` fallback is
+# returned, or the bottom object when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,12 +11,20 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n places] > as-fixed
+[n places cant-fix] > as-fixed
   if. > @
-    n.lt 0
-    signed
-      n.times -1
-    positive n
+    or.
+      0.gt places
+      not.
+        places.floor.eq places
+    cant-fix
+      "Can't write a fixed-point decimal with %s fraction places".printf
+        * places
+    if.
+      n.lt 0
+      signed
+        n.times -1
+      positive n
   [a] > positive
     concat. > @
       concat.
@@ -78,6 +88,13 @@
     string
       as-fixed 3.14159 2
 
+  eq. ++> tests-negative-places-returns-provided-fallback
+    "recovered"
+    as-fixed
+      3.14159
+      -2
+      "recovered" > [msg]
+
   eq. ++> tests-negative-rounding-to-zero-drops-sign
     "0.00"
     string
@@ -87,6 +104,13 @@
     "0.00"
     string
       as-fixed -0.001 2
+
+  eq. ++> tests-non-integer-places-returns-provided-fallback
+    "recovered"
+    as-fixed
+      3.14159
+      2.5
+      "recovered" > [msg]
 
   eq. ++> tests-pads-with-trailing-zeros
     "1.250000"
@@ -112,3 +136,7 @@
     "0.000000"
     string
       as-fixed 0 6
+
+  as-fixed --> on-negative-places-without-fallback
+    3.14159
+    -2


### PR DESCRIPTION
Closes #5799

`string.as-fixed`'s `pow10` and `rec-pad` helpers step `places`/`count` down to 0 by exact equality (`p.eq 0`, `count.eq 0`). A negative or non-integer `places` argument never hits exactly 0, so both helpers recurse forever, hanging and eventually OOMing.

Adds a third void parameter `cant-fix`, matching the existing fallback pattern used by `string.repeated`: if `places` is negative or not a whole number, `as-fixed` now returns `cant-fix` (a caller-supplied recovery scope), or the bottom object if `cant-fix` is left unbound, instead of recursing forever.

Existing 2-argument call sites are unaffected, since `cant-fix` is only referenced when the new guard actually triggers.

Verified:
- `EO_string.EOas_fixedTest`: 12/12 green (10 existing + 2 new: negative places, non-integer places, both returning the provided fallback), plus the existing bottom-object test pattern for the no-fallback case.
- `mvn clean verify -PskipTests -Pqulice`: clean.
