### PR TITLE
Fix the lint warnings in eo-runtime EO sources

### DIFF
--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -19,7 +19,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 +unlint mandatory-package
 
 [@] > bytes

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -53,3 +53,25 @@
   [size] > resized /Q.chunk
   [] > size /Q.number
   [offset data] > write /Q.bool
+
+  eq. ++> tests-chunk-gets-what-was-put
+    malloc.of
+      8
+      seq * > [c]
+        c.put 42
+        c.get
+    42.as-bytes
+
+  eq. ++> tests-chunk-knows-its-size
+    malloc.of
+      3
+      c.size > [c]
+    3
+
+  eq. ++> tests-chunk-reads-a-slice-of-what-was-written
+    malloc.of
+      5
+      seq * > [c]
+        c.write 0 "hello"
+        c.read 1 3
+    "ell".as-bytes

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -1,4 +1,4 @@
-# A `chunk` is a handle to a block of data allocated in heap memory.
+# Handle to a block of data allocated in heap memory.
 # It is created by `malloc.of` (and, indirectly, by `malloc.empty` and
 # `malloc.for`) and passed into the user scope, where it provides the API
 # to read and write the data of the block:
@@ -16,6 +16,8 @@
 #       c.id                # get identifier of the block
 #       c.@                 # the same as c.get
 # ```
+#
+# The `id` is the identifier the allocator gave to the block.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -7,6 +7,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [] > clock
   as-i64. > @

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -61,6 +61,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [] > console
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -9,6 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 [file] > directory
   file > @

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -8,6 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 [path] > file
   path > @

--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -9,6 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint mandatory-package
 
 output. > [name] > getenv
   os.is-windows.if

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -15,24 +15,38 @@
     x.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
       "i64 cannot be divided by zero"
-    result
+    if.
+      eq.
+        and.
+          n.as-bytes.xor x.as-bytes
+          80-00-00-00-00-00-00-00
+        80-00-00-00-00-00-00-00
+      as-bytes.
+        plus.
+          i64 quotient.not
+          i64 00-00-00-00-00-00-00-01
+      i64 quotient
   00-00-00-00-00-00-00-01.left i > [i] > bit
-  magnitude x.as-bytes > bottom
-  as-bytes. > bottom-negated
-    plus.
-      i64 bottom.not
-      i64 00-00-00-00-00-00-00-01
   [index remainder quot] > looped
     if. > @
       index.lt 0
       quot
-      unsigned-gte.if
+      if.
+        eq.
+          or. >> carry-out!
+            and. >> both-negative!
+              shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
+              subtrahend.and 80-00-00-00-00-00-00-00 >> divisor-sign!
+            and. >> mixed-signs-with-nonneg-trial!
+              shifted-sign.xor divisor-sign >> signs-differ!
+              next-rem.xor 80-00-00-00-00-00-00-00 >> trial-nonnegative!
+          80-00-00-00-00-00-00-00
         looped
           index.minus 1
           as-bytes. >> next-rem!
             plus.
               i64 shifted
-              i64 bottom-negated
+              i64 subtrahend
           quot.or >>!
             bit index
         looped
@@ -40,18 +54,11 @@
           or. >> shifted!
             remainder.left 1
             and.
-              top.right index
+              right.
+                magnitude n.as-bytes
+                index
               00-00-00-00-00-00-00-01
           quot
-    eq. > unsigned-gte
-      or. >> carry-out!
-        and. >> both-negative!
-          shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
-          bottom-negated.and 80-00-00-00-00-00-00-00 >> divisor-sign!
-        and. >> mixed-signs-with-nonneg-trial!
-          shifted-sign.xor divisor-sign >> signs-differ!
-          next-rem.xor 80-00-00-00-00-00-00-00 >> trial-nonnegative!
-      80-00-00-00-00-00-00-00
   if. > [b] > magnitude
     eq.
       b.and 80-00-00-00-00-00-00-00
@@ -61,22 +68,16 @@
         i64 b.not
         i64 00-00-00-00-00-00-00-01
     b
-  eq. > negative
-    and.
-      n.as-bytes.xor x.as-bytes
-      80-00-00-00-00-00-00-00
-    80-00-00-00-00-00-00-00
   looped > quotient
     63
     00-00-00-00-00-00-00-00
     00-00-00-00-00-00-00-00
