### PR TITLE
Keep dispatch-referenced const `>>` handle whole (#5883)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -115,12 +115,17 @@
   the shared name. Its "@local" marker is therefore kept here so the surviving
   binding still prints its readable `&gt;&gt; b` handle; the binding itself
   stays cactus-named for "merge-monikers" to fold onto its first reference
-  (#5828).
+  (#5828). A reference reaches the handle either bare (`ξ.b`) or through a
+  method dispatch (`ξ.b.seg`, e.g. `b.gte 1`, #5883), so both spellings are
+  counted — exactly as "eo:multi-referenced" does; counting only the bare shape
+  would leave a handle whose sibling reference is a dispatch looking
+  single-use, dropping "@local" and stranding that dispatch on a synthetic
+  "vL_P" placeholder.
   -->
   <xsl:function name="eo:const-handle" as="xs:boolean">
     <xsl:param name="wrapper" as="element()*"/>
     <xsl:variable name="value" select="$wrapper/o[@base='Φ.dataized']/o[1]"/>
-    <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $wrapper/@name and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
+    <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $wrapper/@name or starts-with(eo:resolved-name(@base), concat($wrapper/@name, '.'))) and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
   </xsl:function>
   <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
   <!--

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-dispatch-referenced-datum.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-dispatch-referenced-datum.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The dispatch-referenced const handle (#5883, see
+# "const-dispatch-referenced-handle") over a plain datum rather than an
+# application: `5 >> c!`. "const-to-dataized" wraps every const in the same
+# `.as-bytes` over `Φ.dataized` shell regardless of what it wraps, so the datum
+# handle is kept whole and hosted onto its first bare reference exactly as the
+# application handle is, while the `c.gte 2` dispatch reference reads back as
+# `c.gte` instead of a synthetic "vL_P" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    5 >> c!
+    c.gte 2 > a
+    42.plus c > b
+
+printed: |
+  [x] > foo
+    c.gte 2 > a
+    42.plus > b
+      5 >> c!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-dispatch-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-dispatch-referenced-handle.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) is kept whole when referenced
+# more than once (#5828), just like the two- and three-reference cases. Here one
+# of the two references is a method dispatch (`c.gte 2`, base `ξ.c.gte`) rather
+# than a bare `c` (#5883). "restore-local-names" must count that dispatch use so
+# the handle still reads as multi-referenced and keeps its "@local" marker;
+# counting only the bare shape left it looking single-use, dropped the marker,
+# and folded the const into the one bare use — stranding the dispatch reference
+# on a synthetic "vL_P" name that resolves to nothing on reparse. The kept
+# handle is hosted onto its first bare reference as a moniker (`x.plus 1 >> c!`
+# under the first `42.plus`), and the dispatch reference reads back as `c.gte`.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    x.plus 1 >> c!
+    c.gte 2 > a
+    42.plus c > b
+
+printed: |
+  [x] > foo
+    c.gte 2 > a
+    42.plus > b
+      x.plus 1 >> c!


### PR DESCRIPTION
Fixes #5883.

## Problem

A const file-local handle (`a >> b!`, #5817) referenced more than once must be kept whole (#5828). But when one of its references was a **method dispatch** (`b.gte 1`, base `ξ.b.gte`) rather than a bare `b`, the handle was folded into one use and the other reference was stranded on a synthetic `vL_P` name that resolves to nothing on reparse:

```
[text] > foo
  mincode.gte 1 > bar          # dispatch reference
  minus. > distance
    number mincode             # bare reference
    42
  text.plus 1 >> mincode!
```

printed as (broken):

```
[text] > foo
  v6_2.gte 1 > bar             # stranded on a name declared nowhere
  minus. > distance
    number (text.plus 1!)      # const folded into this one use, shared name lost
    42
```

## Root cause

Contrary to the issue's initial guess at `inline-cactoos`, a step-by-step trace shows `inline-cactoos` already keeps the `.as-bytes`/`Φ.dataized` handle whole. The real failure is upstream in `restore-local-names.xsl`: its `eo:const-handle` predicate decides whether a const handle is multi-referenced (and so must keep its readable `@local` marker). It counted references with an **exact** name match (`eo:resolved-name(@base) = @name`), which matches a bare `ξ.b` but not a dispatch `ξ.b.seg`. So a handle whose sibling use was a dispatch looked single-use, lost its `@local` marker, and `dataized-to-const` → `merge-monikers` then failed to recognize it as a const handle and folded it — stranding the dispatch reference.

This is independent of what the const wraps (a reference, an application, or a datum), since `const-to-dataized` gives every const the same wrapper shape.

## Fix

Count dispatch references too in `eo:const-handle`, mirroring the existing `eo:multi-referenced` (which already uses `starts-with(eo:resolved-name(@base), concat($name, '.'))`). One-line logic change; the const stays multi-referenced, keeps `@local`, is kept whole, and is hosted onto its first reference as a moniker while the dispatch reference reads back as the bare `b.gte`.

## Tests

Two new print-packs, both passing and round-tripping:

- `const-dispatch-referenced-handle.yaml` — const over an application (`x.plus 1 >> c!`) with one bare and one dispatch reference.
- `const-dispatch-referenced-datum.yaml` — same shape over a plain datum (`5 >> c!`).

Full `eo-printer` module: `229 tests, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkNMRasvAhWJxQ6vwW52Cc)_