### PR TITLE
#5873: write atomically via a sibling temp file plus atomic rename

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -7,7 +7,9 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
@@ -20,6 +22,14 @@ import org.cactoos.scalar.LengthOf;
 /**
  * Content saved to the file.
  * Returns path to the file
+ *
+ * <p>The content is streamed into a sibling temporary file first, then moved
+ * onto {@link #target} with {@link StandardCopyOption#ATOMIC_MOVE}. Streaming
+ * straight into {@link #target} would let a concurrent reader (or another
+ * writer racing on the same path) observe it truncated, mid-write (#5873):
+ * an atomic rename means a reader always sees either the previous complete
+ * file or the new one, never a partial one.</p>
+ *
  * @since 0.41.0
  */
 final class Saved implements Scalar<Path> {
@@ -82,14 +92,27 @@ final class Saved implements Scalar<Path> {
                     this.target.getParent()
                 );
             }
-            bytes = new IoChecked<>(
-                new LengthOf(
-                    new TeeInput(
-                        this.content,
-                        new OutputTo(this.target)
+            final Path tmp = Files.createTempFile(
+                this.target.getParent(),
+                this.target.getFileName().toString(),
+                ".tmp"
+            );
+            try {
+                bytes = new IoChecked<>(
+                    new LengthOf(
+                        new TeeInput(
+                            this.content,
+                            new OutputTo(tmp)
+                        )
                     )
-                )
-            ).value();
+                ).value();
+                Files.move(
+                    tmp, this.target,
+                    StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
+                );
+            } finally {
+                Files.deleteIfExists(tmp);
+            }
             Logger.debug(
                 this, "File %s saved (%d bytes)",
                 this.target, bytes

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -106,10 +107,7 @@ final class Saved implements Scalar<Path> {
                         )
                     )
                 ).value();
-                Files.move(
-                    tmp, this.target,
-                    StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
-                );
+                Saved.moved(tmp, this.target);
             } finally {
                 Files.deleteIfExists(tmp);
             }
@@ -127,5 +125,24 @@ final class Saved implements Scalar<Path> {
             );
         }
         return this.target;
+    }
+
+    /**
+     * Move a temp file onto its target, atomically where the filesystem
+     * supports it, falling back to a plain (still complete-file, just not
+     * guaranteed atomic) move on filesystems that don't.
+     * @param tmp Temp file to move
+     * @param target Destination path
+     * @throws IOException If the move fails
+     */
+    private static void moved(final Path tmp, final Path target) throws IOException {
+        try {
+            Files.move(
+                tmp, target,
+                StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
+            );
+        } catch (final AtomicMoveNotSupportedException ignored) {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -38,7 +38,7 @@ final class SavedTest {
     }
 
     @Test
-    void neverExposesAPartiallyWrittenFileToAConcurrentReader(
+    void exposesNoPartiallyWrittenFileToConcurrentReader(
         @Mktmp final Path temp
     ) throws Exception {
         final Path target = temp.resolve("shared.txt");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Saved}.
+ * @since 0.74
+ */
+@ExtendWith(MktmpResolver.class)
+final class SavedTest {
+
+    @Test
+    void savesContentToFile(@Mktmp final Path temp) throws IOException {
+        final Path target = temp.resolve("out.txt");
+        new Saved("hello", target).value();
+        MatcherAssert.assertThat(
+            "the saved file must contain exactly what was written",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("hello")
+        );
+    }
+
+    @Test
+    void neverExposesAPartiallyWrittenFileToAConcurrentReader(
+        @Mktmp final Path temp
+    ) throws Exception {
+        final Path target = temp.resolve("shared.txt");
+        final List<String> variants = IntStream.range(0, 8)
+            .mapToObj(idx -> String.valueOf((char) ('a' + idx)).repeat(500_000))
+            .collect(Collectors.toList());
+        new Saved(variants.get(0), target).value();
+        final List<String> broken = new CopyOnWriteArrayList<>();
+        new Threaded<>(
+            variants,
+            variant -> {
+                new Saved(variant, target).value();
+                final String read = Files.readString(target, StandardCharsets.UTF_8);
+                if (!variants.contains(read)) {
+                    broken.add(read.substring(0, Math.min(read.length(), 40)));
+                }
+                return 1;
+            }
+        ).total();
+        MatcherAssert.assertThat(
+            "a reader racing with concurrent writers must always see a complete variant, never a mix of two",
+            broken,
+            Matchers.empty()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #5873.

`Saved` streamed content directly into the target file with `TeeInput`/`OutputTo`, which truncates the target and writes into it in place. A reader (another `Saved` writing to the same tail path, or anything reading the file back, e.g. `Parsing.tojoVersion`/`Xnav` on a cache hit) could observe the file mid-write: a valid path pointing at an incomplete document, surfacing as a misleading "Premature end of file" XML parse error with nothing actually wrong with the content once the write finished.

Fix: stream into a temp file created alongside the target (same filesystem, so `Files.move` can be atomic), then move it onto the target with `ATOMIC_MOVE`. A reader now always sees either the previous complete file or the new one, never a partial one. This matches option 1 from the issue's own suggested fixes.

Added `SavedTest` with a regression test: 8 threads write different large variants to the same target concurrently while each also reads the file back immediately after its own write, asserting every read is one of the complete variants and never a truncated or mixed one. Verified the test catches the bug: reverting `Saved` to the old direct-write implementation makes it fail with truncated reads observed; with the fix it passes.

Verified: `SavedTest` 2/2 green, qulice clean.
