### PR TITLE
Fix #5983: keep a single-use `&gt;&gt;` handle standing when applied in an argument slot

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -104,6 +104,29 @@
             </xsl:copy>
           </xsl:when>
           <!--
+          The same applied reference standing in a positional argument slot
+          (`@as` is `αN`) of an application, rather than in a body-binding
+          sibling slot (#5840) or a dispatch receiver (#5844). The relocation
+          branch below would emit the formation copy and the `| args` pipe as
+          two children in place of this reference, but an argument list has no
+          room for the relocated predecessor a pipe binds: the copy would become
+          a stray extra argument of the application and the pipe would keep this
+          reference's positional `@as`, which `to-eo-tree` spells as the
+          unparseable `|:N` (#5983). Leave the handle standing under its
+          `@local` name instead — copy the reference verbatim, keeping its
+          arguments, so it reads back as `bar 1 2` once the drop template below
+          keeps the binding and "merge-monikers" rewrites its cactus base to the
+          handle (`eo:kept-local-ref`), the kept-handle path of #5876 and #5944.
+          Restricted to a single-use formation reached through a positional
+          argument: the sibling and receiver relocations still fire for #5840
+          and #5844, whose references carry no positional `@as`.
+          -->
+          <xsl:when test="eo:arg-applied($target, $name) and (o or @name) and starts-with(@as, $eo:alpha)">
+            <xsl:copy>
+              <xsl:apply-templates select="node()|@*"/>
+            </xsl:copy>
+          </xsl:when>
+          <!--
           The same applied reference, but not standing as the formation's
           immediate following sibling, so the adjacent guard above misses it
           and the bare-reference `otherwise` would drop the argument and name
@@ -123,7 +146,8 @@
           following sibling at all), so the relocation moves it rather than
           duplicating it, the same relocation #5732 proposes for its sibling
           case. Restricted to a single-use formation: a multi-referenced one
-          cannot be folded into just one of its uses.
+          cannot be folded into just one of its uses. A positional-argument
+          reference is handled by the branch above (#5983), not here.
           -->
           <xsl:when test="eo:abstract($target) and (o or @name) and not(eo:multi-referenced($target, $name))">
             <xsl:for-each select="$target">
@@ -201,7 +225,10 @@
   inlined, keep a const that only a vertical layout can spell,
   which is never inlined either (#5910), keep a formation applied through a
   `@pipe` continuation, which is kept in place above its pipe rather than
-  inlined (#5834), keep a based application handle reached by a further
+  inlined (#5834), keep a single-use formation reached through a positional
+  argument (see `eo:arg-applied`), which is left standing rather than relocated
+  into an argument list where its pipe would print as `|:N` (#5983), keep a
+  based application handle reached by a further
   application (see `eo:reapplied`), which has no inline spelling as the head of
   another application and is left standing rather than folded (#5952), and keep
   a binding that a surviving method dispatch still reaches through its name.
@@ -215,7 +242,7 @@
   reads yet would silently vanish (#5914).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:reapplied(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:arg-applied(., @name) or eo:reapplied(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -292,6 +319,27 @@
     <xsl:param name="name" as="xs:string"/>
     <xsl:variable name="next" select="$target/following-sibling::o[1]"/>
     <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, concat('.', $auto)) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
+  </xsl:function>
+  <!--
+  Whether the single-use auto-named abstract formation `$target` is applied by a
+  reference that stands in a positional argument slot of an application — a
+  reference resolving to `$name`, carrying its own argument children or a
+  result-binding `@name`, whose own positional `@as` is `αN`. Unlike the sibling
+  (#5840) and receiver (#5844) relocations, an argument list has no spare slot
+  for the formation copy a `| args` pipe binds: relocating there would turn the
+  copy into a stray extra argument and leave the pipe carrying the reference's
+  `@as`, which `to-eo-tree` spells as the unparseable `|:N` (#5983). The
+  reference is therefore left standing (see the inlining template) and this
+  binding must be kept in place under its `@local` name rather than dropped, so
+  "merge-monikers" can rewrite the reference back to the handle
+  (`eo:kept-local-ref`, the kept-handle path of #5876 and #5944). A
+  multi-referenced formation is excluded — it is already kept whole by the outer
+  guard above — and references inside the formation itself are not counted.
+  -->
+  <xsl:function name="eo:arg-applied" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="eo:abstract($target) and not(eo:multi-referenced($target, $name)) and exists(eo:references($target, $name)[eo:resolved-name(@base) = $name and (o or @name) and starts-with(@as, $eo:alpha)])"/>
   </xsl:function>
   <!--
   Whether the based `&gt;&gt; name` handle `$target` is itself an application

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-applied-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-applied-argument.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-use file-local handle ("[a b] >> bar", R-3.10.12) whose abstract
+# formation is applied by a reference sitting in a positional argument slot
+# ("@as" is "α0") of another application ("x.plus (bar 1 2)"). The #5840/#5844
+# relocation must NOT fire here: an argument list has no spare slot for the
+# formation copy a "| args" pipe binds, so relocating there would turn the copy
+# into a stray second argument of "x.plus" and leave the pipe carrying the
+# reference's "@as", printed as the unparseable "|:0" (#5983). "inline-cactoos"
+# leaves the reference standing verbatim — keeping its "1 2" arguments and its
+# positional "@as", never a "@pipe" — and keeps the "[a b] >> bar" binding in
+# place under its "@local" name, so "merge-monikers" can later rewrite the
+# reference back to the handle (the kept-handle path of #5876 and #5944).
+# "mandatory-as" runs first so the argument carries the positional "@as" the
+# guard keys on, and "restore-local-names" keeps the handle's "@local" marker.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The single-use formation is kept in place under its "@local" handle, not
+  # relocated or dropped.
+  - /object/o[@name='foo']/o[@local='bar' and contains(@name, '🌵') and not(@base)]
+  # The applied reference stays where it is, still an argument (@as='α0') of
+  # "x.plus" and still carrying its own "1 2" arguments.
+  - /object/o[@name='foo']/o[@base='ξ.x.plus' and count(o)=1]/o[@as='α0' and contains(@base, '🌵') and count(o)=2]
+  # The reference was never turned into a "| args" pipe, so nothing prints as
+  # the unparseable "|:0".
+  - /object[count(//o[@pipe])=0]
+  # No second copy of the formation was minted inside the argument list.
+  - /object[count(//o[@local='bar' and contains(@name, '🌵')])=1]
+input: |
+  [x] > foo
+    x.plus (bar 1 2) > @
+    [a b] >> bar
+      a.plus b > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-argument.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> bar` handle (R-3.10.12) whose value is an
+# abstract formation and which is used as the base of an application, exactly as
+# "inline-cactoos-applied-handle", except that the applied reference
+# (`bar 1 2`) sits in a positional argument slot (`@as` is `α0`) of another
+# application (`x.plus (bar 1 2)`) rather than in a body-binding sibling slot
+# (#5840) or a dispatch receiver (#5844). The #5840/#5844 relocation used to
+# fire here too: it moved a copy of the formation to sit directly above the
+# reference and turned the reference into a `| args` pipe. But an argument list
+# has no spare slot for that predecessor — the copy became a stray second
+# argument of `x.plus` and the pipe kept the reference's positional `@as`, which
+# "to-eo-tree" spelled as the unparseable `|:0`; the settling pass then deleted
+# the whole handle from the file (#5983). The fix guards the relocation to
+# references that own a real sibling slot and leaves an argument-slot reference
+# standing under its `@local` name (the kept-handle path of #5876 and #5944):
+# "inline-cactoos" copies the reference verbatim and keeps the binding, and
+# "merge-monikers" rewrites the cactus base back to the handle, so it reads as
+# `bar 1 2` with the `[a b] >> bar` formation left in place.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    x.plus (bar 1 2) > @
+    [a b] >> bar
+      a.plus b > @
+
+printed: |
+  [x] > foo
+    x.plus > @
+      bar 1 2
+    a.plus b > [a b] >> bar


### PR DESCRIPTION
Fixes #5983.

## Problem

The #5840/#5844 relocation branch in `eo-printer/.../print/inline-cactoos.xsl` moved a single-use abstract `>>` formation to sit directly above its applied reference and turned that reference into a `| args` pipe — without checking that the reference owned a sibling slot able to hold the relocated formation.

When the reference sat in a **positional argument** (`@as` is `αN`) of an application, both the relocated copy and the pipe landed inside the argument list:

```eo
[x] > foo
  x.plus (bar 1 2) > @
  times. > [a b] >> bar
    a
    b
```

used to print back as the unparseable:

```eo
[x] > foo
  x.plus > @
    a.times b > [a b] >> bar
    |:0
      1
      2
```

The formation became a second argument of `x.plus`, and the pipe kept the reference's positional `@as`, which `to-eo-tree` spells as `|:0` (the parser rejects `a pipe | must be followed by a space before its arguments`). In real sources the damage was silent: the settling pass then deleted the whole handle object from the file, blocking #5678 for such helpers.

## Fix

Guard the relocation with a new `eo:arg-applied` predicate. A single-use abstract formation reached through a positional-argument reference is now **left standing under its `@local` name** (the kept-handle path of #5876 and #5944) instead of being relocated:

- `inline-cactoos` copies the reference verbatim (keeping its `1 2` arguments and never creating a `@pipe`);
- the drop template keeps the binding in place;
- `merge-monikers` rewrites the cactus base back to the handle (`eo:kept-local-ref`).

So it prints back as `bar 1 2` with the `[a b] >> bar` formation left in place. The sibling (#5840) and receiver (#5844) relocations still fire, since their references carry no positional `@as`.

## Tests

- `print-packs/yaml/inline-cactoos-applied-handle-argument.yaml` — full round-trip pack for the argument-slot shape (prints back correctly and reparses to itself).
- `eo-packs/print/inline-cactoos-applied-argument.yaml` — XMIR-level assertions that the binding is kept, the reference stays an argument carrying its own children, and no `@pipe` is ever produced.

All 293 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYmDgmdADUmHtnqckbvvm1)_