### PR TITLE
Keep the const marker outside the brackets of an inline argument

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -121,6 +121,23 @@ final class Node {
     }
 
     /**
+     * The same node with its suffix dropped.
+     *
+     * <p>An inline const argument that applies arguments of its own is
+     * parenthesised, and its {@code !} marker has to sit outside the
+     * brackets ({@code (inc m)!}), so {@link Pretty} inlines the node
+     * without the suffix and appends the marker itself (#5902).</p>
+     *
+     * @return The node without its suffix
+     */
+    Node bare() {
+        return new Node(
+            this.base, "", this.abstractt, this.test,
+            this.reversed, this.data, this.children
+        );
+    }
+
+    /**
      * Whether this node carries no name suffix anywhere in its subtree.
      *
      * <p>A line is "named" when its {@code tail} holds a {@code > name},

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -445,6 +445,13 @@ final class Pretty {
      * as {@code (01-.as-bool)} would produce EO that fails to parse with
      * "redundant parentheses around a single token" (#5591).</p>
      *
+     * <p>An anonymous inline const argument (#5821) is inlined bare, through
+     * {@link Node#bare}, and its {@code !} marker appended afterwards — after
+     * the closing bracket when the argument is one. Inside the brackets the
+     * marker binds to the last argument instead: {@code (inc m!)} reads as
+     * {@code inc (m!)}, shrinking the const from the whole application down to
+     * one of its arguments and silently changing the program (#5902).</p>
+     *
      * @param args The arguments
      * @return The inlined string, or empty if any argument can't be inlined
      */
@@ -452,7 +459,13 @@ final class Pretty {
         final StringBuilder joined = new StringBuilder();
         Optional<String> result = Optional.of("");
         for (final Node arg : args) {
-            final Optional<String> flat = Pretty.flat(arg);
+            final boolean cnst = "!".equals(arg.tail);
+            final Optional<String> flat;
+            if (cnst) {
+                flat = Pretty.flat(arg.bare());
+            } else {
+                flat = Pretty.flat(arg);
+            }
             if (flat.isEmpty()) {
                 result = Optional.empty();
                 break;
@@ -465,6 +478,9 @@ final class Pretty {
             } else {
                 joined.append('(').append(flat.get()).append(')');
             }
+            if (cnst) {
+                joined.append('!');
+            }
         }
         return result.map(ignored -> joined.toString());
     }
@@ -475,11 +491,10 @@ final class Pretty {
      * data-receiver dispatch is inlined in its suffix shape ({@code
      * 5.plus 3}), never the reversed one.
      *
-     * <p>A name suffix in the tail ({@code > name}, {@code >>}) has no inline
-     * spelling and blocks inlining. The lone {@code !} const marker of an
-     * anonymous inline const argument (#5821) is the exception: it does have
-     * one — the value with a trailing {@code !} ({@code a!}) — so it inlines
-     * and the {@code !} is appended.</p>
+     * <p>Any suffix in the tail ({@code > name}, {@code >>}, {@code !}) has no
+     * inline spelling and blocks inlining. An anonymous inline const argument
+     * (#5821) is spelled by {@link #inlined}, which strips the {@code !} here
+     * and appends it where it belongs (#5902).</p>
      *
      * @param given The node
      * @return The inlined content, or empty
@@ -487,23 +502,15 @@ final class Pretty {
     private static Optional<String> flat(final Node given) {
         final Optional<String> result;
         final Node node = Pretty.suffixed(given).orElse(given);
-        final boolean cnst = "!".equals(node.tail);
-        final String mark;
-        if (cnst) {
-            mark = "!";
-        } else {
-            mark = "";
-        }
         if (node.reversed && node.children.size() <= 1) {
             result = Optional.empty();
-        } else if (node.abstractt || !node.tail.isEmpty() && !cnst
-            || "*".equals(node.base)) {
+        } else if (node.abstractt || !node.tail.isEmpty() || "*".equals(node.base)) {
             result = Optional.empty();
         } else if (node.children.isEmpty()) {
-            result = Optional.of(node.base.concat(mark));
+            result = Optional.of(node.base);
         } else {
             result = Pretty.inlined(node.children)
-                .map(args -> String.join(" ", node.base, args).concat(mark));
+                .map(args -> String.join(" ", node.base, args));
         }
         return result;
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-applied-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-inline-applied-argument.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An inline const argument that applies arguments of its own is parenthesised,
+# and the `!` marker belongs outside the brackets. Inside them it binds to the
+# last argument instead — `(inc m!)` reads as `inc (m!)` — shrinking the const
+# from the whole `inc m` application down to `m` and silently changing the
+# program (#5902).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [m] > foo
+    42.plus (inc m)! > x
+
+printed: |
+  [m] > foo
+    42.plus (inc m)! > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-single-referenced-applied-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-single-referenced-applied-handle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced const file-local handle whose value is an application
+# (`inc m >> n!`, #5817) folds onto its only use site as an anonymous inline
+# const argument (#5821), where it must be spelled `(inc m)!`. Printed as
+# `(inc m!)` the `!` binds to `m` alone, so the side-effecting `inc m` stops
+# being a const and runs once per read of the twice-read `num` (#5902).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [m] > foo
+    m.put > @
+      num.times num
+    inc m >> n!
+    number n > num
+
+printed: |
+  [m] > foo
+    m.put > @
+      num.times num
+    number (inc m)! > num


### PR DESCRIPTION
When the printer inlines a const argument that applies arguments of its
own, it wrapped the whole thing in brackets and left the `!` inside:
`(inc m!)`. That re-parses as `inc (m!)`, so the const covers only the
last argument instead of the whole application. `inlined` now renders
such an argument bare and puts the `!` after the closing bracket, which
gives `(inc m)!`.

The shape shows up in `malloc.eo`: privatize `inc m > n!` to
`inc m >> n!` and `eo:format` folds the single-referenced handle onto
its only use site, where the mangled spelling turns the side-effecting
`inc m` into a plain application. It is then dataized once per read of
the twice-read `num`, the malloc is incremented twice and
`tests-constant-defends-against-side-effects` fails. Nothing about the
fold itself is wrong, only how it was written back out — a user typing
`42.plus (inc m)!` by hand hit the same corruption with no handle
involved.

Two print-packs cover it: the bare inline argument and the handle that
folds into one. `flat` no longer knows about the const marker at all,
since `inlined` is the only caller that could spell one; a const in
receiver position (`(inc m)!.plus`) has no legal spelling anyway, so it
now keeps the vertical form instead of being mangled.

Closes #5902