### PR TITLE
#5790: stop trimming text-block body, only opener indent should be stripped

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -56,7 +56,7 @@ final class LnTextBlock implements Line {
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
         final String joined = Emissions.unescapeBody(
-            String.join(String.valueOf('\n'), globals.tbody()).trim()
+            String.join(String.valueOf('\n'), globals.tbody())
         );
         this.transition(stack, suffix);
         emit.object(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
@@ -6,7 +6,8 @@ sheets: []
 asserts:
   - //o[@base='Φ.string' and o/o[text()='48-69-2C-20-74-68-65-72-65-0A-41-64-69-C3-B3-73']]
   - //o[@base='Φ.string' and o/o[text()='66-69-72-73-74-0A-20-73-65-63-6F-6E-64']]
-  - //o[@base='Φ.string' and o/o[text()='74-68-69-72-64']]
+  - //o[@base='Φ.string' and o/o[text()='20-20-20-74-68-69-72-64']]
+  - //o[@base='Φ.string' and o/o[text()='0A-73-65-63-6F-6E-64']]
 input: |
   [] > main
     """
@@ -21,4 +22,9 @@ input: |
     stdout > mrg
       """
          third
+      """
+    stdout > blank
+      """
+
+      second
       """

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/string-with-double-spaces.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/string-with-double-spaces.yaml
@@ -17,4 +17,4 @@ origin: |
   """ > other
 
 printed: |
-  "z\n  y\n x" > other
+  " z\n  y\n x" > other


### PR DESCRIPTION
Closes #5790

`LnTextBlock.java:59` called `.trim()` on the whole joined text-block body after `Globals.appendTextLine` already correctly strips only the opener's own indent from each line. `String.trim()` only strips whitespace touching the very start/end of the entire joined string, not per-line margins, so:

- Extra indentation beyond the block's margin was silently swallowed when it happened to land on the first or last line, but preserved on any other line.
- An intentional leading blank line in the body was deleted entirely instead of becoming an empty first line.

This contradicts the parser's own spec, `PARSER_SPEC.md:552` (R-3.11.2): "the block's text is the body lines joined by `\n` with the opening indent stripped", nothing about trimming beyond that. Same defect class as issue #5123, which was already fixed once in the old ANTLR-based `XeEoListener` and reappeared here through a different mechanism (`.trim()` instead of an unanchored regex) in the new hand-written parser.

Fix: remove the `.trim()` call. `Globals.appendTextLine` already does the only stripping the spec calls for.

Updated the existing `text-block.yaml` fixture, which baked in the old swallowed-first-line behavior as "expected" (a body with 3 extra leading spaces on its only body line was asserted to come out as `"third"`; with the fix it correctly comes out as `"   third"`). Added a new assertion for the leading-blank-line case (`"\nsecond"` now preserved instead of becoming just `"second"`).

Verified:
- `EoSyntaxTest` (923 parameterized cases, includes the text-block fixture): all green.
- Full `eo-parser` test module: 1013/1013 green.
- `qulice:check -Pqulice` on `eo-parser`: clean.
