### PR TITLE
#6057: reject non-integer tuple index through fallback

### DIFF
--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -23,11 +23,15 @@
       fallback
         "Given index is out of tuple bounds"
       if. > [tup] >> at-fast
-        eq.
-          tup.length.plus -1
-          index
-        tup.head
-        at-fast tup.tail
+        0.eq tup.length
+        fallback
+          "Given index is out of tuple bounds"
+        if.
+          eq.
+            tup.length.plus -1
+            index
+          tup.head
+          at-fast tup.tail
       | ^
   tuple > empty
     T
@@ -286,6 +290,16 @@
         3
         2
         1
+
+  eq. ++> rejects-a-fractional-index
+    "recovered"
+    at.
+      *
+        "zero"
+        "one"
+        "two"
+      1.5
+      "recovered" > [message]
 
   eq. ++> rejects-an-out-of-bounds-index
     "recovered"


### PR DESCRIPTION
Fixes #6057.

## Problem

`tuple.at` routes an invalid index to the caller's `fallback`, but only when the index is below zero or at least the tuple length. A fractional index inside those bounds (for example `1.5` on a three-element tuple) passes both checks and reaches `at-fast`, which compares an integer position against `1.5`. Equality never holds, so the recursion walks off the end and terminates in the empty tuple's "Can't get tail" failure instead of returning the fallback.

## Change

`at-fast` now returns the `fallback` when its recursion reaches the empty tuple. A fractional or `nan` index never equals any integer position, so it walks the whole tuple and lands on the empty one, which now yields the fallback instead of failing.

I deliberately did not add an `is-integer` guard on the index. `at` must dataize its index exactly once (this is what `EOseqTest.tests-seq-single-dataization-int-equal-to-cache-problem-test` pins down, and tuple iteration in `while` relies on it too). Re-reading the index to test it for integrality breaks that contract. Detecting the overrun inside `at-fast` needs no second read of the index, so the single-dataization behaviour is preserved. `±inf` is still handled by the existing bounds check.

## Covered behavior

A new positive regression asserts that `(* "zero" "one" "two").at 1.5 "recovered"` returns `"recovered"`. The existing out-of-bounds, integer, and negative-index tests remain as controls.

## Verification

Ran the full `eo-runtime` test suite. `EOtupleTest` (30/30), `EOseqTest` (9/9) and `EOwhileTest` (10/10) all pass, confirming the fractional case is covered and the single-dataization contract still holds.
