### PR TITLE
Fix #6015: keep the `&gt;&gt; name` handle on a pipe-application line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -90,6 +90,9 @@ final class LnPipe implements Line {
             suffix.attribute(this.span.line(), this.span.indent()),
             null, this.span.line(), this.span.indent()
         );
+        if (!suffix.handle().isEmpty()) {
+            emit.local(suffix.handle());
+        }
         emit.pipe();
         if (suffix.constant()) {
             emit.constant();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-handle.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-vertical-handle.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A pipe-application line may carry a `>> name` file-local handle (§3.14,
+# R-3.10.12): the parser emits the pipe object with its cactus `@name` plus a
+# `@local='name'` marker, exactly as every other handle-bearing line does, so
+# `resolve-local-names` binds the sibling references to the cactus name rather
+# than letting them escape to a global `Φ.tokens` (#6015). The three earlier
+# pipe packs (`pipe-vertical`, `pipe-vertical-named`, `pipe-vertical-bound`)
+# only exercise a bare `| >>`, so none pins the handle-carrying form.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='app']/o[@base='ξ.base' and @name='a🌵5-2' and @local='tokens' and @pipe='']
+  - /object/o[@name='app']/o[@name='a' and @base='ξ.a🌵5-2.at']
+  - /object/o[@name='app']/o[@name='b' and @base='ξ.a🌵5-2.at']
+  - /object/o[@name='app'][count(o[@base='ξ.a🌵5-2.at'])=2]
+  - /object[count(//o[@base='Φ.tokens'])=0]
+input: |
+  [] > app
+    tokens.at 0 > a
+    tokens.at 1 > b
+    [x] > base
+    | >> tokens
+      42

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -42,6 +42,17 @@
   and "merge-monikers" folds it onto its first reference as a moniker, the other
   references reading back as the bare handle. A single-use const still inlines
   to `a!` (#5821).
+
+  A pipe-application handle (`| args &gt;&gt; name`, §3.14 / #6015) is a fourth
+  case. A pipe object carries the "@pipe" marker so that both later passes leave
+  it standing — "inline-cactoos" never inlines it and "merge-monikers" never
+  folds it or rewrites its references. Its readable handle therefore lives or
+  dies entirely in this sheet: like a void, its "@local" marker is KEPT (at any
+  use count) and its references are rewritten back to the handle, so it prints
+  as `| args &gt;&gt; name` with references reading `name`. Unlike a void, its
+  cactus "@name" is NOT promoted — the pipe reads its "&gt;&gt; name" from
+  "@local" — so it stays a bare-named "@pipe" object all the way to
+  "to-eo-tree".
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -194,10 +205,14 @@
     <xsl:variable name="value" select="$wrapper/o[@base='Φ.dataized']/o[1]"/>
     <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $wrapper/@name or starts-with(eo:resolved-name(@base), concat($wrapper/@name, '.'))) and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
   </xsl:function>
-  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]" use="@name"/>
+  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name) or @pipe)]" use="@name"/>
   <!--
-  References: rewrite each cactus segment that names a handled void or a
-  recursive formation back into the readable handle. A formation applied as a
+  References: rewrite each cactus segment that names a handled void, a
+  recursive formation, or a pipe-application handle (`| args &gt;&gt; name`,
+  §3.14 / #6015) back into the readable handle. A pipe object carries the
+  "@pipe" marker, so neither "inline-cactoos" nor "merge-monikers" ever folds it
+  or rewrites its references (both skip "@pipe" bindings); its references are
+  therefore restored here, exactly as a void's are. A formation applied as a
   dispatch receiver (#5844) is deliberately excluded: its cactus name must
   survive so "inline-cactoos" still recognises the reference and pipes it.
   -->
@@ -206,15 +221,20 @@
   </xsl:template>
   <!--
   Handled declaration (void or recursive formation): promote the handle
-  to the visible name. A formation applied as a dispatch receiver (#5844) is
-  not promoted — only its "@local" marker is kept (below) — so its cactus name
-  survives for "inline-cactoos" to pipe against.
+  to the visible name. A formation applied as a dispatch receiver (#5844) and a
+  pipe-application handle (#6015) are not promoted — only their "@local" marker
+  is kept (below) — so their cactus name survives: the dispatch receiver for
+  "inline-cactoos" to pipe against, the pipe handle to read as a `|` line whose
+  "&gt;&gt; name" comes from "@local" rather than a promoted "@name".
   -->
   <xsl:template match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]/@name">
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
-  Keep the marker on voids, on recursive formations, on a formation applied as
+  Keep the marker on voids, on recursive formations, on a pipe-application
+  handle (`| args &gt;&gt; name`, §3.14 / #6015) — never inlined or merged (it
+  carries "@pipe", which both later passes skip), so its readable handle lives
+  or dies here and must be kept at every use count — on a formation applied as
   a dispatch receiver (#5844) — so its relocated pipe predecessor prints its
   readable "&gt;&gt; name" handle — on a multi-referenced binding of any shape
   (an abstract formation, #5876, or a based handle, #5944) — kept whole by
@@ -233,7 +253,7 @@
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:nested-referenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(@pipe) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:nested-referenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named-handle-multi-referenced.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named-handle-multi-referenced.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A pipe-application line carrying a `>> name` file-local handle (§3.14,
+# R-3.10.12), referenced from more than one site (#6015). The parser now keeps
+# the handle's `@local` marker on the pipe object, so "resolve-local-names"
+# binds both `tokens.at` references to the pipe's cactus name. A pipe object
+# carries the "@pipe" marker, so neither "inline-cactoos" nor "merge-monikers"
+# ever folds it or rewrites its references (both skip "@pipe" bindings). Its
+# readable handle is therefore restored entirely by "restore-local-names": the
+# marker survives its drop template and its references read back as `tokens`
+# rather than a synthetic "vL_P" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    tokens.at 0 > a
+    tokens.at 1 > b
+    [x] > base
+    | >> tokens
+      42
+printed: |
+  [] > app
+    tokens.at 0 > a
+    tokens.at 1 > b
+    [x] > base
+    | 42 >> tokens

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-named-handle.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A pipe-application line carrying a `>> name` file-local handle (§3.14,
+# R-3.10.12) reached by a single reference (#6015). A pipe object is never
+# inlined or merged (it carries the "@pipe" marker), so its handle must survive
+# even at a single-use site: "restore-local-names" keeps the "@local" marker on
+# the "@pipe" binding and rewrites the lone `tokens.at` reference back to the
+# readable handle, so the pipe still prints as `| 42 >> tokens` and the
+# reference reads `tokens` rather than a synthetic "vL_P" placeholder.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+    tokens.at 0 > a
+    [x] > base
+    | >> tokens
+      42
+printed: |
+  [] > foo
+    tokens.at 0 > a
+    [x] > base
+    | 42 >> tokens


### PR DESCRIPTION
Fixes #6015.

## Problem

A pipe-application line accepts a `| args >> name` file-local handle (§3.14, R-3.10.12) but the parser threw the name away. `LnPipe.into` emitted the object with the cactus `@name` returned by `suffix.attribute(...)`, but never called `emit.local(suffix.handle())` — the call every other handle-bearing line makes (`LnFormation`, `LnOnlyPhi`, `LnReversed`, `LnVoid`, `ChainEmission`).

Without the `@local` marker, `resolve-local-names` had no table entry, so every sibling reference silently escaped to a non-existent global `Φ.name`, and `eo:format` reprinted the line as a bare `| args >>` with the name gone.

## Fix

**Parser** (`LnPipe.java`) — emit the handle marker, mirroring `LnFormation.java:200-202`:

```java
if (!suffix.handle().isEmpty()) {
    emit.local(suffix.handle());
}
```

**Printer** (`restore-local-names.xsl`) — a pipe object carries the `@pipe` marker, so neither `inline-cactoos` nor `merge-monikers` ever folds it or rewrites its references (both skip `@pipe` bindings). Its readable handle therefore lives or dies entirely in `restore-local-names`, which previously rewrote references only for voids and recursive formations. Two minimal changes:

- Widen the `void-handle` key to also match `@pipe` handles, so their references are rewritten back to the readable `name` instead of a synthetic `vL_P` placeholder.
- Guard the `@local`-drop template with `not(@pipe)`, so a pipe handle keeps its marker at any use count (it is never inlined or merged, so its name must survive here).

The pipe's cactus `@name` is deliberately **not** promoted — the `| args >> name` line reads its `>> name` from `@local`.

## Tests

- `eo-parser` `pipe-vertical-handle.yaml` — pins the parser emission: the pipe object carries `@local` + `@pipe` + a cactus `@name`, both references resolve to that cactus name, and none escapes to `Φ.tokens`.
- `eo-printer` `pipe-named-handle.yaml` and `pipe-named-handle-multi-referenced.yaml` — pin the full round trip for the single- and multi-reference shapes.

All 1517 `eo-parser` tests and 270 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hq2LzATcyPzAs7QkdAGyLw)_