### PR TITLE
#5863: anchor MjPrint's .xmir to .eo extension replace to the trailing extension

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -36,6 +37,11 @@ import org.eolang.printer.Xmir;
     threadSafe = true
 )
 public final class MjPrint extends MjSafe {
+
+    /**
+     * Pattern to catch the trailing .xmir extension.
+     */
+    private static final Pattern XMIR = Pattern.compile("\\.xmir$");
 
     /**
      * Directory with XMIR sources to print.
@@ -116,8 +122,9 @@ public final class MjPrint extends MjSafe {
     private int print(final Path source) throws Exception {
         final Path home = this.printOutputDir.toPath();
         final Path relative = Paths.get(
-            this.printSourcesDir.toPath().relativize(source).toString()
-                .replace(".xmir", ".eo")
+            MjPrint.XMIR.matcher(
+                this.printSourcesDir.toPath().relativize(source).toString()
+            ).replaceFirst(".eo")
         );
         new Saved(
             new Xmir(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -64,6 +64,37 @@ final class MjPrintTest {
         }
     }
 
+    @Test
+    void doesNotMangleADirectoryNameContainingTheXmirSubstring(@Mktmp final Path temp)
+        throws Exception {
+        final Path source = temp.resolve("xmir/v1.xmir-legacy/main.xmir");
+        Files.createDirectories(source.getParent());
+        new Saved(
+            new EoSyntax(
+                new InputOf(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package foo",
+                        "",
+                        "[] > main"
+                    )
+                )
+            ).parsed().toString(),
+            source
+        ).value();
+        final Path output = temp.resolve("eo");
+        new FakeMaven(temp)
+            .with("printSourcesDir", temp.resolve("xmir").toFile())
+            .with("printOutputDir", output.toFile())
+            .execute(new FakeMaven.Print())
+            .result();
+        MatcherAssert.assertThat(
+            "only the trailing .xmir extension should be replaced, the .xmir substring in the directory name must survive untouched",
+            Files.exists(output.resolve("v1.xmir-legacy/main.eo")),
+            Matchers.is(true)
+        );
+    }
+
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/print-packs", glob = "**.yaml")
     void printsXmirToEo(final String pack, @Mktmp final Path temp) throws Exception {


### PR DESCRIPTION
`MjPrint#print` computed the output path with a plain substring replace:

```java
this.printSourcesDir.toPath().relativize(source).toString().replace(".xmir", ".eo")
```

`String#replace(".xmir", ".eo")` replaces every occurrence of the literal substring `.xmir` anywhere in the full relativized path string, not just the file's trailing extension. If any directory component between `printSourcesDir` and the file also contains the substring `.xmir` (for example a directory literally named `v1.xmir-legacy`), that directory name gets silently mangled too, turning it into `v1.eo-legacy` and producing a wrong output path.

`Unplace.java` already has the correct, anchored idiom for this exact class of problem, using a `Pattern` anchored to the end of the string (`$`) so only the trailing extension is affected.

This PR replaces the naive `String#replace` with a `Pattern.compile("\\.xmir$")` anchored to the end of the path string, matching that established pattern.

Added a regression test, `doesNotMangleADirectoryNameContainingTheXmirSubstring`, which prints a file under a directory named `v1.xmir-legacy` and asserts the directory name survives untouched. Verified this test fails against the old naive-replace code (the directory got mangled to `v1.eo-legacy`, so the expected output path did not exist) and passes with the fix.

Closes #5863
