### PR TITLE
#5940: wrap raw IllegalFormatException as a clean ExFailure in printf

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -188,11 +188,38 @@
     "%s%s"
     "Jeff"
 
+  printf *1 --> on-printf-with-comma-flag-on-s
+    "%,s"
+    "Jeff"
+
+  printf *1 --> on-printf-with-comma-flag-on-x
+    "%,x"
+    5
+
+  printf *1 --> on-printf-with-hash-flag-on-s
+    "%#s"
+    "Jeff"
+
+  printf *1 --> on-printf-with-hash-flag-on-x
+    "%#x"
+    5
+
   printf *1 --> on-printf-with-oversized-positional-index
     "%99999999999999999999$s"
     "Jeff"
 
+  printf *1 --> on-printf-with-paren-flag-on-s
+    "%(s"
+    "Jeff"
+
+  printf *1 --> on-printf-with-precision-on-d
+    "%.2d"
+    5
+
+  printf *1 --> on-printf-with-zero-flag-on-x
+    "%0x"
+    5
+
   printf *1 --> on-printf-with-zero-positional-index
     "%0$s"
     "first"
-    "second"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -9,6 +9,7 @@
  */
 package org.eolang.EO_string; // NOPMD
 
+import java.util.IllegalFormatException;
 import java.util.Locale;
 import org.eolang.AtVoid;
 import org.eolang.Atom;
@@ -16,6 +17,7 @@ import org.eolang.Attr;
 import org.eolang.Attrs;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Expect;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -42,22 +44,29 @@ public final class EOprintf extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final String format = new Dataized(this.take("format")).asString();
-        return new Data.ToPhi(
-            String.format(
-                Locale.US,
-                PrintfArgs.javaFormat(format),
-                new PrintfArgs(
-                    format,
-                    Expect.at(this, "args")
-                        .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
-                        .otherwise("be a tuple with the 'length' attribute")
-                        .it(),
-                    Expect.at(this, "args")
-                        .that(phi -> phi.take("at"))
-                        .otherwise("be a tuple with the 'at' attribute")
-                        .it()
-                ).formatted().toArray()
-            )
-        );
+        try {
+            return new Data.ToPhi(
+                String.format(
+                    Locale.US,
+                    PrintfArgs.javaFormat(format),
+                    new PrintfArgs(
+                        format,
+                        Expect.at(this, "args")
+                            .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
+                            .otherwise("be a tuple with the 'length' attribute")
+                            .it(),
+                        Expect.at(this, "args")
+                            .that(phi -> phi.take("at"))
+                            .otherwise("be a tuple with the 'at' attribute")
+                            .it()
+                    ).formatted().toArray()
+                )
+            );
+        } catch (final IllegalFormatException ex) {
+            throw new ExFailure(
+                String.format("The format '%s' is not a valid printf format string", format),
+                ex
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #5940.

`String.format` threw a raw `java.util.IllegalFormatException` whenever a flag or precision was rejected for the effective conversion (`%.2d`, `%#s`, `%,x`, `%(s`, ...), or when the `%x`-to-`%s` rewrite kept a flag that is legal on a numeric conversion but not on a string one (`%#x`, `%0x`). An EO program cannot catch a JVM exception, so the whole dataization crashed with a runtime-internal error instead of the object failing cleanly.

`EOprintf.lambda()` now wraps the `String.format` call and converts any `IllegalFormatException` into an `ExFailure` carrying the offending format string, matching how the object's other error paths already surface `ExFailure` (`PrintfArgs.fmt`, `PrintfArgs.toLong`).

Added tests for all seven reproductions from the issue (`%.2d`, `%#x`, `%0x`, `%,x`, `%,s`, `%#s`, `%(s`), each expecting a clean throw.

Tests: `mvn -pl eo-runtime -o test -Dtest='EO_string.EOprintfTest'` - all passing. Also ran `qulice:check -Pqulice` on the changed Java file, no violations.
