### PR TITLE
Fix #6004: resolve bare-reference alias chains when folding based handles

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -32,6 +32,31 @@
     <xsl:sequence select="substring-after($base, substring-before($base, $auto))"/>
   </xsl:function>
   <!--
+  The based `&gt;&gt; name` handle that `$target` ultimately denotes, chasing a
+  chain of bare-reference aliases to its end. A handle whose value is a plain
+  reference to another auto-named handle (`p &gt;&gt; r` over `E0- &gt;&gt; p`)
+  carries no value of its own — it is a transparent alias — so folding it into a
+  use site must land the real value (`E0-`), not the reference to the next
+  handle in the chain. Each hop follows a `@base` that resolves to another
+  auto-named handle, the current handle carrying no arguments of its own, and
+  stops at the first handle whose `@base` is not such a reference (the one that
+  holds the real value), or at one carrying its own children, an abstract
+  formation or a void — none of which is a transparent alias. A target that is
+  not an alias resolves to itself. Without this the alias's own `@base` is copied
+  to the use site verbatim while the drop template removes the handle it names,
+  stranding a dangling `Φ.v..` (#6004). The chain travelled so far comes along in
+  `$seen`, since two bare aliases can reference each other (`p &gt;&gt; r` beside
+  `r &gt;&gt; p`) — source the parser accepts though it never dataizes — and a
+  repeat has to end the descent rather than recur forever, exactly as the
+  "merged" mode of "merge-monikers" guards its own handle chain (#5918).
+  -->
+  <xsl:function name="eo:alias-target" as="element()">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="seen" as="element()*"/>
+    <xsl:variable name="inner" select="$target/ancestor::o/o[@name=eo:resolved-name($target/@base)][1]"/>
+    <xsl:sequence select="if (contains($target/@base, concat('.', $auto)) and not($target/o) and exists($inner) and not(eo:void($inner)) and not(eo:abstract($inner)) and (every $node in $seen satisfies not($inner is $node))) then eo:alias-target($inner, ($seen, $target)) else $target"/>
+  </xsl:function>
+  <!--
   Inline a reference to an auto-named abstract. A `? >> name` void
   (R-3.4.7 / R-3.10.12) also has a cactus name, so a reference that
   resolves to a void (or to nothing) is left untouched. A recursive
@@ -163,6 +188,21 @@
             </xsl:copy>
           </xsl:when>
           <xsl:otherwise>
+            <!--
+            A based `&gt;&gt; name` handle whose value is a bare reference to
+            another based handle (`p &gt;&gt; r` over `E0- &gt;&gt; p`) is a
+            transparent alias: copying `$target`'s `@base` verbatim would carry
+            the reference to `p` down to the use site, while the drop template
+            below removes `p`'s binding — `p` counts as referenced by `r`, yet
+            that reference now lives only in the copy — stranding a dangling
+            `Φ.v..` that nothing declares (#6004). Resolving the alias chain to
+            its end (see `eo:alias-target`) instead lands the real value (`E0-`)
+            at the site in one step, exactly as `merge-monikers` carries a whole
+            chain of handles to the site it hosts them on (#5918). A target that
+            is not such an alias resolves to itself, so this is the unchanged
+            fold for the ordinary based handle.
+            -->
+            <xsl:variable name="value" select="eo:alias-target($target, ())"/>
             <xsl:element name="o">
               <xsl:if test="@as">
                 <xsl:apply-templates select="@as"/>
@@ -185,8 +225,8 @@
               <xsl:if test="@name and not($keep-name)">
                 <xsl:apply-templates select="@name"/>
               </xsl:if>
-              <xsl:apply-templates select="$target/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
-              <xsl:apply-templates select="$target/node()"/>
+              <xsl:apply-templates select="$value/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
+              <xsl:apply-templates select="$value/node()"/>
               <!--
               The reference is the base of an application (`b 42 &gt; x` over a
               based `a.plus &gt;&gt; b` handle), so it carries its own argument
@@ -202,7 +242,7 @@
               inline spelling here and is left standing above instead (see
               `eo:reapplied`).
               -->
-              <xsl:if test="not($target/o)">
+              <xsl:if test="not($value/o)">
                 <xsl:apply-templates select="o"/>
               </xsl:if>
             </xsl:element>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-aliased-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-aliased-referenced-handle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based `>> name` handle (R-3.10.12) whose value is a bare reference to
+# another based handle (`p >> r`, itself over `E0- >> p`). Folding the single
+# use of `r` used to copy `r`'s own `@base` verbatim, so the reference to `p`
+# travelled to the use site while the drop template removed `p`'s binding —
+# `p` was counted as referenced by `r`, yet that reference now lived only in the
+# copy — leaving a dangling `Φ.v..` that nothing declares (#6004). The fold now
+# resolves the target's own `@base` through the same handle lookup, so the alias
+# chain collapses in one step and `E0-` itself lands at the use site.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [x] > foo
+    x.eq r > @
+    E0- >> p
+    p >> r
+
+printed: |
+  x.eq > [x] > foo
+    E0-

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-aliased-shared-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-aliased-shared-handle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The `string/length.eo` shape of #6004: a based `>> name` handle (`p >> r`)
+# aliases another based handle (`E0- >> p`) that is itself referenced elsewhere
+# (`b.and p`), so it is multi-referenced and kept standing. Folding the single
+# use of the alias `r` must still resolve the chain to the real value (`E0-`),
+# not copy the reference to the kept handle `p` — which would strand a dangling
+# `Φ.v..` at the use site while `p` reads back by name for its other reference.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > foo
+    and. > @
+      b.and p
+      p >> r
+    E0- >> p
+
+printed: |
+  and. > [b] > foo
+    b.and E0-
+    E0-


### PR DESCRIPTION
Closes #6004.

## Problem

A based `>> name` handle whose value is a bare reference to another `>> name` handle was printed as a reference to an object that does not exist. Minimally:

```
[x] > foo
  x.eq r > @
  E0- >> p
  p >> r
```

printed as `x.eq > [x] > foo` / `  v3_2` — a dangling `Φ.v3_2` that nothing declares, which reparses to `Φ.v3_2` (unbound) and reprints unchanged, so the corruption never announces itself. In `string/length.eo`, privatizing the eight byte constants (`80- >> p1` … `p3 >> r4`) triggered it on exactly the two handles whose value aliases another handle — `p2 >> r3` and `p3 >> r4`.

## Cause

Folding the single reference to `r`, `inline-cactoos.xsl` takes the `otherwise` branch and copies the target's attributes verbatim, so `r`'s own `@base` — the reference to `p` — travels to the use site unresolved. The drop template then removes `p`'s binding: `eo:unreferenced` counts `r`'s base as a live reference to `p`, so the binding is not kept, while the reference that justified dropping it now lives only in the folded copy. (The dotted flavour `p.neg >> r` survives because `eo:dispatched` keeps the binding for `merge-monikers`; a plain-base alias has no such guard.)

## Fix

In that branch, resolve the target's own `@base` through the same `ancestor::o/o[@name=…]` lookup the template already performs for the reference, rather than copying it. An alias chain now folds in one step and the real value (`E0-`) itself lands at the use site — the same thing `merge-monikers` already does in its `merged` mode (#5918). A new `eo:alias-target` function chases the chain of bare aliases to its end (stopping at the first handle carrying a real value, its own children, an abstract formation or a void), with a `$seen` accumulator ending the descent on mutually-referencing aliases rather than recurring forever.

## Tests

Two new print-packs, both verified failing before the change and passing after:

- `based-aliased-referenced-handle.yaml` — the isolated single-reference alias chain from the issue.
- `based-aliased-shared-handle.yaml` — the `length.eo` shape, where the aliased handle is itself referenced elsewhere and kept standing.

Full `eo-printer` suite: 303 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196EDYw343Aqrw2BjnwS3LL

---
_Generated by [Claude Code](https://claude.ai/code/session_0196EDYw343Aqrw2BjnwS3LL)_