### PR TITLE
#5851: reject formatting a source when part of it was not recovered

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -4,7 +4,10 @@
  */
 package org.eolang.maven;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -122,7 +125,7 @@ public final class MjFormat extends MjSafe {
      */
     private boolean reformat(final Path source) throws IOException {
         final String actual = new UncheckedText(new TextOf(source)).asString();
-        final String canonical = this.canonical(actual);
+        final String canonical = this.canonical(source, actual);
         final Diff diff = new Diff(actual, canonical);
         final boolean diverged = !diff.same();
         if (diverged && this.autoFix) {
@@ -154,20 +157,97 @@ public final class MjFormat extends MjSafe {
      * source that has not settled by then is laid out as-is and reported
      * divergent, so it fails loudly instead of looping.</p>
      *
+     * @param path The path of the {@code .eo} file, for the error message
      * @param source The current text of the {@code .eo} file
      * @return The canonical text
      * @throws IOException If fails to parse the source
      */
-    private String canonical(final String source) throws IOException {
+    private String canonical(final Path path, final String source) throws IOException {
         String structure = source;
         for (int pass = 0; pass < MjFormat.SETTLE; ++pass) {
-            final String next = new Xmir(new EoSyntax(structure).parsed()).toEO();
+            final String next = new Xmir(MjFormat.parsed(path, structure)).toEO();
             if (next.equals(structure)) {
                 break;
             }
             structure = next;
         }
-        return new Xmir(new EoSyntax(structure).parsed(), this.weights()).toEO();
+        return new Xmir(MjFormat.parsed(path, structure), this.weights()).toEO();
+    }
+
+    /**
+     * Parse a source and verify none of the source was lost in the process.
+     * A source with a genuine syntax error still yields an XMIR carrying
+     * {@code <errors>} (see {@link Parsing}), but the parser also recovers
+     * from many purely cosmetic layout violations (e.g. extra blank lines,
+     * exactly what this goal exists to fix) the same way, tagged with the
+     * same {@code severity="error"} and no other distinguishing marker.
+     * Rejecting every {@code <errors>} entry, as suggested by the issue this
+     * fixes, would therefore also reject this goal's own core use case.
+     *
+     * <p>What actually matters is whether the recovered tree still covers
+     * the whole source: a genuine syntax error (e.g. an unterminated paren
+     * group) makes the parser stop incorporating source lines into the tree
+     * from that point on, while a cosmetic layout error does not lose any
+     * line. So instead of trusting {@code severity} alone, this also checks
+     * that some {@code <o>} element references a line at or past the
+     * source's last non-blank line; if none does, part of the source was
+     * never parsed at all, and this goal would otherwise print back (or, in
+     * {@code -Deo.autoFix} mode, save) a truncated version of it.</p>
+     *
+     * @param source The path of the {@code .eo} file, for the error message
+     * @param structure The current text of the {@code .eo} file
+     * @return The parsed XMIR
+     * @throws IOException If fails to parse the source
+     */
+    private static XML parsed(final Path source, final String structure) throws IOException {
+        final XML xmir = new EoSyntax(structure).parsed();
+        final long errors = new Xnav(xmir.inner())
+            .element("object")
+            .element("errors")
+            .elements(Filter.withName("error"))
+            .filter(MjFormat::severe)
+            .count();
+        if (errors > 0L && MjFormat.truncated(xmir, structure)) {
+            throw new IllegalStateException(
+                String.format(
+                    "%s does not fully parse (%d error(s) found) and part of it was lost, won't format it",
+                    source, errors
+                )
+            );
+        }
+        return xmir;
+    }
+
+    /**
+     * Whether the parsed tree stops short of the source's last non-blank
+     * line, meaning some of the source was never incorporated into it.
+     * @param xmir The parsed XMIR
+     * @param structure The source text that was parsed
+     * @return TRUE if part of the source was not recovered
+     */
+    private static boolean truncated(final XML xmir, final String structure) {
+        final String[] lines = structure.split(String.valueOf('\n'), -1);
+        int last = 0;
+        for (int idx = 0; idx < lines.length; ++idx) {
+            if (!lines[idx].isBlank()) {
+                last = idx + 1;
+            }
+        }
+        return new Xnav(xmir.inner())
+            .path("//o[@line]")
+            .mapToInt(node -> Integer.parseInt(node.attribute("line").text().orElse("0")))
+            .max()
+            .orElse(0) < last;
+    }
+
+    /**
+     * Whether an {@code <error>} element carries error or critical severity.
+     * @param error The error element
+     * @return TRUE if the error is severe
+     */
+    private static boolean severe(final Xnav error) {
+        final String severity = error.attribute("severity").text().orElse("");
+        return "error".equals(severity) || "critical".equals(severity);
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -7,6 +7,8 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
 import org.eolang.parser.EoSyntax;
@@ -81,6 +83,24 @@ final class MjFormatTest {
     }
 
     @Test
+    void failsWhenSourceDoesNotParse(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(MjFormatTest.unparseable())
+                .execute(MjFormat.class),
+            "a source that fails to parse must not be silently formatted"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must explain that the source does not fully parse",
+            writer.toString(),
+            Matchers.containsString("does not fully parse")
+        );
+    }
+
+    @Test
     void appliesCustomIndentationStep(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the printer must indent with the configured number of spaces",
@@ -130,6 +150,21 @@ final class MjFormatTest {
      */
     private static String canonical(final String program) throws IOException {
         return new Xmir(new EoSyntax(program).parsed()).toEO();
+    }
+
+    /**
+     * A source that fails to parse.
+     * @return The EO text
+     */
+    private static String unparseable() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[x] > main",
+            "  (stdout \"Hello!\" x.print > @",
+            ""
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -87,7 +87,7 @@ final class MjFormatTest {
         final IllegalStateException exception = Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)
-                .withProgram(MjFormatTest.unparseable())
+                .withProgram(MjFormatTest.unparsable())
                 .execute(MjFormat.class),
             "a source that fails to parse must not be silently formatted"
         );
@@ -156,7 +156,7 @@ final class MjFormatTest {
      * A source that fails to parse.
      * @return The EO text
      */
-    private static String unparseable() {
+    private static String unparsable() {
         return String.join(
             System.lineSeparator(),
             "+package foo.x",


### PR DESCRIPTION
Closes #5851

`MjFormat.canonical()` parsed each source with `new EoSyntax(structure).parsed()` and printed the result straight back, but never inspected the produced XMIR for `<errors>`. A source that failed to parse still yields an XMIR carrying those `<errors>` (compare `Parsing`, which logs them, and `Linting`, which fails the build on them). `MjFormat` treated that partial XMIR as valid input: in check mode the parse failure was never surfaced, and under `-Deo.autoFix` the file could be overwritten with a canonical form derived from an incomplete parse, destroying the original.

The literal fix suggested on the issue (throw when any `<error>` has `severity` equal to `error` or `critical`) turned out to be too strict once I tested it against the real parser. I dumped the actual XMIR for two cases:

- A source with extra blank lines (exactly what this goal exists to fix): the parser reports `severity="error"` for `"consecutive blank lines forbidden"` and `"more than one trailing blank line"`, but the object tree is fully intact, nothing is lost.
- A source with a genuine syntax break (an unterminated paren group): also `severity="error"`, but the object tree stops short, the real body of the object is missing entirely.

`Emit.java` (the parser's own error-emission code) hardcodes `severity="error"` for every message it emits, regardless of which rule fired. There is no severity distinction between "cosmetic layout nit" and "genuine content loss" in this parser today. A blanket "reject on any severity=error" check would make `MjFormat` reject its own core use case, and I confirmed this concretely: it broke the existing `reformatsDivergentSourceWhenAutoFixIsOn` test.

Fix: instead of trusting `severity` alone, also check whether the parsed tree's deepest `<o>` line reference reaches the source's last non-blank line. A genuine syntax error makes the parser stop incorporating source lines into the tree from that point on; a cosmetic layout error does not lose any line. Only when both conditions hold (a severe error is present, and the tree is missing content) does this now throw:

```java
if (errors > 0L && MjFormat.truncated(xmir, structure)) {
    throw new IllegalStateException(
        String.format(
            "%s does not fully parse (%d error(s) found) and part of it was lost, won't format it",
            source, errors
        )
    );
}
```

Verified:
- `MjFormatTest`: 6/6 green, including a new `failsWhenSourceDoesNotParse` test (an unterminated paren group now throws with a clear message) and the pre-existing `reformatsDivergentSourceWhenAutoFixIsOn` test (extra blank lines still get fixed), both passing together.
- Full `eo-maven-plugin` test module: 350/350 green (excluding the pre-existing `MjPrintTest` failures, also present on unmodified `upstream/master`, unrelated to this change).
- `qulice:check -Pqulice`: clean.
- Ran the real `format` goal against all 153 real `eo-runtime` `.eo` sources: all still report as canonically formatted, no false positives from the new check.
