### PR TITLE
Fix const-handle receiver reference stranded on synthetic id (#5890)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -169,14 +169,21 @@
   The const file-local handle binding a reference `$ref` resolves to but does
   NOT host (the binding folds onto its first reference only). Every other
   reference keeps the readable "@local" handle in place of the obfuscated
-  cactus name, so it reads back as a bare `b` rather than a synthetic "vL_P"
-  name (#5828).
+  cactus name, so it reads back as a bare `b` (or a dispatch `b.seg`) rather
+  than a synthetic "vL_P" name (#5828). The reference is matched by carrying the
+  binding's cactus "@name" as one of its base segments — a bare `ξ.<name>`, a
+  single-segment dispatch `ξ.<name>.<seg>`, or a multi-segment chain
+  `ξ.<name>.<seg>.<seg>` whose receiver position the moniker fold cannot host
+  (#5890) — so a stranded receiver reference reads back by name instead of a
+  synthetic id, the const mirror of `eo:kept-local-ref`. The binding's own
+  subtree and the single hosting reference are excluded.
   -->
   <xsl:function name="eo:kept-const-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
-    <xsl:variable name="binding" select="$owner/o[@name = eo:resolved-ref($ref) and eo:moniker-binding(.) and eo:const-handle(.)][1]"/>
-    <xsl:sequence select="if (exists($binding) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:variable name="candidates" select="$owner/o[eo:moniker-binding(.) and eo:const-handle(.)]"/>
+    <xsl:variable name="binding" select="$candidates[some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name][1]"/>
+    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
   The kept multi-referenced abstract handle binding (`[] &gt;&gt; name`, #5876)

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-segment-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-multi-segment-referenced-handle.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) kept whole (#5828) with one
+# reference a multi-segment dispatch chain (`c.gte.not 2`, base `ξ.c.gte.not`)
+# and one a plain bare argument (`42.plus c`). Only a bare `ξ.<name>` reference
+# or a single-segment dispatch `ξ.<name>.<seg>` (#5883) can host the handle, so
+# the fold lands on the bare `42.plus c` and the multi-segment reference — which
+# neither `eo:resolved-ref` nor the old bare/single-segment `eo:kept-const-ref`
+# recognised — must still read back through the readable "@local" handle
+# (`c.gte.not`) instead of the synthetic "vL_P" cactus id (#5890).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    x.plus 1 >> c!
+    c.gte.not 2 > a
+    42.plus c > b
+
+printed: |
+  [x] > foo
+    c.gte.not 2 > a
+    42.plus > b
+      x.plus 1 >> c!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-receiver-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-receiver-referenced-handle.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) kept whole across several
+# references (#5828) whose earliest reference sits in a receiver position the
+# moniker fold cannot host: `oname.size.gt 6` is the receiver of a reversed
+# `.and` dispatch, so its `oname` reference is a multi-segment chain
+# (`ξ.<name>.size.gt`) that neither inlines bare nor folds as a single-segment
+# reversed dispatch. The handle therefore hosts onto the only hostable
+# reference, the single-segment `oname.slice 0 7` (`slice.` reversed dispatch),
+# and the stranded receiver reference must read back through the readable
+# "@local" handle (`oname.size.gt`) rather than the synthetic "vL_P" cactus id
+# it carried before the fix (#5890) — the const mirror of `eo:kept-local-ref`
+# picking up a `name.seg` dispatch it cannot host.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > os
+    [] > is-windows
+      and. > @
+        oname.size.gt 6
+        eq.
+          oname.slice 0 7
+          "Windows"
+      name >> oname!
+    [] > name /Q.string
+
+printed: |
+  [] > os
+    [] > is-windows
+      (oname.size.gt 6).and > @
+        eq.
+          slice.
+            name >> oname!
+            0
+            7
+          "Windows"
+    [] > name /Q.string


### PR DESCRIPTION
Closes #5890.

## Problem

After #5883 a multi-referenced const file-local handle (`a >> b!`) is kept whole and folds onto its first *hostable* reference, with every other reference rewritten back to the readable `@local` handle. But `eo:kept-const-ref` recognised only two reference shapes (via `eo:resolved-ref`): a bare `ξ.<name>` and a single-segment dispatch `ξ.<name>.<seg>`.

When the earliest reference sits in a receiver position the moniker fold cannot host — a *multi-segment* chain such as `oname.size.gt 6` used as the receiver of a reversed `.and` dispatch (base `ξ.<name>.size.gt`) — it matched neither the hosting path nor `eo:kept-const-ref`. It was therefore left carrying the obfuscated `vL_P` cactus id:

```
(v8_4.size.gt 6).and > @
```

`v8_4` appears nowhere else, so the printed source neither denotes the same object nor parses back to it, and `eo:format` fails the file instead of converging on it. This is the const-handle counterpart of #5844: the receiver position is what the hosting pass skipped.

## Fix

`eo-printer/.../print/merge-monikers.xsl`: match the kept reference by carrying the binding's cactus `@name` as one of its base segments — the same segment-wise test the abstract-handle sibling `eo:kept-local-ref` already uses for `[] >> name` (#5876). Bare, single-segment, and multi-segment references now all read back through the readable `@local` handle, so the stranded receiver prints `oname.size.gt` and no reference is left holding a `vL_P` id. The binding's own subtree and the single hosting reference are excluded, exactly as before.

## Tests

Two new print-packs under `eo-printer/.../print-packs/yaml`, both verified to reprint to themselves (round-trip):

- `const-receiver-referenced-handle.yaml` — the issue's exact reversed-dispatch receiver scenario.
- `const-multi-segment-referenced-handle.yaml` — a plain multi-segment dispatch reference alongside a bare argument.

Full `eo-printer` suite is green (239 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUbNVfTeNWmua9JuEQAR9B)_