### PR TITLE
#6032: fold xsl:import-ed libraries into the transpile cache-key fingerprint

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.func.StickyFunc;
 import org.eolang.parser.OnDefault;
 import org.eolang.parser.OnDetailed;
@@ -65,6 +66,40 @@ final class Transpiling implements Step {
     static final String PRE = "5-pre-transpile";
 
     /**
+     * The XSL steps of the transpile train, in order, ending with
+     * {@code to-java.xsl}. Kept as a single list so both the train in
+     * {@link #compiled(boolean)} and the cache-key fingerprint in
+     * {@link #version()} are derived from the same source.
+     */
+    static final String[] XSLS = {
+        "/org/eolang/parser/parse/set-locators.xsl",
+        "/org/eolang/maven/transpile/set-original-names.xsl",
+        "/org/eolang/maven/transpile/classes.xsl",
+        "/org/eolang/maven/transpile/tests.xsl",
+        "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
+        "/org/eolang/maven/transpile/package.xsl",
+        "/org/eolang/maven/transpile/attrs.xsl",
+        "/org/eolang/maven/transpile/data.xsl",
+        "/org/eolang/maven/transpile/to-java.xsl",
+    };
+
+    /**
+     * Classpath resources {@code xsl:import}-ed by one or more of
+     * {@link #XSLS}, so their content must also be folded into the
+     * cache-key fingerprint in {@link #version()} — editing one of these
+     * shared libraries changes the actual transpile output just as much
+     * as editing a top-level stylesheet does, but leaves {@link #XSLS}
+     * itself unchanged (see #6032). Not part of {@link #XSLS} itself
+     * because that array is also used verbatim to build the actual XSL
+     * train in {@link #compiled(boolean, boolean)}, where its last
+     * element is special-cased as {@code to-java.xsl}.
+     */
+    static final String[] IMPORTS = {
+        "/org/eolang/parser/_funcs.xsl",
+        "/org/eolang/parser/_specials.xsl",
+    };
+
+    /**
      * Parsing trains with XSLs, one per thread, keyed by whether source
      * locations are tracked.
      * <p>
@@ -85,24 +120,6 @@ final class Transpiling implements Step {
      * Cache directory for transpiled sources.
      */
     private static final String CACHE = "transpiled";
-
-    /**
-     * The XSL steps of the transpile train, in order, ending with
-     * {@code to-java.xsl}. Kept as a single list so both the train in
-     * {@link #compiled(boolean)} and the cache-key fingerprint in
-     * {@link #version()} are derived from the same source.
-     */
-    private static final String[] XSLS = {
-        "/org/eolang/parser/parse/set-locators.xsl",
-        "/org/eolang/maven/transpile/set-original-names.xsl",
-        "/org/eolang/maven/transpile/classes.xsl",
-        "/org/eolang/maven/transpile/tests.xsl",
-        "/org/eolang/maven/transpile/anonymous-to-nested.xsl",
-        "/org/eolang/maven/transpile/package.xsl",
-        "/org/eolang/maven/transpile/attrs.xsl",
-        "/org/eolang/maven/transpile/data.xsl",
-        "/org/eolang/maven/transpile/to-java.xsl",
-    };
 
     /**
      * Java extension.
@@ -220,6 +237,30 @@ final class Transpiling implements Step {
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(), saved, this.generatedDir
+        );
+    }
+
+    /**
+     * Cache-key version segment: the plugin version combined with a
+     * fingerprint of the bundled transpile XSLs and the libraries they
+     * {@code xsl:import}. Folding the XSL content in means that a change
+     * in the transformation logic invalidates the global transpile cache
+     * even when the plugin version is unchanged (a constant
+     * {@code -SNAPSHOT} during development), see #5578; folding the
+     * imported libraries in too closes the gap where editing one of
+     * them changed the actual output without changing anything in
+     * {@link #XSLS} itself, see #6032.
+     * @return The version segment for {@link CachePath}
+     */
+    String version() {
+        return String.format(
+            "%s-%s",
+            this.version,
+            new Fingerprint(
+                Stream.concat(
+                    Arrays.stream(Transpiling.XSLS), Arrays.stream(Transpiling.IMPORTS)
+                ).toArray(String[]::new)
+            ).get()
         );
     }
 
@@ -360,19 +401,6 @@ final class Transpiling implements Step {
                 )
             )
         );
