### PR TITLE
#6038: check number payload is exactly 8 bytes before StUnhex.getDouble

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -47,11 +47,14 @@ final class StUnhex extends StEnvelope {
         new StXnav(
             StUnhex.elements("number"),
             xnav -> {
-                final double number = StUnhex.buffer(
+                final ByteBuffer buffer = StUnhex.buffer(
                     StUnhex.undash(xnav.element("o").text().orElse(""))
-                ).getDouble();
-                if (!Double.isNaN(number) && !Double.isInfinite(number)) {
-                    xnav.node().setTextContent(StUnhex.number(number));
+                );
+                if (buffer.remaining() == Double.BYTES) {
+                    final double number = buffer.getDouble();
+                    if (!Double.isNaN(number) && !Double.isInfinite(number)) {
+                        xnav.node().setTextContent(StUnhex.number(number));
+                    }
                 }
             }
         ),

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -181,6 +181,44 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
+    void keepsTooFewNumberBytesUnconverted(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must not crash on a number payload shorter than 8 bytes, but it did",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.number'><o base='Φ.bytes'><o>40-49-0F</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.number' and o[@base='Φ.bytes' and not(o) and text()='40-49-0F']]"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void keepsTooManyNumberBytesUnconverted(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must not silently drop trailing bytes from a number payload longer than 8 bytes, but it did",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.number'><o base='Φ.bytes'><o>40-49-0F-DB-00-00-00-00-11-22</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.number' and o[@base='Φ.bytes' and not(o) and text()='40-49-0F-DB-00-00-00-00-11-22']]"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
     void keepsMalformedBytesUnconverted(final Shift shift, final String type) {
         MatcherAssert.assertThat(
             String.format(


### PR DESCRIPTION
Closes #6038.

`StUnhex`'s number branch called `ByteBuffer.getDouble()` with no check that the payload is exactly 8 bytes. A shorter payload throws `BufferUnderflowException`; a longer one gets its trailing bytes silently dropped (`getDouble()` only reads the first 8), so `40-49-0F-DB-00-00-00-00-11-22` (10 bytes) printed as `50.123870849609375`, computed from only the first 8 bytes, not equivalent to the original program.

Fix: check `buffer.remaining() == Double.BYTES` before calling `getDouble()`. If it isn't, leave the `Φ.number`/`Φ.bytes` structure as-is, matching the strategy the sibling string branch already uses (`decode()`, hardened for #5620) when it can't safely convert.

Tests: added `keepsTooFewNumberBytesUnconverted` and `keepsTooManyNumberBytesUnconverted` to `StUnhexTest`, matching the existing `keepsMalformedBytesUnconverted` pattern for the string branch. Verified both fail against the original code (one with `BufferUnderflowException`, the other with the silently truncated `50.123870849609375`) and pass with the fix.

`mvn -pl eo-printer test -o -Dtest='StUnhexTest'` - 12 tests, all passing.
`mvn -pl eo-printer qulice:check -Pqulice` - clean.
