### PR TITLE
Move Maven proxy translation out of MjSafe

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -8,13 +8,10 @@ import com.jcabi.log.Logger;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +36,14 @@ import org.slf4j.impl.StaticLoggerBinder;
 /**
  * Abstract Mojo for all others.
  * @since 0.1
+ * @todo #6117:60min Take the fan-out of this class under the allowed 30.
+ *  Checkstyle counts 39 dependencies here, which is why the marker below is
+ *  still needed. The parameters are not to blame, they cost eight of them.
+ *  The compositions are: let the objectionary chain ({@link OyIndexed},
+ *  {@link OyCached}, {@link OyRemote}) build itself in a class of its own,
+ *  the hash chain ({@link ChCached}, {@link ChNarrow}, {@link ChRemote}) in
+ *  another one, and turn execWithTimeout() into a {@link Step} decorator.
+ *  Together they take it down to 30 and the marker goes away.
  * @checkstyle ClassFanOutComplexityCheck (1000 lines)
  */
 @SuppressWarnings("PMD.TooManyFields")
@@ -394,7 +399,7 @@ abstract class MjSafe extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Parameter(defaultValue = "${settings}", readonly = true)
-    protected Settings settings;
+    protected Settings settings = new Settings();
 
     /**
      * Placed tojos.
@@ -437,7 +442,9 @@ abstract class MjSafe extends AbstractMojo {
     private Scalar<Objectionary> objectionary = new Synced<>(
         new Sticky<>(
             () -> new OyIndexed(
-                new OyCached(new OyRemote(this.hash, this.proxies()))
+                new OyCached(
+                    new OyRemote(this.hash, new Proxies(this.settings).value())
+                )
             )
         )
     );
@@ -600,23 +607,6 @@ abstract class MjSafe extends AbstractMojo {
                 )
             )
         );
-    }
-
-    /**
-     * Get active proxy from Maven settings.
-     * @return Proxy if any
-     */
-    Proxy[] proxies() {
-        return Optional.ofNullable(this.settings)
-            .map(Settings::getProxies)
-            .orElse(List.of())
-            .stream()
-            .filter(org.apache.maven.settings.Proxy::isActive).map(
-                p -> new Proxy(
-                    Proxy.Type.HTTP,
-                    new InetSocketAddress(p.getHost(), p.getPort())
-                )
-            ).toArray(Proxy[]::new);
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Proxies.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Proxies.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import org.apache.maven.settings.Settings;
+import org.cactoos.Scalar;
+
+/**
+ * Active proxies of Maven settings, translated to the ones of Java.
+ * @since 0.62.0
+ */
+final class Proxies implements Scalar<Proxy[]> {
+
+    /**
+     * Maven settings.
+     */
+    private final Settings settings;
+
+    /**
+     * Ctor.
+     * @param settings Maven settings
+     */
+    Proxies(final Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public Proxy[] value() {
+        return this.settings.getProxies()
+            .stream()
+            .filter(org.apache.maven.settings.Proxy::isActive).map(
+                proxy -> new Proxy(
+                    Proxy.Type.HTTP,
+                    new InetSocketAddress(proxy.getHost(), proxy.getPort())
+                )
+            ).toArray(Proxy[]::new);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProxiesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProxiesTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import org.apache.maven.settings.Settings;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Proxies}.
+ * @since 0.62.0
+ */
+final class ProxiesTest {
+
+    @Test
+    void translatesActiveProxy() {
+        MatcherAssert.assertThat(
+            "Active proxy of settings must keep its address",
+            new Proxies(ProxiesTest.settings("prox.eolang.org", 8431, true)).value(),
+            Matchers.arrayContaining(
+                new Proxy(Proxy.Type.HTTP, new InetSocketAddress("prox.eolang.org", 8431))
+            )
+        );
+    }
+
+    @Test
+    void skipsInactiveProxy() {
+        MatcherAssert.assertThat(
+            "Inactive proxy of settings must be dropped",
+            new Proxies(ProxiesTest.settings("dead.eolang.org", 3129, false)).value(),
+            Matchers.emptyArray()
+        );
+    }
+
+    @Test
+    void staysEmptyWithoutProxies() {
+        MatcherAssert.assertThat(
+            "Settings without proxies must give no proxies at all",
+            new Proxies(new Settings()).value(),
+            Matchers.emptyArray()
+        );
+    }
+
+    /**
+     * Maven settings with a single proxy in them.
+     * @param host Host of the proxy
+     * @param port Port of the proxy
+     * @param active Is the proxy active?
+     * @return Settings with the proxy
+     */
+    private static Settings settings(final String host, final int port, final boolean active) {
+        final org.apache.maven.settings.Proxy proxy = new org.apache.maven.settings.Proxy();
+        proxy.setHost(host);
+        proxy.setPort(port);
+        proxy.setActive(active);
+        final Settings settings = new Settings();
+        settings.addProxy(proxy);
+        return settings;
+    }
+}


### PR DESCRIPTION
`MjSafe` was doing the Settings-to-`java.net.Proxy` translation itself, in `proxies()`, next to the thirty `@Parameter` fields that make up the plugin's public API. That translation has nothing to do with parameters, and it is the reason the Mojo named `java.net.Proxy` and `InetSocketAddress` at all. It now lives in `Proxies`, and the objectionary chain asks for the proxies it needs at the point where it builds `OyRemote`.

One related change: the `settings` field now starts as empty `Settings` rather than null, the same way `tag`, `scope` and `cache` already default in this class. Maven overwrites it on injection, and `Proxies` no longer has to tolerate an uninjected null the way `proxies()` did with `Optional.ofNullable`. Every Mojo test that reaches the objectionary (`MjPullTest`, `MjProbeTest`) runs without injected settings, so this path is covered.

This does not retire the `@checkstyle ClassFanOutComplexityCheck` marker yet. I measured the class with checkstyle: it was at 40 dependencies against the allowed 30, and it is at 39 now. The issue estimates that moving `proxies()` and `execWithTimeout()` clears the cap, but most of what the marker covers is composition, not plumbing imports: the objectionary chain, the hash chain and the timeout together are worth ten, which is exactly what is needed. That is written up as a puzzle in the class Javadoc, with the three compositions spelled out.

Closes #6117
