### PR TITLE
#5294: fix Integer.MIN_VALUE overflow in BytesRaw.shift

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -168,6 +168,10 @@
       -10.as-bytes
     false
 
+  eq. ++> tests-right-with-integer-min-value
+    -1.as-bytes.right -2147483648
+    00-00-00-00-00-00-00-00
+
   eq. ++> tests-right-with-minus-one
     -1.as-bytes.right 4
     0B-FF-00-00-00-00-00-00

--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -70,8 +70,9 @@ final class BytesRaw implements Bytes {
     @Override
     public Bytes shift(final int bits) {
         final byte[] bytes = this.take();
-        final int mod = Math.abs(bits) % Byte.SIZE;
-        final int offset = Math.abs(bits) / Byte.SIZE;
+        final long absolute = Math.abs((long) bits);
+        final int mod = (int) (absolute % Byte.SIZE);
+        final int offset = (int) (absolute / Byte.SIZE);
         final Bytes shifted;
         if (bits < 0) {
             shifted = BytesRaw.shiftLeft(bytes, mod, offset);

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -156,6 +156,15 @@ final class BytesOfTest {
     }
 
     @Test
+    void shiftsIntegerMinValueWithoutOverflow() {
+        MatcherAssert.assertThat(
+            "shift(Integer.MIN_VALUE) should produce an all-zero result, but it didn't",
+            new BytesOf(0xFFFFFFFF).shift(Integer.MIN_VALUE).asNumber(Integer.class),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
     void doesNotSupportNegativeBits() {
         Assertions.assertThrows(
             ExFailure.class,


### PR DESCRIPTION
Closes #5294.

`BytesRaw.shift` computed `Math.abs(bits) % Byte.SIZE` and `Math.abs(bits) / Byte.SIZE` using `int` arithmetic. `Math.abs(Integer.MIN_VALUE)` overflows back to `Integer.MIN_VALUE` (still negative), so for `bits == Integer.MIN_VALUE` the resulting `offset` stayed negative. That negative offset reached `shiftLeft`, where `bytes[source]` was indexed with a negative index, throwing `ArrayIndexOutOfBoundsException` instead of a controlled result.

Fix: widen `bits` to `long` before taking the absolute value. `Math.abs` on a `long` never overflows for any `int` input, so `mod` and `offset` are always computed correctly, including for `Integer.MIN_VALUE`. The resulting `offset` (2^28) is far larger than any realistic byte array, so `shiftLeft`/`shiftRight`'s existing bounds checks correctly produce an all-zero result, same as any other shift wider than the array.

Added `shiftsIntegerMinValueWithoutOverflow` to `BytesOfTest`, asserting `shift(Integer.MIN_VALUE)` returns zero instead of throwing.

Tests: `mvn -pl eo-runtime test -o -Dtest='BytesOfTest'` - all 31 tests passing. Verified the new test reproduces the original crash by temporarily reverting to the old `Math.abs(bits)` (int) computation: it fails with the exact `ArrayIndexOutOfBoundsException: Index -268435456 out of bounds for length 4` reported in the issue.
