### PR TITLE
#5864: assert real correct values in bytes/left.eo and bytes/xor.eo tests

### DIFF
--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -17,11 +17,9 @@
     FF-FF-FF-FF-FF-FF-FF-EE.left 2
     00-00-00-00-00-00-00-47.not
 
-  ++> tests-left-with-even-plus
-    not. > @
-      eq.
-        4.as-bytes.left 3
-        -33.as-bytes
+  eq. ++> tests-left-with-even-plus
+    4.as-bytes.left 3
+    00-80-00-00-00-00-00-00
 
   eq. ++> tests-left-with-minus-one
     eq.
@@ -29,26 +27,18 @@
       7.as-bytes
     false
 
-  ++> tests-left-with-odd-neg
-    not. > @
-      eq.
-        -17.as-bytes.left 1
-        33.as-bytes
+  eq. ++> tests-left-with-odd-neg
+    -17.as-bytes.left 1
+    80-62-00-00-00-00-00-00
 
-  ++> tests-left-with-odd-plus
-    not. > @
-      eq.
-        5.as-bytes.left 3
-        -41.as-bytes
+  eq. ++> tests-left-with-odd-plus
+    5.as-bytes.left 3
+    00-A0-00-00-00-00-00-00
 
-  ++> tests-left-with-zero
-    not. > @
-      eq.
-        2.as-bytes.left 0
-        -3.as-bytes
+  eq. ++> tests-left-with-zero
+    2.as-bytes.left 0
+    40-00-00-00-00-00-00-00
 
-  ++> tests-left-zero
-    not. > @
-      eq.
-        0.as-bytes.left 1
-        -1.as-bytes
+  eq. ++> tests-left-zero
+    0.as-bytes.left 1
+    00-00-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -29,29 +29,21 @@
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
     FF-FF-FF-FF-8E-EA-4C-B1
 
-  ++> tests-xor-with-one-neg-one-plus
-    not. > @
-      eq.
-        -36.as-bytes.xor 43.as-bytes
-        8.as-bytes
+  eq. ++> tests-xor-with-one-neg-one-plus
+    -36.as-bytes.xor 43.as-bytes
+    80-07-80-00-00-00-00-00
 
-  ++> tests-xor-with-two-neg
-    not. > @
-      eq.
-        -1.as-bytes.xor -123.as-bytes
-        -123.as-bytes
+  eq. ++> tests-xor-with-two-neg
+    -1.as-bytes.xor -123.as-bytes
+    7F-AE-C0-00-00-00-00-00
 
-  ++> tests-xor-with-two-plus
-    not. > @
-      eq.
-        53.as-bytes.xor 24.as-bytes
-        -46.as-bytes
+  eq. ++> tests-xor-with-two-plus
+    53.as-bytes.xor 24.as-bytes
+    00-72-80-00-00-00-00-00
 
-  ++> tests-xor-with-zero
-    not. > @
-      eq.
-        0.as-bytes.xor 29.as-bytes
-        -30.as-bytes
+  eq. ++> tests-xor-with-zero
+    0.as-bytes.xor 29.as-bytes
+    40-3D-00-00-00-00-00-00
 
   eq. ++> tests-xor-works
     00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF


### PR DESCRIPTION
Second part of the split for #5864 (first part, `bytes.eo`, is PR #5904; split because the combined diff exceeded the 200-line PR-size CI cap).

`bytes/left.eo` and `bytes/xor.eo` contained the same `not. > @ : eq. (actual) (some-decoy-value)` test pattern described in #5864: it only proves the result is not one specific decoy value, instead of proving the result is the actually correct value.

This PR replaces the 9 such tests in these two files (5 in `bytes/left.eo`, 4 in `bytes/xor.eo`) with real `eq. > @` assertions against the actual correct value, expressed as raw hex byte literals since `.as-bytes` produces the 8-byte IEEE-754 double representation and `left`/`xor` operate bytewise (or as a logical bit-shift) on that representation.

Every value was computed both independently (Python reimplementation of the bitwise/shift algorithm) and by directly invoking the real `BytesOf`/`BytesRaw` runtime classes with the same inputs, and the two matched for all 9 cases before being written into the tests. Both files pass in full after the change (7 tests in `bytes/left.eo`, 9 in `bytes/xor.eo`).

Closes #5864
