### PR TITLE
#5979: return dividend unchanged when divisor is infinite in number.mod

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -17,18 +17,20 @@
       0
     cant-mod
       "cannot calculate mod by zero"
-    if.
-      gt.
-        number x.as-bytes >> dividend
-        0
-      [] >> abs-mod
-        minus. > @
-          abs dividend >> absx
-          times.
-            abs divisor >> absy
-            floor.
-              absx.div absy
-      abs-mod.neg
+    divisor.is-finite.not.if
+      x
+      if.
+        gt.
+          number x.as-bytes >> dividend
+          0
+        [] >> abs-mod
+          minus. > @
+            abs dividend >> absx
+            times.
+              abs divisor >> absy
+              floor.
+                absx.div absy
+        abs-mod.neg
 
   ++> tests-div-mod-compatibility
     eq. > @
@@ -87,6 +89,24 @@
       16
       -200
     16
+
+  eq. ++> tests-mod-negative-dividend-by-positive-infinity
+    mod
+      -5
+      pinf
+    -5
+
+  eq. ++> tests-mod-positive-dividend-by-negative-infinity
+    mod
+      5
+      ninf
+    5
+
+  eq. ++> tests-mod-positive-dividend-by-positive-infinity
+    mod
+      5
+      pinf
+    5
 
   mod --> on-mod-by-zero
     5


### PR DESCRIPTION
Closes #5979.

`abs-mod` computed `absy.times(floor(absx.div absy))` for a finite dividend and infinite divisor. `absx.div absy` is 0 for a finite dividend and infinite divisor, `floor 0` is 0, and infinity times 0 is `nan`, so the subtraction returned `nan` instead of the dividend.

IEEE / Java `%` on a finite value modulo `+/-infinity` returns the value unchanged, so this short-circuits on an infinite divisor before the abs-mod computation and returns `x` directly.

Added tests for a positive dividend by positive infinity, a negative dividend by positive infinity, and a positive dividend by negative infinity.

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_number.EOmodTest'` - all passing.
