### PR TITLE
#6040: add start anchor to string.regex matches

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -52,7 +52,9 @@
         matched-from-index 1 0
     [txt] > matches
       found.exists.and > @
-        found.to.eq txt.length
+        and.
+          found.to.eq txt.length
+          found.from.eq 0
       next. > found
         match txt
 
@@ -61,6 +63,12 @@
       compiled.
         regex "/^[0-9]+$/"
       "123\n"
+
+  not. ++> tests-does-not-match-with-unmatched-leading-characters
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "1abc"
 
   not. ++> tests-does-not-matches-regex-against-the-pattern
     matches.


### PR DESCRIPTION
Closes #6040.

`string.regex`'s `matches` only checked that a match reaches the end of the text (`found.to.eq txt.length`), never that it starts at the beginning. The underlying atom uses `matcher.find(start)`, which is unanchored at the front, so a match starting partway through the text and reaching the end was still reported as a full match. `matches("/[a-z]+/", "1abc")` returned `true`, even though `"1abc"` is not entirely lowercase letters.

Fix: also require `found.from.eq 0`, matching Java's own `Matcher.matches()` semantics (whole-string match: both start at 0 and end at length).

This is the unfinished half of #5779 (closed), which added the end-anchor (`found.to.eq txt.length`) to fix a trailing-newline false match, but never added the corresponding start-anchor.

Test: `tests-does-not-match-with-unmatched-leading-characters`, asserting `matches("/[a-z]+/", "1abc")` is false. Verified it fails against the original code and passes with the fix.

`mvn -pl eo-runtime test -o -Dtest='EO_string.EOregexTest'` - 28 tests, all passing.
