### PR TITLE
Accept bare vertical pipe `|` in the parser (#5887)

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -120,17 +120,21 @@ final class LnPipe implements Line {
     }
 
     /**
-     * Build a token stream positioned just past the leading {@code | }
-     * marker. The {@code |} must be followed by a single space (before
-     * the argument list or suffix).
-     * @return Tokens positioned after {@code "| "}
+     * Build a token stream positioned just past the leading {@code |}
+     * marker. Two shapes are legal (R-3.14.3): the horizontal form
+     * {@code | a b}, whose {@code |} is followed by a space before the
+     * argument list or suffix, and the bare vertical form {@code |}
+     * (nothing after the pipe), which opens for a deeper-indent
+     * argument block just like a {@code vapplication} head. Only a
+     * character glued directly onto the pipe ({@code |x}) is rejected.
+     * @return Tokens positioned after the {@code |}
      */
     private Tokens piped() {
         final String body = this.span.body();
-        if (body.length() < 2 || body.charAt(1) != ' ') {
+        if (body.length() > 1 && body.charAt(1) != ' ') {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "a pipe `|` must be followed by a space"
+                "a pipe `|` must be followed by a space before its arguments"
             );
         }
         final Tokens tokens = new Tokens(body, this.span);

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -131,7 +131,7 @@ final class LnPipe implements Line {
      */
     private Tokens piped() {
         final String body = this.span.body();
-        if (body.length() > 1 && body.charAt(1) != ' ') {
+        if (!"|".equals(body) && !body.startsWith("| ")) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "a pipe `|` must be followed by a space before its arguments"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-bare.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-bare.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A bare `|` (nothing after the pipe) opens the vertical-argument form of a
+# pipe application (R-3.14.3): the deeper-indent body supplies the arguments,
+# exactly as `| 2 3` does horizontally. A pipe need not be followed by a space
+# when it carries no horizontal args, so the printer's own vertical `|` output
+# reparses cleanly (#5887).
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@pipe]
+  - //o[@pipe and count(o)=2]
+  - //o[@pipe and count(o[@base='Φ.number'])=2]
+input: |
+  [] > app
+    foo > @
+      [a b] >>
+        a.plus b > @
+      |
+        2
+        3

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-vertical-in-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-vertical-in-argument.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> rec-split` handle (R-3.10.12) whose value
+# is an abstract formation and which is applied (`rec-split * 0 0`) from the
+# argument slot of another application (the third argument of `if.`), the shape
+# `eo-runtime/src/main/eo/string/split.eo` takes once its recursive helper is
+# written as a `>>` handle (#5678). As with the sibling (#5840) and receiver
+# (#5844) cases, "inline-cactoos" relocates the single-use formation directly
+# above the reference and turns the reference into a `| args` pipe continuation
+# that applies it, so the three arguments (`* 0 0`) are preserved. Here the
+# relocated formation is large, so the layout engine cannot keep the compact
+# one-line `| * 0 0` and prints the pipe in its vertical form: a bare `|`
+# followed by a deeper-indent argument block (R-3.14.3). That output used to be
+# rejected by the parser ("a pipe `|` must be followed by a space"), so the
+# result was not a fixed point and did not reparse; a bare `|` with no
+# horizontal args is now accepted, so the pipe application round-trips with its
+# arguments intact (#5887).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [text] > split
+    if. > @
+      empty
+      *
+      rec-split
+        *
+        0
+        0
+    [accum current] >> rec-split
+      if. > @
+        stop
+        accum
+        rec-split
+          accum
+          current.plus 1
+printed: |
+  [text] > split
+    empty.if > @
+      *
+      stop.if > [accum current] >> rec-split
+        accum
+        rec-split
+          accum
+          current.plus 1
+      |
+        *
+        0
+        0


### PR DESCRIPTION
Closes #5887.

## Problem

`eo:format` on a file-local `>>` handle applied from the argument slot of another application (the shape `string/split.eo` takes once its recursive helper is written as a `>>` handle, per #5678) produced EO that did not reparse.

For `rec-split * 0 0` standing as the third argument of `if.`, `inline-cactoos` relocates the single-use formation directly above the reference and rewrites the reference into a `| args` pipe continuation (the same mechanism as the sibling #5840 and receiver #5844 cases), so the three arguments are preserved. When the relocated formation is large, the layout engine cannot keep the compact one-line `| * 0 0` and prints the pipe in its **vertical** form — a bare `|` followed by a deeper-indent argument block:

```
      |
        *
        0
        0
```

That output was rejected on reparse with `a pipe | must be followed by a space`, so it was not a fixed point and the `format` gate could not stabilise on it.

As [noted on the issue](https://github.com/objectionary/eo/issues/5887#issuecomment-5077058829), a pipe **may** have no space after it — the vertical-argument form (R-3.14.3) is legal EO.

## Fix

`LnPipe` already models both pipe shapes (an empty argument list opens the node for a vertical block, exactly like a `vapplication` head), but its `piped()` tokenizer rejected any line shorter than `| `, so a bare `|` never reached that path. The guard now only rejects a character glued directly onto the pipe (`|x`); a bare `|` carrying no horizontal args is accepted and opens for its vertical argument block. The arguments of the applied reference are preserved and the printed output round-trips.

## Changes

- `eo-parser/.../LnPipe.java` — accept a bare `|` (the vertical-argument form); only reject a non-space character glued directly onto the pipe.
- `eo-parser/.../eo-syntax/pipe-vertical-bare.yaml` — parser test: a bare `|` with a deeper-indent body parses to a pipe application carrying its two arguments.
- `eo-printer/.../print-packs/yaml/pipe-vertical-in-argument.yaml` — printer regression test: a `>>` handle applied from an argument slot prints to a vertical pipe that reparses to itself with its arguments intact.

## Testing

- `eo-parser` full suite: 1505 tests, 0 failures.
- `eo-printer` `XmirTest`: 201 tests, 0 failures (both `printsToEo` fixed-point and `printsToParseableEo` round-trip pass for the new pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtWXbN1dHStAi6dpdPWZQS)_