### PR TITLE
#6060: reject non-integer and non-finite nsplit limit

### DIFF
--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -1,6 +1,7 @@
 # Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
-# If `limit` < 1, the `cant-split` fallback is returned, or the bottom object when unbound.
+# If `limit` is not a finite integer of at least 1 (fractional, nan, infinite,
+# zero or negative), the `cant-split` fallback is returned, or the bottom object when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -11,7 +12,9 @@
 
 [text delimiter limit cant-split] > nsplit
   if. > @
-    1.gt limit
+    or.
+      1.gt limit
+      limit.is-integer.not
     cant-split
       "Invalid limit %d for nsplit, must be at least 1".printf
         * limit
@@ -70,6 +73,22 @@
           0
           0
   delimiter.size >> size!
+
+  eq. ++> tests-nsplit-fractional-limit-returns-provided-fallback
+    "recovered"
+    nsplit
+      "a-b-c"
+      "-"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> tests-nsplit-infinite-limit-returns-provided-fallback
+    "recovered"
+    nsplit
+      "a-b-c"
+      "-"
+      pinf
+      "recovered" > [message]
 
   eq. ++> tests-nsplit-invalid-limit-returns-provided-fallback
     "fallback"


### PR DESCRIPTION
Fixes #6060.

## Problem

`string.nsplit` only rejects a `limit` below one. Fractional and non-finite limits pass the guard and reach `rec-nsplit`, where an integer counter is compared with `limit.minus 1`. For `1.5` the counter clears `0.5` once and yields two parts; for `2.5` it yields three; for `pinf` the counter never reaches the bound, turning a bounded split into an unlimited one. The `cant-split` fallback is never used and the caller gets a plausible but accidental tuple.

## Change

The guard now also rejects a non-integer limit: `limit.is-integer.not` is added next to `1.gt limit`. `is-integer` is false for `nan`, `±inf`, and fractional values, so the accepted domain is exactly a finite integer of at least one. Valid integer limits and the zero/negative fallback path are unchanged.

## Covered behavior

Two new positive regressions assert that `nsplit "a-b-c" "-" 1.5 "recovered"` and `nsplit "a-b-c" "-" pinf "recovered"` both return `"recovered"`. The existing zero-limit fallback and the integer-limit split tests remain as controls.

## Verification

Ran `mvn -pl eo-runtime test -Dtest=EO_string.EOnsplitTest` (11/11).