-  negative.if > result
-    as-bytes.
-      plus.
-        i64 quotient.not
-        i64 00-00-00-00-00-00-00-01
-    i64 quotient
-  magnitude n.as-bytes > top
+  as-bytes. > subtrahend
+    plus.
+      i64
+        not.
+          magnitude x.as-bytes
+      i64 00-00-00-00-00-00-00-01
 
   ++> tests-i64-div-by-i64-one
     eq. > @

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -32,7 +32,7 @@
             if. > @
               tup.length.eq 0
               *
-              without-key.with
+              others.with
                 [] >>
                   ^.hash > hash
                   ^.kbts > kbts
@@ -40,14 +40,14 @@
                   tup.head.value > value
             bytes.hash >> hash!
               tup.head.key.as-bytes >> kbts!
-            @. > prev
-              rec-rebuild tup.tail
-            tuple.filtered > without-key
+            tuple.filtered > others
               prev
               not. > [ent] >>
                 and.
                   ent.hash.eq hash
                   ent.kbts.eq kbts
+            @. > prev
+              rec-rebuild tup.tail
           | pairs
   [entries] > ctor
     [key] > found

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -9,8 +9,8 @@
 # hash code is derived from those bytes rather than from the key itself,
 # so that keys with side effects are never evaluated more than once.
 
-+alias bytes.hash
 +alias tuple.filtered
++alias bytes.hash
 +alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -12,6 +12,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [] > mktemp
   directory > @

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -28,7 +28,7 @@
               point.times > @
                 poly 1
               if. > [depth] > poly
-                depth.gt terms
+                depth.gt 30
                 1
                 1.plus
                   times.
@@ -43,7 +43,6 @@
                         plus. (depth.times 2) 1
                     poly (depth.plus 1)
               point.times point > squared
-              30 > terms
             | (sqrt ((1.minus magnitude).div 2))
         series magnitude
     base

--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -13,14 +13,23 @@
 
 [n cant-convert] > as-i64
   if. > @
-    or. >>
-      exp.eq 2047
+    or.
+      eq.
+        as-number. >> exp
+          as-i64.
+            right.
+              n.as-bytes.and 7F-F0-00-00-00-00-00-00
+              52
+        2047
       or.
         exp.gt 1086
         and.
           exp.eq 1086
           not.
-            negative.and
+            and.
+              eq. >> negative
+                n.as-bytes.and 80-00-00-00-00-00-00-00
+                80-00-00-00-00-00-00-00
               eq.
                 or. >> mantissa
                   n.as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF
@@ -30,21 +39,12 @@
       "Can't convert number %f to i64 because it's out of i64 bounds".printf
         * n
     if.
-      lt.
-        as-number. >> exp
-          as-i64.
-            right.
-              n.as-bytes.and 7F-F0-00-00-00-00-00-00
-              52
-        1023
+      exp.lt 1023
       00-00-00-00-00-00-00-00.as-i64
       if.
         exp.eq 1086
         80-00-00-00-00-00-00-00.as-i64
-        if.
-          eq. >> negative
-            n.as-bytes.and 80-00-00-00-00-00-00-00
-            80-00-00-00-00-00-00-00
+        negative.if
           magnitude.not.as-i64.plus 00-00-00-00-00-00-00-01.as-i64
           as-i64.
             if. >> magnitude

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -14,13 +14,15 @@
       not.
         bts.size.gt 8
     and.
-      exp.eq 7F-F0-00-00-00-00-00-00
+      eq.
+        bts.and 7F-F0-00-00-00-00-00-00
+        7F-F0-00-00-00-00-00-00
       not.
-        mantissa.eq 00-00-00-00-00-00-00-00
+        eq.
+          bts.and 00-0F-FF-FF-FF-FF-FF-FF
+          00-00-00-00-00-00-00-00
     false
   n.as-bytes > bts
-  bts.and 7F-F0-00-00-00-00-00-00 > exp
-  bts.and 00-0F-FF-FF-FF-FF-FF-FF > mantissa
 
   nan.is-nan ++> nan-is-nan
 

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -43,21 +43,20 @@
         t.times
           horner 0
       if. > [k] > horner
-        k.gt terms
+        k.gt 40
         0
         plus.
           1.div
             plus.
               k.times 2
               1
-          squared.times
+          times.
+            t.times t
             horner
               k.plus 1
-      t.times t > squared
       div. > t
         m.minus 1
         m.plus 1
