### PR TITLE
#6058: route infinite repetition count to fallback

### DIFF
--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -1,5 +1,6 @@
 # Returns `text` repeated `times` times.
-# If `times` < 0 or not a whole number, the `cant-repeat` fallback is returned,
+# If `times` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-repeat` fallback is returned,
 # or the bottom object when unbound.
 # If `times` == 0, empty text is returned.
 
@@ -14,8 +15,7 @@
   if. > @
     or.
       0.gt times
-      not.
-        times.floor.eq times
+      times.is-integer.not
     cant-repeat
       "Can't repeat text %f times".printf
         * times
@@ -40,6 +40,13 @@
     repeated
       "hey"
       5
+
+  eq. ++> tests-text-repeated-infinite-times-returns-provided-fallback
+    "recovered"
+    repeated
+      "x"
+      pinf
+      "recovered" > [message]
 
   eq. ++> tests-text-repeated-negative-times-formats-message-as-number
     "Can't repeat text -1.000000 times"


### PR DESCRIPTION
Fixes #6058.

## Problem

`string.repeated` routes a negative or non-whole `times` to its `cant-repeat` fallback, but positive infinity slips through. The guard rejects a value only when `0.gt times` or `times.floor.eq times` is false. `pinf` equals its own floor, so it enters `rec-repeated`, whose counter starts at an integer and stops only on `amount.eq index`; incrementing an integer by one never reaches infinity, so the recursion never terminates and the fallback is ignored.

## Change

The integrality check `not. (times.floor.eq times)` is replaced with `times.is-integer.not`. `is-integer` is true only for a finite value equal to its own floor, so it rejects `nan`, `±inf`, and fractional counts in one condition, while `0.gt times` still rejects negatives. The accepted domain is now exactly a finite non-negative integer. Zero and positive integers are unchanged.

## Covered behavior

A new positive regression asserts that `"x".repeated pinf "recovered"` returns `"recovered"`. The existing negative, fractional, zero, and integer tests remain as controls.

## Verification

Ran `mvn -pl eo-runtime test -Dtest=EO_string.EOrepeatedTest` (7/7).
