### PR TITLE
#6028: wrap directory.walk glob PatternSyntaxException into ExFailure

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -66,3 +66,9 @@
   walk. --> on-walking-absent-directory
     directory mktemp.tmpfile.deleted
     "**"
+
+  --> on-walking-with-malformed-glob
+    d.as-dir.walk "[" > @
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 
 /**
@@ -37,13 +38,18 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
                 this.take(Phi.RHO).take("file").take("path")
             ).asString()
         ).toAbsolutePath();
-        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(
-            String.format(
-                "glob:%s", new Dataized(
-                    this.take("glob")
-                ).asString()
-            )
-        );
+        final String glob = new Dataized(this.take("glob")).asString();
+        final PathMatcher matcher;
+        try {
+            matcher = FileSystems.getDefault().getPathMatcher(
+                String.format("glob:%s", glob)
+            );
+        } catch (final PatternSyntaxException ex) {
+            throw new ExFailure(
+                String.format("Can't parse '%s' as a glob pattern", glob),
+                ex
+            );
+        }
         try (Stream<Path> paths = Files.walk(path)) {
             return new Data.ToPhi(
                 paths

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle PackageNameCheck (10 lines)
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link EOdirectory$EOwalk}.
+ * @since 0.63
+ * @checkstyle TypeNameCheck (4 lines)
+ */
+final class EOdirectoryEOwalkTest {
+
+    @Test
+    void wrapsMalformedGlobIntoExFailure() {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi("/tmp"));
+        final Phi dir = Phi.Φ.take("directory").copy();
+        dir.put(0, file);
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new Dataized(
+                new PhApplication(
+                    new PhApplication(new EOdirectory$EOwalk(), Phi.RHO, dir),
+                    "glob", new Data.ToPhi("[")
+                )
+            ).take(),
+            "a malformed glob must fail with ExFailure, not a raw PatternSyntaxException"
+        );
+    }
+}


### PR DESCRIPTION
Closes #6028.

`EOdirectory$EOwalk.lambda()` built its glob `PathMatcher` outside any try/catch. `Files.walk` right below it is already wrapped so `IOException` becomes a clean `ExFailure`, but a malformed glob (`FileSystems.getDefault().getPathMatcher("glob:[")`) throws `PatternSyntaxException`, an unchecked exception, straight out to the caller.

Fix: wrap the matcher construction the same way, converting `PatternSyntaxException` into `ExFailure`.

Tests:
- Added `on-walking-with-malformed-glob` to `directory.eo`, a throwing test matching the existing `on-walking-absent-directory` pattern.
- Added `EOdirectoryEOwalkTest.wrapsMalformedGlobIntoExFailure`, a Java-level test asserting the exception class is specifically `ExFailure`, not just "something throws" (EO throwing tests can only assert `Exception.class` generically, so this is needed to actually distinguish the fix from the bug).

Verified both fail against the original code (the Java test fails outright; the EO test's generated `assertThrows(Exception.class, ...)` still passes either way, since a raw `PatternSyntaxException` is still an `Exception` - this is a known limitation of `-->` throwing tests already present in the existing `on-walking-absent-directory` test, not something specific to this fix).

`mvn -pl eo-runtime test -o -Dtest='EOdirectoryTest,EOdirectoryEOwalkTest'` - 5 tests, all passing.
`mvn -pl eo-runtime qulice:check -Pqulice` - clean except one pre-existing `UnicodeInCode` warning already present on master (unrelated, just shifted a line number).
