### PR TITLE
fix(#6036): sort formation handles by readable name

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -174,7 +174,7 @@
       <xsl:variable name="sortable" select="eo:abstract(.) and empty(o[@pipe])"/>
       <xsl:apply-templates select="o[not(eo:void(.)) or @local or @args or @type]" mode="tree">
         <xsl:sort data-type="number" select="if (not($sortable)) then 0 else if (eo:void(.)) then 1 else if (@name = $eo:phi) then 2 else if (eo:test-attr(.)) then 4 else 3"/>
-        <xsl:sort select="if (not($sortable) or eo:void(.) or @name = $eo:phi) then '' else string(@name)"/>
+        <xsl:sort select="if (not($sortable) or eo:void(.) or @name = $eo:phi) then '' else string((@local, @name)[1])"/>
       </xsl:apply-templates>
     </line>
   </xsl:template>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-nested-only-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-nested-only-referenced-handle.yaml
@@ -30,5 +30,5 @@ origin: |
 
 printed: |
   [num] > foo
-    num.times num >> squared
     squared.div depth > [depth] > factor
+    num.times num >> squared

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
@@ -27,5 +27,5 @@ origin: |
 printed: |
   [] > foo
     reclen 0 > @
-    inclen i > [i] >> reclen
     reclen n > [n] > inclen
+    inclen i > [i] >> reclen

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -36,7 +36,6 @@
           ""
           string
             text.as-bytes.slice bstart blen
-  text.as-bytes.size >> size!
   minus. > blen
     [index accum result cause] >> recidx
       if. > @
@@ -110,6 +109,7 @@
   C0- > r2
   p2 > r3
   p3 > r4
+  text.as-bytes.size >> size!
 
   eq. ++> tests-no-slice-string
     "no slice".slice


### PR DESCRIPTION
Closes #6036.

## Problem

`to-eo-tree.xsl` emits bound formation attributes alphabetically by name so that textually-reordered but logically-identical bodies print the same way (idempotent, diff-friendly output — #5706). But the secondary sort key at `to-eo-tree.xsl:177` was `string(@name)`, and for a file-local `>>` formation handle `@name` is not the readable name — `restore-local-names.xsl` deliberately leaves the synthetic cactus `@name` (`a🌵L-P`) unpromoted and keeps the handle in `@local`.

As a result every handle sorted as though it were called `a🌵-`: it clustered right after names beginning `aa`, and among handles the source line numbers were compared as text (so a handle declared on line `13` sorted before one on line `5`). Two bodies differing only in the source order of two handles printed differently — losing the very invariant the sort was added for.

## Fix

Sort on `(@local, @name)[1]` rather than on `@name`, so a handle sorts by the readable name kept in `@local` while public bindings keep sorting by `@name`.

## Changes

- `eo-printer/.../print/to-eo-tree.xsl` — the one-line sort-key fix at `:177`.
- `formation-sibling-referenced-handle.yaml` — `printed:` reordered to `inclen` before `reclen`.
- `based-nested-only-referenced-handle.yaml` — `printed:` reordered to `factor` before `squared`.
- `eo-runtime/src/main/eo/string/slice.eo` — reformatted; the `size` handle now sorts alphabetically after `r4` instead of clustering at the top. Verified this is the only runtime `.eo` source whose canonical printed form changes under the fix.

## Verification

`XmirTest` passes in full (275 tests, 0 failures). Reprinting every `eo-runtime/src/main/eo/**.eo` source under the fixed printer shows `slice.eo` as the only file whose canonical layout changes, and its on-disk form now matches the reprint exactly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014A2tmK5i2uRqihhAARxfYp)_