### PR TITLE
#5919: relativize path before glob matching in directory.walk

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -120,6 +120,25 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> tests-walks-with-plain-glob-matches-direct-child-only
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/b.txt"
+      eq.
+        length.
+          d.as-dir.walk "*.txt"
+        1
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   mktemp.open --> on-opening-directory
     "w"
     true > [d]

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -48,13 +48,11 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
             return new Data.ToPhi(
                 paths
                     .filter(p -> matcher.matches(path.relativize(p)))
-                    .map(
-                        p -> {
-                            final Phi file = Phi.Φ.take("file").copy();
-                            file.put(0, new ToPhi(p.toString()));
-                            return file;
-                        }
-                    )
+                    .map(p -> {
+                        final Phi file = Phi.Φ.take("file").copy();
+                        file.put(0, new ToPhi(p.toString()));
+                        return file;
+                    })
                     .toArray(Phi[]::new)
             );
         } catch (final IOException ex) {

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -47,12 +47,13 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
         try (Stream<Path> paths = Files.walk(path)) {
             return new Data.ToPhi(
                 paths
-                    .filter(p -> matcher.matches(path.relativize(p)))
-                    .map(p -> {
-                        final Phi file = Phi.Φ.take("file").copy();
-                        file.put(0, new ToPhi(p.toString()));
-                        return file;
-                    })
+                    .filter(p -> matcher.matches(path.relativize(p))).map(
+                        p -> {
+                            final Phi file = Phi.Φ.take("file").copy();
+                            file.put(0, new ToPhi(p.toString()));
+                            return file;
+                        }
+                    )
                     .toArray(Phi[]::new)
             );
         } catch (final IOException ex) {

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -47,12 +47,11 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
         try (Stream<Path> paths = Files.walk(path)) {
             return new Data.ToPhi(
                 paths
-                    .map(p -> p.toAbsolutePath().toString())
-                    .map(p -> p.substring(p.indexOf(path.toString())))
-                    .filter(p -> matcher.matches(Paths.get(p))).map(
+                    .filter(p -> matcher.matches(path.relativize(p)))
+                    .map(
                         p -> {
                             final Phi file = Phi.Φ.take("file").copy();
-                            file.put(0, new ToPhi(p));
+                            file.put(0, new ToPhi(p.toString()));
                             return file;
                         }
                     )


### PR DESCRIPTION
Closes #5919.

`directory.walk` tried to strip the walk root off each visited path before matching it against the glob, but the code that did it was a no-op: `path` is already absolute, so `p.toAbsolutePath().toString()` stays the same string, and `p.substring(p.indexOf(path.toString()))` cuts from index 0, returning `p` unchanged. The glob ended up matched against the full absolute path instead of a path relative to the walk root.

Because of this, `PathMatcher`'s `*` (which does not cross `/`) never matched a plain glob like `*.txt` against an absolute, multi-segment path. Only globs already starting with `**` (which absorbs the whole absolute prefix) matched anything, and every existing call site already works around this by always prefixing with `**`, so the gap went untested.

Fix: match the glob against `path.relativize(p)` instead. The returned `file` object still gets the real absolute path (`p.toString()`), so callers see no change there.

Added `tests-walks-with-plain-glob-matches-direct-child-only`, which creates one direct `.txt` file and one nested one, then checks a plain `*.txt` glob returns only the direct child. This fails against the old code (returns 0 matches) and passes with this fix.
