### PR TITLE
Reject NAME suffix starting with a non-letter (#5847)

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -360,14 +360,31 @@ final class Suffix {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
-        if (name.charAt(0) < 'a' || name.charAt(0) > 'z') {
+        Suffix.checkLowercaseStart(name, span, home, start);
+        Suffix.endsClean(tail, idx, span, home);
+        return new Suffix.Parsed(form, name, "", false);
+    }
+
+    /**
+     * Reject a name that doesn't start with a lowercase letter — unless
+     * it's the {@code @} void/phi marker, which callers that allow it
+     * (only {@link #named}; {@link #test} rejects {@code @} earlier and
+     * never reaches here with it) pass through untouched.
+     * @param name Extracted name; may be empty
+     * @param span Source span
+     * @param home Source column where the enclosing tail begins
+     * @param at Source column of the name's first character
+     */
+    private static void checkLowercaseStart(
+        final String name, final Span span, final int home, final int at
+    ) {
+        if (!name.isEmpty() && !"@".equals(name)
+            && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
             throw new ParseError(
-                span.line(), home + start,
+                span.line(), home + at,
                 "name must start with a lowercase letter"
             );
         }
-        Suffix.endsClean(tail, idx, span, home);
-        return new Suffix.Parsed(form, name, "", false);
     }
 
     /**
@@ -455,13 +472,7 @@ final class Suffix {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
-        if (!name.isEmpty() && !"@".equals(name)
-            && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
-            throw new ParseError(
-                span.line(), home + begin,
-                "name must start with a lowercase letter"
-            );
-        }
+        Suffix.checkLowercaseStart(name, span, home, begin);
         boolean cnst = false;
         if (idx < tail.length() && tail.charAt(idx) == '!') {
             cnst = true;

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -360,6 +360,12 @@ final class Suffix {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
+        if (name.charAt(0) < 'a' || name.charAt(0) > 'z') {
+            throw new ParseError(
+                span.line(), home + start,
+                "name must start with a lowercase letter"
+            );
+        }
         Suffix.endsClean(tail, idx, span, home);
         return new Suffix.Parsed(form, name, "", false);
     }
@@ -447,6 +453,12 @@ final class Suffix {
             throw new ParseError(
                 span.line(), home + begin,
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
+        if (!name.isEmpty() && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
+            throw new ParseError(
+                span.line(), home + begin,
+                "name must start with a lowercase letter"
             );
         }
         boolean cnst = false;

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -455,7 +455,8 @@ final class Suffix {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
-        if (!name.isEmpty() && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
+        if (!name.isEmpty() && !"@".equals(name)
+            && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
             throw new ParseError(
                 span.line(), home + begin,
                 "name must start with a lowercase letter"

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -39,7 +39,7 @@ package org.eolang.parser;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 final class Suffix {
 
     /**
@@ -373,15 +373,16 @@ final class Suffix {
      * @param name Extracted name; may be empty
      * @param span Source span
      * @param home Source column where the enclosing tail begins
-     * @param at Source column of the name's first character
+     * @param pos Source column of the name's first character
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
     private static void checkLowercaseStart(
-        final String name, final Span span, final int home, final int at
+        final String name, final Span span, final int home, final int pos
     ) {
         if (!name.isEmpty() && !"@".equals(name)
             && (name.charAt(0) < 'a' || name.charAt(0) > 'z')) {
             throw new ParseError(
-                span.line(), home + at,
+                span.line(), home + pos,
                 "name must start with a lowercase letter"
             );
         }

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -355,7 +355,7 @@ final class SuffixTest {
     }
 
     @Test
-    void stillAcceptsAtAsNamedSuffix() {
+    void acceptsAtAsNamedSuffix() {
         MatcherAssert.assertThat(
             "`> @` must keep parsing as Form.NAME — the lowercase-start guard must not"
                 .concat(" reject the phi marker, which desugars through named(), not test()"),

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -319,6 +319,52 @@ final class SuffixTest {
     }
 
     @Test
+    void rejectsUppercaseNamedSuffix() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " > Bar",
+                new Span("[] > Bar", 1), 2
+            ),
+            "`> Bar` must be rejected — a NAME suffix must start with a lowercase letter"
+        );
+    }
+
+    @Test
+    void rejectsDigitLeadingNamedSuffix() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " > 9bad",
+                new Span("[] > 9bad", 1), 2
+            ),
+            "`> 9bad` must be rejected — a NAME suffix cannot start with a digit"
+        );
+    }
+
+    @Test
+    void rejectsUppercasePlusGreaterName() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " +> Bad",
+                new Span("[] +> Bad", 1), 2
+            ),
+            "`+> Bad` must be rejected — a test attribute name must start with a lowercase letter"
+        );
+    }
+
+    @Test
+    void stillAcceptsAtAsNamedSuffix() {
+        MatcherAssert.assertThat(
+            "`> @` must keep parsing as Form.NAME — the lowercase-start guard must not"
+                .concat(" reject the phi marker, which desugars through named(), not test()"),
+            new Suffix(" > @", new Span("[] > @", 1), 2).form(),
+            Matchers.equalTo(Suffix.Form.NAME)
+        );
+    }
+
+    @Test
     void rejectsTrailingGarbageThatIsNotASuffixMarker() {
         Assertions.assertThrows(
             ParseError.class,


### PR DESCRIPTION
`Suffix.named` and `Suffix.test` extract the name token and only guard against the cactus emoji — never check the first char is `[a-z]` per §2.3. So `bar > 42`, `[] > 42`, `bar > -x` all parse and emit invalid XMIR (`name="42"`). Added the same first-char guard used for the cactus check to both paths. Left the `>>` handle path alone since that's tracked separately in #5796.

Fixes #5847.