### PR TITLE
#5969: extract deleted/moved/size/touched into a file/ package

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -14,30 +14,6 @@
   path > @
   @. > as-path
     Q.path path
-  [] > deleted
-    exists.if > @
-      if.
-        outcome.eq 0
-        ^
-        T
-          "Cant delete the file '%s': %s".printf
-            * path removed.output
-      ^
-    removed.code > outcome
-    called. > removed
-      os.is-windows.if
-        win32 *1
-          win
-          path
-        posix *1
-          unix
-          path
-    is-directory.if > unix
-      "rmdir"
-      "unlink"
-    is-directory.if > win
-      "_rmdir"
-      "_unlink"
   eq. > [] > exists
     code.
       os.is-windows.if
@@ -66,24 +42,6 @@
         posix *1
           "stat"
           path
-  [target] > moved
-    if. > @
-      outcome.eq 0
-      file target
-      T
-        "Cant move the file '%s' to '%s': %s".printf
-          * path target renamed.output
-    renamed.code > outcome
-    called. > renamed
-      os.is-windows.if
-        win32 *1
-          "rename"
-          path
-          target
-        posix *1
-          "rename"
-          path
-          target
   [mode scope cant-open] > open
     known.not.if > @
       T
@@ -200,49 +158,6 @@
     not. > writable
       as-bool.
         access.eq "r"
-  [cant-measure] > size
-    if. > @
-      info.code.eq 0
-      info.output.size
-      cant-measure
-    called. > info
-      os.is-windows.if
-        win32 *1
-          "_stat64"
-          path
-        posix *1
-          "stat"
-          path
-  [] > touched
-    exists.if > @
-      ^
-      if.
-        descriptor.eq -1
-        T
-          "Cant touch the file '%s': %s".printf
-            * path created.output
-        seq *
-          closed
-          ^
-    code. > closed
-      os.is-windows.if
-        win32 *1
-          "_close"
-          descriptor
-        posix *1
-          "close"
-          descriptor
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_creat"
-          path
-          win32.mode
-        posix *1
-          "creat"
-          path
-          posix.mode
-    created.code > descriptor
 
   eq. ++> can-append-data-to-a-file
     size.
@@ -253,20 +168,6 @@
         "a"
         f.write "!" > [f]
     13
-
-  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
-
-  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
-    0
-
-  ++> can-move-a-file
-    and. > @
-      exists.
-        temp.moved
-          "%s.dest".printf
-            * temp.path
-      temp.exists.not
-    mktemp.tmpfile > temp
 
   ++> can-read-from-a-file
     eq. > @
@@ -332,26 +233,12 @@
           "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
 
-  ++> can-return-itself-after-deleting
-    temp.deleted.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  ++> can-return-itself-after-touching
-    temp.deleted.touched.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
-
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.
       file "absent.txt"
 
   is-directory. ++> can-tell-that-the-current-directory-is-a-directory
     file "."
-
-  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
-
-  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
 
   exists. ++> can-touch-an-absent-file-on-opening-for-appending
     mktemp.tmpfile.deleted.open
@@ -474,10 +361,6 @@
       f > [f]
       "recovered" > [reason]
 
-  eq. ++> rejects-sizing-an-absent-file
-    -1
-    mktemp.tmpfile.deleted.size -1
-
   mktemp.tmpfile.deleted.is-directory --> stops-on-checking-the-directory-of-an-absent-file
 
   seq * --> stops-on-opening-with-a-wrong-mode
@@ -501,8 +384,6 @@
   mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
     "r+"
     f > [f]
-
-  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file
 
   tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
     @.

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -1,0 +1,35 @@
+# Deletes the file `f` from the filesystem.
+# Returns the same file, unchanged, if it does not exist.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > deleted
+  f.exists.if > @
+    if.
+      removed.code.eq 0
+      f
+      T
+        "Cant delete the file '%s': %s".printf
+          * f.path removed.output
+    f
+  called. > removed
+    os.is-windows.if
+      win32 *1
+        f.is-directory.if "_rmdir" "_unlink"
+        f.path
+      posix *1
+        f.is-directory.if "rmdir" "unlink"
+        f.path
+
+  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+
+  ++> can-return-itself-after-deleting
+    temp.deleted.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting

