### PR TITLE
Keep a shared based >> handle instead of copying it into bare references

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -39,17 +39,19 @@
   auto-named abstract that references its own name; inlining it would
   copy that self-reference back in and fire this template forever, so
   such a target is also left untouched (both the reference and the
-  abstraction stay in place). A dataized-const handle (`a &gt;&gt; b!`,
-  R-3.10.12) reached from more than one site is likewise left untouched:
-  the const is dataized once and cached in that single binding, so folding
-  it into each use would mint an independent const object per reference and
-  drop the shared name (#5828); "merge-monikers" later hosts the kept
-  binding onto its first reference. A plain (non-const) auto-named abstract
-  formation reached from more than one site is left untouched for the same
-  reason (#5876): folding the whole formation into every reference drops its
-  shared handle name and strands any sibling helper it reaches on a synthetic
-  "vL_P" id, so the formation and its "@local" handle are kept in place and
-  "merge-monikers" hosts the kept binding onto its first reference. A const
+  abstraction stay in place). A target that is rebuilt at every site it lands
+  in (see `eo:rebuilt`) and reached from more than one site is likewise left
+  untouched: folding it into every use copies one shared object into several
+  and drops the handle name they all read. A dataized-const handle
+  (`a &gt;&gt; b!`, R-3.10.12) is dataized once and cached in that single
+  binding, so a per-use fold would mint an independent const object per
+  reference (#5828); an abstract formation would strand any sibling helper it
+  reaches on a synthetic "vL_P" id (#5876); and a based handle over an
+  application such as `a.plus 1 &gt;&gt; b` would print the same application
+  twice, folded into the bare reference and left standing for the dispatch
+  ones, which are never inlined (#5956). The binding and its "@local" handle
+  stay in place and "merge-monikers" later hosts them
+  onto the first reference. A const
   whose value reaches another auto-name is kept for a third reason (#5910):
   the folded value can only be laid out vertically, which the anonymous inline
   const argument cannot spell (see "eo:vertical-const" below).
@@ -74,7 +76,7 @@
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
     <xsl:choose>
-      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:vertical-const($target)) and not(eo:multi-referenced($target, $name) and (eo:dataized-const($target) or eo:abstract($target)))">
+      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:vertical-const($target)) and not(eo:multi-referenced($target, $name) and eo:rebuilt($target))">
         <xsl:choose>
           <!--
           The reference is the base of an application — it carries its own
@@ -175,10 +177,10 @@
   <!--
   Drop an inlined auto-named abstract; keep cactus-named voids, keep
   self-referential (recursive) abstracts, which are never inlined, keep a
-  binding no reference reaches at all (#5914), keep a multi-referenced
-  dataized-const handle, which is never inlined (#5828), keep a
-  multi-referenced abstract formation, which is never
-  inlined either (#5876), keep a const that only a vertical layout can spell,
+  binding no reference reaches at all (#5914), keep a multi-referenced binding
+  that is rebuilt at every site — a dataized-const handle (#5828), an abstract
+  formation (#5876) or an application (#5956) — which is never
+  inlined, keep a const that only a vertical layout can spell,
   which is never inlined either (#5910), keep a formation applied through a
   `@pipe` continuation, which is kept in place above its pipe rather than
   inlined (#5834), and keep a binding that a surviving method dispatch still
@@ -192,7 +194,7 @@
   reads yet would silently vanish (#5914).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and (eo:dataized-const(.) or eo:abstract(.))) or eo:piped(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -286,15 +288,29 @@
   </xsl:function>
   <!--
   Whether more than one reference in the binding's owner reaches the auto-name
-  `$name`. Such a shared binding — a const handle (#5828) or an abstract
-  formation (#5876) — is kept whole rather than folded into each use, which
-  would change the object graph or drop the shared handle name, and
-  "merge-monikers" then hosts the kept binding onto its first reference.
+  `$name`. A shared binding that is rebuilt at every site (see `eo:rebuilt`) is
+  kept whole rather than folded into each use, which would change the object
+  graph and drop the shared handle name, and "merge-monikers" then hosts the
+  kept binding onto its first reference.
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="count(eo:references($target, $name)) &gt; 1"/>
+  </xsl:function>
+  <!--
+  Whether `$target` is built anew at every site it is folded into, so that
+  folding a shared one into each of its uses turns one object into several. An
+  abstract formation (#5876), a dataized const (#5828) and an application such
+  as `a.plus 1` (#5956) all are: each copy is its own object. A based handle
+  whose value is a bare reference (`a &gt;&gt; b`) or an argument-less dispatch
+  (`a.as-i32 &gt;&gt; b`) is not — it is a lookup, and every copy reads back the
+  very same object — so a shared one still folds per use and its name goes with
+  it (#5810).
+  -->
+  <xsl:function name="eo:rebuilt" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:sequence select="eo:abstract($target) or exists($target/o)"/>
   </xsl:function>
   <!--
   Whether no reference in the binding's owner reaches the auto-name `$name`.

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -107,13 +107,31 @@
   whose nearest formation ancestor is the binding's own owner and that does
   not sit inside the binding itself. Bare references are listed first, so a
   binding with both spellings still folds into the shorter bare inline and a
-  dispatch hosts only when no bare reference is available.
+  dispatch hosts only when no bare reference is available. A named handle
+  (see `eo:named-handle`) inverts that: a bare host inlines it anonymously
+  (#5810), which drops the very name its other references read back through,
+  so only a dispatch may host it and a handle reached by bare references alone
+  stays standing (#5956).
   -->
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
     <xsl:variable name="refs" select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
-    <xsl:sequence select="($refs[eo:dispatch-seg(.) = ''], $refs[eo:dispatch-seg(.) != ''])"/>
+    <xsl:sequence select="if (eo:named-handle($attr)) then $refs[eo:dispatch-seg(.) != ''] else ($refs[eo:dispatch-seg(.) = ''], $refs[eo:dispatch-seg(.) != ''])"/>
+  </xsl:function>
+  <!--
+  Whether `$attr` is a based `>> name` handle whose readable name must outlive
+  the merge: a plain reference or application (not an abstract formation)
+  carrying its "@local" handle, which "restore-local-names" leaves there only
+  when the binding survives "inline-cactoos" with references still reading it
+  by name — shared (#5944, #5956) or unreached (#5914). A const handle is
+  excluded: it keeps its "@name" and "@local" through a bare inline too (#5828),
+  so it needs no such restriction. An abstract formation carries its name
+  wherever it lands and is excluded for the same reason.
+  -->
+  <xsl:function name="eo:named-handle" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:sequence select="exists($attr/@local) and not(eo:abstract($attr)) and not(eo:const-handle($attr))"/>
   </xsl:function>
   <!--
   The binding that a reference `$ref` should be replaced with, or the empty
@@ -223,20 +241,6 @@
     <xsl:sequence select="string-join((if (eo:shadowed($ref, $binding)) then subsequence($segs, 1, $at - 1) else $eo:xi, string($binding/@local), subsequence($segs, $at + 1)), '.')"/>
   </xsl:function>
   <!--
-  Whether the readable "@local" handle of `$attr` still stands after the merge,
-  so a reference that does not host it may read back through it. An abstract
-  formation carries its "@name" and "@local" to wherever it lands, and a binding
-  no reference hosts stays where it is; a based handle (`a.b &gt;&gt; name`)
-  keeps them only when its host is a method dispatch, which rebuilds the binding
-  whole as the receiver of a reversed dispatch. A bare host inlines it
-  anonymously instead (#5810), leaving no name for anyone else to read.
-  -->
-  <xsl:function name="eo:handle-survives" as="xs:boolean">
-    <xsl:param name="attr" as="element()"/>
-    <xsl:variable name="host" select="eo:moniker-refs($attr)[1]"/>
-    <xsl:sequence select="eo:abstract($attr) or empty($host) or eo:dispatch-seg($host) != ''"/>
-  </xsl:function>
-  <!--
   The kept multi-referenced handle binding a reference `$ref` resolves to but does
   NOT host (the binding folds onto its first reference only,
   `eo:moniker-refs`). Any other reference — a named alias
@@ -246,8 +250,9 @@
   synthetic "vL_P" placeholder, the non-const mirror of `eo:kept-const-ref`
   (which covers the const handles this one leaves out). Both shapes of handle
   reach here: an abstract formation kept whole because it is shared (#5876),
-  and a based handle (`a.b &gt;&gt; name`) kept because a method dispatch
-  reference reaches it, which "inline-cactoos" never inlines (#5944). The
+  and a based handle (`a.b &gt;&gt; name`) kept because it is shared too — by a
+  method dispatch, which "inline-cactoos" never inlines (#5944), or by a bare
+  reference, which it no longer folds a second copy into (#5956). The
   reference is matched by carrying the binding's cactus "@name" as one of its
   base segments; the binding's own subtree is excluded. As with the const
   handle, the reference need not live in the binding's own scope: two mutually
@@ -258,7 +263,7 @@
   -->
   <xsl:function name="eo:kept-local-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and not(eo:const-handle(.)) and exists(@local) and eo:handle-survives(.) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
+    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and not(eo:const-handle(.)) and exists(@local) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -84,12 +84,12 @@
   multi-referenced const handle its "@local" marker is kept here (below) and
   "merge-monikers" folds the surviving binding onto its first reference. A
   based handle ("a.b &gt;&gt; name", R-3.10.12) reached from more than one
-  site is kept for the same reason (#5944): a reference spelled as a method
-  dispatch ("name.seg") is not inlined at all, so the binding outlives
-  "inline-cactoos" and only the hosting reference is folded into it — the
-  others read the handle by name and would otherwise print a synthetic "vL_P".
-  A handle every reference of which is bare is inlined away regardless, its
-  "@local" going with it, so keeping the marker here costs nothing.
+  site is kept for the same reason (#5944): "inline-cactoos" never folds a
+  reference spelled as a method dispatch ("name.seg"), nor any reference to a
+  shared application, since each fold would build the application anew and
+  print one object twice (#5956). The binding therefore outlives that sheet and
+  only the hosting reference is merged into it — the others read the handle by
+  name and would otherwise print a synthetic "vL_P".
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-shared-application.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-shared-application.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle whose value is an application is left in place by
+# "inline-cactoos" once more than one site reaches it (#5956), the same way a
+# shared formation (#5876) and a shared const handle (#5828) are. An
+# application is built anew wherever it lands, so folding it into the bare
+# reference while the dispatch one keeps the binding standing would print the
+# same application twice. Both references stay cactus-named and
+# "merge-monikers" later hosts the kept binding onto the dispatch, the only
+# reference that can carry its readable handle.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The shared application is not dropped: it keeps its cactus name and its
+  # file-local handle.
+  - /object/o[@name='foo']/o[@local='b' and contains(@name, '🌵') and @base='ξ.a.plus']
+  # Neither reference is inlined into a copy of it: the bare reference and the
+  # `.neg` dispatch both stay cactus-named references.
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and @name='x' and not(o)]
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.neg') and @name='y']
+  # No second copy of the application was minted at a reference site.
+  - /object[count(//o[@base='ξ.a.plus'])=1]
+input: |
+  [a] > foo
+    b > x
+    b.neg > y
+    a.plus 1 >> b

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers.yaml
@@ -9,13 +9,14 @@
 # the first bare reference only for the compiler's auto-generated, obfuscated
 # names (the `a🌵` cactus prefix, §9.2); a real, author-chosen name reads best
 # on its own `... > name` line and is left standalone (#5738). Here the
-# file-local handle `>> auto` carries a cactus @name, so its binding is merged
-# onto the first bare `auto` reference (the `auto.gte`/`auto.neg` dispatches
-# cannot host it and stay references), while the real name `value` keeps both
-# its standalone binding and its bare reference. The merged binding is a based
-# value (not an abstract formation), so its obfuscated `@name` and `@local`
-# handle are dropped — the bare reference is unnamed and keeping them would
-# leave a spurious named `auto >>` node that `to-eo-tree` misprints (#5810).
+# file-local handle `>> auto` carries a cactus @name, so its binding is merged,
+# while the real name `value` keeps both its standalone binding and its bare
+# reference. The handle still carries its readable `@local`, which the bare
+# `auto` reference reads back through, so the bare site cannot host it: a bare
+# inline is unnamed, and keeping the name there would leave a spurious
+# `auto >>` node that `to-eo-tree` misprints (#5810). The `auto.gte` dispatch
+# hosts it instead, as a reversed dispatch that rebuilds the binding whole and
+# keeps the name (#5956).
 sheets:
   - /org/eolang/parser/parse/wrap-applications.xsl
   - /org/eolang/parser/parse/resolve-self.xsl
@@ -38,15 +39,17 @@ sheets:
   - /org/eolang/printer/print/merge-monikers.xsl
 asserts:
   # The obfuscated (cactus-named) binding is no longer a direct attribute of
-  # the formation: it has been merged onto its bare reference.
+  # the formation: it has been merged onto its dispatch reference.
   - /object/o[@name='abs' and not(o[starts-with(@name, 'a🌵')])]
-  # It now lives at the first bare-reference site, inside the `if.` block,
-  # keeping the reference's positional marker and gaining the binding's base
-  # and child, but as an anonymous value: the based binding's obfuscated
-  # `@name` and its `@local` handle are dropped (#5810).
-  - /object/o[@name='abs']/o[@name='φ' and @base='.if']/o[not(@name) and not(@local) and @base='Φ.number' and @as='α0']/o[@base='ξ.num.as-bytes']
-  # The method-dispatch use of the cactus name stays a reference.
-  - /object/o[@name='abs']/o[@name='φ']/o[starts-with(@base, 'ξ.a🌵') and ends-with(@base, '.gte')]
+  # It now lives at the `auto.gte` site, inside the `if.` block, as the
+  # receiver of a reversed `gte.` dispatch that keeps the binding's obfuscated
+  # `@name` and its readable `@local` handle.
+  - /object/o[@name='abs']/o[@name='φ' and @base='.if']/o[@base='.gte']/o[starts-with(@name, 'a🌵') and @local='auto' and @base='Φ.number']/o[@base='ξ.num.as-bytes']
+  # The bare use reads back through that handle rather than a copy of the
+  # binding (#5956) or a synthetic cactus id.
+  - /object/o[@name='abs']/o[@name='φ']/o[@base='ξ.auto' and not(@name)]
+  # No cactus reference is left dangling.
+  - /object[count(//o[starts-with(@base, 'ξ.a🌵')])=0]
   # The real name `value` is NOT merged: its standalone binding stays a direct
   # attribute of the formation (#5738).
   - /object/o[@name='abs']/o[@name='value' and @base='Φ.number']/o[@base='ξ.num.as-bytes']

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-shared-handle-bare-only.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-shared-handle-bare-only.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The companion to `based-shared-handle-bare-reference` (#5956) where every
+# reference to the shared based handle is bare. No dispatch is left to host the
+# binding as a reversed one, and a bare host would inline it anonymously
+# (#5810), dropping the very name the other reference reads back through, so
+# the handle stays standing where it is and both references read it by name.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b > x
+    b > y
+    a.plus 1 >> b
+
+printed: |
+  [a] > foo
+    a.plus 1 >> b
+    b > x
+    b > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-shared-handle-bare-reference.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-shared-handle-bare-reference.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) — its value a plain application, neither
+# an abstract formation nor a const — reached by a bare reference and by a
+# method dispatch at once. The dispatch is never inlined, so the binding
+# outlives "inline-cactoos" and "merge-monikers" hosts it there as a reversed
+# one; folding the bare reference away too would copy the same application in a
+# second time, printing one shared object twice (#5956), the based flavour of
+# what #5828 fixed for consts and #5876 for formations. The shared binding is
+# left whole for every reference, and the bare one reads back through its
+# readable handle rather than a synthetic "vL_P" id.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b > x
+    b.neg > y
+    a.plus 1 >> b
+
+printed: |
+  [a] > foo
+    b > x
+    neg. > y
+      a.plus 1 >> b


### PR DESCRIPTION
A `>> name` handle whose value is an application was getting folded into every bare reference that reached it, while the binding itself stayed put for the dispatch references, which are never inlined. The result was one shared object printed as two:

```
[a] > foo          printed as    [a] > foo
  b > x                            a.plus 1 > x
  b.neg > y                        neg. > y
  a.plus 1 >> b                      a.plus 1 >> b
```

`uri.eo` runs straight into this the moment `port-colon-idx` is privatized from `>` to `>>` for the #5678 sweep: the same six-line `has-bracket-host.if` application comes out twice, named under `has-port` and anonymously under `host`.

`inline-cactoos` now keeps any shared target that gets built anew wherever it lands (new `eo:rebuilt`), so an application joins the const handle (#5828) and the abstract formation (#5876) that were already carved out. A based lookup such as `a >> b` or `a.as-i32 >> b` is not a build — every copy reads back the same object — so it still folds per use and #5810 is untouched. In `merge-monikers`, a based binding that still carries its readable `@local` may now only be hosted by a method dispatch, which rebuilds it whole as a reversed dispatch; a bare host inlines it anonymously and would drop the very name the other references read back through. With no dispatch around, the handle just stays standing. That made `eo:handle-survives` always true, so it is gone.

Two new print packs cover the bare+dispatch and the all-bare shapes, plus one eo-pack pinning the behaviour at the fix site. The asserts in `merge-monikers.yaml` had to change: its own input was a live instance of this bug, and it was asserting the duplicated bare inline together with a dangling `ξ.a🌵….gte` reference.

Checked with the 286 eo-printer tests, Qulice on eo-printer, and a full `mvn clean test -pl :eo-runtime -Deo.autoFix` under JDK 23 — 1772 tests green, and not a single `.eo` file in eo-runtime formats differently under the new printer. With `port-colon-idx` privatized, `uri.eo` now comes out with one copy of the application and all four references reading the handle, stable across two format passes. That `uri.eo` edit is deliberately not in here — it belongs to the #5678 sweep.

Closes #5956
