### PR TITLE
#5828: keep a multi-referenced const `&gt;&gt; name!` handle whole

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -29,6 +29,17 @@
   handle, and the marker is KEPT so "to-eo-tree" prints "&gt;&gt; name"
   rather than an anonymous "&gt;&gt;" bound to references to a synthetic
   "vL_P" placeholder.
+
+  A const "&gt;&gt;" handle (`a &gt;&gt; b!`, R-3.10.12) is a third case. Its
+  value is dataized once and cached in a single binding, so a handle referenced
+  more than once must stay one shared object rather than be inlined per use
+  (which would mint an independent const at each site and drop the shared name,
+  #5828). Such a handle is likewise treated as a handled void — its handle,
+  which the parser leaves on the wrapped value inside the "const-to-dataized"
+  `.as-bytes`/`Φ.dataized` shell, is promoted to the wrapper's visible name, its
+  references are rewritten back to the handle, and the marker is kept — so it
+  survives the later passes as a single standalone `a &gt;&gt; b!` binding. A
+  single-use const still inlines to `a!` (#5821).
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -53,13 +64,35 @@
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
-  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
   <!--
-  References: rewrite each cactus segment that names a handled void or a
-  recursive formation back into the readable handle.
+  Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,
+  R-3.10.12) that is referenced more than once. "const-to-dataized" wraps such
+  a const in a `.as-bytes` over `Φ.dataized` node carrying the obfuscated
+  cactus @name, with the readable handle kept as "@local" on the wrapped value.
+  A const is dataized once and cached in that single binding, so every
+  reference shares one const object; inlining it per use (as "inline-cactoos"
+  does for a single-use const, #5821, or a referentially-transparent non-const
+  handle, #5810) would mint an independent const object at each site and drop
+  the shared name. A multi-referenced one is therefore restored here like a
+  handled void: its handle is promoted to the visible name and its references
+  are rewritten back to the handle, so it stays a single standalone
+  `a &gt;&gt; b!` binding that the later passes leave untouched (#5828).
+  -->
+  <xsl:function name="eo:const-handle" as="xs:boolean">
+    <xsl:param name="wrapper" as="element()*"/>
+    <xsl:variable name="value" select="$wrapper/o[@base='Φ.dataized']/o[1]"/>
+    <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $wrapper/@name and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
+  </xsl:function>
+  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
+  <xsl:key name="const-handle" match="o[eo:const-handle(.)]" use="@name"/>
+  <!--
+  References: rewrite each cactus segment that names a handled void, a
+  recursive formation, or a multi-referenced dataized-const handle back into
+  the readable handle. A void or recursive formation carries "@local" itself; a
+  const wrapper keeps the handle on its wrapped value.
   -->
   <xsl:template match="@base">
-    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then key('void-handle', $seg)[1]/@local else $seg), '.')"/>
+    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then string(key('void-handle', $seg)[1]/@local) else if (key('const-handle', $seg)) then string(key('const-handle', $seg)[1]/o[@base='Φ.dataized']/o[1]/@local) else $seg), '.')"/>
   </xsl:template>
   <!--
   Handled declaration (void or recursive formation): promote the handle
