### PR TITLE
Keep the name of a shared based >> handle when printing

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -223,13 +223,31 @@
     <xsl:sequence select="string-join((if (eo:shadowed($ref, $binding)) then subsequence($segs, 1, $at - 1) else $eo:xi, string($binding/@local), subsequence($segs, $at + 1)), '.')"/>
   </xsl:function>
   <!--
-  The kept multi-referenced abstract handle binding (`[] &gt;&gt; name`, #5876)
-  a reference `$ref` resolves to but does NOT host (the binding folds onto its
-  first reference only, `eo:moniker-refs`). Any other reference — a named alias
+  Whether the readable "@local" handle of `$attr` still stands after the merge,
+  so a reference that does not host it may read back through it. An abstract
+  formation carries its "@name" and "@local" to wherever it lands, and a binding
+  no reference hosts stays where it is; a based handle (`a.b &gt;&gt; name`)
+  keeps them only when its host is a method dispatch, which rebuilds the binding
+  whole as the receiver of a reversed dispatch. A bare host inlines it
+  anonymously instead (#5810), leaving no name for anyone else to read.
+  -->
+  <xsl:function name="eo:handle-survives" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:variable name="host" select="eo:moniker-refs($attr)[1]"/>
+    <xsl:sequence select="eo:abstract($attr) or empty($host) or eo:dispatch-seg($host) != ''"/>
+  </xsl:function>
+  <!--
+  The kept multi-referenced handle binding a reference `$ref` resolves to but does
+  NOT host (the binding folds onto its first reference only,
+  `eo:moniker-refs`). Any other reference — a named alias
   `name &gt; a` or a further `name.seg` dispatch that the moniker fold leaves
   in place — keeps the readable "@local" handle in place of the obfuscated
   cactus name, so it reads back as `name` (or `name.seg`) rather than a
-  synthetic "vL_P" placeholder, the abstract mirror of `eo:kept-const-ref`. The
+  synthetic "vL_P" placeholder, the non-const mirror of `eo:kept-const-ref`
+  (which covers the const handles this one leaves out). Both shapes of handle
+  reach here: an abstract formation kept whole because it is shared (#5876),
+  and a based handle (`a.b &gt;&gt; name`) kept because a method dispatch
+  reference reaches it, which "inline-cactoos" never inlines (#5944). The
   reference is matched by carrying the binding's cactus "@name" as one of its
   base segments; the binding's own subtree is excluded. As with the const
   handle, the reference need not live in the binding's own scope: two mutually
@@ -240,7 +258,7 @@
   -->
   <xsl:function name="eo:kept-local-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and eo:abstract(.) and exists(@local) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
+    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and not(eo:const-handle(.)) and exists(@local) and eo:handle-survives(.) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
@@ -370,10 +388,11 @@
     <xsl:attribute name="base" select="eo:handle-base(.., eo:kept-const-ref(..))"/>
   </xsl:template>
   <!--
-  Rewrite a non-hosting reference to a kept multi-referenced abstract handle
-  (`[] &gt;&gt; name`, #5876) from the obfuscated cactus name back to the
+  Rewrite a non-hosting reference to a kept handle — an abstract formation
+  (`[] &gt;&gt; name`, #5876) or a based one (`a.b &gt;&gt; name`, #5944) — from
+  the obfuscated cactus name back to the
   readable "@local" handle, so it reads as `name` (or `name.seg`) instead of a
-  synthetic "vL_P" placeholder, the abstract mirror of the const rewrite above.
+  synthetic "vL_P" placeholder, the non-const mirror of the const rewrite above.
   The single hosting reference is rebuilt from the binding and never reaches
   this template (`eo:kept-local-ref` excludes it).
   -->

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -82,7 +82,14 @@
   ("[] &gt;&gt; name", #5876) is never inlined by "inline-cactoos" (folding
   the whole formation into every use drops its shared handle name), so like a
   multi-referenced const handle its "@local" marker is kept here (below) and
-  "merge-monikers" folds the surviving binding onto its first reference.
+  "merge-monikers" folds the surviving binding onto its first reference. A
+  based handle ("a.b &gt;&gt; name", R-3.10.12) reached from more than one
+  site is kept for the same reason (#5944): a reference spelled as a method
+  dispatch ("name.seg") is not inlined at all, so the binding outlives
+  "inline-cactoos" and only the hosting reference is folded into it — the
+  others read the handle by name and would otherwise print a synthetic "vL_P".
+  A handle every reference of which is bare is inlined away regardless, its
+  "@local" going with it, so keeping the marker here costs nothing.
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
@@ -169,16 +176,17 @@
   <!--
   Keep the marker on voids, on recursive formations, on a formation applied as
   a dispatch receiver (#5844) — so its relocated pipe predecessor prints its
-  readable "&gt;&gt; name" handle — on a multi-referenced abstract formation
-  (#5876) — kept whole by "inline-cactoos" and hosted by "merge-monikers" — on
-  an unreferenced binding of any shape (#5914) — kept where it stands by
+  readable "&gt;&gt; name" handle — on a multi-referenced binding of any shape
+  (an abstract formation, #5876, or a based handle, #5944) — kept whole by
+  "inline-cactoos" and hosted by "merge-monikers" — on an
+  unreferenced binding of any shape (#5914) — kept where it stands by
   "inline-cactoos", having no use site to fold into — and on the value of a
   multi-referenced dataized-const handle (see
   "eo:const-handle") so "to-eo-tree" restores the readable "&gt;&gt; name"
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:abstract(.) and eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-based-handle-local-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-based-handle-local-name.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle ("a.as-i32 >> b", R-3.10.12) — its value a plain
+# application, neither an abstract formation nor a const — reached from more
+# than one site keeps its "@local" marker (#5944), just as a shared formation
+# (#5876) and a shared const (#5828) do. A reference spelled as a method
+# dispatch is never inlined by "inline-cactoos", so the binding outlives that
+# sheet and "merge-monikers" folds only one reference into it; without the
+# marker the remaining references print as a synthetic "vL_P" that binds to
+# nothing. As with the const handle, the cactus "@name" is NOT promoted and the
+# references are NOT rewritten here — that is "merge-monikers"' job, once it
+# knows which reference hosts the binding.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The shared based handle keeps its "@local" marker, and its cactus "@name"
+  # is left obfuscated (not promoted to the handle).
+  - /object/o[@name='foo']/o[@local='b' and contains(@name, '🌵') and @base='ξ.a.as-i32']
+  # Both dispatch references stay cactus-based: rewriting them is left to
+  # "merge-monikers", which knows which one hosts the binding.
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.plus') and @name='x' and o]
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.neg') and @name='y']
+  # No reference was rewritten to a readable "b" base.
+  - /object[not(.//o[contains(@base, 'ξ.b.')])]
+input: |
+  [a] > foo
+    b.plus 1 > x
+    b.neg > y
+    a.as-i32 >> b

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-multi-referenced-handle-kept.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-multi-referenced-handle-kept.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The companion to `based-multi-referenced-handle` (#5944) where no reference can
+# host the kept handle as a moniker: both uses reach it through a multi-segment
+# chain, which the moniker fold leaves expanded. The shared `a.b >> name` handle
+# then stays standing where it is and every reference reads back through its
+# readable handle, never as a synthetic "vL_P" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b.as-i32.neg > x
+    b.as-i32.plus 1 > y
+    a.as-u16 >> b
+
+printed: |
+  [a] > foo
+    a.as-u16 >> b
+    b.as-i32.neg > x
+    b.as-i32.plus 1 > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-multi-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-multi-referenced-handle.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) — its value a plain application, neither
+# an abstract formation nor a const — reached from more than one method dispatch.
+# Such a dispatch is never inlined by "inline-cactoos", so the binding outlives
+# it and "merge-monikers" hosts it onto the first dispatch as a reversed one.
+# The handle must keep its readable name there and every other reference must
+# read back through it: hosting the binding while dropping the name strands the
+# remaining references on a synthetic "vL_P" id that binds to nothing (#5944),
+# the based flavour of what #5876 fixed for formations and #5883 for consts.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b.plus 1 > x
+    b.neg > y
+    a.as-i32 >> b
+
+printed: |
+  [a] > foo
+    plus. > x
+      a.as-i32 >> b
+      1
+    b.neg > y


### PR DESCRIPTION
A based `>> name` file-local handle — one whose value is a plain application, so
neither an abstract formation nor a const — now keeps its readable name when more
than one reference reaches it. `restore-local-names` no longer drops the `@local`
marker of a shared binding just because it is not a formation, and
`merge-monikers` rewrites the references it does not host back to that handle, the
way it already does for shared formations and shared consts.

Without this, `x.as-u16 >> other` used from both `other.eq zero` and
`other.as-i32` printed as an anonymous `x.as-u16 >>` folded into the first use,
with the second one left reading `v25_4` — a name declared nowhere, so the
reformatted source reparsed into a dangling `Φ.v25_4`. The mangled form was also a
fixpoint, so running the formatter again would not have surfaced it. Closes #5944.

Three packs come with it: a round-trip pair for the hosted and the un-hostable
shape, and a sheet-level one pinning the `@local` marker that survives
`restore-local-names`. One neighbouring case is deliberately untouched and filed
separately as #5947: a single bare reference to a based handle still loses its own
`> name` binding when the handle is folded in.
