### PR TITLE
#5773: Fix printf byte format rewriting

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -87,6 +87,18 @@
       14
       false
 
+  eq. ++> tests-printf-applies-precision-to-bytes
+    "40-"
+    printf *1
+      "%.3x"
+      42.as-bytes
+
+  eq. ++> tests-printf-applies-width-to-bytes
+    "  40-45-00-00-00-00-00-00"
+    printf *1
+      "%25x"
+      42.as-bytes
+
   eq. ++> tests-printf-does-not-fail-if-arguments-more-than-formats
     "Hey"
     printf *1
@@ -101,6 +113,18 @@
           "%d"
           42.as-i64
         "42"
+
+  eq. ++> tests-printf-left-aligns-bytes
+    "40-45-00-00-00-00-00-00  "
+    printf *1
+      "%-25x"
+      42.as-bytes
+
+  eq. ++> tests-printf-preserves-escaped-bytes-format
+    "%x"
+    printf
+      "%%x"
+      *
 
   eq. ++> tests-printf-prints-i64-as-number
     "42"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -45,7 +45,7 @@ public final class EOprintf extends PhDefault implements Atom {
         return new Data.ToPhi(
             String.format(
                 Locale.US,
-                format.replaceAll("%\\d+\\$([a-zA-Z])", "%s").replaceAll("%x", "%s"),
+                PrintfArgs.javaFormat(format),
                 new PrintfArgs(
                     format,
                     Expect.at(this, "args")

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -40,16 +40,16 @@ final class PrintfArgs {
 
     /**
      * A single {@code printf} specifier. Group 1 is the optional {@code N$}
-     * positional index; an optional run of flags, an optional width and an
-     * optional {@code .precision} are then skipped; group 2 is the conversion
-     * character. Skipping the flags, width and precision keeps exactly one
+     * positional index; group 2 is an optional run of flags, an optional width
+     * and an optional {@code .precision}; group 3 is the conversion character.
+     * Skipping the flags, width and precision keeps exactly one
      * argument counted per specifier such as {@code %5d}, {@code %.2f} or
      * {@code %-10s}, matching what {@code String.format} consumes on the
      * formatting side. Possessive quantifiers keep the scan linear in the
      * length of the format string, with no backtracking.
      */
     private static final Pattern SPECIFIER = Pattern.compile(
-        "%(\\d++\\$)?+[-#+ 0,(]*+\\d*+(?:\\.\\d++)?+([a-zA-Z%])"
+        "%(\\d++\\$)?+([-#+ 0,(]*+\\d*+(?:\\.\\d++)?+)([a-zA-Z%])"
     );
 
     /**
@@ -97,13 +97,43 @@ final class PrintfArgs {
         this.retriever = phi;
     }
 
+    /**
+     * Adapt an EO printf format for {@link String#format(String, Object...)}.
+     * @param format Format
+     * @return Java format
+     */
+    static String javaFormat(final String format) {
+        final Matcher matcher = PrintfArgs.SPECIFIER.matcher(format);
+        final StringBuilder converted = new StringBuilder(format.length());
+        while (matcher.find()) {
+            final char symbol = matcher.group(3).charAt(0);
+            final char conversion;
+            if (symbol == 'x') {
+                conversion = 's';
+            } else {
+                conversion = symbol;
+            }
+            final String replacement = new StringBuilder(2 + matcher.group(2).length())
+                .append(PrintfArgs.PERCENT)
+                .append(matcher.group(2))
+                .append(conversion)
+                .toString();
+            matcher.appendReplacement(
+                converted,
+                Matcher.quoteReplacement(replacement)
+            );
+        }
+        matcher.appendTail(converted);
+        return converted.toString();
+    }
+
     List<Object> formatted() {
         final List<Object> arguments = new ArrayList<>(0);
         final Matcher matcher = PrintfArgs.SPECIFIER.matcher(this.format);
         long auto = 0L;
         while (matcher.find()) {
             final String positional = matcher.group(1);
-            final char symbol = matcher.group(2).charAt(0);
+            final char symbol = matcher.group(3).charAt(0);
             if (symbol == PrintfArgs.PERCENT) {
                 continue;
             }

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -26,6 +26,15 @@ import org.junit.jupiter.api.Test;
 final class PrintfArgsTest {
 
     @Test
+    void adaptsSpecifiersForJavaFormatter() {
+        MatcherAssert.assertThat(
+            "The adapted format must preserve escaped percents and modifiers",
+            PrintfArgs.javaFormat("%%x %-25x %5x %.3x %1$5d"),
+            Matchers.equalTo("%%x %-25s %5s %.3s %5d")
+        );
+    }
+
+    @Test
     void returnsArgumentsForNumberedSubstitution() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));


### PR DESCRIPTION
## Summary

- replace the two blind format-string substitutions with one specifier-aware rewrite based on `PrintfArgs.SPECIFIER`
- preserve escaped `%%` and flags, width, and precision while adapting EO `%x` arguments to Java `%s`
- add unit and end-to-end coverage for escaped `%x`, alignment, width, precision, and positional width

## Testing

- `mvn -pl eo-runtime -Deo.autoFix -Dtest=PrintfArgsTest test` — passed (10 tests)
- full `eo-runtime` run — 1,753 tests, 0 failures, 0 errors; Qulice completed successfully
- the subsequent local Windows `project-validate` step could not resolve three generated Unicode-named classes under the MS949 user path; this occurs after tests and Qulice

Closes #5773