### PR TITLE
#6071: reject placeholder-recovered sources in eo:format

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -194,6 +194,13 @@ public final class MjFormat extends MjSafe {
      * never parsed at all, and this goal would otherwise print back (or, in
      * {@code -Deo.autoFix} mode, save) a truncated version of it.</p>
      *
+     * <p>Line coverage is necessary but not sufficient: the parser recovers
+     * from some <em>structural</em> errors not by dropping the remaining
+     * lines but by substituting an empty placeholder {@code <o>} for the
+     * piece it could not build and then carrying on. Coverage stays intact,
+     * yet the tree no longer describes the source, so this also rejects a
+     * tree carrying such a {@link #placeholder(XML) placeholder}.</p>
+     *
      * @param source The path of the {@code .eo} file, for the error message
      * @param structure The current text of the {@code .eo} file
      * @return The parsed XMIR
@@ -207,7 +214,8 @@ public final class MjFormat extends MjSafe {
             .elements(Filter.withName("error"))
             .filter(MjFormat::severe)
             .count();
-        if (errors > 0L && MjFormat.truncated(xmir, structure)) {
+        if (errors > 0L
+            && (MjFormat.truncated(xmir, structure) || MjFormat.placeholder(xmir))) {
             throw new IllegalStateException(
                 String.format(
                     "%s does not fully parse (%d error(s) found) and part of it was lost, won't format it",
@@ -238,6 +246,40 @@ public final class MjFormat extends MjSafe {
             .mapToInt(node -> Integer.parseInt(node.attribute("line").text().orElse("0")))
             .max()
             .orElse(0) < last;
+    }
+
+    /**
+     * Whether the parsed tree carries a recovered placeholder node.
+     *
+     * <p>Recovering from a structural error, the parser can substitute an
+     * empty {@code <o>} — one with no {@code base}, no {@code name}, no
+     * child elements and no text — for a node it could not build. A
+     * reversed dispatch left without a receiver, for instance, becomes such
+     * a node, which the printer can only render as {@code []}. Formatting a
+     * tree that carries one would silently rewrite the source into a
+     * different one the parser happens to accept.</p>
+     *
+     * @param xmir The parsed XMIR
+     * @return TRUE if a recovered placeholder stands in for lost source
+     */
+    private static boolean placeholder(final XML xmir) {
+        return new Xnav(xmir.inner())
+            .path("//o")
+            .anyMatch(MjFormat::empty);
+    }
+
+    /**
+     * Whether an {@code <o>} is an empty recovery placeholder, i.e. it
+     * carries neither a {@code base} nor a {@code name} attribute, has no
+     * child elements and holds no text.
+     * @param obj The {@code <o>} element
+     * @return TRUE if the element is such a placeholder
+     */
+    private static boolean empty(final Xnav obj) {
+        return !obj.attribute("base").text().isPresent()
+            && !obj.attribute("name").text().isPresent()
+            && obj.elements(Filter.all()).count() == 0L
+            && obj.text().orElse("").isBlank();
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.57.0
  */
 @ExtendWith(MktmpResolver.class)
+@SuppressWarnings("PMD.TooManyMethods")
 final class MjFormatTest {
 
     @Test
@@ -101,6 +102,36 @@ final class MjFormatTest {
     }
 
     @Test
+    void failsWhenErrorRecoveredWithPlaceholder(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(MjFormatTest.placeholder())
+                .execute(MjFormat.class),
+            "a source recovered with a placeholder node must not be silently formatted"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must explain that the source does not fully parse",
+            writer.toString(),
+            Matchers.containsString("does not fully parse")
+        );
+    }
+
+    @Test
+    void doesNotOverwritePlaceholderRecoveryWhenAutoFixIsOn(@Mktmp final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .with("autoFix", true)
+                .withProgram(MjFormatTest.placeholder())
+                .execute(MjFormat.class),
+            "a source the parser only recovered with a placeholder must not be rewritten"
+        );
+    }
+
+    @Test
     void appliesCustomIndentationStep(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the printer must indent with the configured number of spaces",
@@ -163,6 +194,33 @@ final class MjFormatTest {
             "",
             "[x] > main",
             "  (stdout \"Hello!\" x.print > @",
+            ""
+        );
+    }
+
+    /**
+     * A source the parser only recovers by substituting a placeholder.
+     *
+     * <p>A reversed dispatch left without a receiver ({@code if. > @} with
+     * nothing before the {@code if.}) is reported as an error, but the
+     * parser recovers by standing an empty formation in for the missing
+     * receiver and then covers every remaining line — so the loss is
+     * invisible to a line-coverage check yet the tree no longer describes
+     * the source (see #6071).</p>
+     *
+     * @return The EO text
+     */
+    private static String placeholder() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[] > foo",
+            "  if. > @",
+            "    if.",
+            "    true",
+            "    1",
+            "    2",
             ""
         );
     }


### PR DESCRIPTION
Fixes #6071.

## Problem

`MjFormat.parsed` rejected a source only when a severe `<errors>` entry
coincided with `MjFormat.truncated` reporting that the recovered tree stopped
short of the last non-blank line. That line-coverage proxy is too weak: the
parser recovers from some *structural* errors by substituting an empty
placeholder node and then carries on consuming every remaining line, so
coverage stays intact while the tree no longer describes the source.

A reversed dispatch left without a receiver is one such case:

```eo
[] > foo
  if. > @
    if.
    true
    1
    2
```

The parser reports `reversed dispatch missing receiver` and emits an empty
`<o/>` standing in for the missing receiver. Every line is still covered, so
`truncated` returns `FALSE`, the guard never fires, and under `-Deo.autoFix`
the canonical text (now carrying a literal `[]`) is written over the file. The
error never reaches the user and a source the parser rejected becomes a
different source it accepts.

## Fix

Widen the guard so a recovered placeholder also counts as loss: alongside
`truncated`, reject when the parsed tree contains an `<o>` with neither
`@base` nor `@name`, no child elements and no text — which the printer can
only render as `[]`. The text/child-element checks keep data leaves (e.g.
`<o ...>3F-F0-...</o>`) and named/anonymous non-empty formations from being
mistaken for placeholders.

## Tests

- `failsWhenErrorRecoveredWithPlaceholder` — check mode fails with
  `does not fully parse` on the reversed-dispatch source.
- `doesNotOverwritePlaceholderRecoveryWhenAutoFixIsOn` — `-Deo.autoFix` no
  longer silently rewrites such a source.

All `MjFormatTest` cases pass and `qulice` is clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_019YNtyKFcjn2dxwS8pzjdTP)_