### PR TITLE
#5920: reject HEX literals that lose precision past the double range

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -118,22 +118,7 @@ final class Emissions {
         if (value.kind() == Value.Kind.INTEGER || value.kind() == Value.Kind.FLOAT) {
             Emissions.number(emit, name, value, line);
         } else if (value.kind() == Value.Kind.HEX) {
-            final long hex;
-            try {
-                hex = Long.parseLong(value.raw().substring(2), 16);
-            } catch (final NumberFormatException ex) {
-                final ParseError error = new ParseError(
-                    line, value.pos(),
-                    "hexadecimal literal is out of range"
-                );
-                error.initCause(ex);
-                throw error;
-            }
-            emit.object(name, "Φ.number", line, value.pos());
-            Emissions.bytesCarrier(
-                emit, line, value.pos(),
-                new Hex((double) hex).asString()
-            );
+            Emissions.hex(emit, name, value, line);
         } else if (value.kind() == Value.Kind.BYTES) {
             emit.object(name, "Φ.bytes", line, value.pos());
             emit.object(null, null, line, value.pos());
@@ -296,6 +281,48 @@ final class Emissions {
             }
         }
         return out.toString();
+    }
+
+    /**
+     * Emit a {@code HEX} literal as {@code Φ.number}, rejecting values that
+     * fit a signed 64-bit {@code long} but no longer round-trip exactly
+     * through an IEEE-754 double (the sibling {@code number()} check, for
+     * the base where a plain range check on {@code long} does not catch it).
+     * @param emit Emitter
+     * @param name Name attribute (or {@code null})
+     * @param value Hex value
+     * @param line Source line
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private static void hex(
+        final Emit emit, final String name, final Value value, final int line
+    ) {
+        final long raw;
+        try {
+            raw = Long.parseLong(value.raw().substring(2), 16);
+        } catch (final NumberFormatException ex) {
+            final ParseError error = new ParseError(
+                line, value.pos(),
+                "hexadecimal literal is out of range"
+            );
+            error.initCause(ex);
+            throw error;
+        }
+        final double parsed = raw;
+        if ((long) parsed != raw) {
+            throw new ParseError(
+                line, value.pos(),
+                String.format(
+                    "%s is over-precise, write %s instead",
+                    value.raw(), Emissions.canonicalInteger(parsed)
+                )
+            );
+        }
+        emit.object(name, "Φ.number", line, value.pos());
+        Emissions.bytesCarrier(
+            emit, line, value.pos(),
+            new Hex(parsed).asString()
+        );
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -293,7 +293,7 @@ final class Emissions {
      * @param name Name attribute (or {@code null})
      * @param value Hex value
      * @param line Source line
-     * @checkstyle ParameterNumberCheck (3 lines)
+     * @checkstyle ParameterNumberCheck (6 lines)
      */
     @SuppressWarnings({
         "PMD.AvoidDecimalLiteralsInBigDecimalConstructor",

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -604,8 +604,7 @@ final class LnApplicationTest {
     @Test
     void rejectsOverPreciseHexHead() {
         MatcherAssert.assertThat(
-            "a HEX literal past the exact double integer range must suggest the rounded"
-                .concat(" decimal spelling, matching the INTEGER literal of the same value"),
+            "a HEX literal past the exact double integer range must suggest the rounded decimal spelling, matching the INTEGER literal of the same value",
             Assertions.assertThrows(
                 ParseError.class,
                 () -> LnApplicationTest.parseLine("0x20000000000001 > x")
@@ -613,6 +612,18 @@ final class LnApplicationTest {
             Matchers.equalTo(
                 "0x20000000000001 is over-precise, write 9007199254740992 instead"
             )
+        );
+    }
+
+    @Test
+    void rejectsMaxLongHexHead() {
+        MatcherAssert.assertThat(
+            "0x7FFFFFFFFFFFFFFF must be rejected like the INTEGER literal of the same value, not silently rounded up to 2^63",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> LnApplicationTest.parseLine("0x7FFFFFFFFFFFFFFF > x")
+            ).getMessage(),
+            Matchers.startsWith("0x7FFFFFFFFFFFFFFF is over-precise")
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -602,6 +602,21 @@ final class LnApplicationTest {
     }
 
     @Test
+    void rejectsOverPreciseHexHead() {
+        MatcherAssert.assertThat(
+            "a HEX literal past the exact double integer range must suggest the rounded"
+                .concat(" decimal spelling, matching the INTEGER literal of the same value"),
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> LnApplicationTest.parseLine("0x20000000000001 > x")
+            ).getMessage(),
+            Matchers.equalTo(
+                "0x20000000000001 is over-precise, write 9007199254740992 instead"
+            )
+        );
+    }
+
+    @Test
     void rejectsOverPreciseFloatHead() {
         MatcherAssert.assertThat(
             "a FLOAT literal with dead trailing digits must name the offender and its Double.toString form",


### PR DESCRIPTION
Fixes #5920.

`Emissions.openValue`'s HEX branch cast the parsed `long` straight to `double` with no round-trip check, unlike the sibling `number()` method (added by #5613) which rejects INTEGER/FLOAT literals that cannot be represented exactly as an IEEE-754 double. A HEX literal like `0x20000000000001` (`9007199254740993`, one past 2^53) parsed with no error and silently emitted the bytes for `9007199254740992.0` instead, one less than what was actually written, with no diagnostic. The same value written as an INTEGER literal is already rejected by `number()`.

Fix: extracted the HEX branch into its own `hex()` method (matching the existing `number()`/`group()` pattern in the class, also needed to keep `openValue`'s NCSS under the qulice limit after adding the check), added the same round-trip check used implicitly by `number()`'s `overPrecise` check (`(long) parsed != raw`), and raise a `ParseError` in the same `"%s is over-precise, write %s instead"` style, naming the offending hex spelling and the decimal value it actually parsed to.

Added `rejectsOverPreciseHexHead` to `LnApplicationTest`. Verified it fails against the pre-fix `Emissions.java` (asserted the old unguarded cast) and passes with the fix.

Verified: eo-parser full suite 1506/1506 green (including all 926 `EoSyntaxTest` golden cases), qulice clean.
