### PR TITLE
#6150: refuse a name suffix with nothing but spaces after it

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -553,19 +553,22 @@ final class Suffix {
     }
 
     /**
-     * Whether nothing but spaces is left, so no name can follow. Unlike
+     * Whether nothing but blanks is left, so no name can follow. Unlike
      * {@link #skipSpace(String, int)}, which steps over the single space
-     * a suffix is allowed to have, this looks past every space: two of
-     * them followed by a name is a separate mistake, reported later as
-     * trailing garbage, while two of them followed by nothing leaves the
-     * name empty and has to be refused right here.
+     * a suffix is allowed to have, this looks past every space and tab:
+     * blanks followed by a name are a separate mistake, reported later
+     * as trailing garbage, while blanks followed by nothing leave the
+     * name empty and have to be refused right here. A tab counts because
+     * {@link #terminates(char)} ends a name on it just as a space does,
+     * and nothing upstream keeps tabs out of the tail.
      * @param tail Tail substring
      * @param from Index to look from
-     * @return True if only spaces remain
+     * @return True if only blanks remain
      */
     private static boolean blank(final String tail, final int from) {
         int idx = from;
-        while (idx < tail.length() && tail.charAt(idx) == ' ') {
+        while (idx < tail.length()
+            && (tail.charAt(idx) == ' ' || tail.charAt(idx) == '\t')) {
             idx = idx + 1;
         }
         return idx >= tail.length();

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -442,13 +442,13 @@ final class Suffix {
     private static Parsed named(
         final String tail, final int from, final Span span, final int home
     ) {
-        final int begin = Suffix.skipSpace(tail, from);
-        if (begin >= tail.length()) {
+        if (Suffix.blank(tail, from)) {
             throw new ParseError(
                 span.line(), home + from,
                 "name suffix requires a name"
             );
         }
+        final int begin = Suffix.skipSpace(tail, from);
         int idx = Suffix.skipName(tail, begin);
         final String name = tail.substring(begin, idx);
         if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
@@ -550,6 +550,25 @@ final class Suffix {
             );
         }
         return Suffix.typeAtom(raw, span, home + after);
+    }
+
+    /**
+     * Whether nothing but spaces is left, so no name can follow. Unlike
+     * {@link #skipSpace(String, int)}, which steps over the single space
+     * a suffix is allowed to have, this looks past every space: two of
+     * them followed by a name is a separate mistake, reported later as
+     * trailing garbage, while two of them followed by nothing leaves the
+     * name empty and has to be refused right here.
+     * @param tail Tail substring
+     * @param from Index to look from
+     * @return True if only spaces remain
+     */
+    private static boolean blank(final String tail, final int from) {
+        int idx = from;
+        while (idx < tail.length() && tail.charAt(idx) == ' ') {
+            idx = idx + 1;
+        }
+        return idx >= tail.length();
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-after-a-tab.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-after-a-tab.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "name suffix requires a name"
+input: "[] > app\n  42 >\t\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-after-two-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-after-two-spaces.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "name suffix requires a name"
+input: "[] > app\n  42 >  \n"


### PR DESCRIPTION
Closes #6150

`skipSpace` steps over one space, and the only emptiness check was `begin >= tail.length()`, which two spaces slip past. The name then came out empty and nothing rejected it.

The check now looks past every space before the name is read: if only spaces are left, there is no name and it says so.

It deliberately does not treat two spaces followed by a name the same way. `space-in-tail.yaml` already pins that case to "trailing garbage after name suffix", and this keeps it. The hole was only the case where nothing follows at all.

The test is a typo pack, so it runs through both `checksTypoPacks` and `checksTypoMessages`. It fails on master and passes here. Input is written as a quoted scalar rather than a block, because the case needs trailing spaces and yamllint forbids them in the file.
