### PR TITLE
fix(#5981): return fallback for fractional index in string.at [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -24,9 +24,11 @@
       gte.
         number index
         text.length >> len!
+      not.
+        index.floor.eq index
     fallback
-      "Given index %d is out of text bounds".printf
-        * index
+      "Given index %f is out of text bounds".printf
+        * i
     slice
       text
       index
@@ -56,6 +58,13 @@
       "some"
       10
       "recovered" > [message]
+
+  eq. ++> tests-fractional-index-returns-fallback
+    "fallback"
+    at
+      "some"
+      1.5
+      "fallback" > [message]
 
   at --> on-text-at-index-more-than-length
     "some"


### PR DESCRIPTION
Closes objectionary/eo#5981

## Problem
`string.at` crashes with a leaked `org.eolang.ExFailure` when the index is a non-integer (e.g. `1.5`) that is still within bounds, instead of returning the documented `fallback`. The two guards only rejected `index < 0` and `index >= length`; a fractional in-range index fell through to `slice` which cannot land on a fractional character offset.

## Fix
- Add `not. index.floor.eq index` to the guard `or.` so a fractional index takes the fallback branch (smallest change per the issue's suggested fix).
- Report the caller's original `i` in the out-of-bounds message instead of the resolved `index`, and use `%f` since the reported value can now be fractional.

## Test
- Added `tests-fractional-index-returns-fallback` verifying `at "some" 1.5 "fallback"` returns the provided fallback rather than throwing.

## Verification
- Structural analysis (EO source): the new guard correctly routes any non-integer index to the fallback branch before `slice`.
- `%f` formatting is validated in eolang's `string/printf.eo`.