### PR TITLE
#6098: suggest vertical application in the method continuation error

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -861,7 +861,7 @@ R-5.2.2. When popping an entry at indent `K + 2` (so the new top is at indent `K
 
 R-5.2.3. **MethodDispatch line dispatch.** If the line's kind is `MethodDispatch` (`.method` continuation):
   - **(a) Extend:** If the top's openness ∈ {`open`, `vertical-completed`} AND the top's kind is **not** in the horizontally-completed set (Appendix A) AND the top's kind is **not** `inline-phi-formation`: extend the top's kind to `vmethod` (or to `vmethod-with-hargs` if the new line carries ≥1 hargs), update `named?` if the line carries a name suffix, leave openness `open` (or transition to `horizontal-completed` if the new kind is `vmethod-with-hargs`).
-  - **(b) Reject — horizontally-completed predecessor:** If the top's openness is `horizontal-completed` (equivalently, kind ∈ horizontally-completed set): error `method continuation not allowed after horizontal application` (§9.9).
+  - **(b) Reject — horizontally-completed predecessor:** If the top's openness is `horizontal-completed` (equivalently, kind ∈ horizontally-completed set): error `method continuation not allowed after horizontal application, try vertical application instead` (§9.9).
   - **(b′) Reject — only-phi predecessor:** If the top's kind is `inline-phi-formation` (whose bare-φ form is `open` but is not a method-chain host): error `method continuation not allowed after only-phi formation` (§9.9).
 
 R-5.2.4. **Non-MethodDispatch same-indent line.** If the line's kind is **not** MethodDispatch: the top entry is a *completed previous sibling*. Run close-time checks (§5.3) on it, then **replace** it with a new entry built from the new line. The new entry's `parent_kind` is read from the stack entry below.
@@ -1337,7 +1337,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Indent jump > 1 level | `indent increased by more than one level` |
 | Tab in leading whitespace | `tab character in leading whitespace` |
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
-| `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application` |
+| `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application, try vertical application instead` |
 | `.method` continuation on an only-phi formation | `method continuation not allowed after only-phi formation` |
 | Name suffix on an only-phi φ's argument | `<name> cannot be a named attribute of only-phi formation <formation>, which binds only its φ decoratee` (the formation is described generically as `an only-phi formation` when anonymous) |
 | `.method` line at top level, deeper than parent, or with no same-indent sibling | `method continuation has no expression to attach to` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -128,7 +128,7 @@ final class LnMethod implements Line {
         if (stack.top().openness() == Openness.HORIZONTAL_COMPLETED) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "method continuation not allowed after horizontal application"
+                "method continuation not allowed after horizontal application, try vertical application instead"
             );
         }
         if (stack.top().kind() == Kind.ONLY_PHI_FORMATION) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-after-happlication.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:0] error: 'method continuation not allowed after horizontal application'
+  [2:0] error: 'method continuation not allowed after horizontal application, try vertical application instead'
   .z > w
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-with-hargs-fluent-chain.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/vmethod-with-hargs-fluent-chain.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 4
 message: |-
-  [4:2] error: 'method continuation not allowed after horizontal application'
+  [4:2] error: 'method continuation not allowed after horizontal application, try vertical application instead'
     .with 2 > arr
     ^
 input: |


### PR DESCRIPTION
Closes #6098.

When a `.method` continuation follows a horizontally-completed application (`.with 1` then `.with 2`), the parser rejects it but the error only said `method continuation not allowed after horizontal application`. A reader hits this constantly writing fluent-style method chains and has no idea from the message alone that the fix is to write the same chain vertically instead.

Fix: the message now ends with `, try vertical application instead`, matching the exact wording `@maxonfjvipon` suggested in the linked issue thread.

Test: updated the two existing `eo-typos` fixtures that already exercise this exact error (`vmethod-after-happlication.yaml`, `vmethod-with-hargs-fluent-chain.yaml`) to expect the new wording. Reverted the fix locally and confirmed both fail with the old message; restored the fix and confirmed they pass. Also updated `PARSER_SPEC.md`'s two references to this message (R-5.2.3(b) and the error-message table) to keep the spec in sync with the code.

`mvn -pl eo-parser test -Dtest=EoTest,EoSyntaxTest` - 1012 tests, all passing. qulice clean.