-      40 > terms
   number num.as-bytes > n
 
   lt. ++> tests-ln-fraction

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -50,22 +50,21 @@
                 if.
                   base.gt 0
                   [y] >> expon
-                    whole.times (fraction 1) > @
-                    20 > eterms
+                    times. > @
+                      if.
+                        k.lt 0
+                        1.div
+                          ipow e (abs k)
+                        ipow e (abs k)
+                      fraction 1
                     if. > [j] > fraction
-                      j.gt eterms
+                      j.gt 20
                       1
                       1.plus
                         times.
-                          r.div j
+                          div. (y.minus k) j
                           fraction (j.plus 1)
                     floor. (y.plus 0.5) > k
-                    y.minus k > r
-                    if. > whole
-                      k.lt 0
-                      1.div
-                        ipow e (abs k)
-                      ipow e (abs k)
                   | (expo.times (ln base))
                   nan
             if.

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -26,7 +26,8 @@
       1
       1.minus
         times.
-          squared.div
+          div.
+            reduced.times reduced
             times.
               depth.times 2
               plus.
@@ -35,7 +36,6 @@
           factor
             depth.plus 1
     | 1
-  reduced.times reduced >> squared
 
   lt. ++> tests-sine-is-odd-function
     abs

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -1,10 +1,10 @@
 # Path `path` that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
 
-+alias tuple.reduced
-+alias string.regex
 +alias string.index-of
 +alias string.last-index-of
++alias tuple.reduced
++alias string.regex
 +alias string.replaced
 +alias string.split
 +architect yegor256@gmail.com
@@ -13,6 +13,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 [uri] > path
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -1,7 +1,7 @@
-# Recover from a terminated computation (⊥).
-# Resolves `value` to its normal form; if that is a ⊥, behaves as
-# `alternative`, otherwise as `value`. This is the only way to intercept a
-# ⊥ and keep going: a ⊥ that is never recovered terminates the program.
+# Recovers from a terminated computation.
+# Resolves `value` to its normal form; if that resolution terminates, behaves
+# as `alternative`, otherwise as `value`. This is the only way to intercept a
+# termination and keep going: one that is never recovered ends the program.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -49,6 +49,7 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 +unlint redundant-object
++unlint mandatory-package
 
 [address port] > socket
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -17,6 +17,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [text] > stderr
   seq * > @

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -21,37 +21,38 @@
 
 [text] > stderr
   seq * > @
-    output.write text
+    write.
+      os.is-windows.if
+        [] >>
+          [buffer] > write
+            @. > @
+              output-block.write buffer
+            [] > output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  win32 *1
+                    "_write"
+                    win32.stderr
+                    buffer
+                    buffer.size
+                output-block
+        [] >>
+          [buffer] > write
+            @. > @
+              output-block.write buffer
+            [] > output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  posix *1
+                    "write"
+                    posix.stderr
+                    buffer
+                    buffer.size
+                output-block
+      text
     true
-  os.is-windows.if > output
-    [] >>
-      [buffer] > write
-        @. > @
-          output-block.write buffer
-        [] > output-block
-          true > @
-          seq * > [buffer] > write
-            code.
-              win32 *1
-                "_write"
-                win32.stderr
-                buffer
-                buffer.size
-            output-block
-    [] >>
-      [buffer] > write
-        @. > @
-          output-block.write buffer
-        [] > output-block
-          true > @
-          seq * > [buffer] > write
-            code.
-              posix *1
-                "write"
-                posix.stderr
-                buffer
-                buffer.size
-            output-block
 
   stderr ++> tests-prints-to-stderr
     "Hello, stderr-test!\n"

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -19,6 +19,7 @@
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [] > stdin
   all-lines > @

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -13,6 +13,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
 [text] > stdout
   seq * > @

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -1,7 +1,7 @@
 # Checks if `text` contains all elements from `substrings`.
 
-+alias tuple.reduced
 +alias tuple.mapped
++alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -1,7 +1,7 @@
 # Checks if `text` contains any element from `substrings`.
 
-+alias tuple.reduced
 +alias tuple.mapped
++alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -9,7 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [text] > length
   if. > @

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [text] > low-cased
   string > @

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -20,16 +20,20 @@
     [text] > as-float
       negative.if negated magnitude > @
       index-of unsigned "." > dot
