### PR TITLE
fix(#5981): route fractional indices to fallback in string.at instead of crashing [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -13,6 +13,9 @@
 [text i fallback] > at
   if. > @
     or.
+      floor.
+        i
+        i
       0.gt
         if. >> index!
           0.gt
@@ -21,8 +24,9 @@
             number len
             idx
           idx
+        index!
       gte.
-        number index
+        number index!
         text.length >> len!
     fallback
       "Given index %d is out of text bounds".printf


### PR DESCRIPTION
## What

`string.at` crashes with a leaked `ExFailure` when the index is a non-integer that falls within text bounds (e.g. `at "some" 1.5`), instead of returning the documented `fallback`. Integer indices work correctly.

## Root cause

The guard `or. [0.gt resolved-index] [gte. resolved-index text.length]` only rejects indices that are negative or `>= length`. It never checks whether the (resolved) index is a whole number, so an in-range fractional index reaches `slice text index 1`, which cannot handle fractional character offsets and throws `ExFailure`.

## Fix

Add `floor. i i` as a third branch of the guard `or.`, so a fractional `i` (one whose floor differs from itself) routes the call to the `fallback` branch. Also renamed the two existing guard branches to use the `index!` helper variable (already defined) instead of a bare `index` reference, keeping the logic correct and consistent.

Closes #5981

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH
