### PR TITLE
fix(#5919): relativize walk paths so globs match against relative paths [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -47,8 +47,8 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
         try (Stream<Path> paths = Files.walk(path)) {
             return new Data.ToPhi(
                 paths
-                    .map(p -> p.toAbsolutePath().toString())
-                    .map(p -> p.substring(p.indexOf(path.toString())))
+                    .map(p -> p.toAbsolutePath().normalize())
+                    .map(p -> path.relativize(p).toString())
                     .filter(p -> matcher.matches(Paths.get(p))).map(
                         p -> {
                             final Phi file = Phi.Φ.take("file").copy();


### PR DESCRIPTION
Closes #5919.

## Summary

`directory.walk` tries to strip the walk root off each visited path before glob-matching, but the code is a no-op: `p.substring(p.indexOf(path.toString()))` is always `p.substring(0)` because `Files.walk(path)` only yields entries whose string form starts with the absolute `path`.

Result: every path handed to the `PathMatcher` stays absolute and multi-segment, so a plain glob like `*.txt` never matches a path such as `/tmp/xyz/foo/a.txt` (`*` doesn't cross `/`).

## Fix

Replace the broken substring-no-op with `path.relativize(p).toString()`, plus `normalize()` on the absolute path before relativization to handle dot segments cleanly. This is the canonical Java idiom for the intended operation.

## Verification

`EOdirectory$EOwalk.java` compiles cleanly under OpenJDK 21 (Maven `-pl eo-runtime -am compile` passes; the downstream eo-maven-plugin dependency resolution failure is pre-existing and unrelated).

---
Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH