### PR TITLE
fix(#6030): key WPA lint cache to the analysed XMIR, not the EO sources

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -11,6 +11,7 @@ import com.jcabi.manifests.Manifests;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -131,12 +132,6 @@ final class Linting implements Step {
     private final boolean lintAsPackage;
 
     /**
-     * EO sources directory (for WPA cache key).
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final Path sourcesDir;
-
-    /**
      * Whether to skip linting entirely.
      * @checkstyle MemberNameCheck (5 lines)
      */
@@ -160,10 +155,9 @@ final class Linting implements Step {
      * @param experimental Whether to skip experimental lints
      * @param warning Whether to fail on warnings
      * @param pkg Whether to lint all sources as a package
-     * @param sources EO sources directory
      * @param skip Whether to skip linting entirely
      * @todo #5102:90min Reduce long parameter lists in Linting, Parse, Pull, and similar classes.
-     *  Linting currently takes 13 constructor parameters. Parse, Pull, and Probe have similar
+     *  Linting currently takes 12 constructor parameters. Parse, Pull, and Probe have similar
      *  issues. The long parameter lists make call sites hard to read and fragile — adding a new
      *  option requires updating every call site across the codebase.
      * @checkstyle ParameterNumberCheck (20 lines)
@@ -181,7 +175,6 @@ final class Linting implements Step {
         final boolean experimental,
         final boolean warning,
         final boolean pkg,
-        final Path sources,
         final boolean skip
     ) {
         this.tojos = srcs;
@@ -195,7 +188,6 @@ final class Linting implements Step {
         this.skipExperimentalLints = experimental;
         this.failOnWarning = warning;
         this.lintAsPackage = pkg;
-        this.sourcesDir = sources;
         this.skipLinting = skip;
         this.guard = new ConcurrentCache();
     }
@@ -398,11 +390,13 @@ final class Linting implements Step {
         final List<org.eolang.wpa.Defect> defects;
         if (this.cacheEnabled) {
             final Path wpa = Paths.get("wpa.xmir");
-            final Path target = this.targetDir.resolve(Linting.DIR).resolve(wpa);
+            final Path base = this.targetDir.resolve(Linting.DIR);
+            final Path target = base.resolve(wpa);
+            Files.createDirectories(base);
             this.guard.apply(
-                this.sourcesDir, target, wpa,
+                base, target, wpa,
                 new Cache(
-                    this.cacheDir.resolve(Linting.CACHE),
+                    this.cacheDir.resolve(Linting.CACHE).resolve(this.version),
                     root -> {
                         Logger.info(this, "Linting a package");
                         final Directives all = new Directives().add("defects");

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -46,7 +46,6 @@ public final class MjCompile extends MjSafe {
                         this.skipExperimentalLints,
                         this.failOnWarning,
                         this.lintAsPackage,
-                        this.sourcesDir.toPath(),
                         this.skipLinting
                     )
                 ),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -44,7 +44,6 @@ public final class MjLint extends MjSafe {
             this.skipExperimentalLints,
             this.failOnWarning,
             this.lintAsPackage,
-            this.sourcesDir.toPath(),
             this.skipLinting
         ).exec();
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -56,7 +56,6 @@ final class CompilingTest {
                     false,
                     false,
                     false,
-                    temp,
                     true
                 ),
                 new Resolving(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -50,7 +50,6 @@ final class LintingTest {
                 false,
                 false,
                 false,
-                temp,
                 true
             ).exec(),
             "Linting must be fully skipped when skipLinting is TRUE"

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -159,8 +159,35 @@ final class MjLintTest {
         MatcherAssert.assertThat(
             "WPA results must be saved to cache",
             cache.resolve(Linting.CACHE)
+                .resolve(FakeMaven.pluginVersion())
                 .resolve("wpa.xmir").toFile(),
             FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    void doesNotReuseWholeProgramAnalysisCacheOfAnotherProject(@Mktmp final Path temp)
+        throws IOException {
+        final Path cache = temp.resolve("shared-cache");
+        MjLintTest.linting(temp.resolve("clean"), cache, MjLintTest.flawless())
+            .execute(new FakeMaven.Lint());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> MjLintTest.linting(
+                temp.resolve("broken"), cache, MjLintTest.probmlematic()
+            ).execute(new FakeMaven.Lint()),
+            "WPA error of the second project must be reported, not hidden by the cache of the first"
+        );
+    }
+
+    @Test
+    void lintsPackageWithoutASingleProgram(@Mktmp final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp)
+                .with("lintAsPackage", true)
+                .with("cache", temp.resolve("cache").toFile())
+                .execute(new FakeMaven.Lint()),
+            "Linting a package that has no programs at all must not fail"
         );
     }
 
@@ -426,6 +453,45 @@ final class MjLintTest {
             "",
             "[] > main",
             "  cti true \"critical\" \"msg\" > @",
+        };
+    }
+
+    /**
+     * Maven that lints a package, keeping its EO sources apart from its target directory,
+     * the way a real Maven build does with {@code src/main/eo}.
+     * @param workspace Workspace of the project
+     * @param cache Cache directory, possibly shared with other projects
+     * @param program Program to lint
+     * @return Maven ready to be executed
+     * @throws IOException If fails to save the program
+     */
+    private static FakeMaven linting(
+        final Path workspace, final Path cache, final String... program
+    ) throws IOException {
+        return new FakeMaven(workspace)
+            .with("lintAsPackage", true)
+            .with("cache", cache.toFile())
+            .with("sourcesDir", workspace.resolve("foo").toFile())
+            .withProgram(program);
+    }
+
+    /**
+     * Program without a single defect.
+     * @return Program without defects
+     */
+    private static String[] flawless() {
+        return new String[]{
+            "+home https://www.eolang.org",
+            "+package foo.x",
+            "+version 0.0.0",
+            "+unlint empty-object",
+            "+unlint unit-test-missing",
+            "+unlint mandatory-spdx",
+            "+unlint comment-too-short",
+            "+unlint object-has-data",
+            "",
+            "[x] > main",
+            "  (stdout \"Hello!\" x).print > @",
         };
     }
 


### PR DESCRIPTION
The whole-program-analysis cache hashed sourcesDir, which holds only .eo files, while the cache filter accepts only .xmir. Nothing matched, so the freshness hash was the SHA-256 of an empty input for every project and never changed. Combined with a cache path that carried no plugin version, one project's WPA verdict was reused by every other project on the machine, hiding real defects.

Hash the 3-lint directory instead, which is what the filter was always written for: it excludes wpa.xmir, and wpa.xmir only ever lands there. Add the plugin version to the cache path, the way lintOne already does, so verdicts from an older plugin are not reused. The directory is created before hashing, since a package with no programs of its own would otherwise have nothing to hash.

With sourcesDir no longer read, drop it from Linting and its callers.