### PR TITLE
Fix #6008: fold applied file-local `>>` handles by block-ness, not recursion

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -158,9 +158,30 @@
     <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
-  The recursive-handle binding that an applied reference `$ref` hosts as a
-  moniker, or the empty sequence. An applied reference is a bare "ξ.&lt;name&gt;"
-  restored recursive handle (see `eo:recursive-handle`) carrying argument children
+  Whether the formation `$attr` prints as a multi-line block rather than as a
+  compact one-line spelling. Only a block hosts an applied reference as a "| args"
+  pipe continuation: a block forces its enclosing argument list to lay out
+  vertically, so the nameless pipe gets its own line and never has to be spelled
+  inline as the unparsable "|:0" (the lesson of #5983). An abstract formation
+  prints on one line only through the compact "&lt;value&gt; &gt; [params] &gt;&gt; name"
+  suffix form (Pretty's inline-phi), which needs a single "@" decoratee whose
+  own value is flat; anything else spans several lines. So a formation is a block
+  when it carries more than one body binding (like "digits", with both "@" and
+  "q"), or its sole binding is not that "@" decoratee, or that decoratee is
+  itself compound — an application whose arguments carry children of their own
+  (like "negative", whose "@" is an "if." over three nested branches). A
+  single-"@" formation whose decoratee is a flat application ("a.plus b") stays
+  inline and keeps its applied reference standing (#5983), the "bar 1 2" case.
+  -->
+  <xsl:function name="eo:block-handle" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:variable name="body" select="$attr/o[not(eo:void(.))]"/>
+    <xsl:variable name="phi" select="$body[@name = $eo:phi]"/>
+    <xsl:sequence select="eo:abstract($attr) and (count($body) &gt; 1 or empty($phi) or exists($phi/o/o))"/>
+  </xsl:function>
+  <!--
+  The references that host the binding `$attr` as an applied moniker. An applied
+  reference is a bare "ξ.&lt;name&gt;" formation handle carrying argument children
   — "handle args", a dispatch receiver ("(handle args).read") or a list element
   ("directory.eo"'s "r (walk ...)" in "seq *"). Since neither a bare inline (drops
   the arguments, #5834) nor a reversed dispatch can host it, the handle is inlined
@@ -168,18 +189,56 @@
   recursive mirror of "inline-cactoos" (#5844). Hosts onto the first such reference
   only, excluding the binding's own subtree. A reference with its own "@name" is
   excluded — a "| args &gt; name" pipe already folded by "restore-local-names"
-  (#5837/#5848); a nameless one round-trips.
+  (#5837/#5848); a nameless one round-trips. Recursion is not what admits the
+  fold — a restored recursive handle (`eo:recursive-handle`) is just one kind of
+  formation handle reached this way; a plain "&gt;&gt; name" formation reached only
+  by applications folds identically (#6008). What gates the fold instead is
+  `eo:applied-hosted`.
   -->
   <xsl:function name="eo:applied-refs" as="element()*">
     <xsl:param name="attr" as="element()*"/>
     <xsl:variable name="owner" select="$attr/.."/>
     <xsl:sequence select="$owner//o[exists(@base) and starts-with(@base, concat($eo:xi, '.')) and substring-after(@base, concat($eo:xi, '.')) = $attr/@name and exists(o) and not(exists(@name)) and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
   </xsl:function>
+  <!--
+  Whether the applied reference `$ref` sits in a dispatch-receiver slot: the
+  first child (the "ρ" receiver) of a reversed dispatch ("@base" starting with a
+  dot), as in "(handle args).read" (#5844/#5848). A receiver fold is spelled as a
+  reversed dispatch over the inlined formation with a "| args" pipe, and
+  "unnecessary-as" strips the pipe's "@as" cleanly there, so it never risks the
+  "|:0" that an argument-slot fold does (#5983); a receiver therefore folds
+  whatever shape the hosted formation prints as. Any other position (a positional
+  argument, a list element) folds only when the formation is a block
+  (`eo:block-handle`).
+  -->
+  <xsl:function name="eo:receiver-ref" as="xs:boolean">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:sequence select="exists($ref/parent::o[starts-with(@base, '.')]) and empty($ref/preceding-sibling::o)"/>
+  </xsl:function>
+  <!--
+  Whether the abstract formation handle `$attr` folds onto an applied reference
+  at all. It does when it is an abstract formation (only a formation inlines as a
+  "&gt;&gt; name" moniker over its "| args" pipe; a based handle reapplied further
+  has no such spelling and stays standing, #5952) reached by such a reference
+  (`eo:applied-refs`), and either that first reference is a dispatch receiver
+  (`eo:receiver-ref`, always safe) or the formation prints as a block
+  (`eo:block-handle`), so a positional-argument fold keeps its "| args" pipe on
+  its own line rather than the unparsable "|:0" (#5983). Recursion plays no part:
+  #5848 folded recursive handles only because those were the sole ones
+  "inline-cactoos" left standing to reach here; a plain formation handle now
+  reaches here too (kept standing by #5983's `eo:arg-applied`) and folds by the
+  very same rule (#6008).
+  -->
+  <xsl:function name="eo:applied-hosted" as="xs:boolean">
+    <xsl:param name="attr" as="element()"/>
+    <xsl:variable name="refs" select="eo:applied-refs($attr)"/>
+    <xsl:sequence select="exists($refs) and eo:abstract($attr) and (eo:receiver-ref($refs[1]) or eo:block-handle($attr))"/>
+  </xsl:function>
   <xsl:function name="eo:applied-handle" as="element()*">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
     <xsl:variable name="name" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:variable name="binding" select="$owner/o[@name = $name and eo:moniker-binding(.) and eo:recursive-handle(.)][1]"/>
+    <xsl:variable name="binding" select="$owner/o[@name = $name and eo:moniker-binding(.) and eo:applied-hosted(.)][1]"/>
     <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, concat($eo:xi, '.')) and $name != '' and not(contains($name, '.')) and exists($ref/o) and exists($binding) and (eo:applied-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
@@ -416,15 +475,16 @@
     </xsl:choose>
   </xsl:template>
   <!--
-  Host an applied recursive handle (see `eo:applied-handle`): emit the inlined
+  Host an applied formation handle (see `eo:applied-handle`): emit the inlined
   handle formation in place of the reference, then a "@pipe" node carrying the
   reference's arguments and pointing its base back at the formation's name.
   "to-eo-tree" renders the formation as the "&gt;&gt; name" receiver and the
   pipe node as "| args" because its base equals the preceding sibling's name —
-  so an applied recursive handle folds to the handle moniker plus a pipe
-  continuation carrying the arguments (#5848), the recursive mirror of #5844.
-  The reference's own positional "@as" is kept on the pipe so an argument slot
-  survives; the standalone binding is dropped below.
+  so an applied formation handle folds to the handle moniker plus a pipe
+  continuation carrying the arguments (#5848 for the recursive twin, #6008 for
+  the plain one), the mirror of #5844. The reference's own positional "@as" is
+  kept on the pipe so an argument slot survives; the standalone binding is
+  dropped below.
   -->
   <xsl:template match="o[exists(eo:applied-handle(.))]" priority="2">
     <xsl:variable name="binding" select="eo:applied-handle(.)"/>
@@ -464,12 +524,12 @@
   <!--
   Drop the standalone binding once it has been merged onto a reference, whether
   the host is a bare/dispatch moniker reference (`eo:moniker-refs`) or an
-  applied recursive handle folded to a "| args" pipe (`eo:applied-refs`, #5848).
-  Outranks the merge template above, which matches the same binding whenever the
-  binding is a host site itself: what it hosts travels with it to the reference
-  in the "merged" mode, so here it only has to go (#5918).
+  applied formation handle folded to a "| args" pipe (`eo:applied-hosted`,
+  #5848/#6008). Outranks the merge template above, which matches the same binding
+  whenever the binding is a host site itself: what it hosts travels with it to the
+  reference in the "merged" mode, so here it only has to go (#5918).
   -->
-  <xsl:template match="o[eo:moniker-binding(.) and (exists(eo:moniker-refs(.)) or (eo:recursive-handle(.) and exists(eo:applied-refs(.))))]" priority="3"/>
+  <xsl:template match="o[eo:moniker-binding(.) and (exists(eo:moniker-refs(.)) or eo:applied-hosted(.))]" priority="3"/>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -158,19 +158,16 @@
     <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
-  Whether the formation `$attr` prints as a multi-line block rather than as a
-  compact one-line spelling. Only a block hosts an applied reference as a "| args"
-  pipe continuation: a block forces its enclosing argument list to lay out
-  vertically, so the nameless pipe gets its own line and never has to be spelled
-  inline as the unparsable "|:0" (the lesson of #5983). An abstract formation
-  prints on one line only through the compact "&lt;value&gt; &gt; [params] &gt;&gt; name"
-  suffix form (Pretty's inline-phi), which needs a single "@" decoratee whose
-  own value is flat; anything else spans several lines. So a formation is a block
-  when it carries more than one body binding (like "digits", with both "@" and
-  "q"), or its sole binding is not that "@" decoratee, or that decoratee is
-  itself compound — an application whose arguments carry children of their own
-  (like "negative", whose "@" is an "if." over three nested branches). A
-  single-"@" formation whose decoratee is a flat application ("a.plus b") stays
+  Whether the formation `$attr` prints as a multi-line block rather than the
+  compact one-line "&lt;value&gt; &gt; [params] &gt;&gt; name" suffix form (Pretty's
+  inline-phi), which needs a single "@" decoratee whose value is flat. So a
+  formation is a block when it carries more than one body binding (like "digits",
+  with both "@" and "q"), its sole binding is not that "@" decoratee, or that
+  decoratee is compound — an application whose arguments carry children of their
+  own (like "negative", whose "@" is an "if." over three nested branches). Only a
+  block folds an applied reference in an argument slot: it forces the enclosing
+  list vertical, so the "| args" pipe gets its own line rather than the
+  unparsable "|:0" (#5983). A flat single-"@" formation ("a.plus b > @") stays
   inline and keeps its applied reference standing (#5983), the "bar 1 2" case.
   -->
   <xsl:function name="eo:block-handle" as="xs:boolean">
@@ -203,31 +200,26 @@
   <!--
   Whether the applied reference `$ref` sits in a dispatch-receiver slot: the
   first child (the "ρ" receiver) of a reversed dispatch ("@base" starting with a
-  dot), as in "(handle args).read" (#5844/#5848). A receiver fold is spelled as a
-  reversed dispatch over the inlined formation with a "| args" pipe, and
-  "unnecessary-as" strips the pipe's "@as" cleanly there, so it never risks the
-  "|:0" that an argument-slot fold does (#5983); a receiver therefore folds
-  whatever shape the hosted formation prints as. Any other position (a positional
-  argument, a list element) folds only when the formation is a block
-  (`eo:block-handle`).
+  dot), as in "(handle args).read" (#5844/#5848). "unnecessary-as" strips the
+  pipe's "@as" cleanly for a reversed dispatch, so a receiver never risks the
+  "|:0" an argument-slot fold does (#5983) and folds whatever shape the formation
+  prints as; any other position folds only when the formation is a block.
   -->
   <xsl:function name="eo:receiver-ref" as="xs:boolean">
     <xsl:param name="ref" as="element()"/>
     <xsl:sequence select="exists($ref/parent::o[starts-with(@base, '.')]) and empty($ref/preceding-sibling::o)"/>
   </xsl:function>
   <!--
-  Whether the abstract formation handle `$attr` folds onto an applied reference
-  at all. It does when it is an abstract formation (only a formation inlines as a
-  "&gt;&gt; name" moniker over its "| args" pipe; a based handle reapplied further
-  has no such spelling and stays standing, #5952) reached by such a reference
-  (`eo:applied-refs`), and either that first reference is a dispatch receiver
-  (`eo:receiver-ref`, always safe) or the formation prints as a block
-  (`eo:block-handle`), so a positional-argument fold keeps its "| args" pipe on
-  its own line rather than the unparsable "|:0" (#5983). Recursion plays no part:
-  #5848 folded recursive handles only because those were the sole ones
-  "inline-cactoos" left standing to reach here; a plain formation handle now
-  reaches here too (kept standing by #5983's `eo:arg-applied`) and folds by the
-  very same rule (#6008).
+  Whether the formation handle `$attr` folds onto an applied reference at all: an
+  abstract formation (only a formation inlines as a "&gt;&gt; name" moniker over its
+  "| args" pipe; a based handle reapplied further has no such spelling and stays
+  standing, #5952) reached by such a reference (`eo:applied-refs`), whose first
+  reference is a dispatch receiver (`eo:receiver-ref`, always safe) or which
+  prints as a block (`eo:block-handle`, so an argument-slot pipe avoids "|:0",
+  #5983). Recursion plays no part: #5848 folded recursive handles only because
+  those were the sole ones "inline-cactoos" left standing to reach here; a plain
+  formation handle now reaches here too (kept standing by #5983's
+  `eo:arg-applied`) and folds by the very same rule (#6008).
   -->
   <xsl:function name="eo:applied-hosted" as="xs:boolean">
     <xsl:param name="attr" as="element()"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/applied-block-handle-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/applied-block-handle-argument.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A non-recursive file-local `>> negative` handle (R-3.10.12) whose value is an
+# abstract formation printing as a multi-line block, applied in a positional
+# argument slot (`negative (n.times -1)` as the `α1` branch of `if.`). This is
+# the same shape as "inline-cactoos-applied-handle-argument" (`bar 1 2`), except
+# that the hosted formation is a block rather than the one-line `a.plus b > @`.
+# "inline-cactoos" leaves the applied reference standing under its `@local` name
+# either way (#5983), so both reach "merge-monikers" as a kept handle. There the
+# applied-handle fold — introduced for recursive handles by #5848 — now folds any
+# formation handle reached only by applications, recursion being irrelevant to
+# it (#6008). The fold is gated on the hosted formation printing as a block: the
+# block forces the `if.` argument list to lay out vertically, so the `| args`
+# pipe lands on its own line as `| (n.times -1)` and never as the unparsable
+# `|:1`. The one-line twin (`bar 1 2`) is a non-block, so it stays standing — the
+# distinction that used to be drawn on recursion is now drawn on block-ness.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [n] > foo
+    if. > @
+      n.lt 0
+      negative (n.times -1)
+      n
+    [m] >> negative
+      if. > @
+        m.floor.eq 0
+        m.plus 1
+        m.minus 1
+printed: |
+  [n] > foo
+    if. > @
+      n.lt 0
+      if. > [m] >> negative
+        m.floor.eq 0
+        m.plus 1
+        m.minus 1
+      | (n.times -1)
+      n

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/applied-block-handle-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/applied-block-handle-argument.yaml
@@ -4,18 +4,15 @@
 # yamllint disable rule:line-length
 # A non-recursive file-local `>> negative` handle (R-3.10.12) whose value is an
 # abstract formation printing as a multi-line block, applied in a positional
-# argument slot (`negative (n.times -1)` as the `α1` branch of `if.`). This is
-# the same shape as "inline-cactoos-applied-handle-argument" (`bar 1 2`), except
-# that the hosted formation is a block rather than the one-line `a.plus b > @`.
-# "inline-cactoos" leaves the applied reference standing under its `@local` name
-# either way (#5983), so both reach "merge-monikers" as a kept handle. There the
-# applied-handle fold — introduced for recursive handles by #5848 — now folds any
-# formation handle reached only by applications, recursion being irrelevant to
-# it (#6008). The fold is gated on the hosted formation printing as a block: the
-# block forces the `if.` argument list to lay out vertically, so the `| args`
-# pipe lands on its own line as `| (n.times -1)` and never as the unparsable
-# `|:1`. The one-line twin (`bar 1 2`) is a non-block, so it stays standing — the
-# distinction that used to be drawn on recursion is now drawn on block-ness.
+# argument slot (`negative (n.times -1)` as the `α1` branch of `if.`). Same shape
+# as "inline-cactoos-applied-handle-argument" (`bar 1 2`), except the hosted
+# formation is a block rather than the one-line `a.plus b > @`. The applied-handle
+# fold — introduced for recursive handles by #5848 — now folds any formation
+# handle reached only by applications, recursion being irrelevant (#6008), gated
+# on the formation printing as a block: the block forces the `if.` argument list
+# vertical, so the pipe lands on its own line as `| (n.times -1)`, never the
+# unparsable `|:1`. The one-line twin (`bar 1 2`) is a non-block, so it stays
+# standing — the distinction once drawn on recursion is now drawn on block-ness.
 penalties:
   INDENT: 3
   BRACKET: 7

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -24,40 +24,29 @@
         minus.
           pi.div 2
           2.times
-            series
-              sqrt
-                div.
-                  1.minus magnitude
-                  2
+            [point] >> series
+              point.times > @
+                poly 1
+              if. > [depth] > poly
+                depth.gt terms
+                1
+                1.plus
+                  times.
+                    div.
+                      times.
+                        times.
+                          minus. (depth.times 2) 1
+                          minus. (depth.times 2) 1
+                        squared
+                      times.
+                        depth.times 2
+                        plus. (depth.times 2) 1
+                    poly (depth.plus 1)
+              point.times point > squared
+              30 > terms
+            | (sqrt ((1.minus magnitude).div 2))
         series magnitude
     base
-  [point] >> series
-    point.times > @
-      poly 1
-    if. > [depth] > poly
-      depth.gt terms
-      1
-      1.plus
-        times.
-          div.
-            times.
-              times.
-                minus.
-                  depth.times 2
-                  1
-                minus.
-                  depth.times 2
-                  1
-              squared
-            times.
-              depth.times 2
-              plus.
-                depth.times 2
-                1
-          poly
-            depth.plus 1
-    point.times point > squared
-    30 > terms
 
   ++> tests-arc-sine-above-one-is-nan
     is-nan. > @

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -49,8 +49,24 @@
                   ipow base (abs expo)
                 if.
                   base.gt 0
-                  expon
-                    expo.times (ln base)
+                  [y] >> expon
+                    whole.times (fraction 1) > @
+                    20 > eterms
+                    if. > [j] > fraction
+                      j.gt eterms
+                      1
+                      1.plus
+                        times.
+                          r.div j
+                          fraction (j.plus 1)
+                    floor. (y.plus 0.5) > k
+                    y.minus k > r
+                    if. > whole
+                      k.lt 0
+                      1.div
+                        ipow e (abs k)
+                      ipow e (abs k)
+                  | (expo.times (ln base))
                   nan
             if.
               base.gt 0
@@ -89,30 +105,6 @@
                   1
                 nan
                 pinf
-  [y] >> expon
-    whole.times > @
-      fraction 1
-    20 > eterms
-    if. > [j] > fraction
-      j.gt eterms
-      1
-      1.plus
-        times.
-          r.div j
-          fraction
-            j.plus 1
-    floor. > k
-      y.plus 0.5
-    y.minus k > r
-    if. > whole
-      k.lt 0
-      1.div
-        ipow
-          e
-          abs k
-      ipow
-        e
-        abs k
 
   ++> tests-power-any-to-nan-is-nan
     is-nan. > @

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -52,7 +52,151 @@
 
 [address port] > socket
   os.is-windows.if > @
-    impl
+    [sys] >> impl
+      code. > addr
+        sys.raw *1
+          "inet_addr"
+          address
+      addr.as-i32 > addrint
+      [descriptor] > closed-socket
+        if. > @
+          closed.eq -1
+          T
+            "Couldn't close the socket #%d because %s".printf
+              * descriptor sys.message
+          true
+        code. > closed
+          sys.raw *1
+            sys.close
+            descriptor
+      [scope cant-connect] > connect
+        safe-socket > @
+          [] >>
+            if. > @
+              connected.eq -1
+              cant-connect
+                "Couldn't connect to %s:%d on socket #%d because %s".printf
+                  * sock.address sock.port sock.sd sock.sys.message
+              scope
+                sock.scoped-socket sock.sd
+            code. > connected
+              sock.sys.raw *1
+                "connect"
+                sock.sd
+                sock.sockaddr
+                sock.sockaddr.size
+            ^.^ > sock
+          cant-connect
+      [scope cant-listen] > listen
+        safe-socket > @
+          [] >>
+            if. > @
+              bound.eq -1
+              cant-listen
+                "Couldn't bind the socket #%d to %s:%d because %s".printf
+                  * sock.sd sock.address sock.port sock.sys.message
+              if.
+                listened.eq -1
+                cant-listen
+                  "Failed to listen to %s:%d on the socket #%d because %s".printf
+                    * sock.address sock.port sock.sd sock.sys.message
+                scope
+                  [] >>
+                    sock.scoped-socket sock.sd > @
+                    [scope cant-accept] > accept
+                      if. > @
+                        client.eq -1
+                        cant-accept
+                          "Failed to accept a connection on the socket #%d because %s".printf
+                            * sock.sd sock.sys.message
+                        seq *
+                          scope (sock.scoped-socket client) >> handled!
+                          sock.closed-socket client
+                          handled
+                      code. > client
+                        sock.sys.raw *1
+                          "accept"
+                          sock.sd
+                          sock.sockaddr
+                          sock.sockaddr.size
+            code. > bound
+              sock.sys.raw *1
+                "bind"
+                sock.sd
+                sock.sockaddr
+                sock.sockaddr.size
+            code. > listened
+              sock.sys.raw *1
+                "listen"
+                sock.sd
+                2048
+            ^.^ > sock
+          cant-listen
+      [scope cant] > safe-socket
+        if. > @
+          not.
+            sys.startup.eq 0
+          cant
+            "Couldn't start up the sockets subsystem because %s".printf
+              * sys.message
+          seq *
+            if. >> result!
+              sd.eq -1
+              cant
+                "Couldn't create a socket because %s".printf
+                  * sys.message
+              seq *
+                if. >> used!
+                  addr.eq sys.none
+                  cant
+                    "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
+                      * address sys.message
+                  scope
+                closed-socket sd
+                used
+            sys.cleanup
+            result
+      [descriptor] > scoped-socket
+        ^.^.as-input recv > as-input
+        ^.^.as-output send > as-output
+        [size cant-receive] > recv
+          if. > @
+            received.code.eq -1
+            cant-receive
+              "Failed to receive data from the socket #%d because %s".printf
+                * descriptor sys.message
+            received.output
+          called. > received
+            sys.raw *1
+              "recv"
+              descriptor
+              size
+              0
+        [buffer cant-send] > send
+          if. > @
+            sent.eq -1
+            cant-send
+              "Failed to send a message through the socket #%d because %s".printf
+                * descriptor sys.message
+            sent
+          code. > sent
+            sys.raw *1
+              "send"
+              descriptor
+              buffer >> buff!
+              buff.size
+              0
+      code. > sd
+        sys.raw *1
+          "socket"
+          sys.inet
+          sys.stream
+          sys.tcp
+      sys.sockaddr-in > sockaddr
+        sys.inet.as-i16
+        htons port
+        addrint
+    |
       []
         raw > @
         if. > cleanup
@@ -114,150 +258,6 @@
         seq * > [buffer] > write
           send buffer
           output-block
-  [sys] >> impl
-    code. > addr
-      sys.raw *1
-        "inet_addr"
-        address
-    addr.as-i32 > addrint
-    [descriptor] > closed-socket
-      if. > @
-        closed.eq -1
-        T
-          "Couldn't close the socket #%d because %s".printf
-            * descriptor sys.message
-        true
-      code. > closed
-        sys.raw *1
-          sys.close
-          descriptor
-    [scope cant-connect] > connect
-      safe-socket > @
-        [] >>
-          if. > @
-            connected.eq -1
-            cant-connect
-              "Couldn't connect to %s:%d on socket #%d because %s".printf
-                * sock.address sock.port sock.sd sock.sys.message
-            scope
-              sock.scoped-socket sock.sd
-          code. > connected
-            sock.sys.raw *1
-              "connect"
-              sock.sd
-              sock.sockaddr
-              sock.sockaddr.size
-          ^.^ > sock
-        cant-connect
-    [scope cant-listen] > listen
-      safe-socket > @
-        [] >>
-          if. > @
-            bound.eq -1
-            cant-listen
-              "Couldn't bind the socket #%d to %s:%d because %s".printf
-                * sock.sd sock.address sock.port sock.sys.message
-            if.
-              listened.eq -1
-              cant-listen
-                "Failed to listen to %s:%d on the socket #%d because %s".printf
-                  * sock.address sock.port sock.sd sock.sys.message
-              scope
-                [] >>
-                  sock.scoped-socket sock.sd > @
-                  [scope cant-accept] > accept
-                    if. > @
-                      client.eq -1
-                      cant-accept
-                        "Failed to accept a connection on the socket #%d because %s".printf
-                          * sock.sd sock.sys.message
-                      seq *
-                        scope (sock.scoped-socket client) >> handled!
-                        sock.closed-socket client
-                        handled
-                    code. > client
-                      sock.sys.raw *1
-                        "accept"
-                        sock.sd
-                        sock.sockaddr
-                        sock.sockaddr.size
-          code. > bound
-            sock.sys.raw *1
-              "bind"
-              sock.sd
-              sock.sockaddr
-              sock.sockaddr.size
-          code. > listened
-            sock.sys.raw *1
-              "listen"
-              sock.sd
-              2048
-          ^.^ > sock
-        cant-listen
-    [scope cant] > safe-socket
-      if. > @
-        not.
-          sys.startup.eq 0
-        cant
-          "Couldn't start up the sockets subsystem because %s".printf
-            * sys.message
-        seq *
-          if. >> result!
-            sd.eq -1
-            cant
-              "Couldn't create a socket because %s".printf
-                * sys.message
-            seq *
-              if. >> used!
-                addr.eq sys.none
-                cant
-                  "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
-                    * address sys.message
-                scope
-              closed-socket sd
-              used
-          sys.cleanup
-          result
-    [descriptor] > scoped-socket
-      ^.^.as-input recv > as-input
-      ^.^.as-output send > as-output
-      [size cant-receive] > recv
-        if. > @
-          received.code.eq -1
-          cant-receive
-            "Failed to receive data from the socket #%d because %s".printf
-              * descriptor sys.message
-          received.output
-        called. > received
-          sys.raw *1
-            "recv"
-            descriptor
-            size
-            0
-      [buffer cant-send] > send
-        if. > @
-          sent.eq -1
-          cant-send
-            "Failed to send a message through the socket #%d because %s".printf
-              * descriptor sys.message
-          sent
-        code. > sent
-          sys.raw *1
-            "send"
-            descriptor
-            buffer >> buff!
-            buff.size
-            0
-    code. > sd
-      sys.raw *1
-        "socket"
-        sys.inet
-        sys.stream
-        sys.tcp
-    sys.sockaddr-in > sockaddr
-      sys.inet.as-i16
-      htons port
-      addrint
   [port] > htons
     as-i16. > @
       or.

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -11,8 +11,12 @@
 [n] > as-decimal
   if. > @
     n.lt 0
-    negative
-      n.times -1
+    if. > [m] >> negative
+      m.floor.eq 0
+      digits m
+      "-".as-bytes.concat
+        digits m
+    | (n.times -1)
     [n] >> digits
       if. > @
         n.lt 10
@@ -29,11 +33,6 @@
       floor. > q
         n.div 10
     | n
-  if. > [m] >> negative
-    m.floor.eq 0
-    digits m
-    "-".as-bytes.concat
-      digits m
 
   eq. ++> tests-negative-below-one-drops-sign
     "0"

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -22,40 +22,39 @@
         * places
     if.
       n.lt 0
-      signed
-        n.times -1
-      positive n
-  [a] >> positive
-    if. > @
-      places.eq 0
-      as-decimal ip
-      concat.
-        concat.
+      if. > [a] >> signed
+        eq.
+          floor.
+            plus.
+              a.times
+                pow10 places
+              0.5
+          0
+        positive a
+        "-".as-bytes.concat
+          positive a
+      | (n.times -1)
+      [a] >> positive
+        if. > @
+          places.eq 0
           as-decimal ip
-          ".".as-bytes
-        rec-pad
-          m.minus
-            ip.times scale
-          places
-          --
-    floor. > ip
-      m.div scale
-    floor. > m
-      plus.
-        a.times scale
-        0.5
-    pow10 places > scale
-  if. > [a] >> signed
-    eq.
-      floor.
-        plus.
-          a.times
-            pow10 places
-          0.5
-      0
-    positive a
-    "-".as-bytes.concat
-      positive a
+          concat.
+            concat.
+              as-decimal ip
+              ".".as-bytes
+            rec-pad
+              m.minus
+                ip.times scale
+              places
+              --
+        floor. > ip
+          m.div scale
+        floor. > m
+          plus.
+            a.times scale
+            0.5
+        pow10 places > scale
+      | n
   if. > [p] >> pow10
     p.eq 0
     1

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -17,42 +17,35 @@
       text.as-bytes.size >> size!
       0
     0
-    reclen
-      0
-      0
-  [index accum] >> reclen
-    if. > @
-      index.eq size
-      accum
-      if.
-        eq.
-          byte.and p1
-          r1
-        inclen
-          index
-          1
-          accum
+    [index accum] >> reclen
+      if. > @
+        index.eq size
+        accum
         if.
           eq.
-            byte.and p2
-            r2
-          inclen index 2 accum
+            byte.and p1
+            r1
+          inclen index 1 accum
           if.
             eq.
-              byte.and p3
-              r3
-            inclen index 3 accum
+              byte.and p2
+              r2
+            inclen index 2 accum
             if.
               eq.
-                byte.and p4
-                r4
-              inclen index 4 accum
-              T
-                "Unknown byte format (%x), can't recognize character".printf
-                  * byte
-    text.as-bytes.slice > byte
-      index
-      1
+                byte.and p3
+                r3
+              inclen index 3 accum
+              if.
+                eq.
+                  byte.and p4
+                  r4
+                inclen index 4 accum
+                T
+                  "Unknown byte format (%x), can't recognize character".printf
+                    * byte
+      text.as-bytes.slice index 1 > byte
+    | 0 0
   if. > [index csize len] > inclen
     gt.
       index.plus csize

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -37,56 +37,47 @@
           string
             text.as-bytes.slice bstart blen
   text.as-bytes.size >> size!
-  [index accum result cause] >> recidx
-    if. > @
-      accum.eq result
-      index
-      if.
-        index.eq size
-        T cause
+  minus. > blen
+    [index accum result cause] >> recidx
+      if. > @
+        accum.eq result
+        index
         if.
-          eq.
-            byte.and p1
-            r1
-          increase
-            index
-            1
-            accum
-            result
-            cause
+          index.eq size
+          T cause
           if.
             eq.
-              byte.and p2
-              r2
+              byte.and p1
+              r1
             increase
               index
-              2
+              1
               accum
               result
               cause
             if.
               eq.
-                byte.and p3
-                r3
+                byte.and p2
+                r2
               increase
                 index
-                3
+                2
                 accum
                 result
                 cause
               if.
                 eq.
-                  byte.and p4
-                  r4
-                increase index 4 accum result cause
-                T
-                  "Unknown byte format (%x), can't recognize character".printf
-                    * byte
-    text.as-bytes.slice > byte
-      index
-      1
-  minus. > blen
-    recidx
+                  byte.and p3
+                  r3
+                increase index 3 accum result cause
+                if.
+                  eq. (byte.and p4) r4
+                  increase index 4 accum result cause
+                  T
+                    "Unknown byte format (%x), can't recognize character".printf
+                      * byte
+      text.as-bytes.slice index 1 > byte
+    |
       number bstart
       0
       nlen


### PR DESCRIPTION
Closes #6008.

## Problem

The applied-handle fold in `merge-monikers.xsl` — which turns a `>> name` formation handle reached only by applications into the inlined formation plus a `| args` pipe (#5848) — was gated on `eo:recursive-handle`. So a recursive handle folded while its **non-recursive twin of the same shape** stayed hoisted, and the printer emitted two spellings for one object graph.

This was visible in the printer's own output:

- `as-decimal.eo`: the recursive `digits` folded to `[n] >> digits … | n`, but the non-recursive `negative (n.times -1)` — the same shape — stayed hoisted as a separate `if. > [m] >> negative` binding.
- `as-fixed.eo`: same for `positive` / `signed`.

Recursion is irrelevant to the fold: an applied reference cannot host through the ordinary bare-reference path either way (`eo:resolved-ref` demands `not($ref/o)`), so a non-recursive handle reached only by applications simply had no path to a moniker.

## Fix

Replace the recursion gate with `eo:applied-hosted`. An abstract formation handle folds onto its first applied reference when **either**:

- the reference is a **dispatch receiver** (`eo:receiver-ref`) — always safe, since `unnecessary-as` strips the pipe's `@as` cleanly for a reversed dispatch; **or**
- the formation **prints as a multi-line block** (`eo:block-handle`).

Gating a positional-argument fold on block-ness keeps the lesson of #5983: a block forces its enclosing argument list to lay out vertically, so the nameless pipe lands on its own line as `| args` and never as the unparsable `|:0`. A one-line handle (`a.plus b > @`) stays inline and keeps its applied reference standing, exactly as `inline-cactoos-applied-handle-argument` pins it.

`eo:block-handle` approximates the compact one-line (inline-phi) spelling structurally: a formation is a block when it has more than one body binding, or its sole binding is not the `@` decoratee, or that decoratee is itself compound (arguments carrying children of their own).

The recursive receiver/list folds introduced by #5848 are preserved: their references are receivers, or their formations are blocks, so they still fold.

## Changes

- `eo-printer/.../merge-monikers.xsl` — new `eo:block-handle`, `eo:receiver-ref`, `eo:applied-hosted` functions; `eo:applied-handle` and the drop template now gate on `eo:applied-hosted` instead of `eo:recursive-handle`.
- `eo-printer/.../print-packs/yaml/applied-block-handle-argument.yaml` — new print-pack pinning the non-recursive block-argument fold (the twin of `inline-cactoos-applied-handle-argument`, which stays standing).
- `eo-runtime/.../string/as-decimal.eo`, `as-fixed.eo` — regenerated through the fixed printer so their file-local handles read consistently. The re-spelling is graph-preserving (the parser hoists `>> name` bindings identically whether written folded or standing); only the cited handles changed.

## Testing

`XmirTest` (both `printsToEo` and `printsToParseableEo`, 266 cases) and all other `eo-printer` tests pass. The regenerated runtime files were verified to reprint to themselves (idempotent) under the printer's default penalty weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ggteC7wiwU1wmzckfFwa8)_