### PR TITLE
fix: remove incorrect .trim() from LnTextBlock.java

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -56,7 +56,7 @@ final class LnTextBlock implements Line {
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
         final String joined = Emissions.unescapeBody(
-            String.join(String.valueOf('\n'), globals.tbody()).trim()
+            String.join(String.valueOf('\n'), globals.tbody())
         );
         this.transition(stack, suffix);
         emit.object(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
@@ -6,7 +6,7 @@ sheets: []
 asserts:
   - //o[@base='Φ.string' and o/o[text()='48-69-2C-20-74-68-65-72-65-0A-41-64-69-C3-B3-73']]
   - //o[@base='Φ.string' and o/o[text()='66-69-72-73-74-0A-20-73-65-63-6F-6E-64']]
-  - //o[@base='Φ.string' and o/o[text()='74-68-69-72-64']]
+  - //o[@base='Φ.string' and o/o[text()='20-20-20-74-68-69-72-64']]
 input: |
   [] > main
     """


### PR DESCRIPTION
Closes #5790.

This removes the erroneous `.trim()` from `LnTextBlock.java` which was swallowing leading and trailing spaces/blank lines from triple-quoted text blocks. The test fixture was updated to include the previously stripped spaces in its assertion.