### PR TITLE
Fold recursive `>> name` handle's applied reference above it to pipe (#5848)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -159,41 +159,51 @@
     </xsl:copy>
   </xsl:template>
   <!--
-  The mirror case (#5848): the applied sibling reference sits just ABOVE the
-  recursive handle, not below it. A "| args &gt; name" pipe binds its
-  immediately-preceding sibling, so a reference standing before the handle
-  cannot pipe against it where it is; the #5837 tag-in-place path above only
-  matches a reference whose preceding sibling is the handle, so it never fires
-  and the reference stays expanded ("bar &gt; @"). Relocate it instead: drop
-  the reference from its own position (below) and re-emit it just under the
-  handle, tagged "@pipe", the same relocation "inline-cactoos" performs for a
-  separated non-recursive handle (#5840) — done here because the recursive
-  handle is never inlined and its cactus name is stripped before
-  "inline-cactoos" runs. The reference is suppressed at its origin:
+  The mirror case (#5848): the applied reference sits ABOVE the recursive
+  handle, not below it. A "| args &gt; name" pipe binds its immediately-preceding
+  sibling, so a reference standing before the handle cannot pipe against it
+  where it is; the #5837 tag-in-place path above only matches a reference whose
+  preceding sibling is the handle, so it never fires and the reference stays
+  expanded ("bar &gt; @"). Relocate it instead: suppress the reference at its
+  origin and re-emit it just under the handle tagged "@pipe", the same
+  relocate-and-pipe "inline-cactoos" performs for a separated non-recursive
+  handle (#5840) — done here because the recursive handle is never inlined and
+  its cactus name is stripped before "inline-cactoos" runs. The reference need
+  not be the handle's immediate sibling; any applied reference resolving to the
+  handle among its preceding siblings folds, mirroring #5840's separated case.
+
+  Suppress the reference at its origin. Match any applied reference (one
+  carrying arguments or a name) with a recursive handle among its following
+  siblings, then keep only those that resolve to it — a reference resolving to a
+  different binding still prints in place.
   -->
-  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and following-sibling::o[1][@local and eo:recursive(., @name)] and eo:resolved-name(@base) = following-sibling::o[1]/@name]"/>
+  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and following-sibling::o[@local and eo:recursive(., @name)]]">
+    <xsl:if test="not(following-sibling::o[@local and eo:recursive(., @name) and @name = eo:resolved-name(current()/@base)])">
+      <xsl:copy>
+        <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:if>
+  </xsl:template>
   <!--
-  and re-emitted below the handle. Match the recursive handle whose
-  immediately-preceding sibling is such an applied reference, copy the handle,
-  then emit that reference tagged "@pipe"; "to-eo-tree" renders the "|" because
-  the reference's restored base now equals the preceding sibling's name. A
-  reference already carrying "@pipe" is left as is.
+  Re-emit the suppressed reference below the handle. Match the recursive handle,
+  copy it, then for each applied reference among its preceding siblings that
+  resolves to it emit a "@pipe"-tagged copy; "to-eo-tree" renders the "|"
+  because the reference's restored base now equals the preceding sibling's name.
+  A reference already carrying "@pipe" is left as is. A handle with no such
+  preceding reference (the #5837 reference-below shape) just copies through.
   -->
-  <xsl:template match="o[@local and eo:recursive(., @name) and preceding-sibling::o[1][contains(@base, concat('.', $auto)) and (o or @name)]]">
-    <xsl:variable name="ref" select="preceding-sibling::o[1]"/>
+  <xsl:template match="o[@local and eo:recursive(., @name)]">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
-    <xsl:if test="eo:resolved-name($ref/@base) = @name">
-      <xsl:for-each select="$ref">
-        <xsl:copy>
-          <xsl:if test="not(@pipe)">
-            <xsl:attribute name="pipe"/>
-          </xsl:if>
-          <xsl:apply-templates select="node()|@*"/>
-        </xsl:copy>
-      </xsl:for-each>
-    </xsl:if>
+    <xsl:for-each select="preceding-sibling::o[contains(@base, concat('.', $auto)) and (o or @name) and eo:resolved-name(@base) = current()/@name]">
+      <xsl:copy>
+        <xsl:if test="not(@pipe)">
+          <xsl:attribute name="pipe"/>
+        </xsl:if>
+        <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:for-each>
   </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -158,6 +158,43 @@
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
   </xsl:template>
+  <!--
+  The mirror case (#5848): the applied sibling reference sits just ABOVE the
+  recursive handle, not below it. A "| args &gt; name" pipe binds its
+  immediately-preceding sibling, so a reference standing before the handle
+  cannot pipe against it where it is; the #5837 tag-in-place path above only
+  matches a reference whose preceding sibling is the handle, so it never fires
+  and the reference stays expanded ("bar &gt; @"). Relocate it instead: drop
+  the reference from its own position (below) and re-emit it just under the
+  handle, tagged "@pipe", the same relocation "inline-cactoos" performs for a
+  separated non-recursive handle (#5840) — done here because the recursive
+  handle is never inlined and its cactus name is stripped before
+  "inline-cactoos" runs. The reference is suppressed at its origin:
+  -->
+  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and following-sibling::o[1][@local and eo:recursive(., @name)] and eo:resolved-name(@base) = following-sibling::o[1]/@name]"/>
+  <!--
+  and re-emitted below the handle. Match the recursive handle whose
+  immediately-preceding sibling is such an applied reference, copy the handle,
+  then emit that reference tagged "@pipe"; "to-eo-tree" renders the "|" because
+  the reference's restored base now equals the preceding sibling's name. A
+  reference already carrying "@pipe" is left as is.
+  -->
+  <xsl:template match="o[@local and eo:recursive(., @name) and preceding-sibling::o[1][contains(@base, concat('.', $auto)) and (o or @name)]]">
+    <xsl:variable name="ref" select="preceding-sibling::o[1]"/>
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+    <xsl:if test="eo:resolved-name($ref/@base) = @name">
+      <xsl:for-each select="$ref">
+        <xsl:copy>
+          <xsl:if test="not(@pipe)">
+            <xsl:attribute name="pipe"/>
+          </xsl:if>
+          <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before-separated.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before-separated.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A self-referential (recursive) file-local handle ("[t] &gt;&gt; bar",
+# R-3.10.12) whose body references itself ("bar 55") stays in place, and an
+# applied reference to it ("bar &gt; @") sitting ABOVE the handle must fold to
+# the compact pipe continuation "| &gt; @" below the handle (#5848) even when
+# other bindings ("a.b.c &gt; f", "k.t &gt; p") separate the reference from the
+# handle. This is the recursive mirror of the separated non-recursive case
+# "inline-cactoos" already relocates (#5840): the reference need not be the
+# handle's immediate sibling. "restore-local-names" promotes the recursive
+# handle's "@local" to its visible "@name" and rewrites references from the
+# cactus name to the handle, stripping the cactus name before "inline-cactoos"
+# whose #5834/#5840 machinery only matches cactus-named references; so the
+# restored-recursive path itself suppresses the reference at its origin and
+# re-emits it just below the handle tagged "@pipe", and "to-eo-tree" emits the
+# "|". The unrelated siblings keep their own layout.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    pre.tt > rr
+    bar > @
+    a.b.c > f
+    k.t > p
+    [t] >> bar
+      test 78 > kk
+      bar 55 > ii
+printed: |
+  [] > foo
+    pre.tt > rr
+    a.b.c > f
+    k.t > p
+    [t] >> bar
+      bar 55 > ii
+      test 78 > kk
+    | > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A self-referential (recursive) file-local handle ("[t] &gt;&gt; bar",
+# R-3.10.12) whose body references itself ("bar 55") stays in place, and an
+# applied sibling reference sitting just ABOVE it must fold to the compact pipe
+# continuation "| &gt; @" below the handle (#5848), the mirror of
+# "pipe-recursive-self" (#5837) where the reference sits below the handle.
+# "restore-local-names" promotes the recursive handle's "@local" to its visible
+# "@name" and rewrites references from the cactus name to the handle; that
+# strips the cactus name before "inline-cactoos", whose #5834 pipe logic
+# ("eo:piped") only matches cactus-named references, so without the fix the
+# reference stays expanded as "bar &gt; @" above the handle. The
+# restored-recursive path now relocates that preceding reference to just below
+# the handle and tags it with "@pipe", so "to-eo-tree" emits the "|".
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    bar > @
+    [t] >> bar
+      bar 55 > ii
+printed: |
+  [] > foo
+    [t] >> bar
+      bar 55 > ii
+    | > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
@@ -11,6 +11,13 @@
 # handle under a double-arrow. Without the fix (#5681) the name is dropped:
 # the formation prints as an anonymous "[tup] &gt;&gt;" and its
 # self-references as the synthetic "v6_2" placeholder.
+#
+# The applied reference "reclast list &gt; @" sits just ABOVE the recursive
+# handle; like any applied reference of a "&gt;&gt; name" handle it folds to
+# the compact pipe continuation "| list &gt; @" relocated below the handle
+# (#5848), the mirror of the reference-below fold (#5837). Without that fix the
+# reference stayed expanded above the handle, so the printer emitted two
+# different texts for one object graph.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -40,7 +47,6 @@ printed: |
   [] > last-index-of
     ? >> list
     ? >> wanted
-    reclast list > @
     if. > [tup] >> reclast
       tup.length.eq 0
       -1
@@ -48,3 +54,4 @@ printed: |
         tup.head.eq wanted
         tup.tail.length
         reclast tup.tail
+    | list > @


### PR DESCRIPTION
Fixes #5848.

## Problem

The eo-printer left an applied reference expanded *above* a recursive `>>` handle instead of folding it to the canonical `| > @` below the handle. Feeding this snippet to the printer was a no-op:

```
[] > foo
  bar > @
  [t] >> bar
    bar 55 > ii
```

when the canonical spelling is:

```
[] > foo
  [t] >> bar
    bar 55 > ii
  | > @
```

So the printer emitted two different texts for one object graph.

## Root cause

`restore-local-names.xsl` classifies `[t] >> bar` as recursive (its body references itself through `bar 55`), so it promotes `@local="bar"` to `@name` and de-cactusizes every reference base before `inline-cactoos.xsl` runs. `inline-cactoos` therefore never sees the reference as cactus-named, and its #5834/#5840 relocate-and-pipe machinery cannot fire. The #5837 fix compensates by tagging the reference with `@pipe` inside `restore-local-names` itself, but that template only matches a reference whose *immediately-preceding* sibling is the recursive handle (the reference-below direction). When the reference precedes the handle, nothing tags or relocates it.

## Fix

Handle the reference-above direction in `restore-local-names.xsl`:

- Suppress the applied reference at its origin (a reference whose immediately-following sibling is the recursive handle it resolves to).
- Re-emit it immediately below the recursive handle, tagged `@pipe` — the same relocate-and-pipe that `inline-cactoos` already performs for the non-recursive case (#5840) and the `@pipe` tagging that #5837 performs for the reference-below case.

`to-eo-tree.xsl` renders `@pipe` as `|` once the reference is the handle's following sibling.

## Tests

- Adds `pipe-recursive-self-before.yaml`, the reference-above print-pack from the issue; it reprints to itself (both `printsToEo` and `printsToParseableEo` pass).
- Updates `recursive-local-handle.yaml`, whose expected output encoded the old unfolded form — `reclast list > @` above the handle now folds to `| list > @` below it, consistent with the fix.

All 208 `eo-printer` tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfyqfi9ajYeUB6mzTKNujw)_