### PR TITLE
#5817: accept `!` const marker on a named file-local `>> name` handle

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -366,13 +366,17 @@ final class Suffix {
 
     /**
      * Parse a {@code >>} (auto) suffix, optionally carrying a trailing
-     * file-local handle ({@code >> name}, §3.10) kept as the label.
+     * file-local handle ({@code >> name}, §3.10) kept as the label, and a
+     * {@code !} const marker (R-9.4) either right after {@code >>}
+     * ({@code >>!}) or after the handle ({@code >> name!}, #5817).
      * @param tail Tail substring
      * @param after Index immediately after {@code >>}
      * @param span Source span
      * @param home Source column where tail begins
      * @return Parsed result
-     * @checkstyle ParameterNumberCheck (3 lines)
+     * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle CyclomaticComplexityCheck (45 lines)
+     * @checkstyle NPathComplexityCheck (45 lines)
      */
     private static Parsed auto(
         final String tail, final int after, final Span span, final int home
@@ -399,6 +403,10 @@ final class Suffix {
                 );
             }
             rest = end;
+        }
+        if (!cnst && rest < tail.length() && tail.charAt(rest) == '!') {
+            cnst = true;
+            rest = rest + 1;
         }
         final int trailing = Suffix.skipSpace(tail, rest);
         if (trailing < tail.length() && tail.charAt(trailing) == '/') {

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -239,6 +239,16 @@ final class SuffixTest {
     }
 
     @Test
+    void detectsConstMarkerAfterHandle() {
+        final Suffix suffix = new Suffix(" >> fibo!", new Span("[] >> fibo!", 1), 2);
+        MatcherAssert.assertThat(
+            "`>> name!` must report the const marker and the handle (#5817)",
+            suffix.constant() && "fibo".equals(suffix.handle()),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void rejectsTrailingGarbageAfterPlusGreaterSuffix() {
         final Span span = new Span("[] +> foo garbage", 1);
         Assertions.assertThrows(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-local-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-local-handle.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.as-bytes' and @name='a🌵3-2']/o[@base='Φ.dataized']/o[@base='ξ.a' and @local='b']
+  - //o[@base='.plus']/o[@base='ξ.a🌵3-2']
+input: |
+  [a] > foo
+    42.plus b > x
+    a >> b!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-local-handle-inlined.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-local-handle-inlined.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) used once folds back onto its
+# use site as an anonymous inline const argument, printing `42.plus a! > x`
+# (the round-trip motivated by #5821). Contrast the non-const `a >> b`, which
+# folds to `42.plus a > x`.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    42.plus b > x
+    a >> b!
+
+printed: |
+  [a] > foo
+    42.plus a! > x


### PR DESCRIPTION
Closes #5817.

The parser accepted the `!` const marker on an anonymous file-local handle (`>>!`) and on a plain named binding (`> name!`), but rejected it on a **named** file-local handle (`>> name!`):

```
[a] > foo
  42.plus b > x
  a >> b!
```

failed with `[3:8] error: 'trailing garbage after name suffix'`.

## Root cause

`Suffix.auto` looked for the optional `!` only *right after* `>>` (before the handle name), then read the handle, then `endsClean` rejected anything trailing. So `>>!` and `>> name` parsed, but in `>> name!` the `!` sits *after* the name — past where it was looked for — and got reported as trailing garbage. The sibling `Suffix.named` (`> name`) already does it right: it reads the name first, then checks for a trailing `!`.

## Fix

Add the symmetric post-name `!` check to `Suffix.auto`, mirroring `Suffix.named`. The existing `>>!` (anonymous const) and `>> name` (non-const) spellings keep working; `>> name!` now parses as a const, file-local handle.

## Round-trip with #5821

This unblocks the printer round-trip deferred from #5821: a const file-local handle used once folds onto its use site as an anonymous inline const argument, so

```
[a] > foo
  42.plus b > x
  a >> b!
```

now reprints to `42.plus a! > x` (the non-const `a >> b` still reprints to `42.plus a > x`). The printer fold path for this was already added in #5821; this PR only makes the source spelling parse.

## Tests

- `SuffixTest.detectsConstMarkerAfterHandle` — `>> name!` reports both the const marker and the handle.
- `eo-syntax` pack `const-local-handle.yaml` — `a >> b!` lowers to a `.as-bytes` const wrapper over the local handle `b`.
- Print-pack `const-local-handle-inlined.yaml` — `a >> b!` reprints to `42.plus a! > x`.

All existing parser (1500) and printer (189) tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015jisBPZBvXQDXLkj9n91QF)_