### PR TITLE
Upgrade org.eolang:lints to 0.3.0

### DIFF
--- a/eo-integration-tests/pom.xml
+++ b/eo-integration-tests/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
-      <version>0.18.6</version>
+      <version>0.19.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.2.11</version>
+      <version>0.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
-      <version>0.18.6</version>
+      <version>0.19.1</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -253,21 +253,6 @@
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
               </skipProgramLints>
-              <skipSourceLints>
-                <!--
-                @todo #5611:30min Remove this compound-name suppression once eo-maven-plugin
-                depends on a lints release that contains the fix for objectionary/lints#1030.
-                All genuinely compound names in eo-runtime EO sources (out-of-range, sign-mask,
-                sin-family, etc.) were already renamed to single-word alternatives in this PR.
-                The only remaining violations are the idiomatic `cant-` prefixed names
-                (cant-divide, cant-convert, cant-read, etc.), which objectionary/lints#1030
-                (fixed upstream by objectionary/lints#1031, merged 2026-07-16 but not yet in a
-                published release as of lints 0.2.11) explicitly says are OK and should not be
-                renamed. Bump the <lints> version dependency in eo-maven-plugin/pom.xml once a
-                release containing that fix is published, then delete this suppression.
-                -->
-                <lint>compound-name</lint>
-              </skipSourceLints>
               <keepBinaries>
                 <glob>org/eolang/EO_fs/package-info.class</glob>
                 <glob>org/eolang/EO_number/package-info.class</glob>


### PR DESCRIPTION
## What & why

Upgrades the `org.eolang:lints` dependency in `eo-maven-plugin` from `0.2.11` to `0.3.0`.

## Changes

- **`eo-maven-plugin/pom.xml`**: `org.eolang:lints` `0.2.11` → `0.3.0`.
- **`eo-maven-plugin/pom.xml` & `eo-integration-tests/pom.xml`**: `com.yegor256:tojos` `0.18.6` → `0.19.1`. This is required for compatibility: lints `0.3.0` pulls in `tojos 0.19.1` transitively, and the enforcer's `RequireUpperBoundDeps` rule failed while the direct dependency stayed at `0.18.6`.
- **`eo-runtime/pom.xml`**: removed the temporary `compound-name` lint suppression (and its `@todo #5611`). It was a workaround for [objectionary/lints#1030](https://github.com/objectionary/lints/issues/1030) (idiomatic `cant-` prefixed names being flagged as compound). The fix ([objectionary/lints#1031](https://github.com/objectionary/lints/pull/1031)) is shipped in lints `0.3.0`, so the suppression is no longer needed.

Other transitive dependencies of lints (`eo-parser 0.61.1`, `cactoos 0.61.0`, `xsline 0.23.1`, `jcabi-xml 0.37.1`) are unchanged between `0.2.11` and `0.3.0`, so no further bumps were needed.

## Verification

- `eo-maven-plugin` compiles cleanly against lints `0.3.0` (enforcer passes with the `tojos` bump).
- `eo-runtime` `process-sources` (format + compile + lint) succeeds with the `compound-name` suppression removed — the `cant-` prefixed names are no longer flagged, confirming the #1030 fix is effective.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9FDQmMDafPWHX49pLCqeL)_