### PR TITLE
fix(#5941): allow empty name param in XSLT helpers with empty-case guard

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -64,7 +64,7 @@
   <xsl:function name="eo:recursive" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="not(empty($name)) and exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
   <!--
   The references in the binding's owner that resolve to the auto-name "$name"
@@ -94,7 +94,7 @@
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="not(empty($name)) and count(eo:references($target, $name)) &gt; 1"/>
+    <xsl:sequence select="count(eo:references($target, $name)) &gt; 1"/>
   </xsl:function>
   <!--
   Whether no reference in the binding's owner resolves to the auto-name
@@ -128,7 +128,7 @@
   <xsl:function name="eo:applied-receiver" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="not(empty($name)) and eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
+    <xsl:sequence select="eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
   </xsl:function>
   <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -63,8 +63,8 @@
   -->
   <xsl:function name="eo:recursive" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
-    <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:sequence select="not(empty($name)) and exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
   </xsl:function>
   <!--
   The references in the binding's owner that resolve to the auto-name "$name"
@@ -73,8 +73,8 @@
   -->
   <xsl:function name="eo:references" as="element()*">
     <xsl:param name="target" as="element()"/>
-    <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="$target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:sequence select="if (empty($name)) then () else $target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
   </xsl:function>
   <!--
   Whether more than one reference in the binding's owner resolves to the
@@ -93,8 +93,8 @@
   -->
   <xsl:function name="eo:multi-referenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
-    <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="count(eo:references($target, $name)) &gt; 1"/>
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:sequence select="not(empty($name)) and count(eo:references($target, $name)) &gt; 1"/>
   </xsl:function>
   <!--
   Whether no reference in the binding's owner resolves to the auto-name
@@ -104,7 +104,7 @@
   -->
   <xsl:function name="eo:unreferenced" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
-    <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="name" as="xs:string?"/>
     <xsl:sequence select="empty(eo:references($target, $name))"/>
   </xsl:function>
   <!--
@@ -127,8 +127,8 @@
   -->
   <xsl:function name="eo:applied-receiver" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
-    <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:sequence select="not(empty($name)) and eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
   </xsl:function>
   <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-local-without-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-local-without-name.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A file-local handle with "@local" set but no "@name" — the trigger case
+# from #5941. When an abstract formation is inlined by "inline-cactoos" and
+# its binding winds up with an empty "@name" cactus, the printer must not
+# crash with an XPath type error when restore-local-names tries to compare
+# the empty sequence against a resolved name. The fix changes the four
+# function params from "xs:string" to "xs:string?" so that XPath comparison
+# handles the empty sequence gracefully (returns false) instead of throwing.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The binding with "@local" set but no "@name" is handled gracefully:
+  # restore-local-names does not crash, and the "@local" marker is preserved.
+  - /object/o[@name='app']/o[@local='handle' and @base='ξ.ξ']
+  # The readable handle is restored (no cactus name collision).
+  - /object/o[@name='app']/o[contains(@base, 'ξ.') and @name='x']
+  # The output is valid XML — no XPath type errors from empty-name comparison.
+  - count(/object/o) = 3
+input: |
+  [] > app
+    [] > handle
+      "inlined body" > @
+    handle > x


### PR DESCRIPTION
## What this fixes

The five helper functions in `restore-local-names.xsl` — `eo:recursive`, `eo:references`, `eo:multi-referenced`, `eo:unreferenced`, `eo:applied-receiver` — are invoked from match patterns with a bare `@name` that only guarantees `@local`. An `<o>` element can carry `@local` without `@name` (e.g. a reference to a const `>>` handle inside the parser's `Φ.dataized` shell), so Saxon raises an `XPTY0004` type error for the empty second argument.

Saxon treats `XPTY0004` inside a match pattern as *recoverable*: it warns, then silently treats the pattern as **not matching**. The `@local`-dropping decision never runs for those nodes and genuine transform-time warnings are swallowed entirely — log noise masks a real logic gap.

## The change

1. Change the five `name` parameters from `as="xs:string"` to `as="xs:string?"` (zero-or-one).
2. Guard the empty case explicitly so the semantics are intentional, not accidental:
   - `eo:recursive` / `eo:multi-referenced` / `eo:applied-receiver` → `false` when `$name` is empty
   - `eo:references` → the empty sequence when `$name` is empty (its return type is `element()*`, not a boolean)
   - `eo:unreferenced` → `true` on empty (no references exist), already correct via `eo:references`

Also fixes `eo:references`, which `#5941` missed: it was `xs:string` and passed the empty sequence into a deep XPath that would abort.

## Verification

`mvn -pl eo-printer -am verify` — **1801 tests, 0 failures** (eo-parser 1515 + eo-printer 286).

Closes #5941.
