### PR TITLE
Extract string.slice into its own package file

### DIFF
--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -74,102 +74,6 @@
     p2 > r3
     p3 > r4
     as-bytes.size > size
-  [start len] > slice
-    if. > @
-      nstart.lt 0
-      T
-        "Start index must be >= 0, but was %d".printf
-          * nstart
-      if.
-        nlen.lt 0
-        T
-          "Length to slice must be >= 0, but was %d".printf
-            * nlen
-        seq *
-          recidx >> bstart!
-            0
-            0
-            nstart
-            "Start index (%d) is out of string bounds".printf
-              * nstart
-          blen
-          if.
-            nlen.eq 0
-            ""
-            string
-              as-bytes.slice bstart blen
-    [index accum result cause] >> recidx
-      if. > @
-        accum.eq result
-        index
-        if.
-          index.eq size
-          T cause
-          if.
-            eq.
-              byte.and p1
-              r1
-            increase
-              index
-              1
-              accum
-              result
-              cause
-            if.
-              eq.
-                byte.and p2
-                r2
-              increase
-                index
-                2
-                accum
-                result
-                cause
-              if.
-                eq.
-                  byte.and p3
-                  r3
-                increase index 3 accum result cause
-                if.
-                  eq. (byte.and p4) r4
-                  increase index 4 accum result cause
-                  T
-                    "Unknown byte format (%x), can't recognize character".printf
-                      * byte
-      as-bytes.slice index 1 > byte
-    minus. > blen
-      recidx
-        number bstart
-        0
-        nlen
-        "Start index + length to slice (%d) is out of string bounds".printf
-          *
-            nstart.plus nlen
-      bstart
-    nstart.plus nlen > end
-    if. > [index csize accum result cause] > increase
-      gt.
-        index.plus csize
-        size
-      T
-        "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
-          * csize index as-bytes
-      recidx
-        index.plus csize
-        accum.plus 1
-        result
-        cause
-    number len! > nlen
-    number start! > nstart
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    as-bytes.size > size
 
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
 
@@ -201,12 +105,6 @@
   eq. ++> tests-compares-two-strings
     "x".eq "x"
     true
-
-  eq. ++> tests-no-slice-string
-    "no slice".slice
-      0
-      0
-    ""
 
   "Ф".eq "Ф" ++> tests-one-symbol-string-compares
 
@@ -272,72 +170,6 @@
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
 
-  eq. ++> tests-slice-at-end-with-zero-length
-    "hello".slice
-      5
-      0
-    ""
-
-  eq. ++> tests-slice-empty-string
-    "".slice
-      0
-      0
-    ""
-
-  eq. ++> tests-slice-escape-sequences-line-break
-    "\n".slice
-      0
-      "\n".length
-    "\n"
-
-  eq. ++> tests-slice-escape-sequences-unicode
-    "Ф".slice
-      0
-      "Ф".length
-    "Ф"
-
-  eq. ++> tests-slice-foreign-literals
-    "hello, 大家!".slice
-      7
-      1
-    "大"
-
-  eq. ++> tests-slice-from-start
-    "hello".slice
-      0
-      1
-    "h"
-
-  eq. ++> tests-slice-from-the-end
-    "hello".slice
-      4
-      1
-    "o"
-
-  eq. ++> tests-slice-in-the-middle
-    "hello".slice
-      2
-      3
-    "llo"
-
-  eq. ++> tests-slice-with-n2-byte-characters
-    "привет".slice
-      1
-      2
-    "ри"
-
-  eq. ++> tests-slice-with-n3-byte-characters
-    "The अ is अ".slice
-      1
-      6
-    "he अ i"
-
-  eq. ++> tests-slice-with-n4-byte-characters
-    "One 😀 and 😀 another".slice
-      3
-      8
-    " 😀 and 😀"
-
   "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
 
   eq. ++> tests-supports-escape-sequences
@@ -369,21 +201,6 @@
     78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
   "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> tests-unescapes-symbols
