### PR TITLE
Keep a private eo-printer handle that no reference reaches

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -174,20 +174,24 @@
   <!--
   Drop an inlined auto-named abstract; keep cactus-named voids, keep
   self-referential (recursive) abstracts, which are never inlined, keep a
-  multi-referenced dataized-const handle, which is never inlined (#5828), keep
-  a multi-referenced abstract formation, which is never inlined either (#5876),
-  keep a const that only a vertical layout can spell, which is never inlined
-  either (#5910), keep a formation applied through a `@pipe` continuation,
-  which is kept in place above its pipe rather than inlined (#5834), and keep a
-  binding that a surviving method dispatch still reaches through its name.
-  Such a dispatch reference (`ξ.<name>.<seg>`) is not inlined above — its
-  receiver is buried in a dotted base — so dropping the binding would strand
-  the reference on a synthetic "vL_P" placeholder. Keeping it lets
-  "merge-monikers" host the binding as the receiver of a reversed dispatch
-  instead (#5782).
+  binding no reference reaches at all (#5914), keep a multi-referenced
+  dataized-const handle, which is never inlined (#5828), keep a
+  multi-referenced abstract formation, which is never
+  inlined either (#5876), keep a const that only a vertical layout can spell,
+  which is never inlined either (#5910), keep a formation applied through a
+  `@pipe` continuation, which is kept in place above its pipe rather than
+  inlined (#5834), and keep a binding that a surviving method dispatch still
+  reaches through its name. Such a dispatch reference (`ξ.<name>.<seg>`) is not
+  inlined above — its receiver is buried in a dotted base — so dropping the
+  binding would strand the reference on a synthetic "vL_P" placeholder. Keeping
+  it lets "merge-monikers" host the binding as the receiver of a reversed
+  dispatch instead (#5782). An unreferenced binding is kept because inlining
+  never moved its value anywhere: dropping it deletes the declaration from the
+  printed source, so a private helper formation or const cache that nothing
+  reads yet would silently vanish (#5914).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or (eo:multi-referenced(., @name) and (eo:dataized-const(.) or eo:abstract(.))) or eo:piped(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and (eo:dataized-const(.) or eo:abstract(.))) or eo:piped(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -266,19 +270,40 @@
     <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, concat('.', $auto)) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
   </xsl:function>
   <!--
-  Whether more than one reference in the binding's owner reaches the auto-name
-  `$name` (references inside the binding's own subtree excluded). A reference
-  reaches `$name` either bare (`ξ.<name>`) or through a method dispatch
+  The references in the binding's owner that reach the auto-name `$name`
+  (references inside the binding's own subtree excluded). A reference reaches
+  `$name` either bare (`ξ.<name>`) or through a method dispatch
   (`ξ.<name>.<seg>`, whose resolved name carries the bare name as its leading
-  segment); both are counted. Such a shared binding — a const handle (#5828) or
-  an abstract formation (#5876) — is kept whole rather than folded into each use,
-  which would change the object graph or drop the shared handle name, and
+  segment); both are collected. A reference from inside a nested formation body
+  reaches it as `ξ.ρ.<name>`, which `eo:resolved-name` strips down to the same
+  auto-name, so it is counted like any other.
+  -->
+  <xsl:function name="eo:references" as="element()*">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="$target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
+  </xsl:function>
+  <!--
+  Whether more than one reference in the binding's owner reaches the auto-name
+  `$name`. Such a shared binding — a const handle (#5828) or an abstract
+  formation (#5876) — is kept whole rather than folded into each use, which
+  would change the object graph or drop the shared handle name, and
   "merge-monikers" then hosts the kept binding onto its first reference.
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
+    <xsl:sequence select="count(eo:references($target, $name)) &gt; 1"/>
+  </xsl:function>
+  <!--
+  Whether no reference in the binding's owner reaches the auto-name `$name`.
+  Such a binding has no use site to fold into, so it is kept where it stands
+  rather than dropped (#5914).
+  -->
+  <xsl:function name="eo:unreferenced" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="empty(eo:references($target, $name))"/>
   </xsl:function>
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -242,11 +242,14 @@
   `ξ.<name>.<seg>` becomes a reversed dispatch `<seg>.`
   whose receiver is that inlined binding and whose arguments are the
   reference's own children — the equivalent inline for a dispatch use (#5782).
-  The dispatch also keeps the reference's own `@name` and `@const`, so a named
-  use such as `q. > @` over an anonymous formation round-trips (#5794) and a
-  const one such as `c.gte 2 > a!` keeps its `!` (#5900) — that marker is what
+  The dispatch also keeps the reference's own `@name`, `@local` and `@const`, so
+  a named use such as `q. > @` over an anonymous formation round-trips (#5794),
+  a const one such as `c.gte 2 > a!` keeps its `!` (#5900) — that marker is what
   makes the object dataized once and cached, so losing it would silently turn a
-  cached object into one recomputed at every use.
+  cached object into one recomputed at every use — and a handle hosting another
+  handle in its own receiver (`data.size >> len!` over `b >> data!`) keeps its
+  readable name instead of printing as an anonymous `size. >>!` that its own
+  references no longer resolve to (#5914).
   -->
   <xsl:template match="o[exists(eo:hosted-binding(.))]" priority="1">
     <xsl:variable name="binding" select="eo:hosted-binding(.)"/>
@@ -262,7 +265,7 @@
       <xsl:otherwise>
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
-          <xsl:apply-templates select="@name|@const"/>
+          <xsl:apply-templates select="@name|@local|@const"/>
           <xsl:attribute name="base" select="concat('.', $seg)"/>
           <xsl:element name="o">
             <xsl:apply-templates select="$binding/@*[name() != 'as']"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -67,9 +67,18 @@
     <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
   <!--
+  The references in the binding's owner that resolve to the auto-name "$name"
+  (references inside the binding's own subtree excluded). Mirrors
+  "inline-cactoos".
+  -->
+  <xsl:function name="eo:references" as="element()*">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="$target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
+  </xsl:function>
+  <!--
   Whether more than one reference in the binding's owner resolves to the
-  auto-name "$name" (references inside the binding's own subtree excluded).
-  Mirrors "inline-cactoos". A multi-referenced non-const abstract formation
+  auto-name "$name". A multi-referenced non-const abstract formation
   ("[] &gt;&gt; name", #5876) is never inlined by "inline-cactoos" (folding
   the whole formation into every use drops its shared handle name), so like a
   multi-referenced const handle its "@local" marker is kept here (below) and
@@ -78,7 +87,18 @@
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="count($target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]) &gt; 1"/>
+    <xsl:sequence select="count(eo:references($target, $name)) &gt; 1"/>
+  </xsl:function>
+  <!--
+  Whether no reference in the binding's owner resolves to the auto-name
+  "$name". "inline-cactoos" keeps such a binding where it stands, having no use
+  site to fold it into (#5914), so it reaches "to-eo-tree" and must carry a
+  readable handle rather than print as an anonymous "&gt;&gt;".
+  -->
+  <xsl:function name="eo:unreferenced" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="empty(eo:references($target, $name))"/>
   </xsl:function>
   <!--
   Whether the auto-named abstract formation "$target" is applied by a reference
@@ -150,13 +170,15 @@
   Keep the marker on voids, on recursive formations, on a formation applied as
   a dispatch receiver (#5844) — so its relocated pipe predecessor prints its
   readable "&gt;&gt; name" handle — on a multi-referenced abstract formation
-  (#5876) — kept whole by "inline-cactoos" and hosted by "merge-monikers" — and
-  on the value of a multi-referenced dataized-const handle (see
+  (#5876) — kept whole by "inline-cactoos" and hosted by "merge-monikers" — on
+  an unreferenced binding of any shape (#5914) — kept where it stands by
+  "inline-cactoos", having no use site to fold into — and on the value of a
+  multi-referenced dataized-const handle (see
   "eo:const-handle") so "to-eo-tree" restores the readable "&gt;&gt; name"
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:abstract(.) and eo:multi-referenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:abstract(.) and eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosted-in-const-receiver.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosted-in-const-receiver.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Two chained const file-local handles: `len` dispatches on `data`, and `data` is
+# reached through that dispatch alone. "merge-monikers" hosts `data` into `len`'s
+# value as the receiver of a reversed `size.` dispatch (#5782), and the node it
+# rebuilds there must carry `len`'s own readable "@local" handle beside its
+# "@name" and "@const" — the same reason the marker itself is carried (#5900).
+# Without it `len` printed as an anonymous `size. >>!` while the reference in
+# `slice-byte` still read `len`, a name the next parse resolves to nothing
+# (#5914).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b >> data!
+    data.size >> len!
+    [index] > slice-byte
+      index.lt len > @
+
+printed: |
+  [b] > array
+    size. >> len!
+      b >> data!
+    index.lt len > [index] > slice-byte

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-only-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-only-referenced-handle.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle (`a >> b!`, #5817) whose only reference lives inside
+# a nested `>>` formation body. The reference climbs to it as `ξ.ρ.<name>`, which
+# resolves to the same auto-name, so it counts as a single use and the const
+# folds onto it as the anonymous inline argument `b.size!` (#5821). What broke
+# was the formation around it: nothing references `slice-byte`, so
+# "inline-cactoos" dropped that binding and the const's only reference went with
+# it, leaving a bare `[b] > array` with both declarations gone (#5914).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b.size >> len!
+    [index] >> slice-byte
+      index.lt len > @
+
+printed: |
+  [b] > array
+    index.lt b.size! > [index] >> slice-byte

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-based-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-based-handle.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The based counterpart of `unreferenced-formation-handle`: a plain `>> name`
+# handle (`a >> b`, R-3.10.12) that nothing references. A referenced one is
+# referentially transparent and inlines at every use, its name disappearing by
+# design (#5810); an unreferenced one has no use to inline into, so dropping it
+# deleted the binding from the printed source (#5914).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b > @
+    42 >> unused
+
+printed: |
+  [b] > array
+    b > @
+    42 >> unused

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-const-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-const-handle.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The const counterpart of `unreferenced-based-handle`: a const cache
+# (`a >> b!`, R-3.10.12) that nothing reads. A single-referenced const folds
+# onto its only use as the anonymous `a!` argument (#5821) and a multi-referenced
+# one is kept and hosted as a moniker (#5828); with no reference at all there is
+# no use site either way, so the binding was dropped outright (#5914).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b > @
+    42 >> unused!
+
+printed: |
+  [b] > array
+    b > @
+    42 >> unused!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-formation-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-formation-handle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A private `>>` formation handle (#5876) that nothing in the file references.
+# "inline-cactoos" folds such a handle into its use site and drops the standalone
+# binding, but with no use site there is nowhere to fold it to, so dropping the
+# binding deleted the whole helper from the printed source — a bare
+# `b > [b] > array` came back (#5914). An unreferenced handle is kept where it
+# stands and keeps the readable "@local" name "restore-local-names" preserves
+# for it, exactly as a recursive one does (#5681).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b > @
+    [index] >> slice-byte
+      index > @
+
+printed: |
+  [b] > array
+    b > @
+    index > [index] >> slice-byte


### PR DESCRIPTION
The printer folds a private `>>` handle into its use site and drops the
standalone binding. When nothing references the handle there is no use
site, so the value went nowhere and the declaration was simply deleted:
`[index] >> slice-byte` disappeared from the printed source, and a const
whose only reference lived inside that formation went down with it,
leaving a bare `[b] > array`. Such a handle is now kept where it stands
and keeps its readable name, the same way a recursive one already does.

The other half is `merge-monikers`. When it hosts a handle as the
receiver of a reversed dispatch it rebuilds the host node from the
reference's `@name` and `@const`, but not its `@local` — so a handle
whose own value dispatches on another handle (`data.size >> len!` over
`b >> data!`) printed as an anonymous `size. >>!` while its own
references still read `len`, a name the next parse resolves to nothing.
That is the `size. >>!` + stranded-reference symptom in `bytes/array.eo`,
`i64.eo` and `string/split.eo`.

Worth noting for whoever reads the issue: `eo:multi-referenced` was not
at fault. A reference written inside a nested formation reaches the
handle as `ξ.ρ.<name>`, which resolves to the same auto-name, so it was
counted all along. Five packs cover the shapes; eo-runtime's 153 sources
still print canonically and its suite is green. One neighbouring hole is
still open and predates this change: a moniker whose host site sits
inside another moniker strands, so `data.size >> len!` with two in-scope
uses of `len` prints `v2_2.size >> len!`. I will file that separately.

Closes #5914