### PR TITLE
Reach a file-local handle through an explicit scope

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -24,6 +24,15 @@
   hijacks a same-named public attribute in an unrelated sibling formation.
   This mirrors how "build-fqns" later resolves a name to the nearest
   enclosing formation that owns an attribute of that name.
+
+  A reference may also spell its scope out instead of leaving it to the
+  search: "$.foo" reaches the innermost formation and "^.foo" its parent
+  (§3.14), and each binds to the handle of exactly the formation it names
+  (see `eo:scope`, #5917). Such a reference is the only spelling left when
+  the nested formation rebinds the name it reads - `^.foo &gt; foo` copies
+  the parent's handle into an attribute of the same name, where a bare "foo"
+  would bind to the copy - so leaving it unresolved stranded the handle
+  behind a name nothing owned, and the reference dataized to ⊥.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
@@ -45,13 +54,31 @@
   -->
   <xsl:function name="eo:captor" as="element()?">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="name" as="xs:string" select="$ref/@base"/>
-    <xsl:variable name="scope" as="element()?" select="($ref/ancestor::o[not(@base)][o[@name=$name] or (some $d in descendant::o[@local=$name] satisfies $d/ancestor::o[not(@base)][1] is .)])[last()]"/>
+    <xsl:variable name="name" as="xs:string" select="if (exists($ref/@method)) then substring-after($ref/@base, '.') else string($ref/@base)"/>
+    <xsl:variable name="scope" as="element()?" select="if (exists($ref/@method)) then eo:scope($ref) else ($ref/ancestor::o[not(@base)][o[@name=$name] or (some $d in descendant::o[@local=$name] satisfies $d/ancestor::o[not(@base)][1] is .)])[last()]"/>
     <xsl:sequence select="$scope/descendant::o[@local=$name][ancestor::o[not(@base)][1] is $scope][1]"/>
+  </xsl:function>
+  <!--
+  The formation that the explicit receiver of a dispatch names: "ξ" (written
+  "$") is the innermost formation, "ρ" ("^") is its parent, and every further
+  ".ρ" segment climbs one level more. Such a receiver pins the scope instead
+  of leaving it to the search above, so "^.foo" reaches exactly one formation
+  out and stops there, however many scopes further out also declare the name.
+  A dispatch is still flat at this point in the train - "wrap-method-calls"
+  nests it later - so the receiver of a "@method" node is its preceding
+  sibling; a reversed dispatch ("plus. &gt; y") carries no "@method" and holds
+  its receiver as a child, so it never reaches here. The empty sequence for
+  every other receiver (an application, a global, a name), which names no
+  scope known at parse time.
+  -->
+  <xsl:function name="eo:scope" as="element()?">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="receiver" as="element()?" select="$ref/preceding-sibling::o[1]"/>
+    <xsl:sequence select="if (empty($receiver/@base)) then () else if ($receiver/@base='ξ' and empty($receiver/@method)) then $ref/ancestor::o[not(@base)][1] else if ($receiver/@base='ρ' and empty($receiver/@method)) then $ref/ancestor::o[not(@base)][2] else if ($receiver/@base='.ρ' and exists($receiver/@method)) then eo:scope($receiver)/ancestor::o[not(@base)][1] else ()"/>
   </xsl:function>
   <xsl:template match="o[@base and exists(eo:captor(.))]">
     <xsl:copy>
-      <xsl:attribute name="base" select="eo:captor(.)/@name"/>
+      <xsl:attribute name="base" select="concat(if (exists(@method)) then '.' else '', eo:captor(.)/@name)"/>
       <xsl:apply-templates select="@* except @base"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-explicit-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-explicit-scope.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A reference that spells its scope out instead of leaving it to the search -
+# `$.b` for the innermost formation, `^.b` for its parent, one more `^` per
+# level above that (§3.14) - binds to the handle of exactly the formation it
+# names (#5917). It is the only spelling left to a formation that rebinds the
+# name it reads (`^.b > b`), where a bare `b` is the new attribute; before,
+# such a reference kept the readable name, which nothing owns once the handle
+# takes a cactus one, so it dataized to ⊥.
+sheets:
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+asserts:
+  - /object[not(errors)]
+  # the handle keeps its "@local" marker and gets a cactus name
+  - //o[@local='b' and @name]
+  # all three explicitly scoped references bind to the handle's cactus name
+  - /object[count(//o[@method and @base=concat('.', //o[@local='b']/@name)])=3]
+  # none is left dispatching on the readable handle name
+  - /object[count(//o[@base='.b'])=0]
+input: |
+  [a] > foo
+    a >> b!
+    $.b > x
+    [] > mid
+      ^.b > b
+      [] > deep
+        ^.^.b > y

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -188,20 +188,39 @@
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
+  Whether the bare name of `$binding` would read as something else at `$ref`:
+  some formation between the reference and the one that owns the handle declares
+  that same readable name, so the parser's search — which stops at the nearest
+  scope declaring the name at all — never reaches the handle. The binding a
+  reference stands in counts as such a declaration, and is the reason this
+  happens at all: `^.foo &gt; foo` copies the parent's handle into an attribute
+  of the same name, and inside that formation a bare `foo` is the copy (#5917).
+  -->
+  <xsl:function name="eo:shadowed" as="xs:boolean">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:param name="binding" as="element()"/>
+    <xsl:variable name="owner" select="$binding/.."/>
+    <xsl:sequence select="some $scope in $ref/ancestor::o[eo:abstract(.)][ancestor::o[. is $owner]] satisfies exists($scope/o[@name = $binding/@local or @local = $binding/@local])"/>
+  </xsl:function>
+  <!--
   The base under which a non-hosting reference reads back: the readable "@local"
   handle of the binding it resolves to, plus whatever the reference dispatches on
-  top of it. The obfuscated cactus segment and the `ξ.ρ...` climb in front of it
-  give way to a plain `ξ.&lt;local&gt;`, since a handle is reached by its bare
-  name alone and the parser re-derives the climb in "resolve-local-names". A
-  reference standing in the binding's own scope has no climb to shed; one inside
-  a nested formation does, and spelling it out would print a `^.&lt;local&gt;`
-  that binds to nothing on reparse (#5893).
+  top of it. The obfuscated cactus segment gives way to that handle, and the
+  `ξ.ρ...` climb in front of it to a plain `ξ`, since a handle is reached by its
+  bare name alone and the parser re-derives the climb in "resolve-local-names".
+  A reference standing in the binding's own scope has no climb to shed; one
+  inside a nested formation does, and #5893 spelled it out as a `^.&lt;local&gt;`
+  that bound to nothing on reparse. It binds now (#5917), and a shadowed
+  reference (see `eo:shadowed`) keeps its climb for that reason: the bare name
+  is taken there, so the explicit scope is the only spelling that still reads
+  back as the handle.
   -->
   <xsl:function name="eo:handle-base" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:param name="binding" as="element()"/>
     <xsl:variable name="segs" select="tokenize($ref/@base, '\.')"/>
-    <xsl:sequence select="string-join(($eo:xi, string($binding/@local), subsequence($segs, index-of($segs, string($binding/@name))[1] + 1)), '.')"/>
+    <xsl:variable name="at" select="index-of($segs, string($binding/@name))[1]"/>
+    <xsl:sequence select="string-join((if (eo:shadowed($ref, $binding)) then subsequence($segs, 1, $at - 1) else $eo:xi, string($binding/@local), subsequence($segs, $at + 1)), '.')"/>
   </xsl:function>
   <!--
   The kept multi-referenced abstract handle binding (`[] &gt;&gt; name`, #5876)

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-rebound-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-rebound-referenced-handle.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A const file-local handle read from a nested formation that binds an
+# attribute of the very same name (`^.kbts > kbts`, the shape "map.eo" copies
+# a key's bytes into an entry with). The nested reference cannot read the
+# handle by its bare name - inside that formation the name is the copy - so it
+# keeps the `^` climb it was written with and reads the handle through the
+# formation that owns it (#5917). Before the fix the climb was shed here as it
+# is for an unshadowed reference, printing a `kbts > kbts` that binds to
+# itself.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [tup] > foo
+    tup.as-bytes >> kbts!
+    bytes.hash kbts >> hash!
+    [] > pair
+      ^.kbts > kbts
+
+printed: |
+  [tup] > foo
+    bytes.hash >> hash!
+      tup.as-bytes >> kbts!
+    [] > pair
+      ^.kbts > kbts


### PR DESCRIPTION
A `>> foo` handle could only be read by a bare `foo`. Spell the scope out
instead — `$.foo`, `^.foo`, one more `^` per level above that — and the
reference kept the readable name, which nothing owns once the handle takes its
cactus name, so it dataized to the terminated computation. `resolve-local-names`
now binds such a reference to the handle of exactly the formation it names, and
the printer keeps the `^` climb in front of a handle when the bare name is taken
in a scope in between, instead of always shedding it.

The issue blames the moniker fold in the printer, but that turned out to be
innocent: the nesting it prints (`bytes.hash >> hash!` over `key.as-bytes >>
kbts!`) reparses to the same graph, because the parser hoists the inner handle
back out to the enclosing formation. What actually broke `map.eo` is the two
scopes whose entries copy the key's bytes with `^.kbts > kbts` — the explicit
scope is the only spelling available there, since inside that formation a bare
`kbts` is the copy being defined. Privatising the other two scopes worked before
this change; all four work now, and `EOmapTest`/`EOsetTest` pass.

Verified with 1506 parser, 269 printer and 1760 runtime tests, plus the format
gate over the 229 privatised handles on branch `5678` — canonical before and
after, so nothing reformats. One thing the reviewer may want to know: a handle
whose *only* reference is a named one (`kbts > alias`) is inlined by
`inline-cactoos` with the name dropped, which prints EO that no longer parses.
That is not new — master does it for a bare `kbts > alias` too — and this change
makes the `^.`-spelled variant reach it, so I will file it separately.

Closes #5917