### PR TITLE
Stop randomizing the move retry delay in Saved

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -139,11 +139,15 @@ final class Saved implements Scalar<Path> {
      * POSIX which allows it. The window is brief, so a short retry clears
      * it instead of failing the whole write.</p>
      *
+     * <p>The delay is not randomized (#6109): jcabi multiplies it by a
+     * random factor that may come out zero, and then all the attempts fire
+     * back to back with no waiting at all, which defeats the retry.</p>
+     *
      * @param tmp Temp file to move
      * @param target Destination path
      * @throws IOException If the move fails
      */
-    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
+    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS, randomize = false)
     private static void moved(final Path tmp, final Path target) throws IOException {
         try {
             Files.move(


### PR DESCRIPTION
Sets `randomize = false` on the `@RetryOnFailure` that guards `Saved.moved`, so the backoff between move attempts is a deterministic 1s then 2s instead of a random multiple of one second.

The flake in `SavedTest.retriesMoveWhenTargetTemporarilyBlocked` was not thread starvation. With `randomize` at its default `true`, jcabi computes the wait as `nextInt(2 << attempt) * delay`, so the first wait is `nextInt(4)` seconds and the second is `nextInt(8)` seconds — and both can come out zero. Roughly once in 32 runs all three attempts fire back to back with no waiting at all, which is why the failing runs died in 0.402s on macOS and 0.625s on Windows, both well under a single one-second delay. A probe driving the same scenario through the woven class failed 2 of 120 times before this change and 0 of 120 after, with every run now taking a flat ~1.0s. The test itself is untouched: its 300ms obstruction now always clears before the second attempt.

Two things a reviewer may want to weigh separately. A randomized backoff collapsing to no delay looks like an upstream defect in jcabi-aspects and could be worth an issue there. The same annotation defaults also sit on the network retries in `OyRemote`, `ObjectsIndex`, `CommitHashesText` and `RtCentral`, where a zero delay makes the retry useless rather than flaky — I left those alone to keep this change small.

Closes #6109