### PR TITLE
#5981: fractional in-bounds index returns fallback in string.at

### DIFF
--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -21,16 +21,36 @@
             number len
             idx
           idx
-      gte.
-        number index
-        text.length >> len!
+      or.
+        gte.
+          number index
+          text.length >> len!
+        not.
+          eq.
+            floor.
+              number index
+            number index
     fallback
       "Given index %d is out of text bounds".printf
-        * index
+        * i
     slice
       text
       index
       1
+
+  eq. ++> tests-fractional-in-bounds-index-returns-fallback
+    "recovered"
+    at
+      "some"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> tests-negative-fractional-in-bounds-index-returns-fallback
+    "recovered"
+    at
+      "some"
+      -1.5
+      "recovered" > [message]
 
   eq. ++> tests-returns-char-at-negative-index
     "m"


### PR DESCRIPTION
Closes #5981.

`string.at` let a fractional but in-bounds index (e.g. `1.5`) reach `slice text index 1`, which cannot land on a fractional offset and throws instead of returning the documented `fallback`. Added a third guard, alongside the existing negative/too-large checks, that routes a non-integer index to fallback too.

Also fixed a secondary issue noted in the report: the out-of-bounds message formatted the resolved index instead of the caller's original one, so a negative index like `-10` showed the wrong number in the message.

Added tests for a fractional positive in-bounds index and a fractional negative in-bounds index (which resolves to a fractional positive index through the existing wrap-around logic).

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_string.EOatTest'` - 7 passing.
