### PR TITLE
#5875: scope the duplicate-local-name check to the enclosing formation

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -9,7 +9,9 @@
   anonymous object with its cactus @name plus a "@local='foo'" marker. A
   handle is an attribute of the formation that declares it, so we rewrite a
   @base equal to a handle name into that (reserved) cactus name; a handle
-  declared more than once is an error. The "@local" marker is deliberately
+  declared more than once within the same enclosing formation is an error,
+  but two sibling formations may each declare a same-named handle because
+  resolution is lexically scoped (#5875). The "@local" marker is deliberately
   kept on the declaring object so that later passes (in particular the
   printer, see #5563) can recover the readable handle from the otherwise-
   synthetic cactus name instead of printing a placeholder like "vL_P".
@@ -58,14 +60,14 @@
     <xsl:copy>
       <xsl:apply-templates select="(node() except errors)|@*"/>
       <xsl:variable name="errors" as="element()*">
-        <xsl:for-each-group select="//o[@local]" group-by="@local">
+        <xsl:for-each-group select="//o[@local]" group-by="concat(@local, '#', generate-id(ancestor::o[not(@base)][1]))">
           <xsl:if test="count(current-group()) &gt; 1">
             <xsl:element name="error">
               <xsl:attribute name="check" select="'resolve-local-names'"/>
               <xsl:attribute name="line" select="if (current-group()[2]/@line) then current-group()[2]/@line else 0"/>
               <xsl:attribute name="severity" select="'error'"/>
               <xsl:text>duplicate local name '</xsl:text>
-              <xsl:value-of select="current-grouping-key()"/>
+              <xsl:value-of select="current-group()[1]/@local"/>
               <xsl:text>'</xsl:text>
             </xsl:element>
           </xsl:if>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-duplicate-sibling-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-duplicate-sibling-scope.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The duplicate-local-name check is lexically scoped, matching the resolver
+# (#5875). Two sibling formations may each declare a file-local handle of the
+# same name because a handle never leaks sideways between nested formations, so
+# the two "&gt;&gt; dup" handles below are unambiguous and must not be rejected.
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  # both same-named handles survive, each keeping its "@local" marker
+  - /object[count(//o[@local='dup'])=2]
+  # each handle got its own cactus name
+  - /object[count(//o[@local='dup' and @name])=2]
+input: |
+  [] > app
+    [] > first
+      [n] >> dup
+        n > @
+    [] > second
+      [m] >> dup
+        m > @


### PR DESCRIPTION
Closes #5875.

## Problem

The duplicate-local-name check in `resolve-local-names.xsl` grouped every `//o[@local]` by `@local` across the whole document, reporting `duplicate local name 'x'` for any repetition anywhere in the file. But reference resolution in the same stylesheet is **lexically scoped**: `eo:captor` binds a reference to the nearest enclosing formation that declares the name, and its `is` test deliberately stops at a nested formation boundary so that a handle never leaks up out of, or sideways between, nested formations (#5780).

So two sibling formations that each declare a handle of the same name are unambiguous by the resolver's own rules, yet the file was rejected — forcing invented names in exactly the places where privacy is wanted (e.g. `console.eo` couldn't give both `posix-console` and `windows-console` a `>> input-block`).

## Fix

Key the `for-each-group` on the pair of `@local` and the generated id of the nearest enclosing formation (`ancestor::o[not(@base)][1]`), so a duplicate is only reported when two handles of the same name share the same enclosing formation. The error text now reads the name from `current-group()[1]/@local` instead of the composite grouping key.

## Tests

- Added `resolve-local-names-duplicate-sibling-scope.yaml`: two sibling formations each declaring `>> dup` now parse without error, each keeping its own cactus name.
- Existing same-scope duplicate packs (`resolve-local-names-duplicate.yaml`, `void-local-handle-duplicate.yaml`) still report the error, since their handles share one enclosing formation.

All 46 `EoSyntaxTest#checksEoPacks` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCRbYwaUWHSLHPzLzzzFvG)_