### PR TITLE
Keep multi-referenced abstract handle whole in printer (#5876)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -44,7 +44,12 @@
   the const is dataized once and cached in that single binding, so folding
   it into each use would mint an independent const object per reference and
   drop the shared name (#5828); "merge-monikers" later hosts the kept
-  binding onto its first reference.
+  binding onto its first reference. A plain (non-const) auto-named abstract
+  formation reached from more than one site is left untouched for the same
+  reason (#5876): folding the whole formation into every reference drops its
+  shared handle name and strands any sibling helper it reaches on a synthetic
+  "vL_P" id, so the formation and its "@local" handle are kept in place and
+  "merge-monikers" hosts the kept binding onto its first reference.
 
   The inlined value keeps the target's obfuscated cactus `@name` only when
   the name is still meaningful downstream: an abstract formation, whose name
@@ -66,7 +71,7 @@
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
     <xsl:choose>
-      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:dataized-const($target) and eo:multi-referenced($target, $name))">
+      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:multi-referenced($target, $name) and (eo:dataized-const($target) or eo:abstract($target)))">
         <xsl:choose>
           <!--
           The reference is the base of an application — it carries its own
@@ -150,8 +155,9 @@
   Drop an inlined auto-named abstract; keep cactus-named voids, keep
   self-referential (recursive) abstracts, which are never inlined, keep a
   multi-referenced dataized-const handle, which is never inlined (#5828), keep
-  a formation applied through a `@pipe` continuation, which is kept in place
-  above its pipe rather than inlined (#5834), and keep a binding that a
+  a multi-referenced abstract formation, which is never inlined either (#5876),
+  keep a formation applied through a `@pipe` continuation, which is kept in
+  place above its pipe rather than inlined (#5834), and keep a binding that a
   surviving method dispatch still reaches through its name.
   Such a dispatch reference (`ξ.<name>.<seg>`) is not inlined above — its
   receiver is buried in a dotted base — so dropping the binding would strand
@@ -160,7 +166,7 @@
   instead (#5782).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or (eo:dataized-const(.) and eo:multi-referenced(., @name)) or eo:piped(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or (eo:multi-referenced(., @name) and (eo:dataized-const(.) or eo:abstract(.))) or eo:piped(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -221,18 +227,19 @@
     <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, concat('.', $auto)) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
   </xsl:function>
   <!--
-  Whether more than one reference in the binding's owner resolves to the
-  auto-name `$name` (references inside the binding's own subtree excluded).
-  A const binding reached from several sites must stay a single shared handle
-  rather than be folded into each use: inlining it would mint an independent
-  const object per reference, changing the object graph and dropping the
-  shared name (#5828). "merge-monikers" then hosts the kept binding onto its
-  first reference.
+  Whether more than one reference in the binding's owner reaches the auto-name
+  `$name` (references inside the binding's own subtree excluded). A reference
+  reaches `$name` either bare (`ξ.<name>`) or through a method dispatch
+  (`ξ.<name>.<seg>`, whose resolved name carries the bare name as its leading
+  segment); both are counted. Such a shared binding — a const handle (#5828) or
+  an abstract formation (#5876) — is kept whole rather than folded into each use,
+  which would change the object graph or drop the shared handle name, and
+  "merge-monikers" then hosts the kept binding onto its first reference.
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
+    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
   </xsl:function>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -179,6 +179,24 @@
     <xsl:sequence select="if (exists($binding) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
+  The kept multi-referenced abstract handle binding (`[] &gt;&gt; name`, #5876)
+  a reference `$ref` resolves to but does NOT host (the binding folds onto its
+  first reference only, `eo:moniker-refs`). Any other reference — a named alias
+  `name &gt; a` or a further `name.seg` dispatch that the moniker fold leaves
+  in place — keeps the readable "@local" handle in place of the obfuscated
+  cactus name, so it reads back as `name` (or `name.seg`) rather than a
+  synthetic "vL_P" placeholder, the abstract mirror of `eo:kept-const-ref`. The
+  reference is matched by carrying the binding's cactus "@name" as one of its
+  base segments; the binding's own subtree is excluded.
+  -->
+  <xsl:function name="eo:kept-local-ref" as="element()*">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
+    <xsl:variable name="candidates" select="$owner/o[eo:moniker-binding(.) and eo:abstract(.) and exists(@local)]"/>
+    <xsl:variable name="binding" select="$candidates[some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name][1]"/>
+    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+  </xsl:function>
+  <!--
   Replace the first hosting reference with the merged binding, always keeping
   the reference's positional `@as`. A bare reference becomes the binding
   inlined in place: the binding's other attributes and its children. An
@@ -256,6 +274,18 @@
   -->
   <xsl:template match="o[exists(eo:kept-const-ref(.))]/@base" priority="2">
     <xsl:variable name="binding" select="eo:kept-const-ref(..)"/>
+    <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if ($seg = $binding/@name) then string($binding/@local) else $seg), '.')"/>
+  </xsl:template>
+  <!--
+  Rewrite a non-hosting reference to a kept multi-referenced abstract handle
+  (`[] &gt;&gt; name`, #5876) from the obfuscated cactus name back to the
+  readable "@local" handle, so it reads as `name` (or `name.seg`) instead of a
+  synthetic "vL_P" placeholder, the abstract mirror of the const rewrite above.
+  The single hosting reference is rebuilt from the binding and never reaches
+  this template (`eo:kept-local-ref` excludes it).
+  -->
+  <xsl:template match="o[exists(eo:kept-local-ref(.))]/@base" priority="2">
+    <xsl:variable name="binding" select="eo:kept-local-ref(..)"/>
     <xsl:attribute name="base" select="string-join(for $seg in tokenize(., '\.') return (if ($seg = $binding/@name) then string($binding/@local) else $seg), '.')"/>
   </xsl:template>
   <!--

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -67,6 +67,20 @@
     <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
   <!--
+  Whether more than one reference in the binding's owner resolves to the
+  auto-name "$name" (references inside the binding's own subtree excluded).
+  Mirrors "inline-cactoos". A multi-referenced non-const abstract formation
+  ("[] &gt;&gt; name", #5876) is never inlined by "inline-cactoos" (folding
+  the whole formation into every use drops its shared handle name), so like a
+  multi-referenced const handle its "@local" marker is kept here (below) and
+  "merge-monikers" folds the surviving binding onto its first reference.
+  -->
+  <xsl:function name="eo:multi-referenced" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
+  </xsl:function>
+  <!--
   Whether the auto-named abstract formation "$target" is applied by a reference
   that stands as a dispatch receiver rather than a following sibling. Such a
   reference resolves to "$name", carries its own argument children or a
@@ -130,12 +144,14 @@
   <!--
   Keep the marker on voids, on recursive formations, on a formation applied as
   a dispatch receiver (#5844) — so its relocated pipe predecessor prints its
-  readable "&gt;&gt; name" handle — and on the value of a multi-referenced
-  dataized-const handle (see "eo:const-handle") so "to-eo-tree" restores the
-  readable "&gt;&gt; name" handle; drop it on the other non-void formations,
-  whose handle is inlined away by "inline-cactoos".
+  readable "&gt;&gt; name" handle — on a multi-referenced abstract formation
+  (#5876) — kept whole by "inline-cactoos" and hosted by "merge-monikers" — and
+  on the value of a multi-referenced dataized-const handle (see
+  "eo:const-handle") so "to-eo-tree" restores the readable "&gt;&gt; name"
+  handle; drop it on the other non-void formations, whose handle is inlined
+  away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:abstract(.) and eo:multi-referenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-multi-referenced.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-multi-referenced.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A plain (non-const) `[] >> name` abstract formation referenced from more than
+# one site is left in place by "inline-cactoos" (#5876), the same way a
+# multi-referenced const handle is (#5828). Folding the whole formation into
+# every reference would drop its shared handle name and strand any sibling it
+# reaches on a synthetic "vL_P" id, so the formation and its file-local handle
+# are kept and "merge-monikers" later hosts the kept binding onto its first
+# reference.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The multi-referenced formation is not dropped: it keeps its cactus name
+  # and its file-local handle.
+  - /object/o[@name='foo']/o[@name='a🌵4-2' and @local='helper' and not(@base)]
+  # Neither reference is inlined into a copy of the formation body: the bare
+  # reference and the `.neg` dispatch both stay as cactus-named references.
+  - /object/o[@name='foo']/o[@base='ξ.a🌵4-2' and @name='x']
+  - /object/o[@name='foo']/o[@base='ξ.a🌵4-2.neg' and @name='y']
+  # No copy of the formation body was minted at a reference site.
+  - /object[count(//o[not(@base)]/o[starts-with(@name, 'a🌵')])=1]
+input: |
+  [a] > foo
+    helper > x
+    helper.neg > y
+    q.plus 1 > [q] >> helper

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/abstract-multi-referenced-handle-kept.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/abstract-multi-referenced-handle-kept.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The companion to `abstract-multi-referenced-handle` (#5876) where no reference
+# can host the kept formation as a moniker: a named `helper > x` alias resolves
+# to a reference that carries its own `@name`, so it cannot be inlined in place.
+# With no hostable reference the shared `[] >> name` formation is left standing
+# where it is and every named alias reads back through the readable `@local`
+# handle (`helper`), never as a synthetic "vL_P" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    helper > x
+    helper > y
+    [q] >> helper
+      q.plus 1 > @
+
+printed: |
+  [a] > foo
+    q.plus 1 > [q] >> helper
+    helper > x
+    helper > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/abstract-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/abstract-multi-referenced-handle.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A plain (non-const) `[] >> name` abstract formation (R-3.10.12) referenced
+# more than once must stay a single shared formation rather than be copied into
+# every use. Folding the whole formation into each reference drops its shared
+# handle name — `to-eo-tree` prints the anonymous copies as `[] >>` blocks — and
+# strands any sibling helper the formation reaches on a synthetic "vL_P" id, so
+# the printed source no longer parses back to the same object (#5876). Like the
+# multi-referenced const handle (`const-multi-referenced-handle`, #5828), the
+# formation and its `@local` handle are kept whole and hosted onto the first
+# reference as a moniker (`[q] >> helper` under the first `.plus`); the remaining
+# `helper.neg` dispatch reads back through the readable handle rather than a
+# `vL_P` placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    42.plus helper > x
+    helper.neg > y
+    [q] >> helper
+      q.plus 1 > @
+
+printed: |
+  [a] > foo
+    42.plus > x
+      q.plus 1 > [q] >> helper
+    helper.neg > y


### PR DESCRIPTION
Fixes #5876.

## Problem

`inline-cactoos.xsl` folds a reference to an auto-named abstract into the reference site, making exceptions only for a void, a self-referential (recursive) target, and a multi-referenced *const* handle (#5828). A plain (non-const) `[] >> name` abstract formation referenced more than once got **no** exception, so the whole formation was copied into every reference:

- its shared handle name was dropped — `to-eo-tree` printed the copies as anonymous `[] >>` blocks;
- a handle declared as a sibling of the formation is out of scope inside a copy, so its cactus name survived the pipeline and `to-eo-tree` rewrote it to a synthetic `vL_P` id declared nowhere, so the printed source no longer parsed back to the same object (the same symptom as the recursive case in #5681).

## Fix

Treat a multi-referenced non-const auto-named abstract formation the same way a multi-referenced const handle is treated — keep the formation and its `@local` handle in place and let `merge-monikers` host it on the first reference:

- **`restore-local-names.xsl`** — keep the `@local` marker on a multi-referenced abstract formation (previously dropped, since `inline-cactoos` was expected to inline the formation away), so its readable handle survives to `to-eo-tree`.
- **`inline-cactoos.xsl`** — extend the "left untouched" guard and the drop template so a multi-referenced abstract formation is kept whole rather than copied into each reference. Reference counting now also counts dispatch uses (`name.seg`, whose resolved name carries the bare name as its leading segment), so a formation reached from a bare use *and* a dispatch use is recognised as shared.
- **`merge-monikers.xsl`** — the existing moniker machinery already hosts the kept binding onto its first reference; add the abstract mirror of `eo:kept-const-ref` so every *other* reference (a named alias `name > a` or a further `name.seg` dispatch) reads back through the readable `@local` handle instead of a `vL_P` placeholder.

## Tests

- `print-packs/yaml/abstract-multi-referenced-handle.yaml` — round-trip where the kept formation is hosted onto its first reference as a moniker and the remaining `helper.neg` dispatch reads back readably (the abstract counterpart of `const-multi-referenced-handle.yaml`).
- `print-packs/yaml/abstract-multi-referenced-handle-kept.yaml` — round-trip where no reference can host the formation (named aliases), so the binding is left in place and every alias reads through the readable handle.
- `eo-packs/print/inline-cactoos-multi-referenced.yaml` — asserts at the `inline-cactoos` level that the multi-referenced formation and both of its references are kept rather than copied.

The full `eo-printer` suite (225 tests) passes.

## Scope note

This addresses the abstract-formation duplication the issue targets. The `absx`/`absy`-style residual `vL_P` seen in `mod.eo` comes from a **separate, pre-existing** defect: a non-const *based* `>> name` handle (e.g. `x.abs >> absx`) reached only through method dispatch is kept but loses its `@local`. That reproduces with a single-referenced formation and with no abstract formation at all, so it is independent of the multi-reference fixed here and would be a follow-up change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo3idnjfN9CDuhhz4MyLEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vo3idnjfN9CDuhhz4MyLEZ)_