### PR TITLE
Read a sibling-scope reference to a private formation handle back by name

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -212,13 +212,17 @@
   cactus name, so it reads back as `name` (or `name.seg`) rather than a
   synthetic "vL_P" placeholder, the abstract mirror of `eo:kept-const-ref`. The
   reference is matched by carrying the binding's cactus "@name" as one of its
-  base segments; the binding's own subtree is excluded.
+  base segments; the binding's own subtree is excluded. As with the const
+  handle, the reference need not live in the binding's own scope: two mutually
+  recursive helpers call each other from sibling formations, so a reference
+  climbs out of its own scope to reach the handle and is stranded just the same
+  (#5907), and the binding is looked up in the nearest enclosing formation that
+  declares it.
   -->
   <xsl:function name="eo:kept-local-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
-    <xsl:variable name="candidates" select="$owner/o[eo:moniker-binding(.) and eo:abstract(.) and exists(@local)]"/>
-    <xsl:variable name="binding" select="$candidates[some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name][1]"/>
+    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and eo:abstract(.) and exists(@local) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
+    <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A private `>>` formation handle (#5876) shared by two mutually recursive
+# helpers: `reclen` calls `inclen`, `inclen` calls `reclen`. Neither is directly
+# self-referential, so the handle is not restored as a recursive one, and its
+# second reference lives in the sibling `inclen` scope rather than in the owner.
+# That reference is not hostable, so it must read back through the readable
+# "@local" handle instead of the synthetic "vL_P" cactus id (#5907), the
+# formation mirror of `const-nested-referenced-handle` (#5893).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    reclen 0 > @
+    [n] > inclen
+      reclen n > @
+    [i] >> reclen
+      inclen i > @
+
+printed: |
+  [] > foo
+    reclen 0 > @
+    inclen i > [i] >> reclen
+    reclen n > [n] > inclen


### PR DESCRIPTION
When two helpers are mutually recursive, a reference to a private `>>` formation
handle sits in a sibling formation and has to climb out of its own scope to reach
the handle. `eo:kept-local-ref` only searched the reference's own scope, so that
reference kept the obfuscated cactus name and came out as `vL_C` — a name that
binds to nothing when the file is parsed again.

The lookup now walks every enclosing formation and takes the innermost match,
which is the same widening #5893 made for the const handle. Nothing else was
needed: `eo:handle-base` already drops the `ρ` climb on the way out.

I checked it against `string.eo`, the file the issue names. Privatizing `reclen`
and `recidx` and running `eo:format` no longer strands anything, the formatting is
idempotent, and the runtime suite stays green (1760 tests). That clears the last
two of the 17 recursion helpers in the #5678 sweep.

Closes #5907