### PR TITLE
Pipe the argument of a handle applied as a dispatch receiver (#5844)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -94,22 +94,28 @@
             </xsl:copy>
           </xsl:when>
           <!--
-          The same applied reference, but with another binding sitting between
-          the formation and this use (`67 &gt; t` in #5840): the formation is
-          still a preceding sibling, only no longer the immediate one, so the
-          adjacent guard above misses it and the bare-reference `otherwise`
-          would drop the argument and name exactly as #5834 did. A `|` pipe
-          binds the immediately-preceding sibling, so we relocate the
-          single-use formation to sit directly above this reference — emit a
-          fresh copy of it here (its children inlined as usual) and then the
-          pipe continuation. The formation's original binding is dropped by the
-          drop template below (it is not `eo:piped`, having a non-reference
-          following sibling), so the relocation moves it rather than
+          The same applied reference, but not standing as the formation's
+          immediate following sibling, so the adjacent guard above misses it
+          and the bare-reference `otherwise` would drop the argument and name
+          exactly as #5834 did. Two shapes reach here: another binding sits
+          between the formation and this use (`67 &gt; t` in #5840, the
+          formation still a preceding sibling), or the use is a dispatch
+          receiver buried as the `ρ` of a `.method` node (`(bar 55).a` in
+          #5844), which shares no sibling slot with the formation at all. A `|`
+          pipe binds the immediately-preceding sibling, so in both we relocate
+          the single-use formation to sit directly above this reference — emit
+          a fresh copy of it here (its children inlined as usual) and then the
+          pipe continuation. For the receiver case the copy and the pipe land
+          inside the dispatch block, so `to-eo-tree` renders them as the
+          reversed dispatch's receiver (`[t] &gt;&gt; bar` then `| 55`). The
+          formation's original binding is dropped by the drop template below (it
+          is not `eo:piped`, having a non-reference following sibling, or no
+          following sibling at all), so the relocation moves it rather than
           duplicating it, the same relocation #5732 proposes for its sibling
           case. Restricted to a single-use formation: a multi-referenced one
           cannot be folded into just one of its uses.
           -->
-          <xsl:when test="eo:abstract($target) and (o or @name) and exists(preceding-sibling::o[. is $target]) and not(eo:multi-referenced($target, $name))">
+          <xsl:when test="eo:abstract($target) and (o or @name) and not(eo:multi-referenced($target, $name))">
             <xsl:for-each select="$target">
               <xsl:copy>
                 <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -67,6 +67,29 @@
     <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
   <!--
+  Whether the auto-named abstract formation "$target" is applied by a reference
+  that stands as a dispatch receiver rather than a following sibling. Such a
+  reference resolves to "$name", carries its own argument children or a
+  result-binding "@name" (so a fresh bare-reference inline would drop them,
+  #5834), yet does not sit as a following sibling of the formation, the one
+  shape a "| args &gt; name" pipe (#5834) or its adjacent relocation (#5840)
+  already covers. A dispatch receiver "(bar 55).a" is exactly this: its
+  "bar 55" receiver is buried as the "ρ" of the ".a" node. "inline-cactoos"
+  relocates a copy of the formation into the receiver slot and turns the "ρ"
+  into a "| 55" pipe (#5844); unlike the sibling pipe, that relocated
+  predecessor sits inside the dispatch block, so its readable "&gt;&gt; name"
+  handle is kept here — its "@local" marker survives, though (unlike a void)
+  its cactus "@name" is left obfuscated so "inline-cactoos" still recognises
+  the reference and pipes it. References inside the formation itself are
+  excluded, so a self-referential (recursive) helper is not mistaken for an
+  external use.
+  -->
+  <xsl:function name="eo:applied-receiver" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
+  </xsl:function>
+  <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,
   R-3.10.12) that is referenced more than once. "const-to-dataized" wraps such
   a const in a `.as-bytes` over `Φ.dataized` node carrying the obfuscated
@@ -88,25 +111,31 @@
   <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
   <!--
   References: rewrite each cactus segment that names a handled void or a
-  recursive formation back into the readable handle.
+  recursive formation back into the readable handle. A formation applied as a
+  dispatch receiver (#5844) is deliberately excluded: its cactus name must
+  survive so "inline-cactoos" still recognises the reference and pipes it.
   -->
   <xsl:template match="@base">
     <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if (key('void-handle', $seg)) then key('void-handle', $seg)[1]/@local else $seg), '.')"/>
   </xsl:template>
   <!--
   Handled declaration (void or recursive formation): promote the handle
-  to the visible name.
+  to the visible name. A formation applied as a dispatch receiver (#5844) is
+  not promoted — only its "@local" marker is kept (below) — so its cactus name
+  survives for "inline-cactoos" to pipe against.
   -->
   <xsl:template match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]/@name">
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
-  Keep the marker on voids, on recursive formations, and on the value of a
-  multi-referenced dataized-const handle (see "eo:const-handle") so "to-eo-tree"
-  restores the readable "&gt;&gt; name" handle; drop it on the other non-void
-  formations, whose handle is inlined away by "inline-cactoos".
+  Keep the marker on voids, on recursive formations, on a formation applied as
+  a dispatch receiver (#5844) — so its relocated pipe predecessor prints its
+  readable "&gt;&gt; name" handle — and on the value of a multi-referenced
+  dataized-const handle (see "eo:const-handle") so "to-eo-tree" restores the
+  readable "&gt;&gt; name" handle; drop it on the other non-void formations,
+  whose handle is inlined away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/main/resources/org/eolang/printer/print/unnecessary-as.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/unnecessary-as.xsl
@@ -51,13 +51,25 @@
       <xsl:apply-templates select="text()"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="o[@base and starts-with(@base, '.') and count(o[@as])=count(o)-1]">
+  <!--
+  A reversed dispatch (`.method`, base starting with a dot) whose leading
+  children are the receiver and whose trailing children are the positional
+  arguments carrying `@as`. Normally the receiver is a single child, but a
+  `>>` handle applied as this receiver relocates into two leading children —
+  the formation predecessor and its `| args` pipe continuation (#5844) — so
+  the count of leading receiver children is whatever is left once the `@as`
+  arguments are removed. Emit those leading children untouched, then, if the
+  arguments form the canonical `α0, α1, …` run, strip their now-redundant
+  `@as`.
+  -->
+  <xsl:template match="o[@base and starts-with(@base, '.') and exists(o[@as]) and (count(o[@as])=count(o)-1 or (count(o[@as])=count(o)-2 and exists(o[@pipe])))]">
+    <xsl:variable name="lead" select="count(o) - count(o[@as])"/>
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
-      <xsl:apply-templates select="o[1]"/>
+      <xsl:apply-templates select="o[position()&lt;=$lead]"/>
       <xsl:choose>
-        <xsl:when test="eo:all-alphas(0, o[position()=2])">
-          <xsl:for-each select="o[position()&gt;1]">
+        <xsl:when test="eo:all-alphas(0, o[position()=$lead+1])">
+          <xsl:for-each select="o[position()&gt;$lead]">
             <xsl:variable name="elem">
               <xsl:element name="o">
                 <xsl:for-each select="@*[name()!='as']">
@@ -70,7 +82,7 @@
           </xsl:for-each>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:apply-templates select="o[position()&gt;1]"/>
+          <xsl:apply-templates select="o[position()&gt;$lead]"/>
         </xsl:otherwise>
       </xsl:choose>
       <xsl:apply-templates select="text()"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-applied-receiver-local-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-applied-receiver-local-name.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-use file-local handle ("[t] >> bar", R-3.10.12) whose abstract
+# formation is applied by a reference sitting as a method-dispatch receiver
+# (the "bar 55" head of "(bar 55).a 88"). "inline-cactoos" will relocate the
+# formation into the receiver slot and turn the reference into a "| 55" pipe
+# (#5844); for the relocated predecessor to print its readable ">> bar" handle,
+# "restore-local-names" must keep the "@local" marker instead of dropping it as
+# it does for a plain inlined-away handle. Unlike a void or recursive handle,
+# though, the cactus "@name" is NOT promoted and the reference is NOT rewritten
+# — the binding stays obfuscated so "inline-cactoos" still recognises the
+# reference and pipes it.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The applied formation keeps its "@local" marker, and its cactus "@name" is
+  # left obfuscated (not promoted to the handle).
+  - /object/o[@name='foo']/o[@local='bar' and contains(@name, '🌵') and not(@base)]
+  # Its applied reference (the dispatch receiver) is NOT rewritten to the
+  # handle — it stays cactus-based and still carries its own argument.
+  - /object/o[@name='foo']/o[@base='.a']/o[contains(@base, '🌵') and o]
+  # No reference was rewritten to a readable "bar" base.
+  - /object[not(.//o[contains(@base, 'ξ.bar') or ends-with(@base, '.bar')])]
+input: |
+  [] > foo
+    (bar 55).a 88 > k
+    [t] >> bar

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-receiver.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-receiver.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> bar` handle (R-3.10.12) whose value is an
+# abstract formation and which is used as the base of an application, exactly
+# as "inline-cactoos-applied-handle", except that the applied reference
+# (`bar 55`) sits as a method-dispatch receiver — the `ρ` of `(bar 55).a 88`
+# — rather than as a sibling of the handle. That defeats both #5834 pipe
+# guards: they need the reference to stand as a following sibling of the
+# formation, and a dispatch receiver shares no sibling slot with it, so the
+# reference fell into the bare-reference inline, which rebuilt only the
+# formation and silently dropped the argument (`55`) while keeping the
+# surrounding `.a 88` (#5844). The fix relocates the single-use formation into
+# the receiver slot — a fresh copy directly above the reference, which becomes
+# the `| 55` pipe continuation — so the `|` pipe (binding its immediately
+# preceding sibling) applies it with the `55` intact. "to-eo-tree" then renders
+# the whole thing as the reversed dispatch `a. > k` with the formation and its
+# pipe as the receiver and `88` as the argument. Unlike the sibling pipe cases
+# (#5834 / #5840, which drop the handle name), the relocated predecessor sits
+# inside the dispatch block, so "restore-local-names" keeps its readable
+# `>> bar` handle. The original binding is dropped, so the formation moves
+# rather than duplicating.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    (bar 55).a 88 > k
+    [t] >> bar
+
+printed: |
+  [] > foo
+    a. > k
+      [t] >> bar
+      | 55
+      88


### PR DESCRIPTION
Fixes #5844.

## Problem

`eo-printer` silently dropped an argument when a single-use `>>` handle was applied and that application sat as a method-dispatch receiver. Feeding:

```
[] > foo
  (bar 55).a 88 > k
  [t] >> bar
```

printed as:

```
[] > foo
  a. > k
    [t] >>
    88
```

`bar 55` collapsed into a bare `[t] >>` receiver — the `55` was gone.

## Cause

The `bar 55` receiver is the `ρ` of the `.a` dispatch, so it is never a *following sibling* of its `[t]` formation. Both #5834 pipe guards in `inline-cactoos.xsl` require the applied reference to stand as a following sibling of the formation, so the reference fell into the bare-reference inline `otherwise`, which rebuilds only the formation and discards the reference's own children — the `55`.

## Fix

Handle it as a **relocated pipe**, the way #5840 already handles a *separated* sibling: `inline-cactoos` relocates a single-use applied formation to its reference's site and turns the reference into a `| args` pipe. The #5840 branch was guarded by `exists(preceding-sibling::o[. is $target])`; dropping that guard lets it also fire when the reference is a nested dispatch receiver, so the formation copy and the `| 55` pipe land inside the dispatch block and `to-eo-tree` renders the reversed dispatch `a. > k` with the formation and its pipe as the receiver and `88` as the argument.

Two supporting changes:

- **`restore-local-names.xsl`** keeps the handle's `@local` marker for this shape (a new `eo:applied-receiver` predicate), so the relocated predecessor — which sits *inside* the dispatch block — prints its readable `>> bar` handle rather than an anonymous `>>`. Unlike a void/recursive handle, its cactus `@name` is left obfuscated and its references are not rewritten, so `inline-cactoos` still recognises and pipes it.
- **`unnecessary-as.xsl`** learns that a reversed dispatch whose receiver is a pipe has *two* leading receiver children (the formation predecessor and its `| args` pipe), so it still strips the redundant `@as` from the trailing positional arguments — `88`, not `88:0`.

The example now prints (and reprints to itself) as:

```
[] > foo
  a. > k
    [t] >> bar
    | 55
    88
```

## Tests

- `print-packs/yaml/inline-cactoos-applied-handle-receiver.yaml` — full-pipeline pack covering the receiver case; it reprints to itself.
- `eo-packs/print/restore-applied-receiver-local-name.yaml` — XSL-level pack pinning the `restore-local-names` behaviour (marker kept, name left obfuscated, reference not rewritten).

All 206 tests in `eo-printer` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)