### PR TITLE
Combine receiver-only reversed dispatch into hybrid inline-phi (#5954)

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -331,11 +331,16 @@ final class Pretty {
      * built at all, the hybrid is used unconditionally. Either way the result
      * is only a candidate — the penalty check in {@link #shaped} keeps it only
      * when it beats the plain vertical rendering. A formation decoratee
-     * (its bindings are vertical, not arguments) and a receiver-only
-     * reversed dispatch ({@code not.} with just its receiver, mirroring the
-     * rejection in {@link #flat}) have no hybrid form, so they yield empty
-     * and keep the verbose layout; a reversed dispatch that also carries
-     * arguments ({@code if.} with its branches) does get the hybrid.</p>
+     * (its bindings are vertical, not arguments) has no hybrid form, so it
+     * yields empty and keeps the verbose layout. A reversed dispatch does get
+     * the hybrid whether it carries just its receiver ({@code not.}) or also
+     * arguments ({@code if.} with its branches): unlike {@link #flat}, which
+     * rejects a receiver-only reversed dispatch because it has no horizontal
+     * one-line spelling, the hybrid keeps the dispatch on the head line and
+     * lays the receiver out beneath — a shape {@code LnOnlyPhi} accepts, its
+     * {@code bare()} leaving the φ {@code Openness.OPEN} so the deeper line
+     * attaches as the receiver, with no minimum argument count on close (issue
+     * #5954).</p>
      *
      * <p>The hybrid is also withheld when any line in the decoratee's whole
      * subtree carries a name suffix ({@code [left] >>}, {@code malloc.for >
@@ -374,8 +379,7 @@ final class Pretty {
             ).map(
                 inlined -> this.tab.repeat(indent).concat(inlined).concat(marker)
             );
-            final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty()
-                && !(decoratee.reversed && decoratee.children.size() <= 1);
+            final boolean applied = !decoratee.abstractt && !decoratee.children.isEmpty();
             final boolean unnamed = decoratee.children.stream()
                 .allMatch(Node::nameless);
             if (applied && unnamed) {

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-reversed-receiver-only.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-reversed-receiver-only.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package org.eolang
+
+  [x] > dataized /Q.bytes
+
+    ++> tests-compares-string-with-negative-infinity
+      not. > @
+        ninf.eq "друг"
+
+printed: |
+  +package org.eolang
+
+  [x] > dataized /Q.bytes
+
+    not. ++> tests-compares-string-with-negative-infinity
+      ninf.eq "друг"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-with-data-receiver-args.yaml
@@ -17,4 +17,5 @@ origin: |
         00-.as-bool
 
 printed: |
-  (01-.as-bool.eq 00-.as-bool).not > [] > app
+  not. > [] > app
+    01-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -54,9 +54,8 @@
 
   true.eq true ++> tests-compares-two-bools
 
-  ++> tests-compares-two-different-bool-types
-    not. > @
-      true.eq 42
+  not. ++> tests-compares-two-different-bool-types
+    true.eq 42
 
   ++> tests-compiles-correctly-with-long-duplicate-names
     true > @
@@ -204,9 +203,8 @@
         x.eq 42 > [] > @
     42 > x
 
-  ++> tests-true-and-false-is-false
-    not. > @
-      true.and false
+  not. ++> tests-true-and-false-is-false
+    true.and false
 
   true.as-bool ++> tests-true-as-bool
 

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -106,17 +106,14 @@
 
   F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
 
-  ++> tests-not-with-neg
-    not. > @
-      -1.as-bytes.eq -1.as-bytes.not
+  not. ++> tests-not-with-neg
+    -1.as-bytes.eq -1.as-bytes.not
 
-  ++> tests-not-with-plus
-    not. > @
-      53.as-bytes.eq 53.as-bytes.not
+  not. ++> tests-not-with-plus
+    53.as-bytes.eq 53.as-bytes.not
 
-  ++> tests-not-with-zero
-    not. > @
-      0.as-bytes.eq 0.as-bytes.not
+  not. ++> tests-not-with-zero
+    0.as-bytes.eq 0.as-bytes.not
 
   eq. ++> tests-or-neg-bytes-as-number-with-zero
     as-number.

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -10,6 +10,5 @@
 [b] > as-bool
   b.eq 01- > @
 
-  ++> tests-convertible-to-bool
-    not. > @
-      01-.as-bool.eq 00-.as-bool
+  not. ++> tests-convertible-to-bool
+    01-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -17,9 +17,8 @@
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * b
 
-  ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
-    not. > @
-      00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+  not. ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
+    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> tests-bytes-converts-to-i64
 

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -27,7 +27,8 @@
       "Can't convert non 8 length bytes to a number, bytes are %x".printf
         * b
 
-  FF-F8-00-00-00-00-00-00.as-number.is-nan ++> tests-non-canonical-nan-bytes-route-to-nan
+  is-nan. ++> tests-non-canonical-nan-bytes-route-to-nan
+    FF-F8-00-00-00-00-00-00.as-number
 
   eq. ++> tests-wrong-size-as-number-returns-provided-fallback
     "recovered"

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -58,17 +58,15 @@
     hash 42
     hash 42
 
-  ++> tests-hash-codes-of-different-ints-are-not-equal
-    not. > @
-      eq.
-        hash 42
-        hash 24
+  not. ++> tests-hash-codes-of-different-ints-are-not-equal
+    eq.
+      hash 42
+      hash 24
 
-  ++> tests-hash-codes-of-different-sign-ints-are-not-equal
-    not. > @
-      eq.
-        hash 42
-        hash -42
+  not. ++> tests-hash-codes-of-different-sign-ints-are-not-equal
+    eq.
+      hash 42
+      hash -42
 
   ++> tests-hash-code-string-is-int
     1.eq > @
@@ -81,17 +79,15 @@
     hash "Hello"
     hash "Hello"
 
-  ++> tests-hash-codes-of-same-length-strings-are-not-equal
-    not. > @
-      eq.
-        hash "one"
-        hash "two"
+  not. ++> tests-hash-codes-of-same-length-strings-are-not-equal
+    eq.
+      hash "one"
+      hash "two"
 
-  ++> tests-hash-codes-of-different-strings-are-not-equal
-    not. > @
-      eq.
-        hash "hello"
-        hash "bye!!!"
+  not. ++> tests-hash-codes-of-different-strings-are-not-equal
+    eq.
+      hash "hello"
+      hash "bye!!!"
 
   ++> tests-hash-code-abstract-object-is-int
     1.eq > @
@@ -137,14 +133,12 @@
         4.242e43 >> bigval!
       hash bigval
 
-  ++> tests-hash-codes-of-different-floats-are-not-equal
-    not. > @
-      eq.
-        hash 3.14
-        hash 2.72
+  not. ++> tests-hash-codes-of-different-floats-are-not-equal
+    eq.
+      hash 3.14
+      hash 2.72
 
-  ++> tests-hash-codes-of-different-sign-floats-are-not-equal
-    not. > @
-      eq.
-        hash 3.22
-        hash -3.22
+  not. ++> tests-hash-codes-of-different-sign-floats-are-not-equal
+    eq.
+      hash 3.22
+      hash -3.22

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -46,6 +46,6 @@
     dir.tmpfile > first
     dir.tmpfile > second
 
-  ++> tests-deletes-empty-directory
-    not. > @
-      exists. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made.deleted
+  not. ++> tests-deletes-empty-directory
+    exists.
+      deleted. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -253,14 +253,12 @@
         f.write "!" > [f]
     13
 
-  ++> tests-check-if-absent-file-does-not-exist
-    not. > @
-      exists.
-        file "absent.txt"
+  not. ++> tests-check-if-absent-file-does-not-exist
+    exists.
+      file "absent.txt"
 
-  ++> tests-check-if-current-directory-is-directory
-    is-directory. > @
-      file "."
+  is-directory. ++> tests-check-if-current-directory-is-directory
+    file "."
 
   mktemp.tmpfile.deleted.is-directory ++> tests-checking-absent-file-returns-fallback
     true
@@ -398,29 +396,25 @@
 
   mktemp.tmpfile.deleted.touched.exists ++> tests-touches-a-file
 
-  ++> tests-touches-absent-file-on-opening-for-appending
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "a"
-        true > [f]
+  exists. ++> tests-touches-absent-file-on-opening-for-appending
+    mktemp.tmpfile.deleted.open
+      "a"
+      true > [f]
 
-  ++> tests-touches-absent-file-on-opening-for-reading-or-appending
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "a+"
-        true > [f]
+  exists. ++> tests-touches-absent-file-on-opening-for-reading-or-appending
+    mktemp.tmpfile.deleted.open
+      "a+"
+      true > [f]
 
-  ++> tests-touches-absent-file-on-opening-for-writing
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "w"
-        true > [f]
+  exists. ++> tests-touches-absent-file-on-opening-for-writing
+    mktemp.tmpfile.deleted.open
+      "w"
+      true > [f]
 
-  ++> tests-touches-absent-file-on-opening-for-writing-or-reading
-    exists. > @
-      mktemp.tmpfile.deleted.open
-        "w+"
-        true > [f]
+  exists. ++> tests-touches-absent-file-on-opening-for-writing-or-reading
+    mktemp.tmpfile.deleted.open
+      "w+"
+      true > [f]
 
   eq. ++> tests-truncates-file-opened-for-writing
     size.
@@ -484,10 +478,9 @@
           "!"
     13
 
-  --> an-error-on-touching-temp-file-in-absent-dir
-    tmpfile. > @
-      @.
-        mktemp.as-path.resolved "foo"
+  tmpfile. --> an-error-on-touching-temp-file-in-absent-dir
+    @.
+      mktemp.as-path.resolved "foo"
 
   mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
 

--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -10,12 +10,11 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
-[name] > getenv
-  output. > @
-    os.is-windows.if
-      win32 *1
-        "getenv"
-        name
-      posix *1
-        "getenv"
-        name
+output. > [name] > getenv
+  os.is-windows.if
+    win32 *1
+      "getenv"
+      name
+    posix *1
+      "getenv"
+      name

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -107,19 +107,16 @@
     13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
 
-  ++> tests-i16-eq-false
-    not. > @
-      123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
+  not. ++> tests-i16-eq-false
+    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
 
   123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
 
-  ++> tests-i16-greater-equal
-    not. > @
-      0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
+  not. ++> tests-i16-greater-equal
+    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
 
-  ++> tests-i16-greater-false
-    not. > @
-      0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
+  not. ++> tests-i16-greater-false
+    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
 
   gt. ++> tests-i16-greater-true
     -200.as-i64.as-i32.as-i16
@@ -127,29 +124,25 @@
 
   113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
 
-  ++> tests-i16-gte-false
-    not. > @
-      0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
+  not. ++> tests-i16-gte-false
+    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
 
   -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
 
   42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
 
-  ++> tests-i16-less-equal
-    not. > @
-      10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
+  not. ++> tests-i16-less-equal
+    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
 
-  ++> tests-i16-less-false
-    not. > @
-      10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
+  not. ++> tests-i16-less-false
+    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
 
   10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
 
   50.as-i64.as-i32.as-i16.lte 50.as-i64.as-i32.as-i16 ++> tests-i16-lte-equal
 
-  ++> tests-i16-lte-false
-    not. > @
-      0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
+  not. ++> tests-i16-lte-false
+    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
 
   -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
 

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -115,47 +115,40 @@
     13.as-i64.as-i32.div -5.as-i64.as-i32
     -2.as-i64.as-i32
 
-  ++> tests-i32-eq-false
-    not. > @
-      123.as-i64.as-i32.eq 42.as-i64.as-i32
+  not. ++> tests-i32-eq-false
+    123.as-i64.as-i32.eq 42.as-i64.as-i32
 
   123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
 
-  ++> tests-i32-greater-equal
-    not. > @
-      0.as-i64.as-i32.gt 0.as-i64.as-i32
+  not. ++> tests-i32-greater-equal
+    0.as-i64.as-i32.gt 0.as-i64.as-i32
 
-  ++> tests-i32-greater-false
-    not. > @
-      0.as-i64.as-i32.gt 100.as-i64.as-i32
+  not. ++> tests-i32-greater-false
+    0.as-i64.as-i32.gt 100.as-i64.as-i32
 
   -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
 
   113.as-i64.as-i32.gte 113.as-i64.as-i32 ++> tests-i32-gte-equal
 
-  ++> tests-i32-gte-false
-    not. > @
-      0.as-i64.as-i32.gte 10.as-i64.as-i32
+  not. ++> tests-i32-gte-false
+    0.as-i64.as-i32.gte 10.as-i64.as-i32
 
   -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
 
   42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
 
-  ++> tests-i32-less-equal
-    not. > @
-      10.as-i64.as-i32.lt 10.as-i64.as-i32
+  not. ++> tests-i32-less-equal
+    10.as-i64.as-i32.lt 10.as-i64.as-i32
 
-  ++> tests-i32-less-false
-    not. > @
-      10.as-i64.as-i32.lt -5.as-i64.as-i32
+  not. ++> tests-i32-less-false
+    10.as-i64.as-i32.lt -5.as-i64.as-i32
 
   10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
 
   50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
 
-  ++> tests-i32-lte-false
-    not. > @
-      0.as-i64.as-i32.lte -10.as-i64.as-i32
+  not. ++> tests-i32-lte-false
+    0.as-i64.as-i32.lte -10.as-i64.as-i32
 
   -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
 

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -89,35 +89,30 @@
       as-bytes
       x.as-bytes
 
-  ++> tests-i64-as-bytes-is-not-equal-to-number-bytes
-    not. > @
-      eq.
-        i64 234.as-bytes
-        234.as-i64.as-bytes
+  not. ++> tests-i64-as-bytes-is-not-equal-to-number-bytes
+    eq.
+      i64 234.as-bytes
+      234.as-i64.as-bytes
 
-  ++> tests-i64-eq-false
-    not. > @
-      123.@.eq 42.@
+  not. ++> tests-i64-eq-false
+    123.@.eq 42.@
 
   123.@.eq 123.@ ++> tests-i64-eq-true
 
-  ++> tests-i64-greater-equal
-    not. > @
-      0.as-i64.gt 0.as-i64
+  not. ++> tests-i64-greater-equal
+    0.as-i64.gt 0.as-i64
 
-  ++> tests-i64-greater-false
-    not. > @
-      0.as-i64.gt 100.as-i64
+  not. ++> tests-i64-greater-false
+    0.as-i64.gt 100.as-i64
 
   gt. ++> tests-i64-greater-max-over-min
     i64 7F-FF-FF-FF-FF-FF-FF-FF
     i64 80-00-00-00-00-00-00-00
 
-  ++> tests-i64-greater-min-not-over-max
-    not. > @
-      gt.
-        i64 80-00-00-00-00-00-00-00
-        i64 7F-FF-FF-FF-FF-FF-FF-FF
+  not. ++> tests-i64-greater-min-not-over-max
+    gt.
+      i64 80-00-00-00-00-00-00-00
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
 
   gt. ++> tests-i64-greater-same-sign-large-negatives
     -5000000000000000000.as-i64
@@ -127,9 +122,8 @@
 
   113.as-i64.gte 113.as-i64 ++> tests-i64-gte-equal
 
-  ++> tests-i64-gte-false
-    not. > @
-      0.as-i64.gte 10.as-i64
+  not. ++> tests-i64-gte-false
+    0.as-i64.gte 10.as-i64
 
   -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
 
@@ -145,25 +139,21 @@
 
   -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
 
-  ++> tests-i64-less-equal
-    not. > @
-      10.as-i64.lt 10.as-i64
+  not. ++> tests-i64-less-equal
+    10.as-i64.lt 10.as-i64
 
-  ++> tests-i64-less-false
-    not. > @
-      10.as-i64.lt -5.as-i64
+  not. ++> tests-i64-less-false
+    10.as-i64.lt -5.as-i64
 
   10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
 
-  ++> tests-i64-less-with-large-difference
-    not. > @
-      5000000000000000000.as-i64.lt -5000000000000000000.as-i64
+  not. ++> tests-i64-less-with-large-difference
+    5000000000000000000.as-i64.lt -5000000000000000000.as-i64
 
   50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
 
-  ++> tests-i64-lte-false
-    not. > @
-      0.as-i64.lte -10.as-i64
+  not. ++> tests-i64-lte-false
+    0.as-i64.lte -10.as-i64
 
   -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
 

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -83,9 +83,8 @@
     0D-.as-i8.div FB-.as-i8
     FE-.as-i8
 
-  ++> tests-i8-eq-false
-    not. > @
-      2A-.as-i8.eq 2B-.as-i8
+  not. ++> tests-i8-eq-false
+    2A-.as-i8.eq 2B-.as-i8
 
   2A-.as-i8.eq 2A-.as-i8 ++> tests-i8-eq-true
 
@@ -95,9 +94,8 @@
 
   C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
 
-  ++> tests-i8-less-equal
-    not. > @
-      0A-.as-i8.lt 0A-.as-i8
+  not. ++> tests-i8-less-equal
+    0A-.as-i8.lt 0A-.as-i8
 
   0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
 

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -44,11 +44,10 @@
               rec-rebuild tup.tail
             tuple.filtered > without-key
               prev
-              [ent] >>
-                not. > @
-                  and.
-                    ent.hash.eq hash
-                    ent.kbts.eq kbts
+              not. > [ent] >>
+                and.
+                  ent.hash.eq hash
+                  ent.kbts.eq kbts
           | pairs
   [entries] > ctor
     [key] > found
@@ -79,9 +78,8 @@
         cant-get > [cant-get] > get
           "Object by hash code %d from given key does not exists".printf
             * hash
-    [key] > has
-      exists. > @
-        found key
+    exists. > [key] > has
+      found key
     tuple.mapped > keys
       entries
       entry.key > [entry]
@@ -94,11 +92,10 @@
         with.
           tuple.filtered
             entries
-            [entry] >>
-              not. > @
-                and.
-                  hash.eq entry.hash
-                  kbts.eq entry.kbts
+            not. > [entry] >>
+              and.
+                hash.eq entry.hash
+                kbts.eq entry.kbts
           [] >>
             ^.hash > hash
             ^.kbts > kbts
@@ -110,11 +107,10 @@
       map.ctor > @
         tuple.filtered
           entries
-          [entry] >>
-            not. > @
-              and.
-                hash.eq entry.hash
-                kbts.eq entry.kbts
+          not. > [entry] >>
+            and.
+              hash.eq entry.hash
+              kbts.eq entry.kbts
       bytes.hash >> hash!
         key.as-bytes >> kbts!
   [key value] > entry
@@ -149,29 +145,26 @@
         "two"
     1
 
-  ++> tests-does-not-find-element-by-key-in-hash-map
-    not. > @
-      exists.
-        found.
-          map *
-            map.entry "one" 1
-            map.entry "two" 2
-          "three"
-
-  ++> tests-does-not-have-absent-key-colliding-with-stored-one
-    not. > @
-      has.
-        map *
-          map.entry "Aa" 1
-        "BB"
-
-  ++> tests-does-not-have-element-by-key-in-hash-map
-    not. > @
-      has.
+  not. ++> tests-does-not-find-element-by-key-in-hash-map
+    exists.
+      found.
         map *
           map.entry "one" 1
           map.entry "two" 2
         "three"
+
+  not. ++> tests-does-not-have-absent-key-colliding-with-stored-one
+    has.
+      map *
+        map.entry "Aa" 1
+      "BB"
+
+  not. ++> tests-does-not-have-element-by-key-in-hash-map
+    has.
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "three"
 
   eq. ++> tests-falls-back-for-absent-key-colliding-with-stored-one
     "recovered"

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -157,9 +157,8 @@
     ninf.div 42
     ninf
 
-  ++> tests-negative-infinity-gt-negative-infinity
-    not. > @
-      ninf.gt ninf
+  not. ++> tests-negative-infinity-gt-negative-infinity
+    ninf.gt ninf
 
   ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
     -1.div 0
@@ -335,16 +334,14 @@
 
   pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
 
-  ++> tests-positive-infinity-gt-positive-infinity
-    not. > @
-      pinf.gt pinf
+  not. ++> tests-positive-infinity-gt-positive-infinity
+    pinf.gt pinf
 
   pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
     1.div 0
 
-  ++> tests-positive-infinity-not-gt-nan
-    not. > @
-      pinf.gt nan
+  not. ++> tests-positive-infinity-not-gt-nan
+    pinf.gt nan
 
   eq. ++> tests-positive-infinity-plus-nan
     as-bytes.

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,21 +15,17 @@
     pi.div 2
     arc-sine num
 
-  ++> tests-arc-cosine-above-one-is-nan
-    is-nan. > @
-      arc-cosine 2
+  is-nan. ++> tests-arc-cosine-above-one-is-nan
+    arc-cosine 2
 
-  ++> tests-arc-cosine-below-minus-one-is-nan
-    is-nan. > @
-      arc-cosine -2
+  is-nan. ++> tests-arc-cosine-below-minus-one-is-nan
+    arc-cosine -2
 
-  ++> tests-arc-cosine-of-nan-is-nan
-    is-nan. > @
-      arc-cosine nan
+  is-nan. ++> tests-arc-cosine-of-nan-is-nan
+    arc-cosine nan
 
-  ++> tests-arc-cosine-of-negative-infinity-is-nan
-    is-nan. > @
-      arc-cosine ninf
+  is-nan. ++> tests-arc-cosine-of-negative-infinity-is-nan
+    arc-cosine ninf
 
   eq. ++> tests-arc-cosine-of-negative-one-is-pi
     arc-cosine -1
@@ -57,9 +53,8 @@
         927.295
     1
 
-  ++> tests-arc-cosine-of-positive-infinity-is-nan
-    is-nan. > @
-      arc-cosine pinf
+  is-nan. ++> tests-arc-cosine-of-positive-infinity-is-nan
+    arc-cosine pinf
 
   eq. ++> tests-arc-cosine-of-zero-is-pi-halves
     arc-cosine 0

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -48,13 +48,11 @@
         series magnitude
     base
 
-  ++> tests-arc-sine-above-one-is-nan
-    is-nan. > @
-      arc-sine 2
+  is-nan. ++> tests-arc-sine-above-one-is-nan
+    arc-sine 2
 
-  ++> tests-arc-sine-below-minus-one-is-nan
-    is-nan. > @
-      arc-sine -2
+  is-nan. ++> tests-arc-sine-below-minus-one-is-nan
+    arc-sine -2
 
   lt. ++> tests-arc-sine-is-odd-function
     abs
@@ -76,9 +74,8 @@
           1000
     1
 
-  ++> tests-arc-sine-of-nan-is-nan
-    is-nan. > @
-      arc-sine nan
+  is-nan. ++> tests-arc-sine-of-nan-is-nan
+    arc-sine nan
 
   lt. ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
     abs
@@ -92,9 +89,8 @@
           1000
     1
 
-  ++> tests-arc-sine-of-negative-infinity-is-nan
-    is-nan. > @
-      arc-sine ninf
+  is-nan. ++> tests-arc-sine-of-negative-infinity-is-nan
+    arc-sine ninf
 
   lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
     abs
@@ -128,9 +124,8 @@
         643.5
     1
 
-  ++> tests-arc-sine-of-positive-infinity-is-nan
-    is-nan. > @
-      arc-sine pinf
+  is-nan. ++> tests-arc-sine-of-positive-infinity-is-nan
+    arc-sine pinf
 
   eq. ++> tests-arc-sine-of-zero-is-zero
     arc-sine 0

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -23,13 +23,11 @@
         1000
     1
 
-  ++> tests-cosine-of-nan-is-nan
-    is-nan. > @
-      cosine nan
+  is-nan. ++> tests-cosine-of-nan-is-nan
+    cosine nan
 
-  ++> tests-cosine-of-negative-infinity-is-nan
-    is-nan. > @
-      cosine ninf
+  is-nan. ++> tests-cosine-of-negative-infinity-is-nan
+    cosine ninf
 
   lt. ++> tests-cosine-of-pi-halves-is-zero
     abs
@@ -58,9 +56,8 @@
         500
     1
 
-  ++> tests-cosine-of-positive-infinity-is-nan
-    is-nan. > @
-      cosine pinf
+  is-nan. ++> tests-cosine-of-positive-infinity-is-nan
+    cosine pinf
 
   lt. ++> tests-cosine-of-seventeen-radians
     abs

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -15,9 +15,8 @@
       180
     pi
 
-  ++> tests-degrees-of-nan-is-nan
-    is-nan. > @
-      degrees nan
+  is-nan. ++> tests-degrees-of-nan-is-nan
+    degrees nan
 
   lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
     abs

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -124,46 +124,36 @@
     0.eq 0
     true
 
-  ++> tests-nan-not-eq-nan
-    not. > @
-      nan.eq nan
+  not. ++> tests-nan-not-eq-nan
+    nan.eq nan
 
-  ++> tests-nan-not-eq-number
-    not. > @
-      nan.eq 42
+  not. ++> tests-nan-not-eq-number
+    nan.eq 42
 
   ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
 
-  ++> tests-negative-infinity-not-eq-float
-    not. > @
-      ninf.eq 42.5
+  not. ++> tests-negative-infinity-not-eq-float
+    ninf.eq 42.5
 
-  ++> tests-negative-infinity-not-eq-int
-    not. > @
-      ninf.eq 42
+  not. ++> tests-negative-infinity-not-eq-int
+    ninf.eq 42
 
-  ++> tests-negative-infinity-not-eq-nan
-    not. > @
-      ninf.eq nan
+  not. ++> tests-negative-infinity-not-eq-nan
+    ninf.eq nan
 
-  ++> tests-negative-infinity-not-eq-positive-infinity
-    not. > @
-      ninf.eq pinf
+  not. ++> tests-negative-infinity-not-eq-positive-infinity
+    ninf.eq pinf
 
   pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
 
-  ++> tests-positive-infinity-not-eq-float
-    not. > @
-      pinf.eq 42.5
+  not. ++> tests-positive-infinity-not-eq-float
+    pinf.eq 42.5
 
-  ++> tests-positive-infinity-not-eq-int
-    not. > @
-      pinf.eq 42
+  not. ++> tests-positive-infinity-not-eq-int
+    pinf.eq 42
 
-  ++> tests-positive-infinity-not-eq-nan
-    not. > @
-      pinf.eq nan
+  not. ++> tests-positive-infinity-not-eq-nan
+    pinf.eq nan
 
-  ++> tests-positive-infinity-not-eq-negative-infinity
-    not. > @
-      pinf.eq ninf
+  not. ++> tests-positive-infinity-not-eq-negative-infinity
+    pinf.eq ninf

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -47,6 +47,5 @@
         exp -10
     1.0E-12
 
-  ++> tests-exp-check-nan
-    is-nan. > @
-      exp nan
+  is-nan. ++> tests-exp-check-nan
+    exp nan

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -20,9 +20,8 @@
 
   ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
 
-  ++> tests-number-with-infinite-bytes-is-not-finite
-    not. > @
-      is-finite.
-        number pinf.as-bytes
+  not. ++> tests-number-with-infinite-bytes-is-not-finite
+    is-finite.
+      number pinf.as-bytes
 
   pinf.is-finite.not ++> tests-positive-infinity-is-not-finite

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -70,13 +70,11 @@
 
   ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
 
-  ++> tests-non-canonical-nan-bytes-is-nan
-    is-nan. > @
-      number FF-F8-00-00-00-00-00-00
+  is-nan. ++> tests-non-canonical-nan-bytes-is-nan
+    number FF-F8-00-00-00-00-00-00
 
-  ++> tests-number-with-nan-bytes-is-nan
-    is-nan. > @
-      number nan.as-bytes
+  is-nan. ++> tests-number-with-nan-bytes-is-nan
+    number nan.as-bytes
 
   pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
 

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -71,25 +71,21 @@
     ln 2
     ln 3
 
-  ++> tests-ln-nan
-    is-nan. > @
-      ln nan
+  is-nan. ++> tests-ln-nan
+    ln nan
 
-  ++> tests-ln-negative-infinity
-    is-nan. > @
-      ln ninf
+  is-nan. ++> tests-ln-negative-infinity
+    ln ninf
 
   eq. ++> tests-ln-of-e-one-is-one
     ln e
     1
 
-  ++> tests-ln-of-negative-float-is-nan
-    is-nan. > @
-      ln -2.2
+  is-nan. ++> tests-ln-of-negative-float-is-nan
+    ln -2.2
 
-  ++> tests-ln-of-negative-int-is-nan
-    is-nan. > @
-      ln -42
+  is-nan. ++> tests-ln-of-negative-int-is-nan
+    ln -42
 
   eq. ++> tests-ln-of-one-is-zero
     ln 1

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -106,9 +106,10 @@
                 nan
                 pinf
 
-  ++> tests-power-any-to-nan-is-nan
-    is-nan. > @
-      power 52 nan
+  is-nan. ++> tests-power-any-to-nan-is-nan
+    power
+      52
+      nan
 
   eq. ++> tests-power-as-method-on-number
     2.power 4
@@ -145,9 +146,10 @@
       -3
     0.015625
 
-  ++> tests-power-fractional-of-negative-is-nan
-    is-nan. > @
-      power -4 0.5
+  is-nan. ++> tests-power-fractional-of-negative-is-nan
+    power
+      -4
+      0.5
 
   eq. ++> tests-power-int-to-zero-is-one
     power
@@ -161,13 +163,15 @@
       -12341
     0
 
-  ++> tests-power-nan-to-any-is-nan
-    is-nan. > @
-      power nan 42
+  is-nan. ++> tests-power-nan-to-any-is-nan
+    power
+      nan
+      42
 
-  ++> tests-power-nan-to-nan-is-nan
-    is-nan. > @
-      power nan nan
+  is-nan. ++> tests-power-nan-to-nan-is-nan
+    power
+      nan
+      nan
 
   eq. ++> tests-power-negative-float-to-negative-infinity-is-zero
     power

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -29,9 +29,8 @@
         pi
     1.0E-4
 
-  ++> tests-radians-of-nan-is-nan
-    is-nan. > @
-      radians nan
+  is-nan. ++> tests-radians-of-nan-is-nan
+    radians nan
 
   lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
     abs

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -80,8 +80,7 @@
     next. (random 1654).next.next
     next. (random 1654).next.next
 
-  ++> tests-two-random-numbers-not-equal
-    not. > @
-      eq.
-        random.clocked 123.as-i64
-        random.clocked 456.as-i64
+  not. ++> tests-two-random-numbers-not-equal
+    eq.
+      random.clocked 123.as-i64
+      random.clocked 456.as-i64

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -47,13 +47,11 @@
         1000
     1
 
-  ++> tests-sine-of-nan-is-nan
-    is-nan. > @
-      sine nan
+  is-nan. ++> tests-sine-of-nan-is-nan
+    sine nan
 
-  ++> tests-sine-of-negative-infinity-is-nan
-    is-nan. > @
-      sine ninf
+  is-nan. ++> tests-sine-of-negative-infinity-is-nan
+    sine ninf
 
   lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
     abs
@@ -91,9 +89,8 @@
         500
     1
 
-  ++> tests-sine-of-positive-infinity-is-nan
-    is-nan. > @
-      sine pinf
+  is-nan. ++> tests-sine-of-positive-infinity-is-nan
+    sine pinf
 
   lt. ++> tests-sine-of-seventeen-radians
     abs

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -28,17 +28,14 @@
     sqrt pinf
     pinf
 
-  ++> tests-sqrt-check-infinity-n2
-    is-nan. > @
-      sqrt ninf
+  is-nan. ++> tests-sqrt-check-infinity-n2
+    sqrt ninf
 
-  ++> tests-sqrt-check-nan-input
-    is-nan. > @
-      sqrt nan
+  is-nan. ++> tests-sqrt-check-nan-input
+    sqrt nan
 
-  ++> tests-sqrt-check-negative-input
-    is-nan. > @
-      sqrt -0.1
+  is-nan. ++> tests-sqrt-check-negative-input
+    sqrt -0.1
 
   lt. ++> tests-sqrt-check-zero-input
     abs

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -24,26 +24,22 @@
 
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
 
-  ++> tests-compares-string-with-nan
-    not. > @
-      nan.eq "друг"
+  not. ++> tests-compares-string-with-nan
+    nan.eq "друг"
 
-  ++> tests-compares-string-with-negative-infinity
-    not. > @
-      ninf.eq "друг"
+  not. ++> tests-compares-string-with-negative-infinity
+    ninf.eq "друг"
 
   eq. ++> tests-compares-string-with-positive-infinity
     pinf.eq "друг"
     false
 
-  ++> tests-compares-two-different-string-types
-    not. > @
-      "Hello".eq 42
+  not. ++> tests-compares-two-different-string-types
+    "Hello".eq 42
 
-  ++> tests-compares-two-different-strings
-    not. > @
-      "Hello".eq
-        "Good bye"
+  not. ++> tests-compares-two-different-strings
+    "Hello".eq
+      "Good bye"
 
   eq. ++> tests-compares-two-strings
     "x".eq "x"

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -32,13 +32,12 @@
     ","
     "d!"
 
-  ++> tests-not-contains-all
-    not. > @
-      contains-all *1
-        "qwerty"
-        "qer"
-        "ty"
-        "abc"
+  not. ++> tests-not-contains-all
+    contains-all *1
+      "qwerty"
+      "qer"
+      "ty"
+      "abc"
 
   contains-all *1 ++> tests-successful-contains-all
     "abcdefghijk"

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -17,17 +17,15 @@
     false
     x.or a > [a x]
 
-  ++> test-contains-any-without-substrings
-    not. > @
-      contains-any
-        "text"
-        *
+  not. ++> test-contains-any-without-substrings
+    contains-any
+      "text"
+      *
 
-  ++> tests-contains-any-for-empty-text-and-without-substrings
-    not. > @
-      contains-any
-        ""
-        *
+  not. ++> tests-contains-any-for-empty-text-and-without-substrings
+    contains-any
+      ""
+      *
 
   contains-any *1 ++> tests-contains-any-vert
     "foo bar buzz"
@@ -35,14 +33,13 @@
     " "
     "o"
 
-  ++> tests-not-contains-any
-    not. > @
-      contains-any *1
-        "xyzw"
-        "yx"
-        "zyx"
-        "wx"
-        "abc"
+  not. ++> tests-not-contains-any
+    contains-any *1
+      "xyzw"
+      "yx"
+      "zyx"
+      "wx"
+      "abc"
 
   contains-any *1 ++> tests-successful-contains-any
     "Good morning"

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -37,8 +37,7 @@
     "Hello, world!"
     "o, wo"
 
-  ++> tests-text-does-not-contain-substring
-    not. > @
-      contains
-        "Hello, world!"
-        "Hey"
+  not. ++> tests-text-does-not-contain-substring
+    contains
+      "Hello, world!"
+      "Hey"

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -22,11 +22,10 @@
         size
       substring >> part!
 
-  ++> tests-does-not-end-with-substring
-    not. > @
-      ends-with
-        "Hello world!"
-        "Hello"
+  not. ++> tests-does-not-end-with-substring
+    ends-with
+      "Hello world!"
+      "Hello"
 
   ends-with ++> tests-ends-with-substring
     "Hello world!"

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -13,16 +13,13 @@
     regex "/^[a-zA-Z]+$/"
     text
 
-  ++> tests-checks-if-empty-text-is-not-alpha
-    not. > @
-      is-alpha ""
+  not. ++> tests-checks-if-empty-text-is-not-alpha
+    is-alpha ""
 
   is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
 
-  ++> tests-checks-if-text-with-dashes-is-not-alpha
-    not. > @
-      is-alpha "-w-"
+  not. ++> tests-checks-if-text-with-dashes-is-not-alpha
+    is-alpha "-w-"
 
-  ++> tests-checks-if-text-with-number-is-not-alpha
-    not. > @
-      is-alpha "ab3d"
+  not. ++> tests-checks-if-text-with-number-is-not-alpha
+    is-alpha "ab3d"

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -13,14 +13,12 @@
     regex "/^[A-Za-z0-9]+$/"
     text
 
-  ++> tests-checks-if-empty-text-is-not-alphanumeric
-    not. > @
-      is-alphanumeric ""
+  not. ++> tests-checks-if-empty-text-is-not-alphanumeric
+    is-alphanumeric ""
 
   is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
 
-  ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
-    not. > @
-      is-alphanumeric "-w-"
+  not. ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
+    is-alphanumeric "-w-"
 
   is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,13 +12,11 @@
     regex "/^[\\x00-\\x7F]+$/"
     text
 
-  ++> tests-checks-if-emoji-is-not-ascii
-    not. > @
-      is-ascii "🌵"
+  not. ++> tests-checks-if-emoji-is-not-ascii
+    is-ascii "🌵"
 
-  ++> tests-checks-if-empty-text-is-not-ascii
-    not. > @
-      is-ascii ""
+  not. ++> tests-checks-if-empty-text-is-not-ascii
+    is-ascii ""
 
   is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
 

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,30 +13,25 @@
     regex "/^[0-9]+$/"
     text
 
-  ++> tests-checks-if-empty-text-is-not-digit
-    not. > @
-      is-digit ""
+  not. ++> tests-checks-if-empty-text-is-not-digit
+    is-digit ""
 
   is-digit "2026" ++> tests-checks-if-number-text-is-digit
 
   is-digit "7" ++> tests-checks-if-single-digit-is-digit
 
-  ++> tests-checks-if-text-with-letter-is-not-digit
-    not. > @
-      is-digit "1a2"
+  not. ++> tests-checks-if-text-with-letter-is-not-digit
+    is-digit "1a2"
 
-  ++> tests-checks-if-text-with-space-is-not-digit
-    not. > @
-      is-digit
-        "12 34"
+  not. ++> tests-checks-if-text-with-space-is-not-digit
+    is-digit
+      "12 34"
 
-  ++> tests-checks-if-text-with-special-character-is-not-digit
-    not. > @
-      is-digit "1🌵2"
+  not. ++> tests-checks-if-text-with-special-character-is-not-digit
+    is-digit "1🌵2"
 
-  ++> tests-checks-if-text-with-trailing-newline-is-not-digit
-    not. > @
-      is-digit "123\n"
+  not. ++> tests-checks-if-text-with-trailing-newline-is-not-digit
+    is-digit "123\n"
 
   is-digit ++> tests-checks-if-very-long-number-is-digit
     "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -106,13 +106,12 @@
       "Hey"
       "Jeff"
 
-  ++> tests-printf-does-not-print-i64
-    not. > @
-      eq.
-        printf *1
-          "%d"
-          42.as-i64
-        "42"
+  not. ++> tests-printf-does-not-print-i64
+    eq.
+      printf *1
+        "%d"
+        42.as-i64
+      "42"
 
   eq. ++> tests-printf-left-aligns-bytes
     "40-45-00-00-00-00-00-00  "

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -56,19 +56,17 @@
       next. > found
         match txt
 
-  ++> tests-does-not-match-anchored-pattern-with-trailing-newline
-    not. > @
-      matches.
-        compiled.
-          regex "/^[0-9]+$/"
-        "123\n"
+  not. ++> tests-does-not-match-anchored-pattern-with-trailing-newline
+    matches.
+      compiled.
+        regex "/^[0-9]+$/"
+      "123\n"
 
-  ++> tests-does-not-matches-regex-against-the-pattern
-    not. > @
-      matches.
-        compiled.
-          regex "/[a-z]+/"
-        "123"
+  not. ++> tests-does-not-matches-regex-against-the-pattern
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "123"
 
   eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
     "recovered"
@@ -190,37 +188,32 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  --> on-compiling-invalid-regex-without-fallback
-    compile. > @
-      regex "/[a-z/"
+  compile. --> on-compiling-invalid-regex-without-fallback
+    regex "/[a-z/"
 
-  --> on-getting-from-position-on-not-matched-block
-    from. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  from. --> on-getting-from-position-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  --> on-getting-groups-count-on-not-matched-block
-    count. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  count. --> on-getting-groups-count-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  --> on-getting-groups-on-not-matched-block
-    groups. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  groups. --> on-getting-groups-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  --> on-getting-next-on-not-matched-block
-    next. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  next. --> on-getting-next-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
   group. --> on-getting-specified-group-on-not-matched-block
     next.
@@ -229,24 +222,20 @@
         "123"
     1
 
-  --> on-getting-text-on-not-matched-block
-    text. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  text. --> on-getting-text-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  --> on-getting-to-position-on-not-matched-block
-    to. > @
-      next.
-        match.
-          regex "/[a-z]+/"
-          "123"
+  to. --> on-getting-to-position-on-not-matched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  --> on-missing-closing-slash-in-regex
-    compiled. > @
-      regex "/pattern"
+  compiled. --> on-missing-closing-slash-in-regex
+    regex "/pattern"
 
-  --> on-missing-first-slash-in-regex
-    compiled. > @
-      regex "(.)+"
+  compiled. --> on-missing-first-slash-in-regex
+    regex "(.)+"

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -20,11 +20,10 @@
         size
       substring >> part!
 
-  ++> tests-does-not-start-with-substring
-    not. > @
-      starts-with
-        "Hello, world"
-        "world"
+  not. ++> tests-does-not-start-with-substring
+    starts-with
+      "Hello, world"
+      "world"
 
   starts-with ++> tests-starts-with-substring
     "Hello, world"

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -151,14 +151,13 @@
       3
     2
 
-  ++> tests-package-tuple-does-not-contain-element
-    not. > @
-      contains.
-        *
-          1
-          2
-          3
-        5
+  not. ++> tests-package-tuple-does-not-contain-element
+    contains.
+      *
+        1
+        2
+        3
+      5
 
   eq. ++> tests-package-tuple-index-of-element
     index-of.
@@ -265,17 +264,16 @@
       * 4 0
       * 7 3
 
-  ++> tests-tuple-not-equality
-    not. > @
-      eq.
-        *
-          1
-          2
-          3
-        *
-          3
-          2
-          1
+  not. ++> tests-tuple-not-equality
+    eq.
+      *
+        1
+        2
+        3
+      *
+        3
+        2
+        1
 
   ++> tests-tuple-with
     and. > @

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -28,12 +28,11 @@
       "qwerty"
     "qwerty"
 
-  ++> tests-list-does-not-contain
-    not. > @
-      contains
-        *
-          "Привет"
-          "asdfgh"
-          3
-          "qwerty"
-        "Hi"
+  not. ++> tests-list-does-not-contain
+    contains
+      *
+        "Привет"
+        "asdfgh"
+        3
+        "qwerty"
+      "Hi"

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -13,11 +13,10 @@
   is-empty ++> list-should-be-empty
     *
 
-  ++> tests-list-should-not-be-empty
-    not. > @
-      is-empty *
-        1
-        2
+  not. ++> tests-list-should-not-be-empty
+    is-empty *
+      1
+      2
 
   ++> tests-list-should-not-be-empty-with-one-anon-object
     not. > @

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -26,15 +26,14 @@
         tup.tail.length
     | list
 
-  ++> tests-list-reducedi-bools-array
-    not. > @
-      reducedi
-        *
-          true
-          true
-          false
+  not. ++> tests-list-reducedi-bools-array
+    reducedi
+      *
         true
-        x.and a > [a x i]
+        true
+        false
+      true
+      x.and a > [a x i]
 
   eq. ++> tests-list-reducedi-long-int-array
     reducedi

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -72,9 +72,8 @@
     FF-FF.as-u16.div 00-02.as-u16
     7F-FF.as-u16
 
-  ++> tests-u16-eq-false
-    not. > @
-      00-2A.as-u16.eq 00-2B.as-u16
+  not. ++> tests-u16-eq-false
+    00-2A.as-u16.eq 00-2B.as-u16
 
   00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
 
@@ -82,19 +81,16 @@
 
   00-32.as-u16.gte 00-32.as-u16 ++> tests-u16-gte-equal
 
-  ++> tests-u16-gte-false
-    not. > @
-      00-00.as-u16.gte 00-0A.as-u16
+  not. ++> tests-u16-gte-false
+    00-00.as-u16.gte 00-0A.as-u16
 
   00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
 
-  ++> tests-u16-high-bit-not-less-than-one
-    not. > @
-      FF-FF.as-u16.lt 00-01.as-u16
+  not. ++> tests-u16-high-bit-not-less-than-one
+    FF-FF.as-u16.lt 00-01.as-u16
 
-  ++> tests-u16-less-equal
-    not. > @
-      00-0A.as-u16.lt 00-0A.as-u16
+  not. ++> tests-u16-less-equal
+    00-0A.as-u16.lt 00-0A.as-u16
 
   00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
 

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -72,9 +72,8 @@
     FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
     7F-FF-FF-FF.as-u32
 
-  ++> tests-u32-eq-false
-    not. > @
-      00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
+  not. ++> tests-u32-eq-false
+    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
 
   00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
 
@@ -84,19 +83,16 @@
 
   00-00-00-32.as-u32.gte 00-00-00-32.as-u32 ++> tests-u32-gte-equal
 
-  ++> tests-u32-gte-false
-    not. > @
-      00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
+  not. ++> tests-u32-gte-false
+    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
 
   00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
 
-  ++> tests-u32-high-bit-not-less-than-one
-    not. > @
-      FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
+  not. ++> tests-u32-high-bit-not-less-than-one
+    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
 
-  ++> tests-u32-less-equal
-    not. > @
-      00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
+  not. ++> tests-u32-less-equal
+    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
 
   00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
 

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -73,21 +73,18 @@
     00-00-00-00-00-00-00-32.as-u64
     00-00-00-00-00-00-00-32.as-u64
 
-  ++> tests-u64-gte-false
-    not. > @
-      00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
+  not. ++> tests-u64-gte-false
+    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
 
   eq. ++> tests-u64-has-valid-bytes
     00-00-00-00-00-00-00-2A.as-u64.as-bytes
     00-00-00-00-00-00-00-2A
 
-  ++> tests-u64-high-bit-not-less-than-one
-    not. > @
-      FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
+  not. ++> tests-u64-high-bit-not-less-than-one
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
 
-  ++> tests-u64-less-equal
-    not. > @
-      00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
+  not. ++> tests-u64-less-equal
+    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
 
   lt. ++> tests-u64-less-true
     00-00-00-00-00-00-00-0A.as-u64

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -70,9 +70,8 @@
     C8-.as-u8.div 03-.as-u8
     42-.as-u8
 
-  ++> tests-u8-eq-false
-    not. > @
-      2A-.as-u8.eq 2B-.as-u8
+  not. ++> tests-u8-eq-false
+    2A-.as-u8.eq 2B-.as-u8
 
   2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
 
@@ -80,19 +79,16 @@
 
   32-.as-u8.gte 32-.as-u8 ++> tests-u8-gte-equal
 
-  ++> tests-u8-gte-false
-    not. > @
-      00-.as-u8.gte 0A-.as-u8
+  not. ++> tests-u8-gte-false
+    00-.as-u8.gte 0A-.as-u8
 
   2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
 
-  ++> tests-u8-high-bit-not-less-than-one
-    not. > @
-      FF-.as-u8.lt 01-.as-u8
+  not. ++> tests-u8-high-bit-not-less-than-one
+    FF-.as-u8.lt 01-.as-u8
 
-  ++> tests-u8-less-equal
-    not. > @
-      0A-.as-u8.lt 0A-.as-u8
+  not. ++> tests-u8-less-equal
+    0A-.as-u8.lt 0A-.as-u8
 
   0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
 

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -157,11 +157,10 @@
               m.as-number.plus 1
       3
 
-  ++> tests-last-while-dataization-object-with-false-condition
-    not. > @
-      while
-        1.gt 2 > [i]
-        true > [i]
+  not. ++> tests-last-while-dataization-object-with-false-condition
+    while
+      1.gt 2 > [i]
+      true > [i]
 
   ++> tests-simple-bool-expression-via-malloc-in-while
     eq. > @
@@ -173,11 +172,10 @@
             m.put false > [i] >>
       false
 
-  ++> tests-simple-while-with-false-first
-    not. > @
-      while
-        false > [i]
-        true > [i]
+  not. ++> tests-simple-while-with-false-first
+    while
+      false > [i]
+      true > [i]
 
   ++> tests-while-dataizes-only-first-cycle
     0.eq > @


### PR DESCRIPTION
Fixes #5954.

## Problem

In `Pretty.phi()`, the `applied` predicate ended with a clause
`!(decoratee.reversed && decoratee.children.size() <= 1)` that withheld the
hybrid inline-phi collapse from a reversed dispatch carrying only its
receiver (`not.`), while a reversed dispatch that also carried arguments
(`eq.`, `if.`) got the collapse. As a result the printer kept blocks like

```
++> tests-compares-string-with-negative-infinity
  not. > @
    ninf.eq "друг"
```

in their verbose three-line form as the printer's own fixpoint, instead of
collapsing to

```
not. ++> tests-compares-string-with-negative-infinity
  ninf.eq "друг"
```

## Fix

The withheld clause was justified as mirroring the rejection in `flat`
(`node.reversed && node.children.size() <= 1`), but that rejection concerns
a *horizontal* one-line spelling, which `not.` has no form for. The hybrid
is not horizontal: it keeps `not.` on the head line and lays the receiver
out one indent beneath — exactly the shape `LnOnlyPhi` accepts, its `bare()`
leaving the φ `Openness.OPEN` so the deeper line attaches as the receiver,
with no minimum argument count enforced on close. The verbose and the
collapsed forms parse to the same XMIR tree, so the extra line and indent
buy nothing.

Dropping the clause leaves `applied` as
`!decoratee.abstractt && !decoratee.children.isEmpty()`. The following
`unnamed` guard still withholds the collapse when a name appears anywhere in
the decoratee's subtree, so #5598 and #5604 stay fixed.

## Tests

- Added `hybrid-phi-reversed-receiver-only.yaml`, covering a receiver-only
  reversed dispatch (`not.`) collapsing into the `++>` hybrid.
- Updated `reversed-with-data-receiver-args.yaml`: with the fix, the
  paren-free hybrid (`not. > [] > app` with the receiver beneath) now beats
  the paren-heavy suffixed one-liner `(...).not > [] > app` on penalty, and
  the new form is a fixpoint. Also updated the `phi()` javadoc.

All 272 `XmirTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTuGdDCjqNXrbcV924dAQm)_