### PR TITLE
#5861: fix tuple.back docstring to describe last-N-elements contract

### DIFF
--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -1,4 +1,5 @@
-# Elements of `list` from `index` to the end (supports oversized index).
+# The last `index` elements of `list` (an `index` larger than `list.length`
+# returns the whole `list`).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo


### PR DESCRIPTION
`tuple.back`'s docstring said "Elements of `list` from `index` to the end (supports oversized index)." That describes a position-based slice, but the object's real, tested contract is "the last `index` elements of `list`":

`back([1,2,3,4,5], 2)` returns `[4,5]`, the last 2 elements. Under "from position `index` to the end", that would need to return `[3,4,5]`, not `[4,5]`.

`back([1,2,3,4,5], 10)` (index larger than length) returns the whole list. Under "position" semantics an out-of-range start position should give an empty result, which only makes sense under "last N elements, clamped to the list length".

`tuple/withi.eo` confirms this: it converts a real position into a trailing count before calling `back` (`list.length.minus index`), because `back` itself expects a count, not a position.

This PR only updates the docstring:

```
# The last `index` elements of `list` (an `index` larger than `list.length`
# returns the whole `list`).
```

No functional change. The existing embedded tests already cover this contract and continue to pass.

Closes #5861
