### PR TITLE
Relocate a separated applied `>>` handle so its pipe survives (#5840)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -82,9 +82,39 @@
           tagged `@pipe`, its `@base` still pointing at the kept formation
           directly above it. The guard keeps this to a reference standing
           immediately after its own target, the one shape `to-eo-tree` can
-          render as a compact pipe.
+          render as a compact pipe (the formation stays put, kept by the drop
+          template below).
           -->
           <xsl:when test="eo:abstract($target) and (o or @name) and preceding-sibling::o[1] is $target">
+            <xsl:copy>
+              <xsl:if test="not(@pipe)">
+                <xsl:attribute name="pipe"/>
+              </xsl:if>
+              <xsl:apply-templates select="node()|@*"/>
+            </xsl:copy>
+          </xsl:when>
+          <!--
+          The same applied reference, but with another binding sitting between
+          the formation and this use (`67 &gt; t` in #5840): the formation is
+          still a preceding sibling, only no longer the immediate one, so the
+          adjacent guard above misses it and the bare-reference `otherwise`
+          would drop the argument and name exactly as #5834 did. A `|` pipe
+          binds the immediately-preceding sibling, so we relocate the
+          single-use formation to sit directly above this reference — emit a
+          fresh copy of it here (its children inlined as usual) and then the
+          pipe continuation. The formation's original binding is dropped by the
+          drop template below (it is not `eo:piped`, having a non-reference
+          following sibling), so the relocation moves it rather than
+          duplicating it, the same relocation #5732 proposes for its sibling
+          case. Restricted to a single-use formation: a multi-referenced one
+          cannot be folded into just one of its uses.
+          -->
+          <xsl:when test="eo:abstract($target) and (o or @name) and exists(preceding-sibling::o[. is $target]) and not(eo:multi-referenced($target, $name))">
+            <xsl:for-each select="$target">
+              <xsl:copy>
+                <xsl:apply-templates select="node()|@*"/>
+              </xsl:copy>
+            </xsl:for-each>
             <xsl:copy>
               <xsl:if test="not(@pipe)">
                 <xsl:attribute name="pipe"/>
@@ -173,6 +203,10 @@
   pointing back at the formation, so the formation must stay in place as the
   pipe's named predecessor rather than be dropped (#5834). The bare-reference
   case (no children, no name) folds the formation in and drops it as before.
+  An applied reference separated from the formation by another binding (#5840)
+  is deliberately not matched here: the inlining template relocates a fresh
+  copy of the formation down to the reference's site, so the original binding
+  is dropped by the drop template above rather than kept in place.
   -->
   <xsl:function name="eo:piped" as="xs:boolean">
     <xsl:param name="target" as="element()"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-separated.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-separated.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> bar` handle (R-3.10.12) whose value is an
+# abstract formation and which is used as the base of an application, exactly
+# as "inline-cactoos-applied-handle", except that another binding (`67 > t`)
+# sits between the handle and its applied reference (`bar 8 > x`). That
+# separation used to defeat the #5834 pipe path — both its guards require
+# adjacency — so the reference fell into the bare-reference inline, which
+# rebuilt only the formation and silently dropped the argument (`8`) and the
+# result name (`x`), while the drop template removed the original binding
+# (#5840). The fix relocates the single-use handle to sit directly above its
+# reference so the `|` pipe (which binds the immediately-preceding sibling) can
+# apply it: the formation moves below `67 > t`, keeps its argument and name in
+# the `| 8 > x` continuation, and every attribute of `foo` survives. The
+# readable `bar` handle is dropped since the anonymous formation needs no name
+# for the pipe to refer to it.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    44 > [k] >> bar
+    67 > t
+    bar 8 > x
+
+printed: |
+  [] > foo
+    67 > t
+    44 > [k] >>
+    | 8 > x


### PR DESCRIPTION
Fixes #5840.

## Problem

`eo-printer` dropped an applied `>>` handle reference when another binding sat between the handle and its use. Feeding

```
[] > foo
  44 > [k] >> bar
  67 > t
  bar 8 > x
```

printed as

```
[] > foo
  44 > [k] >>
  67 > t
```

— the whole `bar 8 > x` line (its argument `8` and result name `x`) was silently dropped, and the handle lost its name.

This is the #5834 arg-dropping loss, still live whenever the applied reference is not the handle's immediate neighbour. The #5834 pipe path folds an applied reference into a `| args > name` pipe, but both its guards require adjacency (`preceding-sibling::o[1] is $target` and `eo:piped` testing `following-sibling::o[1]`). With `67 > t` between the handle and `bar 8 > x`, both guards fail, so the reference fell into the bare-reference inline `otherwise`, which rebuilt only the formation and dropped the reference's own children and `@name`, while the drop template removed the original binding.

## Fix

A `|` pipe binds the immediately-preceding sibling, so `inline-cactoos.xsl` now relocates the single-use handle formation to sit directly above its applied reference: it emits a fresh copy of the formation (its children inlined as usual) immediately followed by the `| args > name` pipe continuation. The formation's original binding is dropped by the drop template rather than duplicated (it is not `eo:piped`, having a non-reference following sibling), so the relocation moves it — the same relocation #5732 proposes for its sibling case. The path is restricted to a single-use formation, since a multi-referenced one cannot be folded into just one of its uses.

The example now prints (and reprints to itself) as:

```
[] > foo
  67 > t
  44 > [k] >>
  | 8 > x
```

preserving every binding, with the formation inlined into the application.

## Tests

Adds `inline-cactoos-applied-handle-separated.yaml`, the separated sibling of the existing `inline-cactoos-applied-handle.yaml` pack. It passes both `printsToEo` and `printsToParseableEo` (the expected output reprints to itself). The full `eo-printer` suite (205 tests) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUUshPBXmetxLAc8KMbai8)_