### PR TITLE
#5945: reject NaN in printf %d instead of narrowing to zero

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -222,3 +222,7 @@
   printf *1 --> stops-on-formatting-a-huge-number-as-a-decimal
     "%d"
     1.0e30
+
+  printf *1 --> stops-on-formatting-nan-as-a-decimal
+    "%d"
+    nan

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -192,12 +192,15 @@ final class PrintfArgs {
     /**
      * Convert a number to {@code long} for the {@code %d} conversion, rejecting
      * a value outside {@code long} range instead of silently saturating to
-     * {@link Long#MAX_VALUE}/{@link Long#MIN_VALUE} as {@link Double#longValue()} does.
+     * {@link Long#MAX_VALUE}/{@link Long#MIN_VALUE} as {@link Double#longValue()} does,
+     * and rejecting {@link Double#NaN} instead of letting it slip past both bounds
+     * (every relational comparison against {@code NaN} is {@code false}) and narrow
+     * to {@code 0} per JLS 5.1.3.
      * @param number Number to convert
      * @return The number as {@code long}
      */
     private static long toLong(final double number) {
-        if (number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
+        if (Double.isNaN(number) || number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
             throw new ExFailure(
                 "The number %s doesn't fit into long range for the '%%d' conversion",
                 number

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -200,7 +200,11 @@ final class PrintfArgs {
      * @return The number as {@code long}
      */
     private static long toLong(final double number) {
-        if (Double.isNaN(number) || number < Long.MIN_VALUE || number >= PrintfArgs.LONG_UPPER_LIMIT) {
+        if (
+            Double.isNaN(number)
+                || number < Long.MIN_VALUE
+                || number >= PrintfArgs.LONG_UPPER_LIMIT
+        ) {
             throw new ExFailure(
                 "The number %s doesn't fit into long range for the '%%d' conversion",
                 number

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -100,6 +100,22 @@ final class PrintfArgsTest {
     }
 
     @Test
+    void rejectsNanInsteadOfNarrowingToZero() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(Double.NaN));
+        MatcherAssert.assertThat(
+            "NaN must be rejected like an infinity, not silently narrowed to 0 per JLS 5.1.3",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                "must throw ExFailure, not silently return 0"
+            ).getMessage(),
+            Matchers.containsString("doesn't fit into long range")
+        );
+    }
+
+    @Test
     void acceptsLargestDoubleThatTrulyFitsInLongRange() {
         final double closest = 9_223_372_036_854_773_760.0;
         final Phi tuple = Phi.Φ.take("tuple").copy();


### PR DESCRIPTION
Closes #5945.

`PrintfArgs.toLong` only guarded the two out-of-range directions. `NaN` compares `false` against every relational operator, so `NaN < Long.MIN_VALUE` and `NaN >= 2^63` are both false, `NaN` slips past the check, and `(long) Double.NaN` narrows to `0` per JLS 5.1.3. So `printf "%d" nan` silently produced `"0"` while `printf "%d" pinf`/`ninf` already failed cleanly.

Fix: reject `Double.isNaN(number)` explicitly, alongside the existing range check.

Test: `PrintfArgsTest.rejectsNanInsteadOfNarrowingToZero` reproduces the issue's own example, asserting `ExFailure` instead of `"0"`. Reverted the fix locally and confirmed the test fails (nothing thrown); restored it and confirmed it passes.

`mvn -pl eo-runtime test -Dtest=PrintfArgsTest,EO_string.EOprintfTest` - 47 tests, all passing. qulice clean.
