### PR TITLE
#6039: fix Linting.summary dropping the error count

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -209,6 +209,41 @@ final class Linting implements Step {
         }
     }
 
+    /**
+     * Summarize the counts.
+     * @param counts Counts of errors, warnings, and critical
+     * @return Summary text
+     */
+    static String summary(final Map<Severity, Integer> counts) {
+        final List<String> parts = new ArrayList<>(0);
+        final int critical = counts.get(Severity.CRITICAL);
+        if (critical > 0) {
+            parts.add(Linting.plural(critical, "critical error"));
+        }
+        final int errors = counts.get(Severity.ERROR);
+        if (errors > 0) {
+            parts.add(Linting.plural(errors, "error"));
+        }
+        final int warnings = counts.get(Severity.WARNING);
+        if (warnings > 0) {
+            parts.add(Linting.plural(warnings, "warning"));
+        }
+        if (parts.isEmpty()) {
+            parts.add("no complaints");
+        }
+        final String sum;
+        if (parts.size() < 3) {
+            sum = String.join(" and ", parts);
+        } else {
+            sum = String.format(
+                "%s, and %s",
+                String.join(", ", parts.subList(0, parts.size() - 1)),
+                parts.get(parts.size() - 1)
+            );
+        }
+        return sum;
+    }
+
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void linting() throws IOException {
         final Collection<TjForeign> programs = this.tojos.withXmir();
@@ -491,41 +526,6 @@ final class Linting implements Step {
             txt.append('s');
         }
         return txt.toString();
-    }
-
-    /**
-     * Summarize the counts.
-     * @param counts Counts of errors, warnings, and critical
-     * @return Summary text
-     */
-    private static String summary(final Map<Severity, Integer> counts) {
-        final List<String> parts = new ArrayList<>(0);
-        final int critical = counts.get(Severity.CRITICAL);
-        if (critical > 0) {
-            parts.add(Linting.plural(critical, "critical error"));
-        }
-        final int errors = counts.get(Severity.ERROR);
-        if (errors > 0) {
-            parts.add(Linting.plural(errors, "error"));
-        }
-        final int warnings = counts.get(Severity.WARNING);
-        if (warnings > 0) {
-            parts.add(Linting.plural(warnings, "warning"));
-        }
-        if (parts.isEmpty()) {
-            parts.add("no complaints");
-        }
-        final String sum;
-        if (parts.size() < 3) {
-            sum = String.join(" and ", parts);
-        } else {
-            sum = String.format(
-                "%s, and %s",
-                String.join(", ", parts.subList(0, parts.size() - 2)),
-                parts.get(parts.size() - 1)
-            );
-        }
-        return sum;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -6,6 +6,11 @@ package org.eolang.maven;
 
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import org.eolang.lints.Severity;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -15,6 +20,19 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.31.0
  */
 final class LintingTest {
+
+    @Test
+    void summarizesAllThreeSeveritiesTogether() {
+        final Map<Severity, Integer> counts = new EnumMap<>(Severity.class);
+        counts.put(Severity.CRITICAL, 2);
+        counts.put(Severity.ERROR, 4);
+        counts.put(Severity.WARNING, 7);
+        MatcherAssert.assertThat(
+            "the summary must mention the error count, not just critical and warnings",
+            Linting.summary(counts),
+            Matchers.equalTo("2 critical errors, 4 errors, and 7 warnings")
+        );
+    }
 
     @Test
     void skipsLintingWhenFlagIsSet(@TempDir final Path temp) {


### PR DESCRIPTION
Closes #6039.

`Linting.summary` built the sentence with `parts.subList(0, parts.size() - 2)` for the three-severity case, dropping `parts.get(1)` (the error count) entirely. With 2 critical, 4 errors, and 7 warnings, the message read "2 critical errors, and 7 warnings" - the error count never appeared anywhere. This same `sum` string is used both for the informational log line and for the `IllegalStateException` message that fails the build, so the message that actually stops CI under-reported the real defect count.

Fix: `parts.subList(0, parts.size() - 1)` (everything except the last element), which correctly includes all three parts.

Also widened `Linting.summary` from `private` to package-private so the new test can call it directly with a synthetic `Map<Severity, Integer>`, instead of needing to drive the full linting pipeline through three simultaneous defect types just to reach this one line.

Test: `LintingTest.summarizesAllThreeSeveritiesTogether`, asserting the exact expected sentence for 2 critical / 4 errors / 7 warnings. Verified it fails against the original code (missing "4 errors") and passes with the fix.

`mvn -pl eo-maven-plugin test -o -Dtest='LintingTest'` - 2 tests, all passing.
`mvn -pl eo-maven-plugin qulice:check -Pqulice` - clean.
