### PR TITLE
#5868: remove unused foo formation from tuple.front

### DIFF
--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -25,9 +25,6 @@
           list.length
         list
         rechead list
-  [a] > foo
-    42.plus a! > x
-    43.plus a! > y
   index > idx!
   if. > [tup] > rechead
     tup.length.eq idx


### PR DESCRIPTION
`tuple.front` had an unused formation sitting as a direct sibling of `list`, `index`, and the object's real logic:

```
[a] > foo
  42.plus a! > x
  43.plus a! > y
```

`foo` (with locals `x`, `y`) is not referenced anywhere: not in `front`'s own `@` body, not in `rechead`, not in any of the file's own `++>` tests. It has zero callers and produces no observable effect when the object is dataized.

`git blame` traces the addition to commit `07d38f9e71c` ("xcop fixed"), which touches only this one file and adds exactly these 3 lines. That shape suggests a local scratch snippet accidentally left in the real stdlib file instead of a throwaway one.

This PR removes the unused fragment. No behavior change: all 6 existing tests in the file continue to pass.

Closes #5868
