### PR TITLE
Fix spurious numeric element in `*` star tuple with `|` pipe continuation (#5858)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
@@ -5,12 +5,26 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="tuples-to-stars" version="2.0">
   <!--
-  Performs the reverse operation of "/org/eolang/parser/stars-to-tuples.xsl"
+  Performs the reverse operation of "/org/eolang/parser/stars-to-tuples.xsl".
+
+  Each "Φ.tuple" layer built by that sheet holds three children: the
+  nested tuple (o[1]), the element it appends (o[2]), and a trailing
+  "Φ.number" that carries the tuple's length (o[last()]). The element is
+  therefore whatever sits strictly between the nested tuple and that
+  length marker — selected here as "o[position() != 1 and position() !=
+  last()]" rather than a fixed o[2].
+
+  A "| pipe" continuation (§3.14) whose predecessor formation is floated
+  up out of the argument slot ("vars-float-up.xsl") leaves a layer with
+  only its nested tuple and length marker and no element in between. The
+  positional range then selects nothing, so the layer contributes no star
+  element — where a fixed o[2] would have mis-read the length marker as a
+  spurious numeric element (#5858).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@base = 'Φ.tuple' and o[1][starts-with(@base, 'Φ.tuple')]]">
     <xsl:variable name="arg">
-      <xsl:apply-templates select="o[2]"/>
+      <xsl:apply-templates select="o[position() != 1 and position() != last()]"/>
     </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
@@ -33,7 +47,7 @@
   <xsl:template match="o" mode="inner">
     <xsl:if test="@base = 'Φ.tuple'">
       <xsl:variable name="arg">
-        <xsl:apply-templates select="o[2]"/>
+        <xsl:apply-templates select="o[position() != 1 and position() != last()]"/>
       </xsl:variable>
       <xsl:apply-templates select="o[1]" mode="inner"/>
       <xsl:apply-templates select="$arg" mode="no-as"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
@@ -18,7 +18,7 @@
   up out of the argument slot ("vars-float-up.xsl") leaves a layer with
   only its nested tuple and length marker and no element in between. The
   positional range then selects nothing, so the layer contributes no star
-  element — where a fixed o[2] would have mis-read the length marker as a
+  element — where a fixed o[2] would have taken the length marker for a
   spurious numeric element (#5858).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/star-tuple-with-pipe-continuation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/star-tuple-with-pipe-continuation.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A "*" star tuple whose element carries a "| pipe" continuation (§3.14).
+# The pipe's predecessor formation ("[q] >> h") is floated out of the
+# tuple's argument slot after "stars-to-tuples" has already built the
+# nested tuple with its per-layer length markers, leaving one layer with
+# only its nested tuple and a trailing "Φ.number" length marker and no
+# element in between. The reverse "tuples-to-stars" sheet must skip that
+# length marker rather than materialise it as a spurious numeric element
+# (#5858).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    seq * > @
+      [q] >> h
+        q > @
+      | walked
+      ^
+
+printed: |
+  [] > foo
+    seq * > @
+      q > [q] >> h
+      | walked
+      ^


### PR DESCRIPTION
Fixes #5858.

## Problem

`eo-printer` injected a numeric literal that is not present anywhere in the source when printing a `*` star tuple whose element carries a `|` pipe continuation (§3.14):

```
[] > foo
  seq * > @
    [q] >> h
      q > @
    | walked
    ^
```

printed as (note the spurious `1`):

```
[] > foo
  seq * > @
    1
    q > [q] >> h
    | walked
    ^
```

This made the format both lossy (`seq(tuple(h walked, ^))` became `seq(tuple(1, h walked, ^))`) and non-idempotent.

## Root cause

Each `Φ.tuple` layer built by the parser's `stars-to-tuples.xsl` holds three children: the nested tuple (`o[1]`), the appended element (`o[2]`), and a trailing `Φ.number` that carries the tuple's length (`o[last()]`).

A `| pipe` continuation whose predecessor formation is floated out of the argument slot by `vars-float-up.xsl` runs *after* `stars-to-tuples` has already built the nested tuple with its per-layer length markers. Floating the formation removes the element but leaves the length marker, producing a layer with only `{nested tuple, Φ.number}` and no element in between.

The reverse `tuples-to-stars.xsl` sheet always read a fixed `o[2]` as the element, so for such a gap layer it mis-read the `Φ.number` length marker as an actual element — emitting the spurious `1`.

## Fix

Select the element as the range strictly between the nested tuple `o[1]` and the trailing length marker `o[last()]`:

```
o[position() != 1 and position() != last()]
```

A normal layer still yields its single element; a floated (gap) layer yields nothing, so no length marker leaks into the star. Applied to both the top-level template and the recursive `inner` mode.

## Tests

- Adds `star-tuple-with-pipe-continuation.yaml` to `print-packs/yaml`, covering the exact reported shape. It exercises both `printsToEo` (correct output, no spurious element) and `printsToParseableEo` (idempotent round-trip).
- Full `eo-printer` suite: 216 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtsjS8rJxda978pgzBPXsL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtsjS8rJxda978pgzBPXsL)_