### PR TITLE
#6148: copy the document before the shift writes into it

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/StXnav.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StXnav.java
@@ -61,7 +61,7 @@ public final class StXnav implements Shift {
 
     @Override
     public XML apply(final int position, final XML xml) {
-        final Node dom = xml.inner();
+        final Node dom = xml.inner().cloneNode(true);
         new Xnav(dom).path(this.xpath).forEach(this.fun);
         return new XMLDocument(dom);
     }

--- a/eo-parser/src/test/java/org/eolang/parser/StXnavTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StXnavTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StXnav}.
+ * @since 0.53.0
+ */
+final class StXnavTest {
+
+    @Test
+    void leavesTheGivenXmlAlone() {
+        final XML before = new XMLDocument("<p><o base='a'>text</o></p>");
+        final String snapshot = before.toString();
+        new StXnav("/p/o", node -> node.node().setTextContent("changed")).apply(0, before);
+        MatcherAssert.assertThat(
+            "the shift must not touch the document it was given, only the one it returns",
+            before.toString(),
+            Matchers.equalTo(snapshot)
+        );
+    }
+
+    @Test
+    void appliesTheFunctionToTheResult() {
+        MatcherAssert.assertThat(
+            "the returned document must carry what the function did",
+            new StXnav(
+                "/p/o",
+                node -> node.node().setTextContent("changed")
+            ).apply(0, new XMLDocument("<p><o base='a'>text</o></p>")),
+            XhtmlMatchers.hasXPath("/p/o[text()='changed']")
+        );
+    }
+}


### PR DESCRIPTION
Closes #6148

`apply` took `xml.inner()` and let the function write straight into it, so the caller's document changed under it. It now clones first, and only the returned document carries the change.

Two tests: one that the given `XML` is byte-for-byte the same afterwards, which fails on master, and one that the returned one does carry what the function did, so the copy is not just thrown away.

Checked the users of this shift as well: `StHex` in the parser and `StUnhex` in the printer both still pass, 1616 tests in eo-parser and 319 in eo-printer.
