### PR TITLE
#5828: host a multi-referenced const `&gt;&gt; name!` handle as a moniker

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -31,12 +31,21 @@
   declares the referenced name - as a public attribute "@name" or as a handle
   "@local" - is the reference's scope; the reference binds to a handle only
   when that scope's declaration is itself a handle.
+
+  A handle is an attribute of the formation that declares it wherever it is
+  written in that formation's body, not only as a direct child: a handle
+  written nested inside an application (`42.plus > x` with `a &gt;&gt; b!`
+  beneath it, the moniker spelling the printer emits, #5828) still belongs to
+  the enclosing formation. So a formation owns a handle when some "@local"
+  descendant has that formation as its nearest enclosing formation - the "is"
+  test stops the search at a nested formation boundary, so a handle never
+  leaks up out of, or sideways between, nested formations (#5780).
   -->
   <xsl:function name="eo:captor" as="element()?">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="name" as="xs:string" select="$ref/@base"/>
-    <xsl:variable name="scope" as="element()?" select="($ref/ancestor::o[not(@base)][o[@name=$name or @local=$name]])[last()]"/>
-    <xsl:sequence select="$scope/o[@local=$name][1]"/>
+    <xsl:variable name="scope" as="element()?" select="($ref/ancestor::o[not(@base)][o[@name=$name] or (some $d in descendant::o[@local=$name] satisfies $d/ancestor::o[not(@base)][1] is .)])[last()]"/>
+    <xsl:sequence select="$scope/descendant::o[@local=$name][ancestor::o[not(@base)][1] is $scope][1]"/>
   </xsl:function>
   <xsl:template match="o[@base and exists(eo:captor(.))]">
     <xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-nested-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-nested-scope.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A file-local handle (`a >> b!`, R-3.10.12) written nested inside an
+# application - the moniker spelling the printer emits for a multi-referenced
+# const handle (#5828) - still belongs to the enclosing formation, so every
+# sibling `b` reference binds to it. Previously the handle was only found as a
+# direct child of a formation, so a nested handle left its siblings resolving
+# to a free `b` instead of the handle's cactus name.
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  # the nested handle keeps its "@local" marker and gets a cactus name
+  - /object/o[@name='foo']/o[@base='.plus']/o[@local='b' and @name]
+  # both sibling references bind to the handle's cactus name
+  - /object[count(//o[@base=//o[@local='b']/@name])=2]
+  # no reference is left resolving to the bare, un-scoped `b`
+  - /object[count(//o[@base='b'])=0]
+input: |
+  [a] > foo
+    42.plus > x
+      a >> b!
+    43.plus b > y
+    44.plus b > z

--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -39,7 +39,12 @@
   auto-named abstract that references its own name; inlining it would
   copy that self-reference back in and fire this template forever, so
   such a target is also left untouched (both the reference and the
-  abstraction stay in place).
+  abstraction stay in place). A dataized-const handle (`a &gt;&gt; b!`,
+  R-3.10.12) reached from more than one site is likewise left untouched:
+  the const is dataized once and cached in that single binding, so folding
+  it into each use would mint an independent const object per reference and
+  drop the shared name (#5828); "merge-monikers" later hosts the kept
+  binding onto its first reference.
 
   The inlined value keeps the target's obfuscated cactus `@name` only when
   the name is still meaningful downstream: an abstract formation, whose name
@@ -61,7 +66,7 @@
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
     <xsl:choose>
-      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name))">
+      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:dataized-const($target) and eo:multi-referenced($target, $name))">
         <xsl:element name="o">
           <xsl:if test="@as">
             <xsl:apply-templates select="@as"/>
@@ -79,8 +84,10 @@
   </xsl:template>
   <!--
   Drop an inlined auto-named abstract; keep cactus-named voids, keep
-  self-referential (recursive) abstracts, which are never inlined, and keep
-  a binding that a surviving method dispatch still reaches through its name.
+  self-referential (recursive) abstracts, which are never inlined, keep a
+  multi-referenced dataized-const handle, which is never inlined (#5828), and
+  keep a binding that a surviving method dispatch still reaches through its
+  name.
   Such a dispatch reference (`ξ.<name>.<seg>`) is not inlined above — its
   receiver is buried in a dotted base — so dropping the binding would strand
   the reference on a synthetic "vL_P" placeholder. Keeping it lets
@@ -88,7 +95,7 @@
   instead (#5782).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or (eo:dataized-const(.) and eo:multi-referenced(., @name))">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -116,6 +123,31 @@
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="exists($target/..//o[contains(@base, concat($name, '.')) and not(ancestor-or-self::o[. is $target])])"/>
+  </xsl:function>
+  <!--
+  Whether the auto-named binding `$target` is a dataized-const wrapper: a
+  `.as-bytes` node over a `Φ.dataized` node, the shape "const-to-dataized"
+  leaves behind for a const file-local `&gt;&gt; name!` handle (R-3.10.12).
+  Such a const is dataized once and its result cached in that single binding,
+  so every reference shares one const object.
+  -->
+  <xsl:function name="eo:dataized-const" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:sequence select="$target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized'"/>
+  </xsl:function>
+  <!--
+  Whether more than one reference in the binding's owner resolves to the
+  auto-name `$name` (references inside the binding's own subtree excluded).
+  A const binding reached from several sites must stay a single shared handle
+  rather than be folded into each use: inlining it would mint an independent
+  const object per reference, changing the object graph and dropping the
+  shared name (#5828). "merge-monikers" then hosts the kept binding onto its
+  first reference.
+  -->
+  <xsl:function name="eo:multi-referenced" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
   </xsl:function>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -105,6 +105,33 @@
     <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
+  Whether `$attr` is a const file-local handle (`a &gt;&gt; b!`, R-3.10.12):
+  a based binding (not an abstract formation) carrying both the `!` const
+  marker and its readable "@local" handle. Such a handle is dataized once and
+  cached, so a multi-referenced one is kept whole by "inline-cactoos" (#5828)
+  and reaches here as an ordinary moniker binding. Unlike the non-const based
+  handle (#5810), it keeps its obfuscated "@name" and "@local" when hosted, so
+  "to-eo-tree" prints the merged binding as `a &gt;&gt; b!` rather than the
+  anonymous `a!`.
+  -->
+  <xsl:function name="eo:const-handle" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:sequence select="exists($attr/@const) and exists($attr/@local) and not(eo:abstract($attr))"/>
+  </xsl:function>
+  <!--
+  The const file-local handle binding a reference `$ref` resolves to but does
+  NOT host (the binding folds onto its first reference only). Every other
+  reference keeps the readable "@local" handle in place of the obfuscated
+  cactus name, so it reads back as a bare `b` rather than a synthetic "vL_P"
+  name (#5828).
+  -->
+  <xsl:function name="eo:kept-const-ref" as="element()*">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
+    <xsl:variable name="binding" select="$owner/o[@name = eo:resolved-ref($ref) and eo:moniker-binding(.) and eo:const-handle(.)][1]"/>
+    <xsl:sequence select="if (exists($binding) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+  </xsl:function>
+  <!--
   Replace the first hosting reference with the merged binding, always keeping
   the reference's positional `@as`. A bare reference becomes the binding
   inlined in place: the binding's other attributes and its children. An
@@ -114,7 +141,10 @@
   `@name` (and the `@local` handle it leaves behind), since the bare reference
   is unnamed and carrying the obfuscated name over would turn the inline into
   a spurious named node that `to-eo-tree` prints as its own `a >>` line
-  instead of an anonymous argument (#5810). A single-segment dispatch
+  instead of an anonymous argument (#5810). A const based handle
+  (`a >> b!`, see `eo:const-handle`) is the exception: it keeps its `@name` and
+  `@local`, so `to-eo-tree` prints the readable `a >> b!` and its other
+  references read back as the bare handle `b` (#5828). A single-segment dispatch
   `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
   whose receiver is that inlined binding and whose arguments are the
   reference's own children — the equivalent inline for a dispatch use (#5782).
@@ -128,7 +158,7 @@
       <xsl:when test="$seg = ''">
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
-          <xsl:apply-templates select="$binding/@*[name() != 'as' and (eo:abstract($binding) or (name() != 'name' and name() != 'local'))]"/>
+          <xsl:apply-templates select="$binding/@*[name() != 'as' and (eo:abstract($binding) or eo:const-handle($binding) or (name() != 'name' and name() != 'local'))]"/>
           <xsl:apply-templates select="$binding/node()"/>
         </xsl:element>
       </xsl:when>
@@ -145,6 +175,16 @@
         </xsl:element>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+  <!--
+  Rewrite a non-hosting reference to a const file-local handle from the
+  obfuscated cactus name back to the readable "@local" handle, so it reads as
+  `b` instead of a synthetic "vL_P" placeholder (#5828). The hosting reference
+  is rebuilt from the binding above and never reaches this template.
+  -->
+  <xsl:template match="o[exists(eo:kept-const-ref(.))]/@base" priority="2">
+    <xsl:variable name="binding" select="eo:kept-const-ref(..)"/>
+    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if ($seg = $binding/@name) then string($binding/@local) else $seg), '.')"/>
   </xsl:template>
   <!--
   Drop the standalone binding once it has been merged onto a reference.

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -34,12 +34,14 @@
   value is dataized once and cached in a single binding, so a handle referenced
   more than once must stay one shared object rather than be inlined per use
   (which would mint an independent const at each site and drop the shared name,
-  #5828). Such a handle is likewise treated as a handled void — its handle,
-  which the parser leaves on the wrapped value inside the "const-to-dataized"
-  `.as-bytes`/`Φ.dataized` shell, is promoted to the wrapper's visible name, its
-  references are rewritten back to the handle, and the marker is kept — so it
-  survives the later passes as a single standalone `a &gt;&gt; b!` binding. A
-  single-use const still inlines to `a!` (#5821).
+  #5828). Such a handle keeps its "@local" marker here — the parser leaves it on
+  the wrapped value inside the "const-to-dataized" `.as-bytes`/`Φ.dataized`
+  shell — so the handle survives to "to-eo-tree" and prints as `a &gt;&gt; b!`.
+  Unlike a void, its cactus "@name" is NOT promoted and its references are NOT
+  rewritten: the binding stays obfuscated so "inline-cactoos" leaves it whole
+  and "merge-monikers" folds it onto its first reference as a moniker, the other
+  references reading back as the bare handle. A single-use const still inlines
+  to `a!` (#5821).
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -73,10 +75,10 @@
   reference shares one const object; inlining it per use (as "inline-cactoos"
   does for a single-use const, #5821, or a referentially-transparent non-const
   handle, #5810) would mint an independent const object at each site and drop
-  the shared name. A multi-referenced one is therefore restored here like a
-  handled void: its handle is promoted to the visible name and its references
-  are rewritten back to the handle, so it stays a single standalone
-  `a &gt;&gt; b!` binding that the later passes leave untouched (#5828).
+  the shared name. Its "@local" marker is therefore kept here so the surviving
+  binding still prints its readable `&gt;&gt; b` handle; the binding itself
+  stays cactus-named for "merge-monikers" to fold onto its first reference
+  (#5828).
   -->
   <xsl:function name="eo:const-handle" as="xs:boolean">
     <xsl:param name="wrapper" as="element()*"/>
@@ -84,15 +86,12 @@
     <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $wrapper/@name and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
   </xsl:function>
   <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
-  <xsl:key name="const-handle" match="o[eo:const-handle(.)]" use="@name"/>
   <!--
-  References: rewrite each cactus segment that names a handled void, a
-  recursive formation, or a multi-referenced dataized-const handle back into
-  the readable handle. A void or recursive formation carries "@local" itself; a
-  const wrapper keeps the handle on its wrapped value.
+  References: rewrite each cactus segment that names a handled void or a
+  recursive formation back into the readable handle.
   -->
   <xsl:template match="@base">
-    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then string(key('void-handle', $seg)[1]/@local) else if (key('const-handle', $seg)) then string(key('const-handle', $seg)[1]/o[@base='Φ.dataized']/o[1]/@local) else $seg), '.')"/>
+    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then key('void-handle', $seg)[1]/@local else $seg), '.')"/>
   </xsl:template>
   <!--
   Handled declaration (void or recursive formation): promote the handle
@@ -102,19 +101,10 @@
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
-  Multi-referenced dataized-const handle: promote its handle (kept on the
-  wrapped value) to the wrapper's visible name, so "dataized-to-const" rebuilds
-  a readable `a &gt;&gt; b!` binding rather than a cactus-named one that
-  "merge-monikers" would try to fold onto a use site.
-  -->
-  <xsl:template match="o[eo:const-handle(.)]/@name">
-    <xsl:attribute name="name" select="../o[@base='Φ.dataized']/o[1]/@local"/>
-  </xsl:template>
-  <!--
   Keep the marker on voids, on recursive formations, and on the value of a
-  multi-referenced dataized-const handle so "to-eo-tree" restores the readable
-  "&gt;&gt; name" handle; drop it on the other non-void formations, whose
-  handle is inlined away by "inline-cactoos".
+  multi-referenced dataized-const handle (see "eo:const-handle") so "to-eo-tree"
+  restores the readable "&gt;&gt; name" handle; drop it on the other non-void
+  formations, whose handle is inlined away by "inline-cactoos".
   -->
   <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <xsl:template match="node()|@*">

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
@@ -11,10 +11,6 @@
 # as a moniker (`a >> b!` under the first `.plus`), the remaining references
 # reading back as the bare `b`. Contrast the non-const `a >> b`, which is
 # referentially transparent and safely inlines to `42.plus a` at every use.
-#
-# 'reprints: false' (#5739): the moniker spelling parses the nested handle in a
-# narrower scope than the standalone spelling, so it does not reprint to itself.
-reprints: false
 penalties:
   INDENT: 3
   BRACKET: 7

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-referenced-handle.yaml
@@ -7,9 +7,14 @@
 # in that one binding, so every `b` shares the same object. Inlining it per use
 # (as the single-use const, #5821, folds to `42.plus a!`) would mint an
 # independent const object at each site and drop the shared `b` name, changing
-# the object graph (#5828). The multi-referenced handle is therefore kept whole,
-# printing back exactly as written. Contrast the non-const `a >> b`, which is
+# the object graph (#5828). The kept handle is hosted onto its first reference
+# as a moniker (`a >> b!` under the first `.plus`), the remaining references
+# reading back as the bare `b`. Contrast the non-const `a >> b`, which is
 # referentially transparent and safely inlines to `42.plus a` at every use.
+#
+# 'reprints: false' (#5739): the moniker spelling parses the nested handle in a
+# narrower scope than the standalone spelling, so it does not reprint to itself.
+reprints: false
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -25,6 +30,6 @@ origin: |
 
 printed: |
   [a] > foo
-    a >> b!
-    42.plus b > x
+    42.plus > x
+      a >> b!
     43.plus b > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
@@ -6,10 +6,6 @@
 # kept whole just like the two-reference case (#5828): the single cached const
 # object stays behind one handle, hosted onto the first reference as a moniker,
 # and the remaining references read back as the bare `b`.
-#
-# 'reprints: false' (#5739): the moniker spelling parses the nested handle in a
-# narrower scope than the standalone spelling, so it does not reprint to itself.
-reprints: false
 penalties:
   INDENT: 3
   BRACKET: 7

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-thrice-referenced-handle.yaml
@@ -4,7 +4,12 @@
 # yamllint disable rule:line-length
 # A const file-local handle (`a >> b!`, #5817) shared by three references is
 # kept whole just like the two-reference case (#5828): the single cached const
-# object stays behind one handle and every `b` use points at it.
+# object stays behind one handle, hosted onto the first reference as a moniker,
+# and the remaining references read back as the bare `b`.
+#
+# 'reprints: false' (#5739): the moniker spelling parses the nested handle in a
+# narrower scope than the standalone spelling, so it does not reprint to itself.
+reprints: false
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -21,7 +26,7 @@ origin: |
 
 printed: |
   [a] > foo
-    a >> b!
-    42.plus b > x
+    42.plus > x
+      a >> b!
     43.plus b > y
     44.plus b > z


### PR DESCRIPTION
Follow-up to #5829 (per @yegor256's request for the moniker spelling).

## What changes

A multi-referenced const file-local handle (`a >> b!`, R-3.10.12) is still kept whole — it is never inlined per use, which would mint an independent const object at each site and drop the shared name (#5828). What changes is the printed **shape**: the kept binding is now hosted onto its first reference as a moniker, with the remaining references reading back as the bare handle.

```
[a] > foo               [a] > foo
  a >> b!                 42.plus > x
  42.plus b > x    =>       a >> b!
  43.plus b > y           43.plus b > y
```

## Printer (`eo-printer`)

- **`inline-cactoos`** leaves a multi-referenced dataized-const binding and its references in place (alongside the existing recursive / dispatched guards).
- **`restore-local-names`** keeps the `@local` handle on the wrapped value but leaves the binding cactus-named so it stays eligible for hosting.
- **`merge-monikers`** hosts the const handle onto its first reference keeping `@name`/`@local`/`@const` (so `to-eo-tree` prints `a >> b!`, not the anonymous `a!`), and rewrites the non-hosting references from the cactus name back to the readable handle.

Single-use const still inlines to `a!` (#5821); a non-const `a >> b` is referentially transparent and still inlines to `a` at every use (#5810).

## Parser (`eo-parser`) — the scoping fix

The moniker spelling writes the `>> b` handle **nested** inside an application (`42.plus > x` with `a >> b!` beneath it). The parser's `resolve-local-names` previously found a handle only as a **direct child** of a formation, so a nested handle left its sibling `43.plus b` / `44.plus b` references resolving to a free, un-scoped `b` — the spelling did not round-trip and the object graph changed on reparse.

`eo:captor` now recognises a handle wherever it is written in the formation's body: a formation owns a handle when some `@local` descendant has that formation as its **nearest** enclosing formation. The node-identity test keeps the nested-formation boundary intact, so a handle still never leaks up out of, or sideways between, nested formations (the #5780 sibling-scope rule). With the handle visible to its siblings, the hosted moniker form now reprints to itself — no `reprints: false` needed.

## Tests

Parser (`eo-packs/parse/`):
- `resolve-local-names-nested-scope.yaml` — a nested handle's sibling references resolve to its cactus name (the scoping fix).

Printer (`print-packs/yaml/`):
- `const-multi-referenced-handle.yaml` — two references, hosted moniker form (round-trips).
- `const-thrice-referenced-handle.yaml` — three references, hosted moniker form (round-trips).
- `const-single-referenced-handle.yaml` — single use still inlines to `a!` (unchanged).
- `non-const-multi-referenced-handle.yaml` — non-const contrast still inlines to `a` (unchanged).

All `eo-parser` (1501) and `eo-printer` (161, none skipped) tests pass; all four modified stylesheets pass `xcop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)