### PR TITLE
Enable four more xslint checks

### DIFF
--- a/.github/workflows/xslint.yml
+++ b/.github/workflows/xslint.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: xslint/xslint-action@0.0.7
+      - uses: xslint/xslint-action@0.0.9
         with:
           config: .xslint.yml

--- a/.xslint.yml
+++ b/.xslint.yml
@@ -13,9 +13,5 @@ exclude:
 #  xslint check is already enforced across the whole codebase.
 rules:
   not-creating-element-correctly: "off"
-  not-using-schema-types: "off"
-  short-names: "off"
+  too-many-templates: "off"
   unused-variable: "off"
-  not-using-output: "off"
-  too-many-small-templates: "off"
-  monolithic-design: "off"

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/package.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/package.xsl
@@ -4,6 +4,7 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="package" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
   <!--
   This stylesheet will set the package name for each
   <class> element, using the information from the +package meta.

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/tests.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/tests.xsl
@@ -12,7 +12,7 @@
   <xsl:function name="eo:test-name" as="xs:string">
     <xsl:param name="name" as="xs:string"/>
     <xsl:variable name="parts" select="tokenize($name, '\$')"/>
-    <xsl:variable name="p">
+    <xsl:variable name="result">
       <xsl:for-each select="$parts">
         <xsl:if test="position()&gt;1">
           <xsl:text>$</xsl:text>
@@ -23,7 +23,7 @@
         </xsl:if>
       </xsl:for-each>
     </xsl:variable>
-    <xsl:value-of select="$p"/>
+    <xsl:value-of select="$result"/>
   </xsl:function>
   <xsl:template match="class/@name">
     <xsl:attribute name="name">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -44,7 +44,7 @@
     <xsl:param name="n" as="xs:string"/>
     <xsl:param name="alt" as="xs:string"/>
     <xsl:variable name="parts" select="tokenize($n, '\.')"/>
-    <xsl:variable name="p">
+    <xsl:variable name="package">
       <xsl:for-each select="$parts">
         <xsl:if test="position()!=last()">
           <xsl:value-of select="eo:clean(.)"/>
@@ -52,7 +52,7 @@
         </xsl:if>
       </xsl:for-each>
     </xsl:variable>
-    <xsl:variable name="c">
+    <xsl:variable name="class">
       <xsl:choose>
         <xsl:when test="$parts[last()]">
           <xsl:value-of select="$parts[last()]"/>
@@ -62,7 +62,7 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="pre" select="concat($p, eo:clean($c))"/>
+    <xsl:variable name="pre" select="concat($package, eo:clean($class))"/>
     <xsl:choose>
       <xsl:when test="string-length($pre)&gt;250">
         <xsl:value-of select="concat(substring($pre, 1, 25), $alt)"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
@@ -83,8 +83,8 @@
   </xsl:template>
   <xsl:template match="@type">
     <xsl:variable name="opt" select="ends-with(., '?')"/>
-    <xsl:variable name="t" select="if ($opt) then substring(., 1, string-length(.) - 1) else string(.)"/>
-    <xsl:variable name="homed" select="if (matches($t, '^[A-F]$') or contains($t, '.') or $t=$eo:phi or $t=$eo:program or $t=$eo:rho or $t=$eo:empty or $t=$eo:xi or $t=$eo:bottom or $t=/object/metas/meta[head='alias']/part[1]) then $t else concat('Φ.', $t)"/>
+    <xsl:variable name="type" select="if ($opt) then substring(., 1, string-length(.) - 1) else string(.)"/>
+    <xsl:variable name="homed" select="if (matches($type, '^[A-F]$') or contains($type, '.') or $type=$eo:phi or $type=$eo:program or $type=$eo:rho or $type=$eo:empty or $type=$eo:xi or $type=$eo:bottom or $type=/object/metas/meta[head='alias']/part[1]) then $type else concat('Φ.', $type)"/>
     <xsl:attribute name="type" select="if ($opt) then concat($homed, '?') else $homed"/>
   </xsl:template>
   <xsl:template match="/object/metas/meta[head='also']/(tail|part)">

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/mandatory-as.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/mandatory-as.xsl
@@ -4,6 +4,7 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="mandatory-as" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
   <!--
   Here we are going through all the applications (objects with `@base`), and add `@as`
   attributes for each inner object. The content of `@as` attribute is based on `αN`, where `N` is

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-aliases.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-aliases.xsl
@@ -11,16 +11,16 @@
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="o[@base and not(contains(@base, '.'))]">
-    <xsl:variable name="o" select="."/>
+    <xsl:variable name="object" select="."/>
     <xsl:copy>
       <xsl:attribute name="base">
