### PR TITLE
Fix reversed dispatch dropping the file-local handle of its `&gt;&gt;` suffix

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -100,6 +100,9 @@ final class LnReversed implements Line {
             ".".concat(head.raw()),
             this.span.line(), this.span.indent()
         );
+        if (!suffix.handle().isEmpty()) {
+            emit.local(suffix.handle());
+        }
         if (fragile) {
             emit.fragile();
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -95,10 +95,30 @@ final class LnReversed implements Line {
         Bindings.observeChild(stack, outer, this.span);
         globals.clearBlanks();
         globals.markEmitted();
+        this.emit(emit, suffix, ".".concat(head.raw()), fragile, args, outer);
+    }
+
+    /**
+     * Emit the reversed dispatch's {@code <o base='.<name>'>}, its
+     * file-local handle (for a {@code >> name} auto suffix, #5874), the
+     * fragile/const markers, the horizontal args, and the outer binding
+     * slot. Mirrors the auto-suffix handling of {@link LnFormation},
+     * {@link LnOnlyPhi} and {@link LnVoid}.
+     * @param emit The directives sink
+     * @param suffix The parsed suffix
+     * @param base The dispatch base ({@code .<name>})
+     * @param fragile Whether the dispatch carries the fragile marker
+     * @param args Horizontal args in source order
+     * @param outer Outer inline-binding label, or {@code null}
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private void emit(
+        final Emit emit, final Suffix suffix, final String base,
+        final boolean fragile, final List<Value> args, final String outer
+    ) {
         emit.object(
             suffix.attribute(this.span.line(), this.span.indent()),
-            ".".concat(head.raw()),
-            this.span.line(), this.span.indent()
+            base, this.span.line(), this.span.indent()
         );
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -109,6 +109,21 @@ final class LnReversedTest {
         );
     }
 
+    @Test
+    void emitsLocalHandleForAutoSuffix() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("if. >> index", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `>> name` auto suffix on a reversed dispatch must emit the file-local handle as @local so resolve-local-names.xsl can see it (#5874)",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@local='index' and @base='.if' and not(@method)]"
+            )
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/reversed-local-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/reversed-local-handle.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.if' and @local='pick' and @name='a🌵2-2']
+  - //o[@base='a🌵2-2' and @name='φ']
+  - /object[count(//o[@base='pick'])=0]
+input: |
+  [] > main
+    if. >> pick
+      flag
+      x
+      y
+    pick > @


### PR DESCRIPTION
Closes #5874.

## Problem

A `>>` handle attached to a vertical reversed dispatch with an implicit receiver — like `not. >> first` or `if. >> index!` — never reached the XMIR. In `LnReversed.into` the code emitted the synthetic cactus name via `suffix.attribute(...)`, then `emit.fragile()` and `emit.constant()`, but it never called `emit.local(suffix.handle())`.

Without the `@local` marker, `resolve-local-names.xsl` could not see the handle (its `eo:captor` function looks for a `descendant::o[@local=$name]`), so every reference to the handle name was left untouched and `build-fqns` resolved it to a global `Φ.` that does not exist. The object then failed only at dataization with an unrelated message.

## Fix

Emit the handle right after the `emit.object(...)` call, matching every other line type that accepts an auto suffix (`LnFormation`, `LnOnlyPhi`, `LnVoid`, `ChainEmission`):

```java
if (!suffix.handle().isEmpty()) {
    emit.local(suffix.handle());
}
```

## Test

Added `LnReversedTest#emitsLocalHandleForAutoSuffix`, asserting that `if. >> index` emits `<o local='index' base='.if'>` (no `@method`). All 140 tests in the affected parser suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142yX5DVzddKf2FfKQ2RbNf)_