### PR TITLE
fix(#5977): extract made, deleted and open to directory/ package

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -12,44 +12,7 @@
 
 [file] > directory
   file > @
-  [] > deleted
-    ^.exists.if > @
-      seq *
-        if. > [tup] >> r
-          tup.length.eq 0
-          true
-          seq *
-            tup.head.deleted
-            r tup.tail
-        | (walk "**").at.^
-        ^
-      ^
   true > is-directory
-  [] > made
-    ^.exists.if > @
-      ^
-      seq *
-        made.
-          directory
-            Q.file ^.as-path.dirname
-        if.
-          created.code.eq 0
-          ^
-          T
-            "Cant make the directory '%s': %s".printf
-              * ^.path created.output
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_mkdir"
-          ^.path
-        posix *1
-          "mkdir"
-          ^.path
-          posix.permissions
-  T > [mode scope] > open
-    "The file %s is a directory, can't open for I/O operations".printf
-      * file
   [] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -58,45 +21,6 @@
           * file
     [] > touch /Q.string
   [glob] > walk /Q.tuple
-
-  ++> tests-deletes-directory-with-file-and-dir
-    and. > @
-      and.
-        and.
-          and.
-            inner.is-directory.and inner.exists
-            f.exists
-          d.deleted.exists.not
-        inner.exists.not
-      f.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
-    d.tmpfile > f
-    made. > inner
-      directory d.tmpfile.deleted
-
-  ++> tests-deletes-directory-with-files-recursively
-    and. > @
-      and.
-        and.
-          first.exists.and second.exists
-          d.deleted.exists.not
-        first.exists.not
-      second.exists.not
-    made. > d
-      directory mktemp.tmpfile.deleted
-    d.tmpfile > first
-    d.tmpfile > second
-
-  ++> tests-deletes-empty-directory
-    not. > @
-      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
-
-  ++> tests-makes-new-directory
-    d.exists.and d.is-directory > @
-    made. > d
-      as-dir.
-        mktemp.tmpfile.deleted.as-path.resolved "foo-new"
 
   ++> tests-walks-recursively
     seq * > @
@@ -138,10 +62,6 @@
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
-
-  mktemp.open --> on-opening-directory
-    "w"
-    true > [d]
 
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -1,0 +1,51 @@
+# Recursively deletes the directory `d` and all of its contents.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d] > deleted
+  d.exists.if > @
+    seq *
+      if. > [tup] >> r
+        tup.length.eq 0
+        true
+        seq *
+          tup.head.deleted
+          r tup.tail
+      | (d.walk "**").at.^
+      d
+    d
+
+  ++> tests-deletes-directory-with-file-and-dir
+    and. > @
+      and.
+        and.
+          and.
+            inner.is-directory.and inner.exists
+            f.exists
+          dir.deleted.exists.not
+        inner.exists.not
+      f.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    dir.tmpfile > f
+    as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
+
+  ++> tests-deletes-directory-with-files-recursively
+    and. > @
+      and.
+        and.
+          first.exists.and second.exists
+          dir.deleted.exists.not
+        first.exists.not
+      second.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    dir.tmpfile > first
+    dir.tmpfile > second
+
+  ++> tests-deletes-empty-directory
+    not. > @
+      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -1,0 +1,37 @@
+# Creates the directory `d`, making missing parent directories as needed.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d] > made
+  d.exists.if > @
+    d
+    seq *
+      made.
+        directory
+          file d.as-path.dirname
+      if.
+        created.code.eq 0
+        d
+        T
+          "Cant make the directory '%s': %s".printf
+            * d.path created.output
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_mkdir"
+        d.path
+      posix *1
+        "mkdir"
+        d.path
+        posix.permissions
+
+  ++> tests-makes-new-directory
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-new"

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -1,0 +1,17 @@
+# Always fails: a directory cannot be opened for I/O.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d mode scope] > open
+  T > @
+    "The file %s is a directory, can't open for I/O operations".printf
+      * d
+
+  mktemp.open --> on-opening-directory
+    "w"
+    true > [x]


### PR DESCRIPTION
## Summary
- Add `directory/made.eo`, `directory/deleted.eo`, and `directory/open.eo` with `+package directory` (`[d] > made`, `[d] > deleted`, `[d mode scope] > open`)
- Strip those nested attributes from `directory.eo`; keep `file > @`, `is-directory`, `tmpfile`, and `walk`
- Move subject `++>` / `-->` tests with each attribute; leave walk tests on `directory.eo`
- Own-package-before-`@` (#5931) keeps `directory.deleted` / `directory.open` ahead of the `file` decoratee, including transitively via `mktemp`

Closes #5977.

## Test plan
- [x] `mvn -pl eo-runtime test-compile surefire:test -Dtest=org.eolang.EOdirectoryTest,org.eolang.EO_directory.EOdeletedTest,org.eolang.EO_directory.EOmadeTest,org.eolang.EO_directory.EOopenTest` — 8 tests, 0 failures
- [ ] CI `mvn` / `integration` on this PR
- [ ] Spot-check `mktemp.open --> on-opening-directory` and recursive delete paths


Made with [Cursor](https://cursor.com)