### PR TITLE
#6062: measure regex match positions in Unicode characters

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -95,6 +95,21 @@
             regex "/a*/"
             "xa"
 
+  ++> can-count-supplementary-characters-as-one-position
+    and. > @
+      and.
+        0.eq first.from
+        1.eq first.to
+      and.
+        1.eq second.from
+        2.eq second.to
+    next. > first
+      match.
+        compiled.
+          regex "/./"
+        "😀x"
+    first.next > second
+
   ++> can-expose-groups-on-each-matched-block
     and. > @
       and.
@@ -132,6 +147,11 @@
     compiled.
       regex "/[a-z]+/"
     "hello"
+
+  matches. ++> can-match-a-text-containing-supplementary-characters
+    compiled.
+      regex "/😀x/"
+    "😀x"
 
   matches. ++> can-match-an-entire-pattern
     compiled.

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -84,17 +84,18 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
         final int start = new Expect.Natural(
             Expect.at(this, EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
         ).it();
-        if (start > text.length()) {
+        final int length = text.codePointCount(0, text.length());
+        if (start > length) {
             throw new ExFailure(
                 "the 'start' attribute (%d) must be less than or equal to text length (%d)",
                 start,
-                text.length()
+                length
             );
         }
-        final boolean found = matcher.find(start);
+        final boolean found = matcher.find(text.offsetByCodePoints(0, start));
         final Phi result = match.take("matched");
         if (found) {
-            this.fill(result, matcher);
+            this.fill(result, matcher, text);
         } else {
             this.blank(result);
         }
@@ -105,8 +106,9 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
      * Fill the matched block with the data of a real match.
      * @param result The matched block to fill
      * @param matcher The matcher positioned on the found subsequence
+     * @param text Matched text
      */
-    private void fill(final Phi result, final Matcher matcher) {
+    private void fill(final Phi result, final Matcher matcher, final String text) {
         result.put(
             EOregex$EOpattern$EOmatch$EOmatched_from_index.POSITION,
             this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.POSITION)
@@ -115,8 +117,8 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
             EOregex$EOpattern$EOmatch$EOmatched_from_index.START,
             this.take(EOregex$EOpattern$EOmatch$EOmatched_from_index.START)
         );
-        result.put("from", new Data.ToPhi(matcher.start()));
-        result.put("to", new Data.ToPhi(matcher.end()));
+        result.put("from", new Data.ToPhi(text.codePointCount(0, matcher.start())));
+        result.put("to", new Data.ToPhi(text.codePointCount(0, matcher.end())));
         final Phi[] groups;
         if (matcher.groupCount() > 0) {
             groups = new Phi[matcher.groupCount() + 1];


### PR DESCRIPTION
Fixes #6062.

## Problem

EO string positions are Unicode-character positions, but Java `Matcher` reports and accepts UTF-16 code-unit offsets. The previous atom passed EO positions directly into `Matcher.find(int)` and exposed `Matcher.start()` and `Matcher.end()` unchanged.

The units agree for ASCII and BMP characters, but not for a supplementary character such as `😀`: it occupies one EO position and two UTF-16 code units. As a result, a complete regex match could fail its final length check and `next` could begin at the wrong place.

## Change

Before searching, the atom converts the public EO start position with `String.offsetByCodePoints`. After a match, it converts Java boundaries back with `String.codePointCount` before filling `from` and `to`. The bounds check now uses the same EO character unit.

## Regression coverage

EO tests assert that `/😀x/` fully matches `"😀x"`, and that successive `/./` matches report `0..1` for `😀` and `1..2` for `x`. This covers both public bounds and the start position passed by `next`.

## Verification

Ran `mvn -q -pl eo-runtime test -Deo.autoFix`.