### PR TITLE
#5776: make chunk.put strictly-sized, reject overflow instead of resizing

### DIFF
--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -37,7 +37,9 @@
     0
     size
   if. > [object] > put
-    object.size.gt size
+    and.
+      size.gt 0
+      object.size.gt size
     T
       "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
         * object.size size

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -36,11 +36,14 @@
   read > get
     0
     size
-  seq * > [object] > put
-    write
-      0
-      object
-    get
+  if. > [object] > put
+    object.size.gt size
+    T
+      "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
+        * object.size size
+    seq *
+      write 0 object
+      get
   [offset length] > read /Q.bytes
     ? > cant-read /{Q.string}
   [size] > resized /Q.chunk

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -170,6 +170,11 @@
               (m.resized 3).size.eq 3
               m.get.eq 01-02-03
 
+  eq. ++> tests-malloc-empty-grows-on-first-put
+    malloc.empty
+      m.put 42 > [m]
+    42
+
   malloc.empty ++> tests-malloc-empty-is-empty
     m.size.eq 0 > [m]
 


### PR DESCRIPTION
Closes #5776

`chunk.put` was implemented on top of `write`, which auto-resizes the block when the data does not fit:

```
seq * > [object] > put
  write
    0
    object
  get
```

`Heaps.write` grows the block whenever `end > current size`. This meant `put` silently grew the block whenever the object was larger than it, contradicting its documented strictly-sized overwrite contract. As reported: `malloc.for "Hello" (m.put "Much longer string!")` returned the full 19-byte string and grew the block from 5 to 19 bytes.

Per @yegor256's own comment on the issue: chunk should never automatically resize; only `.resized` should change the block size.

Fix: `put` now compares the dataized object's byte length against the chunk's current `size` before writing, and throws instead of writing when the object does not fit:

```
if. > [object] > put
  object.size.gt size
  T
    "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
      * object.size size
  seq *
    write 0 object
    get
```

`write` itself is untouched (its own `writes-beyond-offset-and-resizes` test still relies on the grow behavior), as is `resized` (the explicit resize API) and `copy`.

The existing `on-overflow-boolean-malloc` / `on-overflow-string-malloc` tests in `malloc.eo` were previously vacuous: they passed only because `put` returned non-boolean bytes that made the test's own `asBool()` throw, not because `put` itself rejected the overflow (as the issue pointed out). They now pass because `put` genuinely throws for the right reason. No test changes were needed for them; the fix alone corrects what they exercise.

Update: the first version of this fix was too strict. `malloc.empty` deliberately allocates a size-0 block so its first `.put` gives it a real size (that is the whole point of `malloc.empty`, and the README's own canonical iteration example, `malloc.empty > [args] > app` then `x.put 2`, relies on exactly this). Rejecting that broke `ReadmeSnippetsIT` in CI. Fixed by only rejecting overflow when the chunk already has a non-zero size:

```
if. > [object] > put
  and.
    size.gt 0
    object.size.gt size
  T
    "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
      * object.size size
  seq *
    write 0 object
    get
```

Growing from size 0 (not yet given a size) is still allowed; a chunk that already has a real size never silently changes. Added `tests-malloc-empty-grows-on-first-put` to cover this.

Verified:
- `EOmallocEOAtomTest`: 37/37 green, including both `on-overflow-*` tests and the new empty-grows test.
- Full `eo-runtime` test module: 1758/1758 green, 0 failures.
- `qulice:check -Pqulice` on `eo-runtime`: no new violations from this change (confirmed the same 100 pre-existing `UnicodeInCode` violations, unrelated to `chunk.eo`, are also present on `upstream/master` before this change, caused by local JDK 21 vs CI's JDK 26 ErrorProne behavior).
- Reran the actual failing CI test locally: `mvn -pl eo-integration-tests install -o -Psnippets -Dit.test='ReadmeSnippetsIT'` — now 5/5 green.
