### PR TITLE
#6118: accept zero-padded integers in scanf

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -56,22 +56,16 @@
     [text] > as-integer
       if. > @
         or.
-          digits.length.gt 19
+          normalized.length.gt 19
           and.
-            digits.length.eq 19
+            normalized.length.eq 19
             not.
               negative.if
-                digits-lte digits "9223372036854775808"
-                digits-lte digits "9223372036854775807"
+                digits-lte normalized "9223372036854775808"
+                digits-lte normalized "9223372036854775807"
         T
           "The number doesn't fit into long range for the '%%d' conversion"
         negative.if negated folded
-      signed.if > digits
-        slice
-          text
-          1
-          text.length.minus 1
-        text
       [a b] > digits-lte
         if. > [index] >> rec
           index.eq a.length
@@ -93,7 +87,7 @@
               rec
                 index.plus 1
         | 0 > @
-      fold-digits digits > folded
+      fold-digits normalized > folded
       folded.times -1 > negated
       eq. > negative
         slice
@@ -101,10 +95,23 @@
           0
           1
         "-"
+      if. > normalized
+        stripped.eq ""
+        "0"
+        stripped
       negative.or > signed
         eq.
           slice text 0 1
           "+"
+      replaced > stripped
+        signed.if
+          slice
+            text
+            1
+            text.length.minus 1
+          text
+        regex "/^0+/"
+        ""
     [group acc] >> convert
       matched.exists.not.if > @
         *
@@ -302,6 +309,21 @@
     head.
       scanf "%d" "+42"
 
+  eq. ++> can-scan-a-zero-padded-integer
+    42
+    head.
+      scanf "%d" "00000000000000000042"
+
+  eq. ++> can-scan-a-zero-padded-negative-integer
+    -42
+    head.
+      scanf "%d" "-00000000000000000042"
+
+  eq. ++> can-scan-many-zeroes-as-zero
+    0
+    head.
+      scanf "%d" "00000000000000000000"
+
   eq. ++> can-scan-what-printf-wrote
     scanf
       "%s is about %d?"
@@ -371,6 +393,10 @@
   scanf --> stops-on-a-nineteen-digit-value-below-long-min
     "%d"
     "-9223372036854775809"
+
+  scanf --> stops-on-a-zero-padded-integer-above-long-max
+    "%d"
+    "00009223372036854775808"
 
   scanf --> stops-on-a-wrong-format
     "%l"


### PR DESCRIPTION
Fixes #6118.

## Problem

[`as-integer`](https://github.com/objectionary/eo/blob/master/eo-runtime/src/main/eo/string/scanf.eo#L56-L74) rejects a `%d` capture by checking the length of its textual digits before converting them. The `%d` pattern accepts leading zeroes, so a valid value such as `00000000000000000042` has twenty digits and is rejected even though its numerical value is `42`.

The overflow guard is the problematic path: it sees the unnormalised representation, while [`fold-digits`](https://github.com/objectionary/eo/blob/master/eo-runtime/src/main/eo/string/scanf.eo#L96) would produce the correct value. This makes accepted input depend on presentation zeroes rather than on the integer being scanned.

## Change

[`without-leading-zeroes`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L98-L127) removes leading zeroes while preserving one zero for an all-zero value. The [`normalized`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L56-L90) unsigned magnitude is now used consistently by both the range guard and `fold-digits`.

The sign is still determined from the original text, so the existing boundary rules remain unchanged: the implementation accepts `Long.MAX_VALUE` and `Long.MIN_VALUE`, but rejects values beyond either bound.

## Regression coverage

The atom tests now cover:

- a positive zero-padded value that previously failed: [`00000000000000000042`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L325-L328);
- the same value with a minus sign: [`-00000000000000000042`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L330-L333);
- an all-zero representation, which must remain zero: [`00000000000000000000`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L335-L338);
- a zero-padded value above `Long.MAX_VALUE`, which must still terminate: [`00009223372036854775808`](https://github.com/gemshrine/eo/blob/6118-scanf-leading-zeroes/eo-runtime/src/main/eo/string/scanf.eo#L410-L412).

The existing non-padded overflow cases remain alongside these tests.

## Verification

`mvn -q -pl eo-runtime test -Deo.autoFix -DskipUTs=false` completes successfully locally. GitHub Actions is running against the updated revision.