### PR TITLE
Fold bare-referenced non-const handle into a moniker (#5996)

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -113,9 +113,13 @@
   an equal count, so the shortest, least-nested moniker wins and a multi-segment
   chain hosts only when no shorter reference can (#5970) — the previously
   stranded tail #5782 left expanded. A named handle (see `eo:named-handle`)
-  inverts the bare rule: a bare host inlines it anonymously (#5810), which drops
-  the very name its other references read back through, so only a dispatch may
-  host it and a handle reached by bare references alone stays standing (#5956).
+  reorders the two spellings: a dispatch host is listed first and a bare host
+  last, the reverse of the default. A bare host once dropped the readable name
+  its other references read back through (#5810), so it was skipped entirely and
+  a handle reached by bare references alone stayed standing (#5956); the
+  merge template now keeps that name at a bare site too (see `eo:named-handle`
+  in the keep-list), so the bare reference hosts when no dispatch does (#5996),
+  and the readable `&gt;&gt; name` still travels to whichever use site wins.
   -->
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
@@ -126,7 +130,7 @@
         <xsl:sort select="count(tokenize(eo:dispatch-seg(.), '\.'))" data-type="number" order="ascending"/>
       </xsl:perform-sort>
     </xsl:variable>
-    <xsl:sequence select="if (eo:named-handle($attr)) then $dispatch else ($refs[eo:dispatch-seg(.) = ''], $dispatch)"/>
+    <xsl:sequence select="if (eo:named-handle($attr)) then ($dispatch, $refs[eo:dispatch-seg(.) = '']) else ($refs[eo:dispatch-seg(.) = ''], $dispatch)"/>
   </xsl:function>
   <!--
   Whether `$attr` is a based `>> name` handle whose readable name must outlive
@@ -283,13 +287,16 @@
   abstract formation keeps its obfuscated `@name`, which `to-eo-tree` renders
   as the anonymous `[...] >>` marker; a based binding — a `>> name` handle
   whose value is a plain reference such as `a >> b` (R-3.10.12) — drops its
-  `@name` (and the `@local` handle it leaves behind), since the bare reference
-  is unnamed and carrying the obfuscated name over would turn the inline into
-  a spurious named node that `to-eo-tree` prints as its own `a >>` line
-  instead of an anonymous argument (#5810). A const based handle
-  (`a >> b!`, see `eo:const-handle`) is the exception: it keeps its `@name` and
+  `@name` (and the `@local` handle it leaves behind) at a single-reference site,
+  since the bare reference is unnamed and carrying the obfuscated name over would
+  turn the inline into a spurious named node that `to-eo-tree` prints as its own
+  `a >>` line instead of an anonymous argument (#5810). A const based handle
+  (`a >> b!`, see `eo:const-handle`) keeps its `@name` and
   `@local`, so `to-eo-tree` prints the readable `a >> b!` and its other
-  references read back as the bare handle `b` (#5828). A dispatch chain
+  references read back as the bare handle `b` (#5828); a named handle
+  (see `eo:named-handle`) reached by bare references alone does the same, keeping
+  its `@name` and `@local` so the readable `a >> b` travels to the bare use it
+  hosts onto while the remaining bare references still read it back (#5996). A dispatch chain
   `ξ.<name>.<seg1>.<seg2>…` becomes a reversed dispatch, one level per segment
   (see `eo:wrap-dispatch`): the innermost hosts the inlined binding, the
   outermost carries the reference's own children as arguments (#5782, #5970).
@@ -315,7 +322,7 @@
         </xsl:variable>
         <xsl:element name="o">
           <xsl:apply-templates select="@as"/>
-          <xsl:copy-of select="$merged/@*[eo:abstract($merged) or eo:const-handle($merged) or (name() != 'name' and name() != 'local')]"/>
+          <xsl:copy-of select="$merged/@*[eo:abstract($merged) or eo:const-handle($merged) or eo:named-handle($merged) or (name() != 'name' and name() != 'local')]"/>
           <xsl:copy-of select="$merged/node()"/>
         </xsl:element>
       </xsl:when>

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-bare-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-bare-handle.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle (`x.as-bytes >> zero`, R-3.10.12) whose value is a
+# plain application and whose references are all bare, with no dispatch among
+# them. Such a handle used to stay standing as its own binding line because the
+# only host allowed for a named handle was a dispatch reference (#5956), so a
+# handle reached by bare references alone had nothing to fold onto and the
+# printer emitted the longer of two spellings of one graph (#5996). It now folds
+# onto the first bare reference, exactly as a const handle already did (#5828):
+# the bare host keeps the handle's `@name` and readable `@local`, so `to-eo-tree`
+# prints the merged binding as `x.as-bytes >> zero` and the remaining bare `zero`
+# reads back through that handle. A dispatch reference, when one exists, still
+# wins over a bare one (see `merge-monikers.yaml`); here none does.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+  - /org/eolang/printer/print/merge-monikers.xsl
+asserts:
+  # The obfuscated (cactus-named) binding is no longer a direct attribute of
+  # the formation: it has been merged onto its first bare reference.
+  - /object/o[@name='foo' and not(o[starts-with(@name, 'a🌵')])]
+  # It now lives at the first `x.eq zero` site, as the `eq` argument, keeping the
+  # binding's obfuscated `@name` and its readable `@local` handle so it prints as
+  # `x.as-bytes >> zero`.
+  - /object/o[@name='foo']//o[@base='ξ.x.eq']/o[starts-with(@name, 'a🌵') and @local='zero' and @base='ξ.x.as-bytes']
+  # The other bare use reads back through that handle rather than a copy of the
+  # binding or a synthetic cactus id.
+  - /object/o[@name='foo']//o[@base='ξ.zero' and not(@name)]
+  # No cactus reference is left dangling.
+  - /object[count(//o[starts-with(@base, 'ξ.a🌵')])=0]
+input: |
+  +package number
+
+  [x] > foo
+    and. > @
+      x.eq zero
+      x.eq zero
+    x.as-bytes >> zero

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-bare-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-bare-referenced-handle.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A file-local `>> name` handle (R-3.10.12) whose value is a plain application
+# and whose references are all bare, with no dispatch among them. Such a handle
+# used to stay standing on its own binding line, printing the longer of two
+# spellings of one graph (#5996), because the only host allowed for a named
+# handle was a dispatch reference (#5956). It now folds onto the first bare
+# reference, exactly as a const handle already did (#5828): the bare host keeps
+# the handle's readable name, so `to-eo-tree` prints the merged binding as
+# `0.as-bytes >> zero` and the second bare `zero` reads back through it. This is
+# the non-const twin of the const `>> zero!`, which already folded.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    and. > @
+      x.eq zero
+      x.eq zero
+    0.as-bytes >> zero
+
+printed: |
+  [x] > foo
+    and. > @
+      x.eq
+        0.as-bytes >> zero
+      x.eq zero

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -20,16 +20,16 @@
     or.
       and.
         or.
-          xbts.eq pzero
-          xbts.eq nzero
+          xbts.eq
+            0.as-bytes >> pzero
+          xbts.eq
+            -0.as-bytes >> nzero
         or.
           eq.
             n.as-bytes >> b!
             pzero
           b.eq nzero
       b.eq xbts
-  -0.as-bytes >> nzero
-  0.as-bytes >> pzero
 
   42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
 

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -16,7 +16,8 @@
       times.
         floor.
           plus.
-            arg.div tau
+            arg.div
+              pi.times 2 >> tau
             0.5
         tau
     if. > [depth] >> factor
@@ -34,7 +35,6 @@
             depth.plus 1
     | 1
   number num.as-bytes > arg
-  pi.times 2 >> tau
   reduced.times reduced > squared
 
   lt. ++> tests-sine-is-odd-function

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -12,7 +12,7 @@
 
 [text target replacement] > replaced
   matched.exists.not.if > @
-    reinit
+    string text! >> reinit
     block.exists.if > [block accum start] >> rec-replaced
       rec-replaced
         block.next
@@ -34,7 +34,6 @@
       start.
         next. >> matched
           target.match reinit
-  string text! >> reinit
 
   eq. ++> tests-does-not-replaces-if-regex-not-found
     replaced


### PR DESCRIPTION
Fixes #5996.

## Problem

A file-local `>> name` handle whose value is a plain application and whose references are all bare never became a moniker: it stayed standing as its own binding line, while the otherwise-identical const twin `>> name!` folds onto its first reference. The only difference between the two shapes was the `!`.

In `number/eq.eo:31-32`, `-0.as-bytes >> nzero` and `0.as-bytes >> pzero` sat at the bottom of the formation even though each is read only by bare references. `number/sine.eo:37`'s `pi.times 2 >> tau` is a third instance. The printer emitted the longer of two spellings of one graph, leaving the binding far from the uses that read it.

`eo:moniker-refs` returned only the *dispatch* references when the binding is an `eo:named-handle`, so a handle reached by bare references alone had nothing to host onto. That anonymity was never a property of the bare reference itself — it came from the attribute filter in the bare-host branch, which already keeps `@name`/`@local` for a const handle (#5828) and an abstract formation, discarding them only for a based one (#5810).

## Fix

Two small changes to `merge-monikers.xsl`, both as prescribed in the issue:

1. In `eo:moniker-refs`, append the bare references *after* the dispatch ones for a named handle (`then ($dispatch, $refs[eo:dispatch-seg(.) = ''])`) rather than discarding them — so a dispatch reference still wins when one exists and a bare reference hosts only when none does.
2. Add `eo:named-handle($merged)` to the bare-host keep-list, so the readable `>> name` travels to the use site exactly as a const handle's does.

The single-reference case of #5810 is unaffected: it reaches the bare-host branch with `@local` already dropped by `restore-local-names`, so it is not a named handle and keeps inlining anonymously.

## Reformatted runtime sources

Because the canonical printed form of these handles changed, three runtime sources that carried a bare-only handle are no longer in canonical form and `MjFormat` (the `format` goal) rejects them. Reformatted them via `-Deo.autoFix` to the now-canonical folded spelling — this is the concrete manifestation of the fix on real code:

- `number/eq.eo` — `nzero`/`pzero`
- `number/sine.eo` — `tau`
- `string/replaced.eo` — `reinit`

The moniker and the expanded spelling parse to the same object graph, so runtime behavior is unchanged.

## Tests

- Added `merge-monikers-bare-handle.yaml` (XSL-transform pack): a based non-const handle reached only by bare references now folds onto the first bare reference (keeping `@name`/`@local`) while the remaining bare use reads back through the handle.
- Added `based-bare-referenced-handle.yaml` (end-to-end `print-packs` pack): covers the fold from origin EO to printed EO.
- The existing `merge-monikers.yaml` (a handle with both a dispatch and a bare reference) still passes: the dispatch continues to win.
- Full `eo-printer` suite green (260 `XmirTest` cases, 0 failures); `eo-runtime` `format` goal passes with the reformatted sources.