### PR TITLE
#5791: reject lone UTF-16 surrogate unicode escapes in string literals

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -295,7 +295,39 @@ final class Emissions {
                 idx = idx + 2;
             }
         }
+        Emissions.rejectLoneSurrogates(out);
         return out.toString();
+    }
+
+    /**
+     * Reject a decoded body containing a UTF-16 surrogate with no matching
+     * partner — a lone {@code \uD800}-{@code \uDFFF} escape has no UTF-8
+     * encoding and would otherwise be silently mangled later. A high
+     * surrogate immediately followed by a low surrogate is a valid pair
+     * (for example a supplementary character spelled as two {@code \\u}
+     * escapes) and is left untouched.
+     * @param text Decoded body to check
+     */
+    private static void rejectLoneSurrogates(final CharSequence text) {
+        int cursor = 0;
+        while (cursor < text.length()) {
+            final char glyph = text.charAt(cursor);
+            if (Character.isHighSurrogate(glyph)
+                && cursor + 1 < text.length()
+                && Character.isLowSurrogate(text.charAt(cursor + 1))) {
+                cursor = cursor + 2;
+                continue;
+            }
+            if (Character.isSurrogate(glyph)) {
+                throw new NumberFormatException(
+                    String.format(
+                        "unicode escape \\u%04X is a lone surrogate, not a valid standalone codepoint",
+                        (int) glyph
+                    )
+                );
+            }
+            cursor = cursor + 1;
+        }
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -662,6 +662,30 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void rejectsLoneSurrogateUnicodeEscape() throws Exception {
+        MatcherAssert.assertThat(
+            "a \\u escape decoding to a lone UTF-16 surrogate (D800-DFFF) must show up as an /object/errors/error entry, not silently emit '?'",
+            EoSyntaxTest.raw(
+                String.join(String.valueOf((char) 10), "[] > foo", "  \"\\uD800\" > @")
+            ).toString(),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'unicode')]"
+            )
+        );
+    }
+
+    @Test
+    void acceptsValidSurrogatePairEscape() throws Exception {
+        MatcherAssert.assertThat(
+            "a high surrogate immediately followed by a low surrogate is a valid pair and must not be rejected",
+            EoSyntaxTest.raw(
+                String.join(String.valueOf((char) 10), "[] > foo", "  \"\\uD83C\\uDF08\" > @")
+            ).toString(),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors/error"))
+        );
+    }
+
+    @Test
     void emitsProgramMetadataAttributes() throws Exception {
         MatcherAssert.assertThat(
             "the <object> root must carry the standard program metadata attributes",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/lone-surrogate-escape-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/lone-surrogate-escape-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unicode')]
+input: |
+  [] > main
+    "\uD800" > n


### PR DESCRIPTION
Closes #5791

`Emissions.appendUnicode` accepted any 4 valid hex digits and cast straight to `char`, including the `D800`-`DFFF` range reserved for UTF-16 surrogate pairs, which is not a valid standalone Unicode scalar value. Writing `"\uD800"` parsed successfully with no error and silently produced the single-byte string `"?"` when later encoded to UTF-8, discarding the user's actual input.

Same defect family already fixed for three siblings in this file: over-precise numeric literals (#5259/#5613), out-of-range octal escapes (#5419), and malformed non-hex `\uZZZZ` (#5257). None of those covered a valid-hex-but-invalid-codepoint `\u` escape.

Fix: after `unescapeBody` assembles the full decoded string, check it for any UTF-16 surrogate that isn't immediately paired with its partner (a high surrogate followed by a low surrogate is a valid pair, e.g. a supplementary character spelled as two `\u` escapes, like an emoji, and must not be rejected). A genuinely lone surrogate throws `NumberFormatException`, which the existing catch block in `Emissions.number()` already turns into a `ParseError`, matching the same reporting path already used for the octal and malformed-hex siblings.

Checking the whole assembled string (not each `\u` escape in isolation) is necessary: an initial attempt that rejected surrogates per-escape broke valid multi-escape surrogate pairs used throughout the project's own naughty-strings test fixture (emoji spelled as `🏳` etc.) — caught by running the full `EoSyntaxTest` suite before finalizing.

Verified:
- New test `rejectsLoneSurrogateUnicodeEscape`: `"\uD800"` now surfaces a `ParseError`.
- New test `acceptsValidSurrogatePairEscape`: `"🌈"` (a valid pair) still parses with no error.
- Full `eo-parser` test module: 1503/1503 green, including the existing naughty-strings fixture with real surrogate-pair emoji.
- `qulice:check -Pqulice`: clean.