-        <xsl:variable name="meta" select="/object/metas/meta[head='alias' and part[1] = $o/@base]"/>
+        <xsl:variable name="meta" select="/object/metas/meta[head='alias' and part[1] = $object/@base]"/>
         <xsl:choose>
           <xsl:when test="$meta">
             <xsl:value-of select="$meta/part[last()]"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="$o/@base"/>
+            <xsl:value-of select="$object/@base"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
@@ -28,16 +28,16 @@
     </xsl:copy>
   </xsl:template>
   <xsl:template match="o[@atom and not(contains(@atom, '.'))]">
-    <xsl:variable name="o" select="."/>
+    <xsl:variable name="object" select="."/>
     <xsl:copy>
       <xsl:attribute name="atom">
-        <xsl:variable name="meta" select="/object/metas/meta[head='alias' and part[1] = $o/@atom]"/>
+        <xsl:variable name="meta" select="/object/metas/meta[head='alias' and part[1] = $object/@atom]"/>
         <xsl:choose>
           <xsl:when test="$meta">
             <xsl:value-of select="$meta/part[last()]"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="$o/@atom"/>
+            <xsl:value-of select="$object/@atom"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
@@ -51,8 +51,8 @@
   </xsl:template>
   <xsl:template match="@type">
     <xsl:variable name="opt" select="ends-with(., '?')"/>
-    <xsl:variable name="t" select="if ($opt) then substring(., 1, string-length(.) - 1) else string(.)"/>
-    <xsl:attribute name="type" select="concat((/object/metas/meta[head='alias' and part[1]=$t]/part[last()], $t)[1], if ($opt) then '?' else '')"/>
+    <xsl:variable name="type" select="if ($opt) then substring(., 1, string-length(.) - 1) else string(.)"/>
+    <xsl:attribute name="type" select="concat((/object/metas/meta[head='alias' and part[1]=$type]/part[last()], $type)[1], if ($opt) then '?' else '')"/>
   </xsl:template>
   <xsl:template match="/object/metas/meta[head='also']/(tail|part)">
     <xsl:variable name="meta" select="/object/metas/meta[head='alias' and part[1] = current()/text()]"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
@@ -38,7 +38,7 @@
     <xsl:apply-templates select="." mode="full"/>
   </xsl:template>
   <xsl:template match="o[eo:abstract(.)]" mode="full" priority="1">
-    <xsl:variable name="o" select="."/>
+    <xsl:variable name="object" select="."/>
     <xsl:copy>
       <xsl:if test="not(@name) and @as">
         <xsl:attribute name="as" select="@as"/>
@@ -46,7 +46,7 @@
       <xsl:apply-templates select="@* except (@as, @float-up)"/>
       <xsl:apply-templates select="node()[not(self::o and eo:test-attr(.))]"/>
       <xsl:for-each select="o/descendant::o[@name]">
-        <xsl:if test="ancestor::o[eo:abstract(.)][1]/generate-id() = generate-id($o)">
+        <xsl:if test="ancestor::o[eo:abstract(.)][1]/generate-id() = generate-id($object)">
           <xsl:apply-templates select="." mode="full"/>
         </xsl:if>
       </xsl:for-each>


### PR DESCRIPTION
Bumps the xslint action to 0.0.9 (xslint 0.0.14) and turns on four more checks
that the pipeline now passes.

Two need no source change — after the recent xslint audit, `oversized-template`
(a single template over 100 XSLT elements) and `function-complexity` (a
function over 50) both report zero here. Two took small fixes:
`not-using-output` — declared `xsl:output` on the two pipeline stages that
lacked it (`transpile/package.xsl`, `parse/mandatory-as.xsl`); and
`short-names` — gave the eight single-letter variables real names, e.g.

```xsl
<xsl:variable name="object" select="."/>
```

instead of `$o`, and `$t`→`$type`, `$p`→`$package`, `$c`→`$class`.

The config now defers only three checks — `not-creating-element-correctly`,
`too-many-templates`, and `unused-variable` — each still carrying findings to
work through under #6006. Also renames two stale config keys that the audit
renamed upstream (`too-many-small-templates`→`too-many-templates`,
`monolithic-design`→`oversized-template`) and drops `not-using-schema-types`,
which xslint removed as not a genuine best practice.