### PR TITLE
#6026: wrap unescapeBody in LnTextBlock to raise ParseError, not NumberFormatException

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -23,7 +23,6 @@ package org.eolang.parser;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class LnTextBlock implements Line {
 
     /**
@@ -55,9 +54,19 @@ final class LnTextBlock implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
-        final String joined = Emissions.unescapeBody(
-            String.join(String.valueOf('\n'), globals.tbody())
-        );
+        final String joined;
+        try {
+            joined = Emissions.unescapeBody(
+                String.join(String.valueOf('\n'), globals.tbody())
+            );
+        } catch (final NumberFormatException ex) {
+            final ParseError error = new ParseError(
+                this.span.line(), this.span.indent(),
+                "invalid unicode or octal escape in text block"
+            );
+            error.initCause(ex);
+            throw error;
+        }
         this.transition(stack, suffix);
         emit.object(
             suffix.attribute(this.span.line(), this.span.indent()),

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -7,6 +7,7 @@ package org.eolang.parser;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -126,6 +127,19 @@ final class LnTextBlockTest {
             "a closer carrying `> name` must mark the level as named",
             stack.top().named(),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsInvalidEscapeInTextBlockBody() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("\\uD800");
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnTextBlock(new Span("\"\"\" > x", 3))
+                .into(new Stack(), globals, new Emit()),
+            "an invalid unicode escape in a text block body must surface as a ParseError, not a raw NumberFormatException"
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/invalid-escape-in-text-block-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/invalid-escape-in-text-block-is-rejected.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unicode')]
+input: |
+  [] > main
+    """
+    \uD800
+    """ > @


### PR DESCRIPTION
Closes #6026.

`LnTextBlock.into` called `Emissions.unescapeBody` directly, with no try/catch. The plain string-literal path (`Emissions.openValue`) wraps the same underlying call in a `try { ... } catch (NumberFormatException) { throw new ParseError(...) }`. The text-block path had no equivalent, so a malformed escape inside a `"""` text block (an out-of-range octal escape, an invalid or truncated `\uXXXX`, a lone surrogate) crashed `EoSyntax.parsed()` with a raw `NumberFormatException` instead of producing a normal `<errors>` entry.

Fix: wrap the `unescapeBody` call the same way the string-literal path already does, converting `NumberFormatException` into a `ParseError` at the text block's line/indent.

Also removed the class's `@SuppressWarnings("PMD.UnnecessaryLocalRule")` — after this change qulice reported it as unused (the `joined` local is no longer flagged by that rule once its initializer is a try/catch block).

Tests: added `LnTextBlockTest.rejectsInvalidEscapeInTextBlockBody`, asserting a text-block body with an invalid `\uD800` escape throws `ParseError` rather than `NumberFormatException`. Verified it fails with the original `NumberFormatException` when the fix is reverted, and passes with the fix in place.

`mvn -pl eo-parser test -o -Dtest='LnTextBlockTest,EoSyntaxTest'` - 940 tests, all passing.
`mvn -pl eo-parser qulice:check -Pqulice` - clean, no violations in the changed files.
