### PR TITLE
#5860: close the Files.walk() stream in PackageInfos#create

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Package info classes.
@@ -60,12 +61,15 @@ final class PackageInfos {
     int create() throws IOException {
         final int size;
         if (Files.exists(this.root)) {
-            final List<Path> dirs = Files.walk(this.root).filter(
-                file -> Files.isDirectory(file)
-                    && !file.equals(this.root)
-                    && !file.equals(this.root.resolve("org"))
-                )
-                .collect(Collectors.toList());
+            final List<Path> dirs;
+            try (Stream<Path> walk = Files.walk(this.root)) {
+                dirs = walk.filter(
+                    file -> Files.isDirectory(file)
+                        && !file.equals(this.root)
+                        && !file.equals(this.root.resolve("org"))
+                    )
+                    .collect(Collectors.toList());
+            }
             for (final Path dir : dirs) {
                 Logger.debug(
                     this,


### PR DESCRIPTION
`PackageInfos#create` opens a `Files.walk()` stream and never closed it. `Files.walk()` opens an underlying directory-traversal resource that the JDK javadoc says must be closed, normally via try-with-resources.

Every other `Files.walk()` call site in the same package (`Walk.java`, `Cache.java`, `Resolving.java`, `Sha.java`) already wraps it in try-with-resources. `PackageInfos.java` was the only one that did not.

This PR wraps the call in try-with-resources, matching the existing pattern in the package. No behavior change: the stream is still filtered and collected into a `List` before the `for` loop runs, exactly as before, just inside the try-with-resources block so the underlying resource is released once collection finishes.

Existing tests in `PackageInfosTest.java` cover `create()`'s behavior fully (return count, file creation, root exclusion, escaping) and all continue to pass unchanged, since this is a pure resource-management fix with no observable output difference.

Closes #5860
