### PR TITLE
Keep the name of a reference that folds a based handle

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -142,20 +142,21 @@
                 <xsl:apply-templates select="@as"/>
               </xsl:if>
               <!--
-              The reference stands as the `φ` decoratee of an auto-named
-              formation, written ahead of the brackets (`false &gt; [] &gt;&gt;`,
-              #5882). Folding a non-abstract handle in (`false &gt;&gt; flag`)
-              copies only the target's attributes, so the reference's own `@name`
-              would be lost and `to-eo-tree` would print the datum as a nameless
-              body line of the formation (`[] &gt;&gt;` with `false` below it),
-              which the parser rejects with "object inside formation must have a
-              name". Carrying the `φ` name over keeps the folded datum the
-              decoratee, so `to-eo-tree` prints it ahead of the head. Only for a
-              non-abstract target: an abstract one keeps its own `@name` (the
-              `[...] &gt;&gt;` marker) and never reaches this branch as a φ
-              decoratee.
+              The reference carries a binding name of its own and the target
+              contributes none — a based `a &gt;&gt; b` handle is neither an
+              abstract formation nor a dataized const, so `$keep-name` is false
+              and its own name is dropped (#5810). Folding then copies only the
+              target's attributes, and the reference's `@name` would go with the
+              fold: `to-eo-tree` prints the value as a nameless body line, which
+              the parser rejects with "object inside formation must have a name".
+              A `φ` decoratee written ahead of the brackets
+              (`false &gt; [] &gt;&gt;`, #5882) loses its head that way and an
+              ordinary binding (`b &gt; x`, #5947) loses its whole name, so the
+              reference's name is carried over in both cases. Never for a target
+              that keeps a name of its own: an abstract formation prints its
+              `[...] &gt;&gt;` marker instead, and the two would collide.
               -->
-              <xsl:if test="@name = $eo:phi and not($keep-name)">
+              <xsl:if test="@name and not($keep-name)">
                 <xsl:apply-templates select="@name"/>
               </xsl:if>
               <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-handle-named-reference.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-handle-named-reference.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) folded into a reference that carries its
+# own binding name. The handle contributes no name of its own — it is neither an
+# abstract formation nor a const (#5810) — so the reference's `> x` must survive
+# the fold. Dropping it leaves a nameless body line that the parser rejects with
+# "object inside formation must have a name" (#5947), turning a valid file into
+# an invalid one.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b > x
+    a.as-i32 >> b
+
+printed: |
+  [a] > foo
+    a.as-i32 > x


### PR DESCRIPTION
When `inline-cactoos` folds a based `>> name` handle into a reference, the
reference now keeps its own binding name. Until now only a `φ` decoratee was
spared, and the rule is widened to every name — safely, because a based handle
contributes no name of its own, so there is nothing for the reference's name to
collide with.

The old behaviour was worse than untidy: `b > x` beside `a.as-i32 >> b` printed
as a bare `a.as-i32` line, and a nameless line inside a formation does not parse
(`object inside formation must have a name`). So `eo:format` could take a valid
file and hand back an invalid one, and a single reference was enough to trigger
it. Closes #5947.

One round-trip pack comes with it. Nothing in `eo-runtime` changes shape — the
gate reformats zero files, which figures, since any source hitting this would
never have parsed. While testing I noticed a neighbour in the same branch of that
template: an *applied* reference (`b 42 > x`) keeps its name now but still loses
its argument, printing `a.plus > x`. Not touched here; I'll file it separately.