-
-  slice. --> on-slicing-end-below-start
-    "some string"
-    2
-    -1
-
-  slice. --> on-slicing-end-greater-actual
-    "some string"
-    7
-    5
-
-  slice. --> on-slicing-start-below-zero
-    "some string"
-    -1
-    1
 
   --> on-taking-length-of-incomplete-n4-byte-character
     length. > @

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -26,7 +26,7 @@
           includes.or
             rec-contains (index.plus 1).as-number
         eq. > includes
-          slice txt index size
+          txt.slice index size
           part
       | 0
   minus. >> end!

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -14,7 +14,7 @@
         part.size >> size!
       txt.size >> length!
     eq.
-      slice
+      slice.
         text >> txt!
         minus.
           number length

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -26,8 +26,7 @@
     -1
     length.
       string
-        slice
-          txt
+        txt.slice
           0
           rec-index-of 0 >> found!
   minus. >> end!
@@ -41,10 +40,7 @@
         idx
         rec-index-of (idx.plus 1).as-number
     eq. > includes
-      slice
-        txt
-        idx
-        size
+      txt.slice idx size
       part
 
   eq. ++> tests-index-of-existed-substring-with-utf

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -26,8 +26,7 @@
     -1
     length.
       string
-        slice
-          txt
+        txt.slice
           0
           rec-index-of >> found!
             minus.
@@ -41,10 +40,7 @@
         idx
         rec-index-of (idx.plus -1).as-number
     eq. > includes
-      slice
-        txt
-        idx
-        size
+      txt.slice idx size
       part
 
   eq. ++> tests-finds-last-index-of-substring

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -1,6 +1,8 @@
-# Takes a piece of a `text` as another `text`.
-# Here `start` must be an integer index to start slicing from,
-# `len` must be an integer which shows how much symbols should be sliced.
+# Takes a piece of the `text` as another `text`, counting characters and not
+# bytes. Here `start` must be a non-negative index to start slicing from, while
+# `len` must be a non-negative amount of characters to take. Both of them walk
+# the UTF-8 sequence character by character, so a multi-byte character counts
+# as one. An index outside the bounds of the `text` terminates the computation.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,11 +10,187 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 
 [text start len] > slice
-  text.slice > @
-    start
-    len
+  if. > @
+    nstart.lt 0
+    T
+      "Start index must be >= 0, but was %d".printf
+        * nstart
+    if.
+      nlen.lt 0
+      T
+        "Length to slice must be >= 0, but was %d".printf
+          * nlen
+      seq *
+        recidx >> bstart!
+          0
+          0
+          nstart
+          "Start index (%d) is out of string bounds".printf
+            * nstart
+        blen
+        if.
+          nlen.eq 0
+          ""
+          string
+            text.as-bytes.slice bstart blen
+  text.as-bytes.size >> size!
+  [index accum result cause] >> recidx
+    if. > @
+      accum.eq result
+      index
+      if.
+        index.eq size
+        T cause
+        if.
+          eq.
+            byte.and p1
+            r1
+          increase
+            index
+            1
+            accum
+            result
+            cause
+          if.
+            eq.
+              byte.and p2
+              r2
+            increase
+              index
+              2
+              accum
+              result
+              cause
+            if.
+              eq.
+                byte.and p3
+                r3
+              increase
+                index
+                3
+                accum
+                result
+                cause
+              if.
+                eq.
+                  byte.and p4
+                  r4
+                increase index 4 accum result cause
+                T
+                  "Unknown byte format (%x), can't recognize character".printf
+                    * byte
+    text.as-bytes.slice > byte
+      index
+      1
+  minus. > blen
+    recidx
+      number bstart
+      0
+      nlen
+      "Start index + length to slice (%d) is out of string bounds".printf
+        *
+          nstart.plus nlen
+    bstart
+  if. > [index csize accum result cause] > increase
+    gt.
+      index.plus csize
+      size
+    T
+      "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
+        *
+          csize
+          index
+          text.as-bytes
+    recidx
+      index.plus csize
+      accum.plus 1
+      result
+      cause
+  number len! > nlen
+  number start! > nstart
+  80- > p1
+  E0- > p2
+  F0- > p3
+  F8- > p4
+  00- > r1
+  C0- > r2
+  p2 > r3
+  p3 > r4
+
+  eq. ++> tests-no-slice-string
+    "no slice".slice
+      0
+      0
+    ""
+
+  eq. ++> tests-slice-at-end-with-zero-length
+    "hello".slice
+      5
+      0
+    ""
+
+  eq. ++> tests-slice-empty-string
+    "".slice
+      0
+      0
+    ""
+
+  eq. ++> tests-slice-escape-sequences-line-break
+    "\n".slice
+      0
+      "\n".length
+    "\n"
+
+  eq. ++> tests-slice-escape-sequences-unicode
+    "Ф".slice
+      0
+      "Ф".length
+    "Ф"
+
+  eq. ++> tests-slice-foreign-literals
+    "hello, 大家!".slice
+      7
+      1
+    "大"
+
+  eq. ++> tests-slice-from-start
+    "hello".slice
+      0
+      1
+    "h"
+
+  eq. ++> tests-slice-from-the-end
+    "hello".slice
+      4
+      1
+    "o"
+
+  eq. ++> tests-slice-in-the-middle
+    "hello".slice
+      2
+      3
+    "llo"
+
+  eq. ++> tests-slice-with-n2-byte-characters
+    "привет".slice
+      1
+      2
+    "ри"
+
+  eq. ++> tests-slice-with-n3-byte-characters
+    "The अ is अ".slice
+      1
+      6
+    "he अ i"
+
+  eq. ++> tests-slice-with-n4-byte-characters
+    "One 😀 and 😀 another".slice
+      3
+      8
+    " 😀 and 😀"
 
   eq. ++> tests-text-slices-the-origin-string
     slice
