### PR TITLE
Rank package extension above the decoratee in take()

### DIFF
--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -38,6 +38,8 @@
     5
     as-number "5"
 
+  42.5.eq "42.5".as-number ++> tests-converts-text-to-number-via-implicit-dispatch
+
   eq. ++> tests-currency-prefixed-text-returns-provided-fallback
     42
     as-number

--- a/eo-runtime/src/main/java/org/eolang/OnClasspath.java
+++ b/eo-runtime/src/main/java/org/eolang/OnClasspath.java
@@ -26,6 +26,12 @@ final class OnClasspath {
      */
     private static final Map<String, Boolean> CACHE = new ConcurrentHashMap<>(0);
 
+    /**
+     * EO name to presence, so that a name asked in EO notation pays the
+     * translation to Java notation at most once.
+     */
+    private static final Map<String, Boolean> OBJECTS = new ConcurrentHashMap<>(0);
+
     private OnClasspath() {
     }
 
@@ -36,6 +42,17 @@ final class OnClasspath {
      */
     static boolean has(final String cls) {
         return OnClasspath.CACHE.computeIfAbsent(cls, OnClasspath::probe);
+    }
+
+    /**
+     * Is there an EO object with this name on the classpath?
+     * @param fqn The fully-qualified EO name, like {@code Φ.string.as-number}
+     * @return TRUE if it exists
+     */
+    static boolean object(final String fqn) {
+        return OnClasspath.OBJECTS.computeIfAbsent(
+            fqn, name -> OnClasspath.has(new JavaPath(name).toString())
+        );
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -76,6 +76,11 @@ public class PhDefault implements Phi, Cloneable {
     private static final Set<String> SPECIAL = Set.of(Phi.LAMBDA, Phi.PHI, Phi.RHO);
 
     /**
+     * The prefix of every forma that lives in the global scope.
+     */
+    private static final String SCOPE = String.format("%s.", PhPackage.GLOBAL);
+
+    /**
      * Data.
      * @checkstyle VisibilityModifierCheck (2 lines)
      */
@@ -219,25 +224,15 @@ public class PhDefault implements Phi, Cloneable {
         this.activate();
         PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
         try {
-            final Phi object;
+            final Phi resolved;
             if (this.attrs.containsKey(name)) {
-                object = this.attrs.get(name).get();
+                resolved = this.attrs.get(name).get();
             } else if (name.equals(Phi.LAMBDA)) {
-                object = new AtomTyped(
+                resolved = new AtomTyped(
                     this, PhDefault.ATOMS.declared(this.forma())
                 ).lambda();
-            } else if (this instanceof Atom) {
-                object = this.take(Phi.LAMBDA).take(name);
-            } else if (this.attrs.containsKey(Phi.PHI)) {
-                object = this.take(Phi.PHI).take(name);
             } else {
-                object = new PhTerminator();
-            }
-            final Phi resolved;
-            if (object instanceof PhTerminator) {
-                resolved = this.extension(name, object);
-            } else {
-                resolved = object;
+                resolved = this.absent(name);
             }
             PhDefault.debug(
                 String.format(
@@ -382,50 +377,87 @@ public class PhDefault implements Phi, Cloneable {
     }
 
     /**
-     * Resolve an absent attribute as an object living in this object's own
-     * package.
+     * Resolve a name that this object doesn't declare among its own attributes.
+     *
+     * <p>The object's own package goes first, because a package object belongs
+     * to the surface of the object itself and must shadow whatever the
+     * decoratee happens to expose under the same name: {@code "42.5".as-number}
+     * has to reach {@code Φ.string.as-number} and not {@code Φ.bytes.as-number}
+     * through the bytes that a string decorates. Only when the package knows
+     * nothing does the lookup descend, into the λ of an atom or into the
+     * decoratee. A name that nobody knows terminates the computation.</p>
+     *
+     * @param name The name of the absent attribute
+     * @return The object bound to that name
+     */
+    private Phi absent(final String name) {
+        final Phi object;
+        if (this.extended(name)) {
+            object = this.extension(name);
+        } else if (this instanceof Atom) {
+            object = this.take(Phi.LAMBDA).take(name);
+        } else if (this.attrs.containsKey(Phi.PHI)) {
+            object = this.take(Phi.PHI).take(name);
+        } else {
+            object = new PhTerminator();
+        }
+        return object;
+    }
+
+    /**
+     * Does this object's own package hold an object with this name?
+     * @param name The name of the absent attribute
+     * @return TRUE if the package extends this object with such an object
+     */
+    private boolean extended(final String name) {
+        return !PhDefault.SPECIAL.contains(name)
+            && this.forma().startsWith(PhDefault.SCOPE)
+            && OnClasspath.object(this.path(name));
+    }
+
+    /**
+     * Take an object living in this object's own package.
      *
      * <p>When {@code (number 42).power} finds no {@code power} attribute, the
      * runtime looks for an object {@code Φ.number.power} in the package named
-     * after this object's forma. If it exists, it is returned with this object
-     * bound as its first argument ({@code α0}), so {@code (number 42).power 3}
-     * reads as {@code number.power 42 3}. The receiver of a package extension
-     * always lives in {@code α0}: implicit dispatch binds it here, while
-     * explicit dispatch through the namespace ({@code number.power 42 3})
-     * leaves the slot for the caller to fill (see {@code PhNest.extension}).
-     * When there's no such object, the terminated
-     * computation stays terminated. When the object exists but has no free
-     * positional attribute to receive the bound object (for example a nullary
-     * object like {@code input.dead}), a clear error is raised instead of the
-     * low-level "attribute is already set / no attributes here" message.</p>
+     * after this object's forma. It is returned with this object bound as its
+     * first argument ({@code α0}), so {@code (number 42).power 3} reads as
+     * {@code number.power 42 3}. The receiver of a package extension always
+     * lives in {@code α0}: implicit dispatch binds it here, while explicit
+     * dispatch through the namespace ({@code number.power 42 3}) leaves the
+     * slot for the caller to fill (see {@code PhNest.extension}). When the
+     * object has no free positional attribute to receive the bound object (for
+     * example a nullary object like {@code input.dead}), a clear error is
+     * raised instead of the low-level "attribute is already set / no
+     * attributes here" message.</p>
      *
      * @param name The name of the absent attribute
-     * @param bottom The terminated computation to keep when there's no such object
-     * @return The package object with this bound, or the given {@code bottom}
+     * @return The package object with this one bound to it
      */
-    private Phi extension(final String name, final Phi bottom) {
-        final String forma = this.forma();
-        Phi found = bottom;
-        if (!PhDefault.SPECIAL.contains(name)
-            && forma.startsWith(String.format("%s.", PhPackage.GLOBAL))) {
-            final String full = String.join(".", forma, name);
-            if (OnClasspath.has(new JavaPath(full).toString())) {
-                final Phi taken = Phi.Φ.take(full.substring(PhPackage.GLOBAL.length() + 1));
-                try {
-                    taken.put(0, this);
-                } catch (final ExAbstract ex) {
-                    throw new ExFailure(
-                        String.format(
-                            "Object '%s' takes no arguments, so it can't be applied to '%s' via the implicit '%s' form",
-                            full, forma, name
-                        ),
-                        ex
-                    );
-                }
-                found = taken;
-            }
+    private Phi extension(final String name) {
+        final String full = this.path(name);
+        final Phi taken = Phi.Φ.take(full.substring(PhDefault.SCOPE.length()));
+        try {
+            taken.put(0, this);
+        } catch (final ExAbstract ex) {
+            throw new ExFailure(
+                String.format(
+                    "Object '%s' takes no arguments, so it can't be applied to '%s' via the implicit '%s' form",
+                    full, this.forma(), name
+                ),
+                ex
+            );
         }
-        return found;
+        return taken;
+    }
+
+    /**
+     * The fully-qualified name of an object in this object's own package.
+     * @param name The name of the object
+     * @return The name, as {@code Φ.string.as-number}
+     */
+    private String path(final String name) {
+        return String.join(".", this.forma(), name);
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhNest.java
+++ b/eo-runtime/src/main/java/org/eolang/PhNest.java
@@ -130,7 +130,7 @@ final class PhNest implements Phi {
      * @return TRUE if it does
      */
     private boolean owns(final String name) {
-        return OnClasspath.has(new JavaPath(String.join(".", this.pkg, name)).toString());
+        return OnClasspath.object(String.join(".", this.pkg, name));
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -47,6 +47,15 @@ final class PhDefaultTest {
     }
 
     @Test
+    void prefersPackageExtensionOverDecoratee() {
+        MatcherAssert.assertThat(
+            "Package object must shadow the same-named attribute of the decoratee, but it didnt",
+            new Dataized(new Data.ToPhi("42.5").take("as-number")).asNumber(),
+            Matchers.equalTo(42.5d)
+        );
+    }
+
+    @Test
     void printsDataAsTerm() {
         MatcherAssert.assertThat(
             "Object with data must render its bytes in φ-term, but it didnt",


### PR DESCRIPTION
`PhDefault.take()` now looks into the object's own package before it
descends into `Λ` or `@`. Own attributes still win first, and a name that
neither the package nor the decoratee knows still terminates.

The old order made every data object silently inherit `bytes`' version of
any name it defines in its own package, because the extension was probed
only after the whole decoratee chain had bottomed out. That is why
`"42.5".as-number` used to die with `Can't convert non 8 length bytes to a
number` instead of reaching `string/as-number.eo`. A package object belongs
to the surface of the object itself — `extension()` binds the receiver at
α0 exactly so that `42.power 3` reads as `number.power 42 3` — so it should
shadow the decoratee the same way a direct attribute does.

Two things worth knowing. The classpath probe now sits on the hot path, so
`OnClasspath` gained a cache keyed by the EO name, which means the
EO-to-Java name translation is paid once per name instead of once per
dispatch; `PhNest` reuses it. And `string/slice.eo` and `tuple/with.eo`
still work only because `string` and `tuple` own those attributes
themselves — once anyone moves those methods into the packages, the
delegating aliases will need real bodies.

Closes #5930