### PR TITLE
#6147: refuse a meta directive that has no name

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -69,6 +69,12 @@ final class LnMeta implements Line {
                 body.substring(space + 1), this.span, space + 1
             );
         }
+        if (head.isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "meta directive requires a name"
+            );
+        }
         Comments.seal(globals, emit, this.span);
         globals.markMeta();
         globals.clearBlanks();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-without-a-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-without-a-name.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "meta directive requires a name"
+input: |
+  + package foo
+
+  [] > app


### PR DESCRIPTION
Closes #6147

`head` came from `body.substring(1)` or `body.substring(1, space)`, and neither branch minded an empty result. A bare `+`, and any `+ name` with a space right after the plus, parsed with no error and emitted `<head/>`.

The practical case is `+ package foo`, which silently dropped the package and put the object in the default one. It now fails to parse instead.

The test is a typo pack, so it runs through both `checksTypoPacks` and `checksTypoMessages`, and it fails on master.
