### PR TITLE
fix(#5952): preserve applied-ref arguments when folding based >> handle

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -163,6 +163,25 @@
               </xsl:if>
               <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
               <xsl:apply-templates select="$target/node()"/>
+              <!--
+              A based `>> name` handle whose value is a plain reference or an
+              argument-less dispatch (R-3.10.12) reaches this `otherwise`
+              because neither of the two branches above — which preserve an
+              applied reference's arguments by keeping the target in place and
+              turning the reference into a `| args` pipe (#5834/#5844) — test
+              for a based, non-abstract target first. Folding the target alone
+              (#5952) would build the node from `$target` only and silently
+              drop the reference's own `o` children. Append them after the
+              target's, guarded to a target that carries no children of its own:
+              handing an already-applied target (e.g. `a.plus 1 >> b` used as
+              `b 42`) a second child would apply the inner application a second
+              time rather than feed the outer reference its argument. A target
+              that does carry children has no inline spelling here and is left
+              standing; the drop template below will keep it.
+              -->
+              <xsl:if test="o and not($target/o)">
+                <xsl:apply-templates select="o"/>
+              </xsl:if>
             </xsl:element>
           </xsl:otherwise>
         </xsl:choose>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-based-handle-applied.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-based-handle-applied.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle (`a.plus >> b`, R-3.10.12) whose value is a plain
+# reference (not an abstract formation) and which is used as a base of an
+# application with an argument (`b 42`). Before #5952, the argument was silently
+# dropped when the handle was folded into the use site, because the `otherwise`
+# branch of the inlining template only copied the target's children and ignored
+# the reference's own `o` children. The fix appends the reference's `o` children
+# after the target's, guarded to a target that carries no children of its own
+# (a target that already carries children has no inline spelling and is left
+# standing by the drop template).
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The based handle is inlined and the argument `42` is preserved.
+  - /object/o[@name='foo']/o[contains(@base, 'a.plus') and o = '42' and @name='x']
+  # No bare handle `b` survives inlining.
+  - count(/object//o[@base='ξ.b'])=0
+  # The inlined result has the right number of children.
+  - count(/object/o) >= 1
+input: |
+  [a] > foo
+    b 42 > x
+    a.plus >> b


### PR DESCRIPTION
## Problem

A based file-local handle (`a >> b`, R-3.10.12) whose value is a plain
reference or an argument-less dispatch, when folded at the use site, loses
the arguments of the reference it is folded into. With

```eo
[a] > foo
b 42 > x
a.plus >> b
```

the printed output was `a.plus > x` — the `42` argument vanished. Before
#5947 the whole `> x` binding disappeared as well; that part is now
preserved. The remaining loss is the argument.

The `otherwise` branch of the inlining template builds the folded node from
the target alone (`<xsl:apply-templates select="$target/node()"/>` at
`inline-cactoos.xsl`), and the reference's own `o` children are never emitted.
The two branches above it that *do* preserve an applied reference's arguments
(keeping the target in place and turning the reference into a `| args` pipe,
#5834/#5844) both test `eo:abstract($target)` first, so a based target —
neither an abstract formation nor a dataized const — never reaches them.

## Fix

Append the reference's own `o` children after the target's children in the
otherwise branch, guarded to a target that carries no children of its own:

```xsl
<xsl:if test="o and not($target/o)">
  <xsl:apply-templates select="o"/>
</xsl:if>
```

Guarding is necessary because handing an already-applied target (e.g.
`a.plus 1 >> b` used as `b 42`) a second child would apply the inner
application a second time rather than feed the outer reference its argument.
A target that already carries children has no inline spelling here and is
left standing (the drop template keeps it).

## Verification

- XML well-formed: `xmllint --noout` passes
- `eo-printer` Maven suite: 286 tests, 0 failures
  (`mvn -pl eo-printer -am verify -DskipITs -Djacoco.skip=true`)

| Check | Result |
|---|---|
| XML well-formed | ✅ |
| Unit/integration tests | ✅ 286/286 |

Closes #5952
