### PR TITLE
Fix #5952: keep applied reference's arguments when folding a based handle

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -76,7 +76,7 @@
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
     <xsl:choose>
-      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:vertical-const($target)) and not(eo:multi-referenced($target, $name) and eo:rebuilt($target))">
+      <xsl:when test="exists($target) and not(eo:void($target)) and not(eo:recursive($target, $name)) and not(eo:vertical-const($target)) and not(eo:multi-referenced($target, $name) and eo:rebuilt($target)) and not(eo:reapplied($target, $name))">
         <xsl:choose>
           <!--
           The reference is the base of an application — it carries its own
@@ -163,6 +163,24 @@
               </xsl:if>
               <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
               <xsl:apply-templates select="$target/node()"/>
+              <!--
+              The reference is the base of an application (`b 42 &gt; x` over a
+              based `a.plus &gt;&gt; b` handle), so it carries its own argument
+              children. Folding only the target's attributes and children —
+              emitting `a.plus` alone — silently drops those arguments and prints
+              `a.plus &gt; x` (#5952), the based flavour of the loss #5834 and
+              #5887 fixed for the abstract and named shapes. The reference's own
+              `o` children are appended after the target's so the `42` survives as
+              `a.plus 42 &gt; x`. Guarded to a target that carries no children of
+              its own: appending to an already-applied target (`a.plus 1 &gt;&gt;
+              b` used as `b 42`) would hand the inner application a second
+              argument rather than apply its result, so such a target has no
+              inline spelling here and is left standing above instead (see
+              `eo:reapplied`).
+              -->
+              <xsl:if test="not($target/o)">
+                <xsl:apply-templates select="o"/>
+              </xsl:if>
             </xsl:element>
           </xsl:otherwise>
         </xsl:choose>
@@ -183,8 +201,11 @@
   inlined, keep a const that only a vertical layout can spell,
   which is never inlined either (#5910), keep a formation applied through a
   `@pipe` continuation, which is kept in place above its pipe rather than
-  inlined (#5834), and keep a binding that a surviving method dispatch still
-  reaches through its name. Such a dispatch reference (`ξ.<name>.<seg>`) is not
+  inlined (#5834), keep a based application handle reached by a further
+  application (see `eo:reapplied`), which has no inline spelling as the head of
+  another application and is left standing rather than folded (#5952), and keep
+  a binding that a surviving method dispatch still reaches through its name.
+  Such a dispatch reference (`ξ.<name>.<seg>`) is not
   inlined above — its receiver is buried in a dotted base — so dropping the
   binding would strand the reference on a synthetic "vL_P" placeholder. Keeping
   it lets "merge-monikers" host the binding as the receiver of a reversed
@@ -194,7 +215,7 @@
   reads yet would silently vanish (#5914).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:reapplied(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -271,6 +292,25 @@
     <xsl:param name="name" as="xs:string"/>
     <xsl:variable name="next" select="$target/following-sibling::o[1]"/>
     <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, concat('.', $auto)) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
+  </xsl:function>
+  <!--
+  Whether the based `&gt;&gt; name` handle `$target` is itself an application
+  carrying its own argument children (`a.plus 1 &gt;&gt; b`) and is reached by a
+  reference that applies it further (`b 42`). The otherwise branch of the
+  inlining template folds a based handle by copying the target's own children
+  and then appending the reference's — which for a target that already carries
+  arguments would hand the inner application a second one rather than apply its
+  result. Such a target has no inline spelling as the head of another
+  application, so both the reference and the binding are left standing rather
+  than folded (#5952). Restricted to based handles: an abstract formation
+  becomes a `| args` pipe (see the two abstract branches above), and a bare or
+  argument-less based handle (`a.plus &gt;&gt; b`) carries no children of its
+  own, so appending the reference's arguments applies it cleanly.
+  -->
+  <xsl:function name="eo:reapplied" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="not(eo:abstract($target)) and not(eo:dataized-const($target)) and exists($target/o) and exists(eo:references($target, $name)[eo:resolved-name(@base) = $name and o])"/>
   </xsl:function>
   <!--
   The references in the binding's owner that reach the auto-name `$name`

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -131,6 +131,25 @@
     <xsl:sequence select="eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
   </xsl:function>
   <!--
+  Whether the based "&gt;&gt; name" handle "$target" is itself an application
+  carrying its own argument children (`a.plus 1 &gt;&gt; b`) and is reached by a
+  reference that applies it further (`b 42`). Such a target has no inline
+  spelling as the head of another application — folding it would hand the inner
+  application a second argument rather than apply its result — so "inline-cactoos"
+  leaves the binding standing (see its "eo:reapplied") rather than folding it.
+  The binding therefore reaches "to-eo-tree" and must keep its readable "@local"
+  handle: "merge-monikers" rewrites the surviving reference back to it
+  ("eo:kept-local-ref"), so it reads as `b 42` rather than a synthetic "vL_P"
+  placeholder (#5952). A const handle (`@const`) and the dataized-const shell
+  (`.as-bytes`) are excluded — they carry their name through a bare inline
+  already (#5828) — and an abstract formation, handled by "eo:applied-receiver".
+  -->
+  <xsl:function name="eo:reapplied" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="not(eo:abstract($target)) and not(exists($target/@const)) and not($target/@base = '.as-bytes') and exists($target/o) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and o and not(ancestor-or-self::o[. is $target])])"/>
+  </xsl:function>
+  <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,
   R-3.10.12) that is referenced more than once. "const-to-dataized" wraps such
   a const in a `.as-bytes` over `Φ.dataized` node carrying the obfuscated
@@ -180,13 +199,16 @@
   (an abstract formation, #5876, or a based handle, #5944) — kept whole by
   "inline-cactoos" and hosted by "merge-monikers" — on an
   unreferenced binding of any shape (#5914) — kept where it stands by
-  "inline-cactoos", having no use site to fold into — and on the value of a
+  "inline-cactoos", having no use site to fold into — on a based application
+  handle reached by a further application (see "eo:reapplied") — left standing
+  by "inline-cactoos", having no inline spelling as the head of another
+  application (#5952) — and on the value of a
   multi-referenced dataized-const handle (see
   "eo:const-handle") so "to-eo-tree" restores the readable "&gt;&gt; name"
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-applied-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-applied-handle.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) whose value is a plain application
+# (`a.plus >> b`), neither an abstract formation nor a const, folded into a
+# reference that applies it (`b 42 > x`). The handle contributes no name of its
+# own (#5810), so the fold copies the target's application and must also carry
+# over the reference's own argument children: dropping them prints `a.plus > x`
+# and silently loses the `42` (#5952), the based flavour of the loss #5834 and
+# #5887 fixed for the abstract and named shapes. The target itself carries no
+# argument of its own, so appending the reference's `42` applies it cleanly.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b 42 > x
+    a.plus >> b
+
+printed: |
+  [a] > foo
+    a.plus 42 > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-reapplied-handle-kept.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-reapplied-handle-kept.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) whose value is already an application
+# carrying its own argument (`a.plus 1 >> b`), reached by a reference that
+# applies it further (`b 42 > x`). Folding would copy the target's `a.plus 1`
+# and then append the reference's `42`, handing the inner `.plus` a second
+# argument rather than applying its result. Such a target has no inline spelling
+# as the head of another application, so both the reference and the binding are
+# left standing rather than folded (#5952, see `eo:reapplied`).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [a] > foo
+    b 42 > x
+    a.plus 1 >> b
+
+printed: |
+  [a] > foo
+    a.plus 1 >> b
+    b 42 > x


### PR DESCRIPTION
Closes #5952.

## Problem

The `otherwise` branch of `inline-cactoos.xsl` built the folded node from the target alone (`<xsl:apply-templates select="$target/node()"/>`), so a based `>> name` file-local handle (R-3.10.12) whose value is a plain reference or application — neither an abstract formation nor a const — dropped the arguments of the reference it was folded into.

`[a] > foo` with `b 42 > x` and `a.plus >> b` printed as `a.plus > x`: the `42` was gone. This is the based flavour of the same silent loss #5834 and #5887 fixed for the abstract and named shapes. The two abstract branches above the `otherwise` that preserve an applied reference's arguments both test `eo:abstract($target)` first, so a based target never reached them.

## Fix

- **`inline-cactoos.xsl`** — in the `otherwise` branch, emit the reference's own `o` children after the target's, so `a.plus >> b` used as `b 42 > x` folds to `a.plus 42 > x`. Guarded to a target that carries no children of its own: appending to an already-applied target (`a.plus 1 >> b` used as `b 42`) would hand the inner application a second argument rather than apply its result. Such a target has no inline spelling here (new `eo:reapplied` predicate) — the reference and the binding are left standing instead.
- **`restore-local-names.xsl`** — mirror `eo:reapplied` so the left-standing binding keeps its readable `@local` handle. `merge-monikers` then rewrites the surviving reference back to the name (`eo:kept-local-ref`), so it reads as `b 42` rather than a synthetic `vL_P` placeholder.

The `eo:reapplied` helper is duplicated across the two sheets, matching the existing convention for `eo:resolved-name`, `eo:references`, `eo:multi-referenced`, and the other shared predicates.

## Tests

Two new print-packs:

- `based-applied-handle.yaml` — the bug from the issue: `a.plus >> b` used as `b 42 > x` now folds to `a.plus 42 > x`.
- `based-reapplied-handle-kept.yaml` — the guarded case: `a.plus 1 >> b` used as `b 42 > x` is left standing as `a.plus 1 >> b` + `b 42 > x`.

Both round-trip through the reprint check. Full `eo-printer` suite green (290 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8GiLLcKKL8CW2r3F6jCH)_