### PR TITLE
#5975: format numeric fallback params with %f instead of %s

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -18,7 +18,7 @@
       not.
         places.floor.eq places
     cant-print
-      "Can't write a fixed-point decimal with %s fraction places".printf
+      "Can't write a fixed-point decimal with %f fraction places".printf
         * places
     if.
       n.lt 0

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -91,6 +91,13 @@
     string
       as-fixed 3.14159 2
 
+  eq. ++> tests-negative-places-formats-message-as-number
+    "Can't write a fixed-point decimal with -2.000000 fraction places"
+    as-fixed
+      3.14159
+      -2
+      message > [message]
+
   eq. ++> tests-negative-places-returns-provided-fallback
     "recovered"
     as-fixed

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -41,6 +41,13 @@
       "hey"
       5
 
+  eq. ++> tests-text-repeated-negative-times-formats-message-as-number
+    "Can't repeat text -1.000000 times"
+    repeated
+      "x"
+      -1
+      message > [message]
+
   eq. ++> tests-text-repeated-negative-times-returns-provided-fallback
     "recovered"
     repeated

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -17,7 +17,7 @@
       not.
         times.floor.eq times
     cant-repeat
-      "Can't repeat text %s times".printf
+      "Can't repeat text %f times".printf
         * times
     string
       if. >> result!


### PR DESCRIPTION
Closes #5975.

`%s` maps to `Dataized::asString`, which reinterprets a number's delta bytes as UTF-8 text instead of formatting the digits, so the `cant-repeat` fallback message in `string.repeated` and the `cant-print` fallback message in `string.as-fixed` showed 8 bytes of raw IEEE-754 garbage instead of the offending value.

`%f` formats the actual number instead, matching the suggestion in the issue (both fallbacks fire for negative or fractional values, so `%d`, which truncates toward zero, would misreport a value like `2.5` as `2`).

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_string.EOrepeatedTest,EO_string.EOas_fixedTest'` - all passing (existing coverage already exercises both fallback paths with the value returned, this just fixes what would be shown if the message itself is surfaced).
