### PR TITLE
#5980: normalize -0.0 to +0.0 in number.abs

### DIFF
--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -12,7 +12,7 @@
     gte.
       number num.as-bytes >> value
       0
-    value
+    0.plus value
     value.neg
 
   eq. ++> tests-abs-float-negative
@@ -30,6 +30,11 @@
   eq. ++> tests-abs-int-positive
     abs 3
     3
+
+  eq. ++> tests-abs-negative-zero-normalizes-sign
+    as-bytes.
+      abs -0
+    00-00-00-00-00-00-00-00
 
   eq. ++> tests-abs-zero
     abs 0


### PR DESCRIPTION
Closes #5980.

`abs -0.0` returned `-0.0` unchanged, because `-0.0 .gte 0` is true, so the non-negative branch passed `value` straight through with its sign bit intact. Only the negating branch normalized the sign, so a negative zero slipped through.

Fixed by adding zero to `value` on the non-negative branch, which clears the sign bit per IEEE 754, matching `Math.abs` semantics.

Added a test that checks the byte representation of `abs -0` directly, since `-0.0 == 0.0` numerically and a plain `eq.` test would not catch a sign difference.

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_number.EOabsTest'` - 6 passing.
