### PR TITLE
#6059: route infinite places to fallback in as-fixed

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -1,8 +1,9 @@
 # Writes the number `n` as fixed-point decimal with exactly `places` fraction
 # digits, rounding to the nearest unit in the last place, so that `2.5` with
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
-# If `places` is negative or not a whole number, the `cant-print` fallback is
-# returned, or the bottom object when unbound.
+# If `places` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-print` fallback is returned, or the bottom object
+# when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -15,8 +16,7 @@
   if. > @
     or.
       0.gt places
-      not.
-        places.floor.eq places
+      places.is-integer.not
     cant-print
       "Can't write a fixed-point decimal with %f fraction places".printf
         * places
@@ -89,6 +89,13 @@
     "3.14"
     string
       as-fixed 3.14159 2
+
+  eq. ++> tests-infinite-places-returns-provided-fallback
+    "recovered"
+    as-fixed
+      1.25
+      pinf
+      "recovered" > [message]
 
   eq. ++> tests-negative-places-formats-message-as-number
     "Can't write a fixed-point decimal with -2.000000 fraction places"


### PR DESCRIPTION
Fixes #6059.

## Problem

`string.as-fixed` sends negative and fractional `places` to its `cant-print` fallback, but positive infinity passes the guard. `pinf` equals its own floor, so it reaches `pow10`, which recurses on `p.minus 1` until `p.eq 0`; `pinf.minus 1` stays `pinf`, so the base case is never reached and the fallback is ignored.

## Change

The integrality check `not. (places.floor.eq places)` is replaced with `places.is-integer.not`, which is true only for a finite value equal to its own floor. It therefore rejects `nan`, `±inf`, and fractional precision in one condition, while `0.gt places` still rejects negatives. The accepted domain is now exactly a finite non-negative integer. `0` and positive integers are unchanged.

## Covered behavior

A new positive regression asserts that `as-fixed 1.25 pinf "recovered"` returns `"recovered"`. The existing negative, fractional, zero-places, and formatting tests remain as controls.

## Verification

Ran `mvn -pl eo-runtime test -Dtest=EO_string.EOas_fixedTest` (16/16).
