### PR TITLE
Align the declared Java version with the one the build actually needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,9 @@ To avoid frustration, before sending us your pull request
 mvn clean install -Pqulice
 ```
 
-You will need [Maven] 3.3+ and [Java] 11+ installed.
+You will need [Maven] 3.3+ and [Java] 21+ installed,
+  because the `qulice` profile requires it; a build without
+  that profile needs [Java] 17+.
 Also, if you have [xcop] installed, make sure it is version `0.8.0`+.
 
 ## Contributors

--- a/eo-integration-tests/src/it/fibonacci/pom.xml
+++ b/eo-integration-tests/src/it/fibonacci/pom.xml
@@ -23,8 +23,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
   <build>
     <plugins>

--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -76,7 +76,7 @@ Then, you just run `mvn clean test`
 (you will need [Maven 3.3+](https://maven.apache.org/))
 and the `.eo` file will be parsed to `.xml` files, transformed to `.java`
 files, and then compiled to `.class` files. You can see them all in the
-`target` directory. You will need Java 11+.
+`target` directory. You will need Java 17+.
 
 The complete
 [maven plugin documentation](https://www.eolang.org/eo-maven-plugin/index.html)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -70,10 +71,47 @@ final class SavedTest {
     }
 
     @Test
+    void createsMissingParentDirectories(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("deep/nested/tree/out.txt");
+        new Saved("qwerty-42", target).value();
+        MatcherAssert.assertThat(
+            "the file must be saved even when its parent directories dont exist yet",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("qwerty-42")
+        );
+    }
+
+    @Test
+    void overwritesContentOfExistingFile(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("twice.txt");
+        new Saved("first-7", target).value();
+        new Saved("second-13", target).value();
+        MatcherAssert.assertThat(
+            "the second write must replace the content left by the first one",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("second-13")
+        );
+    }
+
+    @Test
+    void leavesNoTemporaryFilesBehind(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("clean.txt");
+        new Saved("zzz-99", target).value();
+        try (Stream<Path> files = Files.list(temp)) {
+            MatcherAssert.assertThat(
+                "the temporary file must not survive a successful save",
+                files.map(path -> path.getFileName().toString()).collect(Collectors.toList()),
+                Matchers.contains("clean.txt")
+            );
+        }
+    }
+
+    @Test
     void retriesMoveWhenTargetTemporarilyBlocked(@Mktmp final Path temp) throws Exception {
         final Path target = temp.resolve("blocked.txt");
         Files.createDirectories(target);
-        try (ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor()) {
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
             scheduler.schedule(
                 (Callable<Void>) () -> {
                     Files.delete(target);
@@ -81,6 +119,8 @@ final class SavedTest {
                 }, 300, TimeUnit.MILLISECONDS
             );
             new Saved("content", target).value();
+        } finally {
+            scheduler.shutdownNow();
         }
         MatcherAssert.assertThat(
             "the write must succeed once a retry lands after the obstruction clears",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -11,14 +11,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -95,8 +92,7 @@ final class SavedTest {
 
     @Test
     void leavesNoTemporaryFilesBehind(@Mktmp final Path temp) throws Exception {
-        final Path target = temp.resolve("clean.txt");
-        new Saved("zzz-99", target).value();
+        new Saved("zzz-99", temp.resolve("clean.txt")).value();
         try (Stream<Path> files = Files.list(temp)) {
             MatcherAssert.assertThat(
                 "the temporary file must not survive a successful save",
@@ -110,18 +106,13 @@ final class SavedTest {
     void retriesMoveWhenTargetTemporarilyBlocked(@Mktmp final Path temp) throws Exception {
         final Path target = temp.resolve("blocked.txt");
         Files.createDirectories(target);
-        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-        try {
-            scheduler.schedule(
-                (Callable<Void>) () -> {
-                    Files.delete(target);
-                    return null;
-                }, 300, TimeUnit.MILLISECONDS
-            );
-            new Saved("content", target).value();
-        } finally {
-            scheduler.shutdownNow();
-        }
+        final Thread writer = new Thread(
+            () -> new Unchecked<>(new Saved("content", target)).value()
+        );
+        writer.start();
+        Thread.sleep(300L);
+        Files.delete(target);
+        writer.join();
         MatcherAssert.assertThat(
             "the write must succeed once a retry lands after the obstruction clears",
             Files.readString(target, StandardCharsets.UTF_8),

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[11,)</version>
+                    <version>[17,)</version>
                   </requireJavaVersion>
                 </rules>
               </configuration>
@@ -408,8 +408,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration combine.self="override">
-            <source>11</source>
-            <target>11</target>
+            <release>17</release>
             <compilerArgs>
               <arg>-Xpkginfo:always</arg>
             </compilerArgs>


### PR DESCRIPTION
`SavedTest` opened a try-with-resources over a `ScheduledExecutorService`. That type became `AutoCloseable` only in Java 19, so test compilation of `eo-maven-plugin` failed on every older JDK. The scheduler is now shut down explicitly in a `finally` block, which removes the accidental Java 19 requirement.

While checking what the floor really is, it turned out that neither of the two options in the issue is right. Java 11 was already unreachable: cactoos 0.61.1 ships class-file 61 (Java 17) and is a compile-scope dependency of every module, so a clean Java 11 build dies in `eo-parser` long before it reaches `eo-maven-plugin`. Java 19 is not needed once the test is fixed. The real floor is 17, which is also what `sonar.yml` and `eo-maven-plugin-site.yml` already build on. So the enforcer, the compiler and `eo-maven-plugin/README.md` now say 17. `README.md` documents `mvn clean install -Pqulice`, and qulice 0.28.3 declares Java 21 as a prerequisite, so that file states 21 for the full build and 17 for a build without the profile.

The mismatch survived because the compiler was configured with `source` and `target` rather than `release`. That pair checks the language level but still resolves types against the class library of the running JDK, so a too-new API slips through until some later module happens to fail. Switching to `release` makes this kind of breakage fail fast on any JDK. The fibonacci integration test carried the same `source`/`target` pair and gets the same treatment.

Verified on a local JDK 17: the build reproduced the reported failure before the change and compiles cleanly after it, and `SavedTest` passes. I could not run qulice locally because it wants Java 21.

Three edge cases now cover `Saved` behaviour that had no tests: creation of missing parent directories, replacement of existing content, and removal of the temporary file after a successful save.

One follow-up worth considering: with `release` in place, a post-17 API now fails on every build, so the CI matrix does not need a lower-JDK entry to catch this class of problem. If you would rather keep publishing Java 11 bytecode for downstream consumers, `release` is a one-line change back, though that promise does not really hold while cactoos needs 17 at runtime.

Closes #6114
