### PR TITLE
#6029: replace EObytes$EOslice.natural with Expect.Natural

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -217,3 +217,8 @@
     20-1F-EE-B5-90
     3
     10
+
+  slice. --> on-slice-offset-exceeding-int-range
+    20-1F-EE-B5-90
+    3000000000
+    1

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
@@ -39,8 +39,8 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         final byte[] bytes = new Dataized(this.take(Phi.RHO)).take();
-        final int start = this.natural("start");
-        final int len = this.natural("len");
+        final int start = new Expect.Natural(Expect.at(this, "start")).it();
+        final int len = new Expect.Natural(Expect.at(this, "len")).it();
         final Phi result;
         if ((long) start + len <= bytes.length) {
             result = new Data.ToPhi(Arrays.copyOfRange(bytes, start, start + len));
@@ -57,23 +57,5 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
             );
         }
         return result;
-    }
-
-    /**
-     * Read the given attribute as a non-negative integer, aborting when it is
-     * not one (a contract violation, not a recoverable failure).
-     * @param attr Attribute name
-     * @return The attribute as a non-negative int
-     */
-    private int natural(final String attr) {
-        return Expect.at(this, attr)
-            .that(phi -> new Dataized(phi).asNumber())
-            .otherwise("must be a number")
-            .must(number -> number % 1 == 0)
-            .that(Double::intValue)
-            .otherwise("must be an integer")
-            .must(integer -> integer >= 0)
-            .otherwise("must be a positive integer")
-            .it();
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EObytesEOsliceTest.java
@@ -101,7 +101,37 @@ final class EObytesEOsliceTest {
                     )
                 )
             ).asString(),
-            Matchers.containsString("the 'len' attribute (-5) must be a positive integer")
+            Matchers.containsString("the 'len' attribute (-5) must be greater or equal to zero")
+        );
+    }
+
+    @Test
+    void reportsRealOffsetWhenItExceedsIntRange() {
+        MatcherAssert.assertThat(
+            "an offset above Integer.MAX_VALUE must be rejected with the real value, not silently saturated",
+            new UncheckedText(
+                new TextOf(
+                    Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> new Dataized(
+                            new PhApplication(
+                                new PhApplication(
+                                    new Data.ToPhi("hello, world!")
+                                        .take("as-bytes")
+                                        .take("slice")
+                                        .copy(),
+                                    "start",
+                                    new Data.ToPhi(3.0E9)
+                                ),
+                                "len",
+                                new Data.ToPhi(1)
+                            )
+                        ).asString(),
+                        "doesnt reject an offset above int range"
+                    )
+                )
+            ).asString(),
+            Matchers.containsString("must fit into int range")
         );
     }
 }


### PR DESCRIPTION
Closes #6029.

`EObytes$EOslice.natural` was a private, hand-rolled copy of `Expect.Natural`, missing the int-range guard that `Expect.Natural` already has (added for issue #5295, since `Double::intValue` silently saturates instead of throwing for values outside `int` range). Calling `bytes.slice 3000000000 1` had the offset silently saturate to `2147483647` before the bounds check ran, so the `cant-slice` fallback message reported the wrong offset.

Fix: use `new Expect.Natural(Expect.at(this, attr)).it()` directly and delete the duplicate, matching the precedent already set for `EOmalloc$EOof$EOallocated$EOresized`/`EOchunk$EOresized`.

Note the error message wording changes slightly as a side effect: `Expect.Natural` says "must be greater or equal to zero" where the old duplicate said "must be a positive integer" (0 was always accepted by both, "positive" was just an inaccurate label). Updated `EObytesEOsliceTest.takesWrongSlice` to match.

Tests:
- Added `on-slice-offset-exceeding-int-range` to `bytes.eo`, a throwing test.
- Added `EObytesEOsliceTest.reportsRealOffsetWhenItExceedsIntRange`, a Java-level test asserting the exception message specifically mentions "must fit into int range" - the EO throwing test alone can't distinguish this from the old behavior, since both throw *something* (the old code's saturated offset went out of bounds and failed via the unbound `cant-slice` fallback instead, a different failure with a different message).

Verified both new tests fail against the original code and pass with the fix.

`mvn -pl eo-runtime test -o -Dtest='EObytesEOsliceTest,EObytesTest'` - 48 tests, all passing.
`mvn -pl eo-runtime qulice:check -Pqulice` - clean.
