### PR TITLE
fix(#5973): guard as-decimal with is-finite to prevent infinite recursion on nan/inf [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -13,27 +13,29 @@
     n.lt 0
     negative
       n.times -1
-    [n] >> digits
-      if. > @
-        n.lt 10
-        as-char
-          n.floor.plus 48
-        concat.
-          digits q
+    is-finite. n.if > digits
+        if. > @
+          n.lt 10
           as-char
-            plus.
-              floor.
-                n.minus
-                  q.times 10
-              48
-      floor. > q
-        n.div 10
+            n.floor.plus 48
+          concat.
+            digits q
+            as-char
+              plus.
+                floor.
+                  n.minus
+                    q.times 10
+                48
+        floor. > q
+          n.div 10
+        "Can't write a non-finite number as decimal".fail
     | n
-  if. > [m] >> negative
+  is-finite. m.if > negative
     m.floor.eq 0
     digits m
     "-".as-bytes.concat
       digits m
+    "Can't write a non-finite number as decimal".fail
 
   eq. ++> tests-negative-below-one-drops-sign
     "0"


### PR DESCRIPTION
## What

`string.as-decimal` recurses forever when given a non-finite input (`nan`, `+inf`, `-inf`). The internal `digits` helper recurses with `n / 10` until `n < 10`, but for non-finite values every comparison with `10` is `false` and `n / 10` equals `n`, so it never terminates.

`string.as-fixed` inherits the same failure because its `positive` helper calls `as-decimal ip`.

## Root cause

The `digits` helper in `as-decimal.eo` has no non-finite guard. For `nan` / `+inf` / `-inf`, `n.lt 10` is always `false` and `n.div 10` equals `n`, causing infinite recursion.

## Fix

Guard `digits` with `is-finite. n.if`: when `n` is non-finite, `digits` returns `"Can't write a non-finite number as decimal".fail` instead of recursing. Apply the same guard to the `negative` helper so negative non-finite inputs (e.g. `-inf`) are also caught.

`is-finite` is already a standard EO numeric method (same pattern used in `number/floor.eo`).

## Tests added

- `tests-fails-on-nan`: `as-decimal nan` → fails cleanly
- `tests-fails-on-pinf`: `as-decimal pinf` → fails cleanly
- `tests-fails-on-ninf`: `as-decimal ninf` → fails cleanly

Closes #5973

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH
