### PR TITLE
#6113: exclude SyscallTest from simian, the name it has after the rename

### DIFF
--- a/.github/workflows/simian.yml
+++ b/.github/workflows/simian.yml
@@ -21,4 +21,4 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - run: wget --quiet https://public.yegor256.com/simian.jar -O /tmp/simian.jar
-      - run: java -jar /tmp/simian.jar -threshold=15 "-excludes=**/EOsocketTest.java" "-excludes=**/gen" "-excludes=**/it" "**/*.java"
+      - run: java -jar /tmp/simian.jar -threshold=15 "-excludes=**/SyscallTest.java" "-excludes=**/gen" "-excludes=**/it" "**/*.java"


### PR DESCRIPTION
Closes #6113

`700a5612e6` renamed `EOsocketTest.java` to `SyscallTest.java`, but the simian exclude kept pointing at the old name, so the duplication inside that file started failing the build.

Checked locally with the same jar and arguments the workflow uses. With the old pattern it reports the two blocks from the issue, lines 318-335 and 647-664. With the new one it reports 0 duplicate lines and exits 0.

The duplication itself is untouched. Extracting the shared assertion block out of the two `acceptsConnectionOnSocket()` methods would let the exclude go away entirely, but that is a change to eo-runtime tests and does not belong in a fix for a red master.
