### PR TITLE
#5671: turn the coverage manifest and the raw hits into an LCOV report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn install -Pjacoco -Deo.coverageTracking=true
+      - run: mvn install -Pjacoco -Deo.coverageFile=${{ runner.temp }}/eo-coverage.txt
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: JesseTG/rm@v1.0.3
         with:
           path: ~/.m2/repository/org/eolang
-      - run: mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' clean install
+      - run: mvn -ntp -PskipITs --errors --batch-mode clean install

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Coverage.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Coverage.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Train;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * EO object coverage instrumentation, as configured for one {@code transpile}
+ * run.
+ * <p>
+ *     There are two implementations: {@link CoverageManifest}, which wraps
+ *     every located object into {@code PhCoverage} and records where those
+ *     wrappers went, and {@link Coverage.Off}, which does nothing at all.
+ *     {@link Transpiling} talks to one of them without ever asking which one
+ *     it got.
+ * </p>
+ * @since 0.62.0
+ */
+interface Coverage {
+
+    /**
+     * Whether every located object in the generated Java is wrapped into
+     * {@code PhCoverage}. Both the {@code coverage} parameter of
+     * {@code to-java.xsl} and the transpile cache key are derived from it,
+     * since it changes what the transpiler emits.
+     * @return True if the objects are wrapped
+     */
+    boolean tracked();
+
+    /**
+     * The XMIR that the final {@code to-java.xsl} shift has to be applied
+     * to, with one manifest line per location that shift is going to
+     * instrument in it added to {@code found}.
+     * <p>
+     *     {@link CoverageManifest} applies {@code shifts} here, in front of
+     *     the caller's transpile cache, because a manifest that skips the
+     *     sources the cache answers without transpiling them again would
+     *     under-report the number of instrumented lines. {@link Coverage.Off}
+     *     applies nothing and hands the XMIR back untouched, so a build
+     *     without instrumentation still lets the cache skip the whole train.
+     * </p>
+     * @param xmir The XMIR to transpile
+     * @param shifts Every transpile shift except {@code to-java.xsl}
+     * @param found Where to add the manifest lines
+     * @return The XMIR to transpile further
+     */
+    XML located(XML xmir, Function<XML, XML> shifts, Collection<String> found);
+
+    /**
+     * The train still to be applied to what {@link #located(XML, Function,
+     * Collection)} returned: the whole one when it returned the XMIR
+     * untouched, only {@code to-java.xsl} when it already ran everything
+     * else.
+     * @param whole Every transpile shift, in one train
+     * @param last The final {@code to-java.xsl} shift, alone
+     * @return The train to apply
+     */
+    Train<Shift> pending(Train<Shift> whole, Train<Shift> last);
+
+    /**
+     * Save every manifest line collected during the run, in one write, once
+     * the transpiler's worker pool has drained.
+     * @param found The lines, one per instrumented location
+     * @throws IOException If fails to write
+     */
+    void save(Collection<String> found) throws IOException;
+
+    /**
+     * Coverage that instruments nothing.
+     * @since 0.62.0
+     */
+    final class Off implements Coverage {
+
+        @Override
+        public boolean tracked() {
+            return false;
+        }
+
+        @Override
+        public XML located(
+            final XML xmir, final Function<XML, XML> shifts, final Collection<String> found
+        ) {
+            return xmir;
+        }
+
+        @Override
+        public Train<Shift> pending(final Train<Shift> whole, final Train<Shift> last) {
+            return whole;
+        }
+
+        @Override
+        public void save(final Collection<String> found) {
+            Logger.debug(this, "Coverage is off, no manifest to save");
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -19,15 +19,13 @@ import java.util.function.Function;
 /**
  * The full set of locations the transpiler wrapped into {@code PhCoverage},
  * one line per location: symbolic locator and source line, tab-separated.
- * Built once per {@code transpile} run (see {@link Transpiling}), to be read
- * back later and merged against the raw hits that {@code PhCoverage} itself
- * records at runtime, which is what tells the instrumented lines that were
- * actually touched from the ones that were not. The manifest deliberately
- * does not record a source file for each location: a locator starts with the
- * id of the object it belongs to, and the {@code eo-foreign} catalog already
- * maps every registered id to the source it was compiled from, so repeating
- * that mapping here, once per instrumented location, would only be a second
- * copy of it to keep in step.
+ * Built once per {@code transpile} run (see {@link Transpiling}), then read
+ * back by {@link MjCoverageReport}, which merges it against the raw hits
+ * recorded at runtime by {@code PhCoverage} itself, to tell which
+ * instrumented lines were actually touched. The manifest does not record a
+ * source file for each location: {@link MjCoverageReport} resolves that by
+ * matching a locator's leading object id against the already-existing
+ * {@code eo-foreign} catalog, instead of duplicating that mapping here.
  * @since 0.62.0
  */
 final class CoverageManifest implements Coverage {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Train;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * The full set of locations the transpiler wrapped into {@code PhCoverage},
+ * one line per location: symbolic locator and source line, tab-separated.
+ * Built once per {@code transpile} run (see {@link Transpiling}), to be read
+ * back later and merged against the raw hits that {@code PhCoverage} itself
+ * records at runtime, which is what tells the instrumented lines that were
+ * actually touched from the ones that were not. The manifest deliberately
+ * does not record a source file for each location: a locator starts with the
+ * id of the object it belongs to, and the {@code eo-foreign} catalog already
+ * maps every registered id to the source it was compiled from, so repeating
+ * that mapping here, once per instrumented location, would only be a second
+ * copy of it to keep in step.
+ * @since 0.62.0
+ */
+final class CoverageManifest implements Coverage {
+
+    /**
+     * The condition {@code to-java.xsl} tests in its own
+     * {@code mode="located"} template before emitting a wrapper.
+     */
+    private static final String WHEN = "@line and @pos and not(contains(@loc, '+'))";
+
+    /**
+     * The {@code @base} an unbound (void) attribute carries.
+     */
+    private static final String VOID = "∅";
+
+    /**
+     * Selects exactly the elements that end up wrapped into {@code
+     * PhCoverage}, in the XMIR as it stands right before the final
+     * {@code to-java.xsl} shift runs, so that the manifest is derived from
+     * that structure directly, not by pattern-matching the Java text
+     * {@code to-java.xsl} emits.
+     * <p>
+     *     {@code to-java.xsl} emits a wrapper from a single place, its
+     *     {@code mode="located"} template, and that template is reached from
+     *     exactly four others: {@code match="atom"} applies it to the atom's
+     *     first {@code o} child, {@code match="abstract"} applies it to
+     *     itself, and the two {@code mode="object"} templates, for a plain
+     *     object ({@code @base} set and not starting with a dot) and for a
+     *     method call ({@code @base} starting with a dot, with children),
+     *     apply it to themselves. The four branches below mirror those four,
+     *     each carrying {@link #WHEN}, and the third one also leaves out
+     *     {@link #VOID}, the placeholder of an unbound attribute, which is a
+     *     hole rather than an object: {@code to-java.xsl} turns it into an
+     *     {@code AtVoid} through its own {@code match="void"} template and
+     *     never dispatches on it as an object. Everything else that happens
+     *     to carry the same attributes, a formation with no {@code @base}
+     *     above all, is left out too, because no wrapper is ever emitted for
+     *     it and counting it would inflate the {@code LF} of the report.
+     * </p>
+     */
+    private static final String LOCATED = String.format(
+        String.join(
+            " | ",
+            "//abstract[%1$s]",
+            "//atom/o[1][%1$s]",
+            String.format(
+                "//o[@base and @base!='' and @base!='%s' and not(starts-with(@base, '.')) and %%1$s]",
+                CoverageManifest.VOID
+            ),
+            "//o[starts-with(@base, '.') and * and %1$s]"
+        ),
+        CoverageManifest.WHEN
+    );
+
+    /**
+     * The raw coverage hits file this manifest is paired with.
+     */
+    private final Path hits;
+
+    /**
+     * Ctor.
+     * @param touched The raw coverage hits file this manifest is paired with
+     */
+    CoverageManifest(final Path touched) {
+        this.hits = touched;
+    }
+
+    @Override
+    public boolean tracked() {
+        return true;
+    }
+
+    @Override
+    public XML located(
+        final XML xmir, final Function<XML, XML> shifts, final Collection<String> found
+    ) {
+        final XML located = shifts.apply(xmir);
+        for (final XML element : located.nodes(CoverageManifest.LOCATED)) {
+            found.add(
+                String.format(
+                    "%s\t%s",
+                    element.xpath("@loc").get(0),
+                    element.xpath("@line").get(0)
+                )
+            );
+        }
+        return located;
+    }
+
+    @Override
+    public Train<Shift> pending(final Train<Shift> whole, final Train<Shift> last) {
+        return last;
+    }
+
+    @Override
+    public void save(final Collection<String> found) throws IOException {
+        Files.write(
+            this.path(),
+            found,
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING
+        );
+    }
+
+    /**
+     * Where this manifest is stored: a sibling of the hits file.
+     * @return The path
+     */
+    Path path() {
+        return Paths.get(String.format("%s.manifest", this.hits));
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageReport.java
@@ -1,0 +1,221 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
+
+/**
+ * An LCOV tracefile built from a {@link CoverageManifest} (every location the
+ * transpiler wrapped into {@code PhCoverage}) and the raw hits {@code
+ * PhCoverage} recorded at runtime, one {@code loc:line:pos} line per touched
+ * location. A manifest line whose locator never shows up among the hits is a
+ * line that was never dataized; everything else counts as covered.
+ * @since 0.62.0
+ */
+final class CoverageReport {
+
+    /**
+     * Matches one {@code loc:line:pos} hit line.
+     */
+    private static final Pattern HIT = Pattern.compile("^(.*):(\\d+):(\\d+)$");
+
+    /**
+     * The manifest of all instrumented locations.
+     */
+    private final Path manifest;
+
+    /**
+     * The raw hits file, may not exist yet if nothing was ever touched.
+     */
+    private final Path hits;
+
+    /**
+     * Resolves a location's locator to the source it belongs to.
+     */
+    private final ObjectSources sources;
+
+    /**
+     * The LCOV text, built at most once however many times it is asked for,
+     * since {@link MjCoverageReport} wants both the text itself and the
+     * percentage derived from it.
+     */
+    private final IoChecked<String> lcov;
+
+    /**
+     * Ctor.
+     * @param locations The manifest of all instrumented locations
+     * @param touched The raw hits file
+     * @param registered Resolves a location's locator to the source it belongs to
+     */
+    CoverageReport(final Path locations, final Path touched, final ObjectSources registered) {
+        this.manifest = locations;
+        this.hits = touched;
+        this.sources = registered;
+        this.lcov = new IoChecked<>(new Sticky<>(this::built));
+    }
+
+    /**
+     * The LCOV tracefile text, one {@code SF}/{@code DA}/{@code LF}/
+     * {@code LH}/{@code end_of_record} block per source file, sorted by
+     * file path for a deterministic result.
+     * @return The LCOV text
+     * @throws IOException If fails to read the manifest or the hits file
+     */
+    String text() throws IOException {
+        return this.lcov.value();
+    }
+
+    /**
+     * The percentage of instrumented lines that were touched, derived from
+     * {@link #text()} itself so there is exactly one place that knows the
+     * LCOV grammar.
+     * @return The percentage, from 0 to 100; 100 when nothing is instrumented
+     * @throws IOException If fails to read the manifest or the hits file
+     */
+    double percentage() throws IOException {
+        int total = 0;
+        int covered = 0;
+        for (final String line : this.text().split(System.lineSeparator())) {
+            if (line.startsWith("LF:")) {
+                total += Integer.parseInt(line.substring("LF:".length()));
+            } else if (line.startsWith("LH:")) {
+                covered += Integer.parseInt(line.substring("LH:".length()));
+            }
+        }
+        final double result;
+        if (total == 0) {
+            result = 100.0d;
+        } else {
+            result = covered * 100.0d / total;
+        }
+        return result;
+    }
+
+    /**
+     * Build the LCOV tracefile text.
+     * @return The LCOV text
+     * @throws IOException If fails to read the manifest or the hits file
+     */
+    private String built() throws IOException {
+        final SortedMap<String, SortedMap<Integer, Boolean>> files = this.files();
+        final StringBuilder text = new StringBuilder(files.size() * 64);
+        for (final Map.Entry<String, SortedMap<Integer, Boolean>> file : files.entrySet()) {
+            text.append(String.format("SF:%s%n", file.getKey()));
+            int hit = 0;
+            for (final Map.Entry<Integer, Boolean> line : file.getValue().entrySet()) {
+                final int mark;
+                if (line.getValue()) {
+                    mark = 1;
+                } else {
+                    mark = 0;
+                }
+                hit += mark;
+                text.append(String.format("DA:%d,%d%n", line.getKey(), mark));
+            }
+            text.append(String.format("LF:%d%n", file.getValue().size()))
+                .append(String.format("LH:%d%n", hit))
+                .append("end_of_record").append(System.lineSeparator());
+        }
+        return text.toString();
+    }
+
+    /**
+     * Every instrumented source line, per source file, mapped to whether it
+     * was touched at least once. A manifest line whose locator no registered
+     * object owns is only logged and then skipped: a locator can legitimately
+     * point at something that is not in the {@code eo-foreign} catalog, and
+     * one lost line out of thousands is not worth failing a build over.
+     * @return Source file to its lines, each marked as covered or not
+     * @throws IOException If fails to read the manifest or the hits file
+     */
+    private SortedMap<String, SortedMap<Integer, Boolean>> files() throws IOException {
+        final Set<String> touched = this.touched();
+        final SortedMap<String, SortedMap<Integer, Boolean>> files = new TreeMap<>();
+        for (final String line : Files.readAllLines(this.manifest)) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            final int tab = line.indexOf('\t');
+            if (tab < 0) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "The line '%s' of the coverage manifest %s has no tab in it, while every line there must be a locator and a source line number separated by one",
+                        line, this.manifest
+                    )
+                );
+            }
+            final String loc = line.substring(0, tab);
+            final Optional<String> source = this.sources.source(loc);
+            if (source.isPresent()) {
+                files.computeIfAbsent(source.get(), ignored -> new TreeMap<>()).merge(
+                    this.number(line, line.substring(tab + 1)),
+                    touched.contains(loc),
+                    (was, now) -> was || now
+                );
+            } else {
+                Logger.warn(
+                    this,
+                    "No registered object owns the locator '%s' of %[file]s, the line is skipped",
+                    loc, this.manifest
+                );
+            }
+        }
+        return files;
+    }
+
+    /**
+     * The source line number a manifest line ends with.
+     * @param line The whole line, for the error message
+     * @param tail Everything after the tab
+     * @return The number
+     */
+    private int number(final String line, final String tail) {
+        try {
+            return Integer.parseInt(tail);
+        } catch (final NumberFormatException exception) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The line '%s' of the coverage manifest %s ends with '%s', which is not a source line number",
+                    line, this.manifest, tail
+                ),
+                exception
+            );
+        }
+    }
+
+    /**
+     * The set of locators that were touched at least once.
+     * @return The locators, empty when the hits file does not exist yet
+     * @throws IOException If fails to read the hits file
+     */
+    private Set<String> touched() throws IOException {
+        final Set<String> result = new HashSet<>(0);
+        if (Files.exists(this.hits)) {
+            for (final String line : Files.readAllLines(this.hits)) {
+                if (line.isEmpty()) {
+                    continue;
+                }
+                final Matcher matcher = CoverageReport.HIT.matcher(line);
+                if (matcher.matches()) {
+                    result.add(matcher.group(1));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Turns the raw {@code PhCoverage} hits recorded by {@code eo.coverageFile}
+ * into an LCOV tracefile, merging them against the manifest of all
+ * instrumented locations that {@link MjTranspile} wrote alongside that same
+ * file (see {@link CoverageManifest}). Each location's source file is
+ * resolved from the {@code eo-foreign} catalog that {@code register}
+ * already builds, matched by the object id at the front of its locator
+ * (see {@link ObjectSources}).
+ * <p>
+ *     This goal has to run after the tests that actually touch the
+ *     instrumented objects, so it belongs late in the lifecycle (the
+ *     {@code verify} phase by default), well after {@code transpile}.
+ * </p>
+ * @since 0.62.0
+ */
+@Mojo(
+    name = "coverage-report",
+    defaultPhase = LifecyclePhase.VERIFY,
+    threadSafe = true
+)
+public final class MjCoverageReport extends MjSafe {
+
+    /**
+     * The same raw coverage hits file passed to the {@code transpile} goal.
+     * Deliberately not {@code required}, so that a project that never asked
+     * for instrumentation is told so in plain words by {@link #exec()},
+     * instead of being turned away by Maven's own "parameter is missing or
+     * invalid" before this goal even starts.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "eo.coverageFile")
+    private File coverageFile;
+
+    /**
+     * Where to write the LCOV tracefile. Defaults to a {@code coverage.info}
+     * file next to {@link #coverageFile}.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "eo.coverageReport")
+    private File coverageReport;
+
+    @Override
+    void exec() throws IOException {
+        if (this.coverageFile == null) {
+            throw new IOException(
+                "No coverage manifest can be found, since eo.coverageFile is not set; set it on the transpile goal, so that objects get instrumented, and on this one, so that their hits can be read back"
+            );
+        }
+        final Path hits = this.coverageFile.toPath();
+        final Path manifest = new CoverageManifest(hits).path();
+        if (!Files.exists(manifest)) {
+            throw new IOException(
+                String.format(
+                    "No coverage manifest found at %s; was this project transpiled with eo.coverageFile set to %s?",
+                    manifest, hits
+                )
+            );
+        }
+        final CoverageReport report = new CoverageReport(
+            manifest, hits, new ObjectSources(this.registered())
+        );
+        final Path target = this.target();
+        Files.write(target, report.text().getBytes(StandardCharsets.UTF_8));
+        Logger.info(
+            this, "Coverage report written to %[file]s: %.2f%% of instrumented lines covered",
+            target, report.percentage()
+        );
+    }
+
+    /**
+     * Every registered object id mapped to the source it was compiled from,
+     * relative to the project's basedir, as already tracked by the
+     * {@code eo-foreign} catalog.
+     * @return Object id mapped to its source
+     */
+    private Map<String, String> registered() {
+        final Path base = this.project.getBasedir().toPath();
+        final Map<String, String> ids = new HashMap<>(0);
+        for (final TjForeign tojo : this.scopedTojos().all()) {
+            ids.put(
+                tojo.identifier(),
+                base.relativize(tojo.source().toAbsolutePath()).toString()
+            );
+        }
+        return ids;
+    }
+
+    /**
+     * Where to write the LCOV tracefile.
+     * @return The path, defaulting to a {@code coverage.info} sibling of
+     *  {@link #coverageFile} when {@link #coverageReport} is not set
+     */
+    private Path target() {
+        final Path result;
+        if (this.coverageReport == null) {
+            result = this.coverageFile.toPath().resolveSibling("coverage.info");
+        } else {
+            result = this.coverageReport.toPath();
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
+import java.io.File;
 import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -64,36 +65,42 @@ public final class MjTranspile extends MjSafe {
     private boolean trackLocations;
 
     /**
-     * Whether to wrap every located object in the generated Java into
-     * {@code PhCoverage}, so it records a coverage hit the first time it
-     * is touched at runtime. Off by default, so a production build stays
-     * lean. The hits are appended to the file named by the
-     * {@code eo.coverageFile} system property of the JVM that runs the
-     * compiled program; when that property is absent, every hit is a
-     * silent no-op. In {@code eo-runtime} the {@code coverage-file}
-     * profile turns this on and forwards that property to surefire in
-     * one step (see its {@code pom.xml}).
-     * @todo #5466:60min Turn raw coverage hits into an LCOV report.
-     *  Right now the runtime only produces a raw, append-only
-     *  {@code loc:line:pos} file: the {@code PhCoverage} decorator
-     *  writes every touched location into it, but nothing consumes that
-     *  file yet. Add a reporter step that merges those raw hits against
-     *  the full set of instrumented locations, which the transpiler
-     *  already knows because it emits every wrapper, and produces an
-     *  LCOV ({@code .info}) tracefile plus the covered percentage. LCOV
-     *  is chosen because Codecov and Coveralls consume it directly.
+     * The file to record EO object coverage hits into. When it is
+     * not set (the default), no instrumentation happens; when set,
+     * every located object in the generated Java is wrapped into
+     * {@code PhCoverage}, which appends a hit to this file the first
+     * time the object is touched at runtime. The very same
+     * {@code eo.coverageFile} value also reaches the JVM that later
+     * runs the instrumented code, because {@code eo-runtime} passes
+     * this Maven property straight through to surefire's
+     * {@code systemPropertyVariables} (see its {@code pom.xml}), so
+     * one setting is enough end to end. This same transpile run also
+     * writes the full set of instrumented locations into a sibling
+     * manifest (see {@link CoverageManifest}), so that the two files
+     * together say which of the instrumented lines were reached and
+     * which were not.
+     * @todo #5671:60min Merge the manifest and the hits into an LCOV report.
+     *  The transpiler now writes both halves of the answer, the manifest
+     *  of every instrumented location next to this file and, at runtime,
+     *  the raw {@code loc:line:pos} hits inside it, but nothing reads
+     *  them back yet. Add a goal, late in the lifecycle so that it runs
+     *  after the tests, that reads the two, resolves each locator to the
+     *  {@code .eo} source it came from through the {@code eo-foreign}
+     *  catalog {@code register} already builds, and writes an LCOV
+     *  ({@code .info}) tracefile plus the covered percentage. LCOV is
+     *  the format Codecov and Coveralls consume directly.
      * @todo #5466:30min Enforce a minimum EO object coverage in eo-runtime.
-     *  Once the LCOV report from the puzzle above exists, set
-     *  {@code coverageTracking} on the {@code transpile} execution in
-     *  {@code eo-runtime/pom.xml} and fail the build when the covered
+     *  Once the LCOV report from the puzzle above exists, bind it and set
+     *  {@code coverageFile} on the {@code transpile} execution in
+     *  {@code eo-runtime/pom.xml}, and fail the build when the covered
      *  percentage of dataized {@code .eo} objects drops below a
      *  threshold (for example 80 percent), mirroring how the existing
      *  {@code jacoco} profile binds a {@code check} goal with per-metric
      *  thresholds.
      * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.coverageTracking")
-    private boolean coverageTracking;
+    @Parameter(property = "eo.coverageFile")
+    private File coverageFile;
 
     @Override
     public void exec() throws IOException {
@@ -108,7 +115,7 @@ public final class MjTranspile extends MjSafe {
                 this.transpileTests,
                 this.xslMeasures.toPath(),
                 new Tracking(this.trackTransformationSteps, this.trackLocations),
-                this.coverageTracking
+                this.coverage()
             )
         ).exec();
         if (this.addSourcesRoot) {
@@ -128,5 +135,20 @@ public final class MjTranspile extends MjSafe {
                 gtests
             );
         }
+    }
+
+    /**
+     * The coverage instrumentation configured for this run.
+     * @return A manifest-writing coverage when {@link #coverageFile} is set,
+     *  a do-nothing one otherwise
+     */
+    private Coverage coverage() {
+        final Coverage result;
+        if (this.coverageFile == null) {
+            result = new Coverage.Off();
+        } else {
+            result = new CoverageManifest(this.coverageFile.toPath());
+        }
+        return result;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -76,27 +76,18 @@ public final class MjTranspile extends MjSafe {
      * {@code systemPropertyVariables} (see its {@code pom.xml}), so
      * one setting is enough end to end. This same transpile run also
      * writes the full set of instrumented locations into a sibling
-     * manifest (see {@link CoverageManifest}), so that the two files
-     * together say which of the instrumented lines were reached and
-     * which were not.
-     * @todo #5671:60min Merge the manifest and the hits into an LCOV report.
-     *  The transpiler now writes both halves of the answer, the manifest
-     *  of every instrumented location next to this file and, at runtime,
-     *  the raw {@code loc:line:pos} hits inside it, but nothing reads
-     *  them back yet. Add a goal, late in the lifecycle so that it runs
-     *  after the tests, that reads the two, resolves each locator to the
-     *  {@code .eo} source it came from through the {@code eo-foreign}
-     *  catalog {@code register} already builds, and writes an LCOV
-     *  ({@code .info}) tracefile plus the covered percentage. LCOV is
-     *  the format Codecov and Coveralls consume directly.
+     * manifest (see {@link CoverageManifest});
+     * {@link MjCoverageReport} later merges it against the raw hits,
+     * and resolves each location's source file from the existing
+     * {@code eo-foreign} catalog, to produce an LCOV tracefile.
      * @todo #5466:30min Enforce a minimum EO object coverage in eo-runtime.
-     *  Once the LCOV report from the puzzle above exists, bind it and set
-     *  {@code coverageFile} on the {@code transpile} execution in
-     *  {@code eo-runtime/pom.xml}, and fail the build when the covered
-     *  percentage of dataized {@code .eo} objects drops below a
-     *  threshold (for example 80 percent), mirroring how the existing
-     *  {@code jacoco} profile binds a {@code check} goal with per-metric
-     *  thresholds.
+     *  Now that {@link MjCoverageReport} produces the LCOV report, bind
+     *  it and set {@code coverageFile} on the {@code transpile}
+     *  execution in {@code eo-runtime/pom.xml}, and fail the build when
+     *  the covered percentage of dataized {@code .eo} objects drops
+     *  below a threshold (for example 80 percent), mirroring how the
+     *  existing {@code jacoco} profile binds a {@code check} goal with
+     *  per-metric thresholds.
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(property = "eo.coverageFile")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectSources.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectSources.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves the {@code .eo} source file for a {@code PhCoverage} location's
+ * symbolic locator, by matching the locator's leading object id against the
+ * already-existing {@code eo-foreign} catalog (every registered object is
+ * already mapped there to the source it was compiled from), rather than
+ * having the transpiler duplicate that same mapping into a manifest of its
+ * own for every single instrumented location.
+ * @since 0.62.0
+ */
+final class ObjectSources {
+
+    /**
+     * Every locator this codebase emits starts with the root object marker.
+     */
+    private static final String ROOT = "Φ.";
+
+    /**
+     * Object id (as in {@code eo-foreign}, e.g. {@code string.scanf}) mapped
+     * to the source it was compiled from.
+     */
+    private final Map<String, String> ids;
+
+    /**
+     * Ctor.
+     * @param registered Object id mapped to its source, as in {@code eo-foreign}
+     */
+    ObjectSources(final Map<String, String> registered) {
+        this.ids = registered;
+    }
+
+    /**
+     * The source of the object a location's locator belongs to.
+     * <p>
+     *     A locator is a dot-separated path down from the object it belongs
+     *     to, so the id being looked for is the longest prefix of it that the
+     *     catalog knows. Dropping the trailing segment one at a time and
+     *     asking the catalog about what is left finds that prefix in as many
+     *     lookups as the locator has segments, instead of walking the whole
+     *     catalog once per locator.
+     * </p>
+     * @param locator The locator, e.g. {@code Φ.string.scanf.tokenize}
+     * @return The source, or empty when no registered object owns the locator
+     */
+    Optional<String> source(final String locator) {
+        String rest = locator;
+        if (rest.startsWith(ObjectSources.ROOT)) {
+            rest = rest.substring(ObjectSources.ROOT.length());
+        }
+        Optional<String> result = Optional.empty();
+        while (!rest.isEmpty()) {
+            if (this.ids.containsKey(rest)) {
+                result = Optional.of(this.ids.get(rest));
+                break;
+            }
+            final int dot = rest.lastIndexOf('.');
+            if (dot < 0) {
+                break;
+            }
+            rest = rest.substring(0, dot);
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -117,6 +118,25 @@ final class Transpiling implements Step {
         ThreadLocal.withInitial(HashMap::new);
 
     /**
+     * The name of the train that holds every shift except the final
+     * {@code to-java.xsl} one, in the exact XMIR shape that shift dispatches
+     * on. {@link CoverageManifest} derives the manifest from the result of
+     * this train, so it reads the very structure that produces the Java.
+     */
+    private static final String BEFORE = "before";
+
+    /**
+     * The name of the train that holds the final {@code to-java.xsl} shift
+     * and nothing else.
+     */
+    private static final String LAST = "last";
+
+    /**
+     * The name of the train that holds every shift, in order.
+     */
+    private static final String WHOLE = "whole";
+
+    /**
      * Cache directory for transpiled sources.
      */
     private static final String CACHE = "transpiled";
@@ -178,9 +198,16 @@ final class Transpiling implements Step {
     private final Tracking tracking;
 
     /**
-     * Whether located objects are wrapped into {@code PhCoverage}.
+     * The coverage instrumentation of this run.
      */
-    private final boolean coverage;
+    private final Coverage coverage;
+
+    /**
+     * Every manifest line found while transpiling, from all worker threads,
+     * saved in one write by {@link Coverage#save(Collection)} once the pool
+     * has drained.
+     */
+    private final Collection<String> locations;
 
     /**
      * Cache guard, see {@link ConcurrentCache} for why it is one per instance.
@@ -198,7 +225,7 @@ final class Transpiling implements Step {
      * @param tests Whether to transpile tests
      * @param measures Path to the file where XSL measurements are stored
      * @param diagnostics Which diagnostic artifacts to emit while transpiling
-     * @param cvrg Whether located objects are wrapped into {@code PhCoverage}
+     * @param cvrg The coverage instrumentation of this run
      * @checkstyle ParameterNumberCheck (18 lines)
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -212,7 +239,7 @@ final class Transpiling implements Step {
         final boolean tests,
         final Path measures,
         final Tracking diagnostics,
-        final boolean cvrg
+        final Coverage cvrg
     ) {
         this.sources = srcs;
         this.targetDir = target;
@@ -224,6 +251,7 @@ final class Transpiling implements Step {
         this.xslMeasures = measures;
         this.tracking = diagnostics;
         this.coverage = cvrg;
+        this.locations = new ConcurrentLinkedQueue<>();
         this.guard = new ConcurrentCache();
     }
 
@@ -238,6 +266,7 @@ final class Transpiling implements Step {
             ).total() + new PackageInfos(this.generatedDir).create(),
             this.generatedDir
         );
+        this.coverage.save(this.locations);
     }
 
     /**
@@ -264,7 +293,7 @@ final class Transpiling implements Step {
                     Arrays.stream(Transpiling.XSLS), Arrays.stream(Transpiling.IMPORTS)
                 ).toArray(String[]::new)
             ).get(),
-            this.tracking.locations(), this.coverage
+            this.tracking.locations(), this.coverage.tracked()
         );
     }
 
@@ -283,7 +312,17 @@ final class Transpiling implements Step {
         ).make(base, MjAssemble.XMIR);
         final Supplier<String> hsh = new TojoHash(tojo);
         final AtomicBoolean rewrite = new AtomicBoolean(false);
-        final Function<XML, XML> transform = this.transpilation(source);
+        final XML input = this.coverage.located(
+            xmir,
+            this.transpilation(source, this.train(Transpiling.BEFORE)),
+            this.locations
+        );
+        final Function<XML, XML> transform = this.transpilation(
+            source,
+            this.coverage.pending(
+                this.train(Transpiling.WHOLE), this.train(Transpiling.LAST)
+            )
+        );
         final Path cdir = this.cacheDir.resolve(Transpiling.CACHE);
         final Path tail = base.relativize(target);
         if (this.cacheEnabled) {
@@ -293,7 +332,7 @@ final class Transpiling implements Step {
                     new CachePath(cdir, this.version(), hsh.get()),
                     src -> {
                         rewrite.compareAndSet(false, true);
-                        final String res = transform.apply(xmir).toString();
+                        final String res = transform.apply(input).toString();
                         Logger.debug(
                             this,
                             "Transpiled %[file]s (%s) to %[file]s (%s) (cache miss), version: %s, hash: %s, tail: %s, cache enabled: %b, cache dir: %[file]s",
@@ -313,7 +352,7 @@ final class Transpiling implements Step {
             );
         } else {
             rewrite.compareAndSet(false, true);
-            new Saved(transform.apply(xmir).toString(), target).value();
+            new Saved(transform.apply(input).toString(), target).value();
         }
         return this.javaGenerated(
             rewrite.get(), target, hsh.get(), this.transpileTests && !tojo.discovered()
@@ -370,40 +409,50 @@ final class Transpiling implements Step {
     }
 
     /**
-     * The train for this thread, built once per location-tracking value.
+     * One of the trains for this thread, built once per name and per
+     * location-tracking and instrumentation values.
+     * @param name Which train: {@link #BEFORE}, {@link #LAST} or {@link #WHOLE}
      * @return The train of XSL shifts
      */
-    private Train<Shift> train() {
+    private Train<Shift> train(final String name) {
         final boolean track = this.tracking.locations();
-        final boolean instrument = this.coverage;
+        final boolean instrument = this.coverage.tracked();
         return Transpiling.TRAINS.get().computeIfAbsent(
-            String.format("%b|%b", track, instrument),
-            ignored -> Transpiling.compiled(track, instrument)
+            String.format("%s|%b|%b", name, track, instrument),
+            ignored -> Transpiling.compiled(name, track, instrument)
         );
     }
 
     /**
-     * Build the train of XSL shifts.
+     * Build one of the trains of XSL shifts.
+     * @param name Which train: {@link #BEFORE}, {@link #LAST} or {@link #WHOLE}
      * @param track Whether generated objects carry their source location
      * @param instrument Whether located objects are wrapped into {@code PhCoverage}
      * @return The train of XSL shifts
      */
-    private static Train<Shift> compiled(final boolean track, final boolean instrument) {
-        return new TrFull(
-            new TrJoined<>(
-                new TrClasspath<>(
-                    Arrays.copyOf(Transpiling.XSLS, Transpiling.XSLS.length - 1)
-                ).back(),
-                new TrDefault<>(
-                    new StClasspath(
-                        Transpiling.XSLS[Transpiling.XSLS.length - 1],
-                        String.format("disclaimer %s", new Disclaimer()),
-                        String.format("trackLocations %b", track),
-                        String.format("coverage %b", instrument)
-                    )
-                )
+    private static Train<Shift> compiled(
+        final String name, final boolean track, final boolean instrument
+    ) {
+        final Train<Shift> before = new TrClasspath<Shift>(
+            Arrays.copyOf(Transpiling.XSLS, Transpiling.XSLS.length - 1)
+        ).back();
+        final Train<Shift> last = new TrDefault<>(
+            new StClasspath(
+                Transpiling.XSLS[Transpiling.XSLS.length - 1],
+                String.format("disclaimer %s", new Disclaimer()),
+                String.format("trackLocations %b", track),
+                String.format("coverage %b", instrument)
             )
         );
+        final Train<Shift> shifts;
+        if (Transpiling.BEFORE.equals(name)) {
+            shifts = before;
+        } else if (Transpiling.LAST.equals(name)) {
+            shifts = last;
+        } else {
+            shifts = new TrJoined<>(before, last);
+        }
+        return new TrFull(shifts);
     }
 
     /**
@@ -411,10 +460,11 @@ final class Transpiling implements Step {
      * If transformation steps are tracked - creates a new {@link Xsline}
      * for every XMIR in purpose of thread safety.
      * @param source Path to source XMIR
+     * @param train The train of XSL shifts to apply
      * @return XSL transformation function
      */
-    private Function<XML, XML> transpilation(final Path source) {
-        final Train<Shift> measured = this.measured(this.train());
+    private Function<XML, XML> transpilation(final Path source, final Train<Shift> train) {
+        final Train<Shift> measured = this.measured(train);
         final Function<XML, XML> func;
         if (this.tracking.steps()) {
             func = xml -> new Xsline(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link CoverageManifest}.
+ * @since 0.62.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class CoverageManifestTest {
+
+    @Test
+    void derivesItsPathFromTheHitsFile(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "the manifest must live next to the hits file, with a .manifest suffix",
+            new CoverageManifest(temp.resolve("hits.txt")).path(),
+            Matchers.equalTo(Paths.get(String.format("%s.manifest", temp.resolve("hits.txt"))))
+        );
+    }
+
+    @Test
+    void extractsOneLinePerLocatedElement(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "one line must be found per located element, skipping the ones without both a line and a position and the ones whose locator carries a nested-attribute suffix",
+            CoverageManifestTest.scanned(
+                temp,
+                String.join(
+                    System.lineSeparator(),
+                    "<object><class line='5' pos='0' loc='Φ.foo'>",
+                    "  <attr name='φ'><bound>",
+                    "    <o base='ξ.n' line='5' pos='1' loc='Φ.foo.x'>",
+                    "      <o base='.hello' line='6' pos='3' loc='Φ.foo.x.α0'>",
+                    "        <o base='Φ.number' line='6' pos='4' loc='Φ.foo.x.α0.α0'/>",
+                    "      </o>",
+                    "      <o base='Φ.string' line='7' pos='2' loc='Φ.foo.x.α1+1'/>",
+                    "      <o base='Φ.bytes' loc='Φ.foo.x.α2'/>",
+                    "    </o>",
+                    "  </bound></attr>",
+                    "</class></object>"
+                )
+            ),
+            Matchers.containsInAnyOrder(
+                "Φ.foo.x\t5",
+                "Φ.foo.x.α0\t6",
+                "Φ.foo.x.α0.α0\t6"
+            )
+        );
+    }
+
+    @Test
+    void ignoresElementsThatNeverGetAWrapper(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "a formation, a void placeholder and a childless method call carry a line, a position and a locator too, but to-java.xsl emits no PhCoverage around any of them, so counting them here would inflate the reported number of instrumented lines",
+            CoverageManifestTest.scanned(
+                temp,
+                String.join(
+                    System.lineSeparator(),
+                    "<object><class line='3' pos='0' loc='Φ.foo'>",
+                    "  <attr name='n'><void>",
+                    "    <o base='∅' line='3' pos='1' loc='Φ.foo.n'/>",
+                    "  </void></attr>",
+                    "  <attr name='λ'><atom>",
+                    "    <o loc='Φ.foo.λ'/>",
+                    "    <o base='∅' line='4' pos='6' loc='Φ.foo.λ.x'/>",
+                    "  </atom></attr>",
+                    "  <attr name='φ'><bound>",
+                    "    <o line='5' pos='2' loc='Φ.foo.φ'>",
+                    "      <o base='.tail' line='6' pos='3' loc='Φ.foo.φ.α0'/>",
+                    "    </o>",
+                    "  </bound></attr>",
+                    "</class></object>"
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void savesEveryLineAtOnce(@Mktmp final Path temp) throws Exception {
+        final CoverageManifest manifest = new CoverageManifest(temp.resolve("hits.txt"));
+        manifest.save(Arrays.asList("Φ.main\t5", "Φ.main.α0\t6"));
+        MatcherAssert.assertThat(
+            "every collected line must land in the manifest, one per line",
+            new TextOf(manifest.path()).asString(),
+            Matchers.allOf(
+                Matchers.containsString("Φ.main\t5"),
+                Matchers.containsString("Φ.main.α0\t6")
+            )
+        );
+    }
+
+    @Test
+    void discardsWhatAPreviousRunLeftBehind(@Mktmp final Path temp) throws Exception {
+        final CoverageManifest manifest = new CoverageManifest(temp.resolve("hits.txt"));
+        manifest.save(Collections.singletonList("Φ.gone\t1"));
+        manifest.save(Collections.singletonList("Φ.fresh\t2"));
+        MatcherAssert.assertThat(
+            "the second run must replace the manifest of the first one, not append to it",
+            new TextOf(manifest.path()).asString(),
+            Matchers.not(Matchers.containsString("Φ.gone"))
+        );
+    }
+
+    /**
+     * Every manifest line the given XMIR yields.
+     * @param temp Temporary directory to keep the hits file in
+     * @param xmir The XMIR, as it stands right before {@code to-java.xsl}
+     * @return The lines found
+     */
+    private static Collection<String> scanned(final Path temp, final String xmir) {
+        final Collection<String> found = new ArrayList<>(0);
+        new CoverageManifest(temp.resolve("hits.txt")).located(
+            new XMLDocument(xmir), one -> one, found
+        );
+        return found;
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageReportTest.java
@@ -1,0 +1,228 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link CoverageReport}.
+ * @since 0.62.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class CoverageReportTest {
+
+    /**
+     * Name of the raw hits file, reused across test fixtures.
+     * @checkstyle ProhibitFieldsInTestClassesCheck (5 lines)
+     */
+    private final String hitsfile = "hits.txt";
+
+    /**
+     * Name of the manifest file, reused across test fixtures.
+     * @checkstyle ProhibitFieldsInTestClassesCheck (5 lines)
+     */
+    private final String manifestfile = "hits.txt.manifest";
+
+    @Test
+    void marksManifestLinesAsCoveredOnlyWhenTheirLocatorWasHit(
+        @Mktmp final Path temp
+    ) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        final Path hits = temp.resolve(this.hitsfile);
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "Φ.main\t5",
+                "Φ.main.α0\t6",
+                "Φ.other\t2",
+                ""
+            ),
+            manifest
+        ).value();
+        new Saved(
+            String.format("Φ.main:5:1%n"),
+            hits
+        ).value();
+        MatcherAssert.assertThat(
+            "the touched line must be marked as covered and the untouched ones as not",
+            new CoverageReport(
+                manifest, hits, new ObjectSources(Map.of("main", "main.eo", "other", "other.eo"))
+            ).text(),
+            Matchers.allOf(
+                Matchers.containsString("SF:main.eo"),
+                Matchers.containsString("DA:5,1"),
+                Matchers.containsString("DA:6,0"),
+                Matchers.containsString("SF:other.eo"),
+                Matchers.containsString("DA:2,0"),
+                Matchers.containsString(String.format("LF:2%n")),
+                Matchers.containsString(String.format("LH:1%n"))
+            )
+        );
+    }
+
+    @Test
+    void computesThePercentageOfCoveredLines(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        final Path hits = temp.resolve(this.hitsfile);
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "Φ.main\t5",
+                "Φ.main.α0\t6",
+                "Φ.main.α1\t7",
+                "Φ.main.α2\t8",
+                ""
+            ),
+            manifest
+        ).value();
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "Φ.main:5:1",
+                "Φ.main.α0:6:3",
+                ""
+            ),
+            hits
+        ).value();
+        MatcherAssert.assertThat(
+            "two out of four instrumented lines were hit, so coverage must be 50%",
+            new CoverageReport(manifest, hits, new ObjectSources(Map.of("main", "main.eo")))
+                .percentage(),
+            Matchers.closeTo(50.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void treatsAMissingHitsFileAsZeroPercentCovered(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        new Saved("Φ.main\t5", manifest).value();
+        MatcherAssert.assertThat(
+            "a manifest with no matching hits file means nothing was ever touched",
+            new CoverageReport(
+                manifest, temp.resolve(this.hitsfile), new ObjectSources(Map.of("main", "main.eo"))
+            ).percentage(),
+            Matchers.closeTo(0.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void reportsFullCoverageWhenNothingIsInstrumented(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        new Saved("", manifest).value();
+        MatcherAssert.assertThat(
+            "an empty manifest has nothing to miss, so it must count as fully covered",
+            new CoverageReport(
+                manifest, temp.resolve(this.hitsfile), new ObjectSources(Map.of())
+            ).percentage(),
+            Matchers.closeTo(100.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void skipsALocatorNoRegisteredObjectOwns(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        final Path hits = temp.resolve(this.hitsfile);
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "Φ.main\t5",
+                "Φ.pulled.from.somewhere.else\t9",
+                ""
+            ),
+            manifest
+        ).value();
+        new Saved(String.format("Φ.main:5:1%n"), hits).value();
+        MatcherAssert.assertThat(
+            "an unresolvable locator must cost one line of the report, not the whole build",
+            new CoverageReport(manifest, hits, new ObjectSources(Map.of("main", "main.eo")))
+                .text(),
+            Matchers.allOf(
+                Matchers.containsString("SF:main.eo"),
+                Matchers.containsString("DA:5,1"),
+                Matchers.not(Matchers.containsString("DA:9,0"))
+            )
+        );
+    }
+
+    @Test
+    void failsOnAManifestLineWithoutATab(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        new Saved("Φ.main 5", manifest).value();
+        MatcherAssert.assertThat(
+            "the failure must quote the broken line and name the manifest it came from",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CoverageReport(
+                    manifest,
+                    temp.resolve(this.hitsfile),
+                    new ObjectSources(Map.of("main", "main.eo"))
+                ).text(),
+                "a manifest line with no tab in it must be rejected"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("Φ.main 5"),
+                Matchers.containsString(manifest.toString())
+            )
+        );
+    }
+
+    @Test
+    void failsOnAManifestLineWithoutANumber(@Mktmp final Path temp) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        new Saved("Φ.main\tnot-a-number", manifest).value();
+        MatcherAssert.assertThat(
+            "the failure must quote what was found where a line number was expected",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CoverageReport(
+                    manifest,
+                    temp.resolve(this.hitsfile),
+                    new ObjectSources(Map.of("main", "main.eo"))
+                ).text(),
+                "a manifest line ending with something other than a number must be rejected"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("not-a-number"),
+                Matchers.containsString(manifest.toString())
+            )
+        );
+    }
+
+    @Test
+    void mergesMultipleLocatorsOnTheSameLineIntoOneDaEntry(
+        @Mktmp final Path temp
+    ) throws IOException {
+        final Path manifest = temp.resolve(this.manifestfile);
+        final Path hits = temp.resolve(this.hitsfile);
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "Φ.main.a\t9",
+                "Φ.main.b\t9",
+                ""
+            ),
+            manifest
+        ).value();
+        new Saved(String.format("Φ.main.b:9:2%n"), hits).value();
+        MatcherAssert.assertThat(
+            "a line with two locators must appear once, covered, if either was hit",
+            new CoverageReport(manifest, hits, new ObjectSources(Map.of("main", "main.eo")))
+                .text(),
+            Matchers.allOf(
+                Matchers.containsString("DA:9,1"),
+                Matchers.not(Matchers.containsString("DA:9,0"))
+            )
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link MjCoverageReport}.
+ * @since 0.62.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class MjCoverageReportTest {
+
+    /**
+     * Test eo program from resources.
+     * @checkstyle ProhibitFieldsInTestClassesCheck (5 lines)
+     */
+    private String program;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.program = new TextOf(new ResourceOf("org/eolang/maven/mess.eo")).asString();
+    }
+
+    @Test
+    void buildsAnLcovReportAfterTranspilingAndRunning(@Mktmp final Path temp) throws Exception {
+        final Path hits = temp.resolve("hits.txt");
+        new FakeMaven(temp)
+            .withProgram(this.program)
+            .with("coverageFile", hits.toFile())
+            .execute(new FakeMaven.Transpile());
+        final String[] entry = this.entry(temp.resolve("hits.txt.manifest"));
+        new Saved(String.format("%s:%s:1%n", entry[0], entry[1]), hits).value();
+        new Moja<>(MjCoverageReport.class)
+            .with("coverageFile", hits.toFile())
+            .with("foreign", temp.resolve("eo-foreign.csv").toFile())
+            .with("foreignFormat", "csv")
+            .with("project", new MavenProjectStub())
+            .execute();
+        MatcherAssert.assertThat(
+            "the one locator that was hit must come out as a covered line of the source it belongs to",
+            new TextOf(temp.resolve("coverage.info")).asString(),
+            Matchers.allOf(
+                Matchers.containsString("SF:"),
+                Matchers.containsString(String.format("DA:%s,1", entry[1])),
+                Matchers.matchesRegex("(?s).*\\bLH:[1-9]\\d*.*"),
+                Matchers.containsString("end_of_record")
+            )
+        );
+    }
+
+    @Test
+    void failsWhenNoManifestWasEverWritten(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Moja<>(MjCoverageReport.class)
+                .with("coverageFile", temp.resolve("never-transpiled.txt").toFile())
+                .execute(),
+            "coverage-report must fail when the project was never transpiled with a coverage file"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must explain that no coverage manifest was found, and name the file it looked for",
+            writer.toString(),
+            Matchers.allOf(
+                Matchers.containsString("No coverage manifest found at"),
+                Matchers.containsString("never-transpiled.txt.manifest")
+            )
+        );
+    }
+
+    @Test
+    void failsWhenNoCoverageFileWasEverConfigured(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Moja<>(MjCoverageReport.class)
+                .with("foreign", temp.resolve("eo-foreign.csv").toFile())
+                .with("foreignFormat", "csv")
+                .execute(),
+            "coverage-report must fail when nothing ever asked for instrumentation"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must name the setting that is missing, rather than let Maven turn the goal away with its own wording",
+            writer.toString(),
+            Matchers.containsString("eo.coverageFile is not set")
+        );
+    }
+
+    /**
+     * The first entry of a coverage manifest, split into locator and line.
+     * @param manifest Path to the manifest file
+     * @return The locator and the source line number
+     * @throws Exception If fails to read the manifest
+     */
+    private String[] entry(final Path manifest) throws Exception {
+        return new TextOf(manifest).asString()
+            .trim().split(System.lineSeparator())[0].split("\t");
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,13 +82,13 @@ final class MjTranspileTest {
     }
 
     @Test
-    void wrapsObjectsIntoPhCoverageWhenTrackingEnabled(@Mktmp final Path temp) throws Exception {
+    void wrapsObjectsIntoPhCoverageWhenFileIsSet(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
-            "the generated Java must wrap located objects into PhCoverage when coverageTracking is on",
+            "the generated Java must wrap located objects into PhCoverage when coverageFile is set",
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.program())
-                    .with("coverageTracking", true)
+                    .with("coverageFile", temp.resolve("hits.txt").toFile())
                     .execute(new FakeMaven.Transpile())
                     .result()
                     .get(MjTranspileTest.compiled())
@@ -97,9 +98,31 @@ final class MjTranspileTest {
     }
 
     @Test
+    void writesACoverageManifestWhenFileIsSet(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            String.join(
+                " ",
+                "the manifest must list every location wrapped into PhCoverage,",
+                "one tab-separated locator/line entry per line"
+            ),
+            Arrays.asList(
+                new TextOf(
+                    new FakeMaven(temp)
+                        .withProgram(MjTranspileTest.program())
+                        .with("coverageFile", temp.resolve("hits.txt").toFile())
+                        .execute(new FakeMaven.Transpile())
+                        .result()
+                        .get("hits.txt.manifest")
+                ).asString().trim().split(System.lineSeparator())
+            ),
+            Matchers.everyItem(Matchers.matchesRegex("\\S+\t\\d+"))
+        );
+    }
+
+    @Test
     void keepsGeneratedJavaFreeOfPhCoverageByDefault(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
-            "the generated Java must not mention PhCoverage when coverageTracking is off",
+            "the generated Java must not mention PhCoverage when coverageFile is not set",
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.program())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -46,7 +46,7 @@ final class TranspilingTest {
             false,
             Paths.get("target/xsl-measures.csv"),
             new Tracking(false, false),
-            false
+            new Coverage.Off()
         );
     }
 }

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -188,13 +188,6 @@
           <systemPropertyVariables>
             <eo.version>${project.version}</eo.version>
             <eo.typing>${eo.typing}</eo.typing>
-            <!--
-            Where PhCoverage.hit() appends coverage records at runtime. It
-            pairs with coverageTracking on eo-maven-plugin below, which wraps
-            located objects into PhCoverage at transpile time, so both ends
-            agree on one file (see #5673).
-            -->
-            <eo.coverageFile>${project.build.directory}/coverage.txt</eo.coverageFile>
             <java.util.logging.config.file>
               ${project.basedir}/src/test/resources/jul.properties
             </java.util.logging.config.file>
@@ -235,8 +228,6 @@
           <cacheEnabled>false</cacheEnabled>
           <!-- Tests assert on precise .eo locations in panics (off by default). -->
           <trackLocations>true</trackLocations>
-          <!-- Wrap located objects into PhCoverage so tests record EO coverage. -->
-          <coverageTracking>false</coverageTracking>
         </configuration>
         <executions>
           <execution>
@@ -294,6 +285,38 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <!--
+      EO object coverage, driven end to end by one setting:
+      mvn -Deo.coverageFile=<path> ... . The property is read by the
+      transpile goal of eo-maven-plugin, which then wraps every located
+      object into PhCoverage and writes the manifest of all of them into
+      <path>.manifest, and it is forwarded from here to the JVM that runs
+      the tests, where PhCoverage.hit() appends the touched locations to
+      <path> itself, so that the manifest and the hits can later be merged
+      into a coverage report (see #5673, #5671). Nothing is instrumented
+      when the property is absent, so an ordinary build stays as fast as it
+      was.
+      -->
+      <id>coverage-file</id>
+      <activation>
+        <property>
+          <name>eo.coverageFile</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <eo.coverageFile>${eo.coverageFile}</eo.coverageFile>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>jacoco</id>
       <build>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -293,10 +293,10 @@
       object into PhCoverage and writes the manifest of all of them into
       <path>.manifest, and it is forwarded from here to the JVM that runs
       the tests, where PhCoverage.hit() appends the touched locations to
-      <path> itself, so that the manifest and the hits can later be merged
-      into a coverage report (see #5673, #5671). Nothing is instrumented
-      when the property is absent, so an ordinary build stays as fast as it
-      was.
+      <path> itself. The coverage-report goal reads the same property once
+      more and merges the two into an LCOV tracefile (see #5673, #5671).
+      Nothing is instrumented when the property is absent, so an ordinary
+      build stays as fast as it was.
       -->
       <id>coverage-file</id>
       <activation>


### PR DESCRIPTION
Second half of #5671, split off #5694 as Favixx suggested in review: this one is the report and the mojo, #5694 is the manifest and the transpiler wiring.

Depends on #5694, review that one first. This branch is built on top of it, and since GitHub cannot base a fork pull request on another fork branch, the diff below still shows #5694's commit as well. It will shrink to just the `coverage-report` half once #5694 is merged and this is rebased.

What it adds:

- `MjCoverageReport`, the `eo:coverage-report` goal, bound to `verify` so the tests have already touched the objects by the time it runs.
- `CoverageReport`, which merges the manifest written at transpile time with the raw `loc:line:pos` hits `PhCoverage` appends at runtime, into an LCOV tracefile.
- `ObjectSources`, which resolves a locator to the `.eo` source it came from through the `eo-foreign` catalog `register` already builds, by trimming the locator's trailing segments until the catalog knows what is left.

An unresolvable locator, a pulled object for instance, costs one line of the report and a warning rather than the whole build at `verify`. Malformed manifest lines are rejected with a message that quotes the line and names the file.
