### PR TITLE
#5866: omit the trailing decimal point in string.as-fixed when places=0

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -26,15 +26,18 @@
         n.times -1
       positive n
   [a] > positive
-    concat. > @
+    if. > @
+      places.eq 0
+      as-decimal ip
       concat.
-        as-decimal ip
-        ".".as-bytes
-      rec-pad
-        m.minus
-          ip.times scale
-        places
-        --
+        concat.
+          as-decimal ip
+          ".".as-bytes
+        rec-pad
+          m.minus
+            ip.times scale
+          places
+          --
     floor. > ip
       m.div scale
     floor. > m
@@ -136,6 +139,16 @@
     "0.000000"
     string
       as-fixed 0 6
+
+  eq. ++> tests-zero-places-omits-decimal-point
+    "3"
+    string
+      as-fixed 2.5 0
+
+  eq. ++> tests-zero-places-omits-decimal-point-when-negative
+    "-3"
+    string
+      as-fixed -2.5 0
 
   as-fixed --> on-negative-places-without-fallback
     3.14159


### PR DESCRIPTION
`string.as-fixed` only rejected `places` when it was negative or not a whole number, so `places=0` was accepted. But `positive` (and its sibling `signed`) unconditionally concatenated a `"."` between the integer part and the fraction digits, regardless of how many fraction digits there were. With `places=0`, the digit-padding loop returns an empty string, so `as-fixed 2.5 0` evaluated to `"3."`, a trailing dot with zero fraction digits, instead of `"3"`.

This PR makes `positive` omit the `"."` and the fraction digits entirely when `places` is `0`:

```
[a] > positive
  if. > @
    places.eq 0
    as-decimal ip
    concat.
      concat.
        as-decimal ip
        ".".as-bytes
      rec-pad
        m.minus
          ip.times scale
        places
        --
```

`signed` calls `positive` for its non-negative branch, so negative values with `places=0` are fixed the same way (e.g. `as-fixed -2.5 0` now renders `"-3"` instead of `"-3."`).

Added two tests covering the previously-untested `places=0` case, for both a positive and a negative value. All 14 tests in the file pass (12 existing plus the 2 new ones).

Closes #5866
