### PR TITLE
#5871: keep last-listed value on duplicate keys in map construction, matching .with semantics

### DIFF
--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -32,28 +32,23 @@
             if. > @
               tup.length.eq 0
               *
-              if.
-                has-key prev
-                prev
-                prev.with
-                  [] >>
-                    ^.hash > hash
-                    ^.kbts > kbts
-                    tup.head.key > key
-                    tup.head.value > value
+              without-key.with
+                [] >>
+                  ^.hash > hash
+                  ^.kbts > kbts
+                  tup.head.key > key
+                  tup.head.value > value
             bytes.hash >> hash!
               tup.head.key.as-bytes >> kbts!
-            if. > [ent] > has-key
-              ent.length.eq 0
-              false
-              if.
-                and.
-                  ent.head.hash.eq hash
-                  ent.head.kbts.eq kbts
-                true
-                has-key ent.tail
             @. > prev
               rec-rebuild tup.tail
+            tuple.filtered > without-key
+              prev
+              [ent] >>
+                not. > @
+                  and.
+                    ent.hash.eq hash
+                    ent.kbts.eq kbts
           | pairs
   [key value] > entry
   [entries] > initialized
@@ -216,6 +211,15 @@
     map * > mp
       map.entry "Aa" 1
       map.entry "BB" 2
+
+  ++> tests-map-construction-keeps-last-value-for-duplicate-key
+    2.eq > @
+      get.
+        mp.found 1
+        "unreachable" > [message]
+    map * > mp
+      map.entry 1 1
+      map.entry 1 2
 
   ++> tests-map-get-missing-returns-provided-fallback
     "recovered".eq > @


### PR DESCRIPTION
Closes #5871.

`map`'s construction-time `rec-rebuild` recurses into `tup.tail` first, building `prev` from everything already processed, then checks `has-key(prev)` for the current `tup.head`. If the key is already present, `prev` was returned unchanged and the current entry was silently dropped.

Given how the tuple cons-list is actually built (the newest/last-listed element becomes the new `.head`), this meant `rec-rebuild` processed the FIRST-listed entry into the accumulator first, then discarded any LATER-listed entry with the same key. That's the opposite of `map`'s own explicit `.with` method, which filters out the old entry with a matching key before adding the new one, genuine "last write wins" semantics, and the opposite of the dict/map-literal convention in most mainstream languages.

Fix: instead of a separate `has-key` check with a keep-or-drop branch, always filter the accumulator for any entry with the current key before appending the current one, unconditionally, the same "filter old, append new" shape `.with` already uses. This makes construction-time duplicate-key resolution consistent with `.with`, and removes the now-unused `has-key` helper.

Added `tests-map-construction-keeps-last-value-for-duplicate-key`, building a map from `* (entry 1 1) (entry 1 2)` and checking the value under key `1` is `2` (the later-listed one). This fails against the old code (which kept `1`) and passes with this fix.
