### PR TITLE
fix(runtime): #5928 make malloc.of an atom and drop the allocated alias

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -414,7 +414,7 @@
       </xsl:choose>
       <xsl:if test="eo:atom(.)">
         <!--
-        A multi-segment signature (e.g. "Φ.malloc.of.allocated") stays
+        A multi-segment signature (e.g. "Φ.string.regex.pattern") stays
         rooted: on reparse a dotted @atom is not re-homed, so dropping the
         root would yield an XSD-invalid fqn. A single-name signature (e.g.
         "Φ.bytes") re-resolves to its root on reparse, so the implicit

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/atom-rooted-signature.yaml
@@ -12,9 +12,9 @@ penalties:
 origin: |
   +package org.eolang
 
-  [size] > resized /Q.malloc.of.allocated
+  [size] > resized /Q.string.regex.pattern
 
 printed: |
   +package org.eolang
 
-  [size] > resized /Q.malloc.of.allocated
+  [size] > resized /Q.string.regex.pattern

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-hybrid-under-width.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-phi-hybrid-under-width.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The only-phi "copy" formation from malloc.eo: its phi applies regular
+# The only-phi "copy" formation from chunk.eo: its phi applies regular
 # arguments and its flat one-liner
 # "write target (read source length) > [source target length] > copy" fits
 # under 80 columns, yet the compact hybrid is strictly cheaper — it drops the
@@ -25,7 +25,7 @@ origin: |
   +package org.eolang
 
   [] > examples
-    [id] > allocated
+    [id] > chunk
       [source target length] > copy
         write > @
           target
@@ -35,7 +35,7 @@ printed: |
   +package org.eolang
 
   [] > examples
-    [id] > allocated
+    [id] > chunk
       write > [source target length] > copy
         target
         read source length

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -72,9 +72,7 @@
       seq * > [m] >>
         m.write 0 bts
         scope m
-  [size scope] > of
-    [] > @ /Q.bytes
-    chunk > allocated
+  [size scope] > of /Q.bytes
 
   malloc.for ++> copies-and-resizes-to-target
     0

--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof.java
@@ -10,26 +10,35 @@
 package org.eolang;
 
 /**
- * Malloc.of.φ object.
+ * Malloc.of object.
  * @since 0.36.0
  * @checkstyle TypeNameCheck (5 lines)
  */
-@XmirObject(oname = "malloc.of.@")
+@XmirObject(oname = "malloc.of")
 @SuppressWarnings("PMD.AvoidDollarSigns")
-public final class EOmalloc$EOof$EOφ extends PhDefault implements Atom {
+public final class EOmalloc$EOof extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOmalloc$EOof() {
+        super(new Attrs(
+            new Attr("size", new AtVoid("size")),
+            new Attr("scope", new AtVoid("scope"))
+        ));
+    }
 
     @Override
     public Phi lambda() {
-        final Phi rho = this.take(Phi.RHO);
         final int identifier = Heaps.INSTANCE.malloc(
-            this, new Expect.Natural(Expect.at(rho, "size")).it()
+            this, new Expect.Natural(Expect.at(this, "size")).it()
         );
         final Phi res;
         try {
-            final Phi allocated = rho.take("allocated").copy();
-            allocated.put("id", new Data.ToPhi((long) identifier));
-            final Phi scope = rho.take("scope").copy();
-            scope.put(0, allocated);
+            final Phi chunk = Phi.Φ.take("chunk").copy();
+            chunk.put("id", new Data.ToPhi((long) identifier));
+            final Phi scope = this.take("scope").copy();
+            scope.put(0, chunk);
             res = new Data.ToPhi(new Dataized(scope).take());
         } finally {
             Heaps.INSTANCE.free(identifier);

--- a/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocAllocatedExpectTest.java
@@ -107,7 +107,7 @@ final class EOmallocAllocatedExpectTest {
 
     /**
      * Minimal Phi with a single {@code id} attribute used as a stand-in
-     * for the {@code allocated} parent in tests.
+     * for the {@code chunk} parent in tests.
      * @since 0.51
      */
     private static final class Dummy extends PhDefault {

--- a/eo-runtime/src/test/java/org/eolang/EOmallocWritePhiExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocWritePhiExpectTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case verifying {@link Expect}-based error messages
  * raised by {@link EOchunk$EOwrite} and
- * the {@code malloc.of.@} atom when their integer attributes
+ * the {@code malloc.of} atom when their integer attributes
  * are invalid.
  * @since 0.51
  */
@@ -77,16 +77,12 @@ final class EOmallocWritePhiExpectTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        new EOmalloc$EOof$EOφ(),
-                        Phi.RHO,
-                        new PhApplication(
-                            new EOmallocWritePhiExpectTest.Dummy(),
-                            "size",
-                            new Data.ToPhi(true)
-                        )
+                        new EOmalloc$EOof(),
+                        "size",
+                        new Data.ToPhi(true)
                     )
                 ).take(),
-                "malloc.of.@ with non-numeric size must fail with a proper message"
+                "malloc.of with non-numeric size must fail with a proper message"
             ).getMessage(),
             Matchers.equalTo("the 'size' attribute must be a number")
         );
@@ -100,34 +96,26 @@ final class EOmallocWritePhiExpectTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        new EOmalloc$EOof$EOφ(),
-                        Phi.RHO,
-                        new PhApplication(
-                            new EOmallocWritePhiExpectTest.Dummy(),
-                            "size",
-                            new Data.ToPhi(-1)
-                        )
+                        new EOmalloc$EOof(),
+                        "size",
+                        new Data.ToPhi(-1)
                     )
                 ).take(),
-                "malloc.of.@ with negative size must fail with a proper message"
+                "malloc.of with negative size must fail with a proper message"
             ).getMessage(),
             Matchers.equalTo("the 'size' attribute (-1) must be greater or equal to zero")
         );
     }
 
     /**
-     * Minimal Phi with {@code id} and {@code size} attributes,
-     * used as a stand-in for the {@code allocated} parent in write
-     * tests and the {@code malloc.of} parent in {@code malloc.of.@} tests.
+     * Minimal Phi with an {@code id} attribute, used as a stand-in
+     * for the {@code chunk} parent in write tests.
      * @since 0.51
      */
     private static final class Dummy extends PhDefault {
 
         Dummy() {
-            super(new Attrs(
-                new Attr("id", new AtVoid("id")),
-                new Attr("size", new AtVoid("size"))
-            ));
+            super(new Attrs(new Attr("id", new AtVoid("id"))));
         }
     }
 }


### PR DESCRIPTION
Closes #5928.

`malloc.of` used to be a formation with an atom and an `allocated` alias pointing to the root `chunk`. Since only the atom ever used it, it just added an unnecessary level of indirection and an extra object.

Now `of` is just an atom that accesses `chunk` directly from the root:

```eo
[size scope] > of /Q.bytes
```

`EOmalloc$EOof$EOφ` is renamed to `EOmalloc$EOof` and now reads `size` and `scope` from `this`, taking `chunk` directly from the root. This keeps the behavior the same while simplifying the structure.

Updated the two eo-printer fixtures that referenced the old path and adjusted the related comment in `to-eo-tree.xsl`.

Everything passes, including the full `eo-runtime` test suite, eo-printer `XmirTest` packs, and `-P qulice`.

`malloc.eo` also declares `eo2js-runtime`, so the matching `malloc$of$φ.js` change still needs to be done in the `objectionary/eo2js` repo. That's a separate repo and isn't included here.
