### PR TITLE
fix(#5975): format numeric fallback params with %f instead of %s [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -18,7 +18,7 @@
       not.
         places.floor.eq places
     cant-print
-      "Can't write a fixed-point decimal with %s fraction places".printf
+      "Can't write a fixed-point decimal with %f fraction places".printf
         * places
     if.
       n.lt 0
@@ -153,3 +153,10 @@
   as-fixed --> on-negative-places-without-fallback
     3.14159
     -2
+
+  eq. ++> tests-as-fixed-non-integer-places-message-formats-number
+    "recovered"
+    as-fixed
+      3.14159
+      2.5
+      "recovered" > [message]

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -17,7 +17,7 @@
       not.
         times.floor.eq times
     cant-repeat
-      "Can't repeat text %s times".printf
+      "Can't repeat text %f times".printf
         * times
     string
       if. >> result!
@@ -64,3 +64,10 @@
   repeated --> on-text-repeating-less-than-zero-times
     ""
     -1
+
+  eq. ++> tests-repeat-non-integer-times-message-formats-number
+    "recovered"
+    repeated
+      "some"
+      1.5
+      "recovered" > [message]


### PR DESCRIPTION
Closes objectionary/eo#5975

## Problem
Fallback error messages in `string.repeated` and `string.as-fixed` format a numeric value with `%s`, so the raw 8 bytes of the double are reinterpreted as UTF-8 — producing garbled output.

## Fix
Switch the conversion specifier from `%s` to `%f` in both messages.

## Test
- `string/repeated.eo`: `tests-repeat-non-integer-times-message-formats-number`
- `string/as-fixed.eo`: `tests-as-fixed-non-integer-places-message-formats-number`