### PR TITLE
fix(#5940): EOprintf throws raw IllegalFormatException instead of clean ExFailure

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -9,6 +9,7 @@
  */
 package org.eolang.EO_string; // NOPMD
 
+import java.util.IllegalFormatException;
 import java.util.Locale;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
@@ -16,6 +17,7 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Expect;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -42,22 +44,27 @@ public final class EOprintf extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final String format = new Dataized(this.take("format")).asString();
-        return new Data.ToPhi(
-            String.format(
-                Locale.US,
-                PrintfArgs.javaFormat(format),
-                new PrintfArgs(
-                    format,
-                    Expect.at(this, "args")
-                        .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
-                        .otherwise("be a tuple with the 'length' attribute")
-                        .it(),
-                    Expect.at(this, "args")
-                        .that(phi -> phi.take("at"))
-                        .otherwise("be a tuple with the 'at' attribute")
-                        .it()
-                ).formatted().toArray()
-            )
-        );
+        final String javaFmt = PrintfArgs.javaFormat(format);
+        final Object[] args = new PrintfArgs(
+            format,
+            Expect.at(this, "args")
+                .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
+                .otherwise("be a tuple with the 'length' attribute")
+                .it(),
+            Expect.at(this, "args")
+                .that(phi -> phi.take("at"))
+                .otherwise("be a tuple with the 'at' attribute")
+                .it()
+        ).formatted().toArray();
+        try {
+            return new Data.ToPhi(
+                String.format(Locale.US, javaFmt, args)
+            );
+        } catch (final IllegalFormatException ex) {
+            throw new ExFailure(
+                "The format '%s' is not a valid printf format string",
+                format
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #5940

## Problem
`EO_string.EOprintf` lets a raw `java.util.IllegalFormatException` escape from the JVM when the format string carries a flag or a precision that `String.format` rejects for the effective conversion. An EO program cannot catch a JVM exception, so instead of the object failing cleanly (as an `ExFailure`/⊥ that EO code could recover from), the whole dataization crashes.

## Root cause
`EOprintf.lambda()` calls `String.format(Locale.US, PrintfArgs.javaFormat(format), ...)` with no guard. `PrintfArgs.formatted()` validates the conversion and argument count, but never validates flags/precision, and the subsequent `String.format` is unguarded.

## Fix
Wrap the `String.format()` call in a try-catch that converts any `IllegalFormatException` to an `ExFailure` with a descriptive message, consistent with the other error paths.

## Before/After
| format | before | after |
|--------|--------|-------|
| `%.2d` | throws `java.util.IllegalFormatPrecisionException` | clean ExFailure |
| `%#x` | throws `java.util.FormatFlagsConversionMismatchException` | clean ExFailure |
| `%,s` | throws `java.util.FormatFlagsConversionMismatchException` | clean ExFailure |