### PR TITLE
Bind sock to socket instead of impl in connection error messages

### DIFF
--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -86,7 +86,7 @@
                 sock.sd
                 sock.sockaddr
                 sock.sockaddr.size
-            ^.^ > sock
+            ^.^.^ > sock
           cant-connect
       [scope cant-listen] > listen
         safe-socket > @
@@ -131,7 +131,7 @@
                 "listen"
                 sock.sd
                 2048
-            ^.^ > sock
+            ^.^.^ > sock
           cant-listen
       [scope cant] > safe-socket
         if. > @

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -80,39 +80,37 @@ final class SyscallTest {
     }
 
     @Test
-    void reportsTheReasonOfTheRefusedConnection() throws IOException {
+    void tellsTheFallbackWhichAddressItFailedToReach() throws IOException {
         final SyscallTest.RandomServer refused = new SyscallTest.RandomServer().started();
         refused.stop();
         final Phi socket = Phi.Φ.take("socket").copy();
         socket.put(0, new Data.ToPhi(this.localhost()));
         socket.put(1, new Data.ToPhi(refused.port));
         final Phi connect = socket.take("connect").copy();
-        connect.put(0, new SyscallTest.Simple());
-        connect.put(1, new SyscallTest.Reason());
+        connect.put(1, Phi.Φ.take("dataized").copy());
         MatcherAssert.assertThat(
             "the refused connection should have told the fallback which address it failed to reach, but it didnt",
             new Dataized(connect).asString(),
-            Matchers.containsString(String.format("127.0.0.1:%d", refused.port))
+            Matchers.containsString(String.format("%s:%d", this.localhost(), refused.port))
         );
     }
 
     @Test
-    void reportsTheReasonOfTheFailedBinding() throws IOException {
-        final SyscallTest.RandomServer occupied = new SyscallTest.RandomServer().started();
+    void tellsTheFallbackWhichAddressItFailedToBind() throws IOException {
+        final SyscallTest.RandomServer taken = new SyscallTest.RandomServer().started();
         try {
             final Phi socket = Phi.Φ.take("socket").copy();
             socket.put(0, new Data.ToPhi(this.localhost()));
-            socket.put(1, new Data.ToPhi(occupied.port));
+            socket.put(1, new Data.ToPhi(taken.port));
             final Phi listen = socket.take("listen").copy();
-            listen.put(0, new SyscallTest.Simple());
-            listen.put(1, new SyscallTest.Reason());
+            listen.put(1, Phi.Φ.take("dataized").copy());
             MatcherAssert.assertThat(
-                "the occupied port should have told the fallback which address it failed to bind to, but it didnt",
+                "the taken port should have told the fallback which address it failed to bind to, but it didnt",
                 new Dataized(listen).asString(),
-                Matchers.containsString(String.format("127.0.0.1:%d", occupied.port))
+                Matchers.containsString(String.format("%s:%d", this.localhost(), taken.port))
             );
         } finally {
-            occupied.stop();
+            taken.stop();
         }
     }
 
@@ -903,26 +901,6 @@ final class SyscallTest {
         @Override
         public Phi lambda() {
             return new Data.ToPhi(true);
-        }
-    }
-
-    /**
-     * Fallback that dataizes the message it is given.
-     * reason > [reason]
-     * @since 0.60.0
-     */
-    private static final class Reason extends PhDefault implements Atom {
-
-        /**
-         * Ctor.
-         */
-        Reason() {
-            super(new Attrs(new Attr("reason", new AtVoid("reason"))));
-        }
-
-        @Override
-        public Phi lambda() {
-            return this.take("reason");
         }
     }
 

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -80,6 +80,43 @@ final class SyscallTest {
     }
 
     @Test
+    void reportsTheReasonOfTheRefusedConnection() throws IOException {
+        final SyscallTest.RandomServer refused = new SyscallTest.RandomServer().started();
+        refused.stop();
+        final Phi socket = Phi.Φ.take("socket").copy();
+        socket.put(0, new Data.ToPhi(this.localhost()));
+        socket.put(1, new Data.ToPhi(refused.port));
+        final Phi connect = socket.take("connect").copy();
+        connect.put(0, new SyscallTest.Simple());
+        connect.put(1, new SyscallTest.Reason());
+        MatcherAssert.assertThat(
+            "the refused connection should have told the fallback which address it failed to reach, but it didnt",
+            new Dataized(connect).asString(),
+            Matchers.containsString(String.format("127.0.0.1:%d", refused.port))
+        );
+    }
+
+    @Test
+    void reportsTheReasonOfTheFailedBinding() throws IOException {
+        final SyscallTest.RandomServer occupied = new SyscallTest.RandomServer().started();
+        try {
+            final Phi socket = Phi.Φ.take("socket").copy();
+            socket.put(0, new Data.ToPhi(this.localhost()));
+            socket.put(1, new Data.ToPhi(occupied.port));
+            final Phi listen = socket.take("listen").copy();
+            listen.put(0, new SyscallTest.Simple());
+            listen.put(1, new SyscallTest.Reason());
+            MatcherAssert.assertThat(
+                "the occupied port should have told the fallback which address it failed to bind to, but it didnt",
+                new Dataized(listen).asString(),
+                Matchers.containsString(String.format("127.0.0.1:%d", occupied.port))
+            );
+        } finally {
+            occupied.stop();
+        }
+    }
+
+    @Test
     void sendsAndReceivesMessageViaSocketObject() throws InterruptedException, IOException {
         final String msg = "Hello, Socket!";
         final AtomicReference<byte[]> bytes = new AtomicReference<>();
@@ -866,6 +903,26 @@ final class SyscallTest {
         @Override
         public Phi lambda() {
             return new Data.ToPhi(true);
+        }
+    }
+
+    /**
+     * Fallback that dataizes the message it is given.
+     * reason > [reason]
+     * @since 0.60.0
+     */
+    private static final class Reason extends PhDefault implements Atom {
+
+        /**
+         * Ctor.
+         */
+        Reason() {
+            super(new Attrs(new Attr("reason", new AtVoid("reason"))));
+        }
+
+        @Override
+        public Phi lambda() {
+            return this.take("reason");
         }
     }
 


### PR DESCRIPTION
The anonymous scope that `connect` hands to `safe-socket` bound `sock` two hops up, but it sits three hops below the `socket` formation: its own parent is `connect`, whose parent is `impl`. So `^.^` stopped on `impl`, which declares neither `address` nor `port`, and has no `φ` to descend into. Five of the seven attributes `sock` reaches happen to live on `impl`, which is why this stayed hidden. The other two only appear in the failure messages.

```
-            ^.^ > sock
+            ^.^.^ > sock
```

A refused connection therefore died on the bottom object while formatting its own diagnostic, and the caller never saw the reason. `listen` repeated the same binding, breaking both of its messages the same way. One hop deeper lands on `socket`, which reaches all seven through its `φ`.

Nothing caught this because every test drove the fallback with a fake whose `lambda` returns `true` without dataizing its void attribute, so the `printf` holding `sock.address` went straight into a discarded slot. The two new tests hand `connect` and `listen` a fallback that dataizes the message it is given, and assert the address comes back in it.

Closes #6132
