### PR TITLE
fix(#5933): use byte-based slicing in nsplit to fix multi-byte char mismatch [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -22,6 +22,7 @@
         1.eq limit
         * text
         [accum start current count] >> rec-nsplit
+          text.as-bytes >> bts!
           if. > @
             text.size.eq current
             appended
@@ -40,7 +41,7 @@
               if.
                 and.
                   delimiter.eq
-                    slice text current size
+                    slice bts current size
                   lt.
                     number count
                     minus. (number limit) 1
@@ -61,7 +62,7 @@
           accum.with > appended
             string
               slice
-                text
+                bts
                 start
                 current.minus start
         |


### PR DESCRIPTION
Closes #5933.

## Summary

`string.nsplit` mixes byte-based indices (`current`, `start`, `size` from `text.size` / `delimiter.size`) with character-based `slice` calls. For ASCII this is invisible; for multi-byte strings (UTF-8, CJK, emoji) the units diverge, producing out-of-bounds errors or mis-cut pieces.

## Root Cause

`text.size` and `delimiter.size` reach `bytes.size` through the decoratee, so every index arithmetic is byte-based. But `slice text ...` calls `Φ.string.slice`, which counts characters, not bytes. The sibling `split.eo` avoids this by binding `text.as-bytes >> bts!` and slicing `bts` (byte-based); `nsplit` was overlooked.

## Fix

- Bind `text.as-bytes >> bts!` once inside `rec-nsplit`
- Replace `slice text` with `slice bts` in both the delimiter comparison and the piece-cutting call
- The piece is still wrapped in `string` on line 63, so output type is unchanged

## Verification

All 7 existing ASCII tests pass unchanged. The fix matches the proven pattern in `split.eo` and is a purely additive one-line binding + two one-word replacements.

---
Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH