### PR TITLE
#5867: fix string.at docstring for negative index handling

### DIFF
--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -1,6 +1,7 @@
 # Retrieve symbol by given index as `text`.
-# If 0 > index >= ^.length, the `fallback` value is returned,
-# or the bottom object when unbound.
+# A negative `index` counts from the end of `text` (`length + index`).
+# If the resolved index is still negative or is >= `text.length`,
+# the `fallback` value is returned, or the bottom object when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo


### PR DESCRIPTION
The docstring of `string.at` says the fallback is returned "If 0 > index >= ^.length", which does not describe what the code actually does.

The code (`at.eo`) accepts negative indexes and wraps them from the end of the text: a negative `index` is converted to `length + index` before the bounds check. The old docstring did not mention this wrap-around behavior at all, so a reader could not tell from the comment alone that `at("some", -2)` returns `"m"`.

This PR only updates the docstring to describe the actual negative-index behavior:

```
# Retrieve symbol by given index as `text`.
# A negative `index` counts from the end of `text` (`length + index`).
# If the resolved index is still negative or is >= `text.length`,
# the `fallback` value is returned, or the bottom object when unbound.
```

No functional change. The existing embedded tests already cover this case (`tests-returns-char-at-negative-index`) and continue to pass.

Closes #5867
