### PR TITLE
Keep a private handle that hosts another handle

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -109,11 +109,41 @@
   binding with both spellings still folds into the shorter bare inline and a
   dispatch hosts only when no bare reference is available.
   -->
-  <xsl:function name="eo:moniker-refs" as="element()*">
+  <xsl:function name="eo:hostable-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
     <xsl:variable name="refs" select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
     <xsl:sequence select="($refs[eo:dispatch-seg(.) = ''], $refs[eo:dispatch-seg(.) != ''])"/>
+  </xsl:function>
+  <!--
+  Whether the binding `$attr` is a host site itself: a sibling handle folds onto
+  `$attr`'s own `@base`, the shape `bts.size &gt;&gt; len!` has over
+  `text &gt;&gt; bts!`, where the parser hoisted the inner handle out and left a
+  reference to it in the outer handle's receiver, which the merge below turns
+  into the reversed dispatch that carries it. A sibling that folds onto an
+  earlier reference of its own — the site the author wrote it at, as in
+  "starts-with.eo" — leaves `$attr`'s receiver reading it by name
+  (`eo:kept-const-ref`) and so does not make `$attr` a host site. The sibling's
+  hostable references are read raw here: down a chain of handles every link is
+  a host site for the next, and each one keeps its own line.
+  -->
+  <xsl:function name="eo:hosting" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:sequence select="exists($attr/../o[not(. is $attr) and @name = eo:resolved-ref($attr) and eo:moniker-binding(.) and (eo:hostable-refs(.)[1] is $attr)])"/>
+  </xsl:function>
+  <!--
+  The references that actually host the binding `$attr`: the hostable ones,
+  unless `$attr` is a host site itself (see `eo:hosting`), in which case it
+  hosts nowhere. The merge below rebuilds a relocated binding from its
+  attributes and children alone, so the reversed dispatch that carries the
+  inner handle would never be built at the new site, while the inner binding is
+  dropped as merged — leaving the rebuilt copy on a synthetic "vL_P"
+  placeholder (#5918). Such a binding keeps its own line and hosts the inner
+  handle where it stands.
+  -->
+  <xsl:function name="eo:moniker-refs" as="element()*">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:sequence select="if (eo:hosting($attr)) then () else eo:hostable-refs($attr)"/>
   </xsl:function>
   <!--
   The binding that a reference `$ref` should be replaced with, or the empty

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -109,41 +109,11 @@
   binding with both spellings still folds into the shorter bare inline and a
   dispatch hosts only when no bare reference is available.
   -->
-  <xsl:function name="eo:hostable-refs" as="element()*">
+  <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
     <xsl:variable name="refs" select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
     <xsl:sequence select="($refs[eo:dispatch-seg(.) = ''], $refs[eo:dispatch-seg(.) != ''])"/>
-  </xsl:function>
-  <!--
-  Whether the binding `$attr` is a host site itself: a sibling handle folds onto
-  `$attr`'s own `@base`, the shape `bts.size &gt;&gt; len!` has over
-  `text &gt;&gt; bts!`, where the parser hoisted the inner handle out and left a
-  reference to it in the outer handle's receiver, which the merge below turns
-  into the reversed dispatch that carries it. A sibling that folds onto an
-  earlier reference of its own — the site the author wrote it at, as in
-  "starts-with.eo" — leaves `$attr`'s receiver reading it by name
-  (`eo:kept-const-ref`) and so does not make `$attr` a host site. The sibling's
-  hostable references are read raw here: down a chain of handles every link is
-  a host site for the next, and each one keeps its own line.
-  -->
-  <xsl:function name="eo:hosting" as="xs:boolean">
-    <xsl:param name="attr" as="element()"/>
-    <xsl:sequence select="exists($attr/../o[not(. is $attr) and @name = eo:resolved-ref($attr) and eo:moniker-binding(.) and (eo:hostable-refs(.)[1] is $attr)])"/>
-  </xsl:function>
-  <!--
-  The references that actually host the binding `$attr`: the hostable ones,
-  unless `$attr` is a host site itself (see `eo:hosting`), in which case it
-  hosts nowhere. The merge below rebuilds a relocated binding from its
-  attributes and children alone, so the reversed dispatch that carries the
-  inner handle would never be built at the new site, while the inner binding is
-  dropped as merged — leaving the rebuilt copy on a synthetic "vL_P"
-  placeholder (#5918). Such a binding keeps its own line and hosts the inner
-  handle where it stands.
-  -->
-  <xsl:function name="eo:moniker-refs" as="element()*">
-    <xsl:param name="attr" as="element()"/>
-    <xsl:sequence select="if (eo:hosting($attr)) then () else eo:hostable-refs($attr)"/>
   </xsl:function>
   <!--
   The binding that a reference `$ref` should be replaced with, or the empty
@@ -280,16 +250,22 @@
   handle in its own receiver (`data.size >> len!` over `b >> data!`) keeps its
   readable name instead of printing as an anonymous `size. >>!` that its own
   references no longer resolve to (#5914).
+
+  The binding lands at the reference through the "merged" mode below, which
+  carries whatever the binding hosts down with it (#5918).
   -->
   <xsl:template match="o[exists(eo:hosted-binding(.))]" priority="1">
     <xsl:variable name="binding" select="eo:hosted-binding(.)"/>
     <xsl:variable name="seg" select="eo:dispatch-seg(.)"/>
     <xsl:choose>
       <xsl:when test="$seg = ''">
+        <xsl:variable name="merged" as="element()">
+          <xsl:apply-templates select="$binding" mode="merged"/>
+        </xsl:variable>
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
-          <xsl:apply-templates select="$binding/@*[name() != 'as' and (eo:abstract($binding) or eo:const-handle($binding) or (name() != 'name' and name() != 'local'))]"/>
-          <xsl:apply-templates select="$binding/node()"/>
+          <xsl:copy-of select="$merged/@*[eo:abstract($merged) or eo:const-handle($merged) or (name() != 'name' and name() != 'local')]"/>
+          <xsl:copy-of select="$merged/node()"/>
         </xsl:element>
       </xsl:when>
       <xsl:otherwise>
@@ -297,11 +273,45 @@
           <xsl:apply-templates select="@as"/>
           <xsl:apply-templates select="@name|@local|@const"/>
           <xsl:attribute name="base" select="concat('.', $seg)"/>
-          <xsl:element name="o">
-            <xsl:apply-templates select="$binding/@*[name() != 'as']"/>
-            <xsl:apply-templates select="$binding/node()"/>
-          </xsl:element>
+          <xsl:apply-templates select="$binding" mode="merged"/>
           <xsl:apply-templates select="o"/>
+        </xsl:element>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!--
+  The binding as it lands at the reference it was merged onto: itself, with its
+  own references merged in turn and its positional `@as` left behind (the
+  reference above supplies the slot). A binding is often a host site itself: the
+  parser hoists a handle written inside another handle's receiver out to its own
+  binding (`text &gt;&gt; bts!` under `size. &gt;&gt; len!`) and leaves only a
+  reference behind, so `len`'s own `@base` is what `bts` folds onto. Rebuilding
+  such a binding attribute by attribute would leave that fold undone at the new
+  site while `bts` is dropped as merged, printing a receiver that binds to
+  nothing (#5918); instead the reversed dispatch is built here exactly as above,
+  and recursively, so a whole chain of handles travels to the use site nested
+  inside one another. The chain travelled so far comes along in `$seen`, since
+  two handles can dispatch on each other (`p.plus 1 >> a!` beside
+  `a.plus 2 >> p!`) — source that never dataizes, but that the parser accepts —
+  and a repeat has to end the descent rather than recur forever.
+  -->
+  <xsl:template match="o" mode="merged">
+    <xsl:param name="seen" as="element()*" select="()"/>
+    <xsl:variable name="binding" select="eo:hosted-binding(.)[every $node in $seen satisfies not(. is $node)]"/>
+    <xsl:choose>
+      <xsl:when test="exists($binding)">
+        <xsl:element name="o">
+          <xsl:apply-templates select="@*[name() != 'as' and name() != 'base']"/>
+          <xsl:attribute name="base" select="concat('.', eo:dispatch-seg(.))"/>
+          <xsl:apply-templates select="$binding" mode="merged">
+            <xsl:with-param name="seen" select="($seen, .)"/>
+          </xsl:apply-templates>
+          <xsl:apply-templates select="node()"/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:element name="o">
+          <xsl:apply-templates select="@*[name() != 'as']|node()"/>
         </xsl:element>
       </xsl:otherwise>
     </xsl:choose>
@@ -355,8 +365,11 @@
   Drop the standalone binding once it has been merged onto a reference, whether
   the host is a bare/dispatch moniker reference (`eo:moniker-refs`) or an
   applied recursive handle folded to a "| args" pipe (`eo:applied-refs`, #5848).
+  Outranks the merge template above, which matches the same binding whenever the
+  binding is a host site itself: what it hosts travels with it to the reference
+  in the "merged" mode, so here it only has to go (#5918).
   -->
-  <xsl:template match="o[eo:moniker-binding(.) and (exists(eo:moniker-refs(.)) or (eo:recursive-handle(.) and exists(eo:applied-refs(.))))]" priority="1"/>
+  <xsl:template match="o[eo:moniker-binding(.) and (exists(eo:moniker-refs(.)) or (eo:recursive-handle(.) and exists(eo:applied-refs(.))))]" priority="3"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle-chain.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle-chain.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Three const file-local handles chained through their receivers: `third`
+# dispatches on `second`, which dispatches on `first`. Each handle in the chain
+# is a host site for the next one, so none of them may be relocated onto a use
+# site (#5918); only `first`, which hosts nothing, folds into `second`'s
+# receiver as a reversed `size.` dispatch. Before the guard the whole chain
+# collapsed into `φ` and both inner bindings vanished from the printed source.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [text] > chain
+    plus. >> third!
+      size. >> second!
+        text >> first!
+      1
+    third.eq 0 > @
+
+printed: |
+  [text] > chain
+    third.eq 0 > @
+    second.plus 1 >> third!
+    size. >> second!
+      text >> first!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle-chain.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle-chain.yaml
@@ -3,11 +3,11 @@
 ---
 # yamllint disable rule:line-length
 # Three const file-local handles chained through their receivers: `third`
-# dispatches on `second`, which dispatches on `first`. Each handle in the chain
-# is a host site for the next one, so none of them may be relocated onto a use
-# site (#5918); only `first`, which hosts nothing, folds into `second`'s
-# receiver as a reversed `size.` dispatch. Before the guard the whole chain
-# collapsed into `φ` and both inner bindings vanished from the printed source.
+# dispatches on `second`, which dispatches on `first`. Every link is a host site
+# for the next, so folding `third` onto `φ` has to carry the whole chain along,
+# each handle nested in the receiver of the one above it (#5918). Before the fix
+# the chain was rebuilt attribute by attribute at the new site, so both inner
+# bindings were dropped as merged and vanished from the printed source.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -25,7 +25,9 @@ origin: |
 
 printed: |
   [text] > chain
-    third.eq 0 > @
-    second.plus 1 >> third!
-    size. >> second!
-      text >> first!
+    eq. > @
+      plus. >> third!
+        size. >> second!
+          text >> first!
+        1
+      0

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle whose own receiver reaches a second one: `len` is
+# `bts.size`, and the parser hoists `bts` out to its own binding, leaving its
+# reference in `len`'s receiver. "merge-monikers" hosts `bts` back there as the
+# receiver of the reversed `size.` dispatch (#5782), so `len` is itself a host
+# site and cannot be relocated onto `φ`: the merge rebuilds a relocated binding
+# from its attributes and children alone, so the reversed dispatch carrying
+# `bts` would never be built at the new site while `bts`'s own binding is
+# dropped as merged, stranding the copy on a "vL_P" placeholder (#5918).
+# `len` therefore keeps its own line and `φ` reads it by name.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [text] > split
+    size. >> len!
+      text >> bts!
+    len.eq 0 > @
+
+printed: |
+  [text] > split
+    len.eq 0 > @
+    size. >> len!
+      text >> bts!

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-handle.yaml
@@ -4,13 +4,11 @@
 # yamllint disable rule:line-length
 # A const file-local handle whose own receiver reaches a second one: `len` is
 # `bts.size`, and the parser hoists `bts` out to its own binding, leaving its
-# reference in `len`'s receiver. "merge-monikers" hosts `bts` back there as the
-# receiver of the reversed `size.` dispatch (#5782), so `len` is itself a host
-# site and cannot be relocated onto `φ`: the merge rebuilds a relocated binding
-# from its attributes and children alone, so the reversed dispatch carrying
-# `bts` would never be built at the new site while `bts`'s own binding is
-# dropped as merged, stranding the copy on a "vL_P" placeholder (#5918).
-# `len` therefore keeps its own line and `φ` reads it by name.
+# reference in `len`'s receiver, which "merge-monikers" turns back into the
+# receiver of a reversed `size.` dispatch (#5782). `len` then folds onto `φ` as
+# usual and takes `bts` along, nested inside it. Rebuilding the relocated `len`
+# attribute by attribute left that inner fold undone at the new site while
+# `bts` was dropped as merged, printing `v3_4.size >> len!` (#5918).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -26,6 +24,7 @@ origin: |
 
 printed: |
   [text] > split
-    len.eq 0 > @
-    size. >> len!
-      text >> bts!
+    eq. > @
+      size. >> len!
+        text >> bts!
+      0

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-multi-referenced-handle.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The same guard for a host site read from more than one place: `len` hosts
-# `data` in its receiver, so it stays standalone (#5918) instead of landing on
-# the first of its two uses, and both uses read it by name. A moniker does fold
-# onto the first of several references (#5739), which is why the guard has to
-# live in `eo:moniker-refs` rather than in the single-reference test.
+# The same travel for a host site read from more than one place: `len` hosts
+# `data` in its receiver and folds onto the first of its two uses (#5739),
+# carrying `data` with it (#5918), while the second use keeps reading `len` by
+# name. Before the fix `data` was dropped as merged and the relocated `len` read
+# `v2_2.size`.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -23,7 +23,8 @@ origin: |
 
 printed: |
   [b] > array
-    size. >> len!
-      b >> data!
-    len.plus 1 > x
+    plus. > x
+      size. >> len!
+        b >> data!
+      1
     len.plus 2 > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-multi-referenced-handle.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The same guard for a host site read from more than one place: `len` hosts
+# `data` in its receiver, so it stays standalone (#5918) instead of landing on
+# the first of its two uses, and both uses read it by name. A moniker does fold
+# onto the first of several references (#5739), which is why the guard has to
+# live in `eo:moniker-refs` rather than in the single-reference test.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b >> data!
+    data.size >> len!
+    len.plus 1 > x
+    len.plus 2 > y
+
+printed: |
+  [b] > array
+    size. >> len!
+      b >> data!
+    len.plus 1 > x
+    len.plus 2 > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
@@ -3,10 +3,10 @@
 ---
 # yamllint disable rule:line-length
 # The carry cluster of "i64.eo": a const handle whose value reaches two more of
-# them, one in its receiver and one in its argument, both also read from a
-# sibling binding. `both-negative` is a host site for `shifted-sign`, so it
-# keeps its own line (#5918) and hosts both inner handles where they stand;
-# `signs-differ` reads them by name.
+# them, one in its receiver and one in its argument. Both travel with
+# `both-negative` when it folds onto `φ` (#5918) — the receiver one as the
+# reversed `and.` dispatch's receiver, keeping its name, the argument one as the
+# anonymous inline const a single-use argument folds to (#5821).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -19,13 +19,12 @@ origin: |
     and. >> both-negative!
       shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
       bottom.and 80-00-00-00-00-00-00-00 >> divisor-sign!
-    shifted-sign.xor divisor-sign > signs-differ!
-    both-negative.or signs-differ > @
+    both-negative.eq 00-00-00-00-00-00-00-00 > @
 
 printed: |
   [shifted bottom] > carry
-    both-negative.or signs-differ > @
-    and. >> both-negative!
-      shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
-      bottom.and 80-00-00-00-00-00-00-00 >> divisor-sign!
-    shifted-sign.xor divisor-sign > signs-differ!
+    eq. > @
+      and. >> both-negative!
+        shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
+        bottom.and 80-00-00-00-00-00-00-00!
+      00-00-00-00-00-00-00-00

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The carry cluster of "i64.eo": a const handle whose value reaches two more of
+# them, one in its receiver and one in its argument, both also read from a
+# sibling binding. `both-negative` is a host site for `shifted-sign`, so it
+# keeps its own line (#5918) and hosts both inner handles where they stand;
+# `signs-differ` reads them by name.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [shifted bottom] > carry
+    and. >> both-negative!
+      shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
+      bottom.and 80-00-00-00-00-00-00-00 >> divisor-sign!
+    shifted-sign.xor divisor-sign > signs-differ!
+    both-negative.or signs-differ > @
+
+printed: |
+  [shifted bottom] > carry
+    both-negative.or signs-differ > @
+    and. >> both-negative!
+      shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
+      bottom.and 80-00-00-00-00-00-00-00 >> divisor-sign!
+    shifted-sign.xor divisor-sign > signs-differ!


### PR DESCRIPTION
`merge-monikers` folds a file-local `>>` handle onto its use site, but it rebuilt the relocated binding attribute by attribute. That is fine until the binding is a host site itself: the parser hoists a handle written inside another handle's receiver out to its own binding (`text >> bts!` under `size. >> len!`) and leaves only a reference behind, so the outer handle's own `@base` is what the inner one folds onto. Rebuilt attribute by attribute, that fold never happened at the new site while the inner binding was dropped as merged — hence the dangling `v3_4.size >> len!`. The binding now lands through a `merged` mode that re-applies the hosting rule recursively, so a whole chain of handles travels to the use site nested inside one another. Four print-packs cover the plain shape, a three-deep chain, the `i64.eo` carry cluster and a host site read from two places.

Worth noting that the issue's own diagnosis points at the fold guard in `inline-cactoos`, which is not where this goes wrong — that pass already keeps the const (`eo:vertical-const`), and nothing is nested by the time the printer sees it. Saxon had been reporting the real problem all along as an "ambiguous rule match" between the merge and the drop template; the drop now outranks the merge explicitly, since what the binding hosts travels with it.

`string/split.eo`'s `len` and `size` and `i64.eo`'s `both-negative` can be privatised after this. I ran the format gate over branch `5678`'s sources (229 handles, 153 files): canonical before and after this change, and with those three privatised the gate settles in one `-Deo.autoFix` pass, with all 1760 runtime tests green on the result. On master's printer the same edits print `v47_4.size >> len!` and `v56_8.and divisor-sign >> both-negative!`. The non-const flavour (`size. >> len` over `text >> bts`) is spelled correctly now too, and mutually dispatching handles — source that never dataizes but does parse — end the recursion instead of driving it forever.

Closes #5918