### PR TITLE
#6066: anchor scanf format to the start of input

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -121,6 +121,7 @@
       regex
         chained *1
           "/"
+          "^"
           pattern
           "/"
       read
@@ -235,6 +236,20 @@
       9.999999999E7
       0.01
       100000000
+
+  eq. ++> tests-scanf-does-not-parse-unmatched-leading-text
+    length.
+      scanf
+        "id=%d"
+        "prefix id=42"
+    0
+
+  eq. ++> tests-scanf-ignores-trailing-text-after-match
+    42
+    head.
+      scanf
+        "id=%d"
+        "id=42 suffix"
 
   eq. ++> tests-scanf-with-complex-float
     1991.01


### PR DESCRIPTION
Fixes #6066.

## Problem

`string.scanf` wraps its generated pattern only in slashes and finds the first occurrence anywhere in the input via `regex.match`. When the input does not start with the format's literal prefix, `match` still finds the pattern further along and returns the values from that later substring. For example `scanf "id=%d" "prefix id=42"` returns `42` even though the input does not begin with `id=`.

## Change

The generated regex is now anchored to the start of the input by prefixing it with `^`, so the first character of the format must correspond to the first character of the input. Literal `^`/`$` characters coming from the format are already escaped by the `escaped` helper, so the added anchor cannot collide with them. Trailing input after a match is still allowed.

## Covered behavior

Two new regressions: `scanf "id=%d" "prefix id=42"` now has length `0`, and `scanf "id=%d" "id=42 suffix"` still parses `42`. Existing tests such as `"Im%d %s ..."` on `"Im18 ..."` and `"%s!"` on `"hello!"` confirm start-anchored and trailing-input cases keep working.

## Verification

Ran `mvn -pl eo-runtime test -Dtest=EO_string.EOscanfTest` (17/17).