--- a/eo-runtime/src/main/eo/file/moved.eo
+++ b/eo-runtime/src/main/eo/file/moved.eo
@@ -1,0 +1,39 @@
+# Moves the file `f` to `target` on the filesystem, returning the file
+# at its new location.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f target] > moved
+  if. > @
+    renamed.code.eq 0
+    file target
+    T
+      "Cant move the file '%s' to '%s': %s".printf
+        *
+          f.path
+          target
+          renamed.output
+  called. > renamed
+    os.is-windows.if
+      win32 *1
+        "rename"
+        f.path
+        target
+      posix *1
+        "rename"
+        f.path
+        target
+
+  ++> can-move-a-file
+    and. > @
+      exists.
+        temp.moved
+          "%s.dest".printf
+            * temp.path
+      temp.exists.not
+    mktemp.tmpfile > temp

--- a/eo-runtime/src/main/eo/file/size.eo
+++ b/eo-runtime/src/main/eo/file/size.eo
@@ -1,0 +1,32 @@
+# Size of the file `f` in bytes, or `cant-measure` if the file
+# does not exist.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f cant-measure] > size
+  if. > @
+    info.code.eq 0
+    info.output.size
+    cant-measure
+  called. > info
+    os.is-windows.if
+      win32 *1
+        "_stat64"
+        f.path
+      posix *1
+        "stat"
+        f.path
+
+  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
+    0
+
+  eq. ++> rejects-sizing-an-absent-file
+    -1
+    mktemp.tmpfile.deleted.size -1
+
+  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file

--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -1,0 +1,47 @@
+# Touches the file `f`, creating it if it does not exist yet.
+# Returns the same file, unchanged, if it already exists.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > touched
+  f.exists.if > @
+    f
+    if.
+      descriptor.eq -1
+      T
+        "Cant touch the file '%s': %s".printf
+          * f.path created.output
+      seq *
+        code.
+          os.is-windows.if
+            win32 *1
+              "_close"
+              descriptor
+            posix *1
+              "close"
+              descriptor
+        f
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_creat"
+        f.path
+        win32.mode
+      posix *1
+        "creat"
+        f.path
+        posix.mode
+  created.code > descriptor
+
+  ++> can-return-itself-after-touching
+    temp.deleted.touched.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
+
+  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice


### PR DESCRIPTION
Closes #5969.

`file.eo` defined four attributes that nothing else in the object needs: `deleted`, `moved`, `size`, `touched`. Following the layout of #5501 and the package dispatch of #5486, moved them into a new `file/` package directory (`file/deleted.eo`, `file/moved.eo`, `file/size.eo`, `file/touched.eo`), each taking the file as its first parameter (`[f] > deleted`, `[f target] > moved`, `[f cant-measure] > size`, `[f] > touched`).

Existing call sites (`some-file.deleted`, `some-file.moved target`, etc.) keep working unchanged: an attribute absent on an object dispatches to the object named after its package (#5486), so `f.deleted` resolves to `file.deleted f` automatically.

Checked both caveats from the issue:
- `file` decorates a `path` (`path > @`), and `path` itself eventually decorates a string, so a bare `f.size`/`f.deleted` etc. could in principle resolve through the decoratee before reaching the package - this already works correctly on current master since #5931 (own-package-before-`@` probe), which landed before this PR.
- `directory` decorates `file` and does not override any of the four extracted attributes (verified directly in `directory.eo` - it only overrides `is-directory`), so `some-directory.moved`/`.size`/`.touched`/`.deleted` all still resolve through the decoratee down to `file`'s package. Verified by running `EOdirectoryTest` (4 tests, all passing, unchanged).

Moved each attribute's own `++>` tests along with it (`can-delete-a-file-twice`, `can-return-itself-after-deleting`, `can-tell-that-a-file-is-gone-after-deleting` -> `file/deleted.eo`; `can-move-a-file` -> `file/moved.eo`; `can-measure-an-empty-file-after-touching`, `rejects-sizing-an-absent-file`, `stops-on-sizing-an-absent-file` -> `file/size.eo`; `can-return-itself-after-touching`, `can-touch-a-file`, `can-touch-a-file-twice` -> `file/touched.eo`). Tests that use one of these four as setup for testing something else (e.g. `open`, `is-directory`) stayed in `file.eo`.

Also inlined four single-use locals (`outcome` in both `deleted`/`moved`, `unix`/`win` in `deleted`, `closed` in `touched`) that `eo:lint`'s `redundant-object` rule flagged once they moved out of `file.eo`'s file-level `+unlint redundant-object` - fixed genuinely rather than re-adding the suppression to the new files.

`mvn -pl eo-runtime test` - 1810 tests, all passing, 0 failures (full module run, no regressions). `EOfileTest` (29), `EOdirectoryTest` (4), and the four new `EO_file` package test classes (`EOdeletedTest`, `EOmovedTest`, `EOsizeTest`, `EOtouchedTest`, 10 tests total) all pass. qulice clean.
