### PR TITLE
fix(#5946): tighten scanf %d overflow guard and fix error message [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -83,7 +83,9 @@
         fraction
     [text] > as-integer
       if. > @
-        digits.length.gt 19
+        or.
+          digits.length.gt 19
+          folded.gt 9223372036854775807
         overflow
         signed
       signed-prefix.if > digits
@@ -102,7 +104,7 @@
         "-"
       overflow-message > overflow
       T > overflow-message
-        "The number doesn't fit into long range for the '%d' conversion"
+        "The number doesn't fit into long range for the '%%d' conversion"
       negative.if negated folded > signed
       negative.or > signed-prefix
         eq.


### PR DESCRIPTION
## Summary

Two bugs in `scanf`'s `%d` integer-overflow handling:

### Bug 1: Error message has unescaped `%d`

The overflow message `"The number doesn't fit into long range for the '%d' conversion"` contains an unescaped `%d` format specifier. When `ExFailure` passes this to `String.format` with no arguments, it throws `MissingFormatArgumentException` before the real message is ever shown. Fixed by escaping to `%%d`.

### Bug 2: 19-digit values above `Long.MAX_VALUE` slip through

The guard `digits.length.gt 19` only rejects 20+ digit inputs. A 19-digit value like `9999999999999999999` (\> `Long.MAX_VALUE` = 9223372036854775807) passes the check and is silently accepted. Added a comparison of the folded value against `Long.MAX_VALUE` to reject values that exceed the actual bound.

## Verification

| Input | Before | After |
|-------|--------|-------|
| `"99999999999999999999"` (20 digits) | MissingFormatArgumentException | Clean ExFailure: "doesn't fit into long range" |
| `"9999999999999999999"` (19 digits, > Long.MAX) | silently accepted | ExFailure: rejected |
| `"9223372036854775807"` (Long.MAX_VALUE) | accepted | accepted (unchanged) |
| `"33"` | accepted | accepted (unchanged) |

Closes #5946