### PR TITLE
Fold a recursive `>> name` handle's dispatch reference above it (#5848)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -68,16 +68,38 @@
     <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, concat($eo:xi, '.')) and contains($tail, '.') and substring-before($tail, '.') != '' and not(contains(substring-after($tail, '.'), '.'))) then substring-after($tail, '.') else ''"/>
   </xsl:function>
   <!--
+  Whether `$attr` is a restored recursive `&gt;&gt; name` handle: an abstract
+  formation carrying its readable "@local" handle whose visible "@name" has
+  already been promoted to that same handle by "restore-local-names" (which
+  sets "@name = @local" and rewrites the self-references only for a recursive
+  formation, R-3.10.12 / #5681). Its cactus name is gone, yet when it is used
+  as a method-dispatch receiver it must still host onto that dispatch as a
+  reversed-dispatch moniker (#5848) — the recursive mirror of the non-recursive
+  dispatch fold, where the anonymous formation is inlined (#5782). A void
+  ("@base=∅"), a const handle (cactus "@name" ≠ readable "@local") and a plain
+  cactus binding all fail "@name = @local", so only the restored recursive
+  handle is admitted here.
+  -->
+  <xsl:function name="eo:recursive-handle" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:sequence select="eo:abstract($attr) and exists($attr/@local) and exists($attr/@name) and $attr/@name = $attr/@local"/>
+  </xsl:function>
+  <!--
   Whether `$attr` is a formation attribute eligible to become a moniker:
   auto-named with the cactus prefix (`a🌵`, §9.2), either bound (has a base)
   or an abstract formation (#5794), and neither void, `φ`, a test, nor already
   floated with a pipe (`|`). Only the compiler's obfuscated names are merged;
   a real, author-chosen name such as `value` reads best on its own
-  `... > name` line and stays standalone (#5738).
+  `... > name` line and stays standalone (#5738). A restored recursive handle
+  (see `eo:recursive-handle`) is the exception: its readable name is compiler
+  plumbing that the non-recursive path discards entirely, so it too may host
+  onto a dispatch use (#5848). Its bare uses always carry a `@name` (the
+  `| ... > name` pipe #5837/#5848 leaves them with) and so never resolve as a
+  hostable bare reference, so only a genuine dispatch use folds.
   -->
   <xsl:function name="eo:moniker-binding" as="xs:boolean">
     <xsl:param name="attr" as="element()"/>
-    <xsl:sequence select="exists($attr/@name) and starts-with($attr/@name, concat('a', $eo:cactoos)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
+    <xsl:sequence select="exists($attr/@name) and (starts-with($attr/@name, concat('a', $eo:cactoos)) or eo:recursive-handle($attr)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
   The references, in document order, that can host the binding `$attr`: a bare

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -295,12 +295,19 @@
         -->
         <xsl:value-of select="eo:translate-path($self-rest)"/>
       </xsl:when>
-      <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name])">
+      <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
         <!--
         The run of leading "^." parent hops is redundant: the name is
         absent from each of the N nearer enclosing formations but
         present in the (N+1)-th, so plain scope resolution re-derives
         exactly the very same ρ-chain of length N. Drop the whole run.
+        The second alternative catches a recursive self-reference to a
+        file-local handle hosted as a moniker (#5848): the formation reached
+        after the run carries that very handle name in its "@local", so the
+        hops resolve back to the formation itself and the bare handle name
+        re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
+        handle folded into a reversed-dispatch receiver would print its
+        self-reference as `^.name` instead of the readable `name`.
         -->
         <xsl:value-of select="eo:translate-path($hop-rest)"/>
       </xsl:when>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-before.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-before.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A self-referential (recursive) file-local handle ("[buffer] &gt;&gt; bar",
+# R-3.10.12) whose body references itself ("bar chunk") stays in place, and a
+# reference to it that sits ABOVE the handle and is used as a method-dispatch
+# receiver ("bar.read &gt; @") must fold to the compact reversed dispatch
+# "read. &gt; @" hosting the handle (#5848) — the dispatch analogue of the
+# reference-above pipe fold (#5837/#5848) and the recursive mirror of the
+# non-recursive dispatch fold (#5782), where the anonymous formation is inlined
+# as the reversed dispatch's receiver. "restore-local-names" promotes the
+# recursive handle's "@local" to its visible "@name" (and keeps "@local"),
+# stripping the cactus name before "merge-monikers"; "merge-monikers" now
+# recognises the restored recursive handle as a hostable moniker and folds it
+# onto its dispatch use as a reversed dispatch. The handle keeps its readable
+# "&gt;&gt; bar" name so its self-reference still reads as "bar", not the
+# synthetic placeholder. Without the fix the "bar.read &gt; @" line is a no-op
+# and stays expanded above the handle.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    bar.read > @
+    [buffer] >> bar
+      bar chunk > x
+printed: |
+  [] > foo
+    read. > @
+      [buffer] >> bar
+        bar chunk > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-nested.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-nested.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A harder case of the recursive dispatch fold (#5848): the recursive
+# "[buffer] &gt;&gt; bar" handle's dispatch use ("bar.read") is itself buried
+# under a second dispatch ("... .test 66") that reaches it through its "@"
+# result name. The parser hoists the "&gt; @" binding up to "foo", so the
+# printer canonicalises the nested spelling into two lines — the folded
+# reversed dispatch "read. &gt; @" hosting the handle, and "@.test 66 &gt; z"
+# reading the hoisted result — rather than keeping the writer's nesting. The
+# recursive handle still folds onto its "read" dispatch as a reversed-dispatch
+# moniker and keeps its readable "&gt;&gt; bar" name so "bar chunk" reads by
+# name. This confirms the fold survives when the dispatch use sits inside a
+# larger expression, not just as a direct sibling of the handle.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    test. > z
+      read. > @
+        [buffer] >> bar
+          bar chunk > x
+      66
+printed: |
+  [] > foo
+    read. > @
+      [buffer] >> bar
+        bar chunk > x
+    @.test 66 > z


### PR DESCRIPTION
Follow-up to #5848, covering the method-dispatch reference direction (the previous PR #5849 handled bare/applied references that fold to `| ... > @`).

## Problem

The printer left a **dispatch** reference to a recursive `>>` handle expanded when that reference sits *above* the handle. This snippet was a no-op:

```
[] > foo
  bar.read > @
  [buffer] >> bar
    bar chunk > x
```

The canonical spelling folds the dispatch into a reversed dispatch `read. > @` hosting the handle, exactly like the non-recursive counterpart already does:

```
[] > foo
  read. > @
    [buffer] >> bar
      bar chunk > x
```

## Root cause

`restore-local-names.xsl` promotes a recursive handle's `@local` to its visible `@name` and rewrites its references before `merge-monikers.xsl` runs, so the handle is no longer cactus-named. `merge-monikers` only hosts cactus-named bindings onto their uses, so it skipped the recursive handle and the dispatch stayed expanded.

## Fix

- **`merge-monikers.xsl`**: recognise a *restored recursive handle* — an abstract formation whose `@name` equals its kept `@local` — as a hostable moniker, so it folds onto its dispatch use as a reversed dispatch, keeping the readable `>> name` so self-references still read by name. Its bare uses always carry a `@name` (the `| ... > name` pipe), so they never resolve as hostable bare references and only a genuine dispatch use folds — the pipe cases (#5837/#5848) are untouched.
- **`to-eo-tree.xsl`**: hosting nests the formation one level under the reversed-dispatch node, which made the self-reference print as `^.name`. Extend the redundant-`^`-hop drop to recognise a self-reference whose hopped-to formation carries that handle name in `@local`, so it prints the bare `name`.

## Tests

- Adds `dispatch-recursive-self-before.yaml` (the example from the request; the body is given a name so the formation parses). It reprints to itself — both `printsToEo` and `printsToParseableEo` pass.

All 212 `eo-printer` tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfyqfi9ajYeUB6mzTKNujw)_