### PR TITLE
fix(#5977): extract directory.open to directory/ package

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -47,9 +47,6 @@
           "mkdir"
           ^.path
           posix.permissions
-  T > [mode scope] > open
-    "The file %s is a directory, can't open for I/O operations".printf
-      * file
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -138,10 +135,6 @@
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
-
-  mktemp.open --> on-opening-directory
-    "w"
-    true > [d]
 
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -1,0 +1,17 @@
+# Always fails: a directory cannot be opened for I/O.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir mode scope] > open
+  T > @
+    "The file %s is a directory, can't open for I/O operations".printf
+      * dir
+
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [d]


### PR DESCRIPTION
## Summary
- Add `directory/open.eo` with `+package directory` and `[dir mode scope] > open`
- Remove the nested `open` attribute and `on-opening-directory` from `directory.eo`
- Own-package-before-`@` (#5931) keeps `mktemp.open` on `directory/open`, not `file.open`

Part of #5977 (stacked: open → made → deleted).

## Test plan
- [ ] `mvn -pl eo-runtime test -Dtest=org.eolang.EOdirectoryTest,org.eolang.EO_directory.EOopenTest`
- [ ] Confirm `mktemp.open --> on-opening-directory` still fails with the directory message


Made with [Cursor](https://cursor.com)