### PR TITLE
#5946: escape %d in scanf overflow message, tighten 19-digit bound

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -55,9 +55,16 @@
         text
     [text] > as-integer
       if. > @
-        digits.length.gt 19
+        or.
+          digits.length.gt 19
+          and.
+            digits.length.eq 19
+            not.
+              negative.if
+                digits-lte digits "9223372036854775808"
+                digits-lte digits "9223372036854775807"
         T
-          "The number doesn't fit into long range for the '%d' conversion"
+          "The number doesn't fit into long range for the '%%d' conversion"
         negative.if negated folded
       signed.if > digits
         slice
@@ -65,6 +72,27 @@
           1
           text.length.minus 1
         text
+      [a b] > digits-lte
+        if. > [index] >> rec
+          index.eq a.length
+          true
+          if.
+            lt.
+              as-ascii
+                slice a index 1
+              as-ascii
+                slice b index 1
+            true
+            if.
+              gt.
+                as-ascii
+                  slice a index 1
+                as-ascii
+                  slice b index 1
+              false
+              rec
+                index.plus 1
+        | 0 > @
       fold-digits digits > folded
       folded.times -1 > negated
       eq. > negative
@@ -325,6 +353,24 @@
   scanf --> stops-on-an-oversized-integer
     "%d"
     "99999999999999999999"
+
+  gt. ++> can-scan-a-nineteen-digit-value-at-long-max
+    head.
+      scanf "%d" "9223372036854775807"
+    9000000000000000000
+
+  lt. ++> can-scan-a-nineteen-digit-value-at-long-min
+    head.
+      scanf "%d" "-9223372036854775808"
+    -9000000000000000000
+
+  scanf --> stops-on-a-nineteen-digit-value-above-long-max
+    "%d"
+    "9223372036854775808"
+
+  scanf --> stops-on-a-nineteen-digit-value-below-long-min
+    "%d"
+    "-9223372036854775809"
 
   scanf --> stops-on-a-wrong-format
     "%l"


### PR DESCRIPTION
Closes #5946.

`scanf`'s `as-integer` had two bugs, both in `eo-runtime/src/main/eo/string/scanf.eo`.

**Bug 1**: the overflow message embedded a literal, unescaped `%d`: `"...for the '%d' conversion"`. This message reaches `ExFailure(reason)`, which runs `String.format(reason)` with zero arguments. `String.format` parses that `%d` as a real format specifier with no argument to fill it, throwing `java.util.MissingFormatArgumentException` instead of ever showing the intended message. The sibling Java code already knows this - `PrintfArgs.toLong` writes the same phrase as `'%%d'`. Fixed by escaping it the same way. Verified standalone that `String.format("...'%d'...")` throws `MissingFormatArgumentException` while `String.format("...'%%d'...")` correctly produces the literal text.

**Bug 2**: the overflow guard was `digits.length.gt 19`, which only rejects 20+ digit inputs. `Long.MAX_VALUE` (`9223372036854775807`) has exactly 19 digits, so any 19-digit value above it (e.g. `9223372036854775808`) silently passed the guard and got folded into a lossy value instead of being rejected.

Tightening this needed care: comparing the already-folded `number` (double) against the bound doesn't work, because folding 19 decimal digits one at a time in double arithmetic (`acc*10 + digit`) already accumulates enough rounding error that even `9223372036854775807` itself folds to something other than its true value - checked this empirically before picking an approach. So the fix compares the exact decimal digit string instead: a small recursive `digits-lte` helper (mirroring the file's existing `fold-digits` recursion style) does a character-by-character comparison against `"9223372036854775807"` (`Long.MAX_VALUE`) for a non-negative number, or `"9223372036854775808"` (`Long.MIN_VALUE`'s magnitude) for a negative one - the sign matters here because `-9223372036854775808` is a valid `Long.MIN_VALUE` and must not be rejected even though its magnitude is one more than `Long.MAX_VALUE`'s.

Test: added to the existing EO test suite in `scanf.eo` -
- `can-scan-a-nineteen-digit-value-at-long-max` / `at-long-min`: the exact boundary values are still accepted.
- `stops-on-a-nineteen-digit-value-above-long-max` / `below-long-min`: one past each boundary is rejected.

Reverted the digit-length/bound check locally (keeping the escaped message) and confirmed `mvn -pl eo-runtime test -Dtest=EO_string.EOscanfTest` still passes 21/21 even with the old bug present, since a bare `-->` throw-test can't distinguish "threw for the right reason" from "threw for some other reason" (a known limitation of this style of EO test, not specific to this PR) - so this class of regression is best caught by code review of the fix itself, which mirrors `PrintfArgs.toLong`'s exact escaping pattern and directly implements the digit-string comparison the issue itself suggested. Restored the fix; full suite is 21/21 green either way. qulice clean.