@@ -69,11 +102,21 @@
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
-  Keep the marker on voids and on recursive formations so "to-eo-tree"
-  restores the readable "&gt;&gt; name" handle; drop it on the other
-  non-void formations, whose handle is inlined away by "inline-cactoos".
+  Multi-referenced dataized-const handle: promote its handle (kept on the
+  wrapped value) to the wrapper's visible name, so "dataized-to-const" rebuilds
+  a readable `a &gt;&gt; b!` binding rather than a cactus-named one that
+  "merge-monikers" would try to fold onto a use site.
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name))]/@local"/>
+  <xsl:template match="o[eo:const-handle(.)]/@name">
+    <xsl:attribute name="name" select="../o[@base='Φ.dataized']/o[1]/@local"/>
+  </xsl:template>
+  <!--
+  Keep the marker on voids, on recursive formations, and on the value of a
+  multi-referenced dataized-const handle so "to-eo-tree" restores the readable
+  "&gt;&gt; name" handle; drop it on the other non-void formations, whose
+  handle is inlined away by "inline-cactoos".
+  -->
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) referenced more than once must
+# stay a single shared handle: a const is dataized once and its result cached
+# in that one binding, so every `b` shares the same object. Inlining it per use
+# (as the single-use const, #5821, folds to `42.plus a!`) would mint an
+# independent const object at each site and drop the shared `b` name, changing
+# the object graph (#5828). The multi-referenced handle is therefore kept whole,
+# printing back exactly as written. Contrast the non-const `a >> b`, which is
+# referentially transparent and safely inlines to `42.plus a` at every use.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    a >> b!
+    42.plus b > x
+    43.plus b > y
+
+printed: |
+  [a] > foo
+    a >> b!
+    42.plus b > x
+    43.plus b > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-single-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-single-referenced-handle.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The single-reference counterpart of `const-multi-referenced-handle` (#5828):
+# a const file-local handle (`a >> b!`, #5817) used exactly once has no shared
+# object to preserve, so it folds onto its only use site as an anonymous inline
+# const argument, eliminating the `b` name and printing `42.plus a! > x`
+# (#5821). Only a handle referenced more than once is kept whole.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    a >> b!
+    42.plus b > x
+
+printed: |
+  [a] > foo
+    42.plus a! > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) shared by three references is
+# kept whole just like the two-reference case (#5828): the single cached const
+# object stays behind one handle and every `b` use points at it.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    a >> b!
+    42.plus b > x
+    43.plus b > y
+    44.plus b > z
+
+printed: |
+  [a] > foo
+    a >> b!
+    42.plus b > x
+    43.plus b > y
+    44.plus b > z

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/non-const-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/non-const-multi-referenced-handle.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The non-const counterpart of `const-multi-referenced-handle` (#5828): a plain
+# `a >> b` handle (R-3.10.12) is referentially transparent, so each `b` use is
+# safely inlined to the bare `a` and the handle is dropped, even when referenced
+# more than once. Only the `!` const marker forces the handle to be kept whole.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    a >> b
+    42.plus b > x
+    43.plus b > y
+
+printed: |
+  [a] > foo
+    42.plus a > x
+    43.plus a > y


### PR DESCRIPTION
Fixes #5828.

## Problem

`eo-printer` was inlining a *const* file-local `>> name!` handle (R-3.10.12) at every use site when it is referenced more than once. Given:

```
[a] > foo
  a >> b!
  42.plus b > x
  43.plus b > y
```

the printer produced:

```
[a] > foo
  42.plus a! > x
  43.plus a! > y
```

A const is dataized **once** and its result cached in that single binding, so the two `b` references share one const object. Inlining `a!` at both sites mints two independent const objects (changing the object graph) and drops the shared `b` name.

## Fix

The fix lives in `restore-local-names.xsl`. A multi-referenced dataized-const handle is now treated like a handled void / recursive handle already are:

- its readable handle (which the parser leaves as `@local` on the wrapped value inside the `const-to-dataized` `.as-bytes`/`Φ.dataized` shell) is **promoted to the wrapper's visible name**, and
- every reference is **rewritten from the obfuscated cactus name back to the handle**.

Once promoted, the binding leaves the cactus namespace, so `inline-cactoos` no longer folds it and `merge-monikers` leaves it alone. It survives as a single standalone handle:

```
[a] > foo
  a >> b!
  42.plus b > x
  43.plus b > y
```

Single-use const still inlines to `a!` (#5821); a non-const `a >> b` is referentially transparent and still inlines to `a` at every use (#5810).

## Note on the printed shape

The issue suggested hosting the handle onto the first reference (`42.plus > x` with `a >> b!` nested beneath). That spelling does **not** round-trip: nesting a `>> b` handle under `.plus` rescopes `b` to that `.plus`, so on reparse the sibling `43.plus b` reference becomes unbound and the first use collapses back to a single-use `a!` — reintroducing the very graph corruption this issue is about. A file-local handle can only bind its siblings when it sits at the formation level, so the printer keeps the standalone spelling, which is byte-for-byte identical to the input and reprints to itself (verified by the existing `printsToParseableEo` fixpoint check).

## Tests

Added three print-packs under `eo-printer/.../print-packs/yaml/`:

- `const-multi-referenced-handle.yaml` — the two-reference case from the issue.
- `const-thrice-referenced-handle.yaml` — three references, proving the guard is not arity-specific.
- `non-const-multi-referenced-handle.yaml` — the non-const contrast that still inlines to `a`.

All 195 `eo-printer` tests pass (`printsToEo`, `printsToParseableEo`, and `checksPrintPacks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRocDQjZJmR4sw2Rh1FbDR)_