### PR TITLE
fix(#5954): drop reversed-dispatch hybrid-blocking clause in Pretty.phi() [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -374,8 +374,7 @@ final class Pretty {
             ).map(
                 inlined -> this.tab.repeat(indent).concat(inlined).concat(marker)
             );
-            final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
-                && !(decoratee.reversed && decoratee.children.size() <= 1);
+            final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty();
             final boolean unnamed = decoratee.children.stream()
                 .allMatch(Node::nameless);
             if (applied && unnamed) {


### PR DESCRIPTION
Closes #5954

## Problem
The `applied` predicate in `Pretty.phi()` (`Pretty.java:377-378`) has a clause
`!(decoratee.reversed \&\& decoratee.children.size() <= 1)` that withholds the
hybrid inline-phi collapse from a reversed dispatch carrying only its receiver
(e.g. `not.`). This causes 143 blocks across 47 files under
`eo-runtime/src/main/eo` to be printed in a verbose three-line form when the
compact hybrid form is valid.

## Fix
Drop the `\&\& !(decoratee.reversed \&\& decoratee.children.size() <= 1)` clause,
leaving `applied` as `!decoratee.abstractt \&\& !decoratee.children.isEmpty()`.
The `unnamed` guard on the following line still prevents the collapse when a
name appears anywhere in the decoratee's subtree, so #5598 and #5604 stay fixed.

## Root cause analysis
The javadoc justified the clause as mirroring the rejection in `flat`
(`Pretty.java:514`), but the rejection there concerns a *horizontal* spelling:
`not.` has no one-line inline form. The hybrid is not horizontal — it keeps
`not.` on the head line and lays the receiver out beneath. `LnOnlyPhi` accepts
exactly that shape, and its `bare()` skips the trailing dot leaving the φ
`Openness.OPEN`, so the deeper-indent line attaches as the receiver.

This is a different gap from #5594, #5700, and #5635, which all concerned how
the flat one-liner and the hybrid are weighed against each other rather than
which decoratees may have a hybrid at all.