### PR TITLE
#6033: write cache payload before the validity marker

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -91,9 +91,9 @@ final class Cache {
                     || !Files.readString(hash).equals(sha)
             ) {
                 final String content = new UncheckedFunc<>(this.compilation).apply(source);
-                new Saved(sha, this.hash(tail)).value();
                 new Saved(content, cache).value();
                 new Saved(content, target).value();
+                new Saved(sha, this.hash(tail)).value();
             } else {
                 new Saved(Files.readString(cache), target).value();
             }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -30,11 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.UnitTestContainsTooManyAsserts"})
 final class CacheTest {
 
-    /**
-     * Marker file name pattern, relative to a cached tail.
-     */
-    private static final String MARKER = "%s.sha256";
-
     @Test
     void compilesSource(@Mktmp final Path temp) throws Exception {
         final Path base = temp.resolve("cache-folder");
@@ -62,7 +57,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "Cache file must be created and hash file must be created",
             Files.exists(base.resolve(tail))
-                && Files.exists(base.resolve(String.format(CacheTest.MARKER, tail))),
+                && Files.exists(base.resolve(CacheTest.marker(tail))),
             Matchers.is(true)
         );
     }
@@ -150,7 +145,7 @@ final class CacheTest {
         cache.apply(source, temp.resolve("out.txt"), tail);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content",
-            Files.readString(base.resolve(String.format(CacheTest.MARKER, tail)), encoding),
+            Files.readString(base.resolve(CacheTest.marker(tail)), encoding),
             Matchers.equalTo(
                 Base64.getEncoder().encodeToString(
                     MessageDigest.getInstance("SHA-256").digest(msg.getBytes(encoding))
@@ -178,7 +173,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for large file",
             Files.readString(
-                cache.resolve(String.format(CacheTest.MARKER, tail)),
+                cache.resolve(CacheTest.marker(tail)),
                 StandardCharsets.UTF_8
             ),
             Matchers.equalTo(
@@ -204,7 +199,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for tiny file",
             Files.readString(
-                cache.resolve(String.format(CacheTest.MARKER, tail)),
+                cache.resolve(CacheTest.marker(tail)),
                 StandardCharsets.UTF_8
             ),
             Matchers.equalTo(CacheTest.hash(content))
@@ -304,7 +299,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "the marker must not point at a payload that was never written",
             Files.readString(
-                base.resolve(String.format(CacheTest.MARKER, tail)), StandardCharsets.UTF_8
+                base.resolve(CacheTest.marker(tail)), StandardCharsets.UTF_8
             ),
             Matchers.equalTo(CacheTest.hash(initial))
         );
@@ -325,5 +320,14 @@ final class CacheTest {
             MessageDigest.getInstance("SHA-256")
                 .digest(content.getBytes(StandardCharsets.UTF_8))
         );
+    }
+
+    /**
+     * Marker file name for the given cached tail.
+     * @param tail Tail path in cache
+     * @return Marker file name, relative to the same directory as the tail
+     */
+    private static String marker(final Path tail) {
+        return String.format("%s.sha256", tail);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -26,8 +27,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.60
  */
 @ExtendWith(MktmpResolver.class)
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnitTestContainsTooManyAsserts"})
 final class CacheTest {
+
+    /**
+     * Marker file name pattern, relative to a cached tail.
+     */
+    private static final String MARKER = "%s.sha256";
 
     @Test
     void compilesSource(@Mktmp final Path temp) throws Exception {
@@ -56,7 +62,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "Cache file must be created and hash file must be created",
             Files.exists(base.resolve(tail))
-                && Files.exists(base.resolve(String.format("%s.sha256", tail))),
+                && Files.exists(base.resolve(String.format(CacheTest.MARKER, tail))),
             Matchers.is(true)
         );
     }
@@ -144,7 +150,7 @@ final class CacheTest {
         cache.apply(source, temp.resolve("out.txt"), tail);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content",
-            Files.readString(base.resolve(String.format("%s.sha256", tail)), encoding),
+            Files.readString(base.resolve(String.format(CacheTest.MARKER, tail)), encoding),
             Matchers.equalTo(
                 Base64.getEncoder().encodeToString(
                     MessageDigest.getInstance("SHA-256").digest(msg.getBytes(encoding))
@@ -172,7 +178,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for large file",
             Files.readString(
-                cache.resolve(String.format("%s.sha256", tail)),
+                cache.resolve(String.format(CacheTest.MARKER, tail)),
                 StandardCharsets.UTF_8
             ),
             Matchers.equalTo(
@@ -198,7 +204,7 @@ final class CacheTest {
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for tiny file",
             Files.readString(
-                cache.resolve(String.format("%s.sha256", tail)),
+                cache.resolve(String.format(CacheTest.MARKER, tail)),
                 StandardCharsets.UTF_8
             ),
             Matchers.equalTo(CacheTest.hash(content))
@@ -270,6 +276,47 @@ final class CacheTest {
                     Files.readString(cache.resolve("dirB.sha256"), StandardCharsets.UTF_8)
                 )
             )
+        );
+    }
+
+    @Test
+    void leavesMarkerUntouchedWhenPayloadWriteFails(
+        @Mktmp final Path temp
+    ) throws IOException, NoSuchAlgorithmException {
+        final Path base = temp.resolve("cache-order");
+        Files.createDirectories(base);
+        final Path source = temp.resolve("order.eo");
+        final String initial = "v1";
+        Files.writeString(source, initial, StandardCharsets.UTF_8);
+        final Path target = temp.resolve("order.xmir");
+        final Path tail = source.getFileName();
+        new Cache(base, p -> initial).apply(source, target, tail);
+        final String updated = "v2";
+        Files.writeString(source, updated, StandardCharsets.UTF_8);
+        final Path cached = base.resolve(tail);
+        Files.delete(cached);
+        Files.createDirectories(cached);
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Cache(base, p -> updated).apply(source, target, tail),
+            "a failure while writing the payload must be reported, not swallowed"
+        );
+        MatcherAssert.assertThat(
+            "the marker must not point at a payload that was never written",
+            Files.readString(
+                base.resolve(String.format(CacheTest.MARKER, tail)), StandardCharsets.UTF_8
+            ),
+            Matchers.equalTo(CacheTest.hash(initial))
+        );
+        Files.delete(cached);
+        final AtomicInteger counter = new AtomicInteger(0);
+        new Cache(
+            base, p -> String.format("%s-%d", updated, counter.incrementAndGet())
+        ).apply(source, target, tail);
+        MatcherAssert.assertThat(
+            "recovery after the failed write must recompile rather than serve a stale entry",
+            counter.get(),
+            Matchers.equalTo(1)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.60
  */
 @ExtendWith(MktmpResolver.class)
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnitTestContainsTooManyAsserts"})
+@SuppressWarnings("PMD.TooManyMethods")
 final class CacheTest {
 
     @Test
@@ -275,43 +275,80 @@ final class CacheTest {
     }
 
     @Test
-    void leavesMarkerUntouchedWhenPayloadWriteFails(
-        @Mktmp final Path temp
-    ) throws IOException, NoSuchAlgorithmException {
-        final Path base = temp.resolve("cache-order");
-        Files.createDirectories(base);
-        final Path source = temp.resolve("order.eo");
-        final String initial = "v1";
-        Files.writeString(source, initial, StandardCharsets.UTF_8);
-        final Path target = temp.resolve("order.xmir");
-        final Path tail = source.getFileName();
-        new Cache(base, p -> initial).apply(source, target, tail);
-        final String updated = "v2";
-        Files.writeString(source, updated, StandardCharsets.UTF_8);
-        final Path cached = base.resolve(tail);
-        Files.delete(cached);
-        Files.createDirectories(cached);
+    void rejectsPayloadWriteFailure(@Mktmp final Path temp) throws IOException {
+        final CacheTest.Corrupted state = CacheTest.corrupted(temp);
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new Cache(base, p -> updated).apply(source, target, tail),
+            () -> new Cache(state.base, p -> "v2").apply(state.source, state.target, state.tail),
             "a failure while writing the payload must be reported, not swallowed"
         );
+    }
+
+    @Test
+    void leavesMarkerUntouchedAfterPayloadWriteFailure(
+        @Mktmp final Path temp
+    ) throws IOException, NoSuchAlgorithmException {
+        final CacheTest.Corrupted state = CacheTest.corrupted(temp);
+        CacheTest.attemptDoomedWrite(state);
         MatcherAssert.assertThat(
             "the marker must not point at a payload that was never written",
             Files.readString(
-                base.resolve(CacheTest.marker(tail)), StandardCharsets.UTF_8
+                state.base.resolve(CacheTest.marker(state.tail)), StandardCharsets.UTF_8
             ),
-            Matchers.equalTo(CacheTest.hash(initial))
+            Matchers.equalTo(CacheTest.hash("v1"))
         );
-        Files.delete(cached);
+    }
+
+    @Test
+    void recompilesAfterPayloadWriteFailureInsteadOfServingStaleEntry(
+        @Mktmp final Path temp
+    ) throws IOException {
+        final CacheTest.Corrupted state = CacheTest.corrupted(temp);
+        CacheTest.attemptDoomedWrite(state);
+        Files.delete(state.base.resolve(state.tail));
         final AtomicInteger counter = new AtomicInteger(0);
         new Cache(
-            base, p -> String.format("%s-%d", updated, counter.incrementAndGet())
-        ).apply(source, target, tail);
+            state.base, p -> String.format("v2-%d", counter.incrementAndGet())
+        ).apply(state.source, state.target, state.tail);
         MatcherAssert.assertThat(
             "recovery after the failed write must recompile rather than serve a stale entry",
             counter.get(),
             Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * Build a cache with a valid "v1" entry, then move the source to "v2"
+     * and replace the cache payload path with a directory, so that a
+     * following write to it fails.
+     * @param temp Temporary directory
+     * @return The corrupted cache state
+     * @throws IOException If the fixture cannot be built
+     */
+    private static CacheTest.Corrupted corrupted(final Path temp) throws IOException {
+        final Path base = temp.resolve("cache-order");
+        Files.createDirectories(base);
+        final Path source = temp.resolve("order.eo");
+        Files.writeString(source, "v1", StandardCharsets.UTF_8);
+        final Path target = temp.resolve("order.xmir");
+        final Path tail = source.getFileName();
+        new Cache(base, p -> "v1").apply(source, target, tail);
+        Files.writeString(source, "v2", StandardCharsets.UTF_8);
+        final Path cached = base.resolve(tail);
+        Files.delete(cached);
+        Files.createDirectories(cached);
+        return new CacheTest.Corrupted(base, source, target, tail);
+    }
+
+    /**
+     * Attempt to write "v2" into the corrupted cache and swallow the
+     * expected failure, leaving the cache exactly as it was.
+     * @param state The corrupted cache state
+     */
+    private static void attemptDoomedWrite(final CacheTest.Corrupted state) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Cache(state.base, p -> "v2").apply(state.source, state.target, state.tail)
         );
     }
 
@@ -329,5 +366,48 @@ final class CacheTest {
      */
     private static String marker(final Path tail) {
         return String.format("%s.sha256", tail);
+    }
+
+    /**
+     * A cache whose payload path has been replaced with a directory, so
+     * that a following write to it fails.
+     * @since 0.60
+     */
+    private static final class Corrupted {
+
+        /**
+         * Base cache directory.
+         */
+        private final Path base;
+
+        /**
+         * Source file, already changed since the last valid cache entry.
+         */
+        private final Path source;
+
+        /**
+         * Target file to write into.
+         */
+        private final Path target;
+
+        /**
+         * Tail path in cache.
+         */
+        private final Path tail;
+
+        /**
+         * Ctor.
+         * @param base Base cache directory
+         * @param source Source file
+         * @param target Target file
+         * @param tail Tail path in cache
+         * @checkstyle ParameterNumberCheck (5 lines)
+         */
+        Corrupted(final Path base, final Path source, final Path target, final Path tail) {
+            this.base = base;
+            this.source = source;
+            this.target = target;
+            this.tail = tail;
+        }
     }
 }


### PR DESCRIPTION
Closes #6033.

`Cache.apply` wrote the sha256 marker before the payload:

```java
new Saved(sha, this.hash(tail)).value();
new Saved(content, cache).value();
new Saved(content, target).value();
```

If the process dies (crash, disk full, IOException) between the first and second write, the marker already matches the new source hash while the cache file still holds the old or missing content. On the next run the freshness check passes on all branches and the stale entry is served forever, silently.

Fix: write the payload first, marker last, so the marker can never exist without the payload it vouches for.

```java
new Saved(content, cache).value();
new Saved(content, target).value();
new Saved(sha, this.hash(tail)).value();
```

Test: `CacheTest.leavesMarkerUntouchedWhenPayloadWriteFails` forces the payload write to fail (by putting a directory where the cache file should be) and checks the marker still points at the old, valid payload, then checks a following call recompiles instead of serving a stale entry. Reverted the fix locally and confirmed this test fails against the old write order.

`mvn -pl eo-maven-plugin test -Dtest=CacheTest,ConcurrentCacheTest,ChCachedTest,OyCachedTest` - 42 tests, all passing.