-    }
-
-    /**
-     * Cache-key version segment: the plugin version combined with a
-     * fingerprint of the bundled transpile XSLs. Folding the XSL
-     * content in means that a change in the transformation logic
-     * invalidates the global transpile cache even when the plugin
-     * version is unchanged (a constant {@code -SNAPSHOT} during
-     * development), see #5578.
-     * @return The version segment for {@link CachePath}
-     */
-    private String version() {
-        return String.format("%s-%s", this.version, new Fingerprint(Transpiling.XSLS).get());
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Transpiling}.
+ * @since 0.1
+ */
+final class TranspilingTest {
+
+    @Test
+    void versionFoldsInImportedXslLibraries() {
+        MatcherAssert.assertThat(
+            "the cache-key version must differ from a fingerprint of the top-level XSLS alone, proving the xsl:import-ed libraries are actually folded in",
+            TranspilingTest.transpiling().version(),
+            Matchers.not(
+                Matchers.equalTo(
+                    String.format(
+                        "1.0-SNAPSHOT-%s", new Fingerprint(Transpiling.XSLS).get()
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * A minimal {@link Transpiling} instance for testing its private helpers.
+     * @return A new instance
+     */
+    private static Transpiling transpiling() {
+        return new Transpiling(
+            Collections.emptyList(),
+            Paths.get("target"),
+            Paths.get("target/generated"),
+            Paths.get("target/cache"),
+            true,
+            "1.0-SNAPSHOT",
+            false,
+            Paths.get("target/xsl-measures.csv"),
+            new Tracking(false, false),
+            false
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 final class TranspilingTest {
 
     @Test
-    void versionFoldsInImportedXslLibraries() {
+    void foldsInImportedXslLibrariesIntoVersion() {
         MatcherAssert.assertThat(
             "the cache-key version must differ from a fingerprint of the top-level XSLS alone, proving the xsl:import-ed libraries are actually folded in",
             TranspilingTest.transpiling().version(),


### PR DESCRIPTION
Closes #6032.

`Fingerprint` (introduced for #5578) folds the content of the bundled transpile XSLs into the transpile cache key, so editing one of them invalidates the cache. But `Transpiling.XSLS` only lists the nine top-level stylesheets. Five of them pull in real transformation logic through `xsl:import`: `to-java.xsl`, `attrs.xsl`, `classes.xsl`, and `data.xsl` import `_funcs.xsl` (a shared library of `eo:` functions), and `set-original-names.xsl` imports `_specials.xsl`. Neither imported file was part of the fingerprinted set, so editing `_funcs.xsl` changed the actual transpiled output without changing the cache key, serving stale output from `~/.eo/transpiled/...`.

Fix: added a separate `Transpiling.IMPORTS` array listing the two imported files, and fold both `XSLS` and `IMPORTS` into the fingerprint used by `version()`. Kept as a separate array from `XSLS` rather than appending to it, because `XSLS` is also used verbatim to build the actual XSL train in `compiled(boolean, boolean)`, where its last element is special-cased as `to-java.xsl` - appending to it would have broken the transpile pipeline itself, not just the cache key.

Also widened `XSLS`, `IMPORTS`, and `version()` from `private` to package-private, so the new test can exercise them directly instead of using reflection (this codebase has no reflection-based test precedent, and qulice's `AvoidAccessibilityAlteration` flags `setAccessible()` calls).

Test: `TranspilingTest.versionFoldsInImportedXslLibraries`, asserting a real `Transpiling` instance's `version()` differs from a fingerprint computed over `XSLS` alone. Verified it fails against the original code and passes with the fix.

`mvn -pl eo-maven-plugin test -o -Dtest='TranspilingTest,FingerprintTest,MjTranspileTest'` - 46 tests, all passing.
`mvn -pl eo-maven-plugin qulice:check -Pqulice` - clean.
