### PR TITLE
Keep local handle referenced only from a nested formation scope (#5995)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -108,6 +108,27 @@
     <xsl:sequence select="empty(eo:references($target, $name))"/>
   </xsl:function>
   <!--
+  Whether the auto-name "$name" is reached only from nested formation scopes: it
+  is referenced (so not the "eo:unreferenced" case) yet no reference sits in the
+  binding's own owner scope, every one climbing out of a formation nested inside
+  it. A reference written in the owner's own body has that owner as its nearest
+  formation ancestor; one inside a nested "&gt;&gt;" body has the nested formation
+  instead, so it is excluded. Neither later pass folds such a reference:
+  "inline-cactoos" computes an inline target straight off the base, so a nested
+  method dispatch ("ξ.ρ.&lt;name&gt;.&lt;seg&gt;") resolves to
+  "&lt;name&gt;.&lt;seg&gt;" and finds no target, and "merge-monikers" only hosts
+  a reference whose nearest formation ancestor is the binding's own owner. The
+  binding therefore reaches "to-eo-tree" and its "@local" is kept here (below), so
+  "merge-monikers" rewrites the surviving reference back to the readable handle
+  ("eo:kept-local-ref") — exactly as the multi-referenced spelling of the same
+  shape is — rather than strand it on a synthetic "vL_P" placeholder (#5995).
+  -->
+  <xsl:function name="eo:nested-referenced" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="exists(eo:references($target, $name)) and empty(eo:references($target, $name)[ancestor::o[eo:abstract(.)][1] is $target/..])"/>
+  </xsl:function>
+  <!--
   Whether the auto-named abstract formation "$target" is applied by a reference
   that stands as a dispatch receiver rather than a following sibling. Such a
   reference resolves to "$name", carries its own argument children or a
@@ -199,7 +220,11 @@
   (an abstract formation, #5876, or a based handle, #5944) — kept whole by
   "inline-cactoos" and hosted by "merge-monikers" — on an
   unreferenced binding of any shape (#5914) — kept where it stands by
-  "inline-cactoos", having no use site to fold into — on a based application
+  "inline-cactoos", having no use site to fold into — on a binding reached only
+  from nested formation scopes (see "eo:nested-referenced") — kept whole by
+  "inline-cactoos" (a nested method dispatch is never folded) and hosted by
+  "merge-monikers" onto no reference in its own scope, so every reference reads
+  the handle by name (#5995) — on a based application
   handle reached by a further application (see "eo:reapplied") — left standing
   by "inline-cactoos", having no inline spelling as the head of another
   application (#5952) — and on the value of a
@@ -208,7 +233,7 @@
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:nested-referenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-nested-referenced-local-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-nested-referenced-local-name.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle ("num.times num >> squared", R-3.10.12) whose only
+# reference is a method dispatch from a nested formation scope
+# ("squared.div depth" inside "[depth] >> factor"). The reference climbs to the
+# handle as "ξ.ρ.<name>.div", which "eo:references" strips to the same auto-name,
+# so it is counted as a single use — but no reference sits in the handle's own
+# owner scope. Neither later pass can fold such a reference: "inline-cactoos"
+# computes its inline target straight off the base, so the dispatch resolves to
+# "<name>.div" and finds no target, and "merge-monikers" only hosts a reference
+# whose nearest formation ancestor is the binding's own owner. The "@local"
+# marker is therefore kept here (#5995) so the surviving binding still prints its
+# readable ">> squared" handle and "merge-monikers" rewrites the dispatch back to
+# it, rather than leaving an anonymous ">>" and a dangling "vL_P" reference. As
+# with the multi-referenced based handle (#5944), the cactus "@name" is NOT
+# promoted and the reference is NOT rewritten here — that is "merge-monikers"'
+# job, once it knows which reference (if any) hosts the binding.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The nested-only-referenced based handle keeps its "@local" marker, and its
+  # cactus "@name" is left obfuscated (not promoted to the handle).
+  - /object/o[@name='foo']/o[@local='squared' and contains(@name, '🌵') and @base='ξ.num.times']
+  # The nested dispatch reference stays cactus-based: rewriting it is left to
+  # "merge-monikers".
+  - /object/o[@name='foo']/o[@name='factor']//o[contains(@base, '🌵') and ends-with(@base, '.div')]
+  # No reference was rewritten to a readable "squared" base.
+  - /object[not(.//o[contains(@base, 'squared')])]
+input: |
+  [num] > foo
+    [depth] > factor
+      squared.div depth > @
+    num.times num >> squared

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-nested-only-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-nested-only-referenced-handle.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle ("num.times num >> squared", R-3.10.12) whose only
+# reference is a method dispatch written inside a nested "[depth] >> factor"
+# formation ("squared.div depth"). The reference climbs to the handle as
+# "ξ.ρ.<name>.div", which resolves to the same auto-name, so it counts as a
+# single use — yet no reference sits in the handle's own owner scope. Neither
+# later pass folds it: "inline-cactoos" computes the inline target straight off
+# the base, so "<name>.div" finds no target, and "merge-monikers" only hosts a
+# reference whose nearest formation ancestor is the binding's own owner. What
+# broke was the printer dropping the "@local" handle here, leaving an anonymous
+# "num.times num >>" and a dangling "v4_2.div" that reparses to a nonexistent
+# global object (#5995). The handle is now kept and the dispatch reads back
+# through its readable name, exactly as the multi-referenced spelling of the same
+# shape does (#5944).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [num] > foo
+    [depth] > factor
+      squared.div depth > @
+    num.times num >> squared
+
+printed: |
+  [num] > foo
+    num.times num >> squared
+    squared.div depth > [depth] > factor


### PR DESCRIPTION
Fixes #5995.

## Problem

When a private `>>` handle is referenced exactly once and that single reference is a **method dispatch from a nested formation scope**, `eo-printer` dropped the handle's readable name, leaving an anonymous `>>` binding and a dangling `vL_P` reference that reparses to a nonexistent global object:

```eo
[num] > foo
  [depth] > factor
    squared.div depth > @
  num.times num >> squared
```

printed back (before the fix) as:

```eo
[num] > foo
  num.times num >>
  v4_2.div depth > [depth] > factor
```

The output is stable and parseable, so `eo:format`/`eo:compile` accept it, but `v4_2` resolves to a nonexistent `Φ.foo.v4_2` and the handle is anonymous — silently breaking code at runtime rather than at build time (e.g. privatizing `reduced.times reduced` in `number/sine.eo`).

## Root cause

Three passes disagreed about who folds such a reference:
- `restore-local-names.xsl` dropped the `@local` handle because `eo:unreferenced` saw the nested reference and assumed `inline-cactoos` would fold it.
- `inline-cactoos.xsl` computes the inline target straight off the base, so a dispatch reference (`ξ.ρ.<name>.<seg>`) resolves to `<name>.<seg>` and finds no target — the reference is left untouched.
- `merge-monikers.xsl` refuses to host, since it only accepts references whose nearest formation ancestor is the binding's own owner.

Nothing rewrote the reference, and its readable name was already gone.

## Fix

Add an `eo:nested-referenced` keep guard to the drop template in `restore-local-names.xsl`: keep `@local` when the handle **is** referenced but **no** reference sits in its own owner scope — the case neither later pass can fold. The binding then reaches `to-eo-tree` with its handle intact, and `merge-monikers` rewrites the surviving reference back to it (`eo:kept-local-ref`), exactly as the multi-referenced spelling of the same shape (#5944) already does:

```eo
[num] > foo
  num.times num >> squared
  squared.div depth > [depth] > factor
```

## Tests

- `print-packs/yaml/based-nested-only-referenced-handle.yaml` — full round-trip pack (origin → printed, verified to reprint to itself).
- `eo-packs/print/restore-nested-referenced-local-name.yaml` — sheet-level pack asserting `restore-local-names` keeps `@local` and leaves the cactus name/reference for `merge-monikers`.

All 298 `eo-printer` tests pass (259 `XmirTest`, including both new packs and the round-trip stability check).

---
_Generated by [Claude Code](https://claude.ai/code/session_013eVCgzXxWYQJiEmWQbeubb)_