### PR TITLE
Give an anonymous const argument a spelling of its own

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -138,6 +138,35 @@ final class Node {
     }
 
     /**
+     * The same node as it must be spelled on a line of its own.
+     *
+     * <p>An anonymous inline const argument (#5821) carries a bare {@code !}
+     * marker, and only a horizontal argument slot can hold it: on a line of
+     * its own the marker closes the expression, so the arguments below it
+     * become trailing garbage ({@code or.!}), and behind those arguments it
+     * marks the last one instead of the whole application (#5902). A name
+     * suffix, however, may carry the marker (R-3.10.4), so such a const takes
+     * the auto-name {@code >>} that the same slot already spells for a
+     * formation. The parser floats an auto-named binding up to the enclosing
+     * formation and leaves a reference in its place, which is the very graph
+     * the inline argument builds, so the two spellings agree (#5927).</p>
+     *
+     * @return The node with a suffix its own line can carry
+     */
+    Node lined() {
+        final Node result;
+        if ("!".equals(this.tail)) {
+            result = new Node(
+                this.base, " >>!", this.abstractt, this.test,
+                this.reversed, this.data, this.children
+            );
+        } else {
+            result = this;
+        }
+        return result;
+    }
+
+    /**
      * Whether this node carries no name suffix anywhere in its subtree.
      *
      * <p>A line is "named" when its {@code tail} holds a {@code > name},

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -245,6 +245,15 @@ final class Pretty {
     /**
      * Render a node vertically: the head on this line, each argument
      * laid out on the lines below, indented one level deeper.
+     *
+     * <p>An argument that carries the bare {@code !} of an anonymous inline
+     * const (#5821) takes an auto-name here, through {@link Node#lined()}: the
+     * marker has no spelling on a line of its own, and this is the one place
+     * that puts an argument there. {@link #shaped} prefers the horizontal
+     * rendering whenever such an argument is present, so the auto-name appears
+     * only where no horizontal rendering exists at all — a sibling argument
+     * carrying a name of its own, say (#5927).</p>
+     *
      * @param node The node
      * @param indent The indentation level
      * @return The rendered block
@@ -257,7 +266,7 @@ final class Pretty {
             if (child.test) {
                 block.append('\n');
             }
-            block.append('\n').append(this.layout(child, indent + 1));
+            block.append('\n').append(this.layout(child.lined(), indent + 1));
         }
         return block.toString();
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-argument-beside-moniker.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-argument-beside-moniker.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced private const folded into an argument slot whose
+# application cannot be laid out on one line, because a sibling argument hosts
+# a `>> name!` moniker. The const then lands on a line of its own, where the
+# anonymous `!` marker has nowhere to sit - after the head it closes the
+# expression and the arguments below become trailing garbage (`or.!`), after
+# the arguments it marks the last argument instead of the application. So the
+# const takes the auto-name the same slot spells for a formation, `>>!`, which
+# is a name suffix and may carry the marker (R-3.10.4). The parser floats such
+# a binding up to the enclosing formation and leaves a reference behind, so the
+# object graph is the one the inline argument would have built (#5927).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    bar > @
+      p
+      q
+      p.eq 2
+    x.plus 1 >> p!
+    or. >> q!
+      x.times 3
+      inc x
+
+printed: |
+  [x] > foo
+    bar > @
+      x.plus 1 >> p!
+      or. >>!
+        x.times 3
+        inc x
+      p.eq 2

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-hosting-two-handles.yaml
@@ -6,7 +6,12 @@
 # them, one in its receiver and one in its argument. Both travel with
 # `both-negative` when it folds onto `φ` (#5918) — the receiver one as the
 # reversed `and.` dispatch's receiver, keeping its name, the argument one as the
-# anonymous inline const a single-use argument folds to (#5821).
+# anonymous inline const a single-use argument folds to (#5821). The receiver
+# carries a name of its own, so the two cannot share a line and the argument
+# lands on one of its own, where the bare `!` marker has no spelling: written
+# behind the arguments it marks the last one instead of the application. So it
+# takes the auto-name `>>!` instead, a name suffix the marker may ride
+# (R-3.10.4), which the parser floats back up to the same const (#5927).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -26,5 +31,6 @@ printed: |
     eq. > @
       and. >> both-negative!
         shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
-        bottom.and 80-00-00-00-00-00-00-00!
+        bottom.and >>!
+          80-00-00-00-00-00-00-00
       00-00-00-00-00-00-00-00


### PR DESCRIPTION
A single-referenced private const folds onto its use site as the anonymous `42.plus a!` argument, and only a horizontal argument slot can hold that `!`. When a sibling argument carries a name of its own the application cannot go on one line, so the const lands on a line of its own — where the marker has nowhere to sit. Behind the head it closes the expression and the arguments below become trailing garbage; behind the arguments it marks the last one instead of the whole application. The first shape silently lost an argument on the next parse, the second quietly moved the const marker. Since a name suffix *may* carry the marker, such an argument now takes the auto-name `>>!`, and the parser floats the binding back up to the enclosing formation, which is the very graph the inline argument builds.

A note on the diagnosis in the issue: the moniker fold it blames is innocent, and the minimal reproduction it gives does not reproduce anything — I dumped the XMIR of the origin against the reparsed print and the two graphs are the same, because the parser hoists a handle written inside another handle's value straight back out. The carry cluster on its own is fine too: privatising just those seven names in `i64.eo` passes all 51 `EOi64Test` cases on today's master. What actually blocks the file is `next-quot`, whose folded `quot.or (bit idx)` sits beside the `>> next-rem!` moniker and so ends up on a line of its own as `quot.or!`, dropping `bit idx` and leaving `looped` with two arguments instead of three.

The existing `const-hosting-two-handles` pack had the wrong spelling baked into its expected output — `bottom.and 80-00-00-00-00-00-00-00!`, where the marker binds to the literal rather than to the application — so it is updated here too. Checked: 271 printer tests, 462 plugin tests, and the format gate over master's 153 sources with no churn; the same gate over branch 5678's 155 sources produces output byte-identical to the pristine printer's. With all eleven `looped` helpers in `i64.eo` privatised on top of this, one `-Deo.autoFix` pass settles and all 1760 runtime tests pass, which clears the last blocker for #5678.

Closes #5927