### PR TITLE
fix(#5977): extract directory.made to directory/ package

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -25,28 +25,6 @@
         ^
       ^
   true > is-directory
-  [] > made
-    ^.exists.if > @
-      ^
-      seq *
-        made.
-          directory
-            Q.file ^.as-path.dirname
-        if.
-          created.code.eq 0
-          ^
-          T
-            "Cant make the directory '%s': %s".printf
-              * ^.path created.output
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_mkdir"
-          ^.path
-        posix *1
-          "mkdir"
-          ^.path
-          posix.permissions
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -66,11 +44,9 @@
           d.deleted.exists.not
         inner.exists.not
       f.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
     d.tmpfile > f
-    made. > inner
-      directory d.tmpfile.deleted
+    as-dir. (directory d.tmpfile.deleted).made.as-path > inner
 
   ++> tests-deletes-directory-with-files-recursively
     and. > @
@@ -80,20 +56,13 @@
           d.deleted.exists.not
         first.exists.not
       second.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
     d.tmpfile > first
     d.tmpfile > second
 
   ++> tests-deletes-empty-directory
     not. > @
       exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
-
-  ++> tests-makes-new-directory
-    d.exists.and d.is-directory > @
-    made. > d
-      as-dir.
-        mktemp.tmpfile.deleted.as-path.resolved "foo-new"
 
   ++> tests-walks-recursively
     seq * > @

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -47,9 +47,6 @@
           "mkdir"
           ^.path
           posix.permissions
-  T > [mode scope] > open
-    "The file %s is a directory, can't open for I/O operations".printf
-      * file
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -138,10 +135,6 @@
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
-
-  mktemp.open --> on-opening-directory
-    "w"
-    true > [d]
 
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -1,0 +1,37 @@
+# Creates the directory `dir`, making missing parent directories as needed.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir] > made
+  dir.exists.if > @
+    dir
+    seq *
+      made.
+        directory
+          file dir.as-path.dirname
+      if.
+        created.code.eq 0
+        dir
+        T
+          "Cant make the directory '%s': %s".printf
+            * dir.path created.output
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_mkdir"
+        dir.path
+      posix *1
+        "mkdir"
+        dir.path
+        posix.permissions
+
+  ++> tests-makes-new-directory
+    d.exists.and d.is-directory > @
+    made. > d
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-new"

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -1,0 +1,17 @@
+# Always fails: a directory cannot be opened for I/O.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir mode scope] > open
+  T > @
+    "The file %s is a directory, can't open for I/O operations".printf
+      * dir
+
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [d]


### PR DESCRIPTION
## Summary
- Add `directory/made.eo` with `+package directory` and `[dir] > made`
- Remove the nested `made` attribute and `tests-makes-new-directory` from `directory.eo`
- Update delete-test setup on `directory.eo` to `as-dir. (directory …).made.as-path` so package `made` binds a real directory receiver

**Depends on #5985** (stacked: open → **made** → deleted). Part of #5977.
Review the latest commit once #5985 is in; this branch is based on that PR.

## Test plan
- [x] `mvn -pl eo-runtime test -Dtest=org.eolang.EOdirectoryTest,org.eolang.EO_directory.EOmadeTest`
- [x] Confirm `tests-makes-new-directory` and remaining delete/walk tests that call `made` still pass
