### PR TITLE
#6041: turn Stack first-push-indent IllegalStateException into ParseError

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -170,10 +170,8 @@ final class Stack {
         final String owner;
         if (this.levels.isEmpty()) {
             if (indent != 0) {
-                throw new IllegalStateException(
-                    String.format(
-                        "first push must be at indent 0, was %d", indent
-                    )
+                throw new ParseError(
+                    line, indent, "unexpected indentation, the first object must start at indent 0"
                 );
             }
             parent = Kind.TOP_LEVEL;

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -15,9 +15,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link Stack}.
  * @since 0.1
  */
-@SuppressWarnings({
-    "PMD.TooManyMethods", "PMD.UnnecessaryLocalRule", "PMD.UnitTestContainsTooManyAsserts"
-})
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})
 final class StackTest {
 
     @Test
@@ -42,24 +40,36 @@ final class StackTest {
 
     @Test
     void rejectsFirstPushAtNonZeroIndent() {
-        final ParseError error = Assertions.assertThrows(
+        Assertions.assertThrows(
             ParseError.class,
             () -> new Stack().push(2, 1, Kind.HEAD, Openness.OPEN),
             "first push must be at indent 0 — non-zero indent cannot start a program"
         );
+    }
+
+    @Test
+    void capturesLineOfFirstPushIndentViolation() {
         MatcherAssert.assertThat(
             "the error must carry the offending line",
-            error.line(),
+            StackTest.firstPushIndentViolation().line(),
             Matchers.equalTo(1)
         );
+    }
+
+    @Test
+    void capturesColumnOfFirstPushIndentViolation() {
         MatcherAssert.assertThat(
             "the error must carry the offending column",
-            error.pos(),
+            StackTest.firstPushIndentViolation().pos(),
             Matchers.equalTo(2)
         );
+    }
+
+    @Test
+    void capturesMessageOfFirstPushIndentViolation() {
         MatcherAssert.assertThat(
             "the error message must name the indent-0 requirement",
-            error.getMessage(),
+            StackTest.firstPushIndentViolation().getMessage(),
             Matchers.equalTo(
                 "unexpected indentation, the first object must start at indent 0"
             )
@@ -194,6 +204,17 @@ final class StackTest {
             "after close() the stack cannot retain any entry",
             stack.empty(),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * Trigger the first-push-at-non-zero-indent violation and capture it.
+     * @return The thrown error
+     */
+    private static ParseError firstPushIndentViolation() {
+        return Assertions.assertThrows(
+            ParseError.class,
+            () -> new Stack().push(2, 1, Kind.HEAD, Openness.OPEN)
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link Stack}.
  * @since 0.1
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})
+@SuppressWarnings({
+    "PMD.TooManyMethods", "PMD.UnnecessaryLocalRule", "PMD.UnitTestContainsTooManyAsserts"
+})
 final class StackTest {
 
     @Test
@@ -40,10 +42,27 @@ final class StackTest {
 
     @Test
     void rejectsFirstPushAtNonZeroIndent() {
-        Assertions.assertThrows(
+        final ParseError error = Assertions.assertThrows(
             ParseError.class,
             () -> new Stack().push(2, 1, Kind.HEAD, Openness.OPEN),
             "first push must be at indent 0 — non-zero indent cannot start a program"
+        );
+        MatcherAssert.assertThat(
+            "the error must carry the offending line",
+            error.line(),
+            Matchers.equalTo(1)
+        );
+        MatcherAssert.assertThat(
+            "the error must carry the offending column",
+            error.pos(),
+            Matchers.equalTo(2)
+        );
+        MatcherAssert.assertThat(
+            "the error message must name the indent-0 requirement",
+            error.getMessage(),
+            Matchers.equalTo(
+                "unexpected indentation, the first object must start at indent 0"
+            )
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -41,7 +41,7 @@ final class StackTest {
     @Test
     void rejectsFirstPushAtNonZeroIndent() {
         Assertions.assertThrows(
-            IllegalStateException.class,
+            ParseError.class,
             () -> new Stack().push(2, 1, Kind.HEAD, Openness.OPEN),
             "first push must be at indent 0 — non-zero indent cannot start a program"
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-line-indented-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-line-indented-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'indent')]
+input: |
+  # Sample.
+
+    42 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-line-indented-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-line-indented-is-rejected.yaml
@@ -4,6 +4,8 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[@line='3']
   - /object/errors/error[contains(text(),'indent')]
 input: |
   # Sample.


### PR DESCRIPTION
Closes #6041.

`Stack.push` threw a raw `IllegalStateException` when the very first object line of a program was indented (e.g. one level in, `  42 > x`). `Eo.dispatch` only catches `ParseError`, so this escaped `EoSyntax.parsed()` entirely - no line number, no `<errors>` XMIR entry, no recovery. Neighboring indent violations in the same method (odd indent, step-rule jump) are already surfaced as clean `<errors>` entries elsewhere in the pipeline; only this "first push at non-zero indent" case fell through uncaught.

Fix: throw `ParseError` (with the line/indent already available as method parameters) instead of `IllegalStateException`.

Updated the existing `StackTest.rejectsFirstPushAtNonZeroIndent`, which explicitly asserted the old `IllegalStateException` type, to expect `ParseError` instead.

Test: added `first-object-line-indented-is-rejected.yaml` under `eo-parser/src/test/resources/org/eolang/parser/eo-syntax/`, picked up automatically by `EoSyntaxTest.validatesEoSyntax`. Verified it fails against the original code (the harness's own exception, not a clean `<errors>` entry) and passes with the fix.

`mvn -pl eo-parser test -o -Dtest='EoSyntaxTest,StackTest'` - 951 tests, all passing.
`mvn -pl eo-parser qulice:check -Pqulice` - clean.
