### PR TITLE
#5798: reject non-integer times in string.repeated

### DIFF
--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -1,5 +1,6 @@
 # Returns `text` repeated `times` times.
-# If `times` < 0, the `cant-repeat` fallback is returned, or the bottom object when unbound.
+# If `times` < 0 or not a whole number, the `cant-repeat` fallback is returned,
+# or the bottom object when unbound.
 # If `times` == 0, empty text is returned.
 
 +architect yegor256@gmail.com
@@ -11,10 +12,13 @@
 
 [text times cant-repeat] > repeated
   if. > @
-    0.gt amount
+    or.
+      0.gt times
+      not.
+        times.floor.eq times
     cant-repeat
-      "Can't repeat text %d times".printf
-        * amount
+      "Can't repeat text %s times".printf
+        * times
     string result
   times > amount!
   text > bts!
@@ -43,6 +47,13 @@
     repeated
       "x"
       -1
+      "recovered" > [msg]
+
+  eq. ++> tests-text-repeated-non-integer-times-returns-provided-fallback
+    "recovered"
+    repeated
+      "x"
+      2.5
       "recovered" > [msg]
 
   eq. ++> tests-text-repeated-zero-times-is-empty


### PR DESCRIPTION
Closes #5798

`string.repeated`'s `rec-repeated` helper steps `index` up by exactly 1 until it equals `amount`. A non-integer `times` argument (for example `repeated "x" 2.5`) makes `index` step 1, 2, 3, 4, ... and it never equals 2.5, so the recursion never terminates.

Widens the existing guard (which already rejected `times < 0` via the `cant-repeat` fallback) to also reject a non-integer `times`, returning the same `cant-repeat` fallback, or the bottom object if `cant-repeat` is left unbound. Matches the existing pattern already used by `malloc.of`/`malloc.for` for rejecting fractional sizes, and the same fix just applied to the sibling bug in `string.as-fixed` (#5799, PR #5824).

Verified:
- `EO_string.EOrepeatedTest`: 5/5 green (3 existing + 1 new: non-integer times returns the provided fallback), plus the existing bottom-object test for the no-fallback negative case.
- `mvn clean verify -PskipTests -Pqulice`: clean.
