### PR TITLE
fix(#5969): extract deleted/moved/size/touched to file/ package [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -13,30 +13,6 @@
   path > @
   @. > as-path
     Q.path path
-  [] > deleted
-    exists.if > @
-      if.
-        outcome.eq 0
-        ^
-        T
-          "Cant delete the file '%s': %s".printf
-            * path removed.output
-      ^
-    removed.code > outcome
-    called. > removed
-      os.is-windows.if
-        win32 *1
-          win
-          path
-        posix *1
-          unix
-          path
-    is-directory.if > unix
-      "rmdir"
-      "unlink"
-    is-directory.if > win
-      "_rmdir"
-      "_unlink"
   eq. > [] > exists
     code.
       os.is-windows.if
@@ -65,24 +41,6 @@
         posix *1
           "stat"
           path
-  [target] > moved
-    if. > @
-      outcome.eq 0
-      file target
-      T
-        "Cant move the file '%s' to '%s': %s".printf
-          * path target renamed.output
-    renamed.code > outcome
-    called. > renamed
-      os.is-windows.if
-        win32 *1
-          "rename"
-          path
-          target
-        posix *1
-          "rename"
-          path
-          target
   [mode scope cant-open] > open
     known.not.if > @
       T
@@ -199,49 +157,6 @@
     not. > writable
       as-bool.
         access.eq "r"
-  [cant-measure] > size
-    if. > @
-      info.code.eq 0
-      info.output.size
-      cant-measure
-    called. > info
-      os.is-windows.if
-        win32 *1
-          "_stat64"
-          path
-        posix *1
-          "stat"
-          path
-  [] > touched
-    exists.if > @
-      ^
-      if.
-        descriptor.eq -1
-        T
-          "Cant touch the file '%s': %s".printf
-            * path created.output
-        seq *
-          closed
-          ^
-    code. > closed
-      os.is-windows.if
-        win32 *1
-          "_close"
-          descriptor
-        posix *1
-          "close"
-          descriptor
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_creat"
-          path
-          win32.mode
-        posix *1
-          "creat"
-          path
-          posix.mode
-    created.code > descriptor
 
   eq. ++> tests-appending-data-to-file
     size.

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -1,0 +1,33 @@
+# Delete the `f` file from the filesystem.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > deleted
+  f.exists.if > @
+    if. > @
+      outcome.eq 0
+      ^
+      T
+        "Cant delete the file '%s': %s".printf
+          * f.path removed.output
+    ^
+  removed.code > outcome
+  called. > removed
+    os.is-windows.if
+      win32 *1
+        win
+        f.path
+      posix *1
+        unix
+        f.path
+  f.is-directory.if > unix
+    "rmdir"
+    "unlink"
+  f.is-directory.if > win
+    "_rmdir"
+    "_unlink"

--- a/eo-runtime/src/main/eo/file/moved.eo
+++ b/eo-runtime/src/main/eo/file/moved.eo
@@ -1,0 +1,27 @@
+# Move the `f` file to `target`, returning the new file.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f target] > moved
+  if. > @
+    outcome.eq 0
+    file target
+    T
+      "Cant move the file '%s' to '%s': %s".printf
+        * f.path target renamed.output
+  renamed.code > outcome
+  called. > renamed
+    os.is-windows.if
+      win32 *1
+        "rename"
+        f.path
+        target
+      posix *1
+        "rename"
+        f.path
+        target

--- a/eo-runtime/src/main/eo/file/size.eo
+++ b/eo-runtime/src/main/eo/file/size.eo
@@ -1,0 +1,22 @@
+# Return the size in bytes of the `f` file.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f cant-measure] > size
+  if. > @
+    info.code.eq 0
+    info.output.size
+    cant-measure
+  called. > info
+    os.is-windows.if
+      win32 *1
+        "_stat64"
+        f.path
+      posix *1
+        "stat"
+        f.path

--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -1,0 +1,39 @@
+# Touch the `f` file, creating it if it does not exist yet.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > touched
+  f.exists.if > @
+    ^
+    if. > @
+      descriptor.eq -1
+      T
+        "Cant touch the file '%s': %s".printf
+          * f.path created.output
+      seq *
+        closed
+        ^
+  code. > closed
+    os.is-windows.if
+      win32 *1
+        "_close"
+        descriptor
+      posix *1
+        "close"
+        descriptor
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_creat"
+        f.path
+        win32.mode
+      posix *1
+        "creat"
+        f.path
+        posix.mode
+  created.code > descriptor


### PR DESCRIPTION
## Summary

Extract four attributes that unnecessarily lengthen `file.eo` into their own `file/` package directory:

- `[f] > deleted` — file/deleted.eo
- `[f target] > moved` — file/moved.eo
- `[f cant-measure] > size` — file/size.eo
- `[f] > touched` — file/touched.eo

Each new file carries `+package file` and takes the file as its first argument, matching the established package dispatch pattern from #5501 and #5486.

## Root cause

file.eo (521 lines) bundled `deleted`, `moved`, `size`, `touched` inline, despite none of them depending on `open`, `exists`, or `is-directory` — the dependency runs one way only (the four read only `path`, `exists`, `is-directory`, `^`).

## Fix

- Add `file/deleted.eo`, `file/moved.eo`, `file/size.eo`, `file/touched.eo` with `+package file`
- Remove the four inline definitions from `file.eo` (the `++>`/`-->` tests stay in file.eo and resolve through package dispatch via the own-package-before-`@` probe from #5931)

## Verification

- Dependency check: `deleted`/`touched` occur only in their own definitions plus tests; `size` references are all local parameters or `buffer.size` on bytes.
- `directory.eo` inherits `moved`/`touched` through the decoratee `file`, so package dispatch resolves them via the decoratee's forma.
- File count: file.eo reduced 520→435 lines; four new package files added.

Closes #5969

[FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]