### PR TITLE
fix(#5980): normalize abs(-0.0) to +0.0 [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -10,7 +10,7 @@
 [num] > abs
   if. > @
     value.gte 0
-    value
+    0.plus value
     value.neg
   number num.as-bytes > value
 
@@ -33,3 +33,7 @@
   eq. ++> tests-abs-zero
     abs 0
     0
+
+  eq. ++> tests-abs-negative-zero-returns-positive-zero
+    abs -0.0
+    0.0


### PR DESCRIPTION
Closes objectionary/eo#5980

## Problem
`number.abs -0.0` returns `-0.0` instead of `+0.0`. Since `-0.0 gte 0` is true, the `then` branch returns the value unchanged, preserving the sign bit.

## Fix
Return `0.plus value` instead of bare `value` on the non-negative branch. Per IEEE 754 addition rules, `0.0 + (-0.0) = +0.0`, so the sign is correctly cleared while strictly-positive and zero inputs remain unchanged.

## Test
- Added `tests-abs-negative-zero-returns-positive-zero` verifying `abs -0.0 == 0.0`.