### PR TITLE
fix(#5974): preserve sign of -0.0 base for odd integer exponents in number.power [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -29,8 +29,22 @@
                 0
               if.
                 expo.gt 0
-                0
-                pinf
+                if.
+                  and.
+                    eq.
+                      base.as-bytes
+                      80-00-00-00-00-00-00-00
+                    expo.is-integer.and (expo.div 2).is-integer.not
+                  0.neg
+                  0
+                if.
+                  and.
+                    eq.
+                      base.as-bytes
+                      80-00-00-00-00-00-00-00
+                    expo.is-integer.and (expo.div 2).is-integer.not
+                  ninf
+                  pinf
               expo.is-integer.if
                 if.
                   expo.lt 0


### PR DESCRIPTION
## What

`number.power` returns the wrong sign when the base is negative zero (`-0.0`) and the exponent is an odd integer. The docstring says *"Zeros, infinities and nan follow the same IEEE rules that `Math.pow` obeys"*, but it disagrees with `Math.pow` on the sign of zero.

| call | EO `power` | `Math.pow` |
|---|---|---|
| `power -0.0 -1` | `+Infinity` | `-Infinity` |
| `power -0.0 -3` | `+Infinity` | `-Infinity` |
| `power -0.0 1`  | `+0.0` | `-0.0` |
| `power -0.0 3`  | `+0.0` | `-0.0` |

## Root cause

In the `base.eq 0` branch, `-0.0 .eq 0` is `true` (same as `+0.0`), so the branch always yields the positive-signed literal `0` / `pinf`, ignoring both the sign of the zero base and the parity of the exponent.

## Fix

Detect a negative-zero base via its byte representation (`80-00-00-00-00-00-00-00`) and check that the exponent is an odd integer (`expo.is-integer.and (expo.div 2).is-integer.not`). When both hold:
- For `expo.gt 0`: return `0.neg` (`-0.0`) instead of `0`
- Otherwise: return `ninf` (`-Infinity`) instead of `pinf`

This matches `Math.pow`'s IEEE semantics for `pow(-0.0, y)` with odd-integer `y`.

Closes #5974

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH
