### PR TITLE
Charge a line-leading `(` four times in eo-printer `Penalty` BRACKET term

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -26,7 +26,10 @@ import java.util.Map;
  *   points, multiplied by its nesting depth plus one, so a top-level
  *   bracket costs the flat weight, a bracket nested one level deep costs
  *   twice as much, two levels deep three times, and so on, since deeper
- *   nesting hurts readability more;</li>
+ *   nesting hurts readability more; a parenthesis that is the first
+ *   non-space character of its line pays an extra {@link PenaltyKey#LEADING}
+ *   factor on top, since a group opening a line, before the reader knows
+ *   what it applies to, is the worst place for a bracket;</li>
  *   <li>every explicit phi attribute {@code @} costs
  *   {@link PenaltyKey#PHI} points;</li>
  *   <li>every {@code if} dispatched in suffix position ({@code foo.if})
@@ -118,7 +121,7 @@ final class Penalty {
             final int spaces = Penalty.spaces(line);
             final int applied = Penalty.applied(line);
             total += this.indents(line) * this.weight(PenaltyKey.INDENT);
-            total += Penalty.brackets(line) * this.weight(PenaltyKey.BRACKET);
+            total += this.brackets(line) * this.weight(PenaltyKey.BRACKET);
             total += Penalty.phis(line) * this.weight(PenaltyKey.PHI);
             total += Penalty.ifs(line) * this.weight(PenaltyKey.IF);
             total += Math.max(0, line.length() - this.weight(PenaltyKey.WIDTH))
@@ -253,16 +256,31 @@ final class Penalty {
      * counts as {@code depth + 1} units of the flat {@link PenaltyKey#BRACKET}
      * weight, so the printer leans away from deeply nested one-liners.</p>
      *
+     * <p>A parenthesis that is the first non-space character of its line is
+     * charged {@link PenaltyKey#LEADING} times as much, so it counts as
+     * {@code (depth + 1) * LEADING} units. The start of a line is the worst
+     * place for a group: the reader meets it before knowing what it applies
+     * to, and the line has to be read backwards to make sense of it, so the
+     * printer is pushed away from that layout.</p>
+     *
      * @param line The line
      * @return The weighted number of parentheses
      */
-    private static int brackets(final String line) {
+    private int brackets(final String line) {
+        int lead = 0;
+        while (lead < line.length() && line.charAt(lead) == ' ') {
+            ++lead;
+        }
         int count = 0;
         int depth = 0;
         for (int idx = 0; idx < line.length(); ++idx) {
             final char chr = line.charAt(idx);
             if (chr == '(') {
-                count += depth + 1;
+                int units = depth + 1;
+                if (idx == lead) {
+                    units *= this.weight(PenaltyKey.LEADING);
+                }
+                count += units;
                 ++depth;
             } else if (chr == ')' && depth > 0) {
                 --depth;

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -15,7 +15,7 @@ package org.eolang.printer;
  * one aesthetic is no longer baked into the tool.</p>
  *
  * @since 0.57.0
- * @checkstyle MagicNumberCheck (55 lines)
+ * @checkstyle MagicNumberCheck (65 lines)
  */
 public enum PenaltyKey {
 
@@ -29,6 +29,14 @@ public enum PenaltyKey {
      * parenthesis on a line costs k times this weight.
      */
     BRACKET(19),
+
+    /**
+     * The factor by which an opening parenthesis that is the first non-space
+     * character of its line is charged more heavily, since a group standing at
+     * the start of a line, before the reader knows what it applies to, is the
+     * worst place for a bracket.
+     */
+    LEADING(4),
 
     /**
      * Points charged for each explicit phi attribute {@code @} on a line.

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyKeyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyKeyTest.java
@@ -40,6 +40,19 @@ final class PenaltyKeyTest {
     }
 
     @Test
+    void honoursOverriddenLeadingWeight() {
+        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
+        weights.put(PenaltyKey.LEADING, 1);
+        weights.put(PenaltyKey.SYMBOL, 0);
+        weights.put(PenaltyKey.SPACE, 0);
+        MatcherAssert.assertThat(
+            "A leading parenthesis with the factor tuned to one should cost the same as a mid-line one",
+            new Penalty("(a) > x", weights).points(),
+            Matchers.equalTo(new Penalty("f (a) > x", weights).points())
+        );
+    }
+
+    @Test
     void honoursOverriddenStepWeight() {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.STEP, 4);

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -66,7 +66,9 @@ final class PenaltyTest {
     @ParameterizedTest
     @CsvSource({
         "'f (a) (b)', 38",
-        "'(a (b (c 1)))', 114"
+        "'(a (b (c 1)))', 171",
+        "'f (a).eq b', 19",
+        "'(a).eq b', 76"
     })
     void chargesForParentheses(final String code, final int points) {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
@@ -74,7 +76,7 @@ final class PenaltyTest {
         weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             String.format(
-                "The parentheses in %s should cost %d points, deeper nesting charged more",
+                "The parentheses in %s should cost %d points, deeper nesting and a leading one charged more",
                 code, points
             ),
             new Penalty(code, weights).points(),

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# The origin dispatches off a compound receiver in suffix form, which would
+# open the line with a group. With the default LEADING factor of 4 (issue
+# #5880) that line-leading `(` is charged four times as much, so the receiver
+# is broken out onto its own indented lines instead of standing at the head of
+# the line.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -14,4 +19,6 @@ origin: |
 
 printed: |
   [input] > input-length
-    (input.read 4096).read.^ > chunk
+    ^. > chunk
+      read.
+        input.read 4096

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
@@ -18,9 +18,11 @@ origin: |
 
 printed: |
   [a b c] > math
-    (a.plus b).div > mean
+    div. > mean
+      a.plus b
       c
-    (a.gt b).and > sorted
+    and. > sorted
+      a.gt b
       b.gt c
     a.plus b > sum
     a.plus > weighted

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
@@ -35,7 +35,9 @@ printed: |
     lt. ++> tests-cosine-of-pi-thirds-is-half
       abs
         minus.
-          (cosine (pi.div 3)).times
+          times.
+            cosine
+              pi.div 3
             1000
           500
       1

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
@@ -22,5 +22,6 @@ printed: |
       3
       4
     width.times height > [width height] > rectangle
-    (rectangle 3 4).plus > total
+    plus. > total
+      rectangle 3 4
       rectangle 1 2

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -54,7 +54,9 @@
 
   true.eq true ++> tests-compares-two-bools
 
-  (true.eq 42).not ++> tests-compares-two-different-bool-types
+  ++> tests-compares-two-different-bool-types
+    not. > @
+      true.eq 42
 
   ++> tests-compiles-correctly-with-long-duplicate-names
     true > @
@@ -202,7 +204,9 @@
         x.eq 42 > [] > @
     42 > x
 
-  (true.and false).not ++> tests-true-and-false-is-false
+  ++> tests-true-and-false-is-false
+    not. > @
+      true.and false
 
   true.as-bool ++> tests-true-as-bool
 

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -115,11 +115,17 @@
 
   F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
 
-  (-1.as-bytes.eq -1.as-bytes.not).not ++> tests-not-with-neg
+  ++> tests-not-with-neg
+    not. > @
+      -1.as-bytes.eq -1.as-bytes.not
 
-  (53.as-bytes.eq 53.as-bytes.not).not ++> tests-not-with-plus
+  ++> tests-not-with-plus
+    not. > @
+      53.as-bytes.eq 53.as-bytes.not
 
-  (0.as-bytes.eq 0.as-bytes.not).not ++> tests-not-with-zero
+  ++> tests-not-with-zero
+    not. > @
+      0.as-bytes.eq 0.as-bytes.not
 
   eq. ++> tests-or-neg-bytes-as-number-with-zero
     as-number.

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -11,4 +11,6 @@
   ? >> bts
   bts.eq 01- > @
 
-  (01-.as-bool.eq 00-.as-bool).not ++> tests-convertible-to-bool
+  ++> tests-convertible-to-bool
+    not. > @
+      01-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -44,12 +44,16 @@
             as-bytes.
               data.slice
                 next
-                (number available).minus
+                minus.
+                  number available
                   number next
-            (data.slice 0 next).as-bytes
+            as-bytes.
+              data.slice 0 next
         data.size > available!
         if. > next!
-          (number available).gt requested
+          gt.
+            number available
+            requested
           requested
           available
         size > requested!

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -31,9 +31,15 @@
     0
 
   and. ++> tests-hash-code-bools-is-number
-    (hash true).as-bytes.size.eq
+    eq.
+      size.
+        as-bytes.
+          hash true
       8
-    (hash false).as-bytes.size.eq
+    eq.
+      size.
+        as-bytes.
+          hash false
       8
 
   ++> tests-hash-code-int-is-int

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -40,7 +40,9 @@
       seq * > [mem]
         write.
           write.
-            (to-output mem).write 01-02-03
+            write.
+              to-output mem
+              01-02-03
             04-05-06-07
           08-09-A0
         mem

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -63,7 +63,9 @@
     and. > @
       and.
         and.
-          (inner.is-directory.and inner.exists).and f.exists
+          and.
+            inner.is-directory.and inner.exists
+            f.exists
           d.deleted.exists.not
         inner.exists.not
       f.exists.not
@@ -88,21 +90,35 @@
 
   ++> tests-deletes-empty-directory
     not. > @
-      (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted.exists
+      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
 
   ++> tests-makes-new-directory
     d.exists.and d.is-directory > @
-    (mktemp.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
+    made. > d
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-new"
 
   ++> tests-walks-recursively
     seq * > @
-      (d.resolved "foo/bar").as-dir.made
-      (d.resolved "foo/bar/test.txt").as-file.touched
-      (d.resolved "x/y/z").as-dir.made
-      (d.resolved "x/y/z/a.txt").as-file.touched
-      (d.as-dir.walk "**/*.txt").length.eq
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**/*.txt"
         2
-    (directory mktemp.tmpfile.deleted).made.as-path > d
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
 
   mktemp.open --> on-opening-directory
     "w"

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -52,7 +52,9 @@
   [cant-check] > is-directory
     if. > @
       info.code.eq 0
-      (info.output.mode.div 4096).floor.eq
+      eq.
+        floor.
+          info.output.mode.div 4096
         4
       cant-check
     called. > info
@@ -94,10 +96,14 @@
           open-file
           ^
     mode > access!
-    (access.eq "a").as-bool.or > appending
+    or. > appending
+      as-bool.
+        access.eq "a"
       as-bool.
         access.eq "a+"
-    (access.eq "r").as-bool.or > existing
+    or. > existing
+      as-bool.
+        access.eq "r"
       as-bool.
         access.eq "r+"
     or. > known
@@ -140,14 +146,18 @@
           syscall.rdwr
           writable.if syscall.wronly syscall.rdonly
         plus. > flags
-          (direction.plus creat).plus trunc
+          plus.
+            direction.plus creat
+            trunc
           append
         called. > opened
           syscall.open
             * path flags syscall.mode
         [descriptor] > stream
           [size] > read
-            (input-block --).read size > @
+            read. > @
+              input-block --
+              size
             [buffer] > input-block
               buffer > @
               [size] > read
@@ -175,12 +185,21 @@
                       * descriptor buffer buffer.size
                   output-block
         truncate.if syscall.trunc 0 > trunc
-    (access.eq "w").as-bool.not.and > readable
-      (access.eq "a").as-bool.not
-    (access.eq "w").as-bool.or > truncate
+    and. > readable
+      not.
+        as-bool.
+          access.eq "w"
+      not.
+        as-bool.
+          access.eq "a"
+    or. > truncate
+      as-bool.
+        access.eq "w"
       as-bool.
         access.eq "w+"
-    (access.eq "r").as-bool.not > writable
+    not. > writable
+      as-bool.
+        access.eq "r"
   [cant-measure] > size
     if. > @
       info.code.eq 0
@@ -235,9 +254,14 @@
         f.write "!" > [f]
     13
 
-  (file "absent.txt").exists.not ++> tests-check-if-absent-file-does-not-exist
+  ++> tests-check-if-absent-file-does-not-exist
+    not. > @
+      exists.
+        file "absent.txt"
 
-  (file ".").is-directory ++> tests-check-if-current-directory-is-directory
+  ++> tests-check-if-current-directory-is-directory
+    is-directory. > @
+      file "."
 
   mktemp.tmpfile.deleted.is-directory ++> tests-checking-absent-file-returns-fallback
     true
@@ -317,7 +341,8 @@
           13
           [m] >>
             seq * > @
-              (file src).open
+              open.
+                file src
                 "r"
                 m.put > [f] >>
                   f.read 13
@@ -337,7 +362,9 @@
                 f.write "Hello, world" > [f]
               "r"
               m.put > [f] >>
-                (f.read 7).read 5
+                read.
+                  f.read 7
+                  5
             m
       "world"
 
@@ -439,7 +466,8 @@
           14
           [m] >>
             seq * > @
-              (file src).open
+              open.
+                file src
                 "r"
                 m.put > [f] >>
                   f.read 14
@@ -458,7 +486,9 @@
     13
 
   --> an-error-on-touching-temp-file-in-absent-dir
-    (mktemp.as-path.resolved "foo").@.tmpfile > @
+    tmpfile. > @
+      @.
+        mktemp.as-path.resolved "foo"
 
   mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
 

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -71,7 +71,9 @@
       2
   [x] > times
     i16 right > @
-    (as-i32.times x.as-i16.as-i32).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i32.times x.as-i16.as-i32
       2
       2
 
@@ -103,13 +105,19 @@
     13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
 
-  (123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16).not ++> tests-i16-eq-false
+  ++> tests-i16-eq-false
+    not. > @
+      123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
 
   123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
 
-  (0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16).not ++> tests-i16-greater-equal
+  ++> tests-i16-greater-equal
+    not. > @
+      0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
 
-  (0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16).not ++> tests-i16-greater-false
+  ++> tests-i16-greater-false
+    not. > @
+      0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
 
   gt. ++> tests-i16-greater-true
     -200.as-i64.as-i32.as-i16
@@ -117,21 +125,29 @@
 
   113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
 
-  (0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16).not ++> tests-i16-gte-false
+  ++> tests-i16-gte-false
+    not. > @
+      0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
 
   -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
 
   42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
 
-  (10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16).not ++> tests-i16-less-equal
+  ++> tests-i16-less-equal
+    not. > @
+      10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
 
-  (10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16).not ++> tests-i16-less-false
+  ++> tests-i16-less-false
+    not. > @
+      10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
 
   10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
 
   50.as-i64.as-i32.as-i16.lte 50.as-i64.as-i32.as-i16 ++> tests-i16-lte-equal
 
-  (0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16).not ++> tests-i16-lte-false
+  ++> tests-i16-lte-false
+    not. > @
+      0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
 
   -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
 

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -79,7 +79,9 @@
       4
   [x] > times
     i32 right > @
-    (as-i64.times x.as-i32.as-i64).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i64.times x.as-i32.as-i64
       4
       4
 
@@ -111,33 +113,47 @@
     13.as-i64.as-i32.div -5.as-i64.as-i32
     -2.as-i64.as-i32
 
-  (123.as-i64.as-i32.eq 42.as-i64.as-i32).not ++> tests-i32-eq-false
+  ++> tests-i32-eq-false
+    not. > @
+      123.as-i64.as-i32.eq 42.as-i64.as-i32
 
   123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
 
-  (0.as-i64.as-i32.gt 0.as-i64.as-i32).not ++> tests-i32-greater-equal
+  ++> tests-i32-greater-equal
+    not. > @
+      0.as-i64.as-i32.gt 0.as-i64.as-i32
 
-  (0.as-i64.as-i32.gt 100.as-i64.as-i32).not ++> tests-i32-greater-false
+  ++> tests-i32-greater-false
+    not. > @
+      0.as-i64.as-i32.gt 100.as-i64.as-i32
 
   -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
 
   113.as-i64.as-i32.gte 113.as-i64.as-i32 ++> tests-i32-gte-equal
 
-  (0.as-i64.as-i32.gte 10.as-i64.as-i32).not ++> tests-i32-gte-false
+  ++> tests-i32-gte-false
+    not. > @
+      0.as-i64.as-i32.gte 10.as-i64.as-i32
 
   -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
 
   42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
 
-  (10.as-i64.as-i32.lt 10.as-i64.as-i32).not ++> tests-i32-less-equal
+  ++> tests-i32-less-equal
+    not. > @
+      10.as-i64.as-i32.lt 10.as-i64.as-i32
 
-  (10.as-i64.as-i32.lt -5.as-i64.as-i32).not ++> tests-i32-less-false
+  ++> tests-i32-less-false
+    not. > @
+      10.as-i64.as-i32.lt -5.as-i64.as-i32
 
   10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
 
   50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
 
-  (0.as-i64.as-i32.lte -10.as-i64.as-i32).not ++> tests-i32-lte-false
+  ++> tests-i32-lte-false
+    not. > @
+      0.as-i64.as-i32.lte -10.as-i64.as-i32
 
   -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
 

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -147,9 +147,12 @@
       i64 acc
       looped
         if.
-          (b.and 00-00-00-00-00-00-00-01).eq 00-00-00-00-00-00-00-01
+          eq.
+            b.and 00-00-00-00-00-00-00-01
+            00-00-00-00-00-00-00-01
           as-bytes.
-            (i64 acc).plus
+            plus.
+              i64 acc
               i64 a
           acc
         a.left 1
@@ -209,13 +212,19 @@
     13.as-i64.div -5.as-i64
     -2.as-i64
 
-  (123.@.eq 42.@).not ++> tests-i64-eq-false
+  ++> tests-i64-eq-false
+    not. > @
+      123.@.eq 42.@
 
   123.@.eq 123.@ ++> tests-i64-eq-true
 
-  (0.as-i64.gt 0.as-i64).not ++> tests-i64-greater-equal
+  ++> tests-i64-greater-equal
+    not. > @
+      0.as-i64.gt 0.as-i64
 
-  (0.as-i64.gt 100.as-i64).not ++> tests-i64-greater-false
+  ++> tests-i64-greater-false
+    not. > @
+      0.as-i64.gt 100.as-i64
 
   gt. ++> tests-i64-greater-max-over-min
     i64 7F-FF-FF-FF-FF-FF-FF-FF
@@ -235,7 +244,9 @@
 
   113.as-i64.gte 113.as-i64 ++> tests-i64-gte-equal
 
-  (0.as-i64.gte 10.as-i64).not ++> tests-i64-gte-false
+  ++> tests-i64-gte-false
+    not. > @
+      0.as-i64.gte 10.as-i64
 
   -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
 
@@ -251,9 +262,13 @@
 
   -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
 
-  (10.as-i64.lt 10.as-i64).not ++> tests-i64-less-equal
+  ++> tests-i64-less-equal
+    not. > @
+      10.as-i64.lt 10.as-i64
 
-  (10.as-i64.lt -5.as-i64).not ++> tests-i64-less-false
+  ++> tests-i64-less-false
+    not. > @
+      10.as-i64.lt -5.as-i64
 
   10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
 
@@ -263,7 +278,9 @@
 
   50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
 
-  (0.as-i64.lte -10.as-i64).not ++> tests-i64-lte-false
+  ++> tests-i64-lte-false
+    not. > @
+      0.as-i64.lte -10.as-i64
 
   -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
 

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -29,7 +29,9 @@
         "Can't divide %d by i8 zero".printf
           * as-number
       i8 quotient
-    (as-i16.div xval.as-i16).as-bytes.slice > quotient
+    slice. > quotient
+      as-bytes.
+        as-i16.div xval.as-i16
       1
       1
     x.as-i8 > xval
@@ -40,18 +42,24 @@
   as-i16.lte x.as-i8.as-i16 > [x] > lte
   [x] > minus
     i8 right > @
-    (as-i16.minus x.as-i8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.minus x.as-i8.as-i16
       1
       1
   times FF-.as-i8 > neg
   [x] > plus
     i8 right > @
-    (as-i16.plus x.as-i8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.plus x.as-i8.as-i16
       1
       1
   [x] > times
     i8 right > @
-    (as-i16.times x.as-i8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.times x.as-i8.as-i16
       1
       1
 
@@ -77,7 +85,9 @@
     0D-.as-i8.div FB-.as-i8
     FE-.as-i8
 
-  (2A-.as-i8.eq 2B-.as-i8).not ++> tests-i8-eq-false
+  ++> tests-i8-eq-false
+    not. > @
+      2A-.as-i8.eq 2B-.as-i8
 
   2A-.as-i8.eq 2A-.as-i8 ++> tests-i8-eq-true
 
@@ -87,7 +97,9 @@
 
   C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
 
-  (0A-.as-i8.lt 0A-.as-i8).not ++> tests-i8-less-equal
+  ++> tests-i8-less-equal
+    not. > @
+      0A-.as-i8.lt 0A-.as-i8
 
   0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
 

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -16,7 +16,9 @@
       rec-read
         chunk
         length.plus chunk.size
-    (input.read 4096).read.^ > chunk
+    ^. > chunk
+      read.
+        input.read 4096
   | > @
     input
     0

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -36,8 +36,8 @@
         seq * > @
           written
           input-block chunk written chunk.as-bytes
-        (input.read size).read.^ > chunk
-        (output.write chunk).write.^ > written
+        ^. (input.read size).read > chunk
+        ^. (output.write chunk).write > written
 
   eq. ++> tests-reads-from-bytes-and-writes-to-memory
     malloc.of

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -156,7 +156,8 @@
             m.write 0 "XXX"
             m.write 1 "Y"
             b.put
-              (m.read 0 3).eq
+              eq.
+                m.read 0 3
                 "XYX"
 
   ++> tests-malloc-decreases-block-size
@@ -167,7 +168,7 @@
           01-02-03-04-05
           b.put > [m] >>
             and.
-              (m.resized 3).size.eq 3
+              eq. (m.resized 3).size 3
               m.get.eq 01-02-03
 
   eq. ++> tests-malloc-empty-grows-on-first-put
@@ -197,7 +198,7 @@
           01-02-03-04
           b.put > [m] >>
             and.
-              (m.resized 6).size.eq 6
+              eq. (m.resized 6).size 6
               m.get.eq 01-02-03-04-00-00
 
   eq. ++> tests-malloc-is-strictly-sized-int
@@ -245,7 +246,8 @@
           seq * > [m] >>
             m.write 2 "Hello"
             b.put
-              (m.read 2 5).eq
+              eq.
+                m.read 2 5
                 "Hello"
 
   ++> tests-malloc-rewrites-and-increments-itself
@@ -281,7 +283,8 @@
               "Hello, "
             m.write 7 "Jeff!"
             b.put
-              (m.read 0 12).eq
+              eq.
+                m.read 0 12
                 "Hello, Jeff!"
 
   eq. ++> tests-memory-is-strictly-sized-string

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -46,7 +46,8 @@
         ent.length.eq 0
         false
         if.
-          (ent.head.hash.eq hash).and
+          and.
+            ent.head.hash.eq hash
             ent.head.kbts.eq kbts
           true
           has-key ent.tail
@@ -75,7 +76,8 @@
           prev.exists.if
             prev
             if.
-              (tup.head.hash.eq hash).and
+              and.
+                tup.head.hash.eq hash
                 tup.head.kbts.eq kbts
               [] >>
                 true > exists
@@ -83,7 +85,9 @@
               not-found
         @. > prev
           rec-key-search tup.tail
-    (found key).exists > [key] > has
+    [key] > has
+      exists. > @
+        found key
     tuple.mapped > keys
       entries
       entry.key > [entry]
@@ -98,7 +102,8 @@
             entries
             [entry] >>
               not. > @
-                (hash.eq entry.hash).and
+                and.
+                  hash.eq entry.hash
                   kbts.eq entry.kbts
           [] >>
             ^.hash > hash
@@ -113,7 +118,8 @@
           entries
           [entry] >>
             not. > @
-              (hash.eq entry.hash).and
+              and.
+                hash.eq entry.hash
                 kbts.eq entry.kbts
       bytes.hash kbts > hash!
       key.as-bytes > kbts!
@@ -233,8 +239,10 @@
         0
         [m]
           seq * > @
-            (mp.found 1).exists
-            (mp.found 1).exists
+            exists.
+              mp.found 1
+            exists.
+              mp.found 1
             m
           map * > mp
             map.entry
@@ -254,7 +262,9 @@
       "one"
 
   ++> tests-removes-only-the-given-key-of-colliding-ones
-    (mp.has "Aa").not.and > @
+    and. > @
+      not.
+        mp.has "Aa"
       mp.has "BB"
     without. > mp
       map *

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -64,9 +64,11 @@
       false
       or.
         and.
-          (xbts.eq pzero).or
+          or.
+            xbts.eq pzero
             xbts.eq nzero
-          (bts.eq pzero).or
+          or.
+            bts.eq pzero
             bts.eq nzero
         bts.eq xbts
     as-bytes > bts!
@@ -176,16 +178,25 @@
                   and.
                     and.
                       and.
-                        ((0.eq nan).eq false).and
-                          (0.eq pinf).eq false
-                        (0.eq ninf).eq false
-                      (42.5.eq nan).eq false
-                    (42.5.eq pinf).eq false
-                  (42.5.eq ninf).eq false
-                (0.eq nan).eq false
-              (0.eq pinf).eq false
-            (0.eq ninf).eq false
-          (42.5.eq nan).eq false
+                        and.
+                          eq. (0.eq nan) false
+                          eq. (0.eq pinf) false
+                        eq. (0.eq ninf) false
+                      eq. (42.5.eq nan) false
+                    eq. (42.5.eq pinf) false
+                  eq. (42.5.eq ninf) false
+                eq.
+                  0.eq nan
+                  false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.5.eq nan
+            false
         eq.
           42.5.eq pinf
           false
@@ -209,10 +220,18 @@
         and.
           and.
             and.
-              (0.eq nan).eq false
-              (0.eq pinf).eq false
-            (0.eq ninf).eq false
-          (42.eq nan).eq false
+              eq.
+                0.eq nan
+                false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.eq nan
+            false
         eq.
           42.eq pinf
           false
@@ -251,9 +270,13 @@
     as-bytes.
       0.div 0
 
-  (nan.eq nan).not ++> tests-nan-not-eq-nan
+  ++> tests-nan-not-eq-nan
+    not. > @
+      nan.eq nan
 
-  (nan.eq 42).not ++> tests-nan-not-eq-number
+  ++> tests-nan-not-eq-number
+    not. > @
+      nan.eq 42
 
   eq. ++> tests-nan-not-gt-nan
     nan.gt nan
@@ -316,18 +339,28 @@
 
   ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
 
-  (ninf.gt ninf).not ++> tests-negative-infinity-gt-negative-infinity
+  ++> tests-negative-infinity-gt-negative-infinity
+    not. > @
+      ninf.gt ninf
 
   ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
     -1.div 0
 
-  (ninf.eq 42.5).not ++> tests-negative-infinity-not-eq-float
+  ++> tests-negative-infinity-not-eq-float
+    not. > @
+      ninf.eq 42.5
 
-  (ninf.eq 42).not ++> tests-negative-infinity-not-eq-int
+  ++> tests-negative-infinity-not-eq-int
+    not. > @
+      ninf.eq 42
 
-  (ninf.eq nan).not ++> tests-negative-infinity-not-eq-nan
+  ++> tests-negative-infinity-not-eq-nan
+    not. > @
+      ninf.eq nan
 
-  (ninf.eq pinf).not ++> tests-negative-infinity-not-eq-positive-infinity
+  ++> tests-negative-infinity-not-eq-positive-infinity
+    not. > @
+      ninf.eq pinf
 
   eq. ++> tests-negative-infinity-not-gt-float
     ninf.gt 42.5
@@ -507,20 +540,32 @@
 
   pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
 
-  (pinf.gt pinf).not ++> tests-positive-infinity-gt-positive-infinity
+  ++> tests-positive-infinity-gt-positive-infinity
+    not. > @
+      pinf.gt pinf
 
   pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
     1.div 0
 
-  (pinf.eq 42.5).not ++> tests-positive-infinity-not-eq-float
+  ++> tests-positive-infinity-not-eq-float
+    not. > @
+      pinf.eq 42.5
 
-  (pinf.eq 42).not ++> tests-positive-infinity-not-eq-int
+  ++> tests-positive-infinity-not-eq-int
+    not. > @
+      pinf.eq 42
 
-  (pinf.eq nan).not ++> tests-positive-infinity-not-eq-nan
+  ++> tests-positive-infinity-not-eq-nan
+    not. > @
+      pinf.eq nan
 
-  (pinf.eq ninf).not ++> tests-positive-infinity-not-eq-negative-infinity
+  ++> tests-positive-infinity-not-eq-negative-infinity
+    not. > @
+      pinf.eq ninf
 
-  (pinf.gt nan).not ++> tests-positive-infinity-not-gt-nan
+  ++> tests-positive-infinity-not-gt-nan
+    not. > @
+      pinf.gt nan
 
   eq. ++> tests-positive-infinity-plus-nan
     as-bytes.

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,13 +15,21 @@
     pi.div 2
     arc-sine num
 
-  (arc-cosine 2).is-nan ++> tests-arc-cosine-above-one-is-nan
+  ++> tests-arc-cosine-above-one-is-nan
+    is-nan. > @
+      arc-cosine 2
 
-  (arc-cosine -2).is-nan ++> tests-arc-cosine-below-minus-one-is-nan
+  ++> tests-arc-cosine-below-minus-one-is-nan
+    is-nan. > @
+      arc-cosine -2
 
-  (arc-cosine nan).is-nan ++> tests-arc-cosine-of-nan-is-nan
+  ++> tests-arc-cosine-of-nan-is-nan
+    is-nan. > @
+      arc-cosine nan
 
-  (arc-cosine ninf).is-nan ++> tests-arc-cosine-of-negative-infinity-is-nan
+  ++> tests-arc-cosine-of-negative-infinity-is-nan
+    is-nan. > @
+      arc-cosine ninf
 
   eq. ++> tests-arc-cosine-of-negative-one-is-pi
     arc-cosine -1
@@ -49,7 +57,9 @@
         927.295
     1
 
-  (arc-cosine pinf).is-nan ++> tests-arc-cosine-of-positive-infinity-is-nan
+  ++> tests-arc-cosine-of-positive-infinity-is-nan
+    is-nan. > @
+      arc-cosine pinf
 
   eq. ++> tests-arc-cosine-of-zero-is-pi-halves
     arc-cosine 0

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -40,19 +40,30 @@
           div.
             times.
               times.
-                (depth.times 2).minus 1
-                (depth.times 2).minus 1
+                minus.
+                  depth.times 2
+                  1
+                minus.
+                  depth.times 2
+                  1
               squared
-            (depth.times 2).times
-              (depth.times 2).plus 1
+            times.
+              depth.times 2
+              plus.
+                depth.times 2
+                1
           poly
             depth.plus 1
     point.times point > squared
     30 > terms
 
-  (arc-sine 2).is-nan ++> tests-arc-sine-above-one-is-nan
+  ++> tests-arc-sine-above-one-is-nan
+    is-nan. > @
+      arc-sine 2
 
-  (arc-sine -2).is-nan ++> tests-arc-sine-below-minus-one-is-nan
+  ++> tests-arc-sine-below-minus-one-is-nan
+    is-nan. > @
+      arc-sine -2
 
   lt. ++> tests-arc-sine-is-odd-function
     abs
@@ -74,7 +85,9 @@
           1000
     1
 
-  (arc-sine nan).is-nan ++> tests-arc-sine-of-nan-is-nan
+  ++> tests-arc-sine-of-nan-is-nan
+    is-nan. > @
+      arc-sine nan
 
   lt. ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
     abs
@@ -82,11 +95,15 @@
         times.
           arc-sine -0.5
           1000
-        (pi.div 6).neg.times
+        times.
+          neg.
+            pi.div 6
           1000
     1
 
-  (arc-sine ninf).is-nan ++> tests-arc-sine-of-negative-infinity-is-nan
+  ++> tests-arc-sine-of-negative-infinity-is-nan
+    is-nan. > @
+      arc-sine ninf
 
   lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
     abs
@@ -94,7 +111,9 @@
         times.
           arc-sine -1
           1000
-        (pi.div 2).neg.times
+        times.
+          neg.
+            pi.div 2
           1000
     1
 
@@ -118,7 +137,9 @@
         643.5
     1
 
-  (arc-sine pinf).is-nan ++> tests-arc-sine-of-positive-infinity-is-nan
+  ++> tests-arc-sine-of-positive-infinity-is-nan
+    is-nan. > @
+      arc-sine pinf
 
   eq. ++> tests-arc-sine-of-zero-is-zero
     arc-sine 0

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -23,9 +23,13 @@
         1000
     1
 
-  (cosine nan).is-nan ++> tests-cosine-of-nan-is-nan
+  ++> tests-cosine-of-nan-is-nan
+    is-nan. > @
+      cosine nan
 
-  (cosine ninf).is-nan ++> tests-cosine-of-negative-infinity-is-nan
+  ++> tests-cosine-of-negative-infinity-is-nan
+    is-nan. > @
+      cosine ninf
 
   lt. ++> tests-cosine-of-pi-halves-is-zero
     abs
@@ -54,7 +58,9 @@
         500
     1
 
-  (cosine pinf).is-nan ++> tests-cosine-of-positive-infinity-is-nan
+  ++> tests-cosine-of-positive-infinity-is-nan
+    is-nan. > @
+      cosine pinf
 
   lt. ++> tests-cosine-of-seventeen-radians
     abs
@@ -79,7 +85,8 @@
       minus.
         times.
           cosine
-            (pi.times 10).plus
+            plus.
+              pi.times 10
               pi.div 3
           1000
         500

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -14,7 +14,9 @@
     pi
   number num.as-bytes > value
 
-  (degrees nan).is-nan ++> tests-degrees-of-nan-is-nan
+  ++> tests-degrees-of-nan-is-nan
+    is-nan. > @
+      degrees nan
 
   lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
     abs

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -47,4 +47,6 @@
         exp -10
     1.0E-12
 
-  (exp nan).is-nan ++> tests-exp-check-nan
+  ++> tests-exp-check-nan
+    is-nan. > @
+      exp nan

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -23,14 +23,15 @@
                   sum.as-number.plus
                     subsection
                       a.plus (i.times step)
-                      a.plus
-                        (i.plus 1).times step
+                      a.plus ((i.plus 1).times step)
                 true
               false
             true > [i]
           sum
         as-number. > step
-          (b.minus a).div n
+          div.
+            b.minus a
+            n
   times. > [a b] > subsection
     div.
       b.minus a
@@ -48,7 +49,9 @@
     close-to > @
       as-number.
         integral
-          (x.times x).times x > [x]
+          times. > [x]
+            x.times x
+            x
           1
           10
           100

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -20,6 +20,9 @@
 
   ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
 
-  (number pinf.as-bytes).is-finite.not ++> tests-number-with-infinite-bytes-is-not-finite
+  ++> tests-number-with-infinite-bytes-is-not-finite
+    not. > @
+      is-finite.
+        number pinf.as-bytes
 
   pinf.is-finite.not ++> tests-positive-infinity-is-not-finite

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -58,7 +58,9 @@
 
   ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
 
-  (number nan.as-bytes).is-nan ++> tests-number-with-nan-bytes-is-nan
+  ++> tests-number-with-nan-bytes-is-nan
+    is-nan. > @
+      number nan.as-bytes
 
   pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
 

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -47,7 +47,9 @@
         0
         plus.
           1.div
-            (k.times 2).plus 1
+            plus.
+              k.times 2
+              1
           squared.times
             horner
               k.plus 1
@@ -69,17 +71,25 @@
     ln 2
     ln 3
 
-  (ln nan).is-nan ++> tests-ln-nan
+  ++> tests-ln-nan
+    is-nan. > @
+      ln nan
 
-  (ln ninf).is-nan ++> tests-ln-negative-infinity
+  ++> tests-ln-negative-infinity
+    is-nan. > @
+      ln ninf
 
   eq. ++> tests-ln-of-e-one-is-one
     ln e
     1
 
-  (ln -2.2).is-nan ++> tests-ln-of-negative-float-is-nan
+  ++> tests-ln-of-negative-float-is-nan
+    is-nan. > @
+      ln -2.2
 
-  (ln -42).is-nan ++> tests-ln-of-negative-int-is-nan
+  ++> tests-ln-of-negative-int-is-nan
+    is-nan. > @
+      ln -42
 
   eq. ++> tests-ln-of-one-is-zero
     ln 1

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -33,8 +33,7 @@
     eq. > @
       plus.
         mod dividend divisor
-        divisor.times
-          (dividend.div divisor).as-i64.as-number
+        divisor.times (dividend.div divisor).as-i64.as-number
       dividend
     -13 > dividend
     5 > divisor

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -51,17 +51,25 @@
           if.
             expo.gt 0
             if.
-              (abs base).gt 1
+              gt.
+                abs base
+                1
               pinf
               if.
-                (abs base).eq 1
+                eq.
+                  abs base
+                  1
                 nan
                 0
             if.
-              (abs base).gt 1
+              gt.
+                abs base
+                1
               0
               if.
-                (abs base).eq 1
+                eq.
+                  abs base
+                  1
                 nan
                 pinf
   number num.as-bytes > base
@@ -106,9 +114,13 @@
       b
       n.div 2
   expo.is-integer.and > odd
-    (expo.div 2).is-integer.not
+    not.
+      is-integer.
+        expo.div 2
 
-  (power 52 nan).is-nan ++> tests-power-any-to-nan-is-nan
+  ++> tests-power-any-to-nan-is-nan
+    is-nan. > @
+      power 52 nan
 
   eq. ++> tests-power-as-method-on-number
     2.power 4
@@ -145,7 +157,9 @@
       -3
     0.015625
 
-  (power -4 0.5).is-nan ++> tests-power-fractional-of-negative-is-nan
+  ++> tests-power-fractional-of-negative-is-nan
+    is-nan. > @
+      power -4 0.5
 
   eq. ++> tests-power-int-to-zero-is-one
     power
@@ -159,9 +173,13 @@
       -12341
     0
 
-  (power nan 42).is-nan ++> tests-power-nan-to-any-is-nan
+  ++> tests-power-nan-to-any-is-nan
+    is-nan. > @
+      power nan 42
 
-  (power nan nan).is-nan ++> tests-power-nan-to-nan-is-nan
+  ++> tests-power-nan-to-nan-is-nan
+    is-nan. > @
+      power nan nan
 
   eq. ++> tests-power-negative-float-to-negative-infinity-is-zero
     power

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -28,7 +28,9 @@
         pi
     1.0E-4
 
-  (radians nan).is-nan ++> tests-radians-of-nan-is-nan
+  ++> tests-radians-of-nan-is-nan
+    is-nan. > @
+      radians nan
 
   lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
     abs

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -15,18 +15,18 @@
       as-number.
         plus.
           as-i64.
-            (tbytes.left shift1).and
+            and.
+              tbytes.left shift1
               as-bytes.
-                (one.left 53).as-i64.minus one
+                minus. (one.left 53).as-i64 one
           plus.
             as-i64.
-              (tbytes.left shift3).and
+              and.
+                tbytes.left shift3
                 as-bytes.
-                  (one.left shift1).as-i64.minus one
+                  minus. (one.left shift1).as-i64 one
             as-i64.
-              tbytes.and
-                as-bytes.
-                  (one.left shift3).as-i64.minus one
+              tbytes.and ((one.left shift3).as-i64.minus one).as-bytes
     00-00-00-00-00-00-00-01 > one
     35 > shift1
     17 > shift3
@@ -58,10 +58,12 @@
       and.
         and.
           rand.lt 1
-          (rand.lt 0).not
+          not.
+            rand.lt 0
         and.
           rand.next.lt 1
-          (rand.next.lt 0).not
+          not.
+            rand.next.lt 0
       and.
         rand.next.next.lt 1
         not.
@@ -75,8 +77,8 @@
     random 51 > r
 
   eq. ++> tests-seeded-randoms-are-equal
-    (random 1654).next.next.next
-    (random 1654).next.next.next
+    next. (random 1654).next.next
+    next. (random 1654).next.next
 
   ++> tests-two-random-numbers-not-equal
     not. > @

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -20,8 +20,11 @@
     1.minus
       times.
         squared.div
-          (depth.times 2).times
-            (depth.times 2).plus 1
+          times.
+            depth.times 2
+            plus.
+              depth.times 2
+              1
         factor
           depth.plus 1
   arg.minus > reduced
@@ -45,9 +48,13 @@
         1000
     1
 
-  (sine nan).is-nan ++> tests-sine-of-nan-is-nan
+  ++> tests-sine-of-nan-is-nan
+    is-nan. > @
+      sine nan
 
-  (sine ninf).is-nan ++> tests-sine-of-negative-infinity-is-nan
+  ++> tests-sine-of-negative-infinity-is-nan
+    is-nan. > @
+      sine ninf
 
   lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
     abs
@@ -85,7 +92,9 @@
         500
     1
 
-  (sine pinf).is-nan ++> tests-sine-of-positive-infinity-is-nan
+  ++> tests-sine-of-positive-infinity-is-nan
+    is-nan. > @
+      sine pinf
 
   lt. ++> tests-sine-of-seventeen-radians
     abs
@@ -101,7 +110,9 @@
       minus.
         times.
           sine
-            (pi.times 3).div 2
+            div.
+              pi.times 3
+              2
           1000
         -1000
     1
@@ -123,7 +134,8 @@
       minus.
         times.
           sine
-            (pi.times 10).plus
+            plus.
+              pi.times 10
               pi.div 6
           1000
         500

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -28,11 +28,17 @@
     sqrt pinf
     pinf
 
-  (sqrt ninf).is-nan ++> tests-sqrt-check-infinity-n2
+  ++> tests-sqrt-check-infinity-n2
+    is-nan. > @
+      sqrt ninf
 
-  (sqrt nan).is-nan ++> tests-sqrt-check-nan-input
+  ++> tests-sqrt-check-nan-input
+    is-nan. > @
+      sqrt nan
 
-  (sqrt -0.1).is-nan ++> tests-sqrt-check-negative-input
+  ++> tests-sqrt-check-negative-input
+    is-nan. > @
+      sqrt -0.1
 
   lt. ++> tests-sqrt-check-zero-input
     abs

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -36,7 +36,8 @@
     [] > basename
       string > @
         if.
-          (pth.size.eq 0).or
+          or.
+            pth.size.eq 0
             idx.eq 0
           pth
           as-bytes.
@@ -52,13 +53,15 @@
     [] > dirname
       string > @
         if.
-          (pth.size.eq 0).or
+          or.
+            pth.size.eq 0
             len.eq -1
           pth
           if.
             len.eq 0
             separator
-            (txt.slice 0 len).as-bytes
+            as-bytes.
+              txt.slice 0 len
       string.last-index-of txt separator > len!
       uri > pth!
       string pth > txt
@@ -109,14 +112,17 @@
           if. > [accum segment] >>
             segment.eq ".."
             if.
-              (accum.length.gt 0).and
-                (accum.head.eq "..").not
+              and.
+                accum.length.gt 0
+                not.
+                  accum.head.eq ".."
               accum.tail
               is-absolute.not.if
                 accum.with segment
                 accum
             if.
-              (segment.eq ".").or
+              or.
+                segment.eq "."
                 segment.eq ""
               accum
               accum.with segment
@@ -136,9 +142,13 @@
               obts.size.eq 0
               uri
               if.
-                (obts.slice 0 1).eq separator
+                eq.
+                  obts.slice 0 1
+                  separator
                 obts
-                (uri.concat separator).concat obts
+                concat.
+                  uri.concat separator
+                  obts
       other.as-bytes > obts
     "/" > separator
   os.is-windows.if > separator
@@ -158,7 +168,8 @@
       [] > basename
         string > @
           if.
-            (pth.size.eq 0).or
+            or.
+              pth.size.eq 0
               idx.eq 0
             pth
             as-bytes.
@@ -174,19 +185,22 @@
       [] > dirname
         string > @
           if.
-            (pth.size.eq 0).or
+            or.
+              pth.size.eq 0
               len.eq -1
             pth
             if.
               len.eq 0
               separator
-              (txt.slice 0 len).as-bytes
+              as-bytes.
+                txt.slice 0 len
         string.last-index-of txt separator > len!
         uri > pth!
         string pth > txt
       [] > extname
         if. > @
-          (base.size.eq 0).or
+          or.
+            base.size.eq 0
             idx.eq -1
           ""
           string
@@ -202,16 +216,19 @@
         if. > @
           ubts.size.eq 0
           false
-          (is-root-relative ubts).or
-            (ubts.size.gt 1).and
+          or.
+            is-root-relative ubts
+            and.
+              ubts.size.gt 1
               is-drive-relative ubts
         uri > ubts!
       [uri] > is-drive-relative
-        ((string.regex "/^[a-zA-Z]:/").match uri).next.exists.as-bool > @
+        as-bool. ((string.regex "/^[a-zA-Z]:/").match uri).next.exists > @
       [uri] > is-root-relative
         and. > @
           ubts.size.gt 0
-          (ubts.slice 0 1).eq
+          eq.
+            ubts.slice 0 1
             separator
         uri > ubts!
       [] > normalized
@@ -241,7 +258,9 @@
               concat.
                 is-drive-relative.if
                   if.
-                    (driveless.slice 0 1).eq separator
+                    eq.
+                      driveless.slice 0 1
+                      separator
                     uri.slice 0 3
                     uri.slice 0 2
                   is-root-relative.if separator --
@@ -255,14 +274,17 @@
             if. > [accum segment] >>
               segment.eq ".."
               if.
-                (accum.length.gt 0).and
-                  (accum.head.eq "..").not
+                and.
+                  accum.length.gt 0
+                  not.
+                    accum.head.eq ".."
                 accum.tail
                 driveless-rooted.not.if
                   accum.with segment
                   accum
               if.
-                (segment.eq ".").or
+                or.
+                  segment.eq "."
                   segment.eq ""
                 accum
                 accum.with segment
@@ -279,20 +301,25 @@
           validated
             string
               if.
-                (is-drive-relative valid).as-bool
+                as-bool.
+                  is-drive-relative valid
                 valid
                 if.
-                  (is-root-relative valid).as-bool
+                  as-bool.
+                    is-root-relative valid
                   if.
                     is-drive-relative ubts
-                    (ubts.slice 0 2).concat valid
+                    concat.
+                      ubts.slice 0 2
+                      valid
                     valid
-                  (ubts.concat separator).concat valid
+                  concat. (ubts.concat separator) valid
         uri > ubts!
         separated-correctly other > valid!
       [uri] > separated-correctly
         if. > @
-          (string.index-of pth path.posix.separator).eq
+          eq.
+            string.index-of pth path.posix.separator
             -1
           string ubts
           string repl
@@ -307,13 +334,19 @@
   and. ++> tests-detects-absolute-posix-path
     is-absolute.
       path.posix "/var/www/html"
-    (path.posix "foo/bar/baz").is-absolute.not
+    not.
+      is-absolute.
+        path.posix "foo/bar/baz"
 
   and. ++> tests-detects-absolute-win32-path
-    (path.win32 "C:\\Windows\\Users").is-absolute.and
+    and.
+      is-absolute.
+        path.win32 "C:\\Windows\\Users"
       is-absolute.
         path.win32 "\\Windows\\Users"
-    (path.win32 "temp\\var").is-absolute.not
+    not.
+      is-absolute.
+        path.win32 "temp\\var"
 
   path.separator.eq ++> tests-determines-separator-depending-on-os
     os.is-windows.if

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -103,7 +103,8 @@
           seq * > @
             chunk
             input-block chunk
-          (recv size).as-bytes > chunk
+          as-bytes. > chunk
+            recv size
   [send] > as-output
     [buffer] > write
       @. > @

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -31,7 +31,9 @@
         next-line
         first.if
           buffer.concat line
-          (buffer.concat separator).concat line
+          concat.
+            buffer.concat separator
+            line
         false
     | > @
       next-line
@@ -49,7 +51,8 @@
         or.
           char.eq --
           or.
-            (char.eq "\r").and
+            and.
+              char.eq "\r"
               next.as-bytes.eq "\n"
             char.eq "\n"
         string buffer

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -50,16 +50,24 @@
         index.eq size
         accum
         if.
-          (byte.and p1).eq r1
+          eq.
+            byte.and p1
+            r1
           inclen index 1 accum
           if.
-            (byte.and p2).eq r2
+            eq.
+              byte.and p2
+              r2
             inclen index 2 accum
             if.
-              (byte.and p3).eq r3
+              eq.
+                byte.and p3
+                r3
               inclen index 3 accum
               if.
-                (byte.and p4).eq r4
+                eq.
+                  byte.and p4
+                  r4
                 inclen index 4 accum
                 T
                   "Unknown byte format (%x), can't recognize character".printf
@@ -132,7 +140,9 @@
           index.eq size
           T cause
           if.
-            (byte.and p1).eq r1
+            eq.
+              byte.and p1
+              r1
             increase
               index
               1
@@ -140,7 +150,9 @@
               result
               cause
             if.
-              (byte.and p2).eq r2
+              eq.
+                byte.and p2
+                r2
               increase
                 index
                 2
@@ -148,10 +160,12 @@
                 result
                 cause
               if.
-                (byte.and p3).eq r3
+                eq.
+                  byte.and p3
+                  r3
                 increase index 3 accum result cause
                 if.
-                  (byte.and p4).eq r4
+                  eq. (byte.and p4) r4
                   increase index 4 accum result cause
                   T
                     "Unknown byte format (%x), can't recognize character".printf
@@ -166,17 +180,26 @@
     " ".length
     1
 
-  (nan.eq "друг").not ++> tests-compares-string-with-nan
+  ++> tests-compares-string-with-nan
+    not. > @
+      nan.eq "друг"
 
-  (ninf.eq "друг").not ++> tests-compares-string-with-negative-infinity
+  ++> tests-compares-string-with-negative-infinity
+    not. > @
+      ninf.eq "друг"
 
   eq. ++> tests-compares-string-with-positive-infinity
     pinf.eq "друг"
     false
 
-  ("Hello".eq 42).not ++> tests-compares-two-different-string-types
+  ++> tests-compares-two-different-string-types
+    not. > @
+      "Hello".eq 42
 
-  ("Hello".eq "Good bye").not ++> tests-compares-two-different-strings
+  ++> tests-compares-two-different-strings
+    not. > @
+      "Hello".eq
+        "Good bye"
 
   eq. ++> tests-compares-two-strings
     "x".eq "x"
@@ -365,4 +388,6 @@
     -1
     1
 
-  (string F0-9F-98).length --> on-taking-length-of-incomplete-n4-byte-character
+  --> on-taking-length-of-incomplete-n4-byte-character
+    length. > @
+      string F0-9F-98

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -22,7 +22,10 @@
       concat.
         digits q
         as-char
-          (n.minus (q.times 10)).floor.plus
+          plus.
+            floor.
+              n.minus
+                q.times 10
             48
     floor. > q
       n.div 10

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -63,7 +63,7 @@
           plus.
             floor.
               value.minus
-                (value.div 10).floor.times 10
+                times. (value.div 10).floor 10
             48
         acc
   if. > [a] > signed

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -25,7 +25,9 @@
         if.
           index.eq 0
           pair
-          (acc.concat "-".as-bytes).concat pair
+          concat.
+            acc.concat "-".as-bytes
+            pair
     as-ascii > bval
       bts.slice index 1
     concat. > pair
@@ -34,7 +36,10 @@
           bval.div 16
       hex-digit
         bval.minus
-          (bval.div 16).floor.times 16
+          times.
+            floor.
+              bval.div 16
+            16
   | > @
     0
     --

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -24,7 +24,10 @@
     cant-parse
       "Can't convert text %s to number".printf
         * text
-    (scanf "%f" text).at.^.head
+    head.
+      ^.
+        at.
+          scanf "%f" text
 
   eq. ++> tests-converts-float-text-to-number
     3.14

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -25,8 +25,7 @@
       end.eq idx
       includes
       includes.or
-        rec-contains
-          (idx.plus 1).as-number
+        rec-contains (idx.plus 1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -17,7 +17,8 @@
           tlen
         and.
           slen.eq tlen
-          (sub.eq txt).not
+          not.
+            sub.eq txt
       found.eq -1
     -1
     length.
@@ -36,8 +37,7 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of
-          (idx.plus 1).as-number
+        rec-index-of (idx.plus 1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -15,6 +15,10 @@
 
   is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
 
-  (is-alpha "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alpha
+  ++> tests-checks-if-text-with-dashes-is-not-alpha
+    not. > @
+      is-alpha "-w-"
 
-  (is-alpha "ab3d").not ++> tests-checks-if-text-with-number-is-not-alpha
+  ++> tests-checks-if-text-with-number-is-not-alpha
+    not. > @
+      is-alpha "ab3d"

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -15,6 +15,8 @@
 
   is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
 
-  (is-alphanumeric "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
+  ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
+    not. > @
+      is-alphanumeric "-w-"
 
   is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,7 +12,9 @@
     regex "/^[\\x00-\\x7F]*$/"
     text
 
-  (is-ascii "🌵").not ++> tests-checks-if-emoji-is-not-ascii
+  ++> tests-checks-if-emoji-is-not-ascii
+    not. > @
+      is-ascii "🌵"
 
   is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
 

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,19 +13,30 @@
     regex "/^[0-9]+$/"
     text
 
-  (is-digit "").not ++> tests-checks-if-empty-text-is-not-digit
+  ++> tests-checks-if-empty-text-is-not-digit
+    not. > @
+      is-digit ""
 
   is-digit "2026" ++> tests-checks-if-number-text-is-digit
 
   is-digit "7" ++> tests-checks-if-single-digit-is-digit
 
-  (is-digit "1a2").not ++> tests-checks-if-text-with-letter-is-not-digit
+  ++> tests-checks-if-text-with-letter-is-not-digit
+    not. > @
+      is-digit "1a2"
 
-  (is-digit "12 34").not ++> tests-checks-if-text-with-space-is-not-digit
+  ++> tests-checks-if-text-with-space-is-not-digit
+    not. > @
+      is-digit
+        "12 34"
 
-  (is-digit "1🌵2").not ++> tests-checks-if-text-with-special-character-is-not-digit
+  ++> tests-checks-if-text-with-special-character-is-not-digit
+    not. > @
+      is-digit "1🌵2"
 
-  (is-digit "123\n").not ++> tests-checks-if-text-with-trailing-newline-is-not-digit
+  ++> tests-checks-if-text-with-trailing-newline-is-not-digit
+    not. > @
+      is-digit "123\n"
 
   is-digit ++> tests-checks-if-very-long-number-is-digit
     "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -17,7 +17,8 @@
           tlen
         and.
           slen.eq tlen
-          (sub.eq txt).not
+          not.
+            sub.eq txt
       found.eq -1
     -1
     length.
@@ -36,8 +37,7 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of
-          (idx.plus -1).as-number
+        rec-index-of (idx.plus -1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -17,9 +17,11 @@
       [accum byte] >>
         accum.concat > @
           if.
-            (code.lte maxcode).and
+            and.
+              code.lte maxcode
               code.gte mincode
-            (code.plus distance).as-i64.as-bytes.slice
+            slice.
+              as-bytes. (code.plus distance).as-i64
               7
               1
             byte

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -33,27 +33,37 @@
       if.
         or.
           size.eq 0
-          (current.plus size).gt text.size
+          gt.
+            current.plus size
+            text.size
         rec-nsplit
           accum
           start
-          (current.plus 1).as-number
+          as-number.
+            current.plus 1
           count
         if.
           and.
             delimiter.eq
               slice text current size
-            (number count).lt
-              (number limit).minus 1
+            lt.
+              number count
+              minus.
+                number limit
+                1
           rec-nsplit
             appended
-            (current.plus size).as-number
-            (current.plus size).as-number
-            (count.plus 1).as-number
+            as-number.
+              current.plus size
+            as-number.
+              current.plus size
+            as-number.
+              count.plus 1
           rec-nsplit
             accum
             start
-            (current.plus 1).as-number
+            as-number.
+              current.plus 1
             count
     accum.with > appended
       string

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -58,12 +58,16 @@
 
   ++> tests-does-not-match-anchored-pattern-with-trailing-newline
     not. > @
-      (regex "/^[0-9]+$/").compiled.matches
+      matches.
+        compiled.
+          regex "/^[0-9]+$/"
         "123\n"
 
   ++> tests-does-not-matches-regex-against-the-pattern
     not. > @
-      (regex "/[a-z]+/").compiled.matches
+      matches.
+        compiled.
+          regex "/[a-z]+/"
         "123"
 
   eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
@@ -99,14 +103,18 @@
       and.
         and.
           first.count.eq 3
-          (first.group 1).eq "hello"
+          eq.
+            first.group 1
+            "hello"
         eq.
           first.group 2
           "1"
       and.
         and.
           second.count.eq 3
-          (second.group 1).eq "world"
+          eq.
+            second.group 1
+            "world"
         eq.
           second.group 2
           "2"
@@ -170,7 +178,8 @@
     and. > @
       and.
         and.
-          (second.text.eq "world").and
+          and.
+            second.text.eq "world"
             second.position.eq 2
           second.start.eq 6
         second.from.eq 7
@@ -181,7 +190,9 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  (regex "/[a-z/").compile --> on-compiling-invalid-regex-without-fallback
+  --> on-compiling-invalid-regex-without-fallback
+    compile. > @
+      regex "/[a-z/"
 
   --> on-getting-from-position-on-not-matched-block
     from. > @
@@ -204,7 +215,12 @@
           regex "/[a-z]+/"
           "123"
 
-  ((regex "/[a-z]+/").match "123").next.next --> on-getting-next-on-not-matched-block
+  --> on-getting-next-on-not-matched-block
+    next. > @
+      next.
+        match.
+          regex "/[a-z]+/"
+          "123"
 
   group. --> on-getting-specified-group-on-not-matched-block
     next.
@@ -213,7 +229,12 @@
         "123"
     1
 
-  ((regex "/[a-z]+/").match "123").next.text --> on-getting-text-on-not-matched-block
+  --> on-getting-text-on-not-matched-block
+    text. > @
+      next.
+        match.
+          regex "/[a-z]+/"
+          "123"
 
   --> on-getting-to-position-on-not-matched-block
     to. > @
@@ -222,6 +243,10 @@
           regex "/[a-z]+/"
           "123"
 
-  (regex "/pattern").compiled --> on-missing-closing-slash-in-regex
+  --> on-missing-closing-slash-in-regex
+    compiled. > @
+      regex "/pattern"
 
-  (regex "(.)+").compiled --> on-missing-first-slash-in-regex
+  --> on-missing-first-slash-in-regex
+    compiled. > @
+      regex "(.)+"

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -147,7 +147,8 @@
           next
         rec > next
           index.plus 1
-          (acc.times 10).plus
+          plus.
+            acc.times 10
             minus.
               as-ascii
                 slice text index 1

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -25,22 +25,28 @@
       if.
         or.
           size.eq 0
-          (current.plus size).gt len
+          gt.
+            current.plus size
+            len
         rec-split
           accum
           start
-          (current.plus 1).as-number
+          as-number.
+            current.plus 1
         if.
           delim.eq
             slice bts current size
           rec-split
             appended
-            (current.plus size).as-number
-            (current.plus size).as-number
+            as-number.
+              current.plus size
+            as-number.
+              current.plus size
           rec-split
             accum
             start
-            (current.plus 1).as-number
+            as-number.
+              current.plus 1
     accum.with > appended
       string
         slice

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -28,8 +28,7 @@
       index
       if.
         is-ws char
-        first-non-ws-index
-          (index.plus 1).as-number
+        first-non-ws-index (index.plus 1).as-number
         index
     bts.slice > char!
       index
@@ -43,7 +42,8 @@
         c.eq 0A-
         or.
           c.eq 0B-
-          (c.eq 0C-).or
+          or.
+            c.eq 0C-
             c.eq 0D-
   bts.size > len!
 

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -19,7 +19,9 @@
       bts.slice
         0
         first-non-ws-index
-          (number len).plus -1
+          plus.
+            number len
+            -1
   text > bts!
   [index] > first-non-ws-index
     if. > @
@@ -27,8 +29,7 @@
       0
       if.
         is-ws char
-        first-non-ws-index
-          (index.plus -1).as-number
+        first-non-ws-index (index.plus -1).as-number
         index.plus 1
     bts.slice > char!
       index
@@ -41,7 +42,8 @@
         c.eq 0A-
         or.
           c.eq 0B-
-          (c.eq 0C-).or
+          or.
+            c.eq 0C-
             c.eq 0D-
   bts.size > len!
 

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -17,9 +17,11 @@
       [accum byte] >>
         accum.concat > @
           if.
-            (code.lte maxcode).and
+            and.
+              code.lte maxcode
               code.gte mincode
-            (code.minus distance).as-i64.as-bytes.slice
+            slice.
+              as-bytes. (code.minus distance).as-i64
               7
               1
             byte

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -281,8 +281,12 @@
     and. > @
       and.
         and.
-          (arr.at 0).eq 1
-          (arr.at 1).eq 2
+          eq.
+            arr.at 0
+            1
+          eq.
+            arr.at 1
+            2
         eq.
           arr.at 2
           3

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -29,5 +29,7 @@
           eachi > @
             * 1 2 3
             m.put > [item index] >>
-              (m.as-number.plus item).plus index
+              plus.
+                m.as-number.plus item
+                index
       9

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -22,7 +22,9 @@
         "Can't divide %d by u16 zero".printf
           * as-number
       u16 quotient
-    (as-i32.div xval.as-i32).as-bytes.slice > quotient
+    slice. > quotient
+      as-bytes.
+        as-i32.div xval.as-i32
       2
       2
     x.as-u16 > xval
@@ -33,17 +35,23 @@
   as-i32.lte x.as-u16.as-i32 > [x] > lte
   [x] > minus
     u16 right > @
-    (as-i32.minus x.as-u16.as-i32).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i32.minus x.as-u16.as-i32
       2
       2
   [x] > plus
     u16 right > @
-    (as-i32.plus x.as-u16.as-i32).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i32.plus x.as-u16.as-i32
       2
       2
   [x] > times
     u16 right > @
-    (as-i32.times x.as-u16.as-i32).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i32.times x.as-u16.as-i32
       2
       2
 
@@ -67,7 +75,9 @@
     FF-FF.as-u16.div 00-02.as-u16
     7F-FF.as-u16
 
-  (00-2A.as-u16.eq 00-2B.as-u16).not ++> tests-u16-eq-false
+  ++> tests-u16-eq-false
+    not. > @
+      00-2A.as-u16.eq 00-2B.as-u16
 
   00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
 
@@ -75,13 +85,19 @@
 
   00-32.as-u16.gte 00-32.as-u16 ++> tests-u16-gte-equal
 
-  (00-00.as-u16.gte 00-0A.as-u16).not ++> tests-u16-gte-false
+  ++> tests-u16-gte-false
+    not. > @
+      00-00.as-u16.gte 00-0A.as-u16
 
   00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
 
-  (FF-FF.as-u16.lt 00-01.as-u16).not ++> tests-u16-high-bit-not-less-than-one
+  ++> tests-u16-high-bit-not-less-than-one
+    not. > @
+      FF-FF.as-u16.lt 00-01.as-u16
 
-  (00-0A.as-u16.lt 00-0A.as-u16).not ++> tests-u16-less-equal
+  ++> tests-u16-less-equal
+    not. > @
+      00-0A.as-u16.lt 00-0A.as-u16
 
   00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
 

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -22,7 +22,9 @@
         "Can't divide %d by u32 zero".printf
           * as-number
       u32 quotient
-    (as-i64.div xval.as-i64).as-bytes.slice > quotient
+    slice. > quotient
+      as-bytes.
+        as-i64.div xval.as-i64
       4
       4
     x.as-u32 > xval
@@ -33,17 +35,23 @@
   as-i64.lte x.as-u32.as-i64 > [x] > lte
   [x] > minus
     u32 right > @
-    (as-i64.minus x.as-u32.as-i64).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i64.minus x.as-u32.as-i64
       4
       4
   [x] > plus
     u32 right > @
-    (as-i64.plus x.as-u32.as-i64).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i64.plus x.as-u32.as-i64
       4
       4
   [x] > times
     u32 right > @
-    (as-i64.times x.as-u32.as-i64).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i64.times x.as-u32.as-i64
       4
       4
 
@@ -67,7 +75,9 @@
     FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
     7F-FF-FF-FF.as-u32
 
-  (00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32).not ++> tests-u32-eq-false
+  ++> tests-u32-eq-false
+    not. > @
+      00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
 
   00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
 
@@ -77,7 +87,9 @@
 
   00-00-00-32.as-u32.gte 00-00-00-32.as-u32 ++> tests-u32-gte-equal
 
-  (00-00-00-00.as-u32.gte 00-00-00-0A.as-u32).not ++> tests-u32-gte-false
+  ++> tests-u32-gte-false
+    not. > @
+      00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
 
   00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
 
@@ -85,7 +97,9 @@
     not. > @
       FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
 
-  (00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32).not ++> tests-u32-less-equal
+  ++> tests-u32-less-equal
+    not. > @
+      00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
 
   00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
 

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -22,7 +22,9 @@
         "Can't divide %d by u8 zero".printf
           * as-number
       u8 quotient
-    (as-i16.div xval.as-i16).as-bytes.slice > quotient
+    slice. > quotient
+      as-bytes.
+        as-i16.div xval.as-i16
       1
       1
     x.as-u8 > xval
@@ -33,17 +35,23 @@
   as-i16.lte x.as-u8.as-i16 > [x] > lte
   [x] > minus
     u8 right > @
-    (as-i16.minus x.as-u8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.minus x.as-u8.as-i16
       1
       1
   [x] > plus
     u8 right > @
-    (as-i16.plus x.as-u8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.plus x.as-u8.as-i16
       1
       1
   [x] > times
     u8 right > @
-    (as-i16.times x.as-u8.as-i16).as-bytes.slice > right
+    slice. > right
+      as-bytes.
+        as-i16.times x.as-u8.as-i16
       1
       1
 
@@ -65,7 +73,9 @@
     C8-.as-u8.div 03-.as-u8
     42-.as-u8
 
-  (2A-.as-u8.eq 2B-.as-u8).not ++> tests-u8-eq-false
+  ++> tests-u8-eq-false
+    not. > @
+      2A-.as-u8.eq 2B-.as-u8
 
   2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
 
@@ -73,13 +83,19 @@
 
   32-.as-u8.gte 32-.as-u8 ++> tests-u8-gte-equal
 
-  (00-.as-u8.gte 0A-.as-u8).not ++> tests-u8-gte-false
+  ++> tests-u8-gte-false
+    not. > @
+      00-.as-u8.gte 0A-.as-u8
 
   2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
 
-  (FF-.as-u8.lt 01-.as-u8).not ++> tests-u8-high-bit-not-less-than-one
+  ++> tests-u8-high-bit-not-less-than-one
+    not. > @
+      FF-.as-u8.lt 01-.as-u8
 
-  (0A-.as-u8.lt 0A-.as-u8).not ++> tests-u8-less-equal
+  ++> tests-u8-less-equal
+    not. > @
+      0A-.as-u8.lt 0A-.as-u8
 
   0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
 


### PR DESCRIPTION
Closes #5880.

## What

`Penalty.brackets()` weighed every opening parenthesis by nesting depth alone: a `(` opening with `depth` brackets already open cost `depth + 1` units of the `BRACKET` weight, regardless of where it sat on the line. A `(` standing as the first non-space character of a line — the worst place for a group, since the reader meets it before knowing what it applies to — was charged the same single unit as one sitting mid-line, so the layout search had no reason to avoid it.

## How

- **`Penalty.brackets()`** now charges a `(` that is the first non-space character of its line `(depth + 1) * LEADING` units instead of `depth + 1`, pushing the layout search away from opening a line with a group.
- **`PenaltyKey.LEADING`** — a new tunable with fallback `4` for the factor, keeping it configurable like every other knob.
- **`brackets()` is now an instance method** (was `static`) so it can read the weight from the config.

## Effect on `eo-runtime`

Reformats the **60 `eo-runtime/src/main/eo` sources** that were laid out with line-leading parentheses under the old weight (the ~298 lines noted in the issue, e.g. `(byte.and p1).eq r1` in `string.eo`). Each such group is now broken onto its own indented lines in prefix form (`eq.` / `byte.and p1` / `r1`). Verified with `MjFormat` (`-Deo.autoFix`): all 153 sources are canonical again.

## Tests

- `PenaltyTest.chargesForParentheses` gains rows contrasting a line-leading `(` (`(a).eq b` → 76, i.e. `4 × 19`) with a mid-line one (`f (a).eq b` → 19); the nested `(a (b (c 1)))` expectation is updated to `171` to reflect the leading charge on its first `(`.
- `PenaltyKeyTest.honoursOverriddenLeadingWeight` verifies that tuning `LEADING` to `1` makes a leading `(` cost the same as a mid-line one.
- Four print-packs whose demonstrated layout opened a line with a group (`compound-receiver-suffix`, `dispatch-chains-mixed`, `inline-phi-overflow`, `nested-formation-apply`) are updated to their new vertical rendering. These packs are shared (symlinked) between `eo-printer`'s `XmirTest` and `eo-maven-plugin`'s `MjPrintTest`; the latter has no `LEADING` mojo parameter, so both consumers now agree on the default-weight output.

All `eo-printer` tests, `MjPrintTest`, the `eo-runtime` format check, and `qulice` pass locally.