### PR TITLE
#6042: turn build-fqns.xsl TerminationException into a proper parse error

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -82,13 +82,6 @@
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:if test="$find='φ'">
-          <xsl:message terminate="yes">
-            <xsl:text>The </xsl:text>
-            <xsl:value-of select="$find"/>
-            <xsl:text> object is used, but absent in self or parents scope</xsl:text>
-          </xsl:message>
-        </xsl:if>
         <xsl:copy>
           <xsl:apply-templates select="node()|@*"/>
         </xsl:copy>
@@ -216,6 +209,38 @@
   <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+  <!--
+  A "φ" reference left unresolved by "with-package" above stays as a
+  literal "<o base='φ'>" in the transformed tree (nothing rewrites it).
+  Reporting this here, after the transform, rather than terminating the
+  whole XSL train mid-resolution (as this file used to), lets it surface
+  as a normal <errors> entry with the offending line, consistent with
+  every other diagnostic in this pipeline (see #6042).
+  -->
+  <xsl:template match="/object">
+    <xsl:variable name="transformed" as="item()*">
+      <xsl:apply-templates select="(node() except errors)|@*"/>
+    </xsl:variable>
+    <xsl:copy>
+      <xsl:sequence select="$transformed"/>
+      <xsl:variable name="errors" as="element()*">
+        <xsl:for-each select="$transformed//o[@base='φ']">
+          <error>
+            <xsl:attribute name="check" select="'build-fqns'"/>
+            <xsl:attribute name="line" select="if (@line) then @line else 0"/>
+            <xsl:attribute name="severity" select="'error'"/>
+            <xsl:text>The φ object is used, but absent in self or parents scope</xsl:text>
+          </error>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:if test="not(empty($errors)) or exists(/object/errors)">
+        <errors>
+          <xsl:apply-templates select="/object/errors/error"/>
+          <xsl:copy-of select="$errors"/>
+        </errors>
+      </xsl:if>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'φ')]
+input: |
+  [] > sample
+    @ > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
@@ -4,6 +4,9 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
+  - /object/errors/error[@check='build-fqns']
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[@line='2']
   - /object/errors/error[contains(text(),'φ')]
 input: |
   [] > sample


### PR DESCRIPTION
Closes #6042.

`build-fqns.xsl` aborted the whole XSL pipeline with `<xsl:message terminate="yes">` when `@` (`φ`) is referenced but no `φ` is in scope. This surfaced to the caller as a raw `TerminationException` wrapped in `IllegalArgumentException`, naming an internal XSL file and line number, with no reference to the user's own source location and no `<errors>` XMIR entry - unlike every other diagnostic in this pipeline.

Fix: removed the `terminate="yes"` message. An unresolved `φ` reference now stays as a literal `<o base='φ'>` node in the transformed tree (nothing rewrites it, same as before, just without terminating). Added a new top-level `/object` template that runs the existing per-node resolution as before, then scans the transformed result for any surviving `o[@base='φ']` nodes and emits a proper `<errors><error>` entry for each, merged with whatever errors already existed from earlier shifts in the chain - the same pattern already used by `resolve-self.xsl` for its own "used outside valid scope" check.

One implementation snag along the way: my first attempt declared the intermediate `$transformed` variable without a type, which made Saxon build it as a document-node-rooted temporary tree - `/object`'s own attributes (like `@author`) ended up as children of that document node, which Saxon rejects ("Cannot output an attribute node whose parent is a document node"), breaking every single test. Declaring it `as="item()*"` forces a plain sequence instead, which fixed it.

Test: added `unresolved-phi-is-rejected.yaml` under `eo-parser/src/test/resources/org/eolang/parser/eo-syntax/`, picked up automatically by `EoSyntaxTest.validatesEoSyntax`. Verified it fails against the original code (a raw uncaught exception, not a clean `<errors>` entry) and passes with the fix.

`mvn -pl eo-parser test -o -Dtest='EoSyntaxTest'` - 938 tests, all passing.

Note: I could not run `xslint` locally (no local Ruby setup for it in my environment), so I'm relying on CI for that specific style check; the functional correctness is covered by the full parser test suite above, which exercises hundreds of real EO programs end to end.
