### PR TITLE
#6068: Fix dirname for relative filenames

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -44,17 +44,18 @@
     [] > dirname
       string > @
         if.
-          or.
-            pth.size.eq 0
-            len.eq -1
+          pth.size.eq 0
           uri >> pth!
           if.
-            len.eq 0
-            separator
-            as-bytes.
-              text.slice
-                0
-                string.last-index-of text separator >> len!
+            len.eq -1
+            "."
+            if.
+              len.eq 0
+              separator
+              as-bytes.
+                text.slice
+                  0
+                  string.last-index-of text separator >> len!
       string pth > text
     sys.drive uri > drive
     if. > driveless
@@ -405,6 +406,16 @@
     basename.
       path.posix "/var/www/html/foo\\bar"
     "foo\\bar"
+
+  eq. ++> tests-returns-current-dirname-of-posix-relative-file
+    dirname.
+      path.posix "plain"
+    "."
+
+  eq. ++> tests-returns-current-dirname-of-posix-relative-hidden-file
+    dirname.
+      path.posix ".gitignore"
+    "."
 
   eq. ++> tests-returns-empty-basename-from-path-ended-with-separator
     basename.


### PR DESCRIPTION
## Summary

- return `.` from `path.dirname` for separator-free relative filenames
- handle both ordinary and hidden filenames
- preserve empty-path and root-directory behavior
- add regression tests for `plain` and `.gitignore`

## Root cause

The no-separator case was handled together with the empty-path case. Consequently, a filename could be returned as its own parent directory.

## Testing

- EO canonical formatter
- `mvn install -DskipTests --batch-mode`
- `mvn test -pl :eo-runtime -DskipITs --batch-mode`
- `git diff --check`

Closes #6068

AI assistance was used to investigate the issue and prepare the initial patch. I reviewed the implementation and validated it using the repository checks.