### PR TITLE
#6094: retry Saved.moved on transient move failures

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.maven;
 
+import com.jcabi.aspects.RetryOnFailure;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -11,6 +12,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
@@ -131,10 +133,18 @@ final class Saved implements Scalar<Path> {
      * Move a temp file onto its target, atomically where the filesystem
      * supports it, falling back to a plain (still complete-file, just not
      * guaranteed atomic) move on filesystems that don't.
+     *
+     * <p>Retried on failure: on Windows, {@code REPLACE_EXISTING} throws
+     * {@link java.nio.file.AccessDeniedException} instead of replacing the
+     * target when a concurrent reader has it open at that instant, unlike
+     * POSIX which allows it. The window is brief, so a short retry clears
+     * it instead of failing the whole write.</p>
+     *
      * @param tmp Temp file to move
      * @param target Destination path
      * @throws IOException If the move fails
      */
+    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
     private static void moved(final Path tmp, final Path target) throws IOException {
         try {
             Files.move(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -11,7 +11,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.hamcrest.MatcherAssert;
@@ -62,6 +66,26 @@ final class SavedTest {
             "a reader racing with concurrent writers must always see a complete variant, never a mix of two",
             broken,
             Matchers.empty()
+        );
+    }
+
+    @Test
+    void retriesMoveWhenTargetTemporarilyBlocked(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("blocked.txt");
+        Files.createDirectories(target);
+        try (ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor()) {
+            scheduler.schedule(
+                (Callable<Void>) () -> {
+                    Files.delete(target);
+                    return null;
+                }, 300, TimeUnit.MILLISECONDS
+            );
+            new Saved("content", target).value();
+        }
+        MatcherAssert.assertThat(
+            "the write must succeed once a retry lands after the obstruction clears",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("content")
         );
     }
 }


### PR DESCRIPTION
Closes #6094.

`Saved.moved` moves a temp file onto its target with `ATOMIC_MOVE, REPLACE_EXISTING`, catching only `AtomicMoveNotSupportedException`. On Windows, `Files.move(..., REPLACE_EXISTING)` throws `AccessDeniedException` instead of replacing the target when a concurrent reader/writer has it open at that exact instant. POSIX allows this; Windows blocks it. This surfaced as an intermittent `SavedTest.exposesNoPartiallyWrittenFileToConcurrentReader` failure on `windows-2022` CI (seen on PR #6069, #6056, among others), always the same `AccessDeniedException` on the move.

Fix: `@RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)` on `Saved.moved`, matching the existing retry idiom already used elsewhere in this class for transient IO failures (`CommitHashesText`, `OyRemote`).

Test: `SavedTest.retriesMoveWhenTargetTemporarilyBlocked` makes the target path a directory (any platform, deterministically blocks the move with a real IOException), schedules the obstruction's removal 300ms later on a background thread, well before the 1-second retry fires, then asserts the write ultimately succeeds. Reverted the fix locally and confirmed this test fails without it.

`mvn -pl eo-maven-plugin test -Dtest=SavedTest,CacheTest,ConcurrentCacheTest` - 14 tests, all passing. qulice clean.
