### PR TITLE
#6024: fix number.random next mask restricting output below 0.5

### DIFF
--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -50,7 +50,7 @@
                   (seed.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
                     25214903917.as-i64
               11.as-i64
-          00-0F-FF-FF-FF-FF-FF-FF
+          00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
 
   ++> tests-random-is-in-range
@@ -70,6 +70,12 @@
           rand.next.next.lt 0
     next. > rand
       random 123
+
+  ++> tests-random-next-can-reach-upper-half
+    not. > @
+      rand.lt 0.5
+    next. > rand
+      random 178609
 
   ++> tests-random-with-seed
     not. > @


### PR DESCRIPTION
Closes #6024.

`number.random`'s `next` (line 53) masked its new LCG state with `00-0F-FF-FF-FF-FF-FF-FF` (2^52-1), but `random`'s own `@` divides that state by `00-20-00-00-00-00-00-00.as-i64.as-number` (2^53). Since the masked value can never reach 2^52, dividing by 2^53 bounds every output at just under 0.5, no matter the seed.

The sibling `clocked` builds its equivalent mask correctly as `(one.left 53).as-i64.minus one`, i.e. 2^53-1, matching the same divisor. `next`'s mask looks like a one-hex-digit typo.

Fix: change the mask to `00-1F-FF-FF-FF-FF-FF-FF` (2^53-1).

Test: added `tests-random-next-can-reach-upper-half` with seed 178609, chosen so `(seed * 25214903917 + 11) mod 2^53 >= 2^52`, i.e. the fixed output is just over 0.5. Reverted the fix locally and confirmed the test fails against the old mask (0.5 unreachable by construction), then confirmed it passes with the fix.

`mvn -pl eo-runtime test -Dtest=EOrandomTest` - 5 tests, all passing.
