### PR TITLE
#6031: fold trackLocations/coverageTracking into transpile cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -364,15 +364,22 @@ final class Transpiling implements Step {
 
     /**
      * Cache-key version segment: the plugin version combined with a
-     * fingerprint of the bundled transpile XSLs. Folding the XSL
-     * content in means that a change in the transformation logic
+     * fingerprint of the bundled transpile XSLs, plus the
+     * {@code trackLocations}/{@code coverageTracking} flags. Folding the
+     * XSL content in means that a change in the transformation logic
      * invalidates the global transpile cache even when the plugin
      * version is unchanged (a constant {@code -SNAPSHOT} during
-     * development), see #5578.
+     * development), see #5578. Folding the two flags in means toggling
+     * either one also invalidates the cache, since both change what
+     * {@code to-java.xsl} emits (see #6031).
      * @return The version segment for {@link CachePath}
      */
     private String version() {
-        return String.format("%s-%s", this.version, new Fingerprint(Transpiling.XSLS).get());
+        return String.format(
+            "%s-%s-%b-%b",
+            this.version, new Fingerprint(Transpiling.XSLS).get(),
+            this.tracking.locations(), this.coverage
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -255,6 +255,29 @@ final class MjTranspileTest {
     }
 
     @Test
+    void invalidatesCacheWhenTrackLocationsChanges(@Mktmp final Path temp) throws Exception {
+        final Path cache = temp.resolve("cache");
+        final String src = String.format("+package foo.x%n%n[] > main%n  42.plus 1 > @");
+        new FakeMaven(temp.resolve("first"))
+            .withProgram(src)
+            .with("cache", cache.toFile())
+            .execute(new FakeMaven.Transpile());
+        MatcherAssert.assertThat(
+            "the second run's generated Java must reflect its own trackLocations=true setting instead of reusing the first run's cached trackLocations=false output",
+            new TextOf(
+                new FakeMaven(temp.resolve("second"))
+                    .withProgram(src)
+                    .with("cache", cache.toFile())
+                    .with("trackLocations", true)
+                    .execute(new FakeMaven.Transpile())
+                    .result()
+                    .get(this.compiled)
+            ).asString(),
+            Matchers.containsString("new PhSafe(")
+        );
+    }
+
+    @Test
     void recompilesIfModified(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final Map<String, Path> res = maven


### PR DESCRIPTION
Closes #6031.

`Transpiling.version()` builds the transpile disk cache key from the plugin version plus an XSL-content fingerprint (added for #5578), but not from `trackLocations`/`coverageTracking`. Both flags materially change the generated Java (`to-java.xsl` conditionally emits `new PhSafe(...)` and `new PhCoverage(...)` based on them), and the in-memory per-thread train cache is already keyed on them (`"%b|%b"` in `train()`), but the on-disk `CachePath` used for the actual transpiled-file cache was not. So toggling either flag while reusing an existing `eo.cache` directory served stale, differently-instrumented output.

Fix: fold both booleans into `version()`.

Test: `MjTranspileTest.invalidatesCacheWhenTrackLocationsChanges`, two separate `FakeMaven` projects sharing one cache directory, first with `trackLocations=false`, second with `trackLocations=true`. Asserts the second project's generated Java contains `new PhSafe(`. Verified this fails against the original code (second project's Java has no `PhSafe`, inherited from the first project's cache) and passes with the fix.

`mvn -pl eo-maven-plugin test -o -Dtest='MjTranspileTest'` - 41 tests, all passing.
`mvn -pl eo-maven-plugin qulice:check -Pqulice` - clean.
