### PR TITLE
Extract number.eq into its own package file

### DIFF
--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -56,31 +56,9 @@
             negative.and
               mantissa.eq 00-10-00-00-00-00-00-00
   [x] > div /Q.number
-  [x] > eq
-    if. > @
-      ^.is-nan.or
-        is-nan.
-          number
-            x >> xbts!
-      false
-      or.
-        and.
-          or.
-            xbts.eq pzero
-            xbts.eq nzero
-          or.
-            eq.
-              as-bytes >> b!
-              pzero
-            b.eq nzero
-        b.eq xbts
-    -0.as-bytes > nzero
-    0.as-bytes > pzero
   [x] > gt /Q.bool
   [x] > plus /Q.number
   [x] > times /Q.number
-
-  42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
 
   42.as-bytes.eq 42 ++> tests-as-bytes-equals-to-int-backwards
 
@@ -142,10 +120,6 @@
         1
         n
 
-  eq. ++> tests-compares-two-different-number-types
-    68.eq "12345678"
-    false
-
   eq. ++> tests-div-for-dividend-greater-than-zero
     256.div 16
     16
@@ -165,79 +139,6 @@
       dividend
     -235 > dividend
 
-  eq. ++> tests-float-equal-to-nan-and-infinites-is-false-highload
-    and.
-      and.
-        and.
-          and.
-            and.
-              and.
-                and.
-                  and.
-                    and.
-                      and.
-                        and.
-                          eq. (0.eq nan) false
-                          eq. (0.eq pinf) false
-                        eq. (0.eq ninf) false
-                      eq. (42.5.eq nan) false
-                    eq. (42.5.eq pinf) false
-                  eq. (42.5.eq ninf) false
-                eq.
-                  0.eq nan
-                  false
-              eq.
-                0.eq pinf
-                false
-            eq.
-              0.eq ninf
-              false
-          eq.
-            42.5.eq nan
-            false
-        eq.
-          42.5.eq pinf
-          false
-      eq.
-        42.5.eq ninf
-        false
-    true
-
-  eq. ++> tests-int-eq-false
-    not.
-      123.eq 42
-    true
-
-  eq. ++> tests-int-eq-true
-    123.eq 123
-    true
-
-  eq. ++> tests-int-equal-to-nan-and-infinites-is-false
-    and.
-      and.
-        and.
-          and.
-            and.
-              eq.
-                0.eq nan
-                false
-              eq.
-                0.eq pinf
-                false
-            eq.
-              0.eq ninf
-              false
-          eq.
-            42.eq nan
-            false
-        eq.
-          42.eq pinf
-          false
-      eq.
-        42.eq ninf
-        false
-    true
-
   eq. ++> tests-int-greater-equal
     not.
       0.gt 0
@@ -252,14 +153,6 @@
     -200.gt -1000
     true
 
-  eq. ++> tests-int-zero-eq-to-float-zero
-    0.eq 0
-    true
-
-  eq. ++> tests-int-zero-eq-to-zero
-    0.eq 0
-    true
-
   eq. ++> tests-multiply-by-zero
     1000.times 0
     0
@@ -267,14 +160,6 @@
   nan.as-bytes.eq ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
     as-bytes.
       0.div 0
-
-  ++> tests-nan-not-eq-nan
-    not. > @
-      nan.eq nan
-
-  ++> tests-nan-not-eq-number
-    not. > @
-      nan.eq 42
 
   eq. ++> tests-nan-not-gt-nan
     nan.gt nan
@@ -335,30 +220,12 @@
     ninf.div 42
     ninf
 
-  ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
-
   ++> tests-negative-infinity-gt-negative-infinity
     not. > @
       ninf.gt ninf
 
   ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
     -1.div 0
-
-  ++> tests-negative-infinity-not-eq-float
-    not. > @
-      ninf.eq 42.5
-
-  ++> tests-negative-infinity-not-eq-int
-    not. > @
-      ninf.eq 42
-
-  ++> tests-negative-infinity-not-eq-nan
-    not. > @
-      ninf.eq nan
-
-  ++> tests-negative-infinity-not-eq-positive-infinity
-    not. > @
-      ninf.eq pinf
 
   eq. ++> tests-negative-infinity-not-gt-float
     ninf.gt 42.5
@@ -530,8 +397,6 @@
     pinf.div 42
     pinf
 
-  pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
-
   pinf.gt 42.5 ++> tests-positive-infinity-gt-float
 
   pinf.gt 42 ++> tests-positive-infinity-gt-int
@@ -544,22 +409,6 @@
 
   pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
     1.div 0
-
-  ++> tests-positive-infinity-not-eq-float
-    not. > @
-      pinf.eq 42.5
-
-  ++> tests-positive-infinity-not-eq-int
-    not. > @
-      pinf.eq 42
-
-  ++> tests-positive-infinity-not-eq-nan
-    not. > @
-      pinf.eq nan
-
-  ++> tests-positive-infinity-not-eq-negative-infinity
-    not. > @
-      pinf.eq ninf
 
   ++> tests-positive-infinity-not-gt-nan
     not. > @

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -1,0 +1,169 @@
+# TRUE when the number `n` equals `x`, FALSE otherwise. The comparison follows
+# IEEE 754: a not-a-number value is equal to nothing, not even to itself, while
+# positive and negative zero are equal to each other. Everything else is
+# compared byte by byte, so a value of any other type is simply not equal.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > eq
+  if. > @
+    n.is-nan.or
+      is-nan.
+        number
+          x >> xbts!
+    false
+    or.
+      and.
+        or.
+          xbts.eq pzero
+          xbts.eq nzero
+        or.
+          eq.
+            n.as-bytes >> b!
+            pzero
+          b.eq nzero
+      b.eq xbts
+  -0.as-bytes > nzero
+  0.as-bytes > pzero
+
+  42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
+
+  eq. ++> tests-compares-two-different-number-types
+    68.eq "12345678"
+    false
+
+  eq. ++> tests-compares-two-numbers-via-package
+    eq
+      42
+      42
+    true
+
+  eq. ++> tests-float-equal-to-nan-and-infinites-is-false-highload
+    and.
+      and.
+        and.
+          and.
+            and.
+              and.
+                and.
+                  and.
+                    and.
+                      and.
+                        and.
+                          eq. (0.eq nan) false
+                          eq. (0.eq pinf) false
+                        eq. (0.eq ninf) false
+                      eq. (42.5.eq nan) false
+                    eq. (42.5.eq pinf) false
+                  eq. (42.5.eq ninf) false
+                eq.
+                  0.eq nan
+                  false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.5.eq nan
+            false
+        eq.
+          42.5.eq pinf
+          false
+      eq.
+        42.5.eq ninf
+        false
+    true
+
+  eq. ++> tests-int-eq-false
+    not.
+      123.eq 42
+    true
+
+  eq. ++> tests-int-eq-true
+    123.eq 123
+    true
+
+  eq. ++> tests-int-equal-to-nan-and-infinites-is-false
+    and.
+      and.
+        and.
+          and.
+            and.
+              eq.
+                0.eq nan
+                false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.eq nan
+            false
+        eq.
+          42.eq pinf
+          false
+      eq.
+        42.eq ninf
+        false
+    true
+
+  eq. ++> tests-int-zero-eq-to-float-zero
+    0.eq 0
+    true
+
+  eq. ++> tests-int-zero-eq-to-zero
+    0.eq 0
+    true
+
+  ++> tests-nan-not-eq-nan
+    not. > @
+      nan.eq nan
+
+  ++> tests-nan-not-eq-number
+    not. > @
+      nan.eq 42
+
+  ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
+
+  ++> tests-negative-infinity-not-eq-float
+    not. > @
+      ninf.eq 42.5
+
+  ++> tests-negative-infinity-not-eq-int
+    not. > @
+      ninf.eq 42
+
+  ++> tests-negative-infinity-not-eq-nan
+    not. > @
+      ninf.eq nan
+
+  ++> tests-negative-infinity-not-eq-positive-infinity
+    not. > @
+      ninf.eq pinf
+
+  pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
+
+  ++> tests-positive-infinity-not-eq-float
+    not. > @
+      pinf.eq 42.5
+
+  ++> tests-positive-infinity-not-eq-int
+    not. > @
+      pinf.eq 42
+
+  ++> tests-positive-infinity-not-eq-nan
+    not. > @
+      pinf.eq nan
+
+  ++> tests-positive-infinity-not-eq-negative-infinity
+    not. > @
+      pinf.eq ninf


### PR DESCRIPTION
Moves the IEEE equality check out of the core `number` object into
`number/eq.eo`, the same shape as the `slice`, `length` and `as-i64`
extractions. The number becomes the first argument and every `x.eq y`
call site keeps working through package dispatch.

The judgement call here is which tests travel with the code. `eq` is
the assertion operator for most of `number.eo`, so I only moved the
twenty whose actual subject is equality — the nan and signed-zero
rules, and the infinity comparisons. Everything testing `div`, `plus`
or `times` stays put even though it asserts with `eq`, and so do the
ones comparing bytes rather than numbers.

Nothing needed privatizing: `nzero` and `pzero` leak onto the result
the way `size` did for `slice`, but they don't collide with anything on
the `bool` this returns. This one also went in without the internal
reference problem `as-i64` had, since no code inside `number.eo` names
`eq` bare. I merged master in first, so the three extractions are
verified together — full reactor green at 1513, 274, 463 and 1770
tests, and `eo:format` leaves the sources unchanged.

Part of #5678.