### PR TITLE
Fix #6021: keep a single-use `&gt;&gt;` handle standing when applied from a nested scope

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -152,6 +152,32 @@
             </xsl:copy>
           </xsl:when>
           <!--
+          The same applied reference, but written inside a nested formation
+          body rather than in the handle's own owner scope. Such a reference
+          reaches the handle as `ξ.ρ.` (a `ρ` climb into the enclosing scope
+          where the handle lives), so the relocation branch below would land
+          the fresh formation copy in the nested scope while the pipe node
+          keeps the `ρ` climb: `to-eo-tree`'s adjacency test then sees the
+          pipe's `ξ.ρ.name` base no longer equal `ξ.name` of the copy directly
+          above it and prints the node as an ordinary application on the cactus
+          name, leaving the copy a stray extra argument and orphaning the
+          reference (#6021). An argument list buried in a nested scope has no
+          more room for a relocated predecessor than the positional-argument
+          case above (#5983), so leave the handle standing under its `@local`
+          name instead — copy the reference verbatim, keeping its arguments, so
+          the drop template below keeps the binding in its own scope and
+          "merge-monikers" rewrites the reference back to the handle
+          (`eo:kept-local-ref`), shedding the `ρ` climb (#5893/#5917). Gated on
+          the reference's nearest formation ancestor not being the handle's
+          owner, so the sibling (#5840) and receiver (#5844) relocations below,
+          whose references share the handle's own scope, still fire.
+          -->
+          <xsl:when test="eo:abstract($target) and (o or @name) and not(eo:multi-referenced($target, $name)) and not(ancestor::o[eo:abstract(.)][1] is $target/..)">
+            <xsl:copy>
+              <xsl:apply-templates select="node()|@*"/>
+            </xsl:copy>
+          </xsl:when>
+          <!--
           The same applied reference, but not standing as the formation's
           immediate following sibling, so the adjacent guard above misses it
           and the bare-reference `otherwise` would drop the argument and name
@@ -172,7 +198,8 @@
           duplicating it, the same relocation #5732 proposes for its sibling
           case. Restricted to a single-use formation: a multi-referenced one
           cannot be folded into just one of its uses. A positional-argument
-          reference is handled by the branch above (#5983), not here.
+          reference is handled by the branch above (#5983), and a
+          nested-scope reference by the branch just above (#6021), not here.
           -->
           <xsl:when test="eo:abstract($target) and (o or @name) and not(eo:multi-referenced($target, $name))">
             <xsl:for-each select="$target">
@@ -268,7 +295,10 @@
   inlined (#5834), keep a single-use formation reached through a positional
   argument (see `eo:arg-applied`), which is left standing rather than relocated
   into an argument list where its pipe would print as `|:N` (#5983), keep a
-  based application handle reached by a further
+  single-use formation reached only through a reference in a nested formation
+  scope (see `eo:nested-applied`), which is left standing rather than relocated
+  into that scope where its pipe's `ρ` climb would orphan the reference
+  (#6021), keep a based application handle reached by a further
   application (see `eo:reapplied`), which has no inline spelling as the head of
   another application and is left standing rather than folded (#5952), and keep
   a binding that a surviving method dispatch still reaches through its name.
@@ -282,7 +312,7 @@
   reads yet would silently vanish (#5914).
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:arg-applied(., @name) or eo:reapplied(., @name)">
+    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:arg-applied(., @name) or eo:nested-applied(., @name) or eo:reapplied(., @name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
@@ -380,6 +410,31 @@
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="eo:abstract($target) and not(eo:multi-referenced($target, $name)) and exists(eo:references($target, $name)[eo:resolved-name(@base) = $name and (o or @name) and starts-with(@as, $eo:alpha)])"/>
+  </xsl:function>
+  <!--
+  Whether the single-use auto-named abstract formation `$target` is applied by a
+  reference written inside a nested formation body rather than in the handle's
+  own owner scope. Such a reference reaches the handle through a `ρ` climb
+  (`ξ.ρ.<name>`) into the enclosing scope where the handle lives. Relocating the
+  formation copy down to the reference (the #5840/#5844 branch) would drop it
+  into the nested scope while the pipe node keeps the `ρ` climb, so
+  `to-eo-tree`'s adjacency test no longer matches the copy directly above the
+  pipe and the node prints as an ordinary application, leaving a stray copy and
+  an orphaned reference (#6021). The reference is therefore left standing (see
+  the inlining template) and this binding must be kept in place under its
+  `@local` name rather than relocated, so "merge-monikers" can rewrite the
+  reference back to the handle (`eo:kept-local-ref`), shedding the `ρ` climb
+  (#5893/#5917). A multi-referenced formation is excluded — it is already kept
+  whole by the outer guard above — and references inside the formation itself
+  are not counted. The nearest formation ancestor of the reference is compared
+  against the handle's owner (`$target/..`): the sibling (#5840) and receiver
+  (#5844) relocations, whose references share the handle's own scope, are
+  deliberately not matched here.
+  -->
+  <xsl:function name="eo:nested-applied" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="eo:abstract($target) and not(eo:multi-referenced($target, $name)) and exists(eo:references($target, $name)[eo:resolved-name(@base) = $name and (o or @name) and not(ancestor::o[eo:abstract(.)][1] is $target/..)])"/>
   </xsl:function>
   <!--
   Whether the based `&gt;&gt; name` handle `$target` is itself an application

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-nested-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-nested-argument.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-use file-local handle ("[c] >> is-ws", R-3.10.12) whose abstract
+# formation is applied by a reference ("is-ws index") written inside a nested
+# formation body ("[index] >> helper") rather than in the handle's own owner
+# scope. From that nested scope the reference climbs to the handle as
+# "ξ.ρ.<name>". The #5840/#5844 relocation must NOT fire here: it would drop a
+# fresh copy of the formation into the nested scope and rewrite the reference
+# into a "| args" pipe, but the pipe keeps the "ρ" climb, so "to-eo-tree"'s
+# adjacency test no longer matches the copy directly above it — the pipe prints
+# as an ordinary application on the cactus name ("^.v7_2 index"), the copy
+# becomes a stray extra argument and a second format pass erases the handle's
+# name (#6021). "inline-cactoos" leaves the reference standing verbatim —
+# keeping its "index" argument, never a "@pipe" — and keeps the "[c] >> is-ws"
+# binding in place under its "@local" name, so "merge-monikers" can later
+# rewrite the reference back to the handle and shed the "ρ" climb (#5893/#5917),
+# exactly as the positional-argument case (#5983). "mandatory-as" runs first and
+# "restore-local-names" keeps the handle's "@local" marker.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The single-use formation is kept in place under its "@local" handle, not
+  # relocated into the nested scope or dropped.
+  - /object/o[@name='bar']/o[@local='is-ws' and contains(@name, '🌵') and not(@base)]
+  # The applied reference stays where it is, still inside the nested "helper"
+  # formation and still carrying its own "index" argument.
+  - /object/o[@name='bar']/o[@local='helper']//o[contains(@base, '🌵') and count(o)=1]
+  # The reference was never turned into a "| args" pipe.
+  - /object[count(//o[@pipe])=0]
+  # No second copy of the formation was minted inside the nested scope.
+  - /object[count(//o[@local='is-ws' and contains(@name, '🌵')])=1]
+input: |
+  [text] > bar
+    [index] >> helper
+      if. > @
+        is-ws index
+        index
+        index
+    [c] >> is-ws
+      c.eq 1 > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-nested.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-cactoos-applied-handle-nested.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A single-referenced file-local `>> is-ws` handle (R-3.10.12) whose value is an
+# abstract formation and which is used as the base of an application
+# (`is-ws index`), exactly as "inline-cactoos-applied-handle", except that its
+# only reference sits inside a nested formation body (`[index] >> helper`)
+# rather than in the handle's own owner scope. From that nested scope the
+# reference climbs to the handle as `ξ.ρ.<name>`. The #5840/#5844 relocation
+# used to fire here: it dropped a fresh copy of the formation into the nested
+# scope and rewrote the reference into a `| args` pipe, but the pipe kept the
+# `ρ` climb, so `to-eo-tree`'s adjacency test no longer matched the copy
+# directly above it — the pipe printed as an ordinary application on the cactus
+# name (`^.v7_2 index`), the copy became a stray extra argument, and a second
+# format pass then erased the handle's name altogether (#6021). The fix leaves
+# the handle standing under its `@local` name and copies the reference verbatim
+# (its `index` argument intact), exactly as the positional-argument case
+# (#5983); "merge-monikers" then rewrites the nested reference back to the
+# readable `is-ws` handle and sheds the `ρ` climb (#5893/#5917), so
+# `is-ws index` survives and the `[c] >> is-ws` handle is kept.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [text] > bar
+    [index] >> helper
+      if. > @
+        is-ws index
+        index
+        index
+    [c] >> is-ws
+      c.eq 1 > @
+
+printed: |
+  [text] > bar
+    if. > [index] >> helper
+      is-ws index
+      index
+      index
+    c.eq 1 > [c] >> is-ws


### PR DESCRIPTION
Closes #6021.

## Problem

The `#5840`/`#5844` relocation branch in `inline-cactoos.xsl` moved a single-use abstract `>>` formation to sit directly above its applied reference and rewrote that reference into a `| args` pipe — without checking that the reference lived in the handle's **own owner scope**.

When the reference was written inside a *nested* formation body, it reached the handle through a `ρ` climb (`ξ.ρ.<name>`). The relocated formation copy then landed in the nested scope while the pipe node kept the `ρ` climb, so `to-eo-tree`'s adjacency test (`to-eo-tree.xsl:244`) no longer matched the copy directly above it. The node printed as an ordinary application on the cactus name (`^.v7_2 index`), the formation copy became a stray extra argument, and a second `eo:format` pass then erased the handle's name altogether — leaving broken, name-orphaned code such as `or. > [c] >>`.

Minimal reproduction (before the fix):

```eo
[text] > bar
  [index] >> helper
    if. > @
      is-ws index
      index
      index
  [c] >> is-ws
    c.eq 1 > @
```

printed back as:

```eo
[text] > bar
  [index] >> helper
    if. > @
      c.eq 1 > [c] >> is-ws
      ^.v7_2 index
      index
      index
```

## Fix

Guard the relocation with a new `eo:nested-applied` predicate: a single-use formation reached only through a reference in a nested formation scope is left standing under its `@local` name instead of being relocated — exactly as the positional-argument case of `#5983`.

- A new branch ahead of the relocation branch copies such a reference verbatim (keeping its arguments), gated on the reference's nearest formation ancestor not being the handle's owner: `not(ancestor::o[eo:abstract(.)][1] is $target/..)`.
- The drop template keeps the binding in its own scope via the matching `eo:nested-applied` keep-condition.

`merge-monikers` then rewrites the cactus base back to the readable handle and sheds the `ρ` climb (`#5893`/`#5917`), so `is-ws index` survives and the `[c] >> is-ws` handle is preserved. The sibling (`#5840`) and receiver (`#5844`) relocations, whose references share the handle's own scope, still fire.

## Tests

- `eo-packs/print/inline-cactoos-nested-argument.yaml` — asserts at the XSL level that the handle is kept in place, the reference stays verbatim inside the nested formation, and no `@pipe` is emitted.
- `print-packs/yaml/inline-cactoos-applied-handle-nested.yaml` — end-to-end print pack that reproduces the broken output and pins the correct round-tripping result.

All 312 `eo-printer` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSy5rBd4BSQ1dCG85hDwk6)_