### PR TITLE
Extract string.length into its own package file

### DIFF
--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -17,69 +17,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 +unlint mandatory-package
 
 [as-bytes] > string
   as-bytes > @
-  [] > length
-    if. > @
-      size.eq 0
-      0
-      reclen 0 0
-    [index accum] >> reclen
-      if. > @
-        index.eq size
-        accum
-        if.
-          eq.
-            byte.and p1
-            r1
-          inclen index 1 accum
-          if.
-            eq.
-              byte.and p2
-              r2
-            inclen index 2 accum
-            if.
-              eq.
-                byte.and p3
-                r3
-              inclen index 3 accum
-              if.
-                eq.
-                  byte.and p4
-                  r4
-                inclen index 4 accum
-                T
-                  "Unknown byte format (%x), can't recognize character".printf
-                    * byte
-      as-bytes.slice index 1 > byte
-    if. > [index csize len] > inclen
-      gt.
-        index.plus csize
-        size
-      T
-        "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
-          * csize index as-bytes
-      reclen
-        index.plus csize
-        len.plus 1
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    as-bytes.size > size
 
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
-
-  eq. ++> tests-calculates-length-of-spaces-only
-    " ".length
-    1
 
   ++> tests-compares-string-with-nan
     not. > @
@@ -152,24 +95,6 @@
     "a\n b\n  c"
     "a\n b\n  c"
 
-  ++> tests-reads-the-length-with-n2-byte-characters
-    and. > @
-      str.length.eq 12
-      str.as-bytes.size.eq 16
-    "Hello, друг!" > str
-
-  ++> tests-reads-the-length-with-n3-byte-characters
-    and. > @
-      str.length.eq 16
-      str.as-bytes.size.eq 18
-    "The अ devanagari" > str
-
-  ++> tests-reads-the-length-with-n4-byte-characters
-    and. > @
-      str.length.eq 11
-      str.as-bytes.size.eq 14
-    "The 😀 smile" > str
-
   "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
 
   eq. ++> tests-supports-escape-sequences
@@ -201,7 +126,3 @@
     78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
   "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> tests-unescapes-symbols
-
-  --> on-taking-length-of-incomplete-n4-byte-character
-    length. > @
-      string F0-9F-98

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -1,0 +1,106 @@
+# Counts the characters in the `text`, and not its bytes. The UTF-8 sequence
+# is walked character by character, so a multi-byte character counts as one.
+# A sequence that does not end with a complete character terminates
+# the computation.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
+
+[text] > length
+  if. > @
+    eq.
+      text.as-bytes.size >> size!
+      0
+    0
+    reclen
+      0
+      0
+  [index accum] >> reclen
+    if. > @
+      index.eq size
+      accum
+      if.
+        eq.
+          byte.and p1
+          r1
+        inclen
+          index
+          1
+          accum
+        if.
+          eq.
+            byte.and p2
+            r2
+          inclen index 2 accum
+          if.
+            eq.
+              byte.and p3
+              r3
+            inclen index 3 accum
+            if.
+              eq.
+                byte.and p4
+                r4
+              inclen index 4 accum
+              T
+                "Unknown byte format (%x), can't recognize character".printf
+                  * byte
+    text.as-bytes.slice > byte
+      index
+      1
+  if. > [index csize len] > inclen
+    gt.
+      index.plus csize
+      size
+    T
+      "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
+        *
+          csize
+          index
+          text.as-bytes
+    reclen
+      index.plus csize
+      len.plus 1
+  80- > p1
+  E0- > p2
+  F0- > p3
+  F8- > p4
+  00- > r1
+  C0- > r2
+  p2 > r3
+  p3 > r4
+
+  eq. ++> tests-calculates-length-of-spaces-only
+    " ".length
+    1
+
+  eq. ++> tests-counts-characters-of-the-origin-text
+    length
+      "Hello, world!"
+    13
+
+  ++> tests-reads-the-length-with-n2-byte-characters
+    and. > @
+      str.length.eq 12
+      str.as-bytes.size.eq 16
+    "Hello, друг!" > str
+
+  ++> tests-reads-the-length-with-n3-byte-characters
+    and. > @
+      str.length.eq 16
+      str.as-bytes.size.eq 18
+    "The अ devanagari" > str
+
+  ++> tests-reads-the-length-with-n4-byte-characters
+    and. > @
+      str.length.eq 11
+      str.as-bytes.size.eq 14
+    "The 😀 smile" > str
+
+  length --> on-taking-length-of-incomplete-n4-byte-character
+    string F0-9F-98


### PR DESCRIPTION
Moves the character counter out of the core `string` object into
`string/length.eo`, following the same shape as the `slice` extraction.
The text becomes the first argument, and every existing `text.length`
call site keeps working through package dispatch on the forma. The five
tests move along with the code.

One thing worth a look: `size` is now a private `>>` handle instead of a
public attribute. A package object is the value it returns, so a public
`size` helper would be found before the `bytes.size` of the number that
`length` answers — the same leak that broke `string.length` when `slice`
moved out. Dropping `length` also left `+unlint redundant-object`
unused in `string.eo`, since the byte-mask constants it covered went
with it.

I walked every `.length` call site before touching anything. The ones on
tuples are a different object, and the string ones all have plain string
receivers, so unlike `slice` there were no const-handle sites needing a
fix. Full reactor is green: 1768 runtime tests, no failures, and a
second `eo:format` pass leaves the sources unchanged.

Part of #5678.