### PR TITLE
#6061: preserve empty byte sequences in signed shifts

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -90,7 +90,7 @@ final class BytesRaw implements Bytes {
             );
         }
         final byte[] bytes = this.shift(bits).take();
-        if (this.take()[0] < 0) {
+        if (bytes.length > 0 && this.take()[0] < 0) {
             for (int index = 0; index < bytes.length; index += 1) {
                 final int zeros = BytesRaw.numberOfLeadingZeros(
                     bytes[index]

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -156,6 +156,15 @@ final class BytesOfTest {
     }
 
     @Test
+    void shiftsEmptyBytes() {
+        MatcherAssert.assertThat(
+            "arithmetic shift of empty bytes should preserve them",
+            new BytesOf(new byte[0]).sshift(1).take(),
+            Matchers.equalTo(new byte[0])
+        );
+    }
+
+    @Test
     void shiftsIntegerMinValueWithoutOverflow() {
         MatcherAssert.assertThat(
             "shift(Integer.MIN_VALUE) should produce an all-zero result, but it didn't",


### PR DESCRIPTION
Fixes #6061.

## Problem

`BytesRaw.sshift()` first performs the right shift and then inspects the first byte of the original value to determine whether sign extension is required. For an empty byte sequence, that inspection was an unconditional `this.take()[0]` access, causing `ArrayIndexOutOfBoundsException`.

An empty `Bytes` value is valid, has no sign bit to extend, and the neighbouring unsigned `shift()` already preserves it. The raw JDK exception was therefore both inconsistent and unrelated to the public operation.

## Change

The sign-extension branch now runs only when the shifted sequence contains at least one byte. Non-empty values keep the existing path, including sign extension for a negative leading byte.

## Regression coverage

Added a test asserting that `new BytesOf(new byte[0]).sshift(1)` returns an empty array. It protects the empty-input case while the existing parameterized tests continue to cover positive and negative non-empty shifts.

## Verification

Ran `mvn -q -pl eo-runtime test -Deo.autoFix`.