-      div. > fraction
-        fold-digits
-          slice
-            unsigned
-            dot.plus 1
-            places
-        10.power places
-      not. > has-fraction
-        dot.eq -1
-      has-fraction.if with-fraction whole > magnitude
+      if. > magnitude
+        not.
+          dot.eq -1
+        plus.
+          fold-digits
+            slice unsigned 0 dot
+          div.
+            fold-digits
+              slice
+                unsigned
+                dot.plus 1
+                places
+            10.power places
+        fold-digits unsigned
       magnitude.times -1 > negated
       eq. > negative
         slice
@@ -39,27 +43,23 @@
         "-"
       unsigned.length.minus > places
         dot.plus 1
-      negative.or > signed-prefix
+      negative.or > signed
         eq.
           slice text 0 1
           "+"
-      signed-prefix.if > unsigned
+      signed.if > unsigned
         slice
           text
           1
           text.length.minus 1
         text
-      fold-digits unsigned > whole
-      plus. > with-fraction
-        fold-digits
-          slice unsigned 0 dot
-        fraction
     [text] > as-integer
       if. > @
         digits.length.gt 19
-        overflow
-        signed
-      signed-prefix.if > digits
+        T
+          "The number doesn't fit into long range for the '%d' conversion"
+        negative.if negated folded
+      signed.if > digits
         slice
           text
           1
@@ -73,18 +73,17 @@
           0
           1
         "-"
-      overflow-message > overflow
-      T > overflow-message
-        "The number doesn't fit into long range for the '%d' conversion"
-      negative.if negated folded > signed
-      negative.or > signed-prefix
+      negative.or > signed
         eq.
           slice text 0 1
           "+"
     [group acc] >> convert
       matched.exists.not.if > @
         *
-        next-group
+        if.
+          group.gt specifiers.length
+          acc
+          next
       convert > next
         group.plus 1
         acc.with
@@ -93,24 +92,16 @@
               group.minus 1
               T
             matched.group group
-      if. > next-group
-        group.gt specifiers.length
-        acc
-        next
     | > @
       1
       *
-    [spec text] > converted
-      if. > @
-        spec.eq "s"
-        text
-        as-number-value
-      as-float text > as-float-value
-      as-integer text > as-integer-value
-      if. > as-number-value
+    if. > [spec text] > converted
+      spec.eq "s"
+      text
+      if.
         spec.eq "d"
-        as-integer-value
-        as-float-value
+        as-integer text
+        as-float text
     [text] > fold-digits
       [index acc] >> rec
         if. > @
@@ -127,13 +118,13 @@
               48
       | 0 0 > @
     match. > found
-      regex wrapped
+      regex
+        chained *1
+          "/"
+          pattern
+          "/"
       read
     found.next > matched
-    chained *1 > wrapped
-      "/"
-      pattern
-      "/"
   | > @
     tokens.at
       0
@@ -141,101 +132,93 @@
     tokens.at
       1
       T
-  [ch] >> escaped
-    metachar.if > @
-      escaped-char
+  if. > [ch] >> escaped
+    contains.
+      *
+        "\\"
+        "^"
+        "$"
+        "."
+        "|"
+        "?"
+        "*"
+        "+"
+        "("
+        ")"
+        "["
+        "]"
+        "{"
+        "}"
+        "/"
       ch
-    chained *1 > escaped-char
+    chained *1
       "\\"
       ch
-    metachars.contains ch > metachar
-    * > metachars
-      "\\"
-      "^"
-      "$"
-      "."
-      "|"
-      "?"
-      "*"
-      "+"
-      "("
-      ")"
-      "["
-      "]"
-      "{"
-      "}"
-      "/"
+    ch
   [position accumulated found pending] >> tokenize
     if. > @
       position.gte format.length
-      ended
-      continued
-    slice > ch
-      format
-      position
-      1
-    pending.if > continued
-      if.
-        ch.eq "%"
-        tokenize
-          position.plus 1
-          chained *1
-            accumulated
-            "%"
-          found
-          false
+      pending.if *1
+        T
+          "The format string ends with a dangling percent and no specifier after it"
+        accumulated
+        found
+      pending.if
         if.
-          ch.eq "d"
+          ch.eq "%"
           tokenize
             position.plus 1
             chained *1
               accumulated
-              "([+-]?\\d+)"
-            found.with "d"
+              "%"
+            found
             false
           if.
-            ch.eq "f"
+            ch.eq "d"
             tokenize
               position.plus 1
               chained *1
                 accumulated
-                "([+-]?\\d+(?:\\.\\d+)?)"
-              found.with "f"
+                "([+-]?\\d+)"
+              found.with "d"
               false
             if.
-              ch.eq "s"
+              ch.eq "f"
               tokenize
                 position.plus 1
                 chained *1
                   accumulated
-                  "(\\S+)"
-                found.with "s"
+                  "([+-]?\\d+(?:\\.\\d+)?)"
+                found.with "f"
                 false
-              unsupported-message
-      if.
-        ch.eq "%"
-        tokenize
-          position.plus 1
-          accumulated
-          found
-          true
-        tokenize
-          position.plus 1
-          chained *1
+              if.
+                ch.eq "s"
+                tokenize
+                  position.plus 1
+                  chained *1
+                    accumulated
+                    "(\\S+)"
+                  found.with "s"
+                  false
+                T "Unsupported format specifier"
+        if.
+          ch.eq "%"
+          tokenize
+            position.plus 1
             accumulated
-            piece
-          found
-          false
-    dangling-message > dangling
-    T > dangling-message
-      "The format string ends with a dangling percent and no specifier after it"
-    pending.if *1 > ended
-      dangling
-      accumulated
-      found
-    escaped ch > piece
-    T > unsupported-message
-      "Unsupported format specifier"
+            found
+            true
+          tokenize
+            position.plus 1
+            chained *1
+              accumulated
+              escaped ch
+            found
+            false
+    slice > ch
+      format
+      position
+      1
   | >> tokens
     0
     ""

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [text] > up-cased
   string > @

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -1,4 +1,4 @@
-# The last `index` elements of `list` (an `index` larger than `list.length`
+# Last `index` elements of `list` (an `index` larger than `list.length`
 # returns the whole `list`).
 
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/u64/div.eo
+++ b/eo-runtime/src/main/eo/u64/div.eo
@@ -24,15 +24,18 @@
         n.gte d
         u64 00-00-00-00-00-00-00-01
         u64 00-00-00-00-00-00-00-00
-      final
+      if.
+        gte.
+          n.minus
+            times.
+              u64 q0
+              d
+          d
+        plus.
+          u64 q0
+          u64 00-00-00-00-00-00-00-01
+        u64 q0
   x.as-u64 > d
-  if. > final
-    remainder.gte d
-    q0plus1
-    u64 q0
-  times. > product
-    u64 q0
-    d
   left. > q0
     as-bytes.
       div.
@@ -40,10 +43,6 @@
           n.as-bytes.right 1
         i64 d.as-bytes
     1
-  plus. > q0plus1
-    u64 q0
-    u64 00-00-00-00-00-00-00-01
-  n.minus product > remainder
 
   eq. ++> tests-u64-div-by-large-divisor
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 80-00-00-00-00-00-00-00.as-u64

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -27,7 +27,10 @@
 
 [text] > uri
   text > @
-  has-authority.if > authority
+  if. > authority
+    string.starts-with >> has-authority
+      hier-part
+      "//"
     if.
       not. >> has-authority-path
         eq.
@@ -47,7 +50,9 @@
         authority-path-idx
       after-slashes
     ""
-  has-fragment.if > fragment
+  if. > fragment
+    not. >> has-fragment
+      hash-idx.eq -1
     slice.
       text.slice >> rest
         plus.
@@ -63,44 +68,15 @@
         number
           hash-idx.plus 1
     ""
-  string.starts-with > has-authority
-    hier-part
-    "//"
-  not. > has-fragment
-    hash-idx.eq -1
-  not. > has-port
-    eq.
-      if. >> port-colon-idx
-        string.starts-with host-port "[" >>
-        if.
-          eq.
-            string.index-of >> rel-colon
-              host-port.slice
-                bracket-start
-                host-port.length.minus
-                  number bracket-start
-              ":"
-            -1
-          -1
-          rel-colon.plus
-            plus. >> bracket-start
-              string.index-of host-port "]" >>
-              1
-        string.index-of host-port ":"
-      -1
-  not. > has-query
-    eq.
-      string.index-of before-fragment "?" >> question-idx
-      -1
-  not. > has-userinfo
-    eq.
-      string.index-of authority "@" >> userinfo-at-idx
-      -1
-  has-port.if > host
+  if. > host
+    not. >> has-port
+      port-colon-idx.eq -1
     slice.
       has-userinfo.if >> host-port
         authority.slice
