### PR TITLE
Terminate through T in as-decimal and integral

### DIFF
--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -36,7 +36,7 @@
             div.
               b.minus a
               n
-    trouble
+    T
       "the number of partitions must be a finite positive integer"
   times. > [a b] >> subsection
     div.

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -10,7 +10,7 @@
 
 [n] > as-decimal
   n.is-finite.not.if > @
-    trouble
+    T
       "Can't write a non-finite number as decimal"
     if.
       n.lt 0

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -6,6 +6,7 @@ package org.eolang;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -57,6 +58,42 @@ final class PhiTest {
                 Phi.Φ.take("nan").take("is-finite")
             ).asBool(),
             Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void tellsWhyANonFiniteNumberHasNoDecimalForm() {
+        MatcherAssert.assertThat(
+            "asking nan for its decimal form must not lose the reason written for that moment",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        Phi.Φ.take("string.as-decimal").copy(),
+                        "n",
+                        new Data.ToPhi(Double.NaN)
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("Can't write a non-finite number as decimal")
+        );
+    }
+
+    @Test
+    void tellsWhyAFractionalPartitionCountIsRefused() {
+        MatcherAssert.assertThat(
+            "integrating over 1.5 partitions must not lose the reason written for that moment",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        Phi.Φ.take("number.integral").copy(),
+                        "n",
+                        new Data.ToPhi(1.5)
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("the number of partitions must be a finite positive integer")
         );
     }
 


### PR DESCRIPTION
Closes #6121.

Two EO sources terminated through an object named `trouble`, which exists nowhere in the tree — no `trouble.eo`, no Java atom. The dispatch sailed through linting and transpiling as `new PhDispatch(Phi.Φ, "trouble")`, and at runtime `PhPackage` complained about a missing `org.eolang.EOtrouble` class. So a caller asking `nan` for its decimal form was told a Java class is missing, and the sentence written for that exact moment never arrived. `T` is what was meant, the way `tuple.eo` already uses it:

```
  n.is-finite.not.if > @
    T
      "Can't write a non-finite number as decimal"
```

The nine `-->` tests covering these branches were all green, because `-->` compiles to `assertThrows(Exception.class, ...)` and a missing class satisfies that as well as a real termination. Two assertions in `PhiTest` now pin the messages themselves; both fail on master with `Couldn't find object 'Φ.trouble'`.

Left for later: nothing rejects an unresolvable global. A lint rule in `objectionary/lints` that refuses a dispatch on a global with no object behind it would stop the next one from reaching runtime — worth a separate ticket.