### PR TITLE
#6129: build the substituted class at the instantiation sites too

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -113,21 +113,23 @@ public final class MjTranspile extends MjSafe {
      * full, since the generated files import nothing but
      * {@code org.eolang.*}.
      * <p>
-     *     The substitution reaches the classes that {@code to-java.xsl}
-     *     declares with an {@code extends} clause of their own. An object
-     *     with a {@code @base} extends {@code PhOnce} instead, and keeps
-     *     doing so: {@code PhOnce} is a decorator, and the object it wraps
-     *     is itself substituted, so nothing is lost.
+     *     The substitution reaches every class the generated Java declares
+     *     with an {@code extends} clause of its own, and every object it
+     *     builds with {@code new}: the context of a generated
+     *     {@code apply()}, an anonymous abstract object, and the argument
+     *     of a {@code PhApplication}. An object with a {@code @base}
+     *     extends {@code PhOnce} instead, and keeps doing so:
+     *     {@code PhOnce} is a decorator, and the object it wraps is itself
+     *     substituted, so nothing is lost.
      * </p>
-     * @todo #5955:30min Honour this option at the instantiation sites too.
-     *  Right now {@code to-java.xsl} reads it only where it emits an
-     *  {@code extends} clause, which is what the issue asked for. Three
-     *  more places still hardcode {@code new PhDefault(...)}: the context
-     *  of a generated {@code apply()}, an anonymous abstract object with no
-     *  children, and the argument of a {@code PhApplication}. Objects built
-     *  there stay outside the substituted class, so a tool that relies on
-     *  this option sees only a part of the tree. Convert them the same way
-     *  and assert on them in {@code MjTranspileTest}.
+     * <p>
+     *     Since the generated Java builds objects with {@code new}, the
+     *     named class has to offer the same constructors {@code PhDefault}
+     *     does where the transpiler calls them: the one taking nothing,
+     *     the one taking a location {@code String}, and the one taking a
+     *     {@code byte[]}. A class that leaves one out fails to compile in
+     *     generated sources.
+     * </p>
      */
     @Parameter(property = "eo.phiDefaultClass", defaultValue = "PhDefault")
     private String superclass;

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -478,7 +478,7 @@
     <xsl:value-of select="eo:eol($indent + 2)"/>
     <xsl:text>Phi </xsl:text>
     <xsl:value-of select="$ctx"/>
-    <xsl:text> = new PhDefault(</xsl:text>
+    <xsl:value-of select="concat(' = new ', $phiDefaultClass, '(')"/>
     <xsl:if test="@loc and not(contains(@loc, '🌵'))">
       <xsl:text>"</xsl:text>
       <xsl:value-of select="@loc"/>
@@ -550,7 +550,7 @@
         <xsl:value-of select="eo:loc-to-class(eo:escape-plus(@loc))"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:text>new PhDefault</xsl:text>
+        <xsl:value-of select="concat('new ', $phiDefaultClass)"/>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:text>();</xsl:text>
@@ -717,7 +717,7 @@
     <xsl:value-of select="$name"/>
     <xsl:text> = new PhApplication(</xsl:text>
     <xsl:value-of select="$name"/>
-    <xsl:text>, 0, new PhDefault(</xsl:text>
+    <xsl:value-of select="concat(', 0, new ', $phiDefaultClass, '(')"/>
     <xsl:value-of select="text()"/>
     <xsl:text>));</xsl:text>
   </xsl:template>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -144,6 +144,22 @@ final class MjTranspileTest {
     }
 
     @Test
+    void buildsGivenPhiClassAtInstantiationSites(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the generated Java must instantiate the class named by phiDefaultClass, never PhDefault, so that the whole tree is made of the substituted class",
+            new TextOf(
+                new FakeMaven(temp)
+                    .withProgram(MjTranspileTest.instantiating())
+                    .with("superclass", "org.example.PhInspected")
+                    .execute(new FakeMaven.Transpile())
+                    .result()
+                    .get(MjTranspileTest.compiled())
+            ).asString(),
+            Matchers.not(Matchers.containsString("new PhDefault"))
+        );
+    }
+
+    @Test
     void invalidatesCacheWhenPhiDefaultClassChanges(@Mktmp final Path temp) throws Exception {
         final Path cache = temp.resolve("cache");
         final String src = String.format("+package foo.x%n%n[] > main%n  42 > @");
@@ -481,6 +497,20 @@ final class MjTranspileTest {
                 Matchers.iterableWithSize(1),
                 Matchers.hasItem("package-info.java")
             )
+        );
+    }
+
+    /**
+     * An EO program that makes the transpiler build objects at each of the
+     * three places it emits a {@code new} of the base class: the context of
+     * a generated {@code apply()} for the nested formation, the argument of
+     * a {@code PhApplication} for the number, and an anonymous abstract
+     * object with no children for the empty argument.
+     * @return Source code of the program
+     */
+    private static String instantiating() {
+        return String.format(
+            "+package foo.x%n%n[] > main%n  [] > inner%n    42 > @%n  42.plus > @%n    []"
         );
     }
 


### PR DESCRIPTION
Closes #6129

Resolves the puzzle left by #5955. `to-java.xsl` read `phiDefaultClass` only where it emits an `extends` clause, so three places still hardcoded `new PhDefault(...)` and the objects built there stayed outside the substituted class.

All three now use the option: the context of a generated `apply()`, an anonymous abstract object with no children, and the argument of a `PhApplication`.

The two `((PhDefault) x)` casts and the `PhDefault x = ...` local are left alone on purpose. The named class extends `PhDefault`, so the casts still reach the override through virtual dispatch and `PhDefault` stays a valid type for the local.

Checked the generated Java for a program that reaches all three, with the option set to `org.example.PhInspected`:

```
public final class EOmain extends org.example.PhInspected {
        Phi r = new org.example.PhInspected("Φ.foo.x.main.inner");
        ((PhDefault) r).add("φ", ...
          PhDefault r1 = new org.example.PhInspected();
              rr1 = new PhApplication(rr1, 0, new org.example.PhInspected(new byte[] {...}));
```

That program is what the new test transpiles, asserting the output has no `new PhDefault` left. It fails on the un-fixed code.

One thing worth knowing, added to the javadoc: since the transpiler now calls `new` on the named class, that class has to offer the same constructors `PhDefault` does at those points, the no-arg one, the one taking a location `String` and the one taking a `byte[]`.