-          userinfo-at-idx.plus 1
+          plus.
+            string.index-of authority "@" >> userinfo-at-idx
+            1
           authority.length.minus
             number
               userinfo-at-idx.plus 1
@@ -118,17 +94,39 @@
     hier-part
   has-port.if > port
     host-port.slice
-      port-colon-idx.plus 1
+      plus.
+        if. >> port-colon-idx
+          string.starts-with host-port "[" >>
+          if.
+            eq.
+              string.index-of >> rel-colon
+                host-port.slice
+                  bracket-start
+                  host-port.length.minus
+                    number bracket-start
+                ":"
+              -1
+            -1
+            rel-colon.plus
+              plus. >> bracket-start
+                string.index-of host-port "]" >>
+                1
+          string.index-of host-port ":"
+        1
       host-port.length.minus
         number
           port-colon-idx.plus 1
     ""
-  has-query.if > query
+  if. > query
+    not. >> has-query
+      question-idx.eq -1
     slice.
       has-fragment.if >> before-fragment
         rest.slice 0 hash-idx
         rest
-      question-idx.plus 1
+      plus.
+        string.index-of before-fragment "?" >> question-idx
+        1
       before-fragment.length.minus
         number
           question-idx.plus 1
@@ -136,7 +134,9 @@
   text.slice > scheme
     0
     scheme-colon
-  has-userinfo.if > userinfo
+  if. > userinfo
+    not. >> has-userinfo
+      userinfo-at-idx.eq -1
     authority.slice
       0
       userinfo-at-idx

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -1,8 +1,6 @@
-# A `uri` object parses an RFC 3986 generic URI `text` and exposes its
-# components as read-only attributes: `scheme`, `authority` (together with
-# `userinfo`, `host` and `port` parsed out of it), `path`, `query` and
-# `fragment`. The object is immutable: it only reads parts of `text` and
-# has no mutators.
+# Parses an RFC 3986 generic URI `text` and exposes its components as
+# read-only attributes: `scheme`, `authority` (together with `userinfo`,
+# `host` and `port` parsed out of it), `path`, `query` and `fragment`.
 #
 # Usage, without an authority:
 # ```
@@ -16,6 +14,8 @@
 # x.host > h    # localhost
 # x.port > p    # 899
 # ```
+#
+# The object is immutable: it only reads parts of `text` and has no mutators.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -23,6 +23,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint mandatory-package
 
 [text] > uri
   text > @


### PR DESCRIPTION
This clears 86 of the 338 `[LINT]` warnings that `mvn test` prints in
`eo-runtime`. The first commit is metas and comments: the root-level objects
that were missing `+unlint mandatory-package` now carry it like their 38
siblings, four stale `+unlint redundant-object` metas are gone, `+alias` lines
are sorted by alias name, and the comments on `chunk`, `uri`, `tuple.back` and
`recovered` lost their leading article, gained a final dot, and dropped the `⊥`
glyph. The second commit inlines every object that was named once and used
once, renames the compound names that survive that (`bottom-negated` is
`subtrahend`, `without-key` is `others`, `signed-prefix` is `signed`),
privatises the `uri` predicates `has-authority`, `has-fragment`, `has-port`,
`has-query` and `has-userinfo` into `>>` handles, and adds three unit tests for
`chunk`. 1799 tests pass.

Two things did not get fixed and I think they should not be. `squared` in
`number.arc-sine` stays named: its single reference sits inside the recursive
`poly`, so inlining hands each of the thirty recursion levels its own copy of
the subexpression — `EOarc_sineTest` goes from about 9 seconds to 189 and the
parallel suite runs out of heap. That one is filed as objectionary/lints#1132.

The other 251 warnings are false positives in `lints` and I filed them there:
objectionary/lints#1129 (237 of them — `non-kebab-name`, `sparse-decoration`,
`wrong-test-order` and `unit-test-missing` only recognise `+`-prefixed test
names, while the parser prefixes a `-->` throwing test with `-`),
objectionary/lints#1130 (`sparse-decoration` on `[@] > input`, where the lone φ
is void and so not a decoration at all) and objectionary/lints#1131
(`phi-is-not-first` on a `| > @` pipe, which is bound to the preceding sibling
and can never be moved first). Once those land, `eo-runtime` should be clean.

Closes #5502
