### PR TITLE
fix(#5943): printf %s conversion silently corrupts non-string arguments [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -9,6 +9,7 @@
  */
 package org.eolang.EO_string; // NOPMD
 
+import java.util.IllegalFormatException;
 import java.util.Locale;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
@@ -16,6 +17,7 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Expect;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -42,22 +44,27 @@ public final class EOprintf extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final String format = new Dataized(this.take("format")).asString();
-        return new Data.ToPhi(
-            String.format(
-                Locale.US,
-                PrintfArgs.javaFormat(format),
-                new PrintfArgs(
-                    format,
-                    Expect.at(this, "args")
-                        .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
-                        .otherwise("be a tuple with the 'length' attribute")
-                        .it(),
-                    Expect.at(this, "args")
-                        .that(phi -> phi.take("at"))
-                        .otherwise("be a tuple with the 'at' attribute")
-                        .it()
-                ).formatted().toArray()
-            )
-        );
+        final String javaFmt = PrintfArgs.javaFormat(format);
+        final Object[] args = new PrintfArgs(
+            format,
+            Expect.at(this, "args")
+                .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
+                .otherwise("be a tuple with the 'length' attribute")
+                .it(),
+            Expect.at(this, "args")
+                .that(phi -> phi.take("at"))
+                .otherwise("be a tuple with the 'at' attribute")
+                .it()
+        ).formatted().toArray();
+        try {
+            return new Data.ToPhi(
+                String.format(Locale.US, javaFmt, args)
+            );
+        } catch (final IllegalFormatException ex) {
+            throw new ExFailure(
+                "The format '%s' is not a valid printf format string",
+                format
+            );
+        }
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -17,6 +17,7 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.eolang.BytesOf;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
@@ -63,7 +64,17 @@ final class PrintfArgs {
     private static final double LONG_UPPER_LIMIT = 0x1.0p63;
 
     static {
-        PrintfArgs.CONVERSION.put('s', Dataized::asString);
+        PrintfArgs.CONVERSION.put('s', element -> {
+            final byte[] data = element.take();
+            if (data.length == Double.BYTES) {
+                final double num = new BytesOf(data).asNumber();
+                if (num == Math.floor(num) && !Double.isInfinite(num)) {
+                    return String.valueOf((long) num);
+                }
+                return String.valueOf(num);
+            }
+            return new String(data, java.nio.charset.StandardCharsets.UTF_8);
+        });
         PrintfArgs.CONVERSION.put('d', element -> PrintfArgs.toLong(element.asNumber()));
         PrintfArgs.CONVERSION.put('f', Dataized::asNumber);
         PrintfArgs.CONVERSION.put('x', element -> PrintfArgs.bytesToHex(element.take()));


### PR DESCRIPTION
Fixes #5943

## Problem
`printf`'s `%s` conversion produces mojibake when the argument is not already a string. It reinterprets the argument's raw bytes as UTF-8 instead of converting the object to its textual representation. No error is raised, so the corrupted text flows on silently.

The sibling conversions (`%d`, `%f`, `%b`) all validate and fail cleanly, which makes `%s` the inconsistent one.

## Root cause
`PrintfArgs` maps each conversion to a converter. The `%s` conversion used `Dataized::asString` which accepts any byte length and decodes it as text, so a number (or any non-string object) is silently mis-decoded rather than converted or rejected.

## Fix
Replace `Dataized::asString` with a lambda that:
1. Detects 8-byte data (double precision) and formats it as a decimal string, with whole numbers rendered without trailing '.0'
2. Falls back to UTF-8 string decoding for all other data

This makes `%s` consistent with the documented behavior of 'converts object to string' and with sibling conversions.

## Before/After
| call | before | after |
|------|--------|-------|
| `printf "%s" 42` | `"@E"` (bytes of 42.0 decoded as UTF-8) | `"42"` |
| `printf "%s" 3.14` | mojibake | `"3.14"` |
| `printf "%s" "ok"` | `"ok"` | `"ok"` (unchanged) |
| `printf "%d" 42` | `"42"` | `"42"` (unchanged) |