### PR TITLE
#6027: reject signed and truncated \uXXXX escapes in appendUnicode

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -18,7 +18,7 @@ import java.util.List;
  * §9.4.2).</p>
  *
  * @since 0.1
- * @checkstyle CyclomaticComplexityCheck (600 lines)
+ * @checkstyle CyclomaticComplexityCheck (610 lines)
  * @checkstyle BooleanExpressionComplexityCheck (600 lines)
  */
 @SuppressWarnings({"PMD.UnnecessaryLocalRule", "PMD.TooManyMethods", "PMD.CognitiveComplexity"})
@@ -544,13 +544,21 @@ final class Emissions {
         while (cursor < body.length() && body.charAt(cursor) == 'u') {
             cursor = cursor + 1;
         }
-        if (cursor + 4 > body.length()) {
-            out.append('\\').append(body, start, body.length());
-        } else {
-            out.append(
-                (char) Integer.parseInt(body.substring(cursor, cursor + 4), 16)
+        boolean valid = cursor + 4 <= body.length();
+        for (int idx = cursor; valid && idx < cursor + 4; idx = idx + 1) {
+            valid = Character.digit(body.charAt(idx), 16) >= 0;
+        }
+        if (!valid) {
+            throw new NumberFormatException(
+                String.format(
+                    "unicode escape \\%s is not exactly four hexadecimal digits",
+                    body.substring(start, Math.min(body.length(), cursor + 4))
+                )
             );
         }
+        out.append(
+            (char) Integer.parseInt(body.substring(cursor, cursor + 4), 16)
+        );
         return cursor + 4;
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -675,6 +675,32 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void rejectsSignedUnicodeEscape() throws Exception {
+        MatcherAssert.assertThat(
+            "a \\u escape with a leading sign character must show up as an /object/errors/error entry, not silently consume the sign as a hex digit",
+            EoSyntaxTest.raw(
+                String.join(String.valueOf((char) 10), "[] > foo", "  \"\\u+041\" > @")
+            ).toString(),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'unicode')]"
+            )
+        );
+    }
+
+    @Test
+    void rejectsTruncatedUnicodeEscape() throws Exception {
+        MatcherAssert.assertThat(
+            "a \\u escape with fewer than four hex digits must show up as an /object/errors/error entry, not pass through as literal text",
+            EoSyntaxTest.raw(
+                String.join(String.valueOf((char) 10), "[] > foo", "  \"\\u41\" > @")
+            ).toString(),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'unicode')]"
+            )
+        );
+    }
+
+    @Test
     void acceptsValidSurrogatePairEscape() throws Exception {
         MatcherAssert.assertThat(
             "a high surrogate immediately followed by a low surrogate is a valid pair and must not be rejected",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/signed-unicode-escape-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/signed-unicode-escape-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unicode')]
+input: |
+  [] > main
+    "\u+041" > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/truncated-unicode-escape-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/truncated-unicode-escape-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unicode')]
+input: |
+  [] > main
+    "\u41" > n


### PR DESCRIPTION
Closes #6027.

`Emissions.appendUnicode` decoded a `\uXXXX` escape with `Integer.parseInt(body.substring(cursor, cursor + 4), 16)`, with no check that the 4 characters are actually hex digits. `Integer.parseInt` accepts an optional leading `+`/`-`, so `\u+041` and `\u-001` decoded successfully instead of being rejected. Separately, when fewer than 4 characters remained after `u`, the code appended the raw text and returned with no error at all, so a truncated `\u41` silently passed through as the literal 4 characters `\u41`.

Fix: check all 4 characters are valid hex digits (`Character.digit(c, 16) >= 0`) before parsing, and that 4 characters actually remain. Otherwise throw `NumberFormatException` with a descriptive message, same pattern `appendOctal` already uses for its own out-of-range case. This propagates through the existing `catch (NumberFormatException) -> ParseError` wrapper in `Emissions.openValue`, so both cases now surface as a normal `<errors>` entry instead of silently decoding wrong or passing through unescaped.

Also bumped the class's `@checkstyle CyclomaticComplexityCheck (600 lines)` window to 610 lines — the fix added a few lines before `topLevelInlinePhi`, pushing that pre-existing method just past the old window and triggering a checkstyle violation unrelated to its own complexity.

Tests: added `EoSyntaxTest.rejectsSignedUnicodeEscape` and `EoSyntaxTest.rejectsTruncatedUnicodeEscape`, both asserting a proper `<errors>` entry instead of a wrong decode or silent pass-through. Verified both fail against the original code and pass with the fix.

`mvn -pl eo-parser test -o -Dtest='EoSyntaxTest'` - 934 tests, all passing.
`mvn -pl eo-parser qulice:check -Pqulice` - clean.
