### PR TITLE
Rename eo-runtime test objects for the new bad-test-name lint

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -243,25 +245,25 @@ final class MjParseTest {
     void parsesConcurrentlyWithLotsOfPrograms(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp);
         final int total = 50;
+        final Collection<String> xmirs = new ArrayList<>(total);
         for (int program = 0; program < total; ++program) {
             maven.withProgram(
                 String.format("+package foo.x%n%n[] > main%s", FakeMaven.suffix(program))
             );
-        }
-        for (int program = 0; program < total; ++program) {
-            MatcherAssert.assertThat(
-                "We have to parse concurrently, but we didn't",
-                maven.execute(new FakeMaven.Parse()).result(),
-                Matchers.hasKey(
-                    String.format(
-                        "target/%s/foo/x/main%s.%s",
-                        Parsing.DIR,
-                        FakeMaven.suffix(program),
-                        MjAssemble.XMIR
-                    )
+            xmirs.add(
+                String.format(
+                    "target/%s/foo/x/main%s.%s",
+                    Parsing.DIR,
+                    FakeMaven.suffix(program),
+                    MjAssemble.XMIR
                 )
             );
         }
+        MatcherAssert.assertThat(
+            "All programs must be parsed in a single concurrent run, but some XMIRs are absent",
+            maven.execute(new FakeMaven.Parse()).result().keySet(),
+            Matchers.hasItems(xmirs.toArray(new String[0]))
+        );
     }
 
     @Test

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
@@ -8,11 +8,16 @@
   Here we go through all objects and add @loc attributes
   to all of them. The value of the attribute is a unique locator
   of the object.
+  The locator function takes the object only and reaches the
+  program through it, instead of taking the program as a second
+  argument. Saxon 13.0 binds the arguments of a multi-argument
+  function to the wrong values, once in a while, when one compiled
+  stylesheet transforms many documents in parallel threads (which is
+  what the "parse" goal does).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:import href="/org/eolang/parser/_specials.xsl"/>
   <xsl:function name="eo:locator" as="xs:string">
-    <xsl:param name="program" as="node()"/>
     <xsl:param name="o" as="node()"/>
     <xsl:if test="name($o) != 'o'">
       <xsl:message terminate="yes">
@@ -22,13 +27,13 @@
     <xsl:variable name="ret">
       <xsl:choose>
         <xsl:when test="$o/parent::o">
-          <xsl:value-of select="eo:locator($program, $o/parent::o)"/>
+          <xsl:value-of select="eo:locator($o/parent::o)"/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="$eo:program"/>
-          <xsl:if test="$program/metas/meta[head='package']">
+          <xsl:if test="root($o)/object/metas/meta[head='package']">
             <xsl:text>.</xsl:text>
-            <xsl:value-of select="$program/metas/meta[head='package']/tail"/>
+            <xsl:value-of select="root($o)/object/metas/meta[head='package']/tail"/>
           </xsl:if>
         </xsl:otherwise>
       </xsl:choose>
@@ -61,7 +66,7 @@
   </xsl:function>
   <xsl:template match="o">
     <xsl:copy>
-      <xsl:attribute name="loc" select="eo:locator(/object, .)"/>
+      <xsl:attribute name="loc" select="eo:locator(.)"/>
       <xsl:apply-templates select="node()|@* except @loc"/>
     </xsl:copy>
   </xsl:template>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -223,7 +223,8 @@
         <configuration>
           <foreign>${project.build.directory}/eo-foreign.csv</foreign>
           <foreignFormat>csv</foreignFormat>
-          <failOnWarning>false</failOnWarning>
+          <!-- Every lint warning is an error here; nothing may be tolerated. -->
+          <failOnWarning>true</failOnWarning>
           <offline>true</offline>
           <ignoreRuntime>true</ignoreRuntime>
           <!--
@@ -250,6 +251,11 @@
               <goal>unspile</goal>
             </goals>
             <configuration>
+              <!--
+              Objects with an optional fallback argument, like 'string.as-fixed'
+              or 'win32', are applied with and without it on purpose, and the
+              lint reads every such pair as an inconsistency.
+              -->
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
               </skipProgramLints>

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -28,8 +28,20 @@
     true
     01-.eq x
 
-  ++> tests-app-that-calls-func
-    output.eq 2 > @
+  eq. ++> can-answer-the-left-method-of-a-chosen-branch
+    left.
+      false.if 00-00-00-00-00-00-00-09 00-00-00-00-00-00-00-05
+      1
+    00-00-00-00-00-00-00-0A
+
+  eq. ++> can-answer-the-right-method-of-a-chosen-branch
+    right.
+      true.if 00-00-00-00-00-00-00-05 00-00-00-00-00-00-00-09
+      1
+    00-00-00-00-00-00-00-02
+
+  ++> can-call-a-function-from-an-app
+    app.eq 2 > @
     [] > app
       f * > @
         1
@@ -38,26 +50,25 @@
       [args] > f
         2 > @
         1 > a
-    app > output
 
-  and. ++> tests-compares-bool-to-bytes
-    true.eq 01-
-    false.eq 00-
-
-  and. ++> tests-compares-bool-to-bytes-reverse
-    01-.as-bytes.eq true
-    00-.as-bytes.eq false
-
-  and. ++> tests-compares-bool-to-string
+  and. ++> can-compare-a-bool-to-a-string
     true.eq "\u0001"
     false.eq "\u0000"
 
-  true.eq true ++> tests-compares-two-bools
+  and. ++> can-compare-a-bool-to-bytes
+    true.eq 01-
+    false.eq 00-
 
-  not. ++> tests-compares-two-different-bool-types
+  and. ++> can-compare-bytes-to-a-bool
+    01-.as-bytes.eq true
+    00-.as-bytes.eq false
+
+  true.eq true ++> can-compare-two-bools
+
+  not. ++> can-compare-two-different-bool-types
     true.eq 42
 
-  ++> tests-compiles-correctly-with-long-duplicate-names
+  ++> can-compile-deeply-duplicated-names
     true > @
     [] > long-object-name
       [] > long-object-name
@@ -66,39 +77,34 @@
             [] > long-object-name
               42 > x
 
-  ++> tests-extract-attribute-from-decoratee
+  not. ++> can-conjoin-true-with-false
+    true.and false
+
+  true.as-bool ++> can-convert-true-to-a-bool
+
+  ++> can-extract-an-attribute-from-a-decoratee
     a.foo.eq 43 > @
     return > [] > a
       42.plus 1
     [foo] > return
 
-  eq. ++> tests-forks-on-false-condition
+  eq. ++> can-fork-on-a-false-condition
     if.
       5.eq 8
       123
       42
     42
 
-  eq. ++> tests-forks-on-true-condition
+  eq. ++> can-fork-on-a-true-condition
     if.
       5.eq 5
       123
       42
     123
 
-  eq. ++> tests-if-result-answers-left-method-of-chosen-branch
-    left.
-      false.if 00-00-00-00-00-00-00-09 00-00-00-00-00-00-00-05
-      1
-    00-00-00-00-00-00-00-0A
+  true.not.eq false ++> can-negate-true
 
-  eq. ++> tests-if-result-answers-right-method-of-chosen-branch
-    right.
-      true.if 00-00-00-00-00-00-00-05 00-00-00-00-00-00-00-09
-      1
-    00-00-00-00-00-00-00-02
-
-  ++> tests-nesting-blah-test
+  ++> can-nest-formations-that-call-each-other
     eq. > @
       blah0 0
       39
@@ -189,7 +195,7 @@
                                                                                   blah39 (x.plus 1) > @
                                                                                   x > [x] > blah39
 
-  ++> tests-takes-parent-object
+  ++> can-take-a-parent-object
     eq. > @
       a 42
       42
@@ -197,20 +203,13 @@
       take > @
       x > [] > take
 
-  ++> tests-takes-parent-through-attribute
+  ++> can-take-a-parent-through-an-attribute
     [] > @
       [] > @
         x.eq 42 > [] > @
     42 > x
 
-  not. ++> tests-true-and-false-is-false
-    true.and false
-
-  true.as-bool ++> tests-true-as-bool
-
-  true.not.eq false ++> tests-true-not-is-false
-
-  --> when-applies-to-closed-object
+  --> stops-on-applying-to-a-closed-object
     closed true > @
     x > [x] > a
     a false > closed

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -13,7 +13,7 @@
     string
       buf.as-bytes.concat str.as-bytes
 
-  eq. ++> tests-buffer-builds-simple-string
+  eq. ++> can-build-a-simple-string
     with.
       with.
         buffer "Hello"
@@ -21,11 +21,11 @@
       "Jeff"
     "Hello, Jeff"
 
-  eq. ++> tests-buffer-decorates-string
+  eq. ++> can-decorate-a-string
     buffer "Hello"
     "Hello"
 
-  eq. ++> tests-buffer-decorates-string-after-building
+  eq. ++> can-decorate-a-string-after-building
     length.
       with.
         buffer

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -32,192 +32,192 @@
   [start len] > slice /Q.bytes
     ? > cant-slice /{Q.string}
 
-  eq. ++> tests-and-neg-bytes-as-number-with-leading-zeroes
+  eq. ++> can-and-negative-bytes-with-leading-zeroes
     as-number.
       00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00
     0
 
-  eq. ++> tests-and-neg-bytes-as-number-without-leading-zeroes
+  eq. ++> can-and-negative-bytes-without-leading-zeroes
     as-number.
       00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00
     0
 
-  eq. ++> tests-and-with-one-neg-one-plus
+  eq. ++> can-and-one-negative-with-one-positive
     -7.as-bytes.and 7.as-bytes
     40-1C-00-00-00-00-00-00
 
-  eq. ++> tests-and-with-two-neg
+  eq. ++> can-and-two-negatives
     -6.as-bytes.and -4.as-bytes
     C0-10-00-00-00-00-00-00
 
-  eq. ++> tests-and-with-two-plus
+  eq. ++> can-and-two-positives
     5.as-bytes.and 10.as-bytes
     40-04-00-00-00-00-00-00
 
-  eq. ++> tests-and-with-zero
-    0.as-bytes.and 32.as-bytes
-    00-00-00-00-00-00-00-00
-
-  eq. ++> tests-bitwise-works
+  eq. ++> can-and-two-single-byte-numbers
     as-number.
       1.as-bytes.and 1.as-bytes
     1
 
-  eq. ++> tests-bitwise-works-negative
-    FF-FF-FF-FF-FF-FF-FF-81.as-bytes.or 00-00-00-00-00-00-00-7F.as-bytes
-    FF-FF-FF-FF-FF-FF-FF-FF
+  eq. ++> can-and-with-zero
+    0.as-bytes.and 32.as-bytes
+    00-00-00-00-00-00-00-00
 
-  eq. ++> tests-concat-bools-as-bytes
+  CA-FE-BE-BE.size.eq 4 ++> can-be-written-in-several-lines
+
+  eq. ++> can-concat-bools-as-bytes
     true.as-bytes.concat false.as-bytes
     01-00
 
-  eq. ++> tests-concat-empty
-    --.concat --
-    --
+  eq. ++> can-concat-bytes-with-empty-ones
+    05-5E-78.concat --
+    05-5E-78
 
-  eq. ++> tests-concat-empty-with
+  eq. ++> can-concat-empty-bytes-with-others
     --.concat 05-5E-78
     05-5E-78
 
-  eq. ++> tests-concat-strings
+  eq. ++> can-concat-strings-as-bytes
     string
       "hello ".as-bytes.concat
         "world".as-bytes
     "hello world"
 
-  eq. ++> tests-concat-with-empty
-    05-5E-78.concat --
-    05-5E-78
+  eq. ++> can-concat-two-empty-bytes
+    --.concat --
+    --
 
-  ++> tests-concatenation-of-bytes
+  ++> can-concat-two-long-bytes
     eq. > @
       a.concat b
       02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  ++> tests-conjunction-of-bytes
+  ++> can-conjoin-two-long-bytes
     eq. > @
       a.and b
       02-23-C0-05-5E-70-10
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  F1-20-5F-EC-B5-90-32.size.eq 7 ++> tests-counts-size-of-bytes
+  eq. ++> can-count-the-size-of-a-slice
+    size.
+      20-1F-EE-B5-90-EE-BB.slice 2 3
+    3
 
-  not. ++> tests-not-with-neg
+  F1-20-5F-EC-B5-90-32.size.eq 7 ++> can-count-the-size-of-bytes
+
+  not. ++> can-invert-negative-bytes
     -1.as-bytes.eq -1.as-bytes.not
 
-  not. ++> tests-not-with-plus
+  not. ++> can-invert-positive-bytes
     53.as-bytes.eq 53.as-bytes.not
 
-  not. ++> tests-not-with-zero
+  not. ++> can-invert-zero-bytes
     0.as-bytes.eq 0.as-bytes.not
 
-  eq. ++> tests-or-neg-bytes-as-number-with-zero
+  eq. ++> can-or-negative-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
+
+  eq. ++> can-or-negative-bytes-with-one
+    FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
+    FF-FF-FF-FF-00-00-00-01
+
+  eq. ++> can-or-negative-bytes-with-positive-ones
+    FF-FF-FF-FF-FF-FF-FF-81.as-bytes.or 00-00-00-00-00-00-00-7F.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  eq. ++> can-or-negative-bytes-with-zero
     as-number.
       -4294967296.as-bytes.or 0.as-bytes
     -4294967296
 
-  eq. ++> tests-or-neg-bytes-with-leading-zeroes
-    00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-8E-EA-4C-B1
-
-  eq. ++> tests-or-neg-bytes-with-one
-    FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
-    FF-FF-FF-FF-00-00-00-01
-
-  eq. ++> tests-or-neg-bytes-without-leading-zeroes
+  eq. ++> can-or-negative-bytes-without-leading-zeroes
     00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
     FF-FF-FF-FF-FF-FF-FF-FF
 
-  eq. ++> tests-or-with-one-neg-one-plus
+  eq. ++> can-or-one-negative-with-one-positive
     -7.as-bytes.or 23.as-bytes
     C0-3F-00-00-00-00-00-00
 
-  eq. ++> tests-or-with-two-neg
+  eq. ++> can-or-two-negatives
     -27.as-bytes.or -13.as-bytes
     C0-3B-00-00-00-00-00-00
 
-  eq. ++> tests-or-with-two-plus
+  eq. ++> can-or-two-positives
     5.as-bytes.or 14.as-bytes
     40-3C-00-00-00-00-00-00
 
-  eq. ++> tests-or-with-zero
+  eq. ++> can-or-with-zero
     -11.as-bytes.or 0.as-bytes
     C0-26-00-00-00-00-00-00
 
-  eq. ++> tests-out-of-bounds-slice-returns-provided-fallback
+  eq. ++> can-shift-right-an-even-negative
+    -38.as-bytes.right 1
+    60-21-80-00-00-00-00-00
+
+  eq. ++> can-shift-right-an-even-positive
+    eq.
+      36.as-bytes.right 2
+      -10.as-bytes
+    false
+
+  eq. ++> can-shift-right-an-odd-negative
+    -37.as-bytes.right 3
+    18-08-50-00-00-00-00-00
+
+  eq. ++> can-shift-right-an-odd-positive
+    37.as-bytes.right 3
+    08-08-50-00-00-00-00-00
+
+  eq. ++> can-shift-right-by-zero
+    0.as-bytes.right 2
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-shift-right-minus-one
+    -1.as-bytes.right 4
+    0B-FF-00-00-00-00-00-00
+
+  eq. ++> can-shift-right-the-integer-minimum
+    -1.as-bytes.right -2147483648
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-take-a-part-of-bytes
+    20-1F-EE-B5-90.slice
+      1
+      3
+    1F-EE-B5
+
+  eq. ++> can-turn-bytes-into-a-string
+    "你好, друг!"
+    "你好, друг!"
+
+  eq. ++> rejects-a-slice-whose-start-plus-length-overflows
+    "recovered"
+    20-1F-EE-B5-90.slice
+      2000000000
+      2000000000
+      "recovered" > [message]
+
+  eq. ++> rejects-an-out-of-bounds-slice
     "recovered"
     20-1F-EE-B5-90.slice
       3
       10
       "recovered" > [message]
 
-  eq. ++> tests-right-with-even-neg
-    -38.as-bytes.right 1
-    60-21-80-00-00-00-00-00
+  slice. --> stops-on-a-slice-offset-exceeding-the-int-range
+    20-1F-EE-B5-90
+    3000000000
+    1
 
-  eq. ++> tests-right-with-even-plus
-    eq.
-      36.as-bytes.right 2
-      -10.as-bytes
-    false
-
-  eq. ++> tests-right-with-integer-min-value
-    -1.as-bytes.right -2147483648
-    00-00-00-00-00-00-00-00
-
-  eq. ++> tests-right-with-minus-one
-    -1.as-bytes.right 4
-    0B-FF-00-00-00-00-00-00
-
-  eq. ++> tests-right-with-odd-neg
-    -37.as-bytes.right 3
-    18-08-50-00-00-00-00-00
-
-  eq. ++> tests-right-with-odd-plus
-    37.as-bytes.right 3
-    08-08-50-00-00-00-00-00
-
-  eq. ++> tests-right-with-zero
-    0.as-bytes.right 2
-    00-00-00-00-00-00-00-00
-
-  eq. ++> tests-size-of-part-is-correct
-    size.
-      20-1F-EE-B5-90-EE-BB.slice 2 3
-    3
-
-  eq. ++> tests-slice-with-overflowing-start-plus-len-returns-fallback
-    "recovered"
-    20-1F-EE-B5-90.slice
-      2000000000
-      2000000000
-      "recovered" > [message]
-
-  eq. ++> tests-takes-part-of-bytes
-    20-1F-EE-B5-90.slice
-      1
-      3
-    1F-EE-B5
-
-  eq. ++> tests-turns-bytes-into-a-string
-    "你好, друг!"
-    "你好, друг!"
-
-  CA-FE-BE-BE.size.eq 4 ++> tests-written-in-several-lines
-
-  20-1F.and CA-FE-BE --> on-and-with-different-lengths
-
-  20-1F.or CA-FE-BE --> on-or-with-different-lengths
-
-  slice. --> on-out-of-bounds-slice
+  slice. --> stops-on-an-out-of-bounds-slice
     20-1F-EE-B5-90
     3
     10
 
-  slice. --> on-slice-offset-exceeding-int-range
-    20-1F-EE-B5-90
-    3000000000
-    1
+  20-1F.and CA-FE-BE --> stops-on-and-with-different-lengths
+
+  20-1F.or CA-FE-BE --> stops-on-or-with-different-lengths

--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -24,7 +24,7 @@
     *
     0
 
-  eq. ++> tests-converts-bytes-to-array
+  eq. ++> can-convert-bytes-to-an-array
     array 20-1F-EE-B5-FF
     *
       20-
@@ -33,10 +33,10 @@
       B5-
       FF-
 
-  eq. ++> tests-single-byte-to-array
+  eq. ++> can-convert-a-single-byte-to-an-array
     array 1F-
     * 1F-
 
-  eq. ++> tests-zero-bytes-to-array
+  eq. ++> can-convert-zero-bytes-to-an-array
     array --
     *

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -10,5 +10,5 @@
 [b] > as-bool
   b.eq 01- > @
 
-  not. ++> tests-convertible-to-bool
+  not. ++> can-convert-bytes-to-a-bool
     01-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/bytes/as-bytes.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bytes.eo
@@ -12,4 +12,4 @@
 [b] > as-bytes
   b > @
 
-  20-1F-EE.as-bytes.eq 20-1F-EE ++> tests-bytes-as-bytes-is-itself
+  20-1F-EE.as-bytes.eq 20-1F-EE ++> can-return-itself

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -17,6 +17,6 @@
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * b
 
-  00-33.as-i16.as-bytes.eq 00-33 ++> tests-bytes-converts-to-i16-and-back
+  00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
 
-  01-01-01.as-i16 --> on-bytes-of-wrong-size-as-i16
+  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -17,8 +17,6 @@
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * b
 
-  eq. ++> tests-bytes-converts-to-i32-and-back
-    00-00-00-33.as-i32.as-bytes
-    00-00-00-33
+  00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
 
-  01-01-01-01-01.as-i32 --> on-bytes-of-wrong-size-as-i32
+  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -17,18 +17,18 @@
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * b
 
-  not. ++> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
-    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+  00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> can-convert-bytes-to-i64
 
-  00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> tests-bytes-converts-to-i64
-
-  eq. ++> tests-bytes-converts-to-i64-and-back
+  eq. ++> can-convert-bytes-to-i64-and-back
     00-00-00-00-00-00-00-33.as-i64.as-bytes
     00-00-00-00-00-00-00-33
 
-  eq. ++> tests-wrong-size-as-i64-returns-provided-fallback
+  not. ++> cannot-match-the-bytes-of-the-same-number
+    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+
+  eq. ++> rejects-bytes-of-wrong-size
     "recovered"
     01-01-01-01.as-i64
       "recovered" > [message]
 
-  01-01-01-01.as-i64 --> on-bytes-of-wrong-size-as-i64
+  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-i8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i8.eo
@@ -17,6 +17,6 @@
       "Can't convert non 1 length bytes to i8, bytes are %x".printf
         * b
 
-  2A-.as-i8.as-bytes.eq 2A- ++> tests-bytes-converts-to-i8-and-back
+  2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
 
-  01-01.as-i8 --> on-bytes-of-wrong-size-as-i8
+  01-01.as-i8 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -56,7 +56,7 @@
             as-bytes.
               data.slice 0 next
 
-  ++> tests-makes-an-input-from-bytes-and-reads
+  ++> can-make-an-input-from-bytes-and-read-it
     and. > @
       and.
         and.

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -27,12 +27,12 @@
       "Can't convert non 8 length bytes to a number, bytes are %x".printf
         * b
 
-  is-nan. ++> tests-non-canonical-nan-bytes-route-to-nan
+  is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
     FF-F8-00-00-00-00-00-00.as-number
 
-  eq. ++> tests-wrong-size-as-number-returns-provided-fallback
+  eq. ++> rejects-bytes-of-wrong-size
     "recovered"
     01-01-01-01.as-number
       "recovered" > [message]
 
-  01-01-01-01.as-number --> on-bytes-of-wrong-size-as-number
+  01-01-01-01.as-number --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-u16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u16.eo
@@ -17,6 +17,6 @@
       "Can't convert non 2 length bytes to u16, bytes are %x".printf
         * b
 
-  00-33.as-u16.as-bytes.eq 00-33 ++> tests-bytes-converts-to-u16-and-back
+  00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
 
-  01-01-01.as-u16 --> on-bytes-of-wrong-size-as-u16
+  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-u32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u32.eo
@@ -17,8 +17,6 @@
       "Can't convert non 4 length bytes to u32, bytes are %x".printf
         * b
 
-  eq. ++> tests-bytes-converts-to-u32-and-back
-    00-00-00-33.as-u32.as-bytes
-    00-00-00-33
+  00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
 
-  01-01-01-01-01.as-u32 --> on-bytes-of-wrong-size-as-u32
+  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -17,13 +17,13 @@
       "Can't convert non 8 length bytes to u64, bytes are %x".printf
         * b
 
-  eq. ++> tests-bytes-converts-to-u64-and-back
+  eq. ++> can-convert-bytes-to-u64-and-back
     00-00-00-00-00-00-00-33.as-u64.as-bytes
     00-00-00-00-00-00-00-33
 
-  eq. ++> tests-wrong-size-as-u64-returns-provided-fallback
+  eq. ++> rejects-bytes-of-wrong-size
     "recovered"
     01-01-01-01.as-u64
       "recovered" > [message]
 
-  01-01-01-01.as-u64 --> on-bytes-of-wrong-size-as-u64
+  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/as-u8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u8.eo
@@ -17,6 +17,6 @@
       "Can't convert non 1 length bytes to u8, bytes are %x".printf
         * b
 
-  2A-.as-u8.as-bytes.eq 2A- ++> tests-bytes-converts-to-u8-and-back
+  2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
 
-  01-01.as-u8 --> on-bytes-of-wrong-size-as-u8
+  01-01.as-u8 --> stops-on-bytes-of-wrong-size

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -29,7 +29,7 @@
     0
     0
 
-  and. ++> tests-hash-code-bools-is-number
+  and. ++> can-hash-a-bool-into-a-number
     eq.
       size.
         as-bytes.
@@ -41,55 +41,55 @@
           hash false
       8
 
-  ++> tests-hash-code-int-is-int
+  ++> can-hash-an-integer-into-an-integer
     1.eq > @
       div.
         number
           hash 42 >> inthash!
         number inthash
 
-  ++> tests-hash-codes-of-the-same-nums-are-equal
+  ++> can-hash-equal-numbers-alike
     eq. > @
       hash num
       hash num
     123456789012345680 > num
 
-  eq. ++> tests-hash-codes-of-the-same-ints-are-equal
+  eq. ++> can-hash-equal-integers-alike
     hash 42
     hash 42
 
-  not. ++> tests-hash-codes-of-different-ints-are-not-equal
+  not. ++> can-hash-different-integers-apart
     eq.
       hash 42
       hash 24
 
-  not. ++> tests-hash-codes-of-different-sign-ints-are-not-equal
+  not. ++> can-hash-integers-of-different-signs-apart
     eq.
       hash 42
       hash -42
 
-  ++> tests-hash-code-string-is-int
+  ++> can-hash-a-string-into-an-integer
     1.eq > @
       div.
         number
           hash "hello" >> strhash!
         number strhash
 
-  eq. ++> tests-hash-codes-of-the-same-strings-are-equal
+  eq. ++> can-hash-equal-strings-alike
     hash "Hello"
     hash "Hello"
 
-  not. ++> tests-hash-codes-of-same-length-strings-are-not-equal
+  not. ++> can-hash-strings-of-the-same-length-apart
     eq.
       hash "one"
       hash "two"
 
-  not. ++> tests-hash-codes-of-different-strings-are-not-equal
+  not. ++> can-hash-different-strings-apart
     eq.
       hash "hello"
       hash "bye!!!"
 
-  ++> tests-hash-code-abstract-object-is-int
+  ++> can-hash-an-abstract-object-into-an-integer
     1.eq > @
       div.
         number
@@ -98,14 +98,14 @@
         number objhash
     x > [x] > obj
 
-  ++> tests-hash-codes-of-the-same-abstract-objects-are-equal
+  ++> can-hash-equal-abstract-objects-alike
     eq. > @
       hash value
       hash value
     x > [x] > obj
     obj 42 > value
 
-  ++> tests-hash-codes-of-different-abstract-objects-are-not-equal
+  ++> can-hash-different-abstract-objects-apart
     not. > @
       eq.
         hash
@@ -114,31 +114,31 @@
           obj "42"
     x > [x] > obj
 
-  ++> tests-hash-code-float-is-int
+  ++> can-hash-a-float-into-an-integer
     1.eq > @
       div.
         number
           hash 42.42 >> flthash!
         number flthash
 
-  ++> tests-hash-codes-of-the-same-floats-are-equal
+  ++> can-hash-equal-floats-alike
     eq. > @
       hash emergency
       hash emergency
     0.911 > emergency
 
-  ++> tests-hash-codes-of-the-same-bigvals-are-equal
+  ++> can-hash-equal-big-values-alike
     eq. > @
       hash
         4.242e43 >> bigval!
       hash bigval
 
-  not. ++> tests-hash-codes-of-different-floats-are-not-equal
+  not. ++> can-hash-different-floats-apart
     eq.
       hash 3.14
       hash 2.72
 
-  not. ++> tests-hash-codes-of-different-sign-floats-are-not-equal
+  not. ++> can-hash-floats-of-different-signs-apart
     eq.
       hash 3.22
       hash -3.22

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -11,32 +11,32 @@
 [b x] > left
   b.right x.neg > @
 
-  eq. ++> tests-left-with-even-neg
+  eq. ++> can-shift-left-an-even-negative
     FF-FF-FF-FF-FF-FF-FF-EE.left 2
     00-00-00-00-00-00-00-47.not
 
-  eq. ++> tests-left-with-even-plus
+  eq. ++> can-shift-left-an-even-positive
     4.as-bytes.left 3
     00-80-00-00-00-00-00-00
 
-  eq. ++> tests-left-with-minus-one
+  eq. ++> can-shift-left-an-odd-negative
+    -17.as-bytes.left 1
+    80-62-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-an-odd-positive
+    5.as-bytes.left 3
+    00-A0-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-by-zero
+    2.as-bytes.left 0
+    40-00-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-minus-one
     eq.
       -1.as-bytes.left 3
       7.as-bytes
     false
 
-  eq. ++> tests-left-with-odd-neg
-    -17.as-bytes.left 1
-    80-62-00-00-00-00-00-00
-
-  eq. ++> tests-left-with-odd-plus
-    5.as-bytes.left 3
-    00-A0-00-00-00-00-00-00
-
-  eq. ++> tests-left-with-zero
-    2.as-bytes.left 0
-    40-00-00-00-00-00-00-00
-
-  eq. ++> tests-left-zero
+  eq. ++> can-shift-left-zero-bytes
     0.as-bytes.left 1
     00-00-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -13,37 +13,37 @@
     b.and x.not
     b.not.and x
 
-  eq. ++> tests-one-xor-one-as-number
+  eq. ++> can-xor-negative-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
+
+  eq. ++> can-xor-negative-bytes-without-leading-zeroes
+    00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  eq. ++> can-xor-one-negative-with-one-positive
+    -36.as-bytes.xor 43.as-bytes
+    80-07-80-00-00-00-00-00
+
+  eq. ++> can-xor-one-with-one
     as-number.
       1.as-bytes.xor 1.as-bytes
     0
 
-  eq. ++> tests-xor-neg-bytes-as-number-without-leading-zeroes
-    00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-FF-FF-FF-FF
-
-  eq. ++> tests-xor-neg-bytes-with-leading-zeroes
-    00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
-    FF-FF-FF-FF-8E-EA-4C-B1
-
-  eq. ++> tests-xor-with-one-neg-one-plus
-    -36.as-bytes.xor 43.as-bytes
-    80-07-80-00-00-00-00-00
-
-  eq. ++> tests-xor-with-two-neg
-    -1.as-bytes.xor -123.as-bytes
-    7F-AE-C0-00-00-00-00-00
-
-  eq. ++> tests-xor-with-two-plus
-    53.as-bytes.xor 24.as-bytes
-    00-72-80-00-00-00-00-00
-
-  eq. ++> tests-xor-with-zero
-    0.as-bytes.xor 29.as-bytes
-    40-3D-00-00-00-00-00-00
-
-  eq. ++> tests-xor-works
+  eq. ++> can-xor-two-long-bytes
     00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
     00-00-00-00-71-15-B3-4E
 
-  20-1F.xor CA-FE-BE --> on-xor-with-different-lengths
+  eq. ++> can-xor-two-negatives
+    -1.as-bytes.xor -123.as-bytes
+    7F-AE-C0-00-00-00-00-00
+
+  eq. ++> can-xor-two-positives
+    53.as-bytes.xor 24.as-bytes
+    00-72-80-00-00-00-00-00
+
+  eq. ++> can-xor-with-zero
+    0.as-bytes.xor 29.as-bytes
+    40-3D-00-00-00-00-00-00
+
+  20-1F.xor CA-FE-BE --> stops-on-xor-with-different-lengths

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -54,7 +54,7 @@
   [] > size /Q.number
   [offset data] > write /Q.bool
 
-  eq. ++> tests-chunk-gets-what-was-put
+  eq. ++> can-get-what-was-put
     malloc.of
       8
       seq * > [c]
@@ -62,13 +62,13 @@
         c.get
     42.as-bytes
 
-  eq. ++> tests-chunk-knows-its-size
+  eq. ++> can-know-its-size
     malloc.of
       3
       c.size > [c]
     3
 
-  eq. ++> tests-chunk-reads-a-slice-of-what-was-written
+  eq. ++> can-read-a-slice-of-what-was-written
     malloc.of
       5
       seq * > [c]

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -34,7 +34,7 @@
       | 0
       buffer
 
-  eq. ++> tests-makes-an-output-from-malloc-and-writes
+  eq. ++> can-make-an-output-from-malloc-and-write-to-it
     malloc.of
       10
       seq * > [mem]
@@ -48,7 +48,7 @@
         mem
     01-02-03-04-05-06-07-08-09-A0
 
-  eq. ++> tests-makes-an-output-via-chunk-extension
+  eq. ++> can-make-an-output-via-a-chunk-extension
     malloc.of
       3
       seq * > [mem]
@@ -56,7 +56,7 @@
         mem
     01-02-03
 
-  eq. ++> writes-larger-data-than-provided-block
+  eq. ++> can-write-data-larger-than-the-block
     malloc.of
       2
       seq * > [mem]

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -30,4 +30,4 @@
         as-number.
           timeval.micros.as-i64.div 1000.as-i64
 
-  clock.gt 0 ++> tests-reads-positive-millis
+  clock.gt 0 ++> can-read-positive-millis

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -126,5 +126,5 @@
                 output-block
             buffer
 
-  console.write ++> tests-writes-to-console
+  console.write ++> can-write-to-the-console
     "Hello, console-test!\n"

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -40,7 +40,7 @@
 
 [target] > dataized /Q.bytes
 
-  ++> tests-dataized-does-not-do-recalculation
+  ++> can-avoid-recalculation
     eq. > @
       malloc.for
         0
@@ -55,7 +55,7 @@
             m.as-number.plus 1
       1
 
-  ++> tests-dataizes-as-bytes-behaves-as-exclamationed
+  ++> can-behave-as-a-const-when-dataized-as-bytes
     seq * > @
       func >> cached1!
       func >> cached2!

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -23,7 +23,7 @@
     [] > touch /Q.string
   [glob] > walk /Q.tuple
 
-  ++> tests-walks-recursively
+  ++> can-walk-recursively
     seq * > @
       made.
         as-dir.
@@ -45,7 +45,7 @@
       made.
         directory mktemp.tmpfile.deleted
 
-  ++> tests-walks-with-plain-glob-matches-direct-child-only
+  ++> can-walk-with-a-plain-glob-matching-direct-children-only
     seq * > @
       touched.
         as-file.
@@ -64,11 +64,11 @@
       made.
         directory mktemp.tmpfile.deleted
 
-  walk. --> on-walking-absent-directory
+  walk. --> stops-on-walking-an-absent-directory
     directory mktemp.tmpfile.deleted
     "**"
 
-  --> on-walking-with-malformed-glob
+  --> stops-on-walking-with-a-malformed-glob
     d.as-dir.walk "[" > @
     as-path. > d
       made.

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -20,7 +20,7 @@
       d
     d
 
-  ++> tests-deletes-directory-with-file-and-dir
+  ++> can-delete-a-directory-with-a-file-and-a-directory
     and. > @
       and.
         and.
@@ -34,7 +34,7 @@
     dir.tmpfile > f
     as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
 
-  ++> tests-deletes-directory-with-files-recursively
+  ++> can-delete-a-directory-with-files-recursively
     and. > @
       and.
         and.
@@ -46,6 +46,6 @@
     dir.tmpfile > first
     dir.tmpfile > second
 
-  not. ++> tests-deletes-empty-directory
+  not. ++> can-delete-an-empty-directory
     exists.
       deleted. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -32,7 +32,7 @@
                       d.path
                       posix.permissions
 
-  ++> tests-makes-new-directory
+  ++> can-make-a-new-directory
     dir.exists.and dir.is-directory > @
     made. > dir
       as-dir.

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -12,6 +12,6 @@
     "The file %s is a directory, can't open for I/O operations".printf
       * d
 
-  mktemp.open --> on-opening-directory
+  mktemp.open --> stops-on-opening-a-directory
     "w"
     true > [x]

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -244,7 +244,7 @@
           posix.mode
     created.code > descriptor
 
-  eq. ++> tests-appending-data-to-file
+  eq. ++> can-append-data-to-a-file
     size.
       open.
         mktemp.tmpfile.open
@@ -254,56 +254,12 @@
         f.write "!" > [f]
     13
 
-  not. ++> tests-check-if-absent-file-does-not-exist
-    exists.
-      file "absent.txt"
+  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
 
-  is-directory. ++> tests-check-if-current-directory-is-directory
-    file "."
-
-  mktemp.tmpfile.deleted.is-directory ++> tests-checking-absent-file-returns-fallback
-    true
-
-  mktemp.tmpfile.deleted.exists.not ++> tests-checks-file-does-not-exist-after-deleting
-
-  mktemp.tmpfile.deleted.deleted.exists.not ++> tests-does-not-fail-on-double-deleting
-
-  mktemp.tmpfile.deleted.touched.touched.exists ++> tests-does-not-fail-on-double-touching
-
-  eq. ++> tests-does-not-truncate-file-opened-for-appending
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a"
-        true > [f]
-    12
-
-  eq. ++> tests-does-not-truncate-file-opened-for-reading
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "r"
-        true > [f]
-    12
-
-  eq. ++> tests-does-not-truncate-file-opened-for-reading-or-appending
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a+"
-        true > [f]
-    12
-
-  mktemp.tmpfile.deleted.touched.size.eq ++> tests-measures-empty-file-after-touching
+  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
     0
 
-  ++> tests-moves-a-file
+  ++> can-move-a-file
     and. > @
       exists.
         temp.moved
@@ -312,7 +268,7 @@
       temp.exists.not
     mktemp.tmpfile > temp
 
-  ++> tests-reads-from-file
+  ++> can-read-from-a-file
     eq. > @
       malloc.of
         12
@@ -328,7 +284,25 @@
             m
       "Hello, world"
 
-  ++> tests-reads-from-file-from-different-instances
+  ++> can-read-from-a-file-sequentially
+    eq. > @
+      malloc.of
+        5
+        [m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [f]
+              "r"
+              m.put > [f] >>
+                read.
+                  f.read 7
+                  5
+            m
+      "world"
+
+  ++> can-read-from-a-file-through-different-instances
     seq * > @
       temp.open
         "w"
@@ -348,32 +322,7 @@
     temp.path > source
     mktemp.tmpfile > temp
 
-  ++> tests-reads-from-file-sequentially
-    eq. > @
-      malloc.of
-        5
-        [m]
-          seq * > @
-            open.
-              mktemp.tmpfile.open
-                "w"
-                f.write "Hello, world" > [f]
-              "r"
-              m.put > [f] >>
-                read.
-                  f.read 7
-                  5
-            m
-      "world"
-
-  eq. ++> tests-recovers-from-opening-missing-file-through-fallback
-    "recovered"
-    mktemp.tmpfile.deleted.open
-      "r"
-      f > [f]
-      "recovered" > [reason]
-
-  ++> tests-resolves-and-touches
+  ++> can-resolve-a-path-and-touch-it
     resolved.as-dir.made.tmpfile.exists.and > @
       string.contains
         resolved
@@ -383,41 +332,48 @@
           "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
 
-  ++> tests-returns-self-after-deleting
+  ++> can-return-itself-after-deleting
     temp.deleted.path.eq temp.path > @
     mktemp.tmpfile > temp
 
-  ++> tests-returns-self-after-touching
+  ++> can-return-itself-after-touching
     temp.deleted.touched.path.eq temp.path > @
     mktemp.tmpfile > temp
 
-  eq. ++> tests-sizing-absent-file-returns-fallback
-    -1
-    mktemp.tmpfile.deleted.size -1
+  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
 
-  mktemp.tmpfile.deleted.touched.exists ++> tests-touches-a-file
+  not. ++> can-tell-that-an-absent-file-does-not-exist
+    exists.
+      file "absent.txt"
 
-  exists. ++> tests-touches-absent-file-on-opening-for-appending
+  is-directory. ++> can-tell-that-the-current-directory-is-a-directory
+    file "."
+
+  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
+
+  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
+
+  exists. ++> can-touch-an-absent-file-on-opening-for-appending
     mktemp.tmpfile.deleted.open
       "a"
       true > [f]
 
-  exists. ++> tests-touches-absent-file-on-opening-for-reading-or-appending
+  exists. ++> can-touch-an-absent-file-on-opening-for-reading-or-appending
     mktemp.tmpfile.deleted.open
       "a+"
       true > [f]
 
-  exists. ++> tests-touches-absent-file-on-opening-for-writing
+  exists. ++> can-touch-an-absent-file-on-opening-for-writing
     mktemp.tmpfile.deleted.open
       "w"
       true > [f]
 
-  exists. ++> tests-touches-absent-file-on-opening-for-writing-or-reading
+  exists. ++> can-touch-an-absent-file-on-opening-for-writing-or-reading
     mktemp.tmpfile.deleted.open
       "w+"
       true > [f]
 
-  eq. ++> tests-truncates-file-opened-for-writing
+  eq. ++> can-truncate-a-file-opened-for-writing
     size.
       open.
         mktemp.tmpfile.open
@@ -427,7 +383,7 @@
         true > [f]
     0
 
-  eq. ++> tests-truncates-file-opened-for-writing-or-reading
+  eq. ++> can-truncate-a-file-opened-for-writing-or-reading
     size.
       open.
         mktemp.tmpfile.open
@@ -437,7 +393,7 @@
         true > [f]
     0
 
-  eq. ++> tests-writes-data-to-file
+  eq. ++> can-write-data-to-a-file
     size.
       mktemp.tmpfile.open
         "w"
@@ -445,7 +401,16 @@
           "Hello, world"
     12
 
-  ++> tests-writes-to-file-from-different-instances
+  eq. ++> can-write-to-a-file-sequentially
+    size.
+      mktemp.tmpfile.open
+        "a+"
+        write. > [f]
+          f.write "Hello, world"
+          "!"
+    13
+
+  ++> can-write-to-a-file-through-different-instances
     seq * > @
       temp.open
         "w"
@@ -470,45 +435,79 @@
     temp.path > source
     mktemp.tmpfile > temp
 
-  eq. ++> tests-writes-to-file-sequentially
+  eq. ++> cannot-truncate-a-file-opened-for-appending
     size.
-      mktemp.tmpfile.open
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        true > [f]
+    12
+
+  eq. ++> cannot-truncate-a-file-opened-for-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "r"
+        true > [f]
+    12
+
+  eq. ++> cannot-truncate-a-file-opened-for-reading-or-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
         "a+"
-        write. > [f]
-          f.write "Hello, world"
-          "!"
-    13
+        true > [f]
+    12
 
-  tmpfile. --> an-error-on-touching-temp-file-in-absent-dir
-    @.
-      mktemp.as-path.resolved "foo"
+  mktemp.tmpfile.deleted.is-directory true ++> rejects-checking-an-absent-file
 
-  mktemp.tmpfile.deleted.is-directory --> on-checking-directory-of-absent-file
+  eq. ++> rejects-opening-a-missing-file
+    "recovered"
+    mktemp.tmpfile.deleted.open
+      "r"
+      f > [f]
+      "recovered" > [reason]
 
-  seq * --> on-opening-with-wrong-mode
+  eq. ++> rejects-sizing-an-absent-file
+    -1
+    mktemp.tmpfile.deleted.size -1
+
+  mktemp.tmpfile.deleted.is-directory --> stops-on-checking-the-directory-of-an-absent-file
+
+  seq * --> stops-on-opening-with-a-wrong-mode
     mktemp.tmpfile.open
       "x"
       true > [f]
     true
 
-  mktemp.tmpfile.open --> on-reading-from-file-with-wrong-mode
-    "w"
-    f.read 12 > [f]
-
-  mktemp.tmpfile.deleted.open --> on-reading-from-not-existed-file
-    "r"
-    f > [f]
-
-  mktemp.tmpfile.open --> on-reading-negative-size-from-file
+  mktemp.tmpfile.open --> stops-on-reading-a-negative-size-from-a-file
     "r"
     f.read -5 > [f]
 
-  mktemp.tmpfile.deleted.open --> on-reading-or-writing-from-not-existed-file
+  mktemp.tmpfile.open --> stops-on-reading-from-a-file-with-a-wrong-mode
+    "w"
+    f.read 12 > [f]
+
+  mktemp.tmpfile.deleted.open --> stops-on-reading-from-a-missing-file
+    "r"
+    f > [f]
+
+  mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
     "r+"
     f > [f]
 
-  mktemp.tmpfile.deleted.size --> on-sizing-absent-file
+  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file
 
-  mktemp.tmpfile.open --> on-writing-with-wrong-mode
+  tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
+    @.
+      mktemp.as-path.resolved "foo"
+
+  mktemp.tmpfile.open --> stops-on-writing-with-a-wrong-mode
     "r"
     f.write "Hello" > [f]

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -79,113 +79,119 @@
       2
       2
 
-  eq. ++> tests-i16-as-i32-widens-negative-with-sign-extension
-    -200.as-i64.as-i32.as-i16.as-i32.as-bytes
-    FF-FF-FF-38
+  eq. ++> can-add-one-to-one
+    1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
+    2.as-i64.as-i32.as-i16
 
-  eq. ++> tests-i16-as-i32-widens-positive-with-zero-prefix
-    42.as-i64.as-i32.as-i16.as-i32.as-bytes
-    00-00-00-2A
+  eq. ++> can-add-with-overflow
+    32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
+    -32768.as-i64.as-i32.as-i16
 
-  ++> tests-i16-div-by-i16-one
+  gt. ++> can-be-greater-than-a-smaller-i16
+    -200.as-i64.as-i32.as-i16
+    -1000.as-i64.as-i32.as-i16
+
+  gte. ++> can-be-greater-than-or-equal-to-a-smaller-i16
+    -1000.as-i64.as-i32.as-i16
+    -1100.as-i64.as-i32.as-i16
+
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-i16
+    113.as-i64.as-i32.as-i16
+    113.as-i64.as-i32.as-i16
+
+  lt. ++> can-be-less-than-a-larger-i16
+    10.as-i64.as-i32.as-i16
+    50.as-i64.as-i32.as-i16
+
+  lte. ++> can-be-less-than-or-equal-to-a-larger-i16
+    -200.as-i64.as-i32.as-i16
+    -100.as-i64.as-i32.as-i16
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-i16
+    50.as-i64.as-i32.as-i16
+    50.as-i64.as-i32.as-i16
+
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1.as-i64.as-i32.as-i16
       dividend
     -235.as-i64.as-i32.as-i16 > dividend
 
-  eq. ++> tests-i16-div-by-zero-returns-provided-fallback
+  lt. ++> can-divide-into-less-than-one
+    1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
+    1.as-i64.as-i32.as-i16
+
+  eq. ++> can-divide-with-a-remainder
+    13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
+    -2.as-i64.as-i32.as-i16
+
+  123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> can-equal-the-same-i16
+
+  0.as-i64.as-i32.as-i16.eq 0.as-i64.as-i32.as-i16 ++> can-equal-zero-to-zero
+
+  42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
+    -200.as-i64.as-i32.as-i16.as-bytes
+    FF-38
+
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  eq. ++> can-multiply-with-overflow
+    32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
+    -2.as-i64.as-i32.as-i16
+
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  eq. ++> can-subtract-with-overflow
+    -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
+    32767.as-i64.as-i32.as-i16
+
+  eq. ++> can-widen-a-negative-to-i32-with-sign-extension
+    -200.as-i64.as-i32.as-i16.as-i32.as-bytes
+    FF-FF-FF-38
+
+  eq. ++> can-widen-a-positive-to-i32-with-a-zero-prefix
+    42.as-i64.as-i32.as-i16.as-i32.as-bytes
+    00-00-00-2A
+
+  eq. ++> can-wrap-a-large-positive-product
+    300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
+    24464.as-i64.as-i32.as-i16
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
+    256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-a-larger-i16
+    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-an-equal-i16
+    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i16
+    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-a-smaller-i16
+    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-an-equal-i16
+    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i16
+    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-equal-a-different-i16
+    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     2.as-i64.as-i32.as-i16.div
       0.as-i64.as-i32.as-i16
       "recovered" > [message]
 
-  lt. ++> tests-i16-div-less-than-i16-one
-    1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
-    1.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-div-with-remainder
-    13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
-    -2.as-i64.as-i32.as-i16
-
-  not. ++> tests-i16-eq-false
-    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
-
-  123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> tests-i16-eq-true
-
-  not. ++> tests-i16-greater-equal
-    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
-
-  not. ++> tests-i16-greater-false
-    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
-
-  gt. ++> tests-i16-greater-true
-    -200.as-i64.as-i32.as-i16
-    -1000.as-i64.as-i32.as-i16
-
-  113.as-i64.as-i32.as-i16.gte 113.as-i64.as-i32.as-i16 ++> tests-i16-gte-equal
-
-  not. ++> tests-i16-gte-false
-    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
-
-  -1000.as-i64.as-i32.as-i16.gte -1100.as-i64.as-i32.as-i16 ++> tests-i16-gte-true
-
-  42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> tests-i16-has-valid-bytes
-
-  not. ++> tests-i16-less-equal
-    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
-
-  not. ++> tests-i16-less-false
-    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
-
-  10.as-i64.as-i32.as-i16.lt 50.as-i64.as-i32.as-i16 ++> tests-i16-less-true
-
-  50.as-i64.as-i32.as-i16.lte 50.as-i64.as-i32.as-i16 ++> tests-i16-lte-equal
-
-  not. ++> tests-i16-lte-false
-    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
-
-  -200.as-i64.as-i32.as-i16.lte -100.as-i64.as-i32.as-i16 ++> tests-i16-lte-true
-
-  eq. ++> tests-i16-minus-with-overflow
-    -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-    32767.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-multiply-by-zero
-    1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-one-minus-i16-one
-    1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-one-plus-i16-one
-    1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
-    2.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-plus-with-overflow
-    32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
-    -32768.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-times-with-overflow
-    32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
-    -2.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-times-wraps-large-positive-product
-    300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
-    24464.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-times-wraps-modulo-2-pow-16
-    256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-i16-zero-eq-to-i16-zero
-    0.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
-
-  eq. ++> tests-negative-i16-has-valid-bytes
-    -200.as-i64.as-i32.as-i16.as-bytes
-    FF-38
-
-  div. --> on-division-i16-by-i16-zero
-    2.as-i64.as-i32.as-i16
-    0.as-i64.as-i32.as-i16
+  2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -87,126 +87,134 @@
       4
       4
 
-  eq. ++> tests-i32-as-i64-widens-negative-with-sign-extension
-    -200.as-i64.as-i32.as-i64.as-bytes
-    FF-FF-FF-FF-FF-FF-FF-38
+  eq. ++> can-add-one-to-one
+    1.as-i64.as-i32.plus 1.as-i64.as-i32
+    2.as-i64.as-i32
 
-  eq. ++> tests-i32-as-i64-widens-positive-with-zero-prefix
-    42.as-i64.as-i32.as-i64.as-bytes
-    00-00-00-00-00-00-00-2A
+  eq. ++> can-add-with-overflow
+    2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
+    -2147483648.as-i64.as-i32
 
-  ++> tests-i32-div-by-i32-one
+  -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> can-be-greater-than-a-smaller-i32
+
+  gte. ++> can-be-greater-than-or-equal-to-a-smaller-i32
+    -1000.as-i64.as-i32
+    -1100.as-i64.as-i32
+
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-i32
+    113.as-i64.as-i32
+    113.as-i64.as-i32
+
+  10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> can-be-less-than-a-larger-i32
+
+  lte. ++> can-be-less-than-or-equal-to-a-larger-i32
+    -200.as-i64.as-i32
+    -100.as-i64.as-i32
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-i32
+    50.as-i64.as-i32
+    50.as-i64.as-i32
+
+  eq. ++> can-convert-a-negative-to-i16-and-back
+    -123.as-i64.as-i32
+    -123.as-i64.as-i32.as-i16.as-i32
+
+  eq. ++> can-convert-to-i16-and-back
+    123.as-i64.as-i32
+    123.as-i64.as-i32.as-i16.as-i32
+
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1.as-i64.as-i32
       dividend
     -235.as-i64.as-i32 > dividend
 
-  eq. ++> tests-i32-div-by-zero-returns-provided-fallback
+  lt. ++> can-divide-into-less-than-one
+    1.as-i64.as-i32.div 5.as-i64.as-i32
+    1.as-i64.as-i32
+
+  eq. ++> can-divide-with-a-remainder
+    13.as-i64.as-i32.div -5.as-i64.as-i32
+    -2.as-i64.as-i32
+
+  123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> can-equal-the-same-i32
+
+  0.as-i64.as-i32.eq 0.as-i64.as-i32 ++> can-equal-zero-to-zero
+
+  42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
+    -200.as-i64.as-i32.as-bytes
+    FF-FF-FF-38
+
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.as-i32.times 0.as-i64.as-i32
+    0.as-i64.as-i32
+
+  eq. ++> can-multiply-with-overflow
+    2147483647.as-i64.as-i32.times 2.as-i64.as-i32
+    -2.as-i64.as-i32
+
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.as-i32.minus 1.as-i64.as-i32
+    0.as-i64.as-i32
+
+  eq. ++> can-subtract-with-overflow
+    -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
+    2147483647.as-i64.as-i32
+
+  eq. ++> can-widen-a-negative-to-i64-with-sign-extension
+    -200.as-i64.as-i32.as-i64.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-38
+
+  eq. ++> can-widen-a-positive-to-i64-with-a-zero-prefix
+    42.as-i64.as-i32.as-i64.as-bytes
+    00-00-00-00-00-00-00-2A
+
+  eq. ++> can-wrap-a-large-positive-product
+    100000.as-i64.as-i32.times 100000.as-i64.as-i32
+    1410065408.as-i64.as-i32
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
+    65536.as-i64.as-i32.times 65536.as-i64.as-i32
+    0.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-a-larger-i32
+    0.as-i64.as-i32.gt 100.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-an-equal-i32
+    0.as-i64.as-i32.gt 0.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i32
+    0.as-i64.as-i32.gte 10.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-a-smaller-i32
+    10.as-i64.as-i32.lt -5.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-an-equal-i32
+    10.as-i64.as-i32.lt 10.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i32
+    0.as-i64.as-i32.lte -10.as-i64.as-i32
+
+  not. ++> cannot-equal-a-different-i32
+    123.as-i64.as-i32.eq 42.as-i64.as-i32
+
+  eq. ++> rejects-an-out-of-bounds-conversion-to-i16
+    "recovered"
+    247483647.as-i64.as-i32.as-i16
+      "recovered" > [message]
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     2.as-i64.as-i32.div
       0.as-i64.as-i32
       "recovered" > [message]
 
-  lt. ++> tests-i32-div-less-than-i32-one
-    1.as-i64.as-i32.div 5.as-i64.as-i32
-    1.as-i64.as-i32
+  32768.as-i64.as-i32.as-i16 --> stops-on-converting-i16-max-plus-one-to-i16
 
-  eq. ++> tests-i32-div-with-remainder
-    13.as-i64.as-i32.div -5.as-i64.as-i32
-    -2.as-i64.as-i32
+  -32769.as-i64.as-i32.as-i16 --> stops-on-converting-i16-min-minus-one-to-i16
 
-  not. ++> tests-i32-eq-false
-    123.as-i64.as-i32.eq 42.as-i64.as-i32
+  247483647.as-i64.as-i32.as-i16 --> stops-on-converting-out-of-bounds-to-i16
 
-  123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> tests-i32-eq-true
-
-  not. ++> tests-i32-greater-equal
-    0.as-i64.as-i32.gt 0.as-i64.as-i32
-
-  not. ++> tests-i32-greater-false
-    0.as-i64.as-i32.gt 100.as-i64.as-i32
-
-  -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> tests-i32-greater-true
-
-  113.as-i64.as-i32.gte 113.as-i64.as-i32 ++> tests-i32-gte-equal
-
-  not. ++> tests-i32-gte-false
-    0.as-i64.as-i32.gte 10.as-i64.as-i32
-
-  -1000.as-i64.as-i32.gte -1100.as-i64.as-i32 ++> tests-i32-gte-true
-
-  42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> tests-i32-has-valid-bytes
-
-  not. ++> tests-i32-less-equal
-    10.as-i64.as-i32.lt 10.as-i64.as-i32
-
-  not. ++> tests-i32-less-false
-    10.as-i64.as-i32.lt -5.as-i64.as-i32
-
-  10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> tests-i32-less-true
-
-  50.as-i64.as-i32.lte 50.as-i64.as-i32 ++> tests-i32-lte-equal
-
-  not. ++> tests-i32-lte-false
-    0.as-i64.as-i32.lte -10.as-i64.as-i32
-
-  -200.as-i64.as-i32.lte -100.as-i64.as-i32 ++> tests-i32-lte-true
-
-  eq. ++> tests-i32-minus-with-overflow
-    -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
-    2147483647.as-i64.as-i32
-
-  eq. ++> tests-i32-multiply-by-zero
-    1000.as-i64.as-i32.times 0.as-i64.as-i32
-    0.as-i64.as-i32
-
-  eq. ++> tests-i32-one-minus-i32-one
-    1.as-i64.as-i32.minus 1.as-i64.as-i32
-    0.as-i64.as-i32
-
-  eq. ++> tests-i32-one-plus-i32-one
-    1.as-i64.as-i32.plus 1.as-i64.as-i32
-    2.as-i64.as-i32
-
-  eq. ++> tests-i32-plus-with-overflow
-    2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
-    -2147483648.as-i64.as-i32
-
-  eq. ++> tests-i32-times-with-overflow
-    2147483647.as-i64.as-i32.times 2.as-i64.as-i32
-    -2.as-i64.as-i32
-
-  eq. ++> tests-i32-times-wraps-large-positive-product
-    100000.as-i64.as-i32.times 100000.as-i64.as-i32
-    1410065408.as-i64.as-i32
-
-  eq. ++> tests-i32-times-wraps-modulo-2-pow-32
-    65536.as-i64.as-i32.times 65536.as-i64.as-i32
-    0.as-i64.as-i32
-
-  eq. ++> tests-i32-to-i16-and-back
-    123.as-i64.as-i32
-    123.as-i64.as-i32.as-i16.as-i32
-
-  0.as-i64.as-i32.eq 0.as-i64.as-i32 ++> tests-i32-zero-eq-to-i32-zero
-
-  eq. ++> tests-negative-i32-has-valid-bytes
-    -200.as-i64.as-i32.as-bytes
-    FF-FF-FF-38
-
-  eq. ++> tests-negative-i32-to-i16-and-back
-    -123.as-i64.as-i32
-    -123.as-i64.as-i32.as-i16.as-i32
-
-  eq. ++> tests-out-of-bounds-i32-as-i16-returns-provided-fallback
-    "recovered"
-    247483647.as-i64.as-i32.as-i16
-      "recovered" > [message]
-
-  32768.as-i64.as-i32.as-i16 --> on-converting-i16-max-plus-one-to-i16
-
-  -32769.as-i64.as-i32.as-i16 --> on-converting-i16-min-minus-one-to-i16
-
-  247483647.as-i64.as-i32.as-i16 --> on-converting-to-i16-if-out-of-bounds
-
-  2.as-i64.as-i32.div 0.as-i64.as-i32 --> on-division-i32-by-i32-zero
+  2.as-i64.as-i32.div 0.as-i64.as-i32 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -89,137 +89,139 @@
       as-bytes
       x.as-bytes
 
-  not. ++> tests-i64-as-bytes-is-not-equal-to-number-bytes
-    eq.
-      i64 234.as-bytes
-      234.as-i64.as-bytes
+  eq. ++> can-add-mixed-signs
+    -100.as-i64.plus 42.as-i64
+    -58.as-i64
 
-  not. ++> tests-i64-eq-false
-    123.@.eq 42.@
-
-  123.@.eq 123.@ ++> tests-i64-eq-true
-
-  not. ++> tests-i64-greater-equal
-    0.as-i64.gt 0.as-i64
-
-  not. ++> tests-i64-greater-false
-    0.as-i64.gt 100.as-i64
-
-  gt. ++> tests-i64-greater-max-over-min
-    i64 7F-FF-FF-FF-FF-FF-FF-FF
-    i64 80-00-00-00-00-00-00-00
-
-  not. ++> tests-i64-greater-min-not-over-max
-    gt.
-      i64 80-00-00-00-00-00-00-00
-      i64 7F-FF-FF-FF-FF-FF-FF-FF
-
-  gt. ++> tests-i64-greater-same-sign-large-negatives
-    -5000000000000000000.as-i64
-    -9000000000000000000.as-i64
-
-  -200.as-i64.gt -1000.as-i64 ++> tests-i64-greater-true
-
-  113.as-i64.gte 113.as-i64 ++> tests-i64-gte-equal
-
-  not. ++> tests-i64-gte-false
-    0.as-i64.gte 10.as-i64
-
-  -1000.as-i64.gte -1100.as-i64 ++> tests-i64-gte-true
-
-  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> tests-i64-has-valid-bytes
-
-  eq. ++> tests-i64-i32-max-converts-without-error
-    2147483647.as-i64
-    2147483647.as-i64.as-i32.as-i64
-
-  eq. ++> tests-i64-i32-min-converts-without-error
-    -2147483648.as-i64
-    -2147483648.as-i64.as-i32.as-i64
-
-  -9.223372036854776e18.as-i64.lt 1.as-i64 ++> tests-i64-less-across-full-range
-
-  not. ++> tests-i64-less-equal
-    10.as-i64.lt 10.as-i64
-
-  not. ++> tests-i64-less-false
-    10.as-i64.lt -5.as-i64
-
-  10.as-i64.lt 50.as-i64 ++> tests-i64-less-true
-
-  not. ++> tests-i64-less-with-large-difference
-    5000000000000000000.as-i64.lt -5000000000000000000.as-i64
-
-  50.as-i64.lte 50.as-i64 ++> tests-i64-lte-equal
-
-  not. ++> tests-i64-lte-false
-    0.as-i64.lte -10.as-i64
-
-  -200.as-i64.lte -100.as-i64 ++> tests-i64-lte-true
-
-  eq. ++> tests-i64-minus-one-plus-one-is-zero
+  eq. ++> can-add-one-to-minus-one
     -1.as-i64.plus 1.as-i64
     0.as-i64
 
-  eq. ++> tests-i64-multiply-by-zero
-    1000.as-i64.times 0.as-i64
-    0.as-i64
-
-  eq. ++> tests-i64-one-minus-i64-one
-    1.as-i64.minus 1.as-i64
-    0.as-i64
-
-  eq. ++> tests-i64-one-plus-i64-one
+  eq. ++> can-add-one-to-one
     1.as-i64.plus 1.as-i64
     2.as-i64
 
-  eq. ++> tests-i64-plus-carries-through-all-bytes
+  gt. ++> can-be-greater-among-large-negatives
+    -5000000000000000000.as-i64
+    -9000000000000000000.as-i64
+
+  -200.as-i64.gt -1000.as-i64 ++> can-be-greater-than-a-smaller-i64
+
+  -1000.as-i64.gte -1100.as-i64 ++> can-be-greater-than-or-equal-to-a-smaller-i64
+
+  113.as-i64.gte 113.as-i64 ++> can-be-greater-than-or-equal-to-an-equal-i64
+
+  gt. ++> can-be-greater-when-max-is-over-min
+    i64 7F-FF-FF-FF-FF-FF-FF-FF
+    i64 80-00-00-00-00-00-00-00
+
+  -9.223372036854776e18.as-i64.lt 1.as-i64 ++> can-be-less-across-the-full-range
+
+  10.as-i64.lt 50.as-i64 ++> can-be-less-than-a-larger-i64
+
+  -200.as-i64.lte -100.as-i64 ++> can-be-less-than-or-equal-to-a-larger-i64
+
+  50.as-i64.lte 50.as-i64 ++> can-be-less-than-or-equal-to-an-equal-i64
+
+  not. ++> can-be-less-with-a-large-difference
+    5000000000000000000.as-i64.lt -5000000000000000000.as-i64
+
+  eq. ++> can-carry-an-addition-through-all-bytes
     plus.
       i64 00-FF-FF-FF-FF-FF-FF-FF
       1.as-i64
     i64 01-00-00-00-00-00-00-00
 
-  eq. ++> tests-i64-plus-of-mixed-signs
-    -100.as-i64.plus 42.as-i64
-    -58.as-i64
+  eq. ++> can-convert-a-negative-to-i32-and-back
+    -234.as-i64
+    -234.as-i64.as-i32.as-i64
 
-  eq. ++> tests-i64-plus-wraps-around-at-max
-    plus.
-      i64 7F-FF-FF-FF-FF-FF-FF-FF
-      1.as-i64
-    i64 80-00-00-00-00-00-00-00
+  eq. ++> can-convert-i32-max-without-an-error
+    2147483647.as-i64
+    2147483647.as-i64.as-i32.as-i64
 
-  eq. ++> tests-i64-times-keeps-low-bits-of-large-product
+  eq. ++> can-convert-i32-min-without-an-error
+    -2147483648.as-i64
+    -2147483648.as-i64.as-i32.as-i64
+
+  234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> can-convert-to-i32-and-back
+
+  123.@.eq 123.@ ++> can-equal-the-same-i64
+
+  0.@.eq 0.@ ++> can-equal-zero-to-zero
+
+  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-keep-the-low-bits-of-a-large-product
     2147483647.as-i64.times 2147483647.as-i64
     i64 3F-FF-FF-FF-00-00-00-01
 
-  eq. ++> tests-i64-times-of-mixed-signs
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.times 0.as-i64
+    0.as-i64
+
+  eq. ++> can-multiply-mixed-signs
     -7.as-i64.times 6.as-i64
     -42.as-i64
 
-  eq. ++> tests-i64-times-of-two-negatives
+  eq. ++> can-multiply-two-negatives
     -7.as-i64.times -6.as-i64
     42.as-i64
 
-  eq. ++> tests-i64-times-wraps-modulo-2-pow-64
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.minus 1.as-i64
+    0.as-i64
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
     times.
       i64 40-00-00-00-00-00-00-00
       4.as-i64
     0.as-i64
 
-  234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> tests-i64-to-i32-and-back
+  eq. ++> can-wrap-an-addition-at-max
+    plus.
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+      1.as-i64
+    i64 80-00-00-00-00-00-00-00
 
-  0.@.eq 0.@ ++> tests-i64-zero-eq-to-i64-zero
+  not. ++> cannot-be-greater-than-a-larger-i64
+    0.as-i64.gt 100.as-i64
 
-  -234.as-i64.eq -234.as-i64.as-i32.as-i64 ++> tests-negative-i64-to-i32-and-back
+  not. ++> cannot-be-greater-than-an-equal-i64
+    0.as-i64.gt 0.as-i64
 
-  eq. ++> tests-out-of-bounds-i64-as-i32-returns-provided-fallback
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i64
+    0.as-i64.gte 10.as-i64
+
+  not. ++> cannot-be-greater-when-min-is-under-max
+    gt.
+      i64 80-00-00-00-00-00-00-00
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+
+  not. ++> cannot-be-less-than-a-smaller-i64
+    10.as-i64.lt -5.as-i64
+
+  not. ++> cannot-be-less-than-an-equal-i64
+    10.as-i64.lt 10.as-i64
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i64
+    0.as-i64.lte -10.as-i64
+
+  not. ++> cannot-equal-a-different-i64
+    123.@.eq 42.@
+
+  not. ++> cannot-match-the-bytes-of-the-same-number
+    eq.
+      i64 234.as-bytes
+      234.as-i64.as-bytes
+
+  eq. ++> rejects-an-out-of-bounds-conversion-to-i32
     "recovered"
     3147483647.as-i64.as-i32
       "recovered" > [message]
 
-  2147483648.as-i64.as-i32 --> on-converting-i32-max-plus-one-to-i32
+  2147483648.as-i64.as-i32 --> stops-on-converting-i32-max-plus-one-to-i32
 
-  -2147483649.as-i64.as-i32 --> on-converting-i32-min-minus-one-to-i32
+  -2147483649.as-i64.as-i32 --> stops-on-converting-i32-min-minus-one-to-i32
 
-  3147483647.as-i64.as-i32 --> on-converting-to-i32-if-out-of-bounds
+  3147483647.as-i64.as-i32 --> stops-on-converting-out-of-bounds-to-i32

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -79,48 +79,48 @@
           magnitude x.as-bytes
       i64 00-00-00-00-00-00-00-01
 
-  ++> tests-i64-div-by-i64-one
+  eq. ++> can-divide-a-large-dividend
+    4611686018427387904.as-i64.div 2.as-i64
+    2305843009213693952.as-i64
+
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1.as-i64
       dividend
     -235.as-i64 > dividend
 
-  eq. ++> tests-i64-div-by-zero-returns-provided-fallback
-    "recovered"
-    2.as-i64.div
-      0.as-i64
-      "recovered" > [message]
-
-  lt. ++> tests-i64-div-less-than-i64-one
+  lt. ++> can-divide-into-less-than-one
     1.as-i64.div 5.as-i64
     1.as-i64
 
-  eq. ++> tests-i64-div-min-by-minus-one-wraps
-    div.
-      i64 80-00-00-00-00-00-00-00
-      -1.as-i64
-    i64 80-00-00-00-00-00-00-00
-
-  eq. ++> tests-i64-div-min-by-one-is-min
+  eq. ++> can-divide-min-by-one
     div.
       i64 80-00-00-00-00-00-00-00
       1.as-i64
     i64 80-00-00-00-00-00-00-00
 
-  eq. ++> tests-i64-div-of-large-dividend
-    4611686018427387904.as-i64.div 2.as-i64
-    2305843009213693952.as-i64
-
-  eq. ++> tests-i64-div-of-two-negatives
+  eq. ++> can-divide-two-negatives
     -13.as-i64.div -5.as-i64
     2.as-i64
 
-  eq. ++> tests-i64-div-truncates-toward-zero
-    -13.as-i64.div 5.as-i64
-    -2.as-i64
-
-  eq. ++> tests-i64-div-with-remainder
+  eq. ++> can-divide-with-a-remainder
     13.as-i64.div -5.as-i64
     -2.as-i64
 
-  2.as-i64.div 0.as-i64 --> on-division-i64-by-i64-zero
+  eq. ++> can-truncate-toward-zero
+    -13.as-i64.div 5.as-i64
+    -2.as-i64
+
+  eq. ++> can-wrap-min-divided-by-minus-one
+    div.
+      i64 80-00-00-00-00-00-00-00
+      -1.as-i64
+    i64 80-00-00-00-00-00-00-00
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    2.as-i64.div
+      0.as-i64
+      "recovered" > [message]
+
+  2.as-i64.div 0.as-i64 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -61,80 +61,80 @@
       1
       1
 
-  eq. ++> tests-i8-as-i16-widens-negative-with-sign-extension
-    C8-.as-i8.as-i16.as-bytes
-    FF-C8
-
-  eq. ++> tests-i8-as-i16-widens-positive-with-zero-prefix
-    2A-.as-i8.as-i16.as-bytes
-    00-2A
-
-  eq. ++> tests-i8-div-by-i8-one
-    C8-.as-i8.div 01-.as-i8
-    C8-.as-i8
-
-  eq. ++> tests-i8-div-by-zero-returns-provided-fallback
-    "recovered"
-    02-.as-i8.div
-      00-.as-i8
-      "recovered" > [message]
-
-  eq. ++> tests-i8-div-with-remainder
-    0D-.as-i8.div FB-.as-i8
-    FE-.as-i8
-
-  not. ++> tests-i8-eq-false
-    2A-.as-i8.eq 2B-.as-i8
-
-  2A-.as-i8.eq 2A-.as-i8 ++> tests-i8-eq-true
-
-  32-.as-i8.gte 32-.as-i8 ++> tests-i8-gte-equal
-
-  2A-.as-i8.as-bytes.eq 2A- ++> tests-i8-has-valid-bytes
-
-  C8-.as-i8.as-number.eq -56 ++> tests-i8-high-bit-is-negative
-
-  not. ++> tests-i8-less-equal
-    0A-.as-i8.lt 0A-.as-i8
-
-  0A-.as-i8.lt 32-.as-i8 ++> tests-i8-less-true
-
-  32-.as-i8.lte 32-.as-i8 ++> tests-i8-lte-equal
-
-  eq. ++> tests-i8-minus-with-overflow
-    80-.as-i8.minus 01-.as-i8
-    7F-.as-i8
-
-  2A-.as-i8.neg.eq D6-.as-i8 ++> tests-i8-negation
-
-  C8-.as-i8.lt 0A-.as-i8 ++> tests-i8-negative-less-than-positive
-
-  eq. ++> tests-i8-one-minus-i8-one
-    01-.as-i8.minus 01-.as-i8
-    00-.as-i8
-
-  eq. ++> tests-i8-one-plus-i8-one
+  eq. ++> can-add-one-to-one
     01-.as-i8.plus 01-.as-i8
     02-.as-i8
 
-  eq. ++> tests-i8-plus-with-overflow
+  eq. ++> can-add-with-overflow
     7F-.as-i8.plus 01-.as-i8
     80-.as-i8
 
-  32-.as-i8.gt C8-.as-i8 ++> tests-i8-positive-greater-than-negative
+  32-.as-i8.gte 32-.as-i8 ++> can-be-greater-than-or-equal-to-an-equal-i8
 
-  eq. ++> tests-i8-times
-    06-.as-i8.times 07-.as-i8
-    2A-.as-i8
+  32-.as-i8.gt C8-.as-i8 ++> can-be-greater-when-positive-than-negative
 
-  eq. ++> tests-i8-times-of-two-negatives
-    FF-.as-i8.times FF-.as-i8
-    01-.as-i8
+  0A-.as-i8.lt 32-.as-i8 ++> can-be-less-than-a-larger-i8
 
-  eq. ++> tests-negative-i8-has-valid-bytes
+  32-.as-i8.lte 32-.as-i8 ++> can-be-less-than-or-equal-to-an-equal-i8
+
+  C8-.as-i8.lt 0A-.as-i8 ++> can-be-less-when-negative-than-positive
+
+  eq. ++> can-divide-by-one
+    C8-.as-i8.div 01-.as-i8
+    C8-.as-i8
+
+  eq. ++> can-divide-with-a-remainder
+    0D-.as-i8.div FB-.as-i8
+    FE-.as-i8
+
+  2A-.as-i8.eq 2A-.as-i8 ++> can-equal-the-same-i8
+
+  2A-.as-i8.as-bytes.eq 2A- ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
     -56.as-i64.as-i32.as-i16.as-bytes.slice
       1
       1
     C8-
 
-  02-.as-i8.div 00-.as-i8 --> on-division-i8-by-i8-zero
+  eq. ++> can-multiply-two-negatives
+    FF-.as-i8.times FF-.as-i8
+    01-.as-i8
+
+  eq. ++> can-multiply-two-positives
+    06-.as-i8.times 07-.as-i8
+    2A-.as-i8
+
+  2A-.as-i8.neg.eq D6-.as-i8 ++> can-negate-itself
+
+  C8-.as-i8.as-number.eq -56 ++> can-read-a-high-bit-as-negative
+
+  eq. ++> can-subtract-one-from-one
+    01-.as-i8.minus 01-.as-i8
+    00-.as-i8
+
+  eq. ++> can-subtract-with-overflow
+    80-.as-i8.minus 01-.as-i8
+    7F-.as-i8
+
+  eq. ++> can-widen-a-negative-to-i16-with-sign-extension
+    C8-.as-i8.as-i16.as-bytes
+    FF-C8
+
+  eq. ++> can-widen-a-positive-to-i16-with-a-zero-prefix
+    2A-.as-i8.as-i16.as-bytes
+    00-2A
+
+  not. ++> cannot-be-less-than-an-equal-i8
+    0A-.as-i8.lt 0A-.as-i8
+
+  not. ++> cannot-equal-a-different-i8
+    2A-.as-i8.eq 2B-.as-i8
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    02-.as-i8.div
+      00-.as-i8
+      "recovered" > [message]
+
+  02-.as-i8.div 00-.as-i8 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -22,13 +22,13 @@
       Q.input.copied input m.to-output
       m
 
-  ++> tests-bytes-as-input-and-back
+  ++> can-convert-bytes-to-an-input-and-back
     eq. > @
       Q.input.as-bytes
         bytes.as-input b
       b
     01-02-03-04-05-06-07-08 > b
 
-  eq. ++> tests-returns-empty-bytes-from-dead-input
+  eq. ++> can-return-empty-bytes-from-a-dead-input
     Q.input.as-bytes dead
     --

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -24,7 +24,7 @@
       input
       output
 
-  eq. ++> tests-copies-all-bytes-and-returns-length
+  eq. ++> can-copy-all-bytes-and-return-the-length
     malloc.of
       5
       seq * > [m]
@@ -34,13 +34,13 @@
         m
     01-02-03-04-05
 
-  eq. ++> tests-handles-dead-input
+  eq. ++> can-handle-a-dead-input
     Q.input.copied
       Q.input.dead
       Q.output.dead
     0
 
-  eq. ++> tests-handles-empty-input
+  eq. ++> can-handle-an-empty-input
     malloc.of
       0
       seq * > [m]
@@ -50,7 +50,7 @@
         m
     --
 
-  eq. ++> tests-handles-large-data
+  eq. ++> can-handle-large-data
     20
     malloc.of
       20
@@ -58,7 +58,7 @@
         bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
         m.to-output
 
-  eq. ++> tests-returns-correct-byte-count
+  eq. ++> can-return-the-byte-count
     malloc.of
       10
       Q.input.copied > [m]
@@ -66,7 +66,7 @@
         m.to-output
     10
 
-  eq. ++> tests-returns-zero-for-empty-input
+  eq. ++> can-return-zero-for-an-empty-input
     malloc.of
       0
       Q.input.copied > [m]

--- a/eo-runtime/src/main/eo/input/dead.eo
+++ b/eo-runtime/src/main/eo/input/dead.eo
@@ -15,7 +15,7 @@
       input-block > [size] > read
     | > @
 
-  ++> tests-reads-empty-bytes
+  ++> can-read-empty-bytes
     and. > @
       i1.eq --
       eq.

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -23,12 +23,12 @@
     input
     0
 
-  eq. ++> tests-reads-all-bytes-and-returns-length
+  eq. ++> can-read-all-bytes-and-return-the-length
     Q.input.length
       bytes.as-input 01-02-03-04-05-06-07-08-09-10
     10
 
-  eq. ++> tests-copies-all-bytes-to-output-and-returns-length
+  eq. ++> can-copy-all-bytes-to-an-output-and-return-the-length
     malloc.of
       10
       seq * > [m]

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -39,7 +39,7 @@
         ^. (input.read size).read > chunk
         ^. (output.write chunk).write > written
 
-  eq. ++> tests-reads-from-bytes-and-writes-to-memory
+  eq. ++> can-read-from-bytes-and-write-to-memory
     malloc.of
       5
       read. > [mem]
@@ -49,7 +49,7 @@
         5
     01-02-03-04-05
 
-  eq. ++> tests-reads-from-bytes-and-writes-to-memory-by-portions
+  eq. ++> can-read-from-bytes-and-write-to-memory-by-portions
     malloc.of
       5
       seq * > [m]
@@ -65,7 +65,7 @@
         m
     01-02-03-04-05
 
-  ++> tests-reads-from-bytes-and-writes-to-two-memory-blocks
+  ++> can-read-from-bytes-and-write-to-two-memory-blocks
     eq. > @
       malloc.of
         6

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -74,22 +74,25 @@
         scope m
   [size scope] > of /Q.bytes
 
-  malloc.for ++> copies-and-resizes-to-target
-    0
-    seq * > [m]
-      m.copy
-        3
-        9
-        1
-      m.size.eq 10
+  ++> can-allocate-a-block-of-the-right-size
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          10
+          b.put > [m] >>
+            m.size.eq 10
 
-  eq. ++> tests-allocates-zero-bytes
+  malloc.empty ++> can-allocate-an-empty-block
+    m.size.eq 0 > [m]
+
+  eq. ++> can-allocate-zero-bytes
     0
     malloc.of
       0
       m.size > [m]
 
-  ++> tests-calculates-only-once
+  ++> can-calculate-only-once
     eq. > @
       malloc.for 0 x
       1
@@ -102,48 +105,7 @@
           m.as-number.plus 1
         42
 
-  ++> tests-constant-defends-against-side-effects
-    eq. > @
-      malloc.for
-        7
-        [m] >>
-          m.put > @
-            num.times num
-          number (inc m)! > num
-      64
-    seq * > [x] > inc
-      x.put
-        x.as-number.plus 1
-      x.as-number
-
-  malloc.for ++> tests-copies-data-from-start-to-end
-    01-02-03-04-05-06
-    and. > [m]
-      m.copy
-        0
-        3
-        3
-      m.get.eq 01-02-03-01-02-03
-
-  malloc.for ++> tests-copies-data-inside-itself
-    01-02-03-04-05
-    and. > [m]
-      m.copy
-        1
-        2
-        2
-      m.get.eq 01-02-02-03-05
-
-  ++> tests-malloc-allocates-right-size-block
-    malloc.of > @
-      1
-      [b]
-        malloc.of > @
-          10
-          b.put > [m] >>
-            m.size.eq 10
-
-  ++> tests-malloc-concacts-strings-with-offset
+  ++> can-concat-strings-with-an-offset
     malloc.of > @
       1
       [b]
@@ -157,7 +119,46 @@
                 m.read 0 3
                 "XYX"
 
-  ++> tests-malloc-decreases-block-size
+  malloc.for ++> can-copy-and-resize-to-a-target
+    0
+    seq * > [m]
+      m.copy
+        3
+        9
+        1
+      m.size.eq 10
+
+  malloc.for ++> can-copy-data-from-start-to-end
+    01-02-03-04-05-06
+    and. > [m]
+      m.copy
+        0
+        3
+        3
+      m.get.eq 01-02-03-01-02-03
+
+  malloc.for ++> can-copy-data-inside-itself
+    01-02-03-04-05
+    and. > [m]
+      m.copy
+        1
+        2
+        2
+      m.get.eq 01-02-02-03-05
+
+  ++> can-dataize-a-scope-twice
+    2.eq > @
+      malloc.for
+        0
+        [f]
+          seq > @
+            * second second
+          malloc.of > second
+            1
+            f.put > [s] >>
+              f.as-number.plus 1
+
+  ++> can-decrease-the-block-size
     malloc.of > @
       1
       [b]
@@ -168,26 +169,31 @@
               eq. (m.resized 3).size 3
               m.get.eq 01-02-03
 
-  eq. ++> tests-malloc-empty-grows-on-first-put
-    malloc.empty
-      m.put 42 > [m]
-    42
+  ++> can-defend-a-constant-against-side-effects
+    eq. > @
+      malloc.for
+        7
+        [m] >>
+          m.put > @
+            num.times num
+          number (inc m)! > num
+      64
+    seq * > [x] > inc
+      x.put
+        x.as-number.plus 1
+      x.as-number
 
-  malloc.empty ++> tests-malloc-empty-is-empty
-    m.size.eq 0 > [m]
-
-  eq. ++> tests-malloc-for-writes-first-init-value
-    malloc.for
-      42
-      m > [m]
-    42
-
-  malloc.of ++> tests-malloc-gives-id-to-allocated-block
+  malloc.of ++> can-give-an-id-to-an-allocated-block
     1
     m.put > [m]
       m.id.gt 0
 
-  ++> tests-malloc-increases-block-size
+  eq. ++> can-grow-an-empty-block-on-the-first-put
+    malloc.empty
+      m.put 42 > [m]
+    42
+
+  ++> can-increase-the-block-size
     malloc.of > @
       1
       [b]
@@ -198,23 +204,35 @@
               eq. (m.resized 6).size 6
               m.get.eq 01-02-03-04-00-00
 
-  eq. ++> tests-malloc-is-strictly-sized-int
-    malloc.for
-      12248
-      m.put 2556 > [m]
-    2556
-
-  malloc.for ++> tests-malloc-is-strictly-typed-bool
+  malloc.for ++> can-keep-the-size-of-a-bool-block
     false
     m.put true > [m]
 
-  eq. ++> tests-malloc-is-strictly-typed-float
+  eq. ++> can-keep-the-size-of-a-float-block
     malloc.for
       245.88
       m.put 82.22 > [m]
     82.22
 
-  ++> tests-malloc-puts-over-the-previous-data
+  eq. ++> can-keep-the-size-of-a-string-block
+    malloc.for
+      "Hello"
+      m.put "Prot" > [m]
+    "Proto"
+
+  eq. ++> can-keep-the-size-of-an-integer-block
+    malloc.for
+      12248
+      m.put 2556 > [m]
+    2556
+
+  ++> can-put-into-a-block-made-by-for
+    mem.eq 10 > @
+    malloc.for > mem
+      0
+      m.put 10 > [m]
+
+  ++> can-put-over-the-previous-data
     eq. > @
       42.as-bytes.concat "orld!".as-bytes
       mem
@@ -225,16 +243,7 @@
           "Hello, world!"
         m.put 42
 
-  eq. ++> tests-malloc-read-over-a-limit-returns-fallback
-    01-02
-    malloc.of
-      1
-      m.read > [m]
-        0
-        10
-        01-02 > [ex]
-
-  ++> tests-malloc-reads-with-offset-and-length
+  ++> can-read-with-an-offset-and-a-length
     malloc.of > @
       1
       [b]
@@ -247,7 +256,27 @@
                 m.read 2 5
                 "Hello"
 
-  ++> tests-malloc-rewrites-and-increments-itself
+  ++> can-recurse-without-arguments
+    eq. > @
+      malloc.for
+        4
+        func m > [m] >>
+      0
+    if. > [n] >> func
+      n.as-number.gt 0
+      seq *
+        n.put
+          n.as-number.minus 1
+        func n
+      n
+
+  eq. ++> can-return-the-size-from-a-scope
+    malloc.of
+      5
+      m.size > [m]
+    5
+
+  ++> can-rewrite-and-increment-itself
     mem.eq 6 > @
     malloc.of > mem
       8
@@ -256,19 +285,7 @@
         m.put
           m.as-number.plus 5
 
-  ++> tests-malloc-scope-is-dataized-twice
-    2.eq > @
-      malloc.for
-        0
-        [f]
-          seq > @
-            * second second
-          malloc.of > second
-            1
-            f.put > [s] >>
-              f.as-number.plus 1
-
-  ++> tests-malloc-writes-and-reads
+  ++> can-write-and-read
     malloc.of > @
       1
       [b]
@@ -284,39 +301,13 @@
                 m.read 0 12
                 "Hello, Jeff!"
 
-  eq. ++> tests-memory-is-strictly-sized-string
-    malloc.for
-      "Hello"
-      m.put "Prot" > [m]
-    "Proto"
+  malloc.of ++> can-write-beyond-an-offset-and-resize
+    1
+    seq * > [m]
+      m.write 1 true
+      m.size.eq 2
 
-  ++> tests-puts-into-memory-for
-    mem.eq 10 > @
-    malloc.for > mem
-      0
-      m.put 10 > [m]
-
-  ++> tests-recursion-without-arguments
-    eq. > @
-      malloc.for
-        4
-        func m > [m] >>
-      0
-    if. > [n] >> func
-      n.as-number.gt 0
-      seq *
-        n.put
-          n.as-number.minus 1
-        func n
-      n
-
-  eq. ++> tests-returns-size-from-scope
-    malloc.of
-      5
-      m.size > [m]
-    5
-
-  ++> tests-writes-into-memory-of
+  ++> can-write-into-a-block-made-by-of
     mem.eq 10 > @
     malloc.of > mem
       8
@@ -324,7 +315,7 @@
         m.write 0 10
         m
 
-  and. ++> tests-writes-into-two-malloc-objects
+  and. ++> can-write-into-two-allocated-blocks
     eq.
       malloc.of
         8
@@ -336,44 +327,53 @@
         m.put 20 > [m]
       20
 
-  malloc.of ++> writes-beyond-offset-and-resizes
-    1
-    seq * > [m]
-      m.write 1 true
-      m.size.eq 2
+  eq. ++> can-write-the-initial-value
+    malloc.for
+      42
+      m > [m]
+    42
 
-  malloc.of --> on-changing-size-to-fractional
+  eq. ++> rejects-reading-over-the-limit
+    01-02
+    malloc.of
+      1
+      m.read > [m]
+        0
+        10
+        01-02 > [ex]
+
+  malloc.of --> stops-on-changing-the-size-to-a-fraction
     1
     m.resized 1.5 > [m]
 
-  malloc.of --> on-changing-size-to-negative
+  malloc.of --> stops-on-changing-the-size-to-a-negative
     1
     m.resized -1 > [m]
 
-  malloc.for --> on-copying-with-wrong-length
+  malloc.for --> stops-on-copying-with-a-wrong-length
     0
     m.copy > [m]
       3
       1
       9
 
-  malloc.for --> on-copying-with-wrong-source
+  malloc.for --> stops-on-copying-with-a-wrong-source
     0
     m.copy > [m]
       9
       1
       1
 
-  malloc.for --> on-overflow-boolean-malloc
+  malloc.for --> stops-on-overflowing-a-bool-block
     false
     m.put 8.612486788E7 > [m]
 
-  malloc.for --> on-overflow-string-malloc
+  malloc.for --> stops-on-overflowing-a-string-block
     "Hello"
     m.put > [m]
       "Much longer string!"
 
-  malloc.for --> on-reading-over-a-limit-without-fallback
+  malloc.for --> stops-on-reading-over-the-limit
     10
     m.read > [m]
       0

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -115,7 +115,7 @@
         key.as-bytes >> kbts!
   [key value] > entry
 
-  ++> tests-adds-key-colliding-with-existing-one
+  ++> can-add-a-key-colliding-with-an-existing-one
     and. > @
       2.eq mp.size
       2.eq
@@ -127,7 +127,7 @@
       "BB"
       2
 
-  ++> tests-adds-new-pair-to-hash-map
+  ++> can-add-a-new-pair
     and. > @
       2.eq mp.size
       mp.has "two"
@@ -137,45 +137,7 @@
       "two"
       2
 
-  eq. ++> tests-does-not-change-map-without-non-existed-element
-    size.
-      without.
-        map *
-          map.entry "one" 1
-        "two"
-    1
-
-  not. ++> tests-does-not-find-element-by-key-in-hash-map
-    exists.
-      found.
-        map *
-          map.entry "one" 1
-          map.entry "two" 2
-        "three"
-
-  not. ++> tests-does-not-have-absent-key-colliding-with-stored-one
-    has.
-      map *
-        map.entry "Aa" 1
-      "BB"
-
-  not. ++> tests-does-not-have-element-by-key-in-hash-map
-    has.
-      map *
-        map.entry "one" 1
-        map.entry "two" 2
-      "three"
-
-  eq. ++> tests-falls-back-for-absent-key-colliding-with-stored-one
-    "recovered"
-    get.
-      found.
-        map *
-          map.entry "Aa" 1
-        "BB"
-      "recovered" > [message]
-
-  ++> tests-finds-element-by-key-in-map
+  ++> can-find-an-element-by-a-key
     2.eq found.get > @
     mp.found "two" > found
     map * > mp
@@ -183,7 +145,7 @@
       map.entry "two" 2
       map.entry "three" 3
 
-  ++> tests-finds-value-of-each-key-with-colliding-hash-codes
+  ++> can-find-the-value-of-each-key-with-colliding-hashes
     and. > @
       1.eq first.get
       2.eq second.get
@@ -193,19 +155,19 @@
       map.entry "BB" 2
     mp.found "BB" > second
 
-  has. ++> tests-has-element-with-key-in-hash-map
+  has. ++> can-have-an-element-with-a-key
     map *
       map.entry "one" 1
       map.entry "two" 2
     "two"
 
-  ++> tests-keeps-both-keys-with-colliding-hash-codes
+  ++> can-keep-both-keys-with-colliding-hashes
     2.eq mp.size > @
     map * > mp
       map.entry "Aa" 1
       map.entry "BB" 2
 
-  ++> tests-map-construction-keeps-last-value-for-duplicate-key
+  ++> can-keep-the-last-value-of-a-duplicate-key
     2.eq > @
       get.
         mp.found 1
@@ -214,15 +176,7 @@
       map.entry 1 1
       map.entry 1 2
 
-  ++> tests-map-get-missing-returns-provided-fallback
-    "recovered".eq > @
-      get.
-        mp.found "absent"
-        "recovered" > [message]
-    map * > mp
-      map.entry "one" 1
-
-  ++> tests-map-rebuilds-itself
+  ++> can-rebuild-itself
     2.eq mp.size > @
     map * > mp
       map.entry 1 1
@@ -230,7 +184,7 @@
       map.entry 2 1
       map.entry 2 1
 
-  ++> tests-map-rebuilds-itself-only-once
+  ++> can-rebuild-itself-only-once
     1.eq > @
       malloc.for
         0
@@ -247,7 +201,7 @@
                 m.as-number.plus 1
               1
 
-  ++> tests-removes-element-from-map-by-key
+  ++> can-remove-an-element-by-a-key
     and. > @
       1.eq mp.size
       not.
@@ -258,7 +212,7 @@
         map.entry "two" 2
       "one"
 
-  ++> tests-removes-only-the-given-key-of-colliding-ones
+  ++> can-remove-only-the-given-key-of-colliding-ones
     and. > @
       not.
         mp.has "Aa"
@@ -269,7 +223,7 @@
         map.entry "BB" 2
       "Aa"
 
-  ++> tests-replaces-value-if-pair-with-key-exists-in-map
+  ++> can-replace-the-value-of-an-existing-key
     and. > @
       2.eq mp.size
       3.eq
@@ -282,7 +236,7 @@
       "two"
       3
 
-  eq. ++> tests-returns-list-of-keys
+  eq. ++> can-return-the-list-of-keys
     keys.
       map *
         map.entry 1 2
@@ -293,7 +247,7 @@
       2
       3
 
-  eq. ++> tests-returns-list-of-values
+  eq. ++> can-return-the-list-of-values
     values.
       map *
         map.entry 1 2
@@ -304,7 +258,53 @@
       3
       4
 
-  --> on-map-get-missing-without-fallback
+  eq. ++> cannot-change-without-an-absent-element
+    size.
+      without.
+        map *
+          map.entry "one" 1
+        "two"
+    1
+
+  not. ++> cannot-find-an-element-by-an-absent-key
+    exists.
+      found.
+        map *
+          map.entry "one" 1
+          map.entry "two" 2
+        "three"
+
+  not. ++> cannot-have-an-absent-key-colliding-with-a-stored-one
+    has.
+      map *
+        map.entry "Aa" 1
+      "BB"
+
+  not. ++> cannot-have-an-element-by-an-absent-key
+    has.
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "three"
+
+  eq. ++> rejects-an-absent-key-colliding-with-a-stored-one
+    "recovered"
+    get.
+      found.
+        map *
+          map.entry "Aa" 1
+        "BB"
+      "recovered" > [message]
+
+  ++> rejects-getting-a-missing-key
+    "recovered".eq > @
+      get.
+        mp.found "absent"
+        "recovered" > [message]
+    map * > mp
+      map.entry "one" 1
+
+  --> stops-on-getting-a-missing-key
     get. > @
       mp.found "absent"
     map * > mp

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -45,10 +45,10 @@
               getenv "TMPDIR" >> tmpdir!
           -- > empty
 
-  mktemp.tmpfile.exists ++> creates-tmpfile
+  mktemp.tmpfile.exists ++> can-create-a-temp-file
 
-  mktemp.exists ++> global-temp-dir-exists
+  mktemp.is-directory ++> can-point-at-a-global-temp-directory
 
-  mktemp.is-directory ++> global-temp-dir-is-directory
+  mktemp.exists ++> can-point-at-an-existing-global-temp-directory
 
-  mktemp.path.eq mktemp.path ++> returns-the-same-tmpdir
+  mktemp.path.eq mktemp.path ++> can-return-the-same-temp-directory

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -4,7 +4,7 @@
 # code, by wrapping the original body inside `nop`:
 #
 # ```
-# ++> works-just-fine
+# ++> can-work-just-fine
 #   nop > @
 #     "doesn't work for now"
 # ```
@@ -22,6 +22,6 @@
 [x] > nop
   true > @
 
-  nop "anything" ++> tests-nop-is-true
+  nop 42 ++> accepts-a-number-argument
 
-  nop 42 ++> tests-nop-with-number-is-true
+  nop "anything" ++> can-ignore-a-text-argument

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -21,22 +21,73 @@
   [x] > plus /Q.number
   [x] > times /Q.number
 
-  42.as-bytes.eq 42 ++> tests-as-bytes-equals-to-int-backwards
+  eq. ++> can-add-a-negative-float-to-negative-infinity
+    ninf.plus -42.5
+    ninf
 
-  ++> tests-calculates-fibonacci-number-with-recursion
-    eq. > @
-      fibo 4
-      3
-    if. > [n] > fibo
-      n.lt 3
-      1
-      plus.
-        fibo
-          n.minus 1
-        fibo
-          n.minus 2
+  eq. ++> can-add-a-negative-integer-to-negative-infinity
+    ninf.plus -42
+    ninf
 
-  ++> tests-calculates-fibonacci-number-with-tail
+  eq. ++> can-add-a-positive-float-to-negative-infinity
+    ninf.plus 42.5
+    ninf
+
+  eq. ++> can-add-a-positive-float-to-positive-infinity
+    pinf.plus 42.5
+    pinf
+
+  eq. ++> can-add-a-positive-integer-to-negative-infinity
+    ninf.plus 42
+    ninf
+
+  eq. ++> can-add-nan-to-negative-infinity
+    as-bytes.
+      ninf.plus nan
+    nan.as-bytes
+
+  eq. ++> can-add-nan-to-positive-infinity
+    as-bytes.
+      pinf.plus nan
+    nan.as-bytes
+
+  ninf.eq ++> can-add-negative-infinity-to-negative-infinity
+    ninf.plus ninf
+
+  eq. ++> can-add-negative-infinity-to-positive-infinity
+    as-bytes.
+      pinf.plus ninf
+    nan.as-bytes
+
+  eq. ++> can-add-one-to-one
+    1.plus 1
+    2
+
+  eq. ++> can-add-positive-infinity-to-negative-infinity
+    as-bytes.
+      ninf.plus pinf
+    nan.as-bytes
+
+  eq. ++> can-add-positive-infinity-to-positive-infinity
+    pinf.plus pinf
+    pinf
+
+  lt. ++> can-approximate-a-square-root
+    abs.
+      9.sqrt.minus 3
+    1.0E-9
+
+  pinf.gt 42.5 ++> can-be-greater-than-a-float-when-positive-infinity
+
+  eq. ++> can-be-greater-than-a-smaller-integer
+    -200.gt -1000
+    true
+
+  pinf.gt 42 ++> can-be-greater-than-an-integer-when-positive-infinity
+
+  pinf.gt ninf ++> can-be-greater-than-negative-infinity-when-positive-infinity
+
+  ++> can-calculate-fibonacci-with-a-tail-call
     eq. > @
       fibonacci 4
       3
@@ -57,356 +108,305 @@
         1
         n
 
-  eq. ++> tests-div-for-dividend-greater-than-zero
+  ++> can-calculate-fibonacci-with-recursion
+    eq. > @
+      fibo 4
+      3
+    if. > [n] > fibo
+      n.lt 3
+      1
+      plus.
+        fibo
+          n.minus 1
+        fibo
+          n.minus 2
+
+  42.as-bytes.eq 42 ++> can-compare-its-bytes-to-an-integer
+
+  42.as-bytes.eq 42 ++> can-convert-to-bytes-and-back
+
+  eq. ++> can-divide-a-positive-dividend
     256.div 16
     16
 
-  lt. ++> tests-div-less-than-one
-    1.div 5
-    1
-
-  eq. ++> tests-div-with-remainder
-    floor.
-      13.div -5
-    -3
-
-  ++> tests-division-by-one
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1
       dividend
     -235 > dividend
 
-  eq. ++> tests-int-greater-equal
-    not.
-      0.gt 0
+  seq * ++> can-divide-by-zero
+    2.div 0
     true
 
-  eq. ++> tests-int-greater-false
-    not.
-      0.gt 100
-    true
+  lt. ++> can-divide-into-less-than-one
+    1.div 5
+    1
 
-  eq. ++> tests-int-greater-true
-    -200.gt -1000
-    true
+  eq. ++> can-divide-negative-infinity-by-a-negative-float
+    ninf.div -42.5
+    pinf
 
-  eq. ++> tests-multiply-by-zero
-    1000.times 0
-    0
+  eq. ++> can-divide-negative-infinity-by-a-negative-integer
+    ninf.div -42
+    pinf
 
-  nan.as-bytes.eq ++> tests-nan-as-bytes-is-bytes-of-zero-div-zero
-    as-bytes.
-      0.div 0
+  eq. ++> can-divide-negative-infinity-by-a-positive-float
+    ninf.div 42.5
+    ninf
 
-  eq. ++> tests-nan-not-gt-nan
-    nan.gt nan
-    false
+  eq. ++> can-divide-negative-infinity-by-a-positive-integer
+    ninf.div 42
+    ninf
 
-  eq. ++> tests-nan-not-gt-number
-    nan.gt 42
-    false
-
-  ninf.as-bytes.eq ++> tests-negative-infinity-as-bytes-is-valid
-    as-bytes.
-      -1.div 0
-
-  eq. ++> tests-negative-infinity-div-float-zero
+  eq. ++> can-divide-negative-infinity-by-float-zero
     ninf.div 0
     ninf
 
-  eq. ++> tests-negative-infinity-div-int-zero
+  eq. ++> can-divide-negative-infinity-by-integer-zero
     ninf.div 0
     ninf
 
-  eq. ++> tests-negative-infinity-div-nan
+  eq. ++> can-divide-negative-infinity-by-nan
     as-bytes.
       ninf.div nan
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-div-neg-float-zero
+  eq. ++> can-divide-negative-infinity-by-negative-float-zero
     ninf.div -0
     pinf
 
-  eq. ++> tests-negative-infinity-div-neg-int-zero
-    ninf.div -0
-    pinf
-
-  eq. ++> tests-negative-infinity-div-negative-float
-    ninf.div -42.5
-    pinf
-
-  eq. ++> tests-negative-infinity-div-negative-infinity
+  eq. ++> can-divide-negative-infinity-by-negative-infinity
     as-bytes.
       ninf.div ninf
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-div-negative-int
-    ninf.div -42
+  eq. ++> can-divide-negative-infinity-by-negative-integer-zero
+    ninf.div -0
     pinf
 
-  eq. ++> tests-negative-infinity-div-positive-float
-    ninf.div 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-div-positive-infinity
+  eq. ++> can-divide-negative-infinity-by-positive-infinity
     as-bytes.
       ninf.div pinf
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-div-positive-int
-    ninf.div 42
+  eq. ++> can-divide-positive-infinity-by-a-negative-float
+    pinf.div -42.5
     ninf
 
-  not. ++> tests-negative-infinity-gt-negative-infinity
-    ninf.gt ninf
+  eq. ++> can-divide-positive-infinity-by-a-negative-integer
+    pinf.div -42
+    ninf
 
-  ninf.eq ++> tests-negative-infinity-is-equal-to-one-div-zero
+  eq. ++> can-divide-positive-infinity-by-a-positive-float
+    pinf.div 42.5
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-a-positive-integer
+    pinf.div 42
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-float-zero
+    pinf.div 0
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-integer-zero
+    pinf.div 0
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-nan
+    as-bytes.
+      pinf.div nan
+    nan.as-bytes
+
+  eq. ++> can-divide-positive-infinity-by-negative-float-zero
+    pinf.div -0
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-negative-infinity
+    as-bytes.
+      pinf.div ninf
+    nan.as-bytes
+
+  eq. ++> can-divide-positive-infinity-by-negative-integer-zero
+    pinf.div -0
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-positive-infinity
+    as-bytes.
+      pinf.div pinf
+    nan.as-bytes
+
+  eq. ++> can-divide-with-a-remainder
+    floor.
+      13.div -5
+    -3
+
+  ninf.eq ++> can-equal-minus-one-divided-by-zero-when-negative-infinity
     -1.div 0
 
-  eq. ++> tests-negative-infinity-not-gt-float
-    ninf.gt 42.5
-    false
+  pinf.eq ++> can-equal-one-divided-by-zero-when-positive-infinity
+    1.div 0
 
-  eq. ++> tests-negative-infinity-not-gt-int
-    ninf.gt 42
-    false
-
-  eq. ++> tests-negative-infinity-not-gt-nan
-    ninf.gt nan
-    false
-
-  eq. ++> tests-negative-infinity-not-gt-positive-infinity
-    ninf.gt pinf
-    false
-
-  eq. ++> tests-negative-infinity-plus-nan
+  nan.as-bytes.eq ++> can-expose-the-bytes-of-nan
     as-bytes.
-      ninf.plus nan
-    nan.as-bytes
+      0.div 0
 
-  eq. ++> tests-negative-infinity-plus-negative-float
-    ninf.plus -42.5
-    ninf
-
-  ninf.eq ++> tests-negative-infinity-plus-negative-infinity
-    ninf.plus ninf
-
-  eq. ++> tests-negative-infinity-plus-negative-int
-    ninf.plus -42
-    ninf
-
-  eq. ++> tests-negative-infinity-plus-positive-float
-    ninf.plus 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-plus-positive-infinity
+  ninf.as-bytes.eq ++> can-expose-the-bytes-of-negative-infinity
     as-bytes.
-      ninf.plus pinf
-    nan.as-bytes
+      -1.div 0
 
-  eq. ++> tests-negative-infinity-plus-positive-int
-    ninf.plus 42
+  pinf.as-bytes.eq ++> can-expose-the-bytes-of-positive-infinity
+    as-bytes.
+      1.div 0
+
+  eq. ++> can-multiply-by-zero
+    1000.times 0
+    0
+
+  eq. ++> can-multiply-negative-infinity-by-a-negative-float
+    ninf.times -42.5
+    pinf
+
+  eq. ++> can-multiply-negative-infinity-by-a-negative-integer
+    ninf.times -42
+    pinf
+
+  eq. ++> can-multiply-negative-infinity-by-a-positive-float
+    ninf.times 42.5
     ninf
 
-  eq. ++> tests-negative-infinity-times-float-zero
+  eq. ++> can-multiply-negative-infinity-by-a-positive-integer
+    ninf.times 42
+    ninf
+
+  eq. ++> can-multiply-negative-infinity-by-float-zero
     as-bytes.
       ninf.times 0
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-times-int-zero
+  eq. ++> can-multiply-negative-infinity-by-integer-zero
     as-bytes.
       ninf.times 0
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-times-nan
+  eq. ++> can-multiply-negative-infinity-by-nan
     as-bytes.
       ninf.times nan
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-times-neg-float-zero
+  eq. ++> can-multiply-negative-infinity-by-negative-float-zero
     as-bytes.
       ninf.times -0
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-times-negative-float
-    ninf.times -42.5
-    pinf
-
-  eq. ++> tests-negative-infinity-times-negative-infinity
+  eq. ++> can-multiply-negative-infinity-by-negative-infinity
     ninf.times ninf
     pinf
 
-  eq. ++> tests-negative-infinity-times-negative-int
-    ninf.times -42
-    pinf
-
-  eq. ++> tests-negative-infinity-times-positive-float
-    ninf.times 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-times-positive-infinity
+  eq. ++> can-multiply-negative-infinity-by-positive-infinity
     ninf.times pinf
     ninf
 
-  eq. ++> tests-negative-infinity-times-positive-int
-    ninf.times 42
+  eq. ++> can-multiply-positive-infinity-by-a-negative-float
+    pinf.times -42.5
     ninf
 
-  eq. ++> tests-one-plus-one
-    1.plus 1
-    2
+  eq. ++> can-multiply-positive-infinity-by-a-negative-integer
+    pinf.times -42
+    ninf
 
-  -17.9.abs.eq 17.9 ++> tests-package-absolute-of-negative
+  eq. ++> can-multiply-positive-infinity-by-a-positive-float
+    pinf.times 42.5
+    pinf
 
-  eq. ++> tests-package-modulo-of-two-numbers
-    7.mod 3
-    1
+  eq. ++> can-multiply-positive-infinity-by-a-positive-integer
+    pinf.times 42
+    pinf
 
-  eq. ++> tests-package-power-via-number-namespace
+  eq. ++> can-multiply-positive-infinity-by-float-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-integer-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-nan
+    as-bytes.
+      pinf.times nan
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-negative-float-zero
+    as-bytes.
+      pinf.times -0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-negative-infinity
+    pinf.times ninf
+    ninf
+
+  eq. ++> can-multiply-positive-infinity-by-positive-infinity
+    pinf.times pinf
+    pinf
+
+  eq. ++> can-raise-to-a-power
+    2.power 4
+    16
+
+  eq. ++> can-raise-to-a-power-through-the-package
     number.power
       2
       5
     32
 
-  eq. ++> tests-package-raises-to-power
-    2.power 4
-    16
+  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative
 
-  lt. ++> tests-package-square-root-approximates
-    abs.
-      9.sqrt.minus 3
-    1.0E-9
+  eq. ++> can-take-the-modulo-of-two-numbers
+    7.mod 3
+    1
 
-  pinf.as-bytes.eq ++> tests-positive-infinity-as-bytes-is-valid
-    as-bytes.
-      1.div 0
+  eq. ++> cannot-be-greater-than-a-float-when-negative-infinity
+    ninf.gt 42.5
+    false
 
-  eq. ++> tests-positive-infinity-div-float-zero
-    pinf.div 0
-    pinf
+  eq. ++> cannot-be-greater-than-a-larger-integer
+    not.
+      0.gt 100
+    true
 
-  eq. ++> tests-positive-infinity-div-int-zero
-    pinf.div 0
-    pinf
+  eq. ++> cannot-be-greater-than-a-number-when-nan
+    nan.gt 42
+    false
 
-  eq. ++> tests-positive-infinity-div-nan
-    as-bytes.
-      pinf.div nan
-    nan.as-bytes
+  eq. ++> cannot-be-greater-than-an-equal-integer
+    not.
+      0.gt 0
+    true
 
-  eq. ++> tests-positive-infinity-div-neg-float-zero
-    pinf.div -0
-    ninf
+  eq. ++> cannot-be-greater-than-an-integer-when-negative-infinity
+    ninf.gt 42
+    false
 
-  eq. ++> tests-positive-infinity-div-neg-int-zero
-    pinf.div -0
-    ninf
+  not. ++> cannot-be-greater-than-itself-when-negative-infinity
+    ninf.gt ninf
 
-  eq. ++> tests-positive-infinity-div-negative-float
-    pinf.div -42.5
-    ninf
-
-  eq. ++> tests-positive-infinity-div-negative-infinity
-    as-bytes.
-      pinf.div ninf
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-div-negative-int
-    pinf.div -42
-    ninf
-
-  eq. ++> tests-positive-infinity-div-positive-float
-    pinf.div 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-div-positive-infinity
-    as-bytes.
-      pinf.div pinf
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-div-positive-int
-    pinf.div 42
-    pinf
-
-  pinf.gt 42.5 ++> tests-positive-infinity-gt-float
-
-  pinf.gt 42 ++> tests-positive-infinity-gt-int
-
-  pinf.gt ninf ++> tests-positive-infinity-gt-negative-infinity
-
-  not. ++> tests-positive-infinity-gt-positive-infinity
+  not. ++> cannot-be-greater-than-itself-when-positive-infinity
     pinf.gt pinf
 
-  pinf.eq ++> tests-positive-infinity-is-equal-to-one-div-zero
-    1.div 0
+  eq. ++> cannot-be-greater-than-nan-when-nan
+    nan.gt nan
+    false
 
-  not. ++> tests-positive-infinity-not-gt-nan
+  eq. ++> cannot-be-greater-than-nan-when-negative-infinity
+    ninf.gt nan
+    false
+
+  not. ++> cannot-be-greater-than-nan-when-positive-infinity
     pinf.gt nan
 
-  eq. ++> tests-positive-infinity-plus-nan
-    as-bytes.
-      pinf.plus nan
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-plus-negative-infinity
-    as-bytes.
-      pinf.plus ninf
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-plus-positive-float
-    pinf.plus 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-plus-positive-infinity
-    pinf.plus pinf
-    pinf
-
-  eq. ++> tests-positive-infinity-times-float-zero
-    as-bytes.
-      pinf.times 0
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-times-int-zero
-    as-bytes.
-      pinf.times 0
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-times-nan
-    as-bytes.
-      pinf.times nan
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-times-neg-float-zero
-    as-bytes.
-      pinf.times -0
-    nan.as-bytes
-
-  eq. ++> tests-positive-infinity-times-negative-float
-    pinf.times -42.5
-    ninf
-
-  eq. ++> tests-positive-infinity-times-negative-infinity
-    pinf.times ninf
-    ninf
-
-  eq. ++> tests-positive-infinity-times-negative-int
-    pinf.times -42
-    ninf
-
-  eq. ++> tests-positive-infinity-times-positive-float
-    pinf.times 42.5
-    pinf
-
-  eq. ++> tests-positive-infinity-times-positive-infinity
-    pinf.times pinf
-    pinf
-
-  eq. ++> tests-positive-infinity-times-positive-int
-    pinf.times 42
-    pinf
-
-  42.as-bytes.eq 42 ++> tests-to-bytes-and-backwards
-
-  seq * ++> tests-zero-division
-    2.div 0
-    true
+  eq. ++> cannot-be-greater-than-positive-infinity-when-negative-infinity
+    ninf.gt pinf
+    false

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -15,27 +15,27 @@
     0.plus value
     value.neg
 
-  eq. ++> tests-abs-float-negative
-    abs -17.9
-    17.9
-
-  eq. ++> tests-abs-float-positive
-    abs 13.5
-    13.5
-
-  eq. ++> tests-abs-int-negative
-    abs -3
-    3
-
-  eq. ++> tests-abs-int-positive
-    abs 3
-    3
-
-  eq. ++> tests-abs-negative-zero-normalizes-sign
+  eq. ++> can-normalize-the-sign-of-negative-zero
     as-bytes.
       abs -0
     00-00-00-00-00-00-00-00
 
-  eq. ++> tests-abs-zero
+  eq. ++> can-take-the-absolute-value-of-a-negative-float
+    abs -17.9
+    17.9
+
+  eq. ++> can-take-the-absolute-value-of-a-negative-integer
+    abs -3
+    3
+
+  eq. ++> can-take-the-absolute-value-of-a-positive-float
+    abs 13.5
+    13.5
+
+  eq. ++> can-take-the-absolute-value-of-a-positive-integer
+    abs 3
+    3
+
+  eq. ++> can-take-the-absolute-value-of-zero
     abs 0
     0

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,23 +15,11 @@
     pi.div 2
     arc-sine num
 
-  is-nan. ++> tests-arc-cosine-above-one-is-nan
-    arc-cosine 2
-
-  is-nan. ++> tests-arc-cosine-below-minus-one-is-nan
-    arc-cosine -2
-
-  is-nan. ++> tests-arc-cosine-of-nan-is-nan
-    arc-cosine nan
-
-  is-nan. ++> tests-arc-cosine-of-negative-infinity-is-nan
-    arc-cosine ninf
-
-  eq. ++> tests-arc-cosine-of-negative-one-is-pi
+  eq. ++> can-take-an-arc-cosine-of-minus-one
     arc-cosine -1
     pi
 
-  lt. ++> tests-arc-cosine-of-negative-point-six
+  lt. ++> can-take-an-arc-cosine-of-minus-zero-point-six
     abs
       minus.
         times.
@@ -40,11 +28,15 @@
         2214.297
     1
 
-  eq. ++> tests-arc-cosine-of-one-is-zero
+  eq. ++> can-take-an-arc-cosine-of-one
     arc-cosine 1
     0
 
-  lt. ++> tests-arc-cosine-of-point-six
+  eq. ++> can-take-an-arc-cosine-of-zero
+    arc-cosine 0
+    pi.div 2
+
+  lt. ++> can-take-an-arc-cosine-of-zero-point-six
     abs
       minus.
         times.
@@ -53,9 +45,17 @@
         927.295
     1
 
-  is-nan. ++> tests-arc-cosine-of-positive-infinity-is-nan
-    arc-cosine pinf
+  is-nan. ++> cannot-take-an-arc-cosine-above-one
+    arc-cosine 2
 
-  eq. ++> tests-arc-cosine-of-zero-is-pi-halves
-    arc-cosine 0
-    pi.div 2
+  is-nan. ++> cannot-take-an-arc-cosine-below-minus-one
+    arc-cosine -2
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-nan
+    arc-cosine nan
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-negative-infinity
+    arc-cosine ninf
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-positive-infinity
+    arc-cosine pinf

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -47,13 +47,7 @@
         series magnitude
     base
 
-  is-nan. ++> tests-arc-sine-above-one-is-nan
-    arc-sine 2
-
-  is-nan. ++> tests-arc-sine-below-minus-one-is-nan
-    arc-sine -2
-
-  lt. ++> tests-arc-sine-is-odd-function
+  lt. ++> can-behave-as-an-odd-function
     abs
       times.
         plus.
@@ -62,7 +56,7 @@
         1000
     1
 
-  lt. ++> tests-arc-sine-of-half-is-pi-sixths
+  lt. ++> can-take-an-arc-sine-of-a-half
     abs
       minus.
         times.
@@ -73,10 +67,7 @@
           1000
     1
 
-  is-nan. ++> tests-arc-sine-of-nan-is-nan
-    arc-sine nan
-
-  lt. ++> tests-arc-sine-of-negative-half-is-minus-pi-sixths
+  lt. ++> can-take-an-arc-sine-of-minus-a-half
     abs
       minus.
         times.
@@ -88,10 +79,7 @@
           1000
     1
 
-  is-nan. ++> tests-arc-sine-of-negative-infinity-is-nan
-    arc-sine ninf
-
-  lt. ++> tests-arc-sine-of-negative-one-is-minus-pi-halves
+  lt. ++> can-take-an-arc-sine-of-minus-one
     abs
       minus.
         times.
@@ -103,7 +91,7 @@
           1000
     1
 
-  lt. ++> tests-arc-sine-of-one-is-pi-halves
+  lt. ++> can-take-an-arc-sine-of-one
     abs
       minus.
         times.
@@ -114,7 +102,11 @@
           1000
     1
 
-  lt. ++> tests-arc-sine-of-point-six
+  eq. ++> can-take-an-arc-sine-of-zero
+    arc-sine 0
+    0
+
+  lt. ++> can-take-an-arc-sine-of-zero-point-six
     abs
       minus.
         times.
@@ -123,9 +115,17 @@
         643.5
     1
 
-  is-nan. ++> tests-arc-sine-of-positive-infinity-is-nan
-    arc-sine pinf
+  is-nan. ++> cannot-take-an-arc-sine-above-one
+    arc-sine 2
 
-  eq. ++> tests-arc-sine-of-zero-is-zero
-    arc-sine 0
-    0
+  is-nan. ++> cannot-take-an-arc-sine-below-minus-one
+    arc-sine -2
+
+  is-nan. ++> cannot-take-an-arc-sine-of-nan
+    arc-sine nan
+
+  is-nan. ++> cannot-take-an-arc-sine-of-negative-infinity
+    arc-sine ninf
+
+  is-nan. ++> cannot-take-an-arc-sine-of-positive-infinity
+    arc-sine pinf

--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -54,44 +54,44 @@
               mantissa.right
                 1075.minus exp
 
-  eq. ++> tests-as-i64-converts-fraction-below-one-to-zero
+  eq. ++> can-convert-a-fraction-below-one-to-zero
     0.5.as-i64.as-bytes
     00-00-00-00-00-00-00-00
 
-  eq. ++> tests-as-i64-converts-large-number-with-left-shift
+  eq. ++> can-convert-a-large-number-with-a-left-shift
     1000000000000000000.as-i64.as-bytes
     0D-E0-B6-B3-A7-64-00-00
 
-  eq. ++> tests-as-i64-converts-long-min-boundary
-    -9.223372036854776e18.as-i64.as-bytes
-    80-00-00-00-00-00-00-00
-
-  eq. ++> tests-as-i64-converts-negative-zero-to-zero
+  eq. ++> can-convert-negative-zero-to-zero
     -0.as-i64.as-bytes
     00-00-00-00-00-00-00-00
 
-  eq. ++> tests-as-i64-truncates-negative-toward-zero
-    -3.7.as-i64.as-bytes
-    FF-FF-FF-FF-FF-FF-FF-FD
+  eq. ++> can-convert-the-long-minimum-boundary
+    -9.223372036854776e18.as-i64.as-bytes
+    80-00-00-00-00-00-00-00
 
-  eq. ++> tests-as-i64-truncates-positive-toward-zero
-    3.7.as-i64.as-bytes
-    00-00-00-00-00-00-00-03
-
-  eq. ++> tests-converts-the-origin-number-to-i64
+  eq. ++> can-convert-the-origin-number
     as-bytes.
       as-i64 42
     00-00-00-00-00-00-00-2A
 
-  eq. ++> tests-out-of-range-as-i64-returns-provided-fallback
+  eq. ++> can-truncate-a-negative-toward-zero
+    -3.7.as-i64.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FD
+
+  eq. ++> can-truncate-a-positive-toward-zero
+    3.7.as-i64.as-bytes
+    00-00-00-00-00-00-00-03
+
+  eq. ++> rejects-an-out-of-range-number
     "recovered"
     1.0e30.as-i64
       "recovered" > [message]
 
-  1.0e30.as-i64 --> on-converting-huge-number-to-i64
+  1.0e30.as-i64 --> stops-on-converting-a-huge-number
 
-  9.223372036854776e18.as-i64 --> on-converting-long-max-boundary-to-i64
+  nan.as-i64 --> stops-on-converting-nan
 
-  nan.as-i64 --> on-converting-nan-to-i64
+  pinf.as-i64 --> stops-on-converting-positive-infinity
 
-  pinf.as-i64 --> on-converting-positive-infinity-to-i64
+  9.223372036854776e18.as-i64 --> stops-on-converting-the-long-maximum-boundary

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -13,7 +13,7 @@
     num.plus
       pi.div 2
 
-  lt. ++> tests-cosine-is-even-function
+  lt. ++> can-behave-as-an-even-function
     abs
       times.
         minus.
@@ -23,61 +23,7 @@
         1000
     1
 
-  is-nan. ++> tests-cosine-of-nan-is-nan
-    cosine nan
-
-  is-nan. ++> tests-cosine-of-negative-infinity-is-nan
-    cosine ninf
-
-  lt. ++> tests-cosine-of-pi-halves-is-zero
-    abs
-      times.
-        cosine
-          pi.div 2
-        1000
-    1
-
-  lt. ++> tests-cosine-of-pi-is-minus-one
-    abs
-      minus.
-        times.
-          cosine pi
-          1000
-        -1000
-    1
-
-  lt. ++> tests-cosine-of-pi-thirds-is-half
-    abs
-      minus.
-        times.
-          cosine
-            pi.div 3
-          1000
-        500
-    1
-
-  is-nan. ++> tests-cosine-of-positive-infinity-is-nan
-    cosine pinf
-
-  lt. ++> tests-cosine-of-seventeen-radians
-    abs
-      minus.
-        times.
-          cosine 17
-          1000
-        -275
-    1
-
-  lt. ++> tests-cosine-of-zero-is-one
-    abs
-      minus.
-        times.
-          cosine 0
-          1000
-        1000
-    1
-
-  lt. ++> tests-cosine-reduces-large-angle
+  lt. ++> can-reduce-a-large-angle
     abs
       minus.
         times.
@@ -88,3 +34,57 @@
           1000
         500
     1
+
+  lt. ++> can-take-a-cosine-of-pi
+    abs
+      minus.
+        times.
+          cosine pi
+          1000
+        -1000
+    1
+
+  lt. ++> can-take-a-cosine-of-pi-halves
+    abs
+      times.
+        cosine
+          pi.div 2
+        1000
+    1
+
+  lt. ++> can-take-a-cosine-of-pi-thirds
+    abs
+      minus.
+        times.
+          cosine
+            pi.div 3
+          1000
+        500
+    1
+
+  lt. ++> can-take-a-cosine-of-seventeen-radians
+    abs
+      minus.
+        times.
+          cosine 17
+          1000
+        -275
+    1
+
+  lt. ++> can-take-a-cosine-of-zero
+    abs
+      minus.
+        times.
+          cosine 0
+          1000
+        1000
+    1
+
+  is-nan. ++> cannot-take-a-cosine-of-nan
+    cosine nan
+
+  is-nan. ++> cannot-take-a-cosine-of-negative-infinity
+    cosine ninf
+
+  is-nan. ++> cannot-take-a-cosine-of-positive-infinity
+    cosine pinf

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -15,17 +15,14 @@
       180
     pi
 
-  is-nan. ++> tests-degrees-of-nan-is-nan
-    degrees nan
-
-  lt. ++> tests-degrees-of-negative-pi-is-minus-half-turn
+  lt. ++> can-convert-minus-pi-to-degrees
     abs
       minus.
         degrees pi.neg
         -180
     1.0E-4
 
-  lt. ++> tests-degrees-of-pi-halves-is-quarter-turn
+  lt. ++> can-convert-pi-halves-to-degrees
     abs
       minus.
         degrees
@@ -33,14 +30,14 @@
         90
     1.0E-4
 
-  lt. ++> tests-degrees-of-pi-is-half-turn
+  lt. ++> can-convert-pi-to-degrees
     abs
       minus.
         degrees pi
         180
     1.0E-4
 
-  lt. ++> tests-degrees-of-two-pi-is-full-turn
+  lt. ++> can-convert-two-pi-to-degrees
     abs
       minus.
         degrees
@@ -48,6 +45,9 @@
         360
     1.0E-4
 
-  eq. ++> tests-degrees-of-zero-is-zero
+  eq. ++> can-convert-zero-to-degrees
     degrees 0
     0
+
+  is-nan. ++> cannot-convert-nan-to-degrees
+    degrees nan

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -31,19 +31,55 @@
           b.eq nzero
       b.eq xbts
 
-  42.eq 42.as-bytes ++> tests-as-bytes-equals-to-int
-
-  eq. ++> tests-compares-two-different-number-types
+  eq. ++> can-compare-two-different-number-types
     68.eq "12345678"
     false
 
-  eq. ++> tests-compares-two-numbers-via-package
+  eq. ++> can-compare-two-numbers-through-the-package
     eq
       42
       42
     true
 
-  eq. ++> tests-float-equal-to-nan-and-infinites-is-false-highload
+  42.eq 42.as-bytes ++> can-equal-an-integer-through-bytes
+
+  eq. ++> can-equal-float-zero-to-integer-zero
+    0.eq 0
+    true
+
+  ninf.eq ninf ++> can-equal-negative-infinity-when-negative-infinity
+
+  pinf.eq pinf ++> can-equal-positive-infinity-when-positive-infinity
+
+  eq. ++> can-equal-the-same-integer
+    123.eq 123
+    true
+
+  eq. ++> can-equal-zero-to-zero
+    0.eq 0
+    true
+
+  eq. ++> cannot-equal-a-different-integer
+    not.
+      123.eq 42
+    true
+
+  not. ++> cannot-equal-a-float-when-negative-infinity
+    ninf.eq 42.5
+
+  not. ++> cannot-equal-a-float-when-positive-infinity
+    pinf.eq 42.5
+
+  not. ++> cannot-equal-a-number-when-nan
+    nan.eq 42
+
+  not. ++> cannot-equal-an-integer-when-negative-infinity
+    ninf.eq 42
+
+  not. ++> cannot-equal-an-integer-when-positive-infinity
+    pinf.eq 42
+
+  eq. ++> cannot-equal-nan-or-infinities-when-a-float-under-load
     and.
       and.
         and.
@@ -81,16 +117,7 @@
         false
     true
 
-  eq. ++> tests-int-eq-false
-    not.
-      123.eq 42
-    true
-
-  eq. ++> tests-int-eq-true
-    123.eq 123
-    true
-
-  eq. ++> tests-int-equal-to-nan-and-infinites-is-false
+  eq. ++> cannot-equal-nan-or-infinities-when-an-integer
     and.
       and.
         and.
@@ -116,44 +143,17 @@
         false
     true
 
-  eq. ++> tests-int-zero-eq-to-float-zero
-    0.eq 0
-    true
-
-  eq. ++> tests-int-zero-eq-to-zero
-    0.eq 0
-    true
-
-  not. ++> tests-nan-not-eq-nan
+  not. ++> cannot-equal-nan-when-nan
     nan.eq nan
 
-  not. ++> tests-nan-not-eq-number
-    nan.eq 42
-
-  ninf.eq ninf ++> tests-negative-infinity-eq-negative-infinity
-
-  not. ++> tests-negative-infinity-not-eq-float
-    ninf.eq 42.5
-
-  not. ++> tests-negative-infinity-not-eq-int
-    ninf.eq 42
-
-  not. ++> tests-negative-infinity-not-eq-nan
+  not. ++> cannot-equal-nan-when-negative-infinity
     ninf.eq nan
 
-  not. ++> tests-negative-infinity-not-eq-positive-infinity
-    ninf.eq pinf
-
-  pinf.eq pinf ++> tests-positive-infinity-eq-positive-infinity
-
-  not. ++> tests-positive-infinity-not-eq-float
-    pinf.eq 42.5
-
-  not. ++> tests-positive-infinity-not-eq-int
-    pinf.eq 42
-
-  not. ++> tests-positive-infinity-not-eq-nan
+  not. ++> cannot-equal-nan-when-positive-infinity
     pinf.eq nan
 
-  not. ++> tests-positive-infinity-not-eq-negative-infinity
+  not. ++> cannot-equal-negative-infinity-when-positive-infinity
     pinf.eq ninf
+
+  not. ++> cannot-equal-positive-infinity-when-negative-infinity
+    ninf.eq pinf

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -12,40 +12,40 @@
     e
     num
 
-  eq. ++> tests-exp-check-infinity-n1
-    exp pinf
-    pinf
-
-  eq. ++> tests-exp-check-infinity-n2
-    exp ninf
-    0
-
-  lt. ++> tests-exp-check-n0
-    abs
-      e.minus
-        exp 1
-    1.0E-8
-
-  lt. ++> tests-exp-check-n1
-    abs
-      minus.
-        1.div e
-        exp -1
-    1.0E-8
-
-  lt. ++> tests-exp-check-n2
+  lt. ++> can-exponentiate-five
     abs
       minus.
         power e 5
         exp 5
     1.0E-7
 
-  lt. ++> tests-exp-check-n3
+  lt. ++> can-exponentiate-minus-one
+    abs
+      minus.
+        1.div e
+        exp -1
+    1.0E-8
+
+  lt. ++> can-exponentiate-minus-ten
     abs
       minus.
         power e -10
         exp -10
     1.0E-12
 
-  is-nan. ++> tests-exp-check-nan
+  eq. ++> can-exponentiate-negative-infinity
+    exp ninf
+    0
+
+  lt. ++> can-exponentiate-one
+    abs
+      e.minus
+        exp 1
+    1.0E-8
+
+  eq. ++> can-exponentiate-positive-infinity
+    exp pinf
+    pinf
+
+  is-nan. ++> cannot-exponentiate-nan
     exp nan

--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -22,22 +22,22 @@
       trunc.minus 1
       n.as-i64.as-number
 
-  -3.7.floor.eq -4 ++> tests-floor-negative-fraction
+  -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
 
-  -0.1.floor.eq -1 ++> tests-floor-negative-small-fraction
+  1.0e20.floor.eq 1.0e20 ++> can-floor-a-large-positive-integer
 
-  42.floor.eq 42 ++> tests-floor-of-integer
+  -3.7.floor.eq -4 ++> can-floor-a-negative-fraction
 
-  -1.0e20.floor.eq -1.0e20 ++> tests-floor-of-large-negative-integer
+  -5.floor.eq -5 ++> can-floor-a-negative-integer
 
-  1.0e20.floor.eq 1.0e20 ++> tests-floor-of-large-positive-integer
+  3.7.floor.eq 3 ++> can-floor-a-positive-fraction
 
-  -5.floor.eq -5 ++> tests-floor-of-negative-integer
+  -0.1.floor.eq -1 ++> can-floor-a-small-negative-fraction
 
-  0.floor.eq 0 ++> tests-floor-of-zero
+  42.floor.eq 42 ++> can-floor-an-integer
 
-  3.7.floor.eq 3 ++> tests-floor-positive-fraction
+  ninf.floor.eq ninf ++> can-floor-negative-infinity
 
-  ninf.floor.eq ninf ++> tests-negative-infinity-floor-is-equal-to-self
+  pinf.floor.eq pinf ++> can-floor-positive-infinity
 
-  pinf.floor.eq pinf ++> tests-positive-infinity-floor-is-equal-to-self
+  0.floor.eq 0 ++> can-floor-zero

--- a/eo-runtime/src/main/eo/number/gte.eo
+++ b/eo-runtime/src/main/eo/number/gte.eo
@@ -13,63 +13,63 @@
       x >> value!
     n.eq value
 
-  eq. ++> tests-int-gte-equal
+  eq. ++> can-be-greater-than-or-equal-to-a-float-when-positive-infinity
+    pinf.gte 42.5
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-a-smaller-integer
+    -1000.gte -1100
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-an-equal-integer
     113.gte 113
     true
 
-  eq. ++> tests-int-gte-false
+  eq. ++> can-be-greater-than-or-equal-to-an-integer-when-positive-infinity
+    pinf.gte 42
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-negative-infinity-when-negative-infinity
+    ninf.gte ninf
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-negative-infinity-when-positive-infinity
+    pinf.gte ninf
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-positive-infinity-when-positive-infinity
+    pinf.gte pinf
+    true
+
+  eq. ++> cannot-be-greater-than-or-equal-to-a-float-when-negative-infinity
+    ninf.gte 42.5
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-a-larger-integer
     not.
       0.gte 10
     true
 
-  eq. ++> tests-int-gte-true
-    -1000.gte -1100
-    true
-
-  eq. ++> tests-nan-not-gte-nan
-    nan.gte nan
-    false
-
-  eq. ++> tests-nan-not-gte-number
+  eq. ++> cannot-be-greater-than-or-equal-to-a-number-when-nan
     nan.gte 42
     false
 
-  eq. ++> tests-negative-infinity-gte-negative-infinity
-    ninf.gte ninf
-    true
-
-  eq. ++> tests-negative-infinity-not-gte-float
-    ninf.gte 42.5
-    false
-
-  eq. ++> tests-negative-infinity-not-gte-int
+  eq. ++> cannot-be-greater-than-or-equal-to-an-integer-when-negative-infinity
     ninf.gte 42
     false
 
-  eq. ++> tests-negative-infinity-not-gte-nan
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-nan
+    nan.gte nan
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-negative-infinity
     ninf.gte nan
     false
 
-  eq. ++> tests-negative-infinity-not-gte-positive-infinity
-    ninf.gte pinf
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-positive-infinity
+    pinf.gte nan
     false
 
-  eq. ++> tests-positive-infinity-gte-float
-    pinf.gte 42.5
-    true
-
-  eq. ++> tests-positive-infinity-gte-int
-    pinf.gte 42
-    true
-
-  eq. ++> tests-positive-infinity-gte-negative-infinity
-    pinf.gte ninf
-    true
-
-  eq. ++> tests-positive-infinity-gte-positive-infinity
-    pinf.gte pinf
-    true
-
-  eq. ++> tests-positive-infinity-not-gte-nan
-    pinf.gte nan
+  eq. ++> cannot-be-greater-than-or-equal-to-positive-infinity-when-negative-infinity
+    ninf.gte pinf
     false

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -10,7 +10,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [fun a b n] > integral
-  valid.if > @
+  if. > @
+    n.is-finite.and
+      n.is-integer.and
+        n.gt 0
     as-number.
       malloc.of
         8
@@ -47,11 +50,8 @@
             0.5.times
               a.plus b
         fun b
-  n.is-finite.and > valid
-    n.is-integer.and
-      n.gt 0
 
-  ++> tests-calculates-cube-integral
+  ++> can-integrate-a-cubic-function
     close-to > @
       as-number.
         integral
@@ -75,7 +75,7 @@
         value
         value.neg
 
-  ++> tests-calculates-lineal-integral
+  ++> can-integrate-a-linear-function
     close-to > @
       as-number.
         integral
@@ -97,7 +97,7 @@
         value
         value.neg
 
-  ++> tests-calculates-quadratic-integral
+  ++> can-integrate-a-quadratic-function
     close-to > @
       as-number.
         integral
@@ -119,29 +119,7 @@
         value
         value.neg
 
-  ++> tests-integral-with-evenly-dividing-step
-    close-to > @
-      as-number.
-        integral
-          x > [x]
-          0
-          10
-          10
-      50
-      1.0E-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs
-            value.minus operand
-          err
-        0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
-
-  ++> tests-integral-with-single-partition
+  ++> can-integrate-with-a-single-partition
     close-to > @
       as-number.
         integral
@@ -163,37 +141,59 @@
         value
         value.neg
 
-  integral --> on-integral-with-fractional-partitions
+  ++> can-integrate-with-an-evenly-dividing-step
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          0
+          10
+          10
+      50
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  integral --> stops-on-fractional-partitions
     x > [x]
     0
     1
     1.5
 
-  integral --> on-integral-with-nan-partitions
+  integral --> stops-on-nan-partitions
     x > [x]
     0
     1
     nan
 
-  integral --> on-integral-with-negative-infinite-partitions
-    x > [x]
-    0
-    1
-    ninf
-
-  integral --> on-integral-with-negative-partitions
+  integral --> stops-on-negative-partitions
     x > [x]
     0
     1
     -1
 
-  integral --> on-integral-with-positive-infinite-partitions
+  integral --> stops-on-negatively-infinite-partitions
+    x > [x]
+    0
+    1
+    ninf
+
+  integral --> stops-on-positively-infinite-partitions
     x > [x]
     0
     1
     pinf
 
-  integral --> on-integral-with-zero-partitions
+  integral --> stops-on-zero-partitions
     x > [x]
     0
     1

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -14,14 +14,14 @@
         n.as-bytes.eq 7F-F0-00-00-00-00-00-00
         n.as-bytes.eq FF-F0-00-00-00-00-00-00
 
-  nan.is-finite.not ++> nan-is-not-finite
+  32.is-finite ++> can-be-finite-when-a-simple-number
 
-  32.is-finite ++> simple-number-is-finite
-
-  ninf.is-finite.not ++> tests-negative-infinity-is-not-finite
-
-  not. ++> tests-number-with-infinite-bytes-is-not-finite
+  not. ++> cannot-be-finite-when-built-of-infinite-bytes
     is-finite.
       number pinf.as-bytes
 
-  pinf.is-finite.not ++> tests-positive-infinity-is-not-finite
+  nan.is-finite.not ++> cannot-be-finite-when-nan
+
+  ninf.is-finite.not ++> cannot-be-finite-when-negative-infinity
+
+  pinf.is-finite.not ++> cannot-be-finite-when-positive-infinity

--- a/eo-runtime/src/main/eo/number/is-integer.eo
+++ b/eo-runtime/src/main/eo/number/is-integer.eo
@@ -11,12 +11,12 @@
   n.is-finite.and > @
     n.eq n.floor
 
-  32.5.is-integer.not ++> float-number-is-not-integer
+  32.is-integer ++> can-be-an-integer-when-a-whole-number
 
-  32.is-integer ++> int-number-is-integer
+  32.5.is-integer.not ++> cannot-be-an-integer-when-a-float
 
-  nan.is-integer.not ++> nan-is-not-integer
+  nan.is-integer.not ++> cannot-be-an-integer-when-nan
 
-  ninf.is-integer.not ++> tests-negative-infinity-is-not-integer
+  ninf.is-integer.not ++> cannot-be-an-integer-when-negative-infinity
 
-  pinf.is-integer.not ++> tests-positive-infinity-is-not-integer
+  pinf.is-integer.not ++> cannot-be-an-integer-when-positive-infinity

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -24,60 +24,60 @@
     false
   n.as-bytes > bts
 
-  nan.is-nan ++> nan-is-nan
+  is-nan. ++> can-be-nan-when-built-of-nan-bytes
+    number nan.as-bytes
 
-  eq. ++> tests-nan-div-nan-is-nan
-    as-bytes.
-      nan.div nan
-    nan.as-bytes
+  is-nan. ++> can-be-nan-when-built-of-non-canonical-nan-bytes
+    number FF-F8-00-00-00-00-00-00
 
-  eq. ++> tests-nan-div-number-is-nan
+  nan.is-nan ++> can-be-nan-when-nan
+
+  eq. ++> can-be-nan-when-nan-divided-by-a-number
     as-bytes.
       nan.div 42
     nan.as-bytes
 
-  nan.floor.as-bytes.eq nan.as-bytes ++> tests-nan-floor-is-nan
-
-  eq. ++> tests-nan-minus-nan-is-nan
+  eq. ++> can-be-nan-when-nan-divided-by-nan
     as-bytes.
-      nan.minus nan
+      nan.div nan
     nan.as-bytes
 
-  eq. ++> tests-nan-minus-number-is-nan
+  eq. ++> can-be-nan-when-nan-minus-a-number
     as-bytes.
       nan.minus 42
     nan.as-bytes
 
-  nan.@.as-bytes.eq nan.as-bytes ++> tests-nan-neg-is-nan
-
-  eq. ++> tests-nan-plus-nan-is-nan
+  eq. ++> can-be-nan-when-nan-minus-nan
     as-bytes.
-      nan.plus nan
+      nan.minus nan
     nan.as-bytes
 
-  eq. ++> tests-nan-plus-number-is-nan
+  nan.@.as-bytes.eq nan.as-bytes ++> can-be-nan-when-nan-negated
+
+  eq. ++> can-be-nan-when-nan-plus-a-number
     as-bytes.
       nan.plus 42
     nan.as-bytes
 
-  eq. ++> tests-nan-times-nan-is-nan
+  eq. ++> can-be-nan-when-nan-plus-nan
     as-bytes.
-      nan.times nan
+      nan.plus nan
     nan.as-bytes
 
-  eq. ++> tests-nan-times-number-is-nan
+  eq. ++> can-be-nan-when-nan-times-a-number
     as-bytes.
       nan.times 42
     nan.as-bytes
 
-  ninf.is-nan.not ++> tests-negative-infinity-is-not-nan
+  eq. ++> can-be-nan-when-nan-times-nan
+    as-bytes.
+      nan.times nan
+    nan.as-bytes
 
-  is-nan. ++> tests-non-canonical-nan-bytes-is-nan
-    number FF-F8-00-00-00-00-00-00
+  nan.floor.as-bytes.eq nan.as-bytes ++> can-be-nan-when-the-floor-of-nan
 
-  is-nan. ++> tests-number-with-nan-bytes-is-nan
-    number nan.as-bytes
+  42.5.is-nan.not ++> cannot-be-nan-when-a-simple-number
 
-  pinf.is-nan.not ++> tests-positive-infinity-is-not-nan
+  ninf.is-nan.not ++> cannot-be-nan-when-negative-infinity
 
-  42.5.is-nan.not ++> tests-simple-number-is-not-nan
+  pinf.is-nan.not ++> cannot-be-nan-when-positive-infinity

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -59,48 +59,48 @@
         m.plus 1
   number num.as-bytes > n
 
-  lt. ++> tests-ln-fraction
+  lt. ++> can-stay-monotonic
+    ln 2
+    ln 3
+
+  lt. ++> can-take-a-logarithm-of-a-fraction
     abs
       minus.
         ln 0.5
         -0.6931471805599453
     1.0E-11
 
-  lt. ++> tests-ln-monotonic
-    ln 2
-    ln 3
-
-  is-nan. ++> tests-ln-nan
-    ln nan
-
-  is-nan. ++> tests-ln-negative-infinity
-    ln ninf
-
-  eq. ++> tests-ln-of-e-one-is-one
+  eq. ++> can-take-a-logarithm-of-e
     ln e
     1
 
-  is-nan. ++> tests-ln-of-negative-float-is-nan
-    ln -2.2
-
-  is-nan. ++> tests-ln-of-negative-int-is-nan
-    ln -42
-
-  eq. ++> tests-ln-of-one-is-zero
+  eq. ++> can-take-a-logarithm-of-one
     ln 1
     0
 
-  lt. ++> tests-ln-of-twenty
+  eq. ++> can-take-a-logarithm-of-positive-infinity
+    ln pinf
+    pinf
+
+  lt. ++> can-take-a-logarithm-of-twenty
     abs
       minus.
         ln 20
         2.995732273553991
     1.0E-11
 
-  eq. ++> tests-ln-of-zero-is-negative-infinity
+  eq. ++> can-take-a-logarithm-of-zero
     ln 0
     ninf
 
-  eq. ++> tests-ln-positive-infinity
-    ln pinf
-    pinf
+  is-nan. ++> cannot-take-a-logarithm-of-a-negative-float
+    ln -2.2
+
+  is-nan. ++> cannot-take-a-logarithm-of-a-negative-integer
+    ln -42
+
+  is-nan. ++> cannot-take-a-logarithm-of-nan
+    ln nan
+
+  is-nan. ++> cannot-take-a-logarithm-of-negative-infinity
+    ln ninf

--- a/eo-runtime/src/main/eo/number/lt.eo
+++ b/eo-runtime/src/main/eo/number/lt.eo
@@ -12,58 +12,58 @@
     n.minus
       number x!
 
-  eq. ++> tests-int-less-equal
-    not.
-      10.lt 10
+  ninf.lt 42.5 ++> can-be-less-than-a-float-when-negative-infinity
+
+  10.lt 50 ++> can-be-less-than-a-larger-integer
+
+  ninf.lt 42 ++> can-be-less-than-an-integer-when-negative-infinity
+
+  eq. ++> can-be-less-than-positive-infinity-when-negative-infinity
+    ninf.lt pinf
     true
 
-  eq. ++> tests-int-less-false
+  eq. ++> cannot-be-less-than-a-float-when-positive-infinity
+    pinf.lt 42.5
+    false
+
+  eq. ++> cannot-be-less-than-a-number-when-nan
+    nan.lt 42
+    false
+
+  eq. ++> cannot-be-less-than-a-smaller-integer
     not.
       10.lt -5
     true
 
-  10.lt 50 ++> tests-int-less-true
-
-  eq. ++> tests-nan-not-lt-nan
-    nan.lt nan
-    false
-
-  eq. ++> tests-nan-not-lt-number
-    nan.lt 42
-    false
-
-  ninf.lt 42.5 ++> tests-negative-infinity-lt-float
-
-  ninf.lt 42 ++> tests-negative-infinity-lt-int
-
-  eq. ++> tests-negative-infinity-lt-negative-infinity
-    ninf.lt ninf
-    false
-
-  eq. ++> tests-negative-infinity-lt-positive-infinity
-    ninf.lt pinf
+  eq. ++> cannot-be-less-than-an-equal-integer
+    not.
+      10.lt 10
     true
 
-  eq. ++> tests-negative-infinity-not-lt-nan
-    ninf.lt nan
-    false
-
-  eq. ++> tests-positive-infinity-lt-positive-infinity
-    pinf.lt pinf
-    false
-
-  eq. ++> tests-positive-infinity-not-lt-float
-    pinf.lt 42.5
-    false
-
-  eq. ++> tests-positive-infinity-not-lt-int
+  eq. ++> cannot-be-less-than-an-integer-when-positive-infinity
     pinf.lt 42
     false
 
-  eq. ++> tests-positive-infinity-not-lt-nan
+  eq. ++> cannot-be-less-than-itself-when-negative-infinity
+    ninf.lt ninf
+    false
+
+  eq. ++> cannot-be-less-than-itself-when-positive-infinity
+    pinf.lt pinf
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-nan
+    nan.lt nan
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-negative-infinity
+    ninf.lt nan
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-positive-infinity
     pinf.lt nan
     false
 
-  eq. ++> tests-positive-infinity-not-lt-negative-infinity
+  eq. ++> cannot-be-less-than-negative-infinity-when-positive-infinity
     pinf.lt ninf
     false

--- a/eo-runtime/src/main/eo/number/lte.eo
+++ b/eo-runtime/src/main/eo/number/lte.eo
@@ -13,63 +13,63 @@
       x >> value!
     n.eq value
 
-  eq. ++> tests-int-leq-equal
+  eq. ++> can-be-less-than-or-equal-to-a-float-when-negative-infinity
+    ninf.lte 42.5
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-a-larger-integer
+    -200.lte -100
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-an-equal-integer
     50.lte 50
     true
 
-  eq. ++> tests-int-leq-false
+  eq. ++> can-be-less-than-or-equal-to-an-integer-when-negative-infinity
+    ninf.lte 42
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-negative-infinity-when-negative-infinity
+    ninf.lte ninf
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-positive-infinity-when-negative-infinity
+    ninf.lte pinf
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-positive-infinity-when-positive-infinity
+    pinf.lte pinf
+    true
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-float-when-positive-infinity
+    pinf.lte 42.5
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-number-when-nan
+    nan.lte 42
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-smaller-integer
     not.
       0.lte -10
     true
 
-  eq. ++> tests-int-leq-true
-    -200.lte -100
-    true
-
-  eq. ++> tests-nan-not-lte-nan
-    nan.lte nan
-    false
-
-  eq. ++> tests-nan-not-lte-number
-    nan.lte 42
-    false
-
-  eq. ++> tests-negative-infinity-lte-float
-    ninf.lte 42.5
-    true
-
-  eq. ++> tests-negative-infinity-lte-int
-    ninf.lte 42
-    true
-
-  eq. ++> tests-negative-infinity-lte-negative-infinity
-    ninf.lte ninf
-    true
-
-  eq. ++> tests-negative-infinity-lte-positive-infinity
-    ninf.lte pinf
-    true
-
-  eq. ++> tests-negative-infinity-not-lte-nan
-    ninf.lte nan
-    false
-
-  eq. ++> tests-positive-infinity-lte-positive-infinity
-    pinf.lte pinf
-    true
-
-  eq. ++> tests-positive-infinity-not-lte-float
-    pinf.lte 42.5
-    false
-
-  eq. ++> tests-positive-infinity-not-lte-int
+  eq. ++> cannot-be-less-than-or-equal-to-an-integer-when-positive-infinity
     pinf.lte 42
     false
 
-  eq. ++> tests-positive-infinity-not-lte-nan
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-nan
+    nan.lte nan
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-negative-infinity
+    ninf.lte nan
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-positive-infinity
     pinf.lte nan
     false
 
-  eq. ++> tests-positive-infinity-not-lte-negative-infinity
+  eq. ++> cannot-be-less-than-or-equal-to-negative-infinity-when-positive-infinity
     pinf.lte ninf
     false

--- a/eo-runtime/src/main/eo/number/minus.eo
+++ b/eo-runtime/src/main/eo/number/minus.eo
@@ -12,66 +12,66 @@
     neg.
       number x!
 
-  eq. ++> tests-negative-infinity-minus-nan
+  eq. ++> can-subtract-a-negative-float-from-negative-infinity
+    ninf.minus -42.5
+    ninf
+
+  eq. ++> can-subtract-a-negative-float-from-positive-infinity
+    pinf.minus -42.5
+    pinf
+
+  eq. ++> can-subtract-a-negative-integer-from-negative-infinity
+    ninf.minus -42
+    ninf
+
+  eq. ++> can-subtract-a-negative-integer-from-positive-infinity
+    pinf.minus -42
+    pinf
+
+  eq. ++> can-subtract-a-positive-float-from-negative-infinity
+    ninf.minus 42.5
+    ninf
+
+  eq. ++> can-subtract-a-positive-float-from-positive-infinity
+    pinf.minus 42.5
+    pinf
+
+  eq. ++> can-subtract-a-positive-integer-from-negative-infinity
+    ninf.minus 42
+    ninf
+
+  eq. ++> can-subtract-a-positive-integer-from-positive-infinity
+    pinf.minus 42
+    pinf
+
+  eq. ++> can-subtract-nan-from-negative-infinity
     as-bytes.
       ninf.minus nan
     nan.as-bytes
 
-  eq. ++> tests-negative-infinity-minus-negative-float
-    ninf.minus -42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-negative-infinity
-    as-bytes.
-      ninf.minus ninf
-    nan.as-bytes
-
-  eq. ++> tests-negative-infinity-minus-negative-int
-    ninf.minus -42
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-positive-float
-    ninf.minus 42.5
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-positive-infinity
-    ninf.minus pinf
-    ninf
-
-  eq. ++> tests-negative-infinity-minus-positive-int
-    ninf.minus 42
-    ninf
-
-  eq. ++> tests-one-minus-one
-    1.minus 1
-    0
-
-  eq. ++> tests-positive-infinity-minus-nan
+  eq. ++> can-subtract-nan-from-positive-infinity
     as-bytes.
       pinf.minus nan
     nan.as-bytes
 
-  eq. ++> tests-positive-infinity-minus-negative-float
-    pinf.minus -42.5
-    pinf
+  eq. ++> can-subtract-negative-infinity-from-negative-infinity
+    as-bytes.
+      ninf.minus ninf
+    nan.as-bytes
 
-  eq. ++> tests-positive-infinity-minus-negative-infinity
+  eq. ++> can-subtract-negative-infinity-from-positive-infinity
     pinf.minus ninf
     pinf
 
-  eq. ++> tests-positive-infinity-minus-negative-int
-    pinf.minus -42
-    pinf
+  eq. ++> can-subtract-one-from-one
+    1.minus 1
+    0
 
-  eq. ++> tests-positive-infinity-minus-positive-float
-    pinf.minus 42.5
-    pinf
+  eq. ++> can-subtract-positive-infinity-from-negative-infinity
+    ninf.minus pinf
+    ninf
 
-  eq. ++> tests-positive-infinity-minus-positive-infinity
+  eq. ++> can-subtract-positive-infinity-from-positive-infinity
     as-bytes.
       pinf.minus pinf
     nan.as-bytes
-
-  eq. ++> tests-positive-infinity-minus-positive-int
-    pinf.minus 42
-    pinf

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -32,7 +32,7 @@
                 absx.div absy
         abs-mod.neg
 
-  ++> tests-div-mod-compatibility
+  ++> can-stay-compatible-with-division
     eq. > @
       plus.
         mod dividend divisor
@@ -41,73 +41,73 @@
     -13 > dividend
     5 > divisor
 
-  eq. ++> tests-mod-by-zero-returns-provided-fallback
+  eq. ++> can-take-a-modulo-by-one
+    mod
+      133
+      1
+    0
+
+  eq. ++> can-take-a-modulo-of-a-dividend-below-the-divisor
+    mod
+      -1
+      5
+    -1
+
+  eq. ++> can-take-a-modulo-of-a-negative-by-positive-infinity
+    mod
+      -5
+      pinf
+    -5
+
+  eq. ++> can-take-a-modulo-of-a-positive-by-negative-infinity
+    mod
+      5
+      ninf
+    5
+
+  eq. ++> can-take-a-modulo-of-a-positive-by-positive-infinity
+    mod
+      5
+      pinf
+    5
+
+  eq. ++> can-take-a-modulo-of-minus-one-by-seven
+    mod
+      -1
+      7
+    -1
+
+  eq. ++> can-take-a-modulo-of-one-by-two
+    mod
+      1
+      2
+    1
+
+  eq. ++> can-take-a-modulo-of-sixteen-by-a-large-negative
+    mod
+      16
+      -200
+    16
+
+  eq. ++> can-take-a-modulo-of-zero-by-a-negative
+    mod
+      0
+      -15
+    0
+
+  eq. ++> can-take-a-modulo-of-zero-by-five
+    mod
+      0
+      5
+    0
+
+  eq. ++> rejects-a-modulo-by-zero
     "recovered"
     mod
       5
       0
       "recovered" > [message]
 
-  eq. ++> tests-mod-dividend-by-one
-    mod
-      133
-      1
-    0
-
-  eq. ++> tests-mod-dividend-less-than-divisor
-    mod
-      -1
-      5
-    -1
-
-  eq. ++> tests-mod-n0-n15-neg
-    mod
-      0
-      -15
-    0
-
-  eq. ++> tests-mod-n0-n5
-    mod
-      0
-      5
-    0
-
-  eq. ++> tests-mod-n1-n2
-    mod
-      1
-      2
-    1
-
-  eq. ++> tests-mod-n1-neg-n7
-    mod
-      -1
-      7
-    -1
-
-  eq. ++> tests-mod-n16-n200-neg
-    mod
-      16
-      -200
-    16
-
-  eq. ++> tests-mod-negative-dividend-by-positive-infinity
-    mod
-      -5
-      pinf
-    -5
-
-  eq. ++> tests-mod-positive-dividend-by-negative-infinity
-    mod
-      5
-      ninf
-    5
-
-  eq. ++> tests-mod-positive-dividend-by-positive-infinity
-    mod
-      5
-      pinf
-    5
-
-  mod --> on-mod-by-zero
+  mod --> stops-on-a-modulo-by-zero
     5
     0

--- a/eo-runtime/src/main/eo/number/neg.eo
+++ b/eo-runtime/src/main/eo/number/neg.eo
@@ -10,6 +10,6 @@
 [n] > neg
   n.times -1 > @
 
-  ninf.neg.eq pinf ++> tests-negative-infinity-neg-is-positive-infinity
+  ninf.neg.eq pinf ++> can-negate-negative-infinity
 
-  pinf.neg.eq ninf ++> tests-positive-infinity-neg-is-negative-infinity
+  pinf.neg.eq ninf ++> can-negate-positive-infinity

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -105,20 +105,249 @@
                 nan
                 pinf
 
-  is-nan. ++> tests-power-any-to-nan-is-nan
-    power
-      52
-      nan
-
-  eq. ++> tests-power-as-method-on-number
+  eq. ++> can-be-called-as-a-method-on-a-number
     2.power 4
     16
 
-  eq. ++> tests-power-as-method-with-receiver-bound
+  eq. ++> can-be-called-as-a-method-with-a-bound-receiver
     3.power 2
     9
 
-  lt. ++> tests-power-cube-root-of-twenty-seven
+  eq. ++> can-be-reached-through-the-package
+    power
+      2
+      4
+    16
+
+  eq. ++> can-raise-a-float-to-zero
+    power
+      42.5
+      0
+    1
+
+  eq. ++> can-raise-a-negative-float-to-negative-infinity
+    power
+      -42.5
+      ninf
+    0
+
+  eq. ++> can-raise-a-negative-float-to-positive-infinity
+    power
+      -4.2
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-negative-integer-to-negative-infinity
+    power
+      -42
+      ninf
+    0
+
+  eq. ++> can-raise-a-negative-integer-to-positive-infinity
+    power
+      -10
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-positive-float-to-a-positive-integer
+    power
+      3.5
+      4
+    150.0625
+
+  eq. ++> can-raise-a-positive-float-to-negative-infinity
+    power
+      42.5
+      ninf
+    0
+
+  eq. ++> can-raise-a-positive-float-to-positive-infinity
+    power
+      42.5
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-positive-integer-to-a-positive-integer
+    power
+      2
+      3
+    8
+
+  eq. ++> can-raise-a-positive-integer-to-negative-infinity
+    power
+      42
+      ninf
+    0
+
+  eq. ++> can-raise-a-positive-integer-to-positive-infinity
+    power
+      42
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-zero-base
+    power
+      0
+      145
+    0
+
+  eq. ++> can-raise-an-integer-to-zero
+    power
+      42
+      0
+    1
+
+  eq. ++> can-raise-four-to-five
+    power
+      4
+      5
+    1024
+
+  eq. ++> can-raise-four-to-minus-three
+    power
+      4
+      -3
+    0.015625
+
+  eq. ++> can-raise-negative-infinity-to-a-positive-float
+    power
+      ninf
+      9.9
+    pinf
+
+  eq. ++> can-raise-negative-infinity-to-an-even-integer
+    power
+      ninf
+      10
+    pinf
+
+  eq. ++> can-raise-negative-infinity-to-an-odd-integer
+    power
+      ninf
+      9
+    ninf
+
+  eq. ++> can-raise-negative-infinity-to-negative-infinity
+    power
+      ninf
+      ninf
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-negative-float
+    power
+      pinf
+      -42.2
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-negative-integer
+    power
+      pinf
+      -42
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-positive-float
+    power
+      pinf
+      10.8
+    pinf
+
+  eq. ++> can-raise-positive-infinity-to-a-positive-integer
+    power
+      pinf
+      42
+    pinf
+
+  eq. ++> can-raise-positive-infinity-to-negative-infinity
+    power
+      pinf
+      ninf
+    0
+
+  eq. ++> can-raise-positive-infinity-to-positive-infinity
+    power
+      pinf
+      pinf
+    pinf
+
+  eq. ++> can-raise-three-to-two
+    power
+      3
+      2
+    9
+
+  eq. ++> can-raise-to-a-large-negative-exponent
+    power
+      984782
+      -12341
+    0
+
+  eq. ++> can-raise-to-a-zero-exponent
+    power
+      2
+      0
+    1
+
+  eq. ++> can-raise-two-to-four
+    power
+      2
+      4
+    16
+
+  eq. ++> can-raise-two-to-minus-one
+    power
+      2
+      -1
+    0.5
+
+  eq. ++> can-raise-two-to-minus-three
+    power
+      2
+      -3
+    0.125
+
+  eq. ++> can-raise-two-to-minus-two
+    power
+      2
+      -2
+    0.25
+
+  eq. ++> can-raise-zero-to-a-negative
+    power
+      0
+      -52
+    pinf
+
+  eq. ++> can-raise-zero-to-a-negative-odd-integer
+    power
+      0
+      -567
+    pinf
+
+  eq. ++> can-raise-zero-to-a-positive-float
+    power
+      0
+      4.2
+    0
+
+  eq. ++> can-raise-zero-to-a-positive-integer
+    power
+      0
+      4
+    0
+
+  eq. ++> can-raise-zero-to-negative-infinity
+    power
+      0
+      ninf
+    pinf
+
+  eq. ++> can-raise-zero-to-positive-infinity
+    power
+      0
+      pinf
+    0
+
+  lt. ++> can-take-a-cube-root-of-twenty-seven
     abs
       minus.
         power
@@ -127,265 +356,36 @@
         3
     1.0E-9
 
-  eq. ++> tests-power-float-to-zero-is-one
-    power
-      42.5
-      0
-    1
-
-  eq. ++> tests-power-four-to-five
-    power
-      4
-      5
-    1024
-
-  eq. ++> tests-power-four-to-minus-three
-    power
-      4
-      -3
-    0.015625
-
-  is-nan. ++> tests-power-fractional-of-negative-is-nan
-    power
-      -4
-      0.5
-
-  eq. ++> tests-power-int-to-zero-is-one
-    power
-      42
-      0
-    1
-
-  eq. ++> tests-power-large-negative-exponent
-    power
-      984782
-      -12341
-    0
-
-  is-nan. ++> tests-power-nan-to-any-is-nan
-    power
-      nan
-      42
-
-  is-nan. ++> tests-power-nan-to-nan-is-nan
-    power
-      nan
-      nan
-
-  eq. ++> tests-power-negative-float-to-negative-infinity-is-zero
-    power
-      -42.5
-      ninf
-    0
-
-  eq. ++> tests-power-negative-float-to-positive-infinity-is-positive-infinity
-    power
-      -4.2
-      pinf
-    pinf
-
-  eq. ++> tests-power-negative-infinity-to-even-int-is-positive-infinity
-    power
-      ninf
-      10
-    pinf
-
-  eq. ++> tests-power-negative-infinity-to-negative-infinity-is-zero
-    power
-      ninf
-      ninf
-    0
-
-  eq. ++> tests-power-negative-infinity-to-odd-int-is-negative-infinity
-    power
-      ninf
-      9
-    ninf
-
-  eq. ++> tests-power-negative-infinity-to-positive-float-is-positive-infinity
-    power
-      ninf
-      9.9
-    pinf
-
-  eq. ++> tests-power-negative-int-to-negative-infinity-is-zero
-    power
-      -42
-      ninf
-    0
-
-  eq. ++> tests-power-negative-int-to-positive-infinity-is-positive-infinity
-    power
-      -10
-      pinf
-    pinf
-
-  eq. ++> tests-power-of-three-squared
-    power
-      3
-      2
-    9
-
-  eq. ++> tests-power-of-two-to-four
-    power
-      2
-      4
-    16
-
-  eq. ++> tests-power-of-zero-base
-    power
-      0
-      145
-    0
-
-  eq. ++> tests-power-of-zero-exponent
-    power
-      2
-      0
-    1
-
-  eq. ++> tests-power-positive-float-to-negative-infinity-is-zero
-    power
-      42.5
-      ninf
-    0
-
-  eq. ++> tests-power-positive-float-to-positive-infinity-is-positive-infinity
-    power
-      42.5
-      pinf
-    pinf
-
-  eq. ++> tests-power-positive-float-to-positive-int
-    power
-      3.5
-      4
-    150.0625
-
-  eq. ++> tests-power-positive-infinity-to-negative-float-is-zero
-    power
-      pinf
-      -42.2
-    0
-
-  eq. ++> tests-power-positive-infinity-to-negative-infinity-is-zero
-    power
-      pinf
-      ninf
-    0
-
-  eq. ++> tests-power-positive-infinity-to-negative-int-is-zero
-    power
-      pinf
-      -42
-    0
-
-  eq. ++> tests-power-positive-infinity-to-positive-float-is-positive-infinity
-    power
-      pinf
-      10.8
-    pinf
-
-  eq. ++> tests-power-positive-infinity-to-positive-infinity-is-positive-infinity
-    power
-      pinf
-      pinf
-    pinf
-
-  eq. ++> tests-power-positive-infinity-to-positive-int-is-positive-infinity
-    power
-      pinf
-      42
-    pinf
-
-  eq. ++> tests-power-positive-int-to-negative-infinity-is-zero
-    power
-      42
-      ninf
-    0
-
-  eq. ++> tests-power-positive-int-to-positive-infinity-is-positive-infinity
-    power
-      42
-      pinf
-    pinf
-
-  eq. ++> tests-power-positive-int-to-positive-int
-    power
-      2
-      3
-    8
-
-  lt. ++> tests-power-square-root-of-nine
+  lt. ++> can-take-a-square-root-of-nine
     abs
       minus.
         power 9 0.5
         3
     1.0E-9
 
-  lt. ++> tests-power-square-root-of-two
+  lt. ++> can-take-a-square-root-of-two
     abs
       minus.
         power 2 0.5
         1.4142135623730951
     1.0E-9
 
-  eq. ++> tests-power-two-to-minus-one
+  is-nan. ++> cannot-raise-a-negative-to-a-fraction
     power
-      2
-      -1
-    0.5
+      -4
+      0.5
 
-  eq. ++> tests-power-two-to-minus-three
+  is-nan. ++> cannot-raise-anything-to-nan
     power
-      2
-      -3
-    0.125
+      52
+      nan
 
-  eq. ++> tests-power-two-to-minus-two
+  is-nan. ++> cannot-raise-nan-to-anything
     power
-      2
-      -2
-    0.25
+      nan
+      42
 
-  eq. ++> tests-power-via-number-namespace
+  is-nan. ++> cannot-raise-nan-to-nan
     power
-      2
-      4
-    16
-
-  eq. ++> tests-power-zero-to-negative-infinity-is-positive-infinity
-    power
-      0
-      ninf
-    pinf
-
-  eq. ++> tests-power-zero-to-negative-is-positive-infinity
-    power
-      0
-      -52
-    pinf
-
-  eq. ++> tests-power-zero-to-negative-odd
-    power
-      0
-      -567
-    pinf
-
-  eq. ++> tests-power-zero-to-positive-float-is-zero
-    power
-      0
-      4.2
-    0
-
-  eq. ++> tests-power-zero-to-positive-infinity-is-zero
-    power
-      0
-      pinf
-    0
-
-  eq. ++> tests-power-zero-to-positive-int-is-zero
-    power
-      0
-      4
-    0
+      nan
+      nan

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -15,37 +15,37 @@
       pi
     180
 
-  lt. ++> tests-radians-of-full-turn-is-two-pi
+  lt. ++> can-convert-a-full-turn-to-radians
     abs
       minus.
         radians 360
         pi.times 2
     1.0E-4
 
-  lt. ++> tests-radians-of-half-turn-is-pi
+  lt. ++> can-convert-a-half-turn-to-radians
     abs
       minus.
         radians 180
         pi
     1.0E-4
 
-  is-nan. ++> tests-radians-of-nan-is-nan
-    radians nan
-
-  lt. ++> tests-radians-of-negative-half-turn-is-minus-pi
+  lt. ++> can-convert-a-negative-half-turn-to-radians
     abs
       minus.
         radians -180
         pi.neg
     1.0E-4
 
-  lt. ++> tests-radians-of-quarter-turn-is-pi-halves
+  lt. ++> can-convert-a-quarter-turn-to-radians
     abs
       minus.
         radians 90
         pi.div 2
     1.0E-4
 
-  eq. ++> tests-radians-of-zero-is-zero
+  eq. ++> can-convert-zero-to-radians
     radians 0
     0
+
+  is-nan. ++> cannot-convert-nan-to-radians
+    radians nan

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -53,7 +53,22 @@
           00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
 
-  ++> tests-random-is-in-range
+  not. ++> can-differ-between-two-draws
+    eq.
+      random.clocked 123.as-i64
+      random.clocked 456.as-i64
+
+  ++> can-reach-the-upper-half
+    not. > @
+      rand.lt 0.5
+    next. > rand
+      random 178609
+
+  eq. ++> can-repeat-itself-with-the-same-seed
+    next. (random 1654).next.next
+    next. (random 1654).next.next
+
+  ++> can-stay-in-range
     and. > @
       and.
         and.
@@ -71,22 +86,7 @@
     next. > rand
       random 123
 
-  ++> tests-random-next-can-reach-upper-half
-    not. > @
-      rand.lt 0.5
-    next. > rand
-      random 178609
-
-  ++> tests-random-with-seed
+  ++> can-use-a-seed
     not. > @
       r.next.eq r.next.next
     random 51 > r
-
-  eq. ++> tests-seeded-randoms-are-equal
-    next. (random 1654).next.next
-    next. (random 1654).next.next
-
-  not. ++> tests-two-random-numbers-not-equal
-    eq.
-      random.clocked 123.as-i64
-      random.clocked 456.as-i64

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -37,7 +37,7 @@
             depth.plus 1
     | 1
 
-  lt. ++> tests-sine-is-odd-function
+  lt. ++> can-behave-as-an-odd-function
     abs
       times.
         plus.
@@ -47,13 +47,19 @@
         1000
     1
 
-  is-nan. ++> tests-sine-of-nan-is-nan
-    sine nan
+  lt. ++> can-reduce-a-large-angle
+    abs
+      minus.
+        times.
+          sine
+            plus.
+              pi.times 10
+              pi.div 6
+          1000
+        500
+    1
 
-  is-nan. ++> tests-sine-of-negative-infinity-is-nan
-    sine ninf
-
-  lt. ++> tests-sine-of-negative-pi-halves-is-minus-one
+  lt. ++> can-take-a-sine-of-minus-pi-halves
     abs
       minus.
         times.
@@ -62,7 +68,14 @@
         -1000
     1
 
-  lt. ++> tests-sine-of-pi-halves-is-one
+  lt. ++> can-take-a-sine-of-pi
+    abs
+      times.
+        sine pi
+        1000
+    1
+
+  lt. ++> can-take-a-sine-of-pi-halves
     abs
       minus.
         times.
@@ -72,14 +85,7 @@
         1000
     1
 
-  lt. ++> tests-sine-of-pi-is-zero
-    abs
-      times.
-        sine pi
-        1000
-    1
-
-  lt. ++> tests-sine-of-pi-sixths-is-half
+  lt. ++> can-take-a-sine-of-pi-sixths
     abs
       minus.
         times.
@@ -89,10 +95,7 @@
         500
     1
 
-  is-nan. ++> tests-sine-of-positive-infinity-is-nan
-    sine pinf
-
-  lt. ++> tests-sine-of-seventeen-radians
+  lt. ++> can-take-a-sine-of-seventeen-radians
     abs
       minus.
         times.
@@ -101,7 +104,7 @@
         -961
     1
 
-  lt. ++> tests-sine-of-three-pi-halves-is-minus-one
+  lt. ++> can-take-a-sine-of-three-pi-halves
     abs
       minus.
         times.
@@ -113,7 +116,7 @@
         -1000
     1
 
-  lt. ++> tests-sine-of-two-pi-is-zero
+  lt. ++> can-take-a-sine-of-two-pi
     abs
       times.
         sine
@@ -121,18 +124,15 @@
         1000
     1
 
-  eq. ++> tests-sine-of-zero-is-zero
+  eq. ++> can-take-a-sine-of-zero
     sine 0
     0
 
-  lt. ++> tests-sine-reduces-large-angle
-    abs
-      minus.
-        times.
-          sine
-            plus.
-              pi.times 10
-              pi.div 6
-          1000
-        500
-    1
+  is-nan. ++> cannot-take-a-sine-of-nan
+    sine nan
+
+  is-nan. ++> cannot-take-a-sine-of-negative-infinity
+    sine ninf
+
+  is-nan. ++> cannot-take-a-sine-of-positive-infinity
+    sine pinf

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -18,56 +18,56 @@
       num
       0.5
 
-  lt. ++> tests-sqrt-check-float-input
+  lt. ++> can-approximate-a-square-root-of-four
     abs
       2.minus
         sqrt 4
     1.0E-11
 
-  eq. ++> tests-sqrt-check-infinity-n1
-    sqrt pinf
-    pinf
-
-  is-nan. ++> tests-sqrt-check-infinity-n2
-    sqrt ninf
-
-  is-nan. ++> tests-sqrt-check-nan-input
-    sqrt nan
-
-  is-nan. ++> tests-sqrt-check-negative-input
-    sqrt -0.1
-
-  lt. ++> tests-sqrt-check-zero-input
+  lt. ++> can-approximate-a-square-root-of-zero
     abs
       0.minus
         sqrt 0
     1.0E-11
 
-  lt. ++> tests-sqrt-four
-    abs
-      minus.
-        sqrt 4
-        2
-    1.0E-9
-
-  eq. ++> tests-sqrt-one
-    sqrt 1
-    1
-
-  lt. ++> tests-sqrt-point-five
+  lt. ++> can-take-a-square-root-of-a-half
     abs
       minus.
         sqrt 0.25
         0.5
     1.0E-9
 
-  lt. ++> tests-sqrt-two
+  lt. ++> can-take-a-square-root-of-four
+    abs
+      minus.
+        sqrt 4
+        2
+    1.0E-9
+
+  eq. ++> can-take-a-square-root-of-one
+    sqrt 1
+    1
+
+  eq. ++> can-take-a-square-root-of-positive-infinity
+    sqrt pinf
+    pinf
+
+  lt. ++> can-take-a-square-root-of-two
     abs
       minus.
         sqrt 2
         1.4142135623730951
     1.0E-9
 
-  eq. ++> tests-sqrt-zero
+  eq. ++> can-take-a-square-root-of-zero
     sqrt 0
     0
+
+  is-nan. ++> cannot-take-a-square-root-of-a-negative
+    sqrt -0.1
+
+  is-nan. ++> cannot-take-a-square-root-of-nan
+    sqrt nan
+
+  is-nan. ++> cannot-take-a-square-root-of-negative-infinity
+    sqrt ninf

--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -33,6 +33,6 @@
           name
   [] > name /Q.string
 
-  or. ++> tests-checks-os-family
+  or. ++> can-check-the-os-family
     os.is-windows.or os.is-macos
     os.is-linux

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -14,4 +14,4 @@
       output-block > [buffer] > write
     | > @
 
-  dead.write 01-02-03 ++> writes-bytes-to-nowhere
+  dead.write 01-02-03 ++> can-write-bytes-to-nowhere

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -197,14 +197,14 @@
         string ubts > pth
       ^.separator > separator
 
-  and. ++> tests-detects-absolute-posix-path
+  and. ++> can-detect-an-absolute-posix-path
     is-absolute.
       path.posix "/var/www/html"
     not.
       is-absolute.
         path.posix "foo/bar/baz"
 
-  and. ++> tests-detects-absolute-win32-path
+  and. ++> can-detect-an-absolute-win32-path
     and.
       is-absolute.
         path.win32 "C:\\Windows\\Users"
@@ -214,210 +214,182 @@
       is-absolute.
         path.win32 "temp\\var"
 
-  path.separator.eq ++> tests-determines-separator-depending-on-os
+  path.separator.eq ++> can-determine-the-separator-from-the-os
     os.is-windows.if
       path.win32.separator
       path.posix.separator
 
-  eq. ++> tests-does-not-take-extname-if-ends-with-separator
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          path.separator
-    ""
-
-  eq. ++> tests-does-not-take-extname-on-file-without-extension
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          "html"
-    ""
-
-  eq. ++> tests-normalizes-absolute-win32-path-with-drive
-    normalized.
-      path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal"
-    "C:\\Users\\AppLocal"
-
-  eq. ++> tests-normalizes-absolute-win32-path-without-drive
-    normalized.
-      path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\"
-    "\\Windows\\App\\Local\\"
-
-  eq. ++> tests-normalizes-empty-posix-path-to-current-dir
-    normalized.
-      path.posix ""
-    "."
-
-  eq. ++> tests-normalizes-empty-win32-driveless-path-to-current-dir
-    normalized.
-      path.win32 ""
-    "."
-
-  eq. ++> tests-normalizes-path-to-root
-    normalized.
-      path.posix "/foo/bar/baz/../../../../"
-    "/"
-
-  eq. ++> tests-normalizes-posix-path
-    normalized.
-      path.posix "/foo/bar/.//./baz//../x/"
-    "/foo/bar/x/"
-
-  eq. ++> tests-normalizes-posix-path-collapsing-to-current-dir
-    normalized.
-      path.posix "foo/.."
-    "."
-
-  eq. ++> tests-normalizes-posix-relative-path
-    normalized.
-      path.posix "../../foo/./bar/../x/../y"
-    "../../foo/y"
-
-  eq. ++> tests-normalizes-relative-win32-path
-    normalized.
-      path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
-    "..\\..\\foo\\x\\y\\"
-
-  eq. ++> tests-normalizes-win32-drive-only-path-keeps-drive
+  eq. ++> can-normalize-a-drive-only-win32-path
     normalized.
       path.win32 "C:"
     "C:"
 
-  eq. ++> tests-normalizes-win32-drive-relative-path-keeps-leading-dotdot
+  eq. ++> can-normalize-a-drive-relative-win32-path-keeping-a-leading-dotdot
     normalized.
       path.win32 "C:..\\foo"
     "C:..\\foo"
 
-  eq. ++> tests-normalizes-win32-path-collapsing-to-current-dir
+  eq. ++> can-normalize-a-path-to-the-root
+    normalized.
+      path.posix "/foo/bar/baz/../../../../"
+    "/"
+
+  eq. ++> can-normalize-a-posix-path
+    normalized.
+      path.posix "/foo/bar/.//./baz//../x/"
+    "/foo/bar/x/"
+
+  eq. ++> can-normalize-a-posix-path-collapsing-to-the-current-directory
+    normalized.
+      path.posix "foo/.."
+    "."
+
+  eq. ++> can-normalize-a-relative-posix-path
+    normalized.
+      path.posix "../../foo/./bar/../x/../y"
+    "../../foo/y"
+
+  eq. ++> can-normalize-a-relative-win32-path
+    normalized.
+      path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
+    "..\\..\\foo\\x\\y\\"
+
+  eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.
       path.win32 "foo\\.."
     "."
 
-  eq. ++> tests-normalizes-win32-path-down-to-drive-with-separator
+  eq. ++> can-normalize-a-win32-path-down-to-a-drive-with-a-separator
     normalized.
       path.win32 "C:\\Windows\\.."
     "C:\\"
 
-  eq. ++> tests-normalizes-win32-path-down-to-drive-without-separator
+  eq. ++> can-normalize-a-win32-path-down-to-a-drive-without-a-separator
     normalized.
       path.win32 "C:hello\\.."
     "C:"
 
-  eq. ++> tests-normalizes-win32-path-with-replacing-slashes
+  eq. ++> can-normalize-a-win32-path-replacing-slashes
     normalized.
       path.win32 "/var/www/../html/"
     "\\var\\html\\"
 
-  eq. ++> tests-resolves-posix-absolute-path-against-other-absolute-path
-    resolved.
-      path.posix "/var/temp"
-      "/www/html"
-    "/www/html"
+  eq. ++> can-normalize-an-absolute-win32-path-with-a-drive
+    normalized.
+      path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal"
+    "C:\\Users\\AppLocal"
 
-  eq. ++> tests-resolves-posix-absolute-path-against-other-relative-path
-    resolved.
-      path.posix "/var/temp"
-      "./www/html"
-    "/var/temp/www/html"
+  eq. ++> can-normalize-an-absolute-win32-path-without-a-drive
+    normalized.
+      path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\"
+    "\\Windows\\App\\Local\\"
 
-  eq. ++> tests-resolves-posix-path-against-empty-other
-    resolved.
-      path.posix "/a/b"
-      ""
-    "/a/b"
+  eq. ++> can-normalize-an-empty-driveless-win32-path-to-the-current-directory
+    normalized.
+      path.win32 ""
+    "."
 
-  eq. ++> tests-resolves-posix-relative-path-against-other-absolute-path
-    resolved.
-      path.posix "./var/temp"
-      "/www/html"
-    "/www/html"
+  eq. ++> can-normalize-an-empty-posix-path-to-the-current-directory
+    normalized.
+      path.posix ""
+    "."
 
-  eq. ++> tests-resolves-posix-relative-path-against-other-relative-path
-    resolved.
-      path.posix "./var/temp"
-      "../www/html"
-    "var/www/html"
-
-  eq. ++> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
-    resolved.
-      path.win32 "C:\\users\\local"
-      "D:\\local\\var"
-    "D:\\local\\var"
-
-  eq. ++> tests-resolves-win32-drive-relative-path-against-other-relative-path
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-a-relative-path
     resolved.
       path.win32 "C:\\users\\local"
       ".\\var\\temp"
     "C:\\users\\local\\var\\temp"
 
-  eq. ++> tests-resolves-win32-drive-relative-path-against-other-root-relative-path
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-a-root-relative-path
     resolved.
       path.win32 "C:\\users\\local"
       "\\local\\var"
     "C:\\local\\var"
 
-  eq. ++> tests-resolves-win32-path-against-empty-other
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-another-drive-relative-path
     resolved.
-      path.win32 "C:\\a\\b"
-      ""
-    "C:\\a\\b"
+      path.win32 "C:\\users\\local"
+      "D:\\local\\var"
+    "D:\\local\\var"
 
-  eq. ++> tests-resolves-win32-relative-path-against-other-drive-relative-path
+  eq. ++> can-resolve-a-posix-path-against-an-empty-one
+    resolved.
+      path.posix "/a/b"
+      ""
+    "/a/b"
+
+  eq. ++> can-resolve-a-relative-posix-path-against-an-absolute-path
+    resolved.
+      path.posix "./var/temp"
+      "/www/html"
+    "/www/html"
+
+  eq. ++> can-resolve-a-relative-posix-path-against-another-relative-path
+    resolved.
+      path.posix "./var/temp"
+      "../www/html"
+    "var/www/html"
+
+  eq. ++> can-resolve-a-relative-win32-path-against-a-drive-relative-path
     resolved.
       path.win32 ".\\temp\\var"
       "C:\\Windows\\Users"
     "C:\\Windows\\Users"
 
-  eq. ++> tests-resolves-win32-relative-path-against-other-relative-path
-    resolved.
-      path.win32 ".\\temp\\var"
-      ".\\..\\x"
-    "temp\\x"
-
-  eq. ++> tests-resolves-win32-relative-path-against-other-root-relative-path
+  eq. ++> can-resolve-a-relative-win32-path-against-a-root-relative-path
     resolved.
       path.win32 ".\\temp\\var"
       "\\Windows\\Users"
     "\\Windows\\Users"
 
-  eq. ++> tests-resolves-win32-root-relative-path-against-other-drive-relative-path
+  eq. ++> can-resolve-a-relative-win32-path-against-another-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      ".\\..\\x"
+    "temp\\x"
+
+  eq. ++> can-resolve-a-root-relative-win32-path-against-a-drive-relative-path
     resolved.
       path.win32 "\\users\\local"
       "D:\\hello\\var"
     "D:\\hello\\var"
 
-  eq. ++> tests-resolves-win32-root-relative-path-against-other-relative-path
+  eq. ++> can-resolve-a-root-relative-win32-path-against-a-relative-path
     resolved.
       path.win32 "\\users\\local"
       ".\\hello\\var"
     "\\users\\local\\hello\\var"
 
-  eq. ++> tests-resolves-win32-root-relative-path-against-other-root-relative-path
+  eq. ++> can-resolve-a-root-relative-win32-path-against-another-root-relative-path
     resolved.
       path.win32 "\\users\\local"
       "\\hello\\var"
     "\\hello\\var"
 
-  eq. ++> tests-returns-base-with-backslash-in-path-on-posix
+  eq. ++> can-resolve-a-win32-path-against-an-empty-one
+    resolved.
+      path.win32 "C:\\a\\b"
+      ""
+    "C:\\a\\b"
+
+  eq. ++> can-resolve-an-absolute-posix-path-against-a-relative-path
+    resolved.
+      path.posix "/var/temp"
+      "./www/html"
+    "/var/temp/www/html"
+
+  eq. ++> can-resolve-an-absolute-posix-path-against-another-absolute-path
+    resolved.
+      path.posix "/var/temp"
+      "/www/html"
+    "/www/html"
+
+  eq. ++> can-return-a-basename-with-a-backslash-on-posix
     basename.
       path.posix "/var/www/html/foo\\bar"
     "foo\\bar"
 
-  eq. ++> tests-returns-current-dirname-of-posix-relative-file
-    dirname.
-      path.posix "plain"
-    "."
-
-  eq. ++> tests-returns-current-dirname-of-posix-relative-hidden-file
-    dirname.
-      path.posix ".gitignore"
-    "."
-
-  eq. ++> tests-returns-empty-basename-from-path-ended-with-separator
+  eq. ++> can-return-an-empty-basename-from-a-path-ending-with-a-separator
     basename.
       path.joined
         *
@@ -427,22 +399,17 @@
           path.separator
     ""
 
-  eq. ++> tests-returns-root-dirname-of-posix-single-component
+  eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
     dirname.
-      path.posix "/foo"
-    "/"
+      path.posix ".gitignore"
+    "."
 
-  eq. ++> tests-returns-root-dirname-of-win32-root-relative
+  eq. ++> can-return-the-current-dirname-of-a-relative-posix-file
     dirname.
-      path.win32 "\\foo"
-    "\\"
+      path.posix "plain"
+    "."
 
-  eq. ++> tests-returns-the-same-string-if-no-separator-is-found
-    basename.
-      path "Somebody"
-    "Somebody"
-
-  eq. ++> tests-returns-valid-dirname-from-dir-path
+  eq. ++> can-return-the-dirname-of-a-directory-path
     dirname.
       path.joined
         *
@@ -452,7 +419,7 @@
     path.joined
       * "var" "www"
 
-  eq. ++> tests-returns-valid-dirname-from-file-path
+  eq. ++> can-return-the-dirname-of-a-file-path
     dirname.
       path.joined
         *
@@ -462,7 +429,7 @@
     path.joined
       * "var" "www"
 
-  eq. ++> tests-returns-valid-dirname-from-file-path-without-extension
+  eq. ++> can-return-the-dirname-of-a-file-path-without-an-extension
     dirname.
       path.joined
         *
@@ -472,16 +439,22 @@
     path.joined
       * "var" "www"
 
-  eq. ++> tests-takes-file-extname
-    extname.
-      path.joined
-        *
-          "var"
-          "www"
-          "hello.text"
-    ".text"
+  eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
+    dirname.
+      path.win32 "\\foo"
+    "\\"
 
-  eq. ++> tests-takes-valid-basename
+  eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path
+    dirname.
+      path.posix "/foo"
+    "/"
+
+  eq. ++> can-return-the-same-string-without-a-separator
+    basename.
+      path "Somebody"
+    "Somebody"
+
+  eq. ++> can-take-a-basename
     basename.
       path.joined
         *
@@ -490,3 +463,30 @@
           "html"
           "hello.eo"
     "hello.eo"
+
+  eq. ++> can-take-a-file-extname
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "hello.text"
+    ".text"
+
+  eq. ++> cannot-take-an-extname-from-a-file-without-an-extension
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+    ""
+
+  eq. ++> cannot-take-an-extname-from-a-path-ending-with-a-separator
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          path.separator
+    ""

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -51,7 +51,7 @@
     512
   1 > wronly
 
-  ++> tests-closes-posix-tcp-socket
+  ++> can-close-a-tcp-socket
     os.is-windows.or > @
       seq *
         sd
@@ -69,7 +69,7 @@
         posix.stream
         posix.tcp
 
-  os.is-windows.or ++> tests-invokes-getpid-correctly
+  os.is-windows.or ++> can-invoke-getpid
     gt.
       code.
         posix
@@ -77,22 +77,7 @@
           *
       0
 
-  ++> tests-opens-and-closes-file-via-syscall
-    os.is-windows.or > @
-      seq *
-        code.
-          posix *1
-            "close"
-            fd
-        fd.gt -1
-    code. > fd
-      posix *1
-        "open"
-        "/dev/null"
-        0
-        0
-
-  ++> tests-opens-posix-tcp-socket
+  ++> can-open-a-tcp-socket
     os.is-windows.or > @
       seq *
         code.
@@ -107,7 +92,22 @@
         posix.stream
         posix.tcp
 
-  os.is-windows.or ++> tests-returns-valid-posix-inet-addr-for-localhost
+  ++> can-open-and-close-a-file-through-a-syscall
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "close"
+            fd
+        fd.gt -1
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        0
+        0
+
+  os.is-windows.or ++> can-return-an-inet-address-for-localhost
     eq.
       code.
         posix *1

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -43,30 +43,7 @@
       start.next
     *
 
-  ++> tests-range-with-out-of-bounds
-    rng.eq > @
-      * 1 6
-    range > rng
-      []
-        b 1 > @
-        [num] > b
-          num > @
-          b > next
-            5.plus @
-      10
-
-  ++> tests-range-with-wrong-items-is-an-empty-array
-    tuple.is-empty rng > @
-    range > rng
-      []
-        y 10 > @
-        [num] > y
-          num > @
-          [] > next
-            42 > nothing
-      1
-
-  ++> tests-simple-range-from-one-to-ten
+  ++> can-build-a-range-from-one-to-ten
     rng.eq > @
       *
         1
@@ -87,7 +64,7 @@
             1.plus @
       10
 
-  ++> tests-simple-range-with-floats-from-one-to-five
+  ++> can-build-a-range-of-floats-from-one-to-five
     rng.eq > @
       *
         1
@@ -106,3 +83,26 @@
           x > next
             0.5.plus @
       5
+
+  ++> can-build-a-range-with-out-of-bounds-items
+    rng.eq > @
+      * 1 6
+    range > rng
+      []
+        b 1 > @
+        [num] > b
+          num > @
+          b > next
+            5.plus @
+      10
+
+  ++> can-build-an-empty-range-from-wrong-items
+    tuple.is-empty rng > @
+    range > rng
+      []
+        y 10 > @
+        [num] > y
+          num > @
+          [] > next
+            42 > nothing
+      1

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -20,15 +20,7 @@
           1.plus @
     r.end
 
-  tuple.is-empty ++> tests-naturals-descending-is-empty
-    naturals
-      range 10 1
-
-  tuple.is-empty ++> tests-naturals-from-ten-to-ten-is-empty
-    naturals
-      range 10 10
-
-  eq. ++> tests-naturals-negative-works-as-well
+  eq. ++> can-build-a-range-of-negatives
     naturals
       range -5 0
     *
@@ -38,7 +30,15 @@
       -2
       -1
 
-  eq. ++> tests-simple-naturals-from-one-to-ten
+  tuple.is-empty ++> can-build-an-empty-range-from-ten-to-ten
+    naturals
+      range 10 10
+
+  tuple.is-empty ++> can-build-an-empty-range-when-descending
+    naturals
+      range 10 1
+
+  eq. ++> can-build-naturals-from-one-to-ten
     naturals
       range 1 10
     *

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -16,19 +16,19 @@
   ? > value /A?
   ? > alternative /A
 
-  eq. ++> tests-falls-back-to-alternative-when-terminated
+  eq. ++> can-fall-back-to-the-alternative-when-terminated
     recovered
       2.as-i64.div 0.as-i64
       7
     7
 
-  eq. ++> tests-keeps-the-value-when-not-terminated
+  eq. ++> can-keep-the-value-when-not-terminated
     recovered
       42
       7
     42
 
-  eq. ++> tests-recovers-the-inner-recovery
+  eq. ++> can-recover-an-inner-recovery
     recovered
       recovered
         2.as-i64.div 0.as-i64
@@ -36,7 +36,7 @@
       42
     42
 
-  eq. ++> tests-recovers-when-a-provided-fallback-terminates
+  eq. ++> can-recover-when-a-provided-fallback-terminates
     recovered
       2.as-i64.div
         0.as-i64
@@ -45,6 +45,6 @@
       42
     42
 
-  recovered --> when-both-are-terminated
+  recovered --> stops-on-both-being-terminated
     2.as-i64.div 0.as-i64
     5.as-i64.div 0.as-i64

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -32,19 +32,19 @@
         steps.head
         steps.head
 
-  eq. ++> tests-seq-calculates-and-returns
+  eq. ++> can-calculate-and-return
     1
     seq *
       0
       1
 
-  eq. ++> tests-seq-calculates-and-returns-object
+  eq. ++> can-calculate-and-return-an-object
     "Hello!"
     seq *
       0
       "Hello!"
 
-  ++> tests-seq-single-dataization-float-greater
+  ++> can-dataize-a-float-once-when-greater
     malloc.of > @
       1
       [b]
@@ -58,7 +58,7 @@
                 m.as-number
               0.9
 
-  ++> tests-seq-single-dataization-float-less
+  ++> can-dataize-a-float-once-when-less
     malloc.of > @
       1
       [b]
@@ -72,7 +72,22 @@
                 m.as-number
               1.1
 
-  ++> tests-seq-single-dataization-int-equal-to-cache-problem-test
+  ++> can-dataize-an-integer-once-when-equal
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            eq.
+              seq *
+                m.put 0
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1
+
+  ++> can-dataize-an-integer-once-when-equal-and-cached
     malloc.of > @
       1
       [b]
@@ -89,22 +104,7 @@
                 m
               1
 
-  ++> tests-seq-single-dataization-int-equal-to-test
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          b.put > [m] >>
-            eq.
-              seq *
-                m.put 0
-                m.put
-                  m.as-number.plus 1
-                m.as-number
-              1
-
-  ++> tests-seq-single-dataization-int-less
+  ++> can-dataize-an-integer-once-when-less
     malloc.of > @
       1
       [b]
@@ -118,7 +118,7 @@
                 m.as-number
               2
 
-  ++> tests-seq-single-dataization-int-less-or-equal
+  ++> can-dataize-an-integer-once-when-less-or-equal
     malloc.of > @
       1
       [b]
@@ -132,7 +132,7 @@
                 m.as-number
               1
 
-  true.eq ++> tests-very-long-seq
+  true.eq ++> can-run-a-very-long-sequence
     seq *
       true
       true

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -24,7 +24,7 @@
         lst
         map.entry item true > [item]
 
-  has. ++> tests-appends-new-item-to-set
+  has. ++> can-append-a-new-item
     with.
       set *
         1
@@ -32,7 +32,7 @@
       3
     3
 
-  eq. ++> tests-does-not-append-existed-item-to-set
+  eq. ++> cannot-append-an-existing-item
     size.
       with.
         set *
@@ -41,13 +41,13 @@
         1
     2
 
-  eq. ++> tests-empty-set-has-size-of-zero
+  eq. ++> can-have-a-size-of-zero-when-empty
     size.
       set
         *
     0
 
-  eq. ++> tests-set-rebuilds-itself
+  eq. ++> can-rebuild-itself
     set *
       1
       2

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -54,5 +54,5 @@
       text
     true
 
-  stderr ++> tests-prints-to-stderr
+  stderr ++> can-print-to-stderr
     "Hello, stderr-test!\n"

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -20,5 +20,5 @@
     console.write text
     true
 
-  stdout ++> tests-prints-to-console
+  stdout ++> can-print-to-the-console
     "Hello, stdout-test!\n"

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -22,103 +22,103 @@
 [as-bytes] > string
   as-bytes > @
 
-  D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> tests-bytes-equal-to-string
+  string.contains ++> can-check-containment-through-the-package
+    "hello, world"
+    "world"
 
-  not. ++> tests-compares-string-with-nan
+  not. ++> can-compare-a-string-with-nan
     nan.eq "друг"
 
-  not. ++> tests-compares-string-with-negative-infinity
+  not. ++> can-compare-a-string-with-negative-infinity
     ninf.eq "друг"
 
-  eq. ++> tests-compares-string-with-positive-infinity
+  eq. ++> can-compare-a-string-with-positive-infinity
     pinf.eq "друг"
     false
 
-  not. ++> tests-compares-two-different-string-types
+  "Ф".eq "Ф" ++> can-compare-one-symbol-strings
+
+  not. ++> can-compare-two-different-string-types
     "Hello".eq 42
 
-  not. ++> tests-compares-two-different-strings
+  not. ++> can-compare-two-different-strings
     "Hello".eq
       "Good bye"
 
-  eq. ++> tests-compares-two-strings
+  eq. ++> can-compare-two-equal-strings
     "x".eq "x"
     true
 
-  "Ф".eq "Ф" ++> tests-one-symbol-string-compares
-
-  string.contains ++> tests-package-contains-via-string-namespace
-    "hello, world"
-    "world"
-
-  contains. ++> tests-package-contains-word-in-sentence
+  contains. ++> can-contain-a-word-in-a-sentence
     "hello, world, how are you?"
     "how"
 
-  "eEo".is-alpha ++> tests-package-detects-alphabetic-text
+  "eEo".is-alpha ++> can-detect-alphabetic-text
 
-  "2026".is-digit ++> tests-package-detects-digits
+  "2026".is-digit ++> can-detect-digits
 
-  ends-with. ++> tests-package-ends-with-suffix
+  ends-with. ++> can-end-with-a-suffix
     "hello, world"
     "world"
 
-  eq. ++> tests-package-finds-index-of-character
+  D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> can-equal-a-string-through-bytes
+
+  "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> can-equal-bytes
+
+  eq. ++> can-find-the-index-of-a-character
     "hello".index-of "l"
     2
 
-  "HELLO".low-cased.eq "hello" ++> tests-package-low-cases-text
+  "Abc".eq "Abc" ++> can-hold-a-one-line-text-block
 
-  eq. ++> tests-package-repeats-text
-    "ha".repeated 3
-    "hahaha"
-
-  starts-with. ++> tests-package-starts-with-prefix
-    "hello, world"
-    "hello"
-
-  eq. ++> tests-package-takes-character-at-index
-    "some".at 1
-    "o"
-
-  eq. ++> tests-package-trims-surrounding-spaces
-    "  spaced  ".trimmed
-    "spaced"
-
-  "hello".up-cased.eq "HELLO" ++> tests-package-up-cases-text
-
-  eq. ++> tests-preserves-indentation-in-text
-    "a\n b\n  c"
-    "a\n b\n  c"
-
-  "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> tests-string-equals-to-bytes
-
-  eq. ++> tests-supports-escape-sequences
-    "Hello, друг!\n"
-    "Hello, друг!\n"
-
-  eq. ++> tests-supports-escape-sequences-in-text
-    "Hello, друг!\n"
-    "Hello, друг!\n"
-
-  "\n".eq "\n" ++> tests-supports-escape-sequences-line-break
-
-  "Ф".eq "Ф" ++> tests-supports-escape-sequences-unicode
-
-  "Abc".eq "Abc" ++> tests-text-block-one-line
-
-  "e\ne\ne".eq 65-0A-65-0A-65 ++> tests-text-block-tree-lines
-
-  eq. ++> tests-text-block-with-margin
+  eq. ++> can-hold-a-text-block-with-a-margin
     "z\n  y\n x"
     7A-0A-20-20-79-0A-20-78
 
-  eq. ++> tests-turns-string-into-bytes
+  "e\ne\ne".eq 65-0A-65-0A-65 ++> can-hold-a-three-line-text-block
+
+  "HELLO".low-cased.eq "hello" ++> can-lower-case-text
+
+  eq. ++> can-preserve-indentation-in-a-text-block
+    "a\n b\n  c"
+    "a\n b\n  c"
+
+  eq. ++> can-repeat-text
+    "ha".repeated 3
+    "hahaha"
+
+  starts-with. ++> can-start-with-a-prefix
+    "hello, world"
+    "hello"
+
+  "\n".eq "\n" ++> can-support-a-line-break-escape-sequence
+
+  "Ф".eq "Ф" ++> can-support-a-unicode-escape-sequence
+
+  eq. ++> can-support-escape-sequences
+    "Hello, друг!\n"
+    "Hello, друг!\n"
+
+  eq. ++> can-support-escape-sequences-in-a-text-block
+    "Hello, друг!\n"
+    "Hello, друг!\n"
+
+  eq. ++> can-take-a-character-at-an-index
+    "some".at 1
+    "o"
+
+  eq. ++> can-trim-surrounding-spaces
+    "  spaced  ".trimmed
+    "spaced"
+
+  eq. ++> can-turn-into-bytes
     "€ друг".as-bytes
     E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
 
-  eq. ++> tests-unescapes-slashes
+  eq. ++> can-unescape-slashes
     "x\\b\\f\\u\\r\\t\\n\\'"
     78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
-  "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> tests-unescapes-symbols
+  "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> can-unescape-symbols
+
+  "hello".up-cased.eq "HELLO" ++> can-upper-case-text

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -14,39 +14,39 @@
     as-i16.
       00-.concat char.as-bytes
 
-  eq. ++> tests-reads-code-of-last-lowercase-letter
-    122
-    as-ascii "z"
-
-  eq. ++> tests-reads-code-of-last-printable
-    126
-    as-ascii "~"
-
-  eq. ++> tests-reads-code-of-last-uppercase-letter
-    90
-    as-ascii "Z"
-
-  eq. ++> tests-reads-code-of-lowercase-letter
+  eq. ++> can-read-the-code-of-a-lowercase-letter
     97
     as-ascii "a"
 
-  eq. ++> tests-reads-code-of-nine-digit
-    57
-    as-ascii "9"
-
-  eq. ++> tests-reads-code-of-punctuation
+  eq. ++> can-read-the-code-of-a-punctuation-mark
     33
     as-ascii "!"
 
-  eq. ++> tests-reads-code-of-space
+  eq. ++> can-read-the-code-of-a-space
     32
     as-ascii
       " "
 
-  eq. ++> tests-reads-code-of-uppercase-letter
+  eq. ++> can-read-the-code-of-an-uppercase-letter
     65
     as-ascii "A"
 
-  eq. ++> tests-reads-code-of-zero-digit
+  eq. ++> can-read-the-code-of-the-last-lowercase-letter
+    122
+    as-ascii "z"
+
+  eq. ++> can-read-the-code-of-the-last-printable-character
+    126
+    as-ascii "~"
+
+  eq. ++> can-read-the-code-of-the-last-uppercase-letter
+    90
+    as-ascii "Z"
+
+  eq. ++> can-read-the-code-of-the-nine-digit
+    57
+    as-ascii "9"
+
+  eq. ++> can-read-the-code-of-the-zero-digit
     48
     as-ascii "0"

--- a/eo-runtime/src/main/eo/string/as-char.eo
+++ b/eo-runtime/src/main/eo/string/as-char.eo
@@ -13,38 +13,38 @@
     7
     1
 
-  eq. ++> tests-round-trips-through-as-ascii
+  eq. ++> can-round-trip-through-as-ascii
     "!"
     string
       as-char
         as-ascii "!"
 
-  eq. ++> tests-writes-byte-of-last-printable
-    "~"
-    string
-      as-char 126
-
-  eq. ++> tests-writes-byte-of-last-uppercase-letter
-    "Z"
-    string
-      as-char 90
-
-  eq. ++> tests-writes-byte-of-lowercase-letter
+  eq. ++> can-write-the-byte-of-a-lowercase-letter
     "z"
     string
       as-char 122
 
-  eq. ++> tests-writes-byte-of-space
+  eq. ++> can-write-the-byte-of-a-space
     " "
     string
       as-char 32
 
-  eq. ++> tests-writes-byte-of-uppercase-letter
+  eq. ++> can-write-the-byte-of-an-uppercase-letter
     "A"
     string
       as-char 65
 
-  eq. ++> tests-writes-byte-of-zero-digit
+  eq. ++> can-write-the-byte-of-the-last-printable-character
+    "~"
+    string
+      as-char 126
+
+  eq. ++> can-write-the-byte-of-the-last-uppercase-letter
+    "Z"
+    string
+      as-char 90
+
+  eq. ++> can-write-the-byte-of-the-zero-digit
     "0"
     string
       as-char 48

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -37,53 +37,53 @@
           n.div 10
       | n
 
-  eq. ++> tests-negative-below-one-drops-sign
+  eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"
     string
       as-decimal -0.9
 
-  eq. ++> tests-negative-truncating-to-zero-drops-sign
+  eq. ++> can-drop-the-sign-of-a-negative-truncating-to-zero
     "0"
     string
       as-decimal -0.5
 
-  eq. ++> tests-truncates-negative-fraction
+  eq. ++> can-truncate-a-negative-fraction
     "-7"
     string
       as-decimal -7.89
 
-  eq. ++> tests-truncates-positive-fraction
+  eq. ++> can-truncate-a-positive-fraction
     "42"
     string
       as-decimal 42.987
 
-  eq. ++> tests-writes-multi-digit-number
+  eq. ++> can-write-a-multi-digit-number
     "31415"
     string
       as-decimal 31415
 
-  eq. ++> tests-writes-negative-number
+  eq. ++> can-write-a-negative-number
     "-42"
     string
       as-decimal -42
 
-  eq. ++> tests-writes-number-with-inner-zero
+  eq. ++> can-write-a-number-with-an-inner-zero
     "105"
     string
       as-decimal 105
 
-  eq. ++> tests-writes-single-digit
+  eq. ++> can-write-a-single-digit
     "7"
     string
       as-decimal 7
 
-  eq. ++> tests-writes-zero
+  eq. ++> can-write-zero
     "0"
     string
       as-decimal 0
 
-  as-decimal nan --> on-nan
+  as-decimal nan --> stops-on-nan
 
-  as-decimal ninf --> on-negative-infinity
+  as-decimal ninf --> stops-on-negative-infinity
 
-  as-decimal pinf --> on-positive-infinity
+  as-decimal pinf --> stops-on-positive-infinity

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -80,82 +80,82 @@
             48
         acc
 
-  eq. ++> tests-carries-rounding-into-integer-part
+  eq. ++> can-carry-rounding-into-the-integer-part
     "1.000000"
     string
       as-fixed 0.9999999 6
 
-  eq. ++> tests-honours-custom-places
-    "3.14"
+  eq. ++> can-drop-the-sign-of-a-negative-rounding-to-zero
+    "0.00"
     string
-      as-fixed 3.14159 2
+      as-fixed -1.0E-4 2
 
-  eq. ++> tests-negative-places-formats-message-as-number
+  eq. ++> can-drop-the-sign-of-a-tiny-negative-rounding-to-zero
+    "0.00"
+    string
+      as-fixed -0.001 2
+
+  eq. ++> can-format-the-error-message-of-negative-places
     "Can't write a fixed-point decimal with -2.000000 fraction places"
     as-fixed
       3.14159
       -2
       message > [message]
 
-  eq. ++> tests-negative-places-returns-provided-fallback
+  eq. ++> can-honour-custom-places
+    "3.14"
+    string
+      as-fixed 3.14159 2
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places
+    "3"
+    string
+      as-fixed 2.5 0
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places-when-negative
+    "-3"
+    string
+      as-fixed -2.5 0
+
+  eq. ++> can-pad-with-trailing-zeros
+    "1.250000"
+    string
+      as-fixed 1.25 6
+
+  eq. ++> can-round-to-the-last-place
+    "0.123457"
+    string
+      as-fixed 0.123456789 6
+
+  eq. ++> can-write-a-negative-value
+    "-2.500000"
+    string
+      as-fixed -2.5 6
+
+  eq. ++> can-write-a-single-place
+    "2.5"
+    string
+      as-fixed 2.5 1
+
+  eq. ++> can-write-zero-with-places
+    "0.000000"
+    string
+      as-fixed 0 6
+
+  eq. ++> rejects-negative-places
     "recovered"
     as-fixed
       3.14159
       -2
       "recovered" > [message]
 
-  eq. ++> tests-negative-rounding-to-zero-drops-sign
-    "0.00"
-    string
-      as-fixed -1.0E-4 2
-
-  eq. ++> tests-negative-tiny-rounding-to-zero-drops-sign
-    "0.00"
-    string
-      as-fixed -0.001 2
-
-  eq. ++> tests-non-integer-places-returns-provided-fallback
+  eq. ++> rejects-non-integer-places
     "recovered"
     as-fixed
       3.14159
       2.5
       "recovered" > [message]
 
-  eq. ++> tests-pads-with-trailing-zeros
-    "1.250000"
-    string
-      as-fixed 1.25 6
-
-  eq. ++> tests-rounds-to-last-place
-    "0.123457"
-    string
-      as-fixed 0.123456789 6
-
-  eq. ++> tests-writes-negative-value
-    "-2.500000"
-    string
-      as-fixed -2.5 6
-
-  eq. ++> tests-writes-single-place
-    "2.5"
-    string
-      as-fixed 2.5 1
-
-  eq. ++> tests-writes-zero
-    "0.000000"
-    string
-      as-fixed 0 6
-
-  eq. ++> tests-zero-places-omits-decimal-point
-    "3"
-    string
-      as-fixed 2.5 0
-
-  eq. ++> tests-zero-places-omits-decimal-point-when-negative
-    "-3"
-    string
-      as-fixed -2.5 0
-
-  as-fixed --> on-negative-places-without-fallback
+  as-fixed --> stops-on-negative-places
     3.14159
     -2

--- a/eo-runtime/src/main/eo/string/as-hex.eo
+++ b/eo-runtime/src/main/eo/string/as-hex.eo
@@ -44,27 +44,27 @@
     0
     --
 
-  eq. ++> tests-writes-single-byte
+  eq. ++> can-write-a-single-byte
     "41"
     string
       as-hex "A".as-bytes
 
-  eq. ++> tests-joins-bytes-with-hyphens
+  eq. ++> can-join-bytes-with-hyphens
     "4A-65-66-66"
     string
       as-hex "Jeff".as-bytes
 
-  eq. ++> tests-writes-letter-nibbles
+  eq. ++> can-write-letter-nibbles
     "00-00-00-00-00-00-00-FF"
     string
       as-hex 255.as-i64.as-bytes
 
-  eq. ++> tests-writes-number-bytes
+  eq. ++> can-write-the-bytes-of-a-number
     "40-45-00-00-00-00-00-00"
     string
       as-hex 42.as-bytes
 
-  eq. ++> tests-writes-empty-bytes
+  eq. ++> can-write-empty-bytes
     ""
     string
       as-hex --

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -29,48 +29,48 @@
         at.
           scanf "%f" text
 
-  eq. ++> tests-converts-float-text-to-number
+  eq. ++> can-convert-float-text
     3.14
     as-number "3.14"
 
-  eq. ++> tests-converts-negative-text-to-number
+  eq. ++> can-convert-negative-text
     -42
     as-number "-42"
 
-  eq. ++> tests-converts-text-to-number
+  eq. ++> can-convert-text
     5
     as-number "5"
 
-  42.5.eq "42.5".as-number ++> tests-converts-text-to-number-via-implicit-dispatch
+  42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch
 
-  eq. ++> tests-currency-prefixed-text-returns-provided-fallback
+  eq. ++> rejects-currency-prefixed-text
     42
     as-number
       "$100"
       42 > [message]
 
-  eq. ++> tests-embedded-number-text-returns-provided-fallback
-    42
-    as-number
-      "abc5"
-      42 > [message]
-
-  eq. ++> tests-multiple-dots-text-returns-provided-fallback
-    42
-    as-number
-      "12.34.56"
-      42 > [message]
-
-  eq. ++> tests-non-numeric-text-returns-provided-fallback
+  eq. ++> rejects-non-numeric-text
     42
     as-number
       "Hello"
       42 > [message]
 
-  eq. ++> tests-space-separated-numbers-text-returns-provided-fallback
+  eq. ++> rejects-space-separated-numbers
     42
     as-number
       "1 2 3"
       42 > [message]
 
-  as-number "Hello" --> on-converting-text-to-number
+  eq. ++> rejects-text-with-an-embedded-number
+    42
+    as-number
+      "abc5"
+      42 > [message]
+
+  eq. ++> rejects-text-with-multiple-dots
+    42
+    as-number
+      "12.34.56"
+      42 > [message]
+
+  as-number "Hello" --> stops-on-converting-non-numeric-text

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -38,45 +38,45 @@
       index
       1
 
-  eq. ++> tests-fractional-in-bounds-index-returns-fallback
+  eq. ++> can-return-a-character-at-a-negative-index
+    "m"
+    at
+      "some"
+      -2
+
+  eq. ++> can-return-the-first-character
+    "s"
+    at
+      "some"
+      0
+
+  eq. ++> can-return-the-third-character
+    "m"
+    at
+      "some"
+      2
+
+  eq. ++> rejects-a-fractional-index-in-bounds
     "recovered"
     at
       "some"
       1.5
       "recovered" > [message]
 
-  eq. ++> tests-negative-fractional-in-bounds-index-returns-fallback
+  eq. ++> rejects-a-negative-fractional-index-in-bounds
     "recovered"
     at
       "some"
       -1.5
       "recovered" > [message]
 
-  eq. ++> tests-returns-char-at-negative-index
-    "m"
-    at
-      "some"
-      -2
-
-  eq. ++> tests-returns-first-char
-    "s"
-    at
-      "some"
-      0
-
-  eq. ++> tests-returns-third-char
-    "m"
-    at
-      "some"
-      2
-
-  eq. ++> tests-text-at-out-of-bounds-returns-provided-fallback
+  eq. ++> rejects-an-out-of-bounds-index
     "recovered"
     at
       "some"
       10
       "recovered" > [message]
 
-  at --> on-text-at-index-more-than-length
+  at --> stops-on-an-index-beyond-the-length
     "some"
     10

--- a/eo-runtime/src/main/eo/string/chained.eo
+++ b/eo-runtime/src/main/eo/string/chained.eo
@@ -19,7 +19,7 @@
         text.as-bytes
         accum.concat str.as-bytes > [accum str]
 
-  eq. ++> tests-chains-with-other-strings
+  eq. ++> can-chain-with-other-strings
     "Hello, world!"
     chained *1
       "Hello"
@@ -27,7 +27,7 @@
       "world"
       "!"
 
-  eq. ++> tests-returns-same-text-on-chaining-with-no-strings
+  eq. ++> can-return-the-same-text-without-other-strings
     "Some"
     chained
       "Some"

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -17,29 +17,29 @@
     true
     x.and a > [a x]
 
-  contains-all ++> test-contains-all-without-substrings
+  contains-all ++> can-contain-all-of-no-substrings
     "xyz"
     *
 
-  contains-all ++> tests-contains-all-for-empty-text-and-without-substrings
+  contains-all ++> can-contain-all-of-no-substrings-when-empty
     ""
     *
 
-  contains-all *1 ++> tests-contains-all-vert
+  contains-all *1 ++> can-contain-all-substrings
+    "abcdefghijk"
+    "abc"
+    "ghi"
+
+  contains-all *1 ++> can-contain-all-substrings-written-vertically
     "Hello, world!"
     "ell"
     " "
     ","
     "d!"
 
-  not. ++> tests-not-contains-all
+  not. ++> cannot-contain-all-substrings
     contains-all *1
       "qwerty"
       "qer"
       "ty"
       "abc"
-
-  contains-all *1 ++> tests-successful-contains-all
-    "abcdefghijk"
-    "abc"
-    "ghi"

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -17,31 +17,31 @@
     false
     x.or a > [a x]
 
-  not. ++> test-contains-any-without-substrings
-    contains-any
-      "text"
-      *
+  contains-any *1 ++> can-contain-any-substring
+    "Good morning"
+    "oo"
+    "goo"
 
-  not. ++> tests-contains-any-for-empty-text-and-without-substrings
-    contains-any
-      ""
-      *
-
-  contains-any *1 ++> tests-contains-any-vert
+  contains-any *1 ++> can-contain-any-substring-written-vertically
     "foo bar buzz"
     "bar"
     " "
     "o"
 
-  not. ++> tests-not-contains-any
+  not. ++> cannot-contain-any-of-no-substrings
+    contains-any
+      "text"
+      *
+
+  not. ++> cannot-contain-any-of-no-substrings-when-empty
+    contains-any
+      ""
+      *
+
+  not. ++> cannot-contain-any-substring
     contains-any *1
       "xyzw"
       "yx"
       "zyx"
       "wx"
       "abc"
-
-  contains-any *1 ++> tests-successful-contains-any
-    "Good morning"
-    "oo"
-    "goo"

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -33,11 +33,11 @@
     number length
     size
 
-  contains ++> tests-text-contains-substring
+  contains ++> can-contain-a-substring
     "Hello, world!"
     "o, wo"
 
-  not. ++> tests-text-does-not-contain-substring
+  not. ++> cannot-contain-an-absent-substring
     contains
       "Hello, world!"
       "Hey"

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -22,11 +22,11 @@
         size
       substring >> part!
 
-  not. ++> tests-does-not-end-with-substring
+  ends-with ++> can-end-with-a-substring
+    "Hello world!"
+    "world!"
+
+  not. ++> cannot-end-with-an-absent-substring
     ends-with
       "Hello world!"
       "Hello"
-
-  ends-with ++> tests-ends-with-substring
-    "Hello world!"
-    "world!"

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -43,38 +43,38 @@
       txt.slice idx size
       part
 
-  eq. ++> tests-index-of-existed-substring-with-utf
+  eq. ++> can-find-a-present-substring-in-utf-text
     3
     index-of
       "привет, друг!"
       "в"
 
-  eq. ++> tests-index-of-non-existed-substring-with-more-length
-    -1
-    index-of
-      "Hello"
-      "Somebody"
-
-  eq. ++> tests-index-of-non-existed-substring-with-same-length
-    -1
-    index-of
-      "Hello"
-      "world"
-
-  eq. ++> tests-index-of-non-existed-substring-with-utf
-    -1
-    index-of
-      "привет, друг!"
-      "x"
-
-  eq. ++> tests-returns-valid-index-of-substring
+  eq. ++> can-return-the-index-of-a-substring
     6
     index-of
       "Hello \n world"
       "\n"
 
-  eq. ++> tests-returns-valid-index-of-substring-in-the-end
+  eq. ++> can-return-the-index-of-a-substring-at-the-end
     6
     index-of
       "Hello world"
+      "world"
+
+  eq. ++> cannot-find-a-longer-substring
+    -1
+    index-of
+      "Hello"
+      "Somebody"
+
+  eq. ++> cannot-find-an-absent-substring-in-utf-text
+    -1
+    index-of
+      "привет, друг!"
+      "x"
+
+  eq. ++> cannot-find-an-absent-substring-of-the-same-length
+    -1
+    index-of
+      "Hello"
       "world"

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -13,13 +13,13 @@
     regex "/^[a-zA-Z]+$/"
     text
 
-  not. ++> tests-checks-if-empty-text-is-not-alpha
+  is-alpha "eEo" ++> can-be-alphabetic-when-simple-text
+
+  not. ++> cannot-be-alphabetic-when-empty
     is-alpha ""
 
-  is-alpha "eEo" ++> tests-checks-if-simple-text-is-alpha
-
-  not. ++> tests-checks-if-text-with-dashes-is-not-alpha
-    is-alpha "-w-"
-
-  not. ++> tests-checks-if-text-with-number-is-not-alpha
+  not. ++> cannot-be-alphabetic-with-a-number
     is-alpha "ab3d"
+
+  not. ++> cannot-be-alphabetic-with-dashes
+    is-alpha "-w-"

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -13,12 +13,12 @@
     regex "/^[A-Za-z0-9]+$/"
     text
 
-  not. ++> tests-checks-if-empty-text-is-not-alphanumeric
+  is-alphanumeric "eEo" ++> can-be-alphanumeric-when-simple-text
+
+  is-alphanumeric "ab3d" ++> can-be-alphanumeric-with-a-number
+
+  not. ++> cannot-be-alphanumeric-when-empty
     is-alphanumeric ""
 
-  is-alphanumeric "eEo" ++> tests-checks-if-simple-text-is-alphanumeric
-
-  not. ++> tests-checks-if-text-with-dashes-is-not-alphanumeric
+  not. ++> cannot-be-alphanumeric-with-dashes
     is-alphanumeric "-w-"
-
-  is-alphanumeric "ab3d" ++> tests-checks-if-text-with-number-is-alphanumeric

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,12 +12,12 @@
     regex "/^[\\x00-\\x7F]+$/"
     text
 
-  not. ++> tests-checks-if-emoji-is-not-ascii
-    is-ascii "🌵"
+  is-ascii "123" ++> can-be-ascii-when-digits
 
-  not. ++> tests-checks-if-empty-text-is-not-ascii
+  is-ascii "H311oW" ++> can-be-ascii-when-plain-text
+
+  not. ++> cannot-be-ascii-when-empty
     is-ascii ""
 
-  is-ascii "123" ++> tests-checks-if-string-of-numbers-is-ascii
-
-  is-ascii "H311oW" ++> tests-checks-if-text-is-ascii
+  not. ++> cannot-be-ascii-with-an-emoji
+    is-ascii "🌵"

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,25 +13,25 @@
     regex "/^[0-9]+$/"
     text
 
-  not. ++> tests-checks-if-empty-text-is-not-digit
+  is-digit "2026" ++> can-be-digits-when-a-number
+
+  is-digit "7" ++> can-be-digits-when-a-single-digit
+
+  is-digit ++> can-be-digits-when-a-very-long-number
+    "123456789012345678901234567890123456789012345678901234567890"
+
+  not. ++> cannot-be-digits-when-empty
     is-digit ""
 
-  is-digit "2026" ++> tests-checks-if-number-text-is-digit
-
-  is-digit "7" ++> tests-checks-if-single-digit-is-digit
-
-  not. ++> tests-checks-if-text-with-letter-is-not-digit
+  not. ++> cannot-be-digits-with-a-letter
     is-digit "1a2"
 
-  not. ++> tests-checks-if-text-with-space-is-not-digit
+  not. ++> cannot-be-digits-with-a-space
     is-digit
       "12 34"
 
-  not. ++> tests-checks-if-text-with-special-character-is-not-digit
+  not. ++> cannot-be-digits-with-a-special-character
     is-digit "1🌵2"
 
-  not. ++> tests-checks-if-text-with-trailing-newline-is-not-digit
+  not. ++> cannot-be-digits-with-a-trailing-newline
     is-digit "123\n"
-
-  is-digit ++> tests-checks-if-very-long-number-is-digit
-    "123456789012345678901234567890123456789012345678901234567890"

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -24,7 +24,7 @@
             tup.tail
       | items.head items.tail
 
-  eq. ++> tests-joined-many-strings
+  eq. ++> can-join-many-strings
     "hello-world-dear-friend"
     joined *1
       "-"
@@ -33,13 +33,13 @@
       "dear"
       "friend"
 
-  eq. ++> tests-joined-no-strings
+  eq. ++> can-join-no-strings
     ""
     joined
       "-"
       *
 
-  eq. ++> tests-joined-one-string
+  eq. ++> can-join-one-string
     "some"
     joined *1
       "-"

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -43,31 +43,31 @@
       txt.slice idx size
       part
 
-  eq. ++> tests-finds-last-index-of-substring
+  eq. ++> can-find-the-last-index-of-a-substring
     5
     last-index-of
       "Hey, Hey, Hey"
       "Hey,"
 
-  eq. ++> tests-finds-last-index-of-the-same-string
-    0
-    last-index-of
-      "Hello"
-      "Hello"
-
-  eq. ++> tests-last-index-of-existed-substring-with-utf
+  eq. ++> can-find-the-last-index-of-a-substring-in-utf-text
     3
     last-index-of
       "привет, друг!"
       "в"
 
-  eq. ++> tests-last-index-of-non-existed-substring
+  eq. ++> can-find-the-last-index-of-the-whole-string
+    0
+    last-index-of
+      "Hello"
+      "Hello"
+
+  eq. ++> cannot-find-the-last-index-of-an-absent-substring
     -1
     last-index-of
       "Hello, world"
       "somebody"
 
-  eq. ++> tests-last-index-of-non-existed-substring-with-utf
+  eq. ++> cannot-find-the-last-index-of-an-absent-substring-in-utf-text
     -1
     last-index-of
       "привет, друг!"

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -59,32 +59,32 @@
       index.plus csize
       len.plus 1
 
-  eq. ++> tests-calculates-length-of-spaces-only
+  eq. ++> can-count-a-text-of-spaces-only
     " ".length
     1
 
-  eq. ++> tests-counts-characters-of-the-origin-text
-    length
-      "Hello, world!"
-    13
-
-  ++> tests-reads-the-length-with-n2-byte-characters
-    and. > @
-      str.length.eq 12
-      str.as-bytes.size.eq 16
-    "Hello, друг!" > str
-
-  ++> tests-reads-the-length-with-n3-byte-characters
-    and. > @
-      str.length.eq 16
-      str.as-bytes.size.eq 18
-    "The अ devanagari" > str
-
-  ++> tests-reads-the-length-with-n4-byte-characters
+  ++> can-count-four-byte-characters
     and. > @
       str.length.eq 11
       str.as-bytes.size.eq 14
     "The 😀 smile" > str
 
-  length --> on-taking-length-of-incomplete-n4-byte-character
+  eq. ++> can-count-the-characters-of-the-origin-text
+    length
+      "Hello, world!"
+    13
+
+  ++> can-count-three-byte-characters
+    and. > @
+      str.length.eq 16
+      str.as-bytes.size.eq 18
+    "The अ devanagari" > str
+
+  ++> can-count-two-byte-characters
+    and. > @
+      str.length.eq 12
+      str.as-bytes.size.eq 16
+    "Hello, друг!" > str
+
+  length --> stops-on-an-incomplete-four-byte-character
     string F0-9F-98

--- a/eo-runtime/src/main/eo/string/low-cased.eo
+++ b/eo-runtime/src/main/eo/string/low-cased.eo
@@ -33,10 +33,10 @@
             byte
         as-ascii byte > code
 
-  eq. ++> tests-converts-text-to-lower-case
-    "hello"
-    low-cased "HELLO"
-
-  eq. ++> tests-converts-text-with-low-letters-to-lower-case
+  eq. ++> can-convert-already-lower-cased-text
     "hello"
     low-cased "HeLlO"
+
+  eq. ++> can-convert-text-to-lower-case
+    "hello"
+    low-cased "HELLO"

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -71,24 +71,7 @@
           0
   delimiter.size >> size!
 
-  eq. ++> tests-nsplit-invalid-limit-returns-provided-fallback
-    "fallback"
-    nsplit
-      "text"
-      "-"
-      0
-      "fallback" > [message]
-
-  eq. ++> tests-nsplit-with-dashes-limit-two
-    nsplit
-      "a-b-c-d"
-      "-"
-      2
-    *
-      "a"
-      "b-c-d"
-
-  eq. ++> tests-nsplit-with-empty-strings
+  eq. ++> can-split-into-empty-strings
     nsplit
       "-a-b-c"
       "-"
@@ -98,7 +81,25 @@
       "a"
       "b-c"
 
-  eq. ++> tests-nsplit-with-high-limit
+  eq. ++> can-split-on-a-multi-character-delimiter
+    nsplit
+      "a::b::c::d"
+      "::"
+      2
+    *
+      "a"
+      "b::c::d"
+
+  eq. ++> can-split-on-dashes-with-a-limit-of-two
+    nsplit
+      "a-b-c-d"
+      "-"
+      2
+    *
+      "a"
+      "b-c-d"
+
+  eq. ++> can-split-with-a-high-limit
     nsplit
       "a-b-c"
       "-"
@@ -108,14 +109,14 @@
       "b"
       "c"
 
-  eq. ++> tests-nsplit-with-limit-one
+  eq. ++> can-split-with-a-limit-of-one
     nsplit
       "a-b-c"
       "-"
       1
     * "a-b-c"
 
-  eq. ++> tests-nsplit-with-limit-two
+  eq. ++> can-split-with-a-limit-of-two
     nsplit
       "Cookie: a=1; b=2"
       " "
@@ -124,21 +125,20 @@
       "Cookie:"
       "a=1; b=2"
 
-  eq. ++> tests-nsplit-with-multi-char-delimiter
+  eq. ++> rejects-an-invalid-limit
+    "fallback"
     nsplit
-      "a::b::c::d"
-      "::"
-      2
-    *
-      "a"
-      "b::c::d"
+      "text"
+      "-"
+      0
+      "fallback" > [message]
 
-  nsplit --> on-nsplit-with-limit-zero
+  nsplit --> stops-on-a-limit-of-zero
     "text"
     "-"
     0
 
-  nsplit --> on-nsplit-with-negative-limit
+  nsplit --> stops-on-a-negative-limit
     "text"
     "-"
     -1

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -20,25 +20,31 @@
 
 [format args] > printf /Q.string
 
-  eq. ++> formats-float-always-with-six-fraction-digits
+  eq. ++> can-apply-a-precision-to-bytes
+    "40-"
+    printf *1
+      "%.3x"
+      42.as-bytes
+
+  eq. ++> can-apply-a-width-to-bytes
+    "  40-45-00-00-00-00-00-00"
+    printf *1
+      "%25x"
+      42.as-bytes
+
+  eq. ++> can-format-a-float-with-six-fraction-digits
     "1.250000"
     printf *1
       "%f"
       1.25
 
-  eq. ++> formats-left-justified-with-trailing-spaces
-    "x         "
-    printf *1
-      "%-10s"
-      "x"
-
-  eq. ++> formats-numbered-substitution
+  eq. ++> can-format-a-numbered-substitution
     "Hello, Jeff! Bye, Jeff!"
     printf *1
       "Hello, %s! Bye, %1$s!"
       "Jeff"
 
-  eq. ++> formats-numbered-substitution-with-multiple-args
+  eq. ++> can-format-a-numbered-substitution-with-many-arguments
     "This is the first; This is the first as well; The second; and the 3"
     printf *1
       "This is the %s; This is the %1$s as well; The %s; and the %d"
@@ -46,38 +52,31 @@
       "second"
       3
 
-  eq. ++> formats-precision-to-two-decimals
+  eq. ++> can-format-a-precision-of-two-decimals
     "3.14"
     printf *1
       "%.2f"
       3.1415
 
-  eq. ++> formats-width-with-leading-spaces
+  eq. ++> can-format-a-width-with-leading-spaces
     "   42"
     printf *1
       "%5d"
       42
 
-  eq. ++> formats-with-ordered-numbered-substitutions
-    "first second second is after first"
-    printf *1
-      "%s %s %2$s is after %1$s"
-      "first"
-      "second"
-
-  eq. ++> formats-zero-float-with-six-fraction-digits
+  eq. ++> can-format-a-zero-float-with-six-fraction-digits
     "0.000000"
     printf *1
       "%f"
       0
 
-  eq. ++> rounds-float-carrying-into-integer-part
-    "1.000000"
+  eq. ++> can-format-left-justified-with-trailing-spaces
+    "x         "
     printf *1
-      "%f"
-      0.9999999
+      "%-10s"
+      "x"
 
-  eq. ++> tests-formats-all-objects
+  eq. ++> can-format-objects-of-every-type
     "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
     printf *1
       "string %s, bytes %x, float %f, int %d, bool %b"
@@ -87,63 +86,33 @@
       14
       false
 
-  eq. ++> tests-printf-applies-precision-to-bytes
-    "40-"
+  eq. ++> can-format-ordered-numbered-substitutions
+    "first second second is after first"
     printf *1
-      "%.3x"
-      42.as-bytes
+      "%s %s %2$s is after %1$s"
+      "first"
+      "second"
 
-  eq. ++> tests-printf-applies-width-to-bytes
-    "  40-45-00-00-00-00-00-00"
-    printf *1
-      "%25x"
-      42.as-bytes
-
-  eq. ++> tests-printf-does-not-fail-if-arguments-more-than-formats
+  eq. ++> can-ignore-extra-arguments
     "Hey"
     printf *1
       "%s"
       "Hey"
       "Jeff"
 
-  not. ++> tests-printf-does-not-print-i64
-    eq.
-      printf *1
-        "%d"
-        42.as-i64
-      "42"
-
-  eq. ++> tests-printf-left-aligns-bytes
+  eq. ++> can-left-align-bytes
     "40-45-00-00-00-00-00-00  "
     printf *1
       "%-25x"
       42.as-bytes
 
-  eq. ++> tests-printf-preserves-escaped-bytes-format
+  eq. ++> can-preserve-an-escaped-bytes-format
     "%x"
     printf
       "%%x"
       *
 
-  eq. ++> tests-printf-prints-i64-as-number
-    "42"
-    printf *1
-      "%d"
-      42.as-i64.as-number
-
-  eq. ++> tests-printf-prints-percents
-    "%Jeff"
-    printf *1
-      "%%%s"
-      "Jeff"
-
-  eq. ++> tests-prints-bytes-string
-    "40-45-00-00-00-00-00-00"
-    printf *1
-      "%x"
-      42.as-bytes
-
-  eq. ++> tests-prints-complex-string
+  eq. ++> can-print-a-complex-string
     "Привет 3.140000 Jeff X!"
     printf *1
       "Привет %f %s %s!"
@@ -151,74 +120,105 @@
       "Jeff"
       "X"
 
-  eq. ++> tests-prints-simple-string
+  eq. ++> can-print-a-percent-sign
+    "%Jeff"
+    printf *1
+      "%%%s"
+      "Jeff"
+
+  eq. ++> can-print-a-simple-string
     "Hello, Jeffrey!"
     printf *1
       "Hello, %s!"
       "Jeffrey"
 
-  eq. ++> truncates-negative-float-towards-zero-as-decimal
+  eq. ++> can-print-an-i64-as-a-number
+    "42"
+    printf *1
+      "%d"
+      42.as-i64.as-number
+
+  eq. ++> can-print-bytes
+    "40-45-00-00-00-00-00-00"
+    printf *1
+      "%x"
+      42.as-bytes
+
+  eq. ++> can-round-a-float-carrying-into-the-integer-part
+    "1.000000"
+    printf *1
+      "%f"
+      0.9999999
+
+  eq. ++> can-truncate-a-negative-float-toward-zero
     "-7"
     printf *1
       "%d"
       -7.89
 
-  eq. ++> truncates-positive-float-towards-zero-as-decimal
+  eq. ++> can-truncate-a-positive-float-toward-zero
     "42"
     printf *1
       "%d"
       42.321
 
-  eq. ++> truncates-rather-than-rounds-float-as-decimal
+  eq. ++> can-truncate-rather-than-round-a-float
     "9"
     printf *1
       "%d"
       9.99
 
-  printf *1 --> on-formatting-huge-number-as-decimal
-    "%d"
-    1.0e30
+  not. ++> cannot-print-an-i64
+    eq.
+      printf *1
+        "%d"
+        42.as-i64
+      "42"
 
-  printf --> on-printf-unsupported-format
-    "%o"
-    *
-
-  printf *1 --> on-printf-with-arguments-that-does-not-match
-    "%s%s"
-    "Jeff"
-
-  printf *1 --> on-printf-with-comma-flag-on-s
+  printf *1 --> stops-on-a-comma-flag-with-s
     "%,s"
     "Jeff"
 
-  printf *1 --> on-printf-with-comma-flag-on-x
+  printf *1 --> stops-on-a-comma-flag-with-x
     "%,x"
     5
 
-  printf *1 --> on-printf-with-hash-flag-on-s
+  printf *1 --> stops-on-a-hash-flag-with-s
     "%#s"
     "Jeff"
 
-  printf *1 --> on-printf-with-hash-flag-on-x
+  printf *1 --> stops-on-a-hash-flag-with-x
     "%#x"
     5
 
-  printf *1 --> on-printf-with-oversized-positional-index
-    "%99999999999999999999$s"
-    "Jeff"
-
-  printf *1 --> on-printf-with-paren-flag-on-s
+  printf *1 --> stops-on-a-paren-flag-with-s
     "%(s"
     "Jeff"
 
-  printf *1 --> on-printf-with-precision-on-d
+  printf *1 --> stops-on-a-precision-with-d
     "%.2d"
     5
 
-  printf *1 --> on-printf-with-zero-flag-on-x
+  printf *1 --> stops-on-a-zero-flag-with-x
     "%0x"
     5
 
-  printf *1 --> on-printf-with-zero-positional-index
+  printf *1 --> stops-on-a-zero-positional-index
     "%0$s"
     "first"
+
+  printf *1 --> stops-on-an-oversized-positional-index
+    "%99999999999999999999$s"
+    "Jeff"
+
+  printf --> stops-on-an-unsupported-format
+    "%o"
+    *
+
+  printf *1 --> stops-on-arguments-that-do-not-match
+    "%s%s"
+    "Jeff"
+
+  printf *1 --> stops-on-formatting-a-huge-number-as-a-decimal
+    "%d"
+    1.0e30

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -58,53 +58,7 @@
       next. > found
         match txt
 
-  not. ++> tests-does-not-match-anchored-pattern-with-trailing-newline
-    matches.
-      compiled.
-        regex "/^[0-9]+$/"
-      "123\n"
-
-  not. ++> tests-does-not-match-with-unmatched-leading-characters
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "1abc"
-
-  not. ++> tests-does-not-matches-regex-against-the-pattern
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "123"
-
-  eq. ++> tests-invalid-regex-syntax-returns-provided-fallback
-    "recovered"
-    compile.
-      regex "/[a-z/"
-      "recovered" > [message]
-
-  ++> tests-matched-sequence-has-right-border-indexes
-    and. > @
-      0.eq n.start
-      and.
-        1.eq n.from
-        6.eq n.to
-    next. > n
-      match.
-        regex "/[a-z]+/"
-        "!hello!"
-
-  matches. ++> tests-matches-regex-against-the-pattern
-    compiled.
-      regex "/[a-z]+/"
-    "hello"
-
-  eq. ++> tests-missing-slash-returns-provided-fallback
-    "no-slash"
-    compile.
-      regex "(.)+"
-      "no-slash" > [message]
-
-  ++> tests-regex-contains-valid-groups-on-each-matched-block
+  ++> can-expose-groups-on-each-matched-block
     and. > @
       and.
         and.
@@ -131,48 +85,64 @@
         "!hello1!world2"
     first.next > second
 
-  matches. ++> tests-regex-ignores-comments-in-string
+  matches. ++> can-ignore-comments-in-a-pattern
     compiled.
       regex
         "/(\\d) #ignore this comment/x"
     "4"
 
-  matches. ++> tests-regex-matches-dotall-option
+  matches. ++> can-match-a-text-against-a-pattern
     compiled.
-      regex "/(.*)/s"
-    "too \\n many \\n line \\n Feed\\n"
+      regex "/[a-z]+/"
+    "hello"
 
-  matches. ++> tests-regex-matches-entire-pattern
+  matches. ++> can-match-an-entire-pattern
     compiled.
       regex "/[0-9]/\\d+/"
     "2/75"
 
-  matches. ++> tests-regex-matches-with-case-insensitive-option
+  matches. ++> can-match-with-the-case-insensitive-option
     compiled.
       regex "/(string)/i"
     "StRiNg"
 
-  matches. ++> tests-regex-matches-with-multiline-option
-    compiled.
-      regex "/(^([0-9]+).*)/m"
-    "1 bottle of water on the wall. \\n1 bottle of water."
-
-  matches. ++> tests-regex-matches-with-regex-case-insensitive-and-caps
+  matches. ++> can-match-with-the-case-insensitive-option-and-capitals
     compiled.
       regex "/(word)/i"
     "WORD"
 
-  matches. ++> tests-regex-matches-with-regex-unix-lines
+  matches. ++> can-match-with-the-dotall-option
     compiled.
-      regex "/(.+)/d"
-    "A\\r\\nB\\rC\\nD"
+      regex "/(.*)/s"
+    "too \\n many \\n line \\n Feed\\n"
 
-  matches. ++> tests-regex-matches-with-unicode-case-and-insensitive
+  matches. ++> can-match-with-the-multiline-option
+    compiled.
+      regex "/(^([0-9]+).*)/m"
+    "1 bottle of water on the wall. \\n1 bottle of water."
+
+  matches. ++> can-match-with-the-unicode-case-option
     compiled.
       regex "/(yildirim)/ui"
     "Yıldırım"
 
-  eq. ++> tests-regex-returns-valid-matched-string-sequence
+  matches. ++> can-match-with-the-unix-lines-option
+    compiled.
+      regex "/(.+)/d"
+    "A\\r\\nB\\rC\\nD"
+
+  ++> can-report-the-border-indexes-of-a-match
+    and. > @
+      0.eq n.start
+      and.
+        1.eq n.from
+        6.eq n.to
+    next. > n
+      match.
+        regex "/[a-z]+/"
+        "!hello!"
+
+  eq. ++> can-return-the-matched-string-sequence
     text.
       next.
         match.
@@ -180,7 +150,7 @@
           "!hello!"
     "hello"
 
-  ++> tests-regex-returns-valid-second-matched-block
+  ++> can-return-the-second-matched-block
     and. > @
       and.
         and.
@@ -196,54 +166,84 @@
           regex "/[a-z]+/"
           "!hello!world!"
 
-  compile. --> on-compiling-invalid-regex-without-fallback
+  not. ++> cannot-match-a-text-against-a-wrong-pattern
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "123"
+
+  not. ++> cannot-match-an-anchored-pattern-with-a-trailing-newline
+    matches.
+      compiled.
+        regex "/^[0-9]+$/"
+      "123\n"
+
+  not. ++> cannot-match-with-unmatched-leading-characters
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "1abc"
+
+  eq. ++> rejects-a-pattern-with-a-missing-slash
+    "no-slash"
+    compile.
+      regex "(.)+"
+      "no-slash" > [message]
+
+  eq. ++> rejects-invalid-regex-syntax
+    "recovered"
+    compile.
+      regex "/[a-z/"
+      "recovered" > [message]
+
+  compiled. --> stops-on-a-missing-closing-slash
+    regex "/pattern"
+
+  compiled. --> stops-on-a-missing-first-slash
+    regex "(.)+"
+
+  compile. --> stops-on-compiling-an-invalid-pattern
     regex "/[a-z/"
 
-  from. --> on-getting-from-position-on-not-matched-block
-    next.
-      match.
-        regex "/[a-z]+/"
-        "123"
-
-  count. --> on-getting-groups-count-on-not-matched-block
-    next.
-      match.
-        regex "/[a-z]+/"
-        "123"
-
-  groups. --> on-getting-groups-on-not-matched-block
-    next.
-      match.
-        regex "/[a-z]+/"
-        "123"
-
-  next. --> on-getting-next-on-not-matched-block
-    next.
-      match.
-        regex "/[a-z]+/"
-        "123"
-
-  group. --> on-getting-specified-group-on-not-matched-block
+  group. --> stops-on-taking-a-group-of-an-unmatched-block
     next.
       match.
         regex "/[a-z]+/"
         "123"
     1
 
-  text. --> on-getting-text-on-not-matched-block
+  to. --> stops-on-taking-the-end-position-of-an-unmatched-block
     next.
       match.
         regex "/[a-z]+/"
         "123"
 
-  to. --> on-getting-to-position-on-not-matched-block
+  count. --> stops-on-taking-the-group-count-of-an-unmatched-block
     next.
       match.
         regex "/[a-z]+/"
         "123"
 
-  compiled. --> on-missing-closing-slash-in-regex
-    regex "/pattern"
+  groups. --> stops-on-taking-the-groups-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
 
-  compiled. --> on-missing-first-slash-in-regex
-    regex "(.)+"
+  next. --> stops-on-taking-the-next-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  from. --> stops-on-taking-the-start-position-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  text. --> stops-on-taking-the-text-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -35,39 +35,39 @@
           text >> b!
           1
 
-  eq. ++> tests-text-repeated-five-times
-    "heyheyheyheyhey"
-    repeated
-      "hey"
-      5
-
-  eq. ++> tests-text-repeated-negative-times-formats-message-as-number
+  eq. ++> can-format-the-error-message-of-a-negative-count
     "Can't repeat text -1.000000 times"
     repeated
       "x"
       -1
       message > [message]
 
-  eq. ++> tests-text-repeated-negative-times-returns-provided-fallback
+  eq. ++> can-repeat-a-text-five-times
+    "heyheyheyheyhey"
+    repeated
+      "hey"
+      5
+
+  eq. ++> can-repeat-a-text-zero-times
+    ""
+    repeated
+      "some"
+      0
+
+  eq. ++> rejects-a-negative-count
     "recovered"
     repeated
       "x"
       -1
       "recovered" > [message]
 
-  eq. ++> tests-text-repeated-non-integer-times-returns-provided-fallback
+  eq. ++> rejects-a-non-integer-count
     "recovered"
     repeated
       "x"
       2.5
       "recovered" > [message]
 
-  eq. ++> tests-text-repeated-zero-times-is-empty
-    ""
-    repeated
-      "some"
-      0
-
-  repeated --> on-text-repeating-less-than-zero-times
+  repeated --> stops-on-a-negative-count
     ""
     -1

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -35,37 +35,37 @@
         next. >> matched
           target.match reinit
 
-  eq. ++> tests-does-not-replaces-if-regex-not-found
-    replaced
-      "Hello, world"
-      regex "/[0-9]+/"
-      "12345"
-    "Hello, world"
-
-  eq. ++> tests-replaces-digits-with-string
-    replaced
-      "Hell0, w0rld"
-      regex "/[0-9]+/"
-      "o"
-    "Hello, world"
-
-  eq. ++> tests-replaces-slashes-to-windows-separator
-    replaced
-      "C:\\Windows/foo\\bar/hello.txt"
-      regex "/\\//"
-      "\\"
-    "C:\\Windows\\foo\\bar\\hello.txt"
-
-  eq. ++> tests-replaces-windows-path-with-slash
+  eq. ++> can-replace-a-windows-separator-with-a-slash
     replaced
       "C:\\Windows\\Users\\AppLocal\\shrek"
       regex "/[\\\\:]+/"
       "/"
     "C/Windows/Users/AppLocal/shrek"
 
-  eq. ++> tests-sanitizes-windows-path-with-regex
+  eq. ++> can-replace-digits-with-a-string
+    replaced
+      "Hell0, w0rld"
+      regex "/[0-9]+/"
+      "o"
+    "Hello, world"
+
+  eq. ++> can-replace-slashes-with-a-windows-separator
+    replaced
+      "C:\\Windows/foo\\bar/hello.txt"
+      regex "/\\//"
+      "\\"
+    "C:\\Windows\\foo\\bar\\hello.txt"
+
+  eq. ++> can-sanitize-a-windows-path
     replaced
       "foo\\bar<:>?*\"|baz\\asdf"
       regex "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/"
       ""
     "foo\\barbaz\\asdf"
+
+  eq. ++> cannot-replace-when-the-pattern-is-absent
+    replaced
+      "Hello, world"
+      regex "/[0-9]+/"
+      "12345"
+    "Hello, world"

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -225,7 +225,7 @@
     *
     false
 
-  eq. ++> tests-scanf-complex-case
+  eq. ++> can-scan-a-complex-format
     scanf
       "Im%d %s old and this is! Let's calculate %f + %f= %f"
       "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
@@ -236,44 +236,44 @@
       0.01
       100000000
 
-  eq. ++> tests-scanf-with-complex-float
+  eq. ++> can-scan-a-complex-float
     1991.01
     head.
       scanf
         "this will be=%f"
         "this will be=1991.01"
 
-  eq. ++> tests-scanf-with-complex-int
+  eq. ++> can-scan-a-complex-integer
     734987259
     head.
       scanf "!%d!" "!734987259!"
 
-  eq. ++> tests-scanf-with-complex-string
+  eq. ++> can-scan-a-complex-string
     "test"
     head.
       scanf "some%sstring" "someteststring"
 
-  eq. ++> tests-scanf-with-float
+  eq. ++> can-scan-a-float
     0.24
     head.
       scanf "%f" "0.24"
 
-  eq. ++> tests-scanf-with-int
+  eq. ++> can-scan-an-integer
     33
     head.
       scanf "%d" "33"
 
-  eq. ++> tests-scanf-with-negative-int
+  eq. ++> can-scan-a-negative-integer
     -42
     head.
       scanf "%d" "-42"
 
-  eq. ++> tests-scanf-with-positive-signed-int
+  eq. ++> can-scan-a-positive-signed-integer
     42
     head.
       scanf "%d" "+42"
 
-  eq. ++> tests-scanf-with-printf
+  eq. ++> can-scan-what-printf-wrote
     scanf
       "%s is about %d?"
       printf *1
@@ -284,12 +284,12 @@
       "This"
       8
 
-  eq. ++> tests-scanf-with-string
+  eq. ++> can-scan-a-string
     "hello"
     head.
       scanf "%s" "hello"
 
-  eq. ++> tests-scanf-with-string-int-float
+  eq. ++> can-scan-a-string-an-integer-and-a-float
     scanf
       "%s %d %f"
       "hello 33 0.24"
@@ -298,19 +298,19 @@
       33
       0.24
 
-  eq. ++> tests-scanf-with-string-with-ending
+  eq. ++> can-scan-a-string-followed-by-a-literal
     "hello"
     head.
       scanf "%s!" "hello!"
 
-  scanf --> on-scanf-with-dangling-percent
+  scanf --> stops-on-a-dangling-percent
     "hello%"
     "hello"
 
-  scanf --> on-scanf-with-oversized-int
+  scanf --> stops-on-an-oversized-integer
     "%d"
     "99999999999999999999"
 
-  scanf --> on-scanf-with-wrong-format
+  scanf --> stops-on-a-wrong-format
     "%l"
     "error"

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -107,100 +107,100 @@
   F8- > p4
   00- > r1
   C0- > r2
-  p2 > r3
-  p3 > r4
+  E0- > r3
+  F0- > r4
   text.as-bytes.size >> size!
 
-  eq. ++> tests-no-slice-string
-    "no slice".slice
-      0
-      0
-    ""
-
-  eq. ++> tests-slice-at-end-with-zero-length
-    "hello".slice
-      5
-      0
-    ""
-
-  eq. ++> tests-slice-empty-string
-    "".slice
-      0
-      0
-    ""
-
-  eq. ++> tests-slice-escape-sequences-line-break
+  eq. ++> can-slice-a-line-break-escape-sequence
     "\n".slice
       0
       "\n".length
     "\n"
 
-  eq. ++> tests-slice-escape-sequences-unicode
+  eq. ++> can-slice-a-unicode-escape-sequence
     "Ф".slice
       0
       "Ф".length
     "Ф"
 
-  eq. ++> tests-slice-foreign-literals
+  eq. ++> can-slice-an-empty-string
+    "".slice
+      0
+      0
+    ""
+
+  eq. ++> can-slice-at-the-end-with-a-zero-length
+    "hello".slice
+      5
+      0
+    ""
+
+  eq. ++> can-slice-foreign-literals
     "hello, 大家!".slice
       7
       1
     "大"
 
-  eq. ++> tests-slice-from-start
-    "hello".slice
-      0
-      1
-    "h"
-
-  eq. ++> tests-slice-from-the-end
-    "hello".slice
-      4
-      1
-    "o"
-
-  eq. ++> tests-slice-in-the-middle
-    "hello".slice
-      2
-      3
-    "llo"
-
-  eq. ++> tests-slice-with-n2-byte-characters
-    "привет".slice
-      1
-      2
-    "ри"
-
-  eq. ++> tests-slice-with-n3-byte-characters
-    "The अ is अ".slice
-      1
-      6
-    "he अ i"
-
-  eq. ++> tests-slice-with-n4-byte-characters
+  eq. ++> can-slice-four-byte-characters
     "One 😀 and 😀 another".slice
       3
       8
     " 😀 and 😀"
 
-  eq. ++> tests-text-slices-the-origin-string
+  eq. ++> can-slice-from-the-end
+    "hello".slice
+      4
+      1
+    "o"
+
+  eq. ++> can-slice-from-the-start
+    "hello".slice
+      0
+      1
+    "h"
+
+  eq. ++> can-slice-in-the-middle
+    "hello".slice
+      2
+      3
+    "llo"
+
+  eq. ++> can-slice-nothing
+    "no slice".slice
+      0
+      0
+    ""
+
+  eq. ++> can-slice-the-origin-string
     slice
       "Hello, world!"
       7
       5
     "world"
 
-  slice --> on-slicing-end-below-start
+  eq. ++> can-slice-three-byte-characters
+    "The अ is अ".slice
+      1
+      6
+    "he अ i"
+
+  eq. ++> can-slice-two-byte-characters
+    "привет".slice
+      1
+      2
+    "ри"
+
+  slice --> stops-on-a-start-below-zero
+    "some string"
+    -1
+    1
+
+  slice --> stops-on-an-end-below-the-start
     "some string"
     2
     -1
 
-  slice --> on-slicing-end-greater-actual
+  slice --> stops-on-an-end-beyond-the-length
     "some string"
     7
     5
-
-  slice --> on-slicing-start-below-zero
-    "some string"
-    -1
-    1

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -55,34 +55,7 @@
   size. >> size!
     delimiter >> delim!
 
-  eq. ++> tests-splits-and-returns-strings
-    length.
-      at.
-        split
-          "hello world!"
-          " "
-        1
-    6
-
-  eq. ++> tests-splits-text-by-dash
-    split
-      "a-b-c"
-      "-"
-    *
-      "a"
-      "b"
-      "c"
-
-  eq. ++> tests-splits-text-by-multi-char-delimiter
-    split
-      "a::b::c"
-      "::"
-    *
-      "a"
-      "b"
-      "c"
-
-  eq. ++> tests-splits-text-with-empty-strings
+  eq. ++> can-split-a-text-into-empty-strings
     split
       "-a-b-"
       "-"
@@ -91,3 +64,30 @@
       "a"
       "b"
       ""
+
+  eq. ++> can-split-a-text-on-a-dash
+    split
+      "a-b-c"
+      "-"
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> can-split-a-text-on-a-multi-character-delimiter
+    split
+      "a::b::c"
+      "::"
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> can-split-into-strings
+    length.
+      at.
+        split
+          "hello world!"
+          " "
+        1
+    6

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -20,11 +20,11 @@
         size
       substring >> part!
 
-  not. ++> tests-does-not-start-with-substring
+  starts-with ++> can-start-with-a-substring
+    "Hello, world"
+    "Hello"
+
+  not. ++> cannot-start-with-an-absent-substring
     starts-with
       "Hello, world"
       "world"
-
-  starts-with ++> tests-starts-with-substring
-    "Hello, world"
-    "Hello"

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -43,42 +43,42 @@
             c.eq 0C-
             c.eq 0D-
 
-  eq. ++> tests-text-trimmed-left-many-spaces
-    trimmed-left
-      "     some"
-    "some"
+  eq. ++> can-trim-a-leading-carriage-return
+    trimmed-left "\rvalue"
+    "value"
 
-  eq. ++> tests-text-trimmed-left-one-space
-    trimmed-left
-      " s"
-    "s"
+  eq. ++> can-trim-a-leading-form-feed
+    trimmed-left "\fvalue"
+    "value"
 
-  eq. ++> tests-text-trimmed-left-only-spaces
+  eq. ++> can-trim-a-leading-line-feed
+    trimmed-left "\nvalue"
+    "value"
+
+  eq. ++> can-trim-a-leading-tab
+    trimmed-left "\tvalue"
+    "value"
+
+  eq. ++> can-trim-a-text-of-leading-spaces-only
     trimmed-left
       "     "
     ""
 
-  eq. ++> tests-trimmed-left-empty-text
+  eq. ++> can-trim-an-empty-text
     trimmed-left ""
     ""
 
-  eq. ++> tests-trimmed-left-strips-cr
-    trimmed-left "\rvalue"
-    "value"
+  eq. ++> can-trim-many-leading-spaces
+    trimmed-left
+      "     some"
+    "some"
 
-  eq. ++> tests-trimmed-left-strips-ff
-    trimmed-left "\fvalue"
-    "value"
-
-  eq. ++> tests-trimmed-left-strips-lf
-    trimmed-left "\nvalue"
-    "value"
-
-  eq. ++> tests-trimmed-left-strips-mixed-ws
+  eq. ++> can-trim-mixed-leading-whitespace
     trimmed-left
       " \t\n\f\rvalue"
     "value"
 
-  eq. ++> tests-trimmed-left-strips-tab
-    trimmed-left "\tvalue"
-    "value"
+  eq. ++> can-trim-one-leading-space
+    trimmed-left
+      " s"
+    "s"

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -41,42 +41,42 @@
             c.eq 0C-
             c.eq 0D-
 
-  eq. ++> tests-text-trimmed-right-many-spaces
-    trimmed-right
-      "some     "
-    "some"
-
-  eq. ++> tests-text-trimmed-right-one-space
-    trimmed-right
-      "s "
-    "s"
-
-  eq. ++> tests-text-trimmed-right-only-spaces
+  eq. ++> can-trim-a-text-of-trailing-spaces-only
     trimmed-right
       "     "
     ""
 
-  eq. ++> tests-trimmed-right-empty-text
-    trimmed-right ""
-    ""
-
-  eq. ++> tests-trimmed-right-strips-cr
+  eq. ++> can-trim-a-trailing-carriage-return
     trimmed-right "value\r"
     "value"
 
-  eq. ++> tests-trimmed-right-strips-ff
+  eq. ++> can-trim-a-trailing-form-feed
     trimmed-right "value\f"
     "value"
 
-  eq. ++> tests-trimmed-right-strips-lf
+  eq. ++> can-trim-a-trailing-line-feed
     trimmed-right "value\n"
     "value"
 
-  eq. ++> tests-trimmed-right-strips-mixed-ws
+  eq. ++> can-trim-a-trailing-tab
+    trimmed-right "value\t"
+    "value"
+
+  eq. ++> can-trim-an-empty-text
+    trimmed-right ""
+    ""
+
+  eq. ++> can-trim-many-trailing-spaces
+    trimmed-right
+      "some     "
+    "some"
+
+  eq. ++> can-trim-mixed-trailing-whitespace
     trimmed-right
       "value \t\n\f\r"
     "value"
 
-  eq. ++> tests-trimmed-right-strips-tab
-    trimmed-right "value\t"
-    "value"
+  eq. ++> can-trim-one-trailing-space
+    trimmed-right
+      "s "
+    "s"

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -19,45 +19,45 @@
     trimmed-left
       trimmed-right text
 
-  eq. ++> tests-text-trimmed-empty
-    trimmed ""
-    ""
-
-  eq. ++> tests-text-trimmed-many-spaces
-    trimmed
-      "    some     "
-    "some"
-
-  eq. ++> tests-text-trimmed-one-space-both
-    trimmed
-      " some "
-    "some"
-
-  eq. ++> tests-text-trimmed-one-space-left
-    trimmed
-      " some"
-    "some"
-
-  eq. ++> tests-text-trimmed-one-space-right
-    trimmed
-      "some "
-    "some"
-
-  eq. ++> tests-text-trimmed-only-spaces
-    trimmed
-      "        "
-    ""
-
-  eq. ++> tests-trimmed-preserves-inner-content
+  eq. ++> can-preserve-inner-content
     trimmed "no-whitespace"
     "no-whitespace"
 
-  eq. ++> tests-trimmed-preserves-inner-whitespace
+  eq. ++> can-preserve-inner-whitespace
     trimmed
       "\t hello world \n"
     "hello world"
 
-  eq. ++> tests-trimmed-strips-mixed-ws-both-sides
+  eq. ++> can-trim-a-text-of-spaces-only
+    trimmed
+      "        "
+    ""
+
+  eq. ++> can-trim-an-empty-text
+    trimmed ""
+    ""
+
+  eq. ++> can-trim-many-surrounding-spaces
+    trimmed
+      "    some     "
+    "some"
+
+  eq. ++> can-trim-mixed-whitespace-on-both-sides
     trimmed
       " \t\n\f\rvalue \t\n\f\r"
     "value"
+
+  eq. ++> can-trim-one-leading-space
+    trimmed
+      " some"
+    "some"
+
+  eq. ++> can-trim-one-space-on-both-sides
+    trimmed
+      " some "
+    "some"
+
+  eq. ++> can-trim-one-trailing-space
+    trimmed
+      "some "
+    "some"

--- a/eo-runtime/src/main/eo/string/up-cased.eo
+++ b/eo-runtime/src/main/eo/string/up-cased.eo
@@ -32,10 +32,10 @@
         as-ascii byte > code
   as-ascii "a" >> mincode!
 
-  eq. ++> tests-converts-text-to-upper-case
-    "HELLO"
-    up-cased "hello"
-
-  eq. ++> tests-converts-text-with-upper-letters-to-upper-case
+  eq. ++> can-convert-already-upper-cased-text
     "HELLO"
     up-cased "HeLlO"
+
+  eq. ++> can-convert-text-to-upper-case
+    "HELLO"
+    up-cased "hello"

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -48,13 +48,15 @@
       found.head
       true
 
-  eq. ++> tests-empty-switch-returns-provided-fallback
-    "recovered"
-    switch
-      *
-      "recovered" > [message]
+  switch * ++> can-return-true-when-all-cases-are-false
+    *
+      false
+      "false1"
+    *
+      false
+      "false2"
 
-  ++> tests-switch-complex-case
+  ++> can-switch-on-a-complex-case
     eq. > @
       switch *
         *
@@ -71,13 +73,13 @@
     "1".eq "2" > c2
     true > c3
 
-  eq. ++> tests-switch-simple-case
+  eq. ++> can-switch-on-a-simple-case
     switch *
       * false "1"
       * true "2"
     "2"
 
-  ++> tests-switch-strings-case
+  ++> can-switch-on-strings
     eq. > @
       switch *
         *
@@ -92,20 +94,18 @@
       "password is correct!"
     "swordfish" > password
 
-  switch * ++> tests-switch-with-all-false-cases
-    *
-      false
-      "false1"
-    *
-      false
-      "false2"
-
-  eq. ++> tests-switch-with-several-true-cases
+  eq. ++> can-switch-on-the-first-of-several-true-cases
     switch *
       * true "TRUE1"
       * false "FALSE"
       * true "TRUE2"
     "TRUE1"
 
-  switch --> on-empty-switch
+  eq. ++> rejects-an-empty-switch
+    "recovered"
+    switch
+      *
+      "recovered" > [message]
+
+  switch --> stops-on-an-empty-switch
     *

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -51,209 +51,7 @@
     as-number.
       length.plus 1
 
-  ++> tests-creates-empty-tuple-with-number
-    eq. > @
-      a.at 0
-      3
-    tuple.empty.with 3 > a
-
-  ++> tests-empty-tuple-length
-    eq. > @
-      length.
-        elements.
-          array
-            *
-      0
-    [elements] > array
-
-  ++> tests-gets-lengths-of-empty-tuple
-    a.length.eq 0 > @
-    * > a
-
-  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-through-special-syntax
-    0
-
-  tuple.empty.length.eq ++> tests-gets-lengths-of-empty-tuple-without-additional-obj
-    0
-
-  eq. ++> tests-makes-tuple-through-special-syntax
-    length.
-      * 1 2
-    2
-
-  ++> tests-non-empty-tuple-length-test
-    eq. > @
-      length.
-        elements.
-          array *
-            "a"
-            "b"
-            "c"
-            "d"
-            "e"
-      5
-    [elements] > array
-
-  eq. ++> tests-out-of-bounds-at-returns-provided-fallback
-    "recovered"
-    at.
-      *
-        1
-        2
-        3
-        4
-      20
-      "recovered" > [message]
-
-  eq. ++> tests-package-tuple-concatenates-with-another
-    concat.
-      * 0 1
-      * 2 3
-    *
-      0
-      1
-      2
-      3
-
-  contains. ++> tests-package-tuple-contains-element
-    *
-      1
-      2
-      3
-    2
-
-  tuple.contains ++> tests-package-tuple-contains-via-tuple-namespace
-    *
-      1
-      2
-      3
-    2
-
-  not. ++> tests-package-tuple-does-not-contain-element
-    contains.
-      *
-        1
-        2
-        3
-      5
-
-  eq. ++> tests-package-tuple-index-of-element
-    index-of.
-      *
-        10
-        20
-        30
-      20
-    1
-
-  ++> tests-tuple-as-a-bound-attribute-size-0
-    tup.length.eq 0 > @
-    * > tup
-
-  ++> tests-tuple-as-a-bound-attribute-size-1
-    eq. > @
-      tup.at 0
-      100
-    * 100 > tup
-
-  ++> tests-tuple-as-a-bound-attribute-size-2
-    and. > @
-      eq.
-        array.at 0
-        1
-      eq.
-        array.at 1
-        2
-    * > array
-      1
-      2
-
-  ++> tests-tuple-empty-fluent-with-indented-keyword
-    and. > @
-      and.
-        eq.
-          array.at 0
-          1
-        eq.
-          array.at 1
-          2
-      eq.
-        array.at 2
-        3
-    with. > array
-      with.
-        tuple.empty.with 1
-        2
-      3
-
-  eq. ++> tests-tuple-equality
-    *
-      1
-      2
-      3
-    *
-      1
-      2
-      3
-
-  ++> tests-tuple-fluent-with
-    and. > @
-      and.
-        eq.
-          array.at 0
-          1
-        eq.
-          array.at 1
-          2
-      eq.
-        array.at 2
-        3
-    with. > array
-      with.
-        tuple.empty.with 1
-        2
-      3
-
-  ++> tests-tuple-fluent-with-indented
-    and. > @
-      and.
-        eq.
-          array.at 0
-          1
-        eq.
-          array.at 1
-          2
-      eq.
-        array.at 2
-        3
-    with. > array
-      with.
-        tuple.empty.with 1
-        2
-      3
-
-  eq. ++> tests-tuple-nested-equality
-    *
-      * 0 1
-      * 4 0
-      * 7 3
-    *
-      * 0 1
-      * 4 0
-      * 7 3
-
-  not. ++> tests-tuple-not-equality
-    eq.
-      *
-        1
-        2
-        3
-      *
-        3
-        2
-        1
-
-  ++> tests-tuple-with
+  ++> can-add-an-item
     and. > @
       and.
         and.
@@ -276,7 +74,179 @@
         3
       "with"
 
-  ++> tests-tuple-with-negative-index-gets-first
+  ++> can-be-a-bound-attribute-of-one-item
+    eq. > @
+      tup.at 0
+      100
+    * 100 > tup
+
+  ++> can-be-a-bound-attribute-of-two-items
+    and. > @
+      eq.
+        array.at 0
+        1
+      eq.
+        array.at 1
+        2
+    * > array
+      1
+      2
+
+  ++> can-be-a-bound-attribute-when-empty
+    tup.length.eq 0 > @
+    * > tup
+
+  ++> can-build-a-tuple-fluently
+    and. > @
+      and.
+        eq.
+          array.at 0
+          1
+        eq.
+          array.at 1
+          2
+      eq.
+        array.at 2
+        3
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
+
+  ++> can-build-a-tuple-fluently-when-indented
+    and. > @
+      and.
+        eq.
+          array.at 0
+          1
+        eq.
+          array.at 1
+          2
+      eq.
+        array.at 2
+        3
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
+
+  ++> can-build-an-empty-tuple-with-an-indented-keyword
+    and. > @
+      and.
+        eq.
+          array.at 0
+          1
+        eq.
+          array.at 1
+          2
+      eq.
+        array.at 2
+        3
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
+
+  tuple.contains ++> can-check-containment-through-the-package
+    *
+      1
+      2
+      3
+    2
+
+  eq. ++> can-concat-with-another-tuple
+    concat.
+      * 0 1
+      * 2 3
+    *
+      0
+      1
+      2
+      3
+
+  contains. ++> can-contain-an-element
+    *
+      1
+      2
+      3
+    2
+
+  ++> can-create-an-empty-tuple-with-a-number
+    eq. > @
+      a.at 0
+      3
+    tuple.empty.with 3 > a
+
+  eq. ++> can-equal-a-nested-tuple
+    *
+      * 0 1
+      * 4 0
+      * 7 3
+    *
+      * 0 1
+      * 4 0
+      * 7 3
+
+  eq. ++> can-equal-another-tuple
+    *
+      1
+      2
+      3
+    *
+      1
+      2
+      3
+
+  eq. ++> can-find-the-index-of-an-element
+    index-of.
+      *
+        10
+        20
+        30
+      20
+    1
+
+  ++> can-get-the-length-of-an-empty-tuple
+    a.length.eq 0 > @
+    * > a
+
+  tuple.empty.length.eq ++> can-get-the-length-of-an-empty-tuple-through-special-syntax
+    0
+
+  tuple.empty.length.eq ++> can-get-the-length-of-an-empty-tuple-without-an-extra-object
+    0
+
+  eq. ++> can-make-a-tuple-through-special-syntax
+    length.
+      * 1 2
+    2
+
+  ++> can-report-the-length-of-a-non-empty-tuple
+    eq. > @
+      length.
+        elements.
+          array *
+            "a"
+            "b"
+            "c"
+            "d"
+            "e"
+      5
+    [elements] > array
+
+  ++> can-report-the-length-of-an-empty-tuple
+    eq. > @
+      length.
+        elements.
+          array
+            *
+      0
+    [elements] > array
+
+  ++> can-take-the-first-item-by-a-negative-index
     eq. > @
       array.at -5
       0
@@ -287,7 +257,7 @@
       3
       4
 
-  ++> tests-tuple-with-negative-index-gets-last
+  ++> can-take-the-last-item-by-a-negative-index
     eq. > @
       array.at -1
       4
@@ -298,11 +268,45 @@
       3
       4
 
-  tuple.empty.head --> on-getting-head-from-empty-tuple
+  not. ++> cannot-contain-an-absent-element
+    contains.
+      *
+        1
+        2
+        3
+      5
 
-  tuple.empty.tail --> on-getting-tail-from-empty-tuple
+  not. ++> cannot-equal-a-different-tuple
+    eq.
+      *
+        1
+        2
+        3
+      *
+        3
+        2
+        1
 
-  --> on-out-of-tuple-bounds-with-negative-index
+  eq. ++> rejects-an-out-of-bounds-index
+    "recovered"
+    at.
+      *
+        1
+        2
+        3
+        4
+      20
+      "recovered" > [message]
+
+  at. --> stops-on-a-wrong-index
+    *
+      1
+      2
+      3
+      4
+    20
+
+  --> stops-on-an-out-of-bounds-negative-index
     array.at -6 > @
     * > array
       0
@@ -311,10 +315,6 @@
       3
       4
 
-  at. --> on-wrong-tuple-at
-    *
-      1
-      2
-      3
-      4
-    20
+  tuple.empty.head --> stops-on-taking-the-head-of-an-empty-tuple
+
+  tuple.empty.tail --> stops-on-taking-the-tail-of-an-empty-tuple

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -21,7 +21,20 @@
         accum.with item
         accum
 
-  eq. ++> tests-large-index-in-back
+  eq. ++> can-take-a-back-slice
+    back
+      *
+        1
+        2
+        3
+        4
+        5
+      2
+    *
+      4
+      5
+
+  eq. ++> can-take-a-back-slice-with-a-large-index
     back
       *
         1
@@ -37,20 +50,7 @@
       4
       5
 
-  eq. ++> tests-simple-back
-    back
-      *
-        1
-        2
-        3
-        4
-        5
-      2
-    *
-      4
-      5
-
-  is-empty ++> tests-zero-index-in-back
+  is-empty ++> can-take-a-back-slice-with-a-zero-index
     back
       *
         1

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -15,7 +15,7 @@
       accum
       item
 
-  ++> tests-concatenates-lists
+  ++> can-concat-two-lists
     and. > @
       1.eq
         list3.at 0
@@ -31,7 +31,7 @@
         3
       0
 
-  eq. ++> tests-concatenates-with-tuple
+  eq. ++> can-concat-with-a-tuple
     concat *1
       * 0 1
       2

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -12,7 +12,7 @@
     -1.eq
       index-of list element
 
-  contains ++> tests-list-contains-number
+  contains ++> can-contain-a-number
     *
       "qwerty"
       "asdfgh"
@@ -20,7 +20,7 @@
       "qwerty"
     3
 
-  contains ++> tests-list-contains-string
+  contains ++> can-contain-a-string
     *
       "qwerty"
       "asdfgh"
@@ -28,7 +28,7 @@
       "qwerty"
     "qwerty"
 
-  not. ++> tests-list-does-not-contain
+  not. ++> cannot-contain-an-absent-item
     contains
       *
         "Привет"

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -14,11 +14,18 @@
     list
     func item > [item index] >>
 
-  each ++> tests-each-empty-list
-    *
-    false > [x]
+  ++> can-iterate-over-a-list
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            * 1 2 3
+            m.put > [i] >>
+              m.as-number.plus i
+      6
 
-  eq. ++> tests-each-returns-last-func-result
+  eq. ++> can-return-the-result-of-the-last-call
     each
       *
         1
@@ -27,18 +34,7 @@
       x > [x]
     3
 
-  ++> tests-each-single-element
-    eq. > @
-      malloc.for
-        0
-        [m]
-          each > @
-            * 7
-            m.put > [i] >>
-              m.as-number.plus i
-      7
-
-  ++> tests-each-sums-more-numbers
+  ++> can-sum-many-numbers
     eq. > @
       malloc.for
         0
@@ -49,13 +45,17 @@
               m.as-number.plus i
       60
 
-  ++> tests-iterates-with-each
+  ++> can-walk-a-single-element-list
     eq. > @
       malloc.for
         0
         [m]
           each > @
-            * 1 2 3
+            * 7
             m.put > [i] >>
               m.as-number.plus i
-      6
+      7
+
+  each ++> can-walk-an-empty-list
+    *
+    false > [x]

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -19,7 +19,7 @@
       acc
       func item index
 
-  ++> tests-iterates-with-eachi
+  ++> can-iterate-over-a-list-with-indexes
     eq. > @
       malloc.for
         0

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -16,16 +16,7 @@
     list
     func item > [item index] >>
 
-  eq. ++> tests-filtered-with-bools
-    filtered
-      *
-        true
-        false
-        true
-      v.not > [v]
-    * false
-
-  eq. ++> tests-simple-filtered
+  eq. ++> can-filter-a-list
     filtered
       *
         3
@@ -38,3 +29,12 @@
       3
       4
       5
+
+  eq. ++> can-filter-bools
+    filtered
+      *
+        true
+        false
+        true
+      v.not > [v]
+    * false

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -24,7 +24,7 @@
     recfilter tup.tail > next
   | list > @
 
-  eq. ++> tests-filteredi-with-lt
+  eq. ++> can-filter-by-a-less-than-condition
     filteredi
       *
         3
@@ -37,7 +37,7 @@
       1
       2
 
-  eq. ++> tests-filteredi-with-string-length
+  eq. ++> can-filter-by-string-length
     filteredi
       *
         "Hello"
@@ -47,12 +47,12 @@
       v.length.gt 4 > [v i]
     * "Hello"
 
-  is-empty ++> tests-filteredi-with-empty-list
+  is-empty ++> can-filter-an-empty-list
     filteredi
       *
       v.lt 3 > [v i]
 
-  eq. ++> tests-filteredi-by-index
+  eq. ++> can-filter-by-index
     filteredi
       *
         3
@@ -63,7 +63,7 @@
       1
       4
 
-  eq. ++> tests-filteredi-with-bools
+  eq. ++> can-filter-bools-with-indexes
     filteredi
       *
         true

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -29,7 +29,18 @@
           rechead tup.tail
         | list
 
-  eq. ++> tests-complex-front
+  eq. ++> can-take-a-front-slice
+    front
+      *
+        1
+        2
+        3
+        4
+        5
+      1
+    * 1
+
+  eq. ++> can-take-a-front-slice-of-a-complex-list
     front
       *
         "foo"
@@ -41,7 +52,7 @@
       "foo"
       2.2
 
-  eq. ++> tests-complex-front-with-negative
+  eq. ++> can-take-a-front-slice-of-a-complex-list-with-a-negative-index
     front
       *
         "foo"
@@ -54,7 +65,7 @@
       00-01
       "bar"
 
-  eq. ++> tests-front-with-negative
+  eq. ++> can-take-a-front-slice-with-a-negative-index
     front
       *
         1
@@ -63,7 +74,15 @@
       -1
     * 3
 
-  eq. ++> tests-list-front-with-length-index
+  is-empty ++> can-take-a-front-slice-with-a-zero-index
+    front
+      *
+        1
+        2
+        3
+      0
+
+  eq. ++> can-take-a-front-slice-with-the-length-as-index
     front
       *
         1
@@ -74,22 +93,3 @@
       1
       2
       3
-
-  is-empty ++> tests-list-front-with-zero-index
-    front
-      *
-        1
-        2
-        3
-      0
-
-  eq. ++> tests-simple-front
-    front
-      *
-        1
-        2
-        3
-        4
-        5
-      1
-    * 1

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -23,16 +23,7 @@
           recidx tup.tail >> next!
     | list
 
-  eq. ++> tests-does-not-find-index-of
-    -1
-    index-of
-      *
-        "qwerty"
-        2
-        3
-      7
-
-  eq. ++> tests-finds-index-of-string
+  eq. ++> can-find-the-index-of-a-string
     1
     index-of
       *
@@ -41,7 +32,7 @@
         3
       "qwerty"
 
-  eq. ++> tests-returns-first-index-of-element
+  eq. ++> can-return-the-first-index-of-an-element
     0
     index-of
       *
@@ -50,7 +41,7 @@
         -1
       -1
 
-  eq. ++> tests-returns-index-of
+  eq. ++> can-return-the-index-of-an-element
     1
     index-of
       *
@@ -58,3 +49,12 @@
         2
         3
       2
+
+  eq. ++> cannot-find-the-index-of-an-absent-item
+    -1
+    index-of
+      *
+        "qwerty"
+        2
+        3
+      7

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -10,21 +10,21 @@
 [list] > is-empty
   0.eq list.length > @
 
-  is-empty ++> list-should-be-empty
+  is-empty ++> can-be-empty-when-built-empty
     *
 
-  not. ++> tests-list-should-not-be-empty
-    is-empty *
-      1
-      2
-
-  ++> tests-list-should-not-be-empty-with-one-anon-object
+  ++> cannot-be-empty-with-one-anonymous-object
     not. > @
       is-empty xs
     * > xs
       [f]
 
-  ++> tests-list-should-not-be-empty-with-three-objects
+  not. ++> cannot-be-empty-with-one-item
+    is-empty *
+      1
+      2
+
+  ++> cannot-be-empty-with-three-objects
     not. > @
       is-empty xs
     * > xs

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -18,7 +18,7 @@
       rec t.tail
   | list > @
 
-  eq. ++> tests-finds-last-index-of
+  eq. ++> can-find-the-last-index-of-an-item
     1
     last-index-of
       *
@@ -27,7 +27,7 @@
         3
       2
 
-  eq. ++> tests-finds-last-index-of-repeated
+  eq. ++> can-find-the-last-index-of-a-repeated-item
     2
     last-index-of
       *
@@ -36,7 +36,7 @@
         24
       24
 
-  eq. ++> tests-last-index-of-not-found
+  eq. ++> cannot-find-the-last-index-of-an-absent-item
     -1
     last-index-of
       *
@@ -45,13 +45,13 @@
         3
       0
 
-  eq. ++> tests-last-index-of-empty
+  eq. ++> cannot-find-the-last-index-in-an-empty-list
     -1
     last-index-of
       *
       "abc"
 
-  eq. ++> tests-last-index-of-unicode
+  eq. ++> can-find-the-last-index-of-a-unicode-item
     3
     last-index-of
       *

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -14,7 +14,7 @@
     list
     func item > [item idx] >>
 
-  eq. ++> tests-simple-list-mapping
+  eq. ++> can-map-a-list
     mapped
       *
         1

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -17,7 +17,7 @@
     accum.with > [accum item idx] >>
       func item idx
 
-  eq. ++> tests-list-mappedi-should-work
+  eq. ++> can-map-a-list-with-indexes
     mappedi
       *
         1

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -22,37 +22,37 @@
         item
         max
 
-  eq. ++> tests-maximum-of-array-is-first
+  eq. ++> can-take-a-maximum-of-one-item
+    maximum
+      * 42
+    42
+
+  eq. ++> can-take-a-maximum-that-is-first
     maximum *
       25
       12
       -2
     25
 
-  eq. ++> tests-maximum-of-array-is-in-the-center
+  eq. ++> can-take-a-maximum-that-is-in-the-middle
     maximum *
       12
       25
       -2
     25
 
-  eq. ++> tests-maximum-of-array-is-last
+  eq. ++> can-take-a-maximum-that-is-last
     maximum *
       12
       -2
       25
     25
 
-  eq. ++> tests-maximum-of-empty-returns-provided-fallback
+  eq. ++> rejects-an-empty-list
     "recovered"
     maximum
       *
       "recovered" > [msg]
 
-  eq. ++> tests-maximum-of-one-item-array
-    maximum
-      * 42
-    42
-
-  maximum --> on-taking-maximum-from-empty-sequence
+  maximum --> stops-on-an-empty-list
     *

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -22,37 +22,37 @@
         item
         min
 
-  eq. ++> tests-minimum-of-array-is-first
+  eq. ++> can-take-a-minimum-of-one-item
+    minimum
+      * 42
+    42
+
+  eq. ++> can-take-a-minimum-that-is-first
     minimum *
       -2
       25
       12
     -2
 
-  eq. ++> tests-minimum-of-array-is-in-the-center
+  eq. ++> can-take-a-minimum-that-is-in-the-middle
     minimum *
       12
       -2
       25
     -2
 
-  eq. ++> tests-minimum-of-array-is-last
+  eq. ++> can-take-a-minimum-that-is-last
     minimum *
       12
       25
       -2
     -2
 
-  eq. ++> tests-minimum-of-empty-returns-provided-fallback
+  eq. ++> rejects-an-empty-list
     "recovered"
     minimum
       *
       "recovered" > [msg]
 
-  eq. ++> tests-minimum-of-one-item-array
-    minimum
-      * 42
-    42
-
-  minimum --> on-taking-minimum-from-empty-sequence
+  minimum --> stops-on-an-empty-list
     *

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -18,7 +18,7 @@
       accum
       item
 
-  eq. ++> tests-list-reduce-without-index
+  eq. ++> can-reduce-a-list
     reduced
       *
         1
@@ -29,7 +29,7 @@
       a.times x > [a x]
     -24
 
-  eq. ++> tests-list-reduced-printing
+  eq. ++> can-reduce-a-list-into-a-string
     reduced
       * 0 1
       ""

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -26,16 +26,18 @@
         tup.tail.length
     | list
 
-  not. ++> tests-list-reducedi-bools-array
-    reducedi
-      *
-        true
-        true
-        false
-      true
-      x.and a > [a x i]
+  ++> can-reduce-a-list-with-indexes
+    6.eq > @
+      reducedi
+        * 1 1
+        0
+        x.plus > [a x i] >>
+          a.plus
+            at.
+              * 2 2
+              i
 
-  eq. ++> tests-list-reducedi-long-int-array
+  eq. ++> can-reduce-a-long-integer-list-with-indexes
     reducedi
       *
         0
@@ -87,7 +89,16 @@
       x.plus a > [a x i]
     1
 
-  ++> tests-list-reducedi-nested-functions
+  not. ++> can-reduce-bools-with-indexes
+    reducedi
+      *
+        true
+        true
+        false
+      true
+      x.and a > [a x i]
+
+  ++> can-reduce-with-nested-functions
     eq. > @
       reducedi
         * 10 500
@@ -100,14 +111,3 @@
             acc.minus x
       10.plus
         0.minus 500
-
-  ++> tests-reduce-list-with-index
-    6.eq > @
-      reducedi
-        * 1 1
-        0
-        x.plus > [a x i] >>
-          a.plus
-            at.
-              * 2 2
-              i

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -13,18 +13,7 @@
     shift
     list.length
 
-  eq. ++> tests-shifted-with-shift-greater-than-length
-    shifted
-      *
-        8
-        2
-        3
-        4
-        5
-      6
-    *
-
-  eq. ++> tests-shifted-with-shift-less-than-length
+  eq. ++> can-shift-by-less-than-the-length
     shifted
       *
         8
@@ -37,3 +26,14 @@
       3
       4
       5
+
+  eq. ++> can-shift-by-more-than-the-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      6
+    *

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -43,7 +43,7 @@
         accum.with item
         accum
 
-  eq. ++> tests-simple-slice
+  eq. ++> can-slice-a-list
     slice
       *
         1
@@ -59,31 +59,7 @@
       4
       5
 
-  eq. ++> tests-slice-with-end-gt-length
-    slice
-      *
-        "foo"
-        "bar"
-        "buzz"
-      1
-      10
-    *
-      "bar"
-      "buzz"
-
-  eq. ++> tests-slice-with-end-lt-negative-length
-    slice
-      *
-        "A"
-        "b"
-        "C"
-        "d"
-        "E"
-      2
-      -9
-    *
-
-  eq. ++> tests-slice-with-negative-end
+  eq. ++> can-slice-with-a-negative-end
     slice
       *
         "a"
@@ -101,7 +77,7 @@
       "xyz"
       82.42
 
-  eq. ++> tests-slice-with-negative-start
+  eq. ++> can-slice-with-a-negative-start
     slice
       *
         8
@@ -118,7 +94,7 @@
       3
       8
 
-  eq. ++> tests-slice-with-negative-start-and-end
+  eq. ++> can-slice-with-a-negative-start-and-end
     slice
       *
         8
@@ -133,7 +109,7 @@
       0
       0
 
-  eq. ++> tests-slice-with-negative-start-gte-end
+  eq. ++> can-slice-with-a-negative-start-not-below-the-end
     slice
       *
         "f"
@@ -146,7 +122,34 @@
       3
     *
 
-  eq. ++> tests-slice-with-start-gte-end-both-negative
+  eq. ++> can-slice-with-a-start-below-the-negative-length
+    slice
+      *
+        9
+        99
+        999
+        9999
+      -10
+      3
+    *
+      9
+      99
+      999
+
+  eq. ++> can-slice-with-a-start-not-below-a-negative-end
+    slice
+      *
+        8
+        -2
+        33-53
+        -1
+        33
+        "Y"
+      4
+      -5
+    *
+
+  eq. ++> can-slice-with-a-start-not-below-the-end-when-both-negative
     slice
       *
         3
@@ -160,7 +163,7 @@
       -5
     *
 
-  eq. ++> tests-slice-with-start-gte-end-both-positive
+  eq. ++> can-slice-with-a-start-not-below-the-end-when-both-positive
     slice
       *
         3
@@ -171,29 +174,26 @@
       0
     *
 
-  eq. ++> tests-slice-with-start-gte-negative-end
+  eq. ++> can-slice-with-an-end-below-the-negative-length
     slice
       *
-        8
-        -2
-        33-53
-        -1
-        33
-        "Y"
-      4
-      -5
+        "A"
+        "b"
+        "C"
+        "d"
+        "E"
+      2
+      -9
     *
 
-  eq. ++> tests-slice-with-start-lt-negative-length
+  eq. ++> can-slice-with-an-end-beyond-the-length
     slice
       *
-        9
-        99
-        999
-        9999
-      -10
-      3
+        "foo"
+        "bar"
+        "buzz"
+      1
+      10
     *
-      9
-      99
-      999
+      "bar"
+      "buzz"

--- a/eo-runtime/src/main/eo/tuple/with.eo
+++ b/eo-runtime/src/main/eo/tuple/with.eo
@@ -10,7 +10,7 @@
 [list x] > with
   list.with x > @
 
-  eq. ++> tests-list-simple-with
+  eq. ++> can-add-an-item
     with
       * 1 2
       3

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -16,7 +16,7 @@
       list
       list.length.minus index
 
-  eq. ++> tests-insert-with-zero-index
+  eq. ++> can-insert-at-a-zero-index
     withi
       *
         1
@@ -34,7 +34,7 @@
       4
       5
 
-  eq. ++> tests-simple-insert
+  eq. ++> can-insert-at-an-index
     withi
       *
         1

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -16,7 +16,7 @@
       accum
       accum.with item
 
-  eq. ++> tests-list-without
+  eq. ++> can-drop-an-item
     without
       *
         1

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -16,7 +16,7 @@
       accum
       accum.with item
 
-  eq. ++> tests-list-withouti
+  eq. ++> can-drop-an-item-by-index
     withouti
       *
         1
@@ -27,7 +27,7 @@
       1
       3
 
-  ++> tests-list-withouti-complex-case
+  ++> can-drop-an-item-by-index-in-a-complex-list
     eq. > @
       foo *
         1
@@ -38,7 +38,7 @@
       a
       0
 
-  eq. ++> tests-list-withouti-nested-array
+  eq. ++> can-drop-an-item-by-index-in-a-nested-list
     withouti
       *
         "smthg"

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -52,74 +52,74 @@
       2
       2
 
-  eq. ++> tests-u16-as-i32-widens-with-zero-prefix
-    FF-FF.as-u16.as-i32.as-bytes
-    00-00-FF-FF
+  eq. ++> can-add-one-to-one
+    00-01.as-u16.plus 00-01.as-u16
+    00-02.as-u16
 
-  FF-FF.as-u16.as-number.eq 65535 ++> tests-u16-as-number-is-unsigned
+  eq. ++> can-add-with-overflow
+    FF-FF.as-u16.plus 00-01.as-u16
+    00-00.as-u16
 
-  eq. ++> tests-u16-div-by-u16-one
+  00-32.as-u16.gte 00-32.as-u16 ++> can-be-greater-than-or-equal-to-an-equal-u16
+
+  00-0A.as-u16.lt 00-32.as-u16 ++> can-be-less-than-a-larger-u16
+
+  00-32.as-u16.lte 00-32.as-u16 ++> can-be-less-than-or-equal-to-an-equal-u16
+
+  00-00.as-u16.lt FF-FF.as-u16 ++> can-be-less-than-the-maximum-when-zero
+
+  FF-FF.as-u16.as-number.eq 65535 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
     FF-FF.as-u16.div 00-01.as-u16
     FF-FF.as-u16
 
-  eq. ++> tests-u16-div-by-zero-returns-provided-fallback
+  eq. ++> can-divide-without-a-sign
+    FF-FF.as-u16.div 00-02.as-u16
+    7F-FF.as-u16
+
+  00-2A.as-u16.eq 00-2A.as-u16 ++> can-equal-the-same-u16
+
+  00-2A.as-u16.as-bytes.eq 00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    00-06.as-u16.times 00-07.as-u16
+    00-2A.as-u16
+
+  eq. ++> can-subtract
+    00-05.as-u16.minus 00-03.as-u16
+    00-02.as-u16
+
+  eq. ++> can-subtract-with-underflow
+    00-00.as-u16.minus 00-01.as-u16
+    FF-FF.as-u16
+
+  FF-FF.as-u16.gt 00-01.as-u16 ++> can-treat-a-high-bit-as-magnitude-when-greater
+
+  eq. ++> can-widen-to-i32-with-a-zero-prefix
+    FF-FF.as-u16.as-i32.as-bytes
+    00-00-FF-FF
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
+    01-00.as-u16.times 01-00.as-u16
+    00-00.as-u16
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u16
+    00-00.as-u16.gte 00-0A.as-u16
+
+  not. ++> cannot-be-less-than-an-equal-u16
+    00-0A.as-u16.lt 00-0A.as-u16
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF.as-u16.lt 00-01.as-u16
+
+  not. ++> cannot-equal-a-different-u16
+    00-2A.as-u16.eq 00-2B.as-u16
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     00-02.as-u16.div
       00-00.as-u16
       "recovered" > [message]
 
-  eq. ++> tests-u16-div-is-unsigned
-    FF-FF.as-u16.div 00-02.as-u16
-    7F-FF.as-u16
-
-  not. ++> tests-u16-eq-false
-    00-2A.as-u16.eq 00-2B.as-u16
-
-  00-2A.as-u16.eq 00-2A.as-u16 ++> tests-u16-eq-true
-
-  FF-FF.as-u16.gt 00-01.as-u16 ++> tests-u16-greater-treats-high-bit-as-magnitude
-
-  00-32.as-u16.gte 00-32.as-u16 ++> tests-u16-gte-equal
-
-  not. ++> tests-u16-gte-false
-    00-00.as-u16.gte 00-0A.as-u16
-
-  00-2A.as-u16.as-bytes.eq 00-2A ++> tests-u16-has-valid-bytes
-
-  not. ++> tests-u16-high-bit-not-less-than-one
-    FF-FF.as-u16.lt 00-01.as-u16
-
-  not. ++> tests-u16-less-equal
-    00-0A.as-u16.lt 00-0A.as-u16
-
-  00-0A.as-u16.lt 00-32.as-u16 ++> tests-u16-less-true
-
-  00-32.as-u16.lte 00-32.as-u16 ++> tests-u16-lte-equal
-
-  eq. ++> tests-u16-minus
-    00-05.as-u16.minus 00-03.as-u16
-    00-02.as-u16
-
-  eq. ++> tests-u16-minus-with-underflow
-    00-00.as-u16.minus 00-01.as-u16
-    FF-FF.as-u16
-
-  eq. ++> tests-u16-one-plus-u16-one
-    00-01.as-u16.plus 00-01.as-u16
-    00-02.as-u16
-
-  eq. ++> tests-u16-plus-with-overflow
-    FF-FF.as-u16.plus 00-01.as-u16
-    00-00.as-u16
-
-  eq. ++> tests-u16-times
-    00-06.as-u16.times 00-07.as-u16
-    00-2A.as-u16
-
-  eq. ++> tests-u16-times-wraps-modulo-2-pow-16
-    01-00.as-u16.times 01-00.as-u16
-    00-00.as-u16
-
-  00-00.as-u16.lt FF-FF.as-u16 ++> tests-u16-zero-less-than-max
-
-  00-02.as-u16.div 00-00.as-u16 --> on-division-u16-by-u16-zero
+  00-02.as-u16.div 00-00.as-u16 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -52,76 +52,82 @@
       4
       4
 
-  eq. ++> tests-u32-as-i64-widens-with-zero-prefix
-    FF-FF-FF-FF.as-u32.as-i64.as-bytes
-    00-00-00-00-FF-FF-FF-FF
+  eq. ++> can-add-one-to-one
+    00-00-00-01.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-02.as-u32
 
-  FF-FF-FF-FF.as-u32.as-number.eq 4294967295 ++> tests-u32-as-number-is-unsigned
+  eq. ++> can-add-with-overflow
+    FF-FF-FF-FF.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-00.as-u32
 
-  eq. ++> tests-u32-div-by-u32-one
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-u32
+    00-00-00-32.as-u32
+    00-00-00-32.as-u32
+
+  00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> can-be-less-than-a-larger-u32
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-u32
+    00-00-00-32.as-u32
+    00-00-00-32.as-u32
+
+  lt. ++> can-be-less-than-the-maximum-when-zero
+    00-00-00-00.as-u32
+    FF-FF-FF-FF.as-u32
+
+  FF-FF-FF-FF.as-u32.as-number.eq 4294967295 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
     FF-FF-FF-FF.as-u32.div 00-00-00-01.as-u32
     FF-FF-FF-FF.as-u32
 
-  eq. ++> tests-u32-div-by-zero-returns-provided-fallback
+  eq. ++> can-divide-without-a-sign
+    FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
+    7F-FF-FF-FF.as-u32
+
+  00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> can-equal-the-same-u32
+
+  00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    00-00-00-06.as-u32.times 00-00-00-07.as-u32
+    00-00-00-2A.as-u32
+
+  eq. ++> can-subtract
+    00-00-00-05.as-u32.minus 00-00-00-03.as-u32
+    00-00-00-02.as-u32
+
+  eq. ++> can-subtract-with-underflow
+    00-00-00-00.as-u32.minus 00-00-00-01.as-u32
+    FF-FF-FF-FF.as-u32
+
+  gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
+    FF-FF-FF-FF.as-u32
+    00-00-00-01.as-u32
+
+  eq. ++> can-widen-to-i64-with-a-zero-prefix
+    FF-FF-FF-FF.as-u32.as-i64.as-bytes
+    00-00-00-00-FF-FF-FF-FF
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
+    00-01-00-00.as-u32.times 00-01-00-00.as-u32
+    00-00-00-00.as-u32
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u32
+    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
+
+  not. ++> cannot-be-less-than-an-equal-u32
+    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
+
+  not. ++> cannot-equal-a-different-u32
+    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     00-00-00-02.as-u32.div
       00-00-00-00.as-u32
       "recovered" > [message]
 
-  eq. ++> tests-u32-div-is-unsigned
-    FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
-    7F-FF-FF-FF.as-u32
-
-  not. ++> tests-u32-eq-false
-    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
-
-  00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> tests-u32-eq-true
-
-  gt. ++> tests-u32-greater-treats-high-bit-as-magnitude
-    FF-FF-FF-FF.as-u32
-    00-00-00-01.as-u32
-
-  00-00-00-32.as-u32.gte 00-00-00-32.as-u32 ++> tests-u32-gte-equal
-
-  not. ++> tests-u32-gte-false
-    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
-
-  00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> tests-u32-has-valid-bytes
-
-  not. ++> tests-u32-high-bit-not-less-than-one
-    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
-
-  not. ++> tests-u32-less-equal
-    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
-
-  00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> tests-u32-less-true
-
-  00-00-00-32.as-u32.lte 00-00-00-32.as-u32 ++> tests-u32-lte-equal
-
-  eq. ++> tests-u32-minus
-    00-00-00-05.as-u32.minus 00-00-00-03.as-u32
-    00-00-00-02.as-u32
-
-  eq. ++> tests-u32-minus-with-underflow
-    00-00-00-00.as-u32.minus 00-00-00-01.as-u32
-    FF-FF-FF-FF.as-u32
-
-  eq. ++> tests-u32-one-plus-u32-one
-    00-00-00-01.as-u32.plus 00-00-00-01.as-u32
-    00-00-00-02.as-u32
-
-  eq. ++> tests-u32-plus-with-overflow
-    FF-FF-FF-FF.as-u32.plus 00-00-00-01.as-u32
-    00-00-00-00.as-u32
-
-  eq. ++> tests-u32-times
-    00-00-00-06.as-u32.times 00-00-00-07.as-u32
-    00-00-00-2A.as-u32
-
-  eq. ++> tests-u32-times-wraps-modulo-2-pow-32
-    00-01-00-00.as-u32.times 00-01-00-00.as-u32
-    00-00-00-00.as-u32
-
-  00-00-00-00.as-u32.lt FF-FF-FF-FF.as-u32 ++> tests-u32-zero-less-than-max
-
-  00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> on-division-u32-by-u32-zero
+  00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -55,69 +55,71 @@
           i64 as-bytes
           i64 x.as-u64.as-bytes
 
-  gt. ++> tests-u64-as-number-is-unsigned
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
-    0
-
-  00-00-00-00-00-00-00-2A.as-u64.as-number.eq 42 ++> tests-u64-as-number-small
-
-  eq. ++> tests-u64-eq-true
-    00-00-00-00-00-00-00-2A.as-u64
-    00-00-00-00-00-00-00-2A.as-u64
-
-  gt. ++> tests-u64-greater-treats-high-bit-as-magnitude
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
-    00-00-00-00-00-00-00-01.as-u64
-
-  gte. ++> tests-u64-gte-equal
-    00-00-00-00-00-00-00-32.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  not. ++> tests-u64-gte-false
-    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
-
-  eq. ++> tests-u64-has-valid-bytes
-    00-00-00-00-00-00-00-2A.as-u64.as-bytes
-    00-00-00-00-00-00-00-2A
-
-  not. ++> tests-u64-high-bit-not-less-than-one
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
-
-  not. ++> tests-u64-less-equal
-    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
-
-  lt. ++> tests-u64-less-true
-    00-00-00-00-00-00-00-0A.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  lte. ++> tests-u64-lte-equal
-    00-00-00-00-00-00-00-32.as-u64
-    00-00-00-00-00-00-00-32.as-u64
-
-  eq. ++> tests-u64-minus
-    00-00-00-00-00-00-00-05.as-u64.minus 00-00-00-00-00-00-00-03.as-u64
-    00-00-00-00-00-00-00-02.as-u64
-
-  eq. ++> tests-u64-minus-with-underflow
-    00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
-
-  eq. ++> tests-u64-one-plus-u64-one
+  eq. ++> can-add-one-to-one
     00-00-00-00-00-00-00-01.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
     00-00-00-00-00-00-00-02.as-u64
 
-  eq. ++> tests-u64-plus-with-overflow
+  eq. ++> can-add-with-overflow
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
     00-00-00-00-00-00-00-00.as-u64
 
-  eq. ++> tests-u64-times
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-u64
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lt. ++> can-be-less-than-a-larger-u64
+    00-00-00-00-00-00-00-0A.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-u64
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lt. ++> can-be-less-than-the-maximum-when-zero
+    00-00-00-00-00-00-00-00.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> can-convert-a-small-value-to-a-number
+    00-00-00-00-00-00-00-2A.as-u64.as-number
+    42
+
+  gt. ++> can-convert-to-an-unsigned-number
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    0
+
+  eq. ++> can-equal-the-same-u64
+    00-00-00-00-00-00-00-2A.as-u64
+    00-00-00-00-00-00-00-2A.as-u64
+
+  eq. ++> can-expose-valid-bytes
+    00-00-00-00-00-00-00-2A.as-u64.as-bytes
+    00-00-00-00-00-00-00-2A
+
+  eq. ++> can-multiply
     00-00-00-00-00-00-00-06.as-u64.times 00-00-00-00-00-00-00-07.as-u64
     00-00-00-00-00-00-00-2A.as-u64
 
-  eq. ++> tests-u64-times-wraps-modulo-2-pow-64
+  eq. ++> can-subtract
+    00-00-00-00-00-00-00-05.as-u64.minus 00-00-00-00-00-00-00-03.as-u64
+    00-00-00-00-00-00-00-02.as-u64
+
+  eq. ++> can-subtract-with-underflow
+    00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+    00-00-00-00-00-00-00-01.as-u64
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
     00-00-00-01-00-00-00-00.as-u64.times 00-00-00-01-00-00-00-00.as-u64
     00-00-00-00-00-00-00-00.as-u64
 
-  lt. ++> tests-u64-zero-less-than-max
-    00-00-00-00-00-00-00-00.as-u64
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u64
+    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> cannot-be-less-than-an-equal-u64
+    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64

--- a/eo-runtime/src/main/eo/u64/div.eo
+++ b/eo-runtime/src/main/eo/u64/div.eo
@@ -44,32 +44,32 @@
         i64 d.as-bytes
     1
 
-  eq. ++> tests-u64-div-by-large-divisor
+  eq. ++> can-divide-a-small-value-by-a-larger-divisor
+    00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  eq. ++> can-divide-by-a-large-divisor
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 80-00-00-00-00-00-00-00.as-u64
     00-00-00-00-00-00-00-01.as-u64
 
-  eq. ++> tests-u64-div-by-u64-one
+  eq. ++> can-divide-by-one
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-01.as-u64
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64
 
-  eq. ++> tests-u64-div-by-zero-returns-provided-fallback
+  eq. ++> can-divide-with-a-remainder
+    00-00-00-00-00-00-00-2A.as-u64.div 00-00-00-00-00-00-00-05.as-u64
+    00-00-00-00-00-00-00-08.as-u64
+
+  eq. ++> can-divide-without-a-sign
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
+    7F-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     00-00-00-00-00-00-00-02.as-u64.div
       00-00-00-00-00-00-00-00.as-u64
       "recovered" > [message]
 
-  eq. ++> tests-u64-div-is-unsigned
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
-    7F-FF-FF-FF-FF-FF-FF-FF.as-u64
-
-  eq. ++> tests-u64-div-small-not-reaching-large-divisor
-    00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64
-    00-00-00-00-00-00-00-00.as-u64
-
-  eq. ++> tests-u64-div-with-remainder
-    00-00-00-00-00-00-00-2A.as-u64.div 00-00-00-00-00-00-00-05.as-u64
-    00-00-00-00-00-00-00-08.as-u64
-
-  div. --> on-division-u64-by-u64-zero
+  div. --> stops-on-division-by-zero
     00-00-00-00-00-00-00-02.as-u64
     00-00-00-00-00-00-00-00.as-u64

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -52,78 +52,80 @@
       1
       1
 
-  FF-.as-u8.as-i16.as-bytes.eq 00-FF ++> tests-u8-as-i16-widens-with-zero-prefix
+  eq. ++> can-add-one-to-one
+    01-.as-u8.plus 01-.as-u8
+    02-.as-u8
 
-  FF-.as-u8.as-number.eq 255 ++> tests-u8-as-number-is-unsigned
+  eq. ++> can-add-with-overflow
+    FF-.as-u8.plus 01-.as-u8
+    00-.as-u8
 
-  eq. ++> tests-u8-div-by-u8-one
+  32-.as-u8.gte 32-.as-u8 ++> can-be-greater-than-or-equal-to-an-equal-u8
+
+  0A-.as-u8.lt 32-.as-u8 ++> can-be-less-than-a-larger-u8
+
+  32-.as-u8.lte 32-.as-u8 ++> can-be-less-than-or-equal-to-an-equal-u8
+
+  00-.as-u8.lt FF-.as-u8 ++> can-be-less-than-the-maximum-when-zero
+
+  FF-.as-u8.as-number.eq 255 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
     FF-.as-u8.div 01-.as-u8
     FF-.as-u8
 
-  eq. ++> tests-u8-div-by-zero-returns-provided-fallback
+  eq. ++> can-divide-without-a-sign
+    C8-.as-u8.div 03-.as-u8
+    42-.as-u8
+
+  2A-.as-u8.eq 2A-.as-u8 ++> can-equal-the-same-u8
+
+  2A-.as-u8.as-bytes.eq 2A- ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    06-.as-u8.times 07-.as-u8
+    2A-.as-u8
+
+  eq. ++> can-read-the-maximum-byte-as-unsigned
+    255.as-i64.as-i32.as-i16
+    FF-.as-u8.as-i16
+
+  eq. ++> can-subtract
+    05-.as-u8.minus 03-.as-u8
+    02-.as-u8
+
+  eq. ++> can-subtract-with-underflow
+    00-.as-u8.minus 01-.as-u8
+    FF-.as-u8
+
+  FF-.as-u8.gt 01-.as-u8 ++> can-treat-a-high-bit-as-magnitude-when-greater
+
+  FF-.as-u8.as-i16.as-bytes.eq 00-FF ++> can-widen-to-i16-with-a-zero-prefix
+
+  eq. ++> can-wrap-a-large-product
+    FF-.as-u8.times FF-.as-u8
+    01-.as-u8
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-eighth
+    10-.as-u8.times 10-.as-u8
+    00-.as-u8
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u8
+    00-.as-u8.gte 0A-.as-u8
+
+  not. ++> cannot-be-less-than-an-equal-u8
+    0A-.as-u8.lt 0A-.as-u8
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-.as-u8.lt 01-.as-u8
+
+  not. ++> cannot-equal-a-different-u8
+    2A-.as-u8.eq 2B-.as-u8
+
+  eq. ++> rejects-division-by-zero
     "recovered"
     02-.as-u8.div
       00-.as-u8
       "recovered" > [message]
 
-  eq. ++> tests-u8-div-is-unsigned
-    C8-.as-u8.div 03-.as-u8
-    42-.as-u8
-
-  not. ++> tests-u8-eq-false
-    2A-.as-u8.eq 2B-.as-u8
-
-  2A-.as-u8.eq 2A-.as-u8 ++> tests-u8-eq-true
-
-  FF-.as-u8.gt 01-.as-u8 ++> tests-u8-greater-treats-high-bit-as-magnitude
-
-  32-.as-u8.gte 32-.as-u8 ++> tests-u8-gte-equal
-
-  not. ++> tests-u8-gte-false
-    00-.as-u8.gte 0A-.as-u8
-
-  2A-.as-u8.as-bytes.eq 2A- ++> tests-u8-has-valid-bytes
-
-  not. ++> tests-u8-high-bit-not-less-than-one
-    FF-.as-u8.lt 01-.as-u8
-
-  not. ++> tests-u8-less-equal
-    0A-.as-u8.lt 0A-.as-u8
-
-  0A-.as-u8.lt 32-.as-u8 ++> tests-u8-less-true
-
-  32-.as-u8.lte 32-.as-u8 ++> tests-u8-lte-equal
-
-  255.as-i64.as-i32.as-i16.eq FF-.as-u8.as-i16 ++> tests-u8-max-byte-is-unsigned
-
-  eq. ++> tests-u8-minus
-    05-.as-u8.minus 03-.as-u8
-    02-.as-u8
-
-  eq. ++> tests-u8-minus-with-underflow
-    00-.as-u8.minus 01-.as-u8
-    FF-.as-u8
-
-  eq. ++> tests-u8-one-plus-u8-one
-    01-.as-u8.plus 01-.as-u8
-    02-.as-u8
-
-  eq. ++> tests-u8-plus-with-overflow
-    FF-.as-u8.plus 01-.as-u8
-    00-.as-u8
-
-  eq. ++> tests-u8-times
-    06-.as-u8.times 07-.as-u8
-    2A-.as-u8
-
-  eq. ++> tests-u8-times-wraps-large-product
-    FF-.as-u8.times FF-.as-u8
-    01-.as-u8
-
-  eq. ++> tests-u8-times-wraps-modulo-2-pow-8
-    10-.as-u8.times 10-.as-u8
-    00-.as-u8
-
-  00-.as-u8.lt FF-.as-u8 ++> tests-u8-zero-less-than-max
-
-  02-.as-u8.div 00-.as-u8 --> on-division-u8-by-u8-zero
+  02-.as-u8.div 00-.as-u8 --> stops-on-division-by-zero

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -142,87 +142,87 @@
       userinfo-at-idx
     ""
 
-  eq. ++> tests-parses-bracketed-ipv6-host-with-port
+  eq. ++> can-parse-a-bracketed-ipv6-host-with-a-port
     host.
       uri "http://[::1]:8080/p"
     "[::1]"
 
-  eq. ++> tests-parses-bracketed-ipv6-host-without-port
+  eq. ++> can-parse-a-bracketed-ipv6-host-without-a-port
     host.
       uri "http://[2001:db8::1]/p"
     "[2001:db8::1]"
 
-  eq. ++> tests-parses-bracketed-ipv6-port
-    port.
-      uri "http://[::1]:8080/p"
-    "8080"
-
-  eq. ++> tests-parses-empty-host-of-triple-slash-uri
-    host.
-      uri "file:///etc/passwd"
-    ""
-
-  eq. ++> tests-parses-empty-path-of-authority-only-uri
-    path.
-      uri "pgsql://localhost:899"
-    ""
-
-  eq. ++> tests-parses-fragment-without-leading-hash
+  eq. ++> can-parse-a-fragment-without-a-leading-hash
     fragment.
       uri "http://host/some/path?x=1#top"
     "top"
 
-  eq. ++> tests-parses-host-alongside-userinfo
+  eq. ++> can-parse-a-host-alongside-userinfo
     host.
       uri "http://user:pass@host:80/some/path"
     "host"
 
-  eq. ++> tests-parses-host-of-authority-with-port
-    host.
-      uri "pgsql://localhost:899"
-    "localhost"
-
-  eq. ++> tests-parses-path-alongside-userinfo-authority
+  eq. ++> can-parse-a-path-alongside-a-userinfo-authority
     path.
       uri "http://user:pass@host:80/some/path"
     "/some/path"
 
-  eq. ++> tests-parses-path-of-bare-scheme-uri
-    path.
-      uri "pgsql:localhost:899"
-    "localhost:899"
-
-  eq. ++> tests-parses-path-of-triple-slash-uri
-    path.
-      uri "file:///etc/passwd"
-    "/etc/passwd"
-
-  eq. ++> tests-parses-port-alongside-userinfo
+  eq. ++> can-parse-a-port-alongside-userinfo
     port.
       uri "http://user:pass@host:80/some/path"
     "80"
 
-  eq. ++> tests-parses-port-of-authority-with-port
-    port.
-      uri "pgsql://localhost:899"
-    "899"
-
-  eq. ++> tests-parses-query-without-leading-question-mark
+  eq. ++> can-parse-a-query-without-a-leading-question-mark
     query.
       uri "http://host/some/path?x=1#top"
     "x=1"
 
-  eq. ++> tests-parses-scheme-of-bare-scheme-uri
+  eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
+    host.
+      uri "file:///etc/passwd"
+    ""
+
+  eq. ++> can-parse-the-empty-path-of-an-authority-only-uri
+    path.
+      uri "pgsql://localhost:899"
+    ""
+
+  eq. ++> can-parse-the-host-of-an-authority-with-a-port
+    host.
+      uri "pgsql://localhost:899"
+    "localhost"
+
+  eq. ++> can-parse-the-path-of-a-bare-scheme-uri
+    path.
+      uri "pgsql:localhost:899"
+    "localhost:899"
+
+  eq. ++> can-parse-the-path-of-a-triple-slash-uri
+    path.
+      uri "file:///etc/passwd"
+    "/etc/passwd"
+
+  eq. ++> can-parse-the-port-of-a-bracketed-ipv6-host
+    port.
+      uri "http://[::1]:8080/p"
+    "8080"
+
+  eq. ++> can-parse-the-port-of-an-authority
+    port.
+      uri "pgsql://localhost:899"
+    "899"
+
+  eq. ++> can-parse-the-scheme-of-a-bare-scheme-uri
     scheme.
       uri "pgsql:localhost:899"
     "pgsql"
 
-  eq. ++> tests-parses-scheme-of-triple-slash-uri
+  eq. ++> can-parse-the-scheme-of-a-triple-slash-uri
     scheme.
       uri "file:///etc/passwd"
     "file"
 
-  eq. ++> tests-parses-userinfo-of-authority
+  eq. ++> can-parse-the-userinfo-of-an-authority
     userinfo.
       uri "http://user:pass@host:80/some/path"
     "user:pass"

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -47,7 +47,16 @@
     | 0
     false
 
-  ++> tests-iterating-tuple-with-while-using-external-iterator
+  ++> can-dataize-only-the-first-cycle
+    0.eq > @
+      malloc.for
+        42
+        [m]
+          while > @
+            i.eq 0 > [i]
+            m.put i > [i] >>
+
+  ++> can-iterate-a-tuple-with-an-external-iterator
     data.eq array.length > @
     * > array
       1
@@ -70,7 +79,7 @@
                   iter.as-number.plus 1
     array.length.plus -1 > max
 
-  ++> tests-iterating-tuple-with-while-using-internal-iterator
+  ++> can-iterate-a-tuple-with-an-internal-iterator
     data.eq array.length > @
     * > array
       1
@@ -97,7 +106,7 @@
                     iter.as-number.plus 1
     array.length.plus -1 > max
 
-  ++> tests-iterating-tuple-with-while-without-body-multiple
+  ++> can-iterate-a-tuple-without-a-body-many-times
     data.eq array.length > @
     * > array
       1
@@ -123,7 +132,7 @@
               acc
     array.length > max
 
-  ++> tests-iterating-tuple-with-while-without-body-single
+  ++> can-iterate-a-tuple-without-a-body-once
     data.eq array.length > @
     * 1 > array
     malloc.for > data
@@ -146,7 +155,32 @@
               acc
     array.length > max
 
-  ++> tests-last-while-dataization-object
+  ++> can-loop-on-a-bool-expression-kept-in-malloc
+    eq. > @
+      malloc.for
+        true
+        [m]
+          while > @
+            m > [i] >>
+            m.put false > [i] >>
+      false
+
+  ++> can-loop-over-a-simple-iteration
+    eq. > @
+      malloc.for
+        0
+        [m]
+          while > @
+            i.lt 10 > [i]
+            m.put i > [i] >>
+      9
+
+  not. ++> can-loop-when-the-condition-is-false-first
+    while
+      false > [i]
+      true > [i]
+
+  ++> can-return-the-last-dataized-object
     eq. > @
       malloc.for
         0
@@ -157,41 +191,7 @@
               m.as-number.plus 1
       3
 
-  not. ++> tests-last-while-dataization-object-with-false-condition
+  not. ++> can-return-the-last-dataized-object-with-a-false-condition
     while
       1.gt 2 > [i]
       true > [i]
-
-  ++> tests-simple-bool-expression-via-malloc-in-while
-    eq. > @
-      malloc.for
-        true
-        [m]
-          while > @
-            m > [i] >>
-            m.put false > [i] >>
-      false
-
-  not. ++> tests-simple-while-with-false-first
-    while
-      false > [i]
-      true > [i]
-
-  ++> tests-while-dataizes-only-first-cycle
-    0.eq > @
-      malloc.for
-        42
-        [m]
-          while > @
-            i.eq 0 > [i]
-            m.put i > [i] >>
-
-  ++> tests-while-simple-iteration
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            i.lt 10 > [i]
-            m.put i > [i] >>
-      9

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -52,7 +52,7 @@
   02-02 > version
   32769 > wronly
 
-  os.is-windows.not.or ++> tests-returns-valid-win32-inet-addr-for-localhost
+  os.is-windows.not.or ++> can-return-an-inet-address-for-localhost
     eq.
       code.
         win32 *1


### PR DESCRIPTION
Bumps `org.eolang:lints` to 0.4.0 and renames all 1423 test objects in `eo-runtime`
to the convention its new `bad-test-name` lint requires: `can-` for a capability,
`cannot-` for its absence, `rejects-` for a fallback path, and `stops-on-` for a
throwing `-->` test. So `tests-large-index-in-back` becomes
`can-take-a-back-slice-with-a-large-index`, and `on-bytes-of-wrong-size-as-i32`
becomes `stops-on-bytes-of-wrong-size`. Three more warnings go away with it: `bool`
no longer renames `app` into `output`, `string.slice` binds `r3`/`r4` to their own
byte literals instead of aliasing the `p2`/`p3` masks, and `number.integral` inlines
the single-use `valid`.

Without this, the 0.4.0 bump alone turns `eo:lint` on `eo-runtime` into 1577
warnings, 1320 of them `bad-test-name`, which buries every real finding. It also
seemed worth doing name by name rather than by regex — a few of the old names were
plainly wrong about what they tested (`tests-exp-check-n2` is `exp 5`, not a
negative; `tests-malloc-is-strictly-sized-int` asserts that the block *keeps* its
size; `tests-switch-with-all-false-cases` asserts `switch` returns `true`). The big
diff is mostly `eo:format` re-sorting the attributes after the rename; I diffed every
file's non-declaration content against `master` to confirm nothing was lost. `mvn
test` passes with 1810 tests.

Two things for the reviewer. This supersedes #5836, which does the same version bump.
And 253 warnings survive, all of them the one false positive in
objectionary/lints#1129 — its fix is still sitting in objectionary/lints#1136, so
0.4.0 ships the old `starts-with(@name, '+')` predicates and every `-->` test still
gets linted as ordinary code. I checked all 253 by hand: the 209 `non-kebab-name` and
`sparse-decoration` ones all point at a `-->` line, and the 44 `wrong-test-order`
ones all point at the last `++>` test of a file whose next sibling is a `-->` test.
They should vanish on the next `lints` release.

Closes #6083
