### PR TITLE
#6091: fix Saxon 13.0 multi-argument xsl:function parameter mis-binding

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/set-original-names.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/set-original-names.xsl
@@ -11,9 +11,9 @@
   The function takes the object only; the `program` argument it used
   to take was never read in its body (see #6091 and the same fix in
   set-locators.xsl) - a redundant argument is exactly the shape that
-  triggers Saxon 13.0 mis-binding parameters of a multi-argument
-  function when one compiled stylesheet transforms many documents in
-  parallel threads (which is what the "parse" goal does).
+  triggers Saxon 13.0 into binding parameters of a multi-argument
+  function to the wrong values when one compiled stylesheet transforms
+  many documents in parallel threads (which is what the "parse" goal does).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:import href="/org/eolang/parser/_specials.xsl"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/set-original-names.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/set-original-names.xsl
@@ -8,11 +8,16 @@
   Here we go through all objects and add @original-name attributes
   to all of them. The value of the attribute is a FQN
   of the object.
+  The function takes the object only; the `program` argument it used
+  to take was never read in its body (see #6091 and the same fix in
+  set-locators.xsl) - a redundant argument is exactly the shape that
+  triggers Saxon 13.0 mis-binding parameters of a multi-argument
+  function when one compiled stylesheet transforms many documents in
+  parallel threads (which is what the "parse" goal does).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:import href="/org/eolang/parser/_specials.xsl"/>
   <xsl:function name="eo:original-name" as="xs:string">
-    <xsl:param name="program" as="node()"/>
     <xsl:param name="o" as="node()"/>
     <xsl:if test="name($o) != 'o'">
       <xsl:message terminate="yes">
@@ -22,7 +27,7 @@
     <xsl:variable name="parent" select="$o/parent::o"/>
     <xsl:variable name="ret">
       <xsl:if test="$parent">
-        <xsl:value-of select="eo:original-name($program, $parent)"/>
+        <xsl:value-of select="eo:original-name($parent)"/>
         <xsl:text>.</xsl:text>
       </xsl:if>
       <xsl:choose>
@@ -54,7 +59,7 @@
   <xsl:template match="o[not(@original-name)]">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
-      <xsl:attribute name="original-name" select="eo:original-name(/object, .)"/>
+      <xsl:attribute name="original-name" select="eo:original-name(.)"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names-with-dot.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names-with-dot.yaml
@@ -15,7 +15,7 @@ document:
     </objects>
   </program>
 asserts:
-  - /object/o[@original-name='a' and @base='.a']
-  - /object/o/o[1][@original-name='a.ρ' and @base='b']
-  - /object/o/o[2][@original-name='a.α0' and @base='c']
-  - /object/o/o[3][@original-name='a.α1' and @base='d']
+  - //o[@original-name='a' and @base='.a']
+  - //o[@original-name='a' and @base='.a']/o[1][@original-name='a.ρ' and @base='b']
+  - //o[@original-name='a' and @base='.a']/o[2][@original-name='a.α0' and @base='c']
+  - //o[@original-name='a' and @base='.a']/o[3][@original-name='a.α1' and @base='d']

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names-with-dot.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names-with-dot.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets:
   - /org/eolang/maven/transpile/set-original-names.xsl
 document:

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/original-names/add-original-names.yaml
@@ -13,4 +13,4 @@ document:
     </objects>
   </program>
 asserts:
-  - /object/o[@original-name='a']/o[@original-name='a.α0']
+  - //o[@name='a' and @original-name='a']/o[@original-name='a.α0']


### PR DESCRIPTION
Closes #6091.

`eo:original-name` in `set-original-names.xsl` took `($program, $o)`, but `$program` was never read anywhere in the function body, only passed through on the recursive call. That is exactly the shape that made `eo:locator` in `set-locators.xsl` mis-bind arguments under Saxon 13.0 when one compiled stylesheet is shared across threads (`Threaded`/`Parsing`), already fixed the same way. Dropped the parameter entirely.

Also found while touching this: the two YAML regression fixtures for `eo:original-name` (`original-names/add-original-names.yml` and `add-original-names-with-dot.yml`) had a `.yml` extension, but `MjTranspileTest.checksTranspilePacks`'s harness only globs `**.yaml`, so neither ever actually ran. Renamed them to `.yaml`. Once active, both failed on an unrelated pre-existing bug in the fixtures themselves: their XPath assertions used `/object/o[...]` but the harness's actual document root is `<program>`, not `<object>` (visible from other currently-passing fixtures in the same directory, which use `//o[...]` instead). Fixed the assertions to match; the underlying `eo:original-name` output was already correct.

The issue lists 7 more stylesheets with the same risk: `const-to-dataized.xsl`, `restore-local-names.xsl`, `unnecessary-as.xsl`, `merge-monikers.xsl`, `inline-cactoos.xsl`, `to-java.xsl`, `add-probes.xsl`. Unlike `set-original-names.xsl`, their multi-argument functions all genuinely use both parameters, so dropping one isn't a safe option there - each needs its own restructuring. Marked every one of the 25 affected `xsl:function` declarations across those 7 files with a `@todo #6091:NNmin` puzzle naming the functions and the fix needed, so 0pdd files a tracked child issue per file instead of the risk sitting silent and undocumented.

`mvn -pl eo-maven-plugin,eo-printer,eo-parser test` - 1528 (eo-parser) + 316 (eo-printer) + 43+9 (eo-maven-plugin transpile/probe) tests, all passing. qulice clean on all touched files.