@@ -20,3 +198,18 @@
       7
       5
     "world"
+
+  slice --> on-slicing-end-below-start
+    "some string"
+    2
+    -1
+
+  slice --> on-slicing-end-greater-actual
+    "some string"
+    7
+    5
+
+  slice --> on-slicing-start-below-zero
+    "some string"
+    -1
+    1

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -31,7 +31,7 @@
               current.plus 1
           if.
             delim.eq
-              slice bts current size
+              bts.slice current size
             rec-split
               appended
               as-number.
@@ -45,8 +45,7 @@
                 current.plus 1
       accum.with > appended
         string
-          slice
-            bts
+          bts.slice
             start
             current.minus start
     |

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -14,7 +14,7 @@
         part.size >> size!
       txt.size >> length!
     eq.
-      slice
+      slice.
         text >> txt!
         0
         size


### PR DESCRIPTION
This moves `slice` out of the core `string` object and into `eo-runtime/src/main/eo/string/slice.eo`, the same way `u64.div` and `i64.div` were moved. The receiver now arrives as the first argument `text`, so the body reaches `as-bytes` through it, and package dispatch keeps every `.slice` call site working untouched. The twelve slicing tests and the three error tests move along with the code, and the wrapper that used to sit in that file — it just delegated back to `string.slice` — is gone.

Two things only showed up once the wrapper was out of the way. First, a package object *is* the value it hands back, so `slice`'s public `size` helper stayed reachable on the result and answered with the length of the source text; that broke `string.length`, so `size` is private now. Second, `contains`, `ends-with`, `starts-with`, `index-of`, `last-index-of` and `split` were slicing bytes all along without saying so: a `!` const handle dataizes to bytes, and the old wrapper quietly re-dispatched onto `bytes.slice`. A real char-based body flipped them to characters and broke UTF-8 (`index-of "привет, друг!" "в"` started blowing up), so those six now spell it out as `txt.slice`.

`nsplit` has the same byte/character muddle but no const handle to save it, so it is genuinely broken for multi-byte text today; that is filed separately as #5933 and left alone here. The `p1`..`r4` constants in the moved code trip `redundant-object`, so the file carries the same `+unlint` that `string.eo` already had for them — `string.eo`'s twin `length` object still needs it. Full reactor is green: 1513 + 274 + 463 + 1767 tests, no failures.

Part of #5678.