### PR TITLE
#5796: Reject scope symbols as auto-name handles

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.parser;
 
+import java.util.Set;
+
 /**
  * A parsed name suffix — §3.10 of the spec.
  *
@@ -48,6 +50,11 @@ final class Suffix {
      * {@link #terminates} so dotted FQNs are still consumed whole.
      */
     private static final String NAME_BOUNDARIES = ",.|':;?[]{}()";
+
+    /**
+     * Scope symbols that cannot be used as file-local handles.
+     */
+    private static final Set<String> SCOPES = Set.of("@", "^", "$");
 
     /**
      * Suffix form.
@@ -396,6 +403,7 @@ final class Suffix {
                 end = end + 1;
             }
             handle = tail.substring(begin, end);
+            Suffix.rejectScope(handle, span, home + begin);
             if (handle.codePoints().anyMatch(cp -> cp == 0x1F335)) {
                 throw new ParseError(
                     span.line(), home + begin,
@@ -417,6 +425,23 @@ final class Suffix {
         }
         Suffix.endsClean(tail, trailing, span, home);
         return new Suffix.Parsed(Form.AUTO, handle, "", cnst);
+    }
+
+    /**
+     * Reject a scope symbol used as a file-local handle.
+     * @param handle File-local handle
+     * @param span Source span
+     * @param column Source column of the handle
+     */
+    private static void rejectScope(
+        final String handle, final Span span, final int column
+    ) {
+        if (Suffix.SCOPES.contains(handle)) {
+            throw new ParseError(
+                span.line(), column,
+                "file-local handle must be an identifier, not a scope symbol"
+            );
+        }
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -8,6 +8,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link Suffix}.
@@ -225,6 +227,19 @@ final class SuffixTest {
             "`>> fibo` must yield Form.AUTO carrying the file-local handle",
             new Suffix(" >> fibo", new Span("[] >> fibo", 1), 2).handle(),
             Matchers.equalTo("fibo")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"@", "^", "$"})
+    void rejectsScopeSymbolsAsAutoNameHandles(final String symbol) {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " >> ".concat(symbol),
+                new Span("[] >> ".concat(symbol), 1), 2
+            ),
+            "a scope symbol must not be accepted as a file-local handle"
         );
     }
 


### PR DESCRIPTION
## Summary

- reject `@`, `^`, and `$` when they are parsed as file-local handles after `>>`
- keep the existing auto-name parsing path and error location intact
- add parameterized regression coverage for all three reserved scope symbols

## Testing

- `mvn -pl eo-parser -Dtest=SuffixTest test` — 44 tests passed
- `mvn -pl eo-parser test` — 1,503 tests passed, 3 skipped
- `mvn -pl eo-parser -PskipTests -Pqulice verify --batch-mode` — passed

Closes #5796