### PR TITLE
Revert "Charge a line-leading `(` four times in eo-printer `Penalty` BRACKET term" (#5881)

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Penalty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Penalty.java
@@ -26,10 +26,7 @@ import java.util.Map;
  *   points, multiplied by its nesting depth plus one, so a top-level
  *   bracket costs the flat weight, a bracket nested one level deep costs
  *   twice as much, two levels deep three times, and so on, since deeper
- *   nesting hurts readability more; a parenthesis that is the first
- *   non-space character of its line pays an extra {@link PenaltyKey#LEADING}
- *   factor on top, since a group opening a line, before the reader knows
- *   what it applies to, is the worst place for a bracket;</li>
+ *   nesting hurts readability more;</li>
  *   <li>every explicit phi attribute {@code @} costs
  *   {@link PenaltyKey#PHI} points;</li>
  *   <li>every {@code if} dispatched in suffix position ({@code foo.if})
@@ -121,7 +118,7 @@ final class Penalty {
             final int spaces = Penalty.spaces(line);
             final int applied = Penalty.applied(line);
             total += this.indents(line) * this.weight(PenaltyKey.INDENT);
-            total += this.brackets(line) * this.weight(PenaltyKey.BRACKET);
+            total += Penalty.brackets(line) * this.weight(PenaltyKey.BRACKET);
             total += Penalty.phis(line) * this.weight(PenaltyKey.PHI);
             total += Penalty.ifs(line) * this.weight(PenaltyKey.IF);
             total += Math.max(0, line.length() - this.weight(PenaltyKey.WIDTH))
@@ -256,31 +253,16 @@ final class Penalty {
      * counts as {@code depth + 1} units of the flat {@link PenaltyKey#BRACKET}
      * weight, so the printer leans away from deeply nested one-liners.</p>
      *
-     * <p>A parenthesis that is the first non-space character of its line is
-     * charged {@link PenaltyKey#LEADING} times as much, so it counts as
-     * {@code (depth + 1) * LEADING} units. The start of a line is the worst
-     * place for a group: the reader meets it before knowing what it applies
-     * to, and the line has to be read backwards to make sense of it, so the
-     * printer is pushed away from that layout.</p>
-     *
      * @param line The line
      * @return The weighted number of parentheses
      */
-    private int brackets(final String line) {
-        int lead = 0;
-        while (lead < line.length() && line.charAt(lead) == ' ') {
-            ++lead;
-        }
+    private static int brackets(final String line) {
         int count = 0;
         int depth = 0;
         for (int idx = 0; idx < line.length(); ++idx) {
             final char chr = line.charAt(idx);
             if (chr == '(') {
-                int units = depth + 1;
-                if (idx == lead) {
-                    units *= this.weight(PenaltyKey.LEADING);
-                }
-                count += units;
+                count += depth + 1;
                 ++depth;
             } else if (chr == ')' && depth > 0) {
                 --depth;

--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -15,7 +15,7 @@ package org.eolang.printer;
  * one aesthetic is no longer baked into the tool.</p>
  *
  * @since 0.57.0
- * @checkstyle MagicNumberCheck (65 lines)
+ * @checkstyle MagicNumberCheck (55 lines)
  */
 public enum PenaltyKey {
 
@@ -29,14 +29,6 @@ public enum PenaltyKey {
      * parenthesis on a line costs k times this weight.
      */
     BRACKET(19),
-
-    /**
-     * The factor by which an opening parenthesis that is the first non-space
-     * character of its line is charged more heavily, since a group standing at
-     * the start of a line, before the reader knows what it applies to, is the
-     * worst place for a bracket.
-     */
-    LEADING(4),
 
     /**
      * Points charged for each explicit phi attribute {@code @} on a line.

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyKeyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyKeyTest.java
@@ -40,19 +40,6 @@ final class PenaltyKeyTest {
     }
 
     @Test
-    void honoursOverriddenLeadingWeight() {
-        final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
-        weights.put(PenaltyKey.LEADING, 1);
-        weights.put(PenaltyKey.SYMBOL, 0);
-        weights.put(PenaltyKey.SPACE, 0);
-        MatcherAssert.assertThat(
-            "A leading parenthesis with the factor tuned to one should cost the same as a mid-line one",
-            new Penalty("(a) > x", weights).points(),
-            Matchers.equalTo(new Penalty("f (a) > x", weights).points())
-        );
-    }
-
-    @Test
     void honoursOverriddenStepWeight() {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
         weights.put(PenaltyKey.STEP, 4);

--- a/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/PenaltyTest.java
@@ -66,9 +66,7 @@ final class PenaltyTest {
     @ParameterizedTest
     @CsvSource({
         "'f (a) (b)', 38",
-        "'(a (b (c 1)))', 171",
-        "'f (a).eq b', 19",
-        "'(a).eq b', 76"
+        "'(a (b (c 1)))', 114"
     })
     void chargesForParentheses(final String code, final int points) {
         final Map<PenaltyKey, Integer> weights = new EnumMap<>(PenaltyKey.class);
@@ -76,7 +74,7 @@ final class PenaltyTest {
         weights.put(PenaltyKey.SPACE, 0);
         MatcherAssert.assertThat(
             String.format(
-                "The parentheses in %s should cost %d points, deeper nesting and a leading one charged more",
+                "The parentheses in %s should cost %d points, deeper nesting charged more",
                 code, points
             ),
             new Penalty(code, weights).points(),

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/compound-receiver-suffix.yaml
@@ -2,11 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The origin dispatches off a compound receiver in suffix form, which would
-# open the line with a group. With the default LEADING factor of 4 (issue
-# #5880) that line-leading `(` is charged four times as much, so the receiver
-# is broken out onto its own indented lines instead of standing at the head of
-# the line.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -19,6 +14,4 @@ origin: |
 
 printed: |
   [input] > input-length
-    ^. > chunk
-      read.
-        input.read 4096
+    (input.read 4096).read.^ > chunk

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-chains-mixed.yaml
@@ -18,11 +18,9 @@ origin: |
 
 printed: |
   [a b c] > math
-    div. > mean
-      a.plus b
+    (a.plus b).div > mean
       c
-    and. > sorted
-      a.gt b
+    (a.gt b).and > sorted
       b.gt c
     a.plus b > sum
     a.plus > weighted

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-overflow.yaml
@@ -35,9 +35,7 @@ printed: |
     lt. ++> tests-cosine-of-pi-thirds-is-half
       abs
         minus.
-          times.
-            cosine
-              pi.div 3
+          (cosine (pi.div 3)).times
             1000
           500
       1

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/nested-formation-apply.yaml
@@ -22,6 +22,5 @@ printed: |
       3
       4
     width.times height > [width height] > rectangle
-    plus. > total
-      rectangle 3 4
+    (rectangle 3 4).plus > total
       rectangle 1 2

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -54,9 +54,7 @@
 
   true.eq true ++> tests-compares-two-bools
 
-  ++> tests-compares-two-different-bool-types
-    not. > @
-      true.eq 42
+  (true.eq 42).not ++> tests-compares-two-different-bool-types
 
   ++> tests-compiles-correctly-with-long-duplicate-names
     true > @
@@ -204,9 +202,7 @@
         x.eq 42 > [] > @
     42 > x
 
-  ++> tests-true-and-false-is-false
-    not. > @
-      true.and false
+  (true.and false).not ++> tests-true-and-false-is-false
 
   true.as-bool ++> tests-true-as-bool
 

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -115,17 +115,11 @@
 
   F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
 
-  ++> tests-not-with-neg
-    not. > @
-      -1.as-bytes.eq -1.as-bytes.not
+  (-1.as-bytes.eq -1.as-bytes.not).not ++> tests-not-with-neg
 
-  ++> tests-not-with-plus
-    not. > @
-      53.as-bytes.eq 53.as-bytes.not
+  (53.as-bytes.eq 53.as-bytes.not).not ++> tests-not-with-plus
 
-  ++> tests-not-with-zero
-    not. > @
-      0.as-bytes.eq 0.as-bytes.not
+  (0.as-bytes.eq 0.as-bytes.not).not ++> tests-not-with-zero
 
   eq. ++> tests-or-neg-bytes-as-number-with-zero
     as-number.

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -11,6 +11,4 @@
   ? >> bts
   bts.eq 01- > @
 
-  ++> tests-convertible-to-bool
-    not. > @
-      01-.as-bool.eq 00-.as-bool
+  (01-.as-bool.eq 00-.as-bool).not ++> tests-convertible-to-bool

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -44,16 +44,12 @@
             as-bytes.
               data.slice
                 next
-                minus.
-                  number available
+                (number available).minus
                   number next
-            as-bytes.
-              data.slice 0 next
+            (data.slice 0 next).as-bytes
         data.size > available!
         if. > next!
-          gt.
-            number available
-            requested
+          (number available).gt requested
           requested
           available
         size > requested!

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -31,15 +31,9 @@
     0
 
   and. ++> tests-hash-code-bools-is-number
-    eq.
-      size.
-        as-bytes.
-          hash true
+    (hash true).as-bytes.size.eq
       8
-    eq.
-      size.
-        as-bytes.
-          hash false
+    (hash false).as-bytes.size.eq
       8
 
   ++> tests-hash-code-int-is-int

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -40,9 +40,7 @@
       seq * > [mem]
         write.
           write.
-            write.
-              to-output mem
-              01-02-03
+            (to-output mem).write 01-02-03
             04-05-06-07
           08-09-A0
         mem

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -63,9 +63,7 @@
     and. > @
       and.
         and.
-          and.
-            inner.is-directory.and inner.exists
-            f.exists
+          (inner.is-directory.and inner.exists).and f.exists
           d.deleted.exists.not
         inner.exists.not
       f.exists.not
@@ -90,35 +88,21 @@
 
   ++> tests-deletes-empty-directory
     not. > @
-      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
+      (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted.exists
 
   ++> tests-makes-new-directory
     d.exists.and d.is-directory > @
-    made. > d
-      as-dir.
-        mktemp.tmpfile.deleted.as-path.resolved "foo-new"
+    (mktemp.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
 
   ++> tests-walks-recursively
     seq * > @
-      made.
-        as-dir.
-          d.resolved "foo/bar"
-      touched.
-        as-file.
-          d.resolved "foo/bar/test.txt"
-      made.
-        as-dir.
-          d.resolved "x/y/z"
-      touched.
-        as-file.
-          d.resolved "x/y/z/a.txt"
-      eq.
-        length.
-          d.as-dir.walk "**/*.txt"
+      (d.resolved "foo/bar").as-dir.made
+      (d.resolved "foo/bar/test.txt").as-file.touched
+      (d.resolved "x/y/z").as-dir.made
+      (d.resolved "x/y/z/a.txt").as-file.touched
+      (d.as-dir.walk "**/*.txt").length.eq
         2
-    as-path. > d
-      made.
-        directory mktemp.tmpfile.deleted
+    (directory mktemp.tmpfile.deleted).made.as-path > d
 
   mktemp.open --> on-opening-directory
     "w"

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -52,9 +52,7 @@
   [cant-check] > is-directory
     if. > @
       info.code.eq 0
-      eq.
-        floor.
-          info.output.mode.div 4096
+      (info.output.mode.div 4096).floor.eq
         4
       cant-check
     called. > info
@@ -96,14 +94,10 @@
           open-file
           ^
     mode > access!
-    or. > appending
-      as-bool.
-        access.eq "a"
+    (access.eq "a").as-bool.or > appending
       as-bool.
         access.eq "a+"
-    or. > existing
-      as-bool.
-        access.eq "r"
+    (access.eq "r").as-bool.or > existing
       as-bool.
         access.eq "r+"
     or. > known
@@ -146,18 +140,14 @@
           syscall.rdwr
           writable.if syscall.wronly syscall.rdonly
         plus. > flags
-          plus.
-            direction.plus creat
-            trunc
+          (direction.plus creat).plus trunc
           append
         called. > opened
           syscall.open
             * path flags syscall.mode
         [descriptor] > stream
           [size] > read
-            read. > @
-              input-block --
-              size
+            (input-block --).read size > @
             [buffer] > input-block
               buffer > @
               [size] > read
@@ -185,21 +175,12 @@
                       * descriptor buffer buffer.size
                   output-block
         truncate.if syscall.trunc 0 > trunc
-    and. > readable
-      not.
-        as-bool.
-          access.eq "w"
-      not.
-        as-bool.
-          access.eq "a"
-    or. > truncate
-      as-bool.
-        access.eq "w"
+    (access.eq "w").as-bool.not.and > readable
+      (access.eq "a").as-bool.not
+    (access.eq "w").as-bool.or > truncate
       as-bool.
         access.eq "w+"
-    not. > writable
-      as-bool.
-        access.eq "r"
+    (access.eq "r").as-bool.not > writable
   [cant-measure] > size
     if. > @
       info.code.eq 0
@@ -254,14 +235,9 @@
         f.write "!" > [f]
     13
 
-  ++> tests-check-if-absent-file-does-not-exist
-    not. > @
-      exists.
-        file "absent.txt"
+  (file "absent.txt").exists.not ++> tests-check-if-absent-file-does-not-exist
 
-  ++> tests-check-if-current-directory-is-directory
-    is-directory. > @
-      file "."
+  (file ".").is-directory ++> tests-check-if-current-directory-is-directory
 
   mktemp.tmpfile.deleted.is-directory ++> tests-checking-absent-file-returns-fallback
     true
@@ -341,8 +317,7 @@
           13
           [m] >>
             seq * > @
-              open.
-                file src
+              (file src).open
                 "r"
                 m.put > [f] >>
                   f.read 13
@@ -362,9 +337,7 @@
                 f.write "Hello, world" > [f]
               "r"
               m.put > [f] >>
-                read.
-                  f.read 7
-                  5
+                (f.read 7).read 5
             m
       "world"
 
@@ -466,8 +439,7 @@
           14
           [m] >>
             seq * > @
-              open.
-                file src
+              (file src).open
                 "r"
                 m.put > [f] >>
                   f.read 14
@@ -486,9 +458,7 @@
     13
 
   --> an-error-on-touching-temp-file-in-absent-dir
-    tmpfile. > @
-      @.
-        mktemp.as-path.resolved "foo"
+    (mktemp.as-path.resolved "foo").@.tmpfile > @
 
   mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
 

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -71,9 +71,7 @@
       2
   [x] > times
     i16 right > @
-    slice. > right
-      as-bytes.
-        as-i32.times x.as-i16.as-i32
+    (as-i32.times x.as-i16.as-i32).as-bytes.slice > right
       2
       2
 
@@ -105,19 +103,13 @@
     13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
 
-  ++> tests-i16-eq-false
-    not. > @
-      123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
+  (123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16).not ++> tests-i16-eq-false
 
   123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
 
-  ++> tests-i16-greater-equal
-    not. > @
-      0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
+  (0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16).not ++> tests-i16-greater-equal
 
-  ++> tests-i16-greater-false
-    not. > @
-      0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
+  (0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16).not ++> tests-i16-greater-false
 
   gt. ++> tests-i16-greater-true
     -200.as-i64.as-i32.as-i16
@@ -125,29 +117,21 @@
 
   113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
 
-  ++> tests-i16-gte-false
-    not. > @
-      0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
+  (0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16).not ++> tests-i16-gte-false
 
   -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
 
   42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
 
-  ++> tests-i16-less-equal
-    not. > @
-      10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
+  (10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16).not ++> tests-i16-less-equal
 
-  ++> tests-i16-less-false
-    not. > @
-      10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
+  (10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16).not ++> tests-i16-less-false
 
   10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
 
   50.as-i64.as-i32.as-i16.lte 50.as-i64.as-i32.as-i16 ++> tests-i16-lte-equal
 
-  ++> tests-i16-lte-false
-    not. > @
-      0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
+  (0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16).not ++> tests-i16-lte-false
 
   -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
 

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -79,9 +79,7 @@
       4
   [x] > times
     i32 right > @
-    slice. > right
-      as-bytes.
-        as-i64.times x.as-i32.as-i64
+    (as-i64.times x.as-i32.as-i64).as-bytes.slice > right
       4
       4
 
@@ -113,47 +111,33 @@
     13.as-i64.as-i32.div -5.as-i64.as-i32
     -2.as-i64.as-i32
 
-  ++> tests-i32-eq-false
-    not. > @
-      123.as-i64.as-i32.eq 42.as-i64.as-i32
+  (123.as-i64.as-i32.eq 42.as-i64.as-i32).not ++> tests-i32-eq-false
 
   123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
 
-  ++> tests-i32-greater-equal
-    not. > @
-      0.as-i64.as-i32.gt 0.as-i64.as-i32
+  (0.as-i64.as-i32.gt 0.as-i64.as-i32).not ++> tests-i32-greater-equal
 
-  ++> tests-i32-greater-false
-    not. > @
-      0.as-i64.as-i32.gt 100.as-i64.as-i32
+  (0.as-i64.as-i32.gt 100.as-i64.as-i32).not ++> tests-i32-greater-false
 
   -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
 
   113.as-i64.as-i32.gte 113.as-i64.as-i32 ++> tests-i32-gte-equal
 
-  ++> tests-i32-gte-false
-    not. > @
-      0.as-i64.as-i32.gte 10.as-i64.as-i32
+  (0.as-i64.as-i32.gte 10.as-i64.as-i32).not ++> tests-i32-gte-false
 
   -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
 
   42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
 
-  ++> tests-i32-less-equal
-    not. > @
-      10.as-i64.as-i32.lt 10.as-i64.as-i32
+  (10.as-i64.as-i32.lt 10.as-i64.as-i32).not ++> tests-i32-less-equal
 
-  ++> tests-i32-less-false
-    not. > @
-      10.as-i64.as-i32.lt -5.as-i64.as-i32
+  (10.as-i64.as-i32.lt -5.as-i64.as-i32).not ++> tests-i32-less-false
 
   10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
 
   50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
 
-  ++> tests-i32-lte-false
-    not. > @
-      0.as-i64.as-i32.lte -10.as-i64.as-i32
+  (0.as-i64.as-i32.lte -10.as-i64.as-i32).not ++> tests-i32-lte-false
 
   -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
 

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -147,12 +147,9 @@
       i64 acc
       looped
         if.
-          eq.
-            b.and 00-00-00-00-00-00-00-01
-            00-00-00-00-00-00-00-01
+          (b.and 00-00-00-00-00-00-00-01).eq 00-00-00-00-00-00-00-01
           as-bytes.
-            plus.
-              i64 acc
+            (i64 acc).plus
               i64 a
           acc
         a.left 1
@@ -212,19 +209,13 @@
     13.as-i64.div -5.as-i64
     -2.as-i64
 
-  ++> tests-i64-eq-false
-    not. > @
-      123.@.eq 42.@
+  (123.@.eq 42.@).not ++> tests-i64-eq-false
 
   123.@.eq 123.@ ++> tests-i64-eq-true
 
-  ++> tests-i64-greater-equal
-    not. > @
-      0.as-i64.gt 0.as-i64
+  (0.as-i64.gt 0.as-i64).not ++> tests-i64-greater-equal
 
-  ++> tests-i64-greater-false
-    not. > @
-      0.as-i64.gt 100.as-i64
+  (0.as-i64.gt 100.as-i64).not ++> tests-i64-greater-false
 
   gt. ++> tests-i64-greater-max-over-min
     i64 7F-FF-FF-FF-FF-FF-FF-FF
@@ -244,9 +235,7 @@
 
   113.as-i64.gte 113.as-i64 ++> tests-i64-gte-equal
 
-  ++> tests-i64-gte-false
-    not. > @
-      0.as-i64.gte 10.as-i64
+  (0.as-i64.gte 10.as-i64).not ++> tests-i64-gte-false
 
   -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
 
@@ -262,13 +251,9 @@
 
   -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
 
-  ++> tests-i64-less-equal
-    not. > @
-      10.as-i64.lt 10.as-i64
+  (10.as-i64.lt 10.as-i64).not ++> tests-i64-less-equal
 
-  ++> tests-i64-less-false
-    not. > @
-      10.as-i64.lt -5.as-i64
+  (10.as-i64.lt -5.as-i64).not ++> tests-i64-less-false
 
   10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
 
@@ -278,9 +263,7 @@
 
   50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
 
-  ++> tests-i64-lte-false
-    not. > @
-      0.as-i64.lte -10.as-i64
+  (0.as-i64.lte -10.as-i64).not ++> tests-i64-lte-false
 
   -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
 

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -29,9 +29,7 @@
         "Can't divide %d by i8 zero".printf
           * as-number
       i8 quotient
-    slice. > quotient
-      as-bytes.
-        as-i16.div xval.as-i16
+    (as-i16.div xval.as-i16).as-bytes.slice > quotient
       1
       1
     x.as-i8 > xval
@@ -42,24 +40,18 @@
   as-i16.lte x.as-i8.as-i16 > [x] > lte
   [x] > minus
     i8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.minus x.as-i8.as-i16
+    (as-i16.minus x.as-i8.as-i16).as-bytes.slice > right
       1
       1
   times FF-.as-i8 > neg
   [x] > plus
     i8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.plus x.as-i8.as-i16
+    (as-i16.plus x.as-i8.as-i16).as-bytes.slice > right
       1
       1
   [x] > times
     i8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.times x.as-i8.as-i16
+    (as-i16.times x.as-i8.as-i16).as-bytes.slice > right
       1
       1
 
@@ -85,9 +77,7 @@
     0D-.as-i8.div FB-.as-i8
     FE-.as-i8
 
-  ++> tests-i8-eq-false
-    not. > @
-      2A-.as-i8.eq 2B-.as-i8
+  (2A-.as-i8.eq 2B-.as-i8).not ++> tests-i8-eq-false
 
   2A-.as-i8.eq 2A-.as-i8 ++> tests-i8-eq-true
 
@@ -97,9 +87,7 @@
 
   C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
 
-  ++> tests-i8-less-equal
-    not. > @
-      0A-.as-i8.lt 0A-.as-i8
+  (0A-.as-i8.lt 0A-.as-i8).not ++> tests-i8-less-equal
 
   0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
 

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -16,9 +16,7 @@
       rec-read
         chunk
         length.plus chunk.size
-    ^. > chunk
-      read.
-        input.read 4096
+    (input.read 4096).read.^ > chunk
   | > @
     input
     0

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -36,8 +36,8 @@
         seq * > @
           written
           input-block chunk written chunk.as-bytes
-        ^. (input.read size).read > chunk
-        ^. (output.write chunk).write > written
+        (input.read size).read.^ > chunk
+        (output.write chunk).write.^ > written
 
   eq. ++> tests-reads-from-bytes-and-writes-to-memory
     malloc.of

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -156,8 +156,7 @@
             m.write 0 "XXX"
             m.write 1 "Y"
             b.put
-              eq.
-                m.read 0 3
+              (m.read 0 3).eq
                 "XYX"
 
   ++> tests-malloc-decreases-block-size
@@ -168,7 +167,7 @@
           01-02-03-04-05
           b.put > [m] >>
             and.
-              eq. (m.resized 3).size 3
+              (m.resized 3).size.eq 3
               m.get.eq 01-02-03
 
   eq. ++> tests-malloc-empty-grows-on-first-put
@@ -198,7 +197,7 @@
           01-02-03-04
           b.put > [m] >>
             and.
-              eq. (m.resized 6).size 6
+              (m.resized 6).size.eq 6
               m.get.eq 01-02-03-04-00-00
 
   eq. ++> tests-malloc-is-strictly-sized-int
@@ -246,8 +245,7 @@
           seq * > [m] >>
             m.write 2 "Hello"
             b.put
-              eq.
-                m.read 2 5
+              (m.read 2 5).eq
                 "Hello"
 
   ++> tests-malloc-rewrites-and-increments-itself
@@ -283,8 +281,7 @@
               "Hello, "
             m.write 7 "Jeff!"
             b.put
-              eq.
-                m.read 0 12
+              (m.read 0 12).eq
                 "Hello, Jeff!"
 
   eq. ++> tests-memory-is-strictly-sized-string

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -46,8 +46,7 @@
         ent.length.eq 0
         false
         if.
-          and.
-            ent.head.hash.eq hash
+          (ent.head.hash.eq hash).and
             ent.head.kbts.eq kbts
           true
           has-key ent.tail
@@ -76,8 +75,7 @@
           prev.exists.if
             prev
             if.
-              and.
-                tup.head.hash.eq hash
+              (tup.head.hash.eq hash).and
                 tup.head.kbts.eq kbts
               [] >>
                 true > exists
@@ -85,9 +83,7 @@
               not-found
         @. > prev
           rec-key-search tup.tail
-    [key] > has
-      exists. > @
-        found key
+    (found key).exists > [key] > has
     tuple.mapped > keys
       entries
       entry.key > [entry]
@@ -102,8 +98,7 @@
             entries
             [entry] >>
               not. > @
-                and.
-                  hash.eq entry.hash
+                (hash.eq entry.hash).and
                   kbts.eq entry.kbts
           [] >>
             ^.hash > hash
@@ -118,8 +113,7 @@
           entries
           [entry] >>
             not. > @
-              and.
-                hash.eq entry.hash
+              (hash.eq entry.hash).and
                 kbts.eq entry.kbts
       bytes.hash kbts > hash!
       key.as-bytes > kbts!
@@ -239,10 +233,8 @@
         0
         [m]
           seq * > @
-            exists.
-              mp.found 1
-            exists.
-              mp.found 1
+            (mp.found 1).exists
+            (mp.found 1).exists
             m
           map * > mp
             map.entry
@@ -262,9 +254,7 @@
       "one"
 
   ++> tests-removes-only-the-given-key-of-colliding-ones
-    and. > @
-      not.
-        mp.has "Aa"
+    (mp.has "Aa").not.and > @
       mp.has "BB"
     without. > mp
       map *

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -64,11 +64,9 @@
       false
       or.
         and.
-          or.
-            xbts.eq pzero
+          (xbts.eq pzero).or
             xbts.eq nzero
-          or.
-            bts.eq pzero
+          (bts.eq pzero).or
             bts.eq nzero
         bts.eq xbts
     as-bytes > bts!
@@ -178,25 +176,16 @@
                   and.
                     and.
                       and.
-                        and.
-                          eq. (0.eq nan) false
-                          eq. (0.eq pinf) false
-                        eq. (0.eq ninf) false
-                      eq. (42.5.eq nan) false
-                    eq. (42.5.eq pinf) false
-                  eq. (42.5.eq ninf) false
-                eq.
-                  0.eq nan
-                  false
-              eq.
-                0.eq pinf
-                false
-            eq.
-              0.eq ninf
-              false
-          eq.
-            42.5.eq nan
-            false
+                        ((0.eq nan).eq false).and
+                          (0.eq pinf).eq false
+                        (0.eq ninf).eq false
+                      (42.5.eq nan).eq false
+                    (42.5.eq pinf).eq false
+                  (42.5.eq ninf).eq false
+                (0.eq nan).eq false
+              (0.eq pinf).eq false
+            (0.eq ninf).eq false
+          (42.5.eq nan).eq false
         eq.
           42.5.eq pinf
           false
@@ -220,18 +209,10 @@
         and.
           and.
             and.
-              eq.
-                0.eq nan
-                false
-              eq.
-                0.eq pinf
-                false
-            eq.
-              0.eq ninf
-              false
-          eq.
-            42.eq nan
-            false
+              (0.eq nan).eq false
+              (0.eq pinf).eq false
+            (0.eq ninf).eq false
+          (42.eq nan).eq false
         eq.
           42.eq pinf
           false
@@ -270,13 +251,9 @@
     as-bytes.
       0.div 0
 
-  ++> tests-nan-not-eq-nan
-    not. > @
-      nan.eq nan
+  (nan.eq nan).not ++> tests-nan-not-eq-nan
 
-  ++> tests-nan-not-eq-number
-    not. > @
-      nan.eq 42
+  (nan.eq 42).not ++> tests-nan-not-eq-number
 
   eq. ++> tests-nan-not-gt-nan
     nan.gt nan
@@ -339,28 +316,18 @@
 
   ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
 
-  ++> tests-negative-infinity-gt-negative-infinity
-    not. > @
-      ninf.gt ninf
+  (ninf.gt ninf).not ++> tests-negative-infinity-gt-negative-infinity
 
   ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
     -1.div 0
 
-  ++> tests-negative-infinity-not-eq-float
-    not. > @
-      ninf.eq 42.5
+  (ninf.eq 42.5).not ++> tests-negative-infinity-not-eq-float
 
-  ++> tests-negative-infinity-not-eq-int
-    not. > @
-      ninf.eq 42
+  (ninf.eq 42).not ++> tests-negative-infinity-not-eq-int
 
-  ++> tests-negative-infinity-not-eq-nan
-    not. > @
-      ninf.eq nan
+  (ninf.eq nan).not ++> tests-negative-infinity-not-eq-nan
 
-  ++> tests-negative-infinity-not-eq-positive-infinity
-    not. > @
-      ninf.eq pinf
+  (ninf.eq pinf).not ++> tests-negative-infinity-not-eq-positive-infinity
 
   eq. ++> tests-negative-infinity-not-gt-float
     ninf.gt 42.5
@@ -540,32 +507,20 @@
 
   pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
 
-  ++> tests-positive-infinity-gt-positive-infinity
-    not. > @
-      pinf.gt pinf
+  (pinf.gt pinf).not ++> tests-positive-infinity-gt-positive-infinity
 
   pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
     1.div 0
 
-  ++> tests-positive-infinity-not-eq-float
-    not. > @
-      pinf.eq 42.5
+  (pinf.eq 42.5).not ++> tests-positive-infinity-not-eq-float
 
-  ++> tests-positive-infinity-not-eq-int
-    not. > @
-      pinf.eq 42
+  (pinf.eq 42).not ++> tests-positive-infinity-not-eq-int
 
-  ++> tests-positive-infinity-not-eq-nan
-    not. > @
-      pinf.eq nan
+  (pinf.eq nan).not ++> tests-positive-infinity-not-eq-nan
 
-  ++> tests-positive-infinity-not-eq-negative-infinity
-    not. > @
-      pinf.eq ninf
+  (pinf.eq ninf).not ++> tests-positive-infinity-not-eq-negative-infinity
 
-  ++> tests-positive-infinity-not-gt-nan
-    not. > @
-      pinf.gt nan
+  (pinf.gt nan).not ++> tests-positive-infinity-not-gt-nan
 
   eq. ++> tests-positive-infinity-plus-nan
     as-bytes.

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,21 +15,13 @@
     pi.div 2
     arc-sine num
 
-  ++> tests-arc-cosine-above-one-is-nan
-    is-nan. > @
-      arc-cosine 2
+  (arc-cosine 2).is-nan ++> tests-arc-cosine-above-one-is-nan
 
-  ++> tests-arc-cosine-below-minus-one-is-nan
-    is-nan. > @
-      arc-cosine -2
+  (arc-cosine -2).is-nan ++> tests-arc-cosine-below-minus-one-is-nan
 
-  ++> tests-arc-cosine-of-nan-is-nan
-    is-nan. > @
-      arc-cosine nan
+  (arc-cosine nan).is-nan ++> tests-arc-cosine-of-nan-is-nan
 
-  ++> tests-arc-cosine-of-negative-infinity-is-nan
-    is-nan. > @
-      arc-cosine ninf
+  (arc-cosine ninf).is-nan ++> tests-arc-cosine-of-negative-infinity-is-nan
 
   eq. ++> tests-arc-cosine-of-negative-one-is-pi
     arc-cosine -1
@@ -57,9 +49,7 @@
         927.295
     1
 
-  ++> tests-arc-cosine-of-positive-infinity-is-nan
-    is-nan. > @
-      arc-cosine pinf
+  (arc-cosine pinf).is-nan ++> tests-arc-cosine-of-positive-infinity-is-nan
 
   eq. ++> tests-arc-cosine-of-zero-is-pi-halves
     arc-cosine 0

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -40,30 +40,19 @@
           div.
             times.
               times.
-                minus.
-                  depth.times 2
-                  1
-                minus.
-                  depth.times 2
-                  1
+                (depth.times 2).minus 1
+                (depth.times 2).minus 1
               squared
-            times.
-              depth.times 2
-              plus.
-                depth.times 2
-                1
+            (depth.times 2).times
+              (depth.times 2).plus 1
           poly
             depth.plus 1
     point.times point > squared
     30 > terms
 
-  ++> tests-arc-sine-above-one-is-nan
-    is-nan. > @
-      arc-sine 2
+  (arc-sine 2).is-nan ++> tests-arc-sine-above-one-is-nan
 
-  ++> tests-arc-sine-below-minus-one-is-nan
-    is-nan. > @
-      arc-sine -2
+  (arc-sine -2).is-nan ++> tests-arc-sine-below-minus-one-is-nan
 
   lt. ++> tests-arc-sine-is-odd-function
     abs
@@ -85,9 +74,7 @@
           1000
     1
 
-  ++> tests-arc-sine-of-nan-is-nan
-    is-nan. > @
-      arc-sine nan
+  (arc-sine nan).is-nan ++> tests-arc-sine-of-nan-is-nan
 
   lt. ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
     abs
@@ -95,15 +82,11 @@
         times.
           arc-sine -0.5
           1000
-        times.
-          neg.
-            pi.div 6
+        (pi.div 6).neg.times
           1000
     1
 
-  ++> tests-arc-sine-of-negative-infinity-is-nan
-    is-nan. > @
-      arc-sine ninf
+  (arc-sine ninf).is-nan ++> tests-arc-sine-of-negative-infinity-is-nan
 
   lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
     abs
@@ -111,9 +94,7 @@
         times.
           arc-sine -1
           1000
-        times.
-          neg.
-            pi.div 2
+        (pi.div 2).neg.times
           1000
     1
 
@@ -137,9 +118,7 @@
         643.5
     1
 
-  ++> tests-arc-sine-of-positive-infinity-is-nan
-    is-nan. > @
-      arc-sine pinf
+  (arc-sine pinf).is-nan ++> tests-arc-sine-of-positive-infinity-is-nan
 
   eq. ++> tests-arc-sine-of-zero-is-zero
     arc-sine 0

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -23,13 +23,9 @@
         1000
     1
 
-  ++> tests-cosine-of-nan-is-nan
-    is-nan. > @
-      cosine nan
+  (cosine nan).is-nan ++> tests-cosine-of-nan-is-nan
 
-  ++> tests-cosine-of-negative-infinity-is-nan
-    is-nan. > @
-      cosine ninf
+  (cosine ninf).is-nan ++> tests-cosine-of-negative-infinity-is-nan
 
   lt. ++> tests-cosine-of-pi-halves-is-zero
     abs
@@ -58,9 +54,7 @@
         500
     1
 
-  ++> tests-cosine-of-positive-infinity-is-nan
-    is-nan. > @
-      cosine pinf
+  (cosine pinf).is-nan ++> tests-cosine-of-positive-infinity-is-nan
 
   lt. ++> tests-cosine-of-seventeen-radians
     abs
@@ -85,8 +79,7 @@
       minus.
         times.
           cosine
-            plus.
-              pi.times 10
+            (pi.times 10).plus
               pi.div 3
           1000
         500

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -14,9 +14,7 @@
     pi
   number num.as-bytes > value
 
-  ++> tests-degrees-of-nan-is-nan
-    is-nan. > @
-      degrees nan
+  (degrees nan).is-nan ++> tests-degrees-of-nan-is-nan
 
   lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
     abs

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -47,6 +47,4 @@
         exp -10
     1.0E-12
 
-  ++> tests-exp-check-nan
-    is-nan. > @
-      exp nan
+  (exp nan).is-nan ++> tests-exp-check-nan

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -23,15 +23,14 @@
                   sum.as-number.plus
                     subsection
                       a.plus (i.times step)
-                      a.plus ((i.plus 1).times step)
+                      a.plus
+                        (i.plus 1).times step
                 true
               false
             true > [i]
           sum
         as-number. > step
-          div.
-            b.minus a
-            n
+          (b.minus a).div n
   times. > [a b] > subsection
     div.
       b.minus a
@@ -49,9 +48,7 @@
     close-to > @
       as-number.
         integral
-          times. > [x]
-            x.times x
-            x
+          (x.times x).times x > [x]
           1
           10
           100

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -20,9 +20,6 @@
 
   ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
 
-  ++> tests-number-with-infinite-bytes-is-not-finite
-    not. > @
-      is-finite.
-        number pinf.as-bytes
+  (number pinf.as-bytes).is-finite.not ++> tests-number-with-infinite-bytes-is-not-finite
 
   pinf.is-finite.not ++> tests-positive-infinity-is-not-finite

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -58,9 +58,7 @@
 
   ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
 
-  ++> tests-number-with-nan-bytes-is-nan
-    is-nan. > @
-      number nan.as-bytes
+  (number nan.as-bytes).is-nan ++> tests-number-with-nan-bytes-is-nan
 
   pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
 

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -47,9 +47,7 @@
         0
         plus.
           1.div
-            plus.
-              k.times 2
-              1
+            (k.times 2).plus 1
           squared.times
             horner
               k.plus 1
@@ -71,25 +69,17 @@
     ln 2
     ln 3
 
-  ++> tests-ln-nan
-    is-nan. > @
-      ln nan
+  (ln nan).is-nan ++> tests-ln-nan
 
-  ++> tests-ln-negative-infinity
-    is-nan. > @
-      ln ninf
+  (ln ninf).is-nan ++> tests-ln-negative-infinity
 
   eq. ++> tests-ln-of-e-one-is-one
     ln e
     1
 
-  ++> tests-ln-of-negative-float-is-nan
-    is-nan. > @
-      ln -2.2
+  (ln -2.2).is-nan ++> tests-ln-of-negative-float-is-nan
 
-  ++> tests-ln-of-negative-int-is-nan
-    is-nan. > @
-      ln -42
+  (ln -42).is-nan ++> tests-ln-of-negative-int-is-nan
 
   eq. ++> tests-ln-of-one-is-zero
     ln 1

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -33,7 +33,8 @@
     eq. > @
       plus.
         mod dividend divisor
-        divisor.times (dividend.div divisor).as-i64.as-number
+        divisor.times
+          (dividend.div divisor).as-i64.as-number
       dividend
     -13 > dividend
     5 > divisor

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -51,25 +51,17 @@
           if.
             expo.gt 0
             if.
-              gt.
-                abs base
-                1
+              (abs base).gt 1
               pinf
               if.
-                eq.
-                  abs base
-                  1
+                (abs base).eq 1
                 nan
                 0
             if.
-              gt.
-                abs base
-                1
+              (abs base).gt 1
               0
               if.
-                eq.
-                  abs base
-                  1
+                (abs base).eq 1
                 nan
                 pinf
   number num.as-bytes > base
@@ -114,13 +106,9 @@
       b
       n.div 2
   expo.is-integer.and > odd
-    not.
-      is-integer.
-        expo.div 2
+    (expo.div 2).is-integer.not
 
-  ++> tests-power-any-to-nan-is-nan
-    is-nan. > @
-      power 52 nan
+  (power 52 nan).is-nan ++> tests-power-any-to-nan-is-nan
 
   eq. ++> tests-power-as-method-on-number
     2.power 4
@@ -157,9 +145,7 @@
       -3
     0.015625
 
-  ++> tests-power-fractional-of-negative-is-nan
-    is-nan. > @
-      power -4 0.5
+  (power -4 0.5).is-nan ++> tests-power-fractional-of-negative-is-nan
 
   eq. ++> tests-power-int-to-zero-is-one
     power
@@ -173,13 +159,9 @@
       -12341
     0
 
-  ++> tests-power-nan-to-any-is-nan
-    is-nan. > @
-      power nan 42
+  (power nan 42).is-nan ++> tests-power-nan-to-any-is-nan
 
-  ++> tests-power-nan-to-nan-is-nan
-    is-nan. > @
-      power nan nan
+  (power nan nan).is-nan ++> tests-power-nan-to-nan-is-nan
 
   eq. ++> tests-power-negative-float-to-negative-infinity-is-zero
     power

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -28,9 +28,7 @@
         pi
     1.0E-4
 
-  ++> tests-radians-of-nan-is-nan
-    is-nan. > @
-      radians nan
+  (radians nan).is-nan ++> tests-radians-of-nan-is-nan
 
   lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
     abs

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -15,18 +15,18 @@
       as-number.
         plus.
           as-i64.
-            and.
-              tbytes.left shift1
+            (tbytes.left shift1).and
               as-bytes.
-                minus. (one.left 53).as-i64 one
+                (one.left 53).as-i64.minus one
           plus.
             as-i64.
-              and.
-                tbytes.left shift3
+              (tbytes.left shift3).and
                 as-bytes.
-                  minus. (one.left shift1).as-i64 one
+                  (one.left shift1).as-i64.minus one
             as-i64.
-              tbytes.and ((one.left shift3).as-i64.minus one).as-bytes
+              tbytes.and
+                as-bytes.
+                  (one.left shift3).as-i64.minus one
     00-00-00-00-00-00-00-01 > one
     35 > shift1
     17 > shift3
@@ -58,12 +58,10 @@
       and.
         and.
           rand.lt 1
-          not.
-            rand.lt 0
+          (rand.lt 0).not
         and.
           rand.next.lt 1
-          not.
-            rand.next.lt 0
+          (rand.next.lt 0).not
       and.
         rand.next.next.lt 1
         not.
@@ -77,8 +75,8 @@
     random 51 > r
 
   eq. ++> tests-seeded-randoms-are-equal
-    next. (random 1654).next.next
-    next. (random 1654).next.next
+    (random 1654).next.next.next
+    (random 1654).next.next.next
 
   ++> tests-two-random-numbers-not-equal
     not. > @

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -20,11 +20,8 @@
     1.minus
       times.
         squared.div
-          times.
-            depth.times 2
-            plus.
-              depth.times 2
-              1
+          (depth.times 2).times
+            (depth.times 2).plus 1
         factor
           depth.plus 1
   arg.minus > reduced
@@ -48,13 +45,9 @@
         1000
     1
 
-  ++> tests-sine-of-nan-is-nan
-    is-nan. > @
-      sine nan
+  (sine nan).is-nan ++> tests-sine-of-nan-is-nan
 
-  ++> tests-sine-of-negative-infinity-is-nan
-    is-nan. > @
-      sine ninf
+  (sine ninf).is-nan ++> tests-sine-of-negative-infinity-is-nan
 
   lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
     abs
@@ -92,9 +85,7 @@
         500
     1
 
-  ++> tests-sine-of-positive-infinity-is-nan
-    is-nan. > @
-      sine pinf
+  (sine pinf).is-nan ++> tests-sine-of-positive-infinity-is-nan
 
   lt. ++> tests-sine-of-seventeen-radians
     abs
@@ -110,9 +101,7 @@
       minus.
         times.
           sine
-            div.
-              pi.times 3
-              2
+            (pi.times 3).div 2
           1000
         -1000
     1
@@ -134,8 +123,7 @@
       minus.
         times.
           sine
-            plus.
-              pi.times 10
+            (pi.times 10).plus
               pi.div 6
           1000
         500

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -28,17 +28,11 @@
     sqrt pinf
     pinf
 
-  ++> tests-sqrt-check-infinity-n2
-    is-nan. > @
-      sqrt ninf
+  (sqrt ninf).is-nan ++> tests-sqrt-check-infinity-n2
 
-  ++> tests-sqrt-check-nan-input
-    is-nan. > @
-      sqrt nan
+  (sqrt nan).is-nan ++> tests-sqrt-check-nan-input
 
-  ++> tests-sqrt-check-negative-input
-    is-nan. > @
-      sqrt -0.1
+  (sqrt -0.1).is-nan ++> tests-sqrt-check-negative-input
 
   lt. ++> tests-sqrt-check-zero-input
     abs

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -36,8 +36,7 @@
     [] > basename
       string > @
         if.
-          or.
-            pth.size.eq 0
+          (pth.size.eq 0).or
             idx.eq 0
           pth
           as-bytes.
@@ -53,15 +52,13 @@
     [] > dirname
       string > @
         if.
-          or.
-            pth.size.eq 0
+          (pth.size.eq 0).or
             len.eq -1
           pth
           if.
             len.eq 0
             separator
-            as-bytes.
-              txt.slice 0 len
+            (txt.slice 0 len).as-bytes
       string.last-index-of txt separator > len!
       uri > pth!
       string pth > txt
@@ -112,17 +109,14 @@
           if. > [accum segment] >>
             segment.eq ".."
             if.
-              and.
-                accum.length.gt 0
-                not.
-                  accum.head.eq ".."
+              (accum.length.gt 0).and
+                (accum.head.eq "..").not
               accum.tail
               is-absolute.not.if
                 accum.with segment
                 accum
             if.
-              or.
-                segment.eq "."
+              (segment.eq ".").or
                 segment.eq ""
               accum
               accum.with segment
@@ -142,13 +136,9 @@
               obts.size.eq 0
               uri
               if.
-                eq.
-                  obts.slice 0 1
-                  separator
+                (obts.slice 0 1).eq separator
                 obts
-                concat.
-                  uri.concat separator
-                  obts
+                (uri.concat separator).concat obts
       other.as-bytes > obts
     "/" > separator
   os.is-windows.if > separator
@@ -168,8 +158,7 @@
       [] > basename
         string > @
           if.
-            or.
-              pth.size.eq 0
+            (pth.size.eq 0).or
               idx.eq 0
             pth
             as-bytes.
@@ -185,22 +174,19 @@
       [] > dirname
         string > @
           if.
-            or.
-              pth.size.eq 0
+            (pth.size.eq 0).or
               len.eq -1
             pth
             if.
               len.eq 0
               separator
-              as-bytes.
-                txt.slice 0 len
+              (txt.slice 0 len).as-bytes
         string.last-index-of txt separator > len!
         uri > pth!
         string pth > txt
       [] > extname
         if. > @
-          or.
-            base.size.eq 0
+          (base.size.eq 0).or
             idx.eq -1
           ""
           string
@@ -216,19 +202,16 @@
         if. > @
           ubts.size.eq 0
           false
-          or.
-            is-root-relative ubts
-            and.
-              ubts.size.gt 1
+          (is-root-relative ubts).or
+            (ubts.size.gt 1).and
               is-drive-relative ubts
         uri > ubts!
       [uri] > is-drive-relative
-        as-bool. ((string.regex "/^[a-zA-Z]:/").match uri).next.exists > @
+        ((string.regex "/^[a-zA-Z]:/").match uri).next.exists.as-bool > @
       [uri] > is-root-relative
         and. > @
           ubts.size.gt 0
-          eq.
-            ubts.slice 0 1
+          (ubts.slice 0 1).eq
             separator
         uri > ubts!
       [] > normalized
@@ -258,9 +241,7 @@
               concat.
                 is-drive-relative.if
                   if.
-                    eq.
-                      driveless.slice 0 1
-                      separator
+                    (driveless.slice 0 1).eq separator
                     uri.slice 0 3
                     uri.slice 0 2
                   is-root-relative.if separator --
@@ -274,17 +255,14 @@
             if. > [accum segment] >>
               segment.eq ".."
               if.
-                and.
-                  accum.length.gt 0
-                  not.
-                    accum.head.eq ".."
+                (accum.length.gt 0).and
+                  (accum.head.eq "..").not
                 accum.tail
                 driveless-rooted.not.if
                   accum.with segment
                   accum
               if.
-                or.
-                  segment.eq "."
+                (segment.eq ".").or
                   segment.eq ""
                 accum
                 accum.with segment
@@ -301,25 +279,20 @@
           validated
             string
               if.
-                as-bool.
-                  is-drive-relative valid
+                (is-drive-relative valid).as-bool
                 valid
                 if.
-                  as-bool.
-                    is-root-relative valid
+                  (is-root-relative valid).as-bool
                   if.
                     is-drive-relative ubts
-                    concat.
-                      ubts.slice 0 2
-                      valid
+                    (ubts.slice 0 2).concat valid
                     valid
-                  concat. (ubts.concat separator) valid
+                  (ubts.concat separator).concat valid
         uri > ubts!
         separated-correctly other > valid!
       [uri] > separated-correctly
         if. > @
-          eq.
-            string.index-of pth path.posix.separator
+          (string.index-of pth path.posix.separator).eq
             -1
           string ubts
           string repl
@@ -334,19 +307,13 @@
   and. ++> tests-detects-absolute-posix-path
     is-absolute.
       path.posix "/var/www/html"
-    not.
-      is-absolute.
-        path.posix "foo/bar/baz"
+    (path.posix "foo/bar/baz").is-absolute.not
 
   and. ++> tests-detects-absolute-win32-path
-    and.
-      is-absolute.
-        path.win32 "C:\\Windows\\Users"
+    (path.win32 "C:\\Windows\\Users").is-absolute.and
       is-absolute.
         path.win32 "\\Windows\\Users"
-    not.
-      is-absolute.
-        path.win32 "temp\\var"
+    (path.win32 "temp\\var").is-absolute.not
 
   path.separator.eq ++> tests-determines-separator-depending-on-os
     os.is-windows.if

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -103,8 +103,7 @@
           seq * > @
             chunk
             input-block chunk
-          as-bytes. > chunk
-            recv size
+          (recv size).as-bytes > chunk
   [send] > as-output
     [buffer] > write
       @. > @

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -31,9 +31,7 @@
         next-line
         first.if
           buffer.concat line
-          concat.
-            buffer.concat separator
-            line
+          (buffer.concat separator).concat line
         false
     | > @
       next-line
@@ -51,8 +49,7 @@
         or.
           char.eq --
           or.
-            and.
-              char.eq "\r"
+            (char.eq "\r").and
               next.as-bytes.eq "\n"
             char.eq "\n"
         string buffer

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -50,24 +50,16 @@
         index.eq size
         accum
         if.
-          eq.
-            byte.and p1
-            r1
+          (byte.and p1).eq r1
           inclen index 1 accum
           if.
-            eq.
-              byte.and p2
-              r2
+            (byte.and p2).eq r2
             inclen index 2 accum
             if.
-              eq.
-                byte.and p3
-                r3
+              (byte.and p3).eq r3
               inclen index 3 accum
               if.
-                eq.
-                  byte.and p4
-                  r4
+                (byte.and p4).eq r4
                 inclen index 4 accum
                 T
                   "Unknown byte format (%x), can't recognize character".printf
@@ -140,9 +132,7 @@
           index.eq size
           T cause
           if.
-            eq.
-              byte.and p1
-              r1
+            (byte.and p1).eq r1
             increase
               index
               1
@@ -150,9 +140,7 @@
               result
               cause
             if.
-              eq.
-                byte.and p2
-                r2
+              (byte.and p2).eq r2
               increase
                 index
                 2
@@ -160,12 +148,10 @@
                 result
                 cause
               if.
-                eq.
-                  byte.and p3
-                  r3
+                (byte.and p3).eq r3
                 increase index 3 accum result cause
                 if.
-                  eq. (byte.and p4) r4
+                  (byte.and p4).eq r4
                   increase index 4 accum result cause
                   T
                     "Unknown byte format (%x), can't recognize character".printf
@@ -180,26 +166,17 @@
     " ".length
     1
 
-  ++> tests-compares-string-with-nan
-    not. > @
-      nan.eq "друг"
+  (nan.eq "друг").not ++> tests-compares-string-with-nan
 
-  ++> tests-compares-string-with-negative-infinity
-    not. > @
-      ninf.eq "друг"
+  (ninf.eq "друг").not ++> tests-compares-string-with-negative-infinity
 
   eq. ++> tests-compares-string-with-positive-infinity
     pinf.eq "друг"
     false
 
-  ++> tests-compares-two-different-string-types
-    not. > @
-      "Hello".eq 42
+  ("Hello".eq 42).not ++> tests-compares-two-different-string-types
 
-  ++> tests-compares-two-different-strings
-    not. > @
-      "Hello".eq
-        "Good bye"
+  ("Hello".eq "Good bye").not ++> tests-compares-two-different-strings
 
   eq. ++> tests-compares-two-strings
     "x".eq "x"
@@ -388,6 +365,4 @@
     -1
     1
 
-  --> on-taking-length-of-incomplete-n4-byte-character
-    length. > @
-      string F0-9F-98
+  (string F0-9F-98).length --> on-taking-length-of-incomplete-n4-byte-character

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -22,10 +22,7 @@
       concat.
         digits q
         as-char
-          plus.
-            floor.
-              n.minus
-                q.times 10
+          (n.minus (q.times 10)).floor.plus
             48
     floor. > q
       n.div 10

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -63,7 +63,7 @@
           plus.
             floor.
               value.minus
-                times. (value.div 10).floor 10
+                (value.div 10).floor.times 10
             48
         acc
   if. > [a] > signed

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -25,9 +25,7 @@
         if.
           index.eq 0
           pair
-          concat.
-            acc.concat "-".as-bytes
-            pair
+          (acc.concat "-".as-bytes).concat pair
     as-ascii > bval
       bts.slice index 1
     concat. > pair
@@ -36,10 +34,7 @@
           bval.div 16
       hex-digit
         bval.minus
-          times.
-            floor.
-              bval.div 16
-            16
+          (bval.div 16).floor.times 16
   | > @
     0
     --

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -24,10 +24,7 @@
     cant-parse
       "Can't convert text %s to number".printf
         * text
-    head.
-      ^.
-        at.
-          scanf "%f" text
+    (scanf "%f" text).at.^.head
 
   eq. ++> tests-converts-float-text-to-number
     3.14

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -25,7 +25,8 @@
       end.eq idx
       includes
       includes.or
-        rec-contains (idx.plus 1).as-number
+        rec-contains
+          (idx.plus 1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -17,8 +17,7 @@
           tlen
         and.
           slen.eq tlen
-          not.
-            sub.eq txt
+          (sub.eq txt).not
       found.eq -1
     -1
     length.
@@ -37,7 +36,8 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus 1).as-number
+        rec-index-of
+          (idx.plus 1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -15,10 +15,6 @@
 
   is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
 
-  ++> tests-checks-if-text-with-dashes-is-not-alpha
-    not. > @
-      is-alpha "-w-"
+  (is-alpha "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alpha
 
-  ++> tests-checks-if-text-with-number-is-not-alpha
-    not. > @
-      is-alpha "ab3d"
+  (is-alpha "ab3d").not ++> tests-checks-if-text-with-number-is-not-alpha

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -15,8 +15,6 @@
 
   is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
 
-  ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
-    not. > @
-      is-alphanumeric "-w-"
+  (is-alphanumeric "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
 
   is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,9 +12,7 @@
     regex "/^[\\x00-\\x7F]*$/"
     text
 
-  ++> tests-checks-if-emoji-is-not-ascii
-    not. > @
-      is-ascii "🌵"
+  (is-ascii "🌵").not ++> tests-checks-if-emoji-is-not-ascii
 
   is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
 

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,30 +13,19 @@
     regex "/^[0-9]+$/"
     text
 
-  ++> tests-checks-if-empty-text-is-not-digit
-    not. > @
-      is-digit ""
+  (is-digit "").not ++> tests-checks-if-empty-text-is-not-digit
 
   is-digit "2026" ++> tests-checks-if-number-text-is-digit
 
   is-digit "7" ++> tests-checks-if-single-digit-is-digit
 
-  ++> tests-checks-if-text-with-letter-is-not-digit
-    not. > @
-      is-digit "1a2"
+  (is-digit "1a2").not ++> tests-checks-if-text-with-letter-is-not-digit
 
-  ++> tests-checks-if-text-with-space-is-not-digit
-    not. > @
-      is-digit
-        "12 34"
+  (is-digit "12 34").not ++> tests-checks-if-text-with-space-is-not-digit
 
-  ++> tests-checks-if-text-with-special-character-is-not-digit
-    not. > @
-      is-digit "1🌵2"
+  (is-digit "1🌵2").not ++> tests-checks-if-text-with-special-character-is-not-digit
 
-  ++> tests-checks-if-text-with-trailing-newline-is-not-digit
-    not. > @
-      is-digit "123\n"
+  (is-digit "123\n").not ++> tests-checks-if-text-with-trailing-newline-is-not-digit
 
   is-digit ++> tests-checks-if-very-long-number-is-digit
     "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -17,8 +17,7 @@
           tlen
         and.
           slen.eq tlen
-          not.
-            sub.eq txt
+          (sub.eq txt).not
       found.eq -1
     -1
     length.
@@ -37,7 +36,8 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus -1).as-number
+        rec-index-of
+          (idx.plus -1).as-number
     eq. > includes
       slice
         txt

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -17,11 +17,9 @@
       [accum byte] >>
         accum.concat > @
           if.
-            and.
-              code.lte maxcode
+            (code.lte maxcode).and
               code.gte mincode
-            slice.
-              as-bytes. (code.plus distance).as-i64
+            (code.plus distance).as-i64.as-bytes.slice
               7
               1
             byte

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -33,37 +33,27 @@
       if.
         or.
           size.eq 0
-          gt.
-            current.plus size
-            text.size
+          (current.plus size).gt text.size
         rec-nsplit
           accum
           start
-          as-number.
-            current.plus 1
+          (current.plus 1).as-number
           count
         if.
           and.
             delimiter.eq
               slice text current size
-            lt.
-              number count
-              minus.
-                number limit
-                1
+            (number count).lt
+              (number limit).minus 1
           rec-nsplit
             appended
-            as-number.
-              current.plus size
-            as-number.
-              current.plus size
-            as-number.
-              count.plus 1
+            (current.plus size).as-number
+            (current.plus size).as-number
+            (count.plus 1).as-number
           rec-nsplit
             accum
             start
-            as-number.
-              current.plus 1
+            (current.plus 1).as-number
             count
     accum.with > appended
       string

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -58,16 +58,12 @@
 
   ++> tests-does-not-match-anchored-pattern-with-trailing-newline
     not. > @
-      matches.
-        compiled.
-          regex "/^[0-9]+$/"
+      (regex "/^[0-9]+$/").compiled.matches
         "123\n"
 
   ++> tests-does-not-matches-regex-against-the-pattern
     not. > @
-      matches.
-        compiled.
-          regex "/[a-z]+/"
+      (regex "/[a-z]+/").compiled.matches
         "123"
 
   eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
@@ -103,18 +99,14 @@
       and.
         and.
           first.count.eq 3
-          eq.
-            first.group 1
-            "hello"
+          (first.group 1).eq "hello"
         eq.
           first.group 2
           "1"
       and.
         and.
           second.count.eq 3
-          eq.
-            second.group 1
-            "world"
+          (second.group 1).eq "world"
         eq.
           second.group 2
           "2"
@@ -178,8 +170,7 @@
     and. > @
       and.
         and.
-          and.
-            second.text.eq "world"
+          (second.text.eq "world").and
             second.position.eq 2
           second.start.eq 6
         second.from.eq 7
@@ -190,9 +181,7 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  --> on-compiling-invalid-regex-without-fallback
-    compile. > @
-      regex "/[a-z/"
+  (regex "/[a-z/").compile --> on-compiling-invalid-regex-without-fallback
 
   --> on-getting-from-position-on-not-matched-block
     from. > @
@@ -215,12 +204,7 @@
           regex "/[a-z]+/"
           "123"
 
-  --> on-getting-next-on-not-matched-block
-    next. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  ((regex "/[a-z]+/").match "123").next.next --> on-getting-next-on-not-matched-block
 
   group. --> on-getting-specified-group-on-not-matched-block
     next.
@@ -229,12 +213,7 @@
         "123"
     1
 
-  --> on-getting-text-on-not-matched-block
-    text. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  ((regex "/[a-z]+/").match "123").next.text --> on-getting-text-on-not-matched-block
 
   --> on-getting-to-position-on-not-matched-block
     to. > @
@@ -243,10 +222,6 @@
           regex "/[a-z]+/"
           "123"
 
-  --> on-missing-closing-slash-in-regex
-    compiled. > @
-      regex "/pattern"
+  (regex "/pattern").compiled --> on-missing-closing-slash-in-regex
 
-  --> on-missing-first-slash-in-regex
-    compiled. > @
-      regex "(.)+"
+  (regex "(.)+").compiled --> on-missing-first-slash-in-regex

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -147,8 +147,7 @@
           next
         rec > next
           index.plus 1
-          plus.
-            acc.times 10
+          (acc.times 10).plus
             minus.
               as-ascii
                 slice text index 1

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -25,28 +25,22 @@
       if.
         or.
           size.eq 0
-          gt.
-            current.plus size
-            len
+          (current.plus size).gt len
         rec-split
           accum
           start
-          as-number.
-            current.plus 1
+          (current.plus 1).as-number
         if.
           delim.eq
             slice bts current size
           rec-split
             appended
-            as-number.
-              current.plus size
-            as-number.
-              current.plus size
+            (current.plus size).as-number
+            (current.plus size).as-number
           rec-split
             accum
             start
-            as-number.
-              current.plus 1
+            (current.plus 1).as-number
     accum.with > appended
       string
         slice

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -28,7 +28,8 @@
       index
       if.
         is-ws char
-        first-non-ws-index (index.plus 1).as-number
+        first-non-ws-index
+          (index.plus 1).as-number
         index
     bts.slice > char!
       index
@@ -42,8 +43,7 @@
         c.eq 0A-
         or.
           c.eq 0B-
-          or.
-            c.eq 0C-
+          (c.eq 0C-).or
             c.eq 0D-
   bts.size > len!
 

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -19,9 +19,7 @@
       bts.slice
         0
         first-non-ws-index
-          plus.
-            number len
-            -1
+          (number len).plus -1
   text > bts!
   [index] > first-non-ws-index
     if. > @
@@ -29,7 +27,8 @@
       0
       if.
         is-ws char
-        first-non-ws-index (index.plus -1).as-number
+        first-non-ws-index
+          (index.plus -1).as-number
         index.plus 1
     bts.slice > char!
       index
@@ -42,8 +41,7 @@
         c.eq 0A-
         or.
           c.eq 0B-
-          or.
-            c.eq 0C-
+          (c.eq 0C-).or
             c.eq 0D-
   bts.size > len!
 

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -17,11 +17,9 @@
       [accum byte] >>
         accum.concat > @
           if.
-            and.
-              code.lte maxcode
+            (code.lte maxcode).and
               code.gte mincode
-            slice.
-              as-bytes. (code.minus distance).as-i64
+            (code.minus distance).as-i64.as-bytes.slice
               7
               1
             byte

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -281,12 +281,8 @@
     and. > @
       and.
         and.
-          eq.
-            arr.at 0
-            1
-          eq.
-            arr.at 1
-            2
+          (arr.at 0).eq 1
+          (arr.at 1).eq 2
         eq.
           arr.at 2
           3

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -29,7 +29,5 @@
           eachi > @
             * 1 2 3
             m.put > [item index] >>
-              plus.
-                m.as-number.plus item
-                index
+              (m.as-number.plus item).plus index
       9

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -22,9 +22,7 @@
         "Can't divide %d by u16 zero".printf
           * as-number
       u16 quotient
-    slice. > quotient
-      as-bytes.
-        as-i32.div xval.as-i32
+    (as-i32.div xval.as-i32).as-bytes.slice > quotient
       2
       2
     x.as-u16 > xval
@@ -35,23 +33,17 @@
   as-i32.lte x.as-u16.as-i32 > [x] > lte
   [x] > minus
     u16 right > @
-    slice. > right
-      as-bytes.
-        as-i32.minus x.as-u16.as-i32
+    (as-i32.minus x.as-u16.as-i32).as-bytes.slice > right
       2
       2
   [x] > plus
     u16 right > @
-    slice. > right
-      as-bytes.
-        as-i32.plus x.as-u16.as-i32
+    (as-i32.plus x.as-u16.as-i32).as-bytes.slice > right
       2
       2
   [x] > times
     u16 right > @
-    slice. > right
-      as-bytes.
-        as-i32.times x.as-u16.as-i32
+    (as-i32.times x.as-u16.as-i32).as-bytes.slice > right
       2
       2
 
@@ -75,9 +67,7 @@
     FF-FF.as-u16.div 00-02.as-u16
     7F-FF.as-u16
 
-  ++> tests-u16-eq-false
-    not. > @
-      00-2A.as-u16.eq 00-2B.as-u16
+  (00-2A.as-u16.eq 00-2B.as-u16).not ++> tests-u16-eq-false
 
   00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
 
@@ -85,19 +75,13 @@
 
   00-32.as-u16.gte 00-32.as-u16 ++> tests-u16-gte-equal
 
-  ++> tests-u16-gte-false
-    not. > @
-      00-00.as-u16.gte 00-0A.as-u16
+  (00-00.as-u16.gte 00-0A.as-u16).not ++> tests-u16-gte-false
 
   00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
 
-  ++> tests-u16-high-bit-not-less-than-one
-    not. > @
-      FF-FF.as-u16.lt 00-01.as-u16
+  (FF-FF.as-u16.lt 00-01.as-u16).not ++> tests-u16-high-bit-not-less-than-one
 
-  ++> tests-u16-less-equal
-    not. > @
-      00-0A.as-u16.lt 00-0A.as-u16
+  (00-0A.as-u16.lt 00-0A.as-u16).not ++> tests-u16-less-equal
 
   00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
 

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -22,9 +22,7 @@
         "Can't divide %d by u32 zero".printf
           * as-number
       u32 quotient
-    slice. > quotient
-      as-bytes.
-        as-i64.div xval.as-i64
+    (as-i64.div xval.as-i64).as-bytes.slice > quotient
       4
       4
     x.as-u32 > xval
@@ -35,23 +33,17 @@
   as-i64.lte x.as-u32.as-i64 > [x] > lte
   [x] > minus
     u32 right > @
-    slice. > right
-      as-bytes.
-        as-i64.minus x.as-u32.as-i64
+    (as-i64.minus x.as-u32.as-i64).as-bytes.slice > right
       4
       4
   [x] > plus
     u32 right > @
-    slice. > right
-      as-bytes.
-        as-i64.plus x.as-u32.as-i64
+    (as-i64.plus x.as-u32.as-i64).as-bytes.slice > right
       4
       4
   [x] > times
     u32 right > @
-    slice. > right
-      as-bytes.
-        as-i64.times x.as-u32.as-i64
+    (as-i64.times x.as-u32.as-i64).as-bytes.slice > right
       4
       4
 
@@ -75,9 +67,7 @@
     FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
     7F-FF-FF-FF.as-u32
 
-  ++> tests-u32-eq-false
-    not. > @
-      00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
+  (00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32).not ++> tests-u32-eq-false
 
   00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
 
@@ -87,9 +77,7 @@
 
   00-00-00-32.as-u32.gte 00-00-00-32.as-u32 ++> tests-u32-gte-equal
 
-  ++> tests-u32-gte-false
-    not. > @
-      00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
+  (00-00-00-00.as-u32.gte 00-00-00-0A.as-u32).not ++> tests-u32-gte-false
 
   00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
 
@@ -97,9 +85,7 @@
     not. > @
       FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
 
-  ++> tests-u32-less-equal
-    not. > @
-      00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
+  (00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32).not ++> tests-u32-less-equal
 
   00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
 

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -22,9 +22,7 @@
         "Can't divide %d by u8 zero".printf
           * as-number
       u8 quotient
-    slice. > quotient
-      as-bytes.
-        as-i16.div xval.as-i16
+    (as-i16.div xval.as-i16).as-bytes.slice > quotient
       1
       1
     x.as-u8 > xval
@@ -35,23 +33,17 @@
   as-i16.lte x.as-u8.as-i16 > [x] > lte
   [x] > minus
     u8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.minus x.as-u8.as-i16
+    (as-i16.minus x.as-u8.as-i16).as-bytes.slice > right
       1
       1
   [x] > plus
     u8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.plus x.as-u8.as-i16
+    (as-i16.plus x.as-u8.as-i16).as-bytes.slice > right
       1
       1
   [x] > times
     u8 right > @
-    slice. > right
-      as-bytes.
-        as-i16.times x.as-u8.as-i16
+    (as-i16.times x.as-u8.as-i16).as-bytes.slice > right
       1
       1
 
@@ -73,9 +65,7 @@
     C8-.as-u8.div 03-.as-u8
     42-.as-u8
 
-  ++> tests-u8-eq-false
-    not. > @
-      2A-.as-u8.eq 2B-.as-u8
+  (2A-.as-u8.eq 2B-.as-u8).not ++> tests-u8-eq-false
 
   2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
 
@@ -83,19 +73,13 @@
 
   32-.as-u8.gte 32-.as-u8 ++> tests-u8-gte-equal
 
-  ++> tests-u8-gte-false
-    not. > @
-      00-.as-u8.gte 0A-.as-u8
+  (00-.as-u8.gte 0A-.as-u8).not ++> tests-u8-gte-false
 
   2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
 
-  ++> tests-u8-high-bit-not-less-than-one
-    not. > @
-      FF-.as-u8.lt 01-.as-u8
+  (FF-.as-u8.lt 01-.as-u8).not ++> tests-u8-high-bit-not-less-than-one
 
-  ++> tests-u8-less-equal
-    not. > @
-      0A-.as-u8.lt 0A-.as-u8
+  (0A-.as-u8.lt 0A-.as-u8).not ++> tests-u8-less-equal
 
   0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
 


### PR DESCRIPTION
Reverts the merge of #5881 (merge commit `a15d4ac`), which was merged prematurely.

This restores `master` to its state before #5881: the `eo-printer` `Penalty`/`PenaltyKey` change (line-leading `(` factor, `PenaltyKey.LEADING`) and the 60 reformatted `eo-runtime` sources are undone (68 files, 317+/851−).

No work is lost — the reverted change still lives on branch `claude/eo-issue-5880-9pgo5r` (commit `d549501`) and can be re-applied later via a fresh PR when it's the right time to merge #5880.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpAfSHDLaaXL9mJuqNB4zv)_