### PR TITLE
Print folded φ decoratee ahead of auto-named formation head (#5882)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -138,6 +138,23 @@
               <xsl:if test="@as">
                 <xsl:apply-templates select="@as"/>
               </xsl:if>
+              <!--
+              The reference stands as the `φ` decoratee of an auto-named
+              formation, written ahead of the brackets (`false &gt; [] &gt;&gt;`,
+              #5882). Folding a non-abstract handle in (`false &gt;&gt; flag`)
+              copies only the target's attributes, so the reference's own `@name`
+              would be lost and `to-eo-tree` would print the datum as a nameless
+              body line of the formation (`[] &gt;&gt;` with `false` below it),
+              which the parser rejects with "object inside formation must have a
+              name". Carrying the `φ` name over keeps the folded datum the
+              decoratee, so `to-eo-tree` prints it ahead of the head. Only for a
+              non-abstract target: an abstract one keeps its own `@name` (the
+              `[...] &gt;&gt;` marker) and never reaches this branch as a φ
+              decoratee.
+              -->
+              <xsl:if test="@name = $eo:phi and not($keep-name)">
+                <xsl:apply-templates select="@name"/>
+              </xsl:if>
               <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
               <xsl:apply-templates select="$target/node()"/>
             </xsl:element>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-phi-decoratee-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-phi-decoratee-handle.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> flag` handle (R-3.10.12) whose value is a
+# plain non-abstract datum (`false`) and whose sole reference is the `φ`
+# decoratee of an auto-named formation, written ahead of the brackets
+# (`false > [] >>`, #5882). Inlining folds the datum into the reference, but the
+# `otherwise` branch copies only the target's attributes, so the reference's own
+# `@name = φ` used to be lost and `to-eo-tree` printed the datum as a nameless
+# body line of the formation (`[] >>` with `false` below it) — a shape EO has no
+# spelling for, which the parser rejects with "object inside formation must have
+# a name". "inline-cactoos" now carries the `φ` name over, keeping the folded
+# datum the decoratee, so it is printed ahead of the head exactly as the input
+# spells it and the output reparses cleanly.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    * > @
+      flag > [] >>
+      22
+    false >> flag
+
+printed: |
+  [] > foo
+    * > @
+      false > [] >>
+      22


### PR DESCRIPTION
Fixes #5882.

## Problem

The canonical printer turned a valid program into one the parser rejects. This EO parses fine:

```
[] > foo
  * > @
    flag > [] >>
    22
  false >> flag
```

but `Xmir.toEO` printed it as:

```
[] > foo
  * > @
    [] >>
      false
    22
```

and reparsing that fails with `[4:6] error: 'object inside formation must have a name'`.

## Root cause

`inline-cactoos.xsl` folds the single-referenced non-abstract handle `false >> flag` into its only reference. That reference is the `φ` decoratee of the auto-named formation `[] >>`, written ahead of the brackets. The `otherwise` (bare-reference) branch copies only the *target's* attributes, so the reference's own `@name = φ` was dropped. `to-eo-tree.xsl` then had no decoratee to place ahead of the head and printed the datum `false` as an ordinary body line of the formation — a shape EO has no spelling for.

## Fix

Carry the `φ` name over during inlining (for a non-abstract target) so the folded datum stays the formation's decoratee. `to-eo-tree`'s existing inline-φ machinery then prints it ahead of the head as `false > [] >>`, exactly as the input spells it, and the output reparses cleanly. An abstract target keeps its own `@name` (the `[...] >>` marker) and never reaches this branch as a φ decoratee, so the guard is scoped to the non-abstract case.

## Tests

- New print-pack `inline-cactoos-phi-decoratee-handle.yaml` reproduces the issue's program and asserts the parseable `false > [] >>` output; it is exercised by both `XmirTest.printsToEo` and `XmirTest.printsToParseableEo`.
- Full `eo-printer` suite passes (236 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0193oYEivoc13c7a1szW46Cd)_