### PR TITLE
#5869: make empty string character predicates consistently false

### DIFF
--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -13,6 +13,8 @@
     regex "/^[a-zA-Z]+$/"
     text
 
+  (is-alpha "").not ++> tests-checks-if-empty-text-is-not-alpha
+
   is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
 
   (is-alpha "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alpha

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -13,6 +13,8 @@
     regex "/^[A-Za-z0-9]+$/"
     text
 
+  (is-alphanumeric "").not ++> tests-checks-if-empty-text-is-not-alphanumeric
+
   is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
 
   (is-alphanumeric "-w-").not ++> tests-checks-if-text-with-dashes-is-not-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -9,10 +9,12 @@
 
 [text] > is-ascii
   matches. > @
-    regex "/^[\\x00-\\x7F]*$/"
+    regex "/^[\\x00-\\x7F]+$/"
     text
 
   (is-ascii "🌵").not ++> tests-checks-if-emoji-is-not-ascii
+
+  (is-ascii "").not ++> tests-checks-if-empty-text-is-not-ascii
 
   is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
 


### PR DESCRIPTION
Closes #5869.

The sibling character-class predicates already follow a non-empty-match convention: `is-alpha`, `is-alphanumeric`, and `is-digit` use `+`, and `is-digit` explicitly tests that an empty string is false. `is-ascii` was the outlier because its regex used `*`.

This change:

- changes `is-ascii` from zero-or-more to one-or-more ASCII characters;
- adds explicit empty-string tests to `is-alpha`, `is-alphanumeric`, and `is-ascii` so the shared contract cannot drift again.

Validation:

- the new tests initially produced one failure in `EOis_asciiTest` while the other runtime tests passed (`1763` run, one new failure, `19` skipped);
- after the fix, the three focused generated test classes pass: `12` tests, zero failures;
- all `153` EO runtime sources pass the canonical formatter;
- the `eo-runtime` compile phase succeeds.
