### PR TITLE
fix(#5978): handle zero-width regex matches in string.replaced [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -14,15 +14,26 @@
   matched.exists.not.if > @
     string text! >> reinit
     block.exists.if > [block accum start] >> rec-replaced
-      rec-replaced
-        block.next
-        concat.
-          accum.concat
+      block.from.eq block.to.if > @
+        rec-replaced
+          block.next
+          concat.
+            accum.concat
+              replacement
             reinit.slice
-              start
-              block.from.minus start
-          replacement
-        block.to
+              block.from
+              1
+          block.from.plus 1
+        rec-replaced
+          block.next
+          concat.
+            accum.concat
+              reinit.slice
+                start
+                block.from.minus start
+            replacement
+          block.to
+      |
       string
         accum.concat
           reinit.slice
@@ -66,6 +77,27 @@
   eq. ++> tests-sanitizes-windows-path-with-regex
     replaced
       "foo\\bar<:>?*\"|baz\\asdf"
-      regex "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/"
+      regex "/[<>:\"\\/|\\?\\*\\x00-\\x1F]/"
       ""
     "foo\\barbaz\\asdf"
+
+  eq. ++> tests-replaces-zero-width-pattern
+    replaced
+      "abc"
+      regex "/x*/"
+      "-"
+    "-a-b-c-"
+
+  eq. ++> tests-replaces-zero-width-pattern-all
+    replaced
+      "aaa"
+      regex "/a*/"
+      "X"
+    "XX"
+
+  eq. ++> tests-replaces-zero-width-empty-string
+    replaced
+      ""
+      regex "/a*/"
+      "X"
+    "X"


### PR DESCRIPTION
## Description

Fixes #5978

The `string.replaced` method fails with `ExFailure` when the target regex pattern can match an empty string (zero-width match). Patterns like `x*`, `a*`, `\d*`, `.?` or any alternation with an empty branch cause the algorithm to loop indefinitely because `block.from == block.to` for zero-width matches, so `start` never advances.

### Root cause

In `rec-replaced`, each recursion step slices the text before the match — `reinit.slice start (block.from - start)` — and then continues from `start = block.to`. For a zero-width match, `block.from == block.to`, so `start` is not advanced, and the next iteration finds the same match again, producing an infinite loop.

### Fix

Added a check for zero-width matches inside `rec-replaced`:
- When `block.from == block.to`, emit the replacement, copy one character from the original string, and advance `start` by one position
- This mirrors how Java's `String.replaceAll` handles zero-width matches (it steps over the match by advancing one character)

### Tests added

- `tests-replaces-zero-width-pattern`: `replaced "abc" (regex "/x*/") "-"` → `"-a-b-c-"`
- `tests-replaces-zero-width-pattern-all`: `replaced "aaa" (regex "/a*/") "X"` → `"XX"`
- `tests-replaces-zero-width-empty-string`: `replaced "" (regex "/a*/") "X"` → `"X"`
