### PR TITLE
Fold recursive `>> name` handle's applied sibling to pipe (#5837)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -107,6 +107,28 @@
   formations, whose handle is inlined away by "inline-cactoos".
   -->
   <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <!--
+  When a recursive "&gt;&gt; name" handle is restored, its cactus name is
+  promoted to the visible "@name" and every reference is rewritten from the
+  cactus name to the handle. That strips the cactus name before
+  "inline-cactoos" runs, so its #5834 pipe-continuation logic
+  (`eo:piped`) — which only matches cactus-named references — never fires
+  and the applied sibling reference stays expanded (`bar &gt; x`) instead of
+  folding to the compact `| &gt; x`. Mirror `eo:piped` here: tag the handle's
+  immediately-following applied sibling reference — one carrying arguments or
+  a name — with `pipe=""`. "to-eo-tree" renders "@pipe" when the base equals
+  the preceding sibling's name, so tagging alone emits the "|". A reference
+  that already carries "@pipe" (an already-piped handle round-tripping) is
+  left as is.
+  -->
+  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and preceding-sibling::o[1][@local and eo:recursive(., @name)] and eo:resolved-name(@base) = preceding-sibling::o[1]/@name]">
+    <xsl:copy>
+      <xsl:if test="not(@pipe)">
+        <xsl:attribute name="pipe"/>
+      </xsl:if>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A self-referential (recursive) file-local handle ("[] &gt;&gt; bar",
+# R-3.10.12) whose body references itself ("bbb bar") stays in place, but the
+# applied sibling reference just below it must still fold to the compact pipe
+# continuation "| &gt; x" (#5837). "restore-local-names" promotes the recursive
+# handle's "@local" to its visible "@name" and rewrites references from the
+# cactus name to the handle; that strips the cactus name before
+# "inline-cactoos", whose #5834 pipe logic ("eo:piped") only matches
+# cactus-named references, so without the fix the reference stays expanded as
+# "bar &gt; x". The restored-recursive path now tags that reference with
+# "@pipe" itself, mirroring "eo:piped", so "to-eo-tree" emits the "|".
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    [] >> bar
+      bbb bar > z
+    bar > x
+printed: |
+  [] > foo
+    [] >> bar
+      bbb bar > z
+    | > x


### PR DESCRIPTION
Fixes #5837.

## Problem

Feeding `eo-printer` a self-referential (recursive) file-local handle whose applied sibling should fold to a compact pipe continuation was a no-op:

```
[] > foo
  [] >> bar
    bbb bar > z
  bar > x
```

The `bar > x` line stayed expanded, but the canonical spelling is `| > x` (the `[] >> bar` formation itself stays, since it is recursive). Because the expected `| > x` form is idempotent, the printer emitted two different texts for one object graph.

## Root cause

`restore-local-names.xsl` classifies `[] >> bar` as recursive (its body references itself through `bbb bar`), so it promotes `@local="bar"` to `@name` and rewrites every reference base from the cactus name (`ξ.a🌵…`) to `ξ.bar`. That pass runs **before** `inline-cactoos.xsl`, whose #5834 pipe-continuation logic (`eo:piped`) only matches cactus-named references (`o[contains(@base, '.a🌵')]`). Once the cactus name is stripped, nothing folds the reference, and `merge-monikers.xsl` skips it too (it needs a cactus `@name`). The non-recursive counterpart already folds, and an already-piped recursive handle round-trips (`pipe-recursive.yaml`), so this was the one gap.

## Fix

Tag the reference with `@pipe` on the restored-recursive path in `restore-local-names.xsl`: when a recursive `>> name` handle is restored, mark its immediately-following applied sibling reference (one carrying arguments or a name) with `pipe=""`, mirroring `eo:piped`. `to-eo-tree.xsl` already renders `@pipe` when the base equals the preceding sibling's name, so tagging alone emits the `|`. A reference that already carries `@pipe` (an already-piped handle round-tripping) is left untouched.

## Tests

Added `pipe-recursive-self.yaml` covering the snippet above. Both `printsToEo` (prints to the expected text) and `printsToParseableEo` (the expected text reprints to itself — idempotent) pass. Full `XmirTest` suite: 165 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQzLCvqAnncApnv887ksF

---
_Generated by [Claude Code](https://claude.ai/code/session_013hQzLCvqAnncApnv887ksF)_