### PR TITLE
Extract socket i/o adapters into their own package files

### DIFF
--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -91,29 +91,6 @@
                 *
         posix > raw
         0 > startup
-  [recv] > as-input
-    [size] > read
-      @. > @
-        read.
-          input-block --
-          size
-      [buffer] > input-block
-        buffer > @
-        [size] > read
-          seq * > @
-            chunk
-            input-block chunk
-          as-bytes. > chunk
-            recv size
-  [send] > as-output
-    [buffer] > write
-      @. > @
-        output-block.write buffer
-      [] > output-block
-        true > @
-        seq * > [buffer] > write
-          send buffer
-          output-block
   [sys] >> impl
     code. > addr
       sys.raw *1
@@ -219,8 +196,8 @@
           sys.cleanup
           result
     [descriptor] > scoped-socket
-      ^.^.as-input recv > as-input
-      ^.^.as-output send > as-output
+      socket.as-input recv > as-input
+      socket.as-output send > as-output
       [size cant-receive] > recv
         if. > @
           received.code.eq -1

--- a/eo-runtime/src/main/eo/socket/as-input.eo
+++ b/eo-runtime/src/main/eo/socket/as-input.eo
@@ -1,0 +1,33 @@
+# Turns the `recv` function of a socket into an `input`, so that bytes arriving
+# on the socket can be pulled through the `input` protocol. Here `recv` must be
+# an object that takes the amount of bytes to fetch and answers with them.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package socket
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[recv] > as-input
+  [size] > read
+    @. > @
+      read.
+        input-block --
+        size
+    [buffer] > input-block
+      buffer > @
+      [size] > read
+        seq * > @
+          chunk
+          input-block chunk
+        as-bytes. > chunk
+          recv size
+
+  ++> tests-reads-the-bytes-that-recv-answers
+    eq. > @
+      read.
+        as-input recv
+        3
+      01-02-03
+    01-02-03-04-05.slice 0 size > [size] > recv

--- a/eo-runtime/src/main/eo/socket/as-output.eo
+++ b/eo-runtime/src/main/eo/socket/as-output.eo
@@ -1,0 +1,32 @@
+# Turns the `send` function of a socket into an `output`, so that bytes can be
+# pushed to the socket through the `output` protocol. Here `send` must be an
+# object that takes the buffer to push out and answers with the amount of bytes
+# that left.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package socket
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[send] > as-output
+  [buffer] > write
+    @. > @
+      output-block.write buffer
+    [] > output-block
+      true > @
+      seq * > [buffer] > write
+        send buffer
+        output-block
+
+  ++> tests-hands-the-buffer-over-to-send
+    malloc.of > @
+      3
+      [m]
+        seq * > @
+          write.
+            as-output snd
+            01-02-03
+          m.get.eq 01-02-03
+        m.put buffer > [buffer] > snd


### PR DESCRIPTION
Moves `as-input` and `as-output` out of the core `socket` object into
`socket/as-input.eo` and `socket/as-output.eo`. They travel together
because they are the same idea pointing in two directions and are used
side by side in `scoped-socket`. This also creates the `socket`
package, which did not exist before.

These two break the pattern of the earlier extractions in one way:
neither gains a receiver argument. `as-input` only ever used the `recv`
handed to it and `as-output` only the `send`, never the socket itself,
so adding a socket parameter would mean carrying something unused.
Their two call sites in `scoped-socket` now name the package objects
instead of climbing `^.^`.

The nice side effect is that once they stand apart from `socket` they
need no network to exercise, so each one gets a unit test that feeds it
a stub — `recv` answering canned bytes, `send` writing into a malloc
block so the test can check the buffer arrived intact. That is two more
tests than `socket` had before, and the rest of it keeps its
`unit-test-missing` unlint. Full reactor green at 1513, 274, 463 and
1771 tests.

Part of #5678.