### PR TITLE
fix(#5977): extract directory.deleted to directory/ package

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -12,18 +12,6 @@
 
 [file] > directory
   file > @
-  [] > deleted
-    ^.exists.if > @
-      seq *
-        if. > [tup] >> r
-          tup.length.eq 0
-          true
-          seq *
-            tup.head.deleted
-            r tup.tail
-        | (walk "**").at.^
-        ^
-      ^
   true > is-directory
   [] > tmpfile
     ^.exists.if > @
@@ -33,36 +21,6 @@
           * file
     [] > touch /Q.string
   [glob] > walk /Q.tuple
-
-  ++> tests-deletes-directory-with-file-and-dir
-    and. > @
-      and.
-        and.
-          and.
-            inner.is-directory.and inner.exists
-            f.exists
-          d.deleted.exists.not
-        inner.exists.not
-      f.exists.not
-    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
-    d.tmpfile > f
-    as-dir. (directory d.tmpfile.deleted).made.as-path > inner
-
-  ++> tests-deletes-directory-with-files-recursively
-    and. > @
-      and.
-        and.
-          first.exists.and second.exists
-          d.deleted.exists.not
-        first.exists.not
-      second.exists.not
-    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
-    d.tmpfile > first
-    d.tmpfile > second
-
-  ++> tests-deletes-empty-directory
-    not. > @
-      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
 
   ++> tests-walks-recursively
     seq * > @

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -25,28 +25,6 @@
         ^
       ^
   true > is-directory
-  [] > made
-    ^.exists.if > @
-      ^
-      seq *
-        made.
-          directory
-            Q.file ^.as-path.dirname
-        if.
-          created.code.eq 0
-          ^
-          T
-            "Cant make the directory '%s': %s".printf
-              * ^.path created.output
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_mkdir"
-          ^.path
-        posix *1
-          "mkdir"
-          ^.path
-          posix.permissions
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -66,11 +44,9 @@
           d.deleted.exists.not
         inner.exists.not
       f.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
     d.tmpfile > f
-    made. > inner
-      directory d.tmpfile.deleted
+    as-dir. (directory d.tmpfile.deleted).made.as-path > inner
 
   ++> tests-deletes-directory-with-files-recursively
     and. > @
@@ -80,20 +56,13 @@
           d.deleted.exists.not
         first.exists.not
       second.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
     d.tmpfile > first
     d.tmpfile > second
 
   ++> tests-deletes-empty-directory
     not. > @
       exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
-
-  ++> tests-makes-new-directory
-    d.exists.and d.is-directory > @
-    made. > d
-      as-dir.
-        mktemp.tmpfile.deleted.as-path.resolved "foo-new"
 
   ++> tests-walks-recursively
     seq * > @

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -47,9 +47,6 @@
           "mkdir"
           ^.path
           posix.permissions
-  T > [mode scope] > open
-    "The file %s is a directory, can't open for I/O operations".printf
-      * file
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -138,10 +135,6 @@
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
-
-  mktemp.open --> on-opening-directory
-    "w"
-    true > [d]
 
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -1,0 +1,51 @@
+# Recursively deletes the directory `dir` and all of its contents.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir] > deleted
+  dir.exists.if > @
+    seq *
+      if. > [tup] >> r
+        tup.length.eq 0
+        true
+        seq *
+          tup.head.deleted
+          r tup.tail
+      | (dir.walk "**").at.^
+      dir
+    dir
+
+  ++> tests-deletes-directory-with-file-and-dir
+    and. > @
+      and.
+        and.
+          and.
+            inner.is-directory.and inner.exists
+            f.exists
+          d.deleted.exists.not
+        inner.exists.not
+      f.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
+    d.tmpfile > f
+    as-dir. (directory d.tmpfile.deleted).made.as-path > inner
+
+  ++> tests-deletes-directory-with-files-recursively
+    and. > @
+      and.
+        and.
+          first.exists.and second.exists
+          d.deleted.exists.not
+        first.exists.not
+      second.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > d
+    d.tmpfile > first
+    d.tmpfile > second
+
+  ++> tests-deletes-empty-directory
+    not. > @
+      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -1,0 +1,37 @@
+# Creates the directory `dir`, making missing parent directories as needed.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir] > made
+  dir.exists.if > @
+    dir
+    seq *
+      made.
+        directory
+          file dir.as-path.dirname
+      if.
+        created.code.eq 0
+        dir
+        T
+          "Cant make the directory '%s': %s".printf
+            * dir.path created.output
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_mkdir"
+        dir.path
+      posix *1
+        "mkdir"
+        dir.path
+        posix.permissions
+
+  ++> tests-makes-new-directory
+    d.exists.and d.is-directory > @
+    made. > d
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-new"

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -1,0 +1,17 @@
+# Always fails: a directory cannot be opened for I/O.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[dir mode scope] > open
+  T > @
+    "The file %s is a directory, can't open for I/O operations".printf
+      * dir
+
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [d]


### PR DESCRIPTION
## Summary
- Add `directory/deleted.eo` with `+package directory` and `[dir] > deleted`
- Remove the nested `deleted` attribute and its three `++>` tests from `directory.eo`
- Own-package-before-`@` (#5931) keeps recursive directory delete ahead of `file.deleted`

**Depends on #5986** (stacked: open → made → **deleted**). Closes #5977 once the stack lands.

## Test plan
- [x] `mvn -pl eo-runtime test -Dtest=org.eolang.EOdirectoryTest,org.eolang.EO_directory.EOdeletedTest`
- [x] Confirm recursive delete tests and walk tests still pass
