### PR TITLE
#5973: reject non-finite input in string.as-decimal instead of recursing forever

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -9,30 +9,33 @@
 +spdx SPDX-License-Identifier: MIT
 
 [n] > as-decimal
-  if. > @
-    n.lt 0
-    if. > [m] >> negative
-      m.floor.eq 0
-      digits m
-      "-".as-bytes.concat
+  n.is-finite.not.if > @
+    trouble
+      "Can't write a non-finite number as decimal"
+    if.
+      n.lt 0
+      if. > [m] >> negative
+        m.floor.eq 0
         digits m
-    | (n.times -1)
-    [n] >> digits
-      if. > @
-        n.lt 10
-        as-char
-          n.floor.plus 48
-        concat.
-          digits q
+        "-".as-bytes.concat
+          digits m
+      | (n.times -1)
+      [n] >> digits
+        if. > @
+          n.lt 10
           as-char
-            plus.
-              floor.
-                n.minus
-                  q.times 10
-              48
-      floor. > q
-        n.div 10
-    | n
+            n.floor.plus 48
+          concat.
+            digits q
+            as-char
+              plus.
+                floor.
+                  n.minus
+                    q.times 10
+                48
+        floor. > q
+          n.div 10
+      | n
 
   eq. ++> tests-negative-below-one-drops-sign
     "0"
@@ -78,3 +81,9 @@
     "0"
     string
       as-decimal 0
+
+  as-decimal nan --> on-nan
+
+  as-decimal ninf --> on-negative-infinity
+
+  as-decimal pinf --> on-positive-infinity


### PR DESCRIPTION
Closes #5973.

`digits` bottoms out on `n.lt 10`, but every comparison with a non-finite `n` is false, and `q = floor(n / 10)` stays `nan`/`inf`, so `digits` called itself with an unchanging argument and never terminated (about 2500 nested frames for `nan`/`+-inf`).

Guards non-finite input at the top with `n.is-finite`, calling the void `trouble` attribute with a message instead of entering the recursion. This is the same bottom-object convention already used by fallback params elsewhere in this codebase, just without a caller-supplied fallback since `as-decimal` takes none.

`string.as-fixed` calls `as-decimal` internally, so it now surfaces the same clean failure instead of inheriting the runaway recursion.

Added tests for `nan`, `+inf` and `-inf` all expecting a clean throw instead of a hang.

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_string.EOas_decimalTest'` - all passing.
