### PR TITLE
fix(#5945): reject NaN explicitly in printf %d conversion [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -198,9 +198,9 @@ final class PrintfArgs {
      * @return The number as {@code long}
      */
     private static long toLong(final double number) {
-        if (number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
+        if (Double.isNaN(number) || number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
             throw new ExFailure(
-                "The number %s doesn't fit into long range for the '%%d' conversion",
+                "The number %s can't be converted to long for the '%%d' conversion",
                 number
             );
         }


### PR DESCRIPTION
## Summary

`printf`'s `%d` conversion silently turns `nan` into `0`, while `±∞` is correctly rejected. This is inconsistent — NaN is no more a valid integer than infinity is.

## Root cause

`PrintfArgs.toLong(double)` guards only the two out-of-range directions:
`number < Long.MIN_VALUE || number >= LONG_UPPER_LIMIT`

NaN compares `false` against every relational operator, so it slips past the guard and `(long) Double.NaN` is `0` (JLS 5.1.3).

## Fix

Add `Double.isNaN(number)` to the guard check. Also update the error message to reflect the broader check.

## Verification

| call | before | after |
|---|---|---|
| `printf "%d" nan` | `"0"` — silent, wrong | ExFailure |
| `printf "%d" pinf` | ExFailure | ExFailure (unchanged) |
| `printf "%d" 42` | `"42"` | `"42"` (unchanged) |

Closes #5945