### PR TITLE
#5779: reject anchored regex match with trailing newline

### DIFF
--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -14,13 +14,17 @@
 [] > os
   name > @
   as-bool. > is-linux
-    matches.
-      string.regex "/linux/i"
-      name
+    exists.
+      next.
+        match.
+          string.regex "/linux/i"
+          name
   as-bool. > is-macos
-    matches.
-      string.regex "/mac/i"
-      name
+    exists.
+      next.
+        match.
+          string.regex "/mac/i"
+          name
   [] > is-windows
     and. > @
       oname.size.gt 6

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -207,8 +207,7 @@
               is-drive-relative ubts
         uri > ubts!
       [uri] > is-drive-relative
-        as-bool. > @
-          (string.regex "/^[a-zA-Z]:/").matches uri
+        ((string.regex "/^[a-zA-Z]:/").match uri).next.exists.as-bool > @
       [uri] > is-root-relative
         and. > @
           ubts.size.gt 0

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -25,5 +25,7 @@
 
   (is-digit "1🌵2").not ++> tests-checks-if-text-with-special-character-is-not-digit
 
+  (is-digit "123\n").not ++> tests-checks-if-text-with-trailing-newline-is-not-digit
+
   is-digit ++> tests-checks-if-very-long-number-is-digit
     "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -50,7 +50,16 @@
       [position start] > matched-from-index /Q.string.regex.pattern.match.matched
       matched. > next
         matched-from-index 1 0
-    (match txt).next.exists > [txt] > matches
+    [txt] > matches
+      found.exists.and > @
+        found.to.eq txt.length
+      next. > found
+        match txt
+
+  ++> tests-does-not-match-anchored-pattern-with-trailing-newline
+    not. > @
+      (regex "/^[0-9]+$/").compiled.matches
+        "123\n"
 
   ++> tests-does-not-matches-regex-against-the-pattern
     not. > @


### PR DESCRIPTION
Closes #5779

`string.regex`'s `matches` was implemented via inline-phi as `(match txt).next.exists`, which returns true whenever ANY prefix of `txt` matches the pattern, even if the match does not consume the whole string. Java's `Matcher.find()` (used under the hood) stops at the first match it finds and does not require it to reach the end of input.

This means an anchored pattern like `/^[0-9]+$/` wrongly matched `"123\n"`, because `find()` matches `"123"` and stops before the trailing newline, even though `^...$` is supposed to anchor to the whole line/string.

Fix: `matches` now also checks that the matched span's end index equals `txt.length`, rejecting any match that does not cover the entire string. `is-digit`, which is built on `matches`, inherits the fix automatically.

Verified:
- New test `tests-does-not-match-anchored-pattern-with-trailing-newline` in `regex.eo`.
- New test `tests-checks-if-text-with-trailing-newline-is-not-digit` in `is-digit.eo`.
- `EOregexTest` (26/26), `EOis_digitTest` (7/7), `EOis_asciiTest` (3/3) all green.
- `qulice:check -Pqulice` on `eo-runtime`: no new violations (pre-existing 100 `UnicodeInCode` violations confirmed present on `upstream/master` too, unrelated to this change, caused by local JDK 21 vs CI's JDK 26 ErrorProne behavior).


Update: CI caught a real regression from this fix. `path.eo`'s win32 `is-drive-relative` used `(string.regex "/^[a-zA-Z]:/").matches uri`, a prefix check ("does the URI start with a drive letter and a colon"), never meant to be a full-string match. It happened to work only because `matches` used to be unanchored. After the fix above, it stopped matching real drive-relative paths, breaking 11 `EOpathTest` win32 tests.

Fixed by switching `is-drive-relative` to the lower-level unanchored `match`/`next`/`exists` path, the one this issue explicitly reserves for this kind of use ("Leave the match/next iteration path, used by scanf-style callers, on its current unanchored find()"). `regex.eo` itself was not touched again.

```
[uri] > is-drive-relative
  ((string.regex "/^[a-zA-Z]:/").match uri).next.exists.as-bool > @
```

Verified:
- `EOpathTest`: 43/43 green (was 11 errors).
- `EOregexTest` (27/27), `EOis_digitTest` (8/8), `EOis_asciiTest` (3/3): still green, no regression on the original fix.
- Full `eo-runtime` test module: 1759/1759 green.
- `qulice:check -Pqulice`: same 100 pre-existing, unrelated `UnicodeInCode` violations, zero new ones.


Update 2: same root cause hit `os.is-linux`/`os.is-macos`, which also used the now-strict `matches` with unanchored, case-insensitive patterns (`/linux/i`, `/mac/i`) meant as substring search (e.g. detecting that `"Mac OS X"` contains `"mac"`). Broke `EOosEOAtomTest.tests_checks_os_family` on macOS CI runners (`os.name` is `"Mac OS X"`, not equal to `"mac"`). `is-windows` was untouched, it never used regex. Fixed with the same unanchored `match`/`next`/`exists` pattern as `path.eo` above.

Verified: `EOosEOAtomTest` 1/1 green (was failing), full `eo-runtime` suite 1759/1759 green, qulice clean.

Note: the `mvn (macos-15-intel, 26)` CI run before this fix also showed unrelated `EOfileTest` failures (temp-file open races). `file.eo` does not use `regex`/`matches` and does not depend on `is-macos`/`is-linux` (only `is-windows`, which is not regex-based), so those are very likely pre-existing macOS runner flakiness, not caused by this branch. Will keep an eye on it after this push.
