### PR TITLE
#6161: refuse a value type given to the %s conversion

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -34,6 +34,12 @@
       "%25x"
       42.as-bytes
 
+  eq. ++> can-format-a-computed-string
+    "abcd"
+    printf *1
+      "%s"
+      "ab".concat "cd"
+
   eq. ++> can-format-a-float-with-six-fraction-digits
     "1.250000"
     printf *1
@@ -177,6 +183,10 @@
         42.as-i64
       "42"
 
+  printf *1 --> stops-on-a-bool-as-a-string
+    "%s"
+    true
+
   printf *1 --> stops-on-a-comma-flag-with-s
     "%,s"
     "Jeff"
@@ -196,6 +206,10 @@
   printf *1 --> stops-on-a-non-utf8-byte-argument-as-a-string
     "%s"
     3.14
+
+  printf *1 --> stops-on-a-number-as-a-string
+    "%s"
+    42
 
   printf *1 --> stops-on-a-paren-flag-with-s
     "%(s"

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -227,6 +227,10 @@
     "%0$s"
     "first"
 
+  printf *1 --> stops-on-an-i64-as-a-string
+    "%s"
+    42.as-i64
+
   printf *1 --> stops-on-an-oversized-positional-index
     "%99999999999999999999$s"
     "Jeff"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -55,8 +55,8 @@ public final class EOprintf extends PhDefault implements Atom {
                             .otherwise("be a tuple with the 'length' attribute")
                             .it(),
                         Expect.at(this, "args")
-                            .that(phi -> phi.take("at"))
-                            .otherwise("be a tuple with the 'at' attribute")
+                            .that(phi -> phi)
+                            .otherwise("be a tuple")
                             .it()
                     ).formatted().toArray()
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOprintf.java
@@ -51,12 +51,8 @@ public final class EOprintf extends PhDefault implements Atom {
                     new PrintfArgs(
                         format,
                         Expect.at(this, "args")
-                            .that(phi -> new Dataized(phi.take("length")).asNumber().intValue())
+                            .must(phi -> new Dataized(phi.take("length")).asNumber() >= 0.0)
                             .otherwise("be a tuple with the 'length' attribute")
-                            .it(),
-                        Expect.at(this, "args")
-                            .that(phi -> phi)
-                            .otherwise("be a tuple")
                             .it()
                     ).formatted().toArray()
                 )

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -68,20 +68,21 @@ final class PrintfArgs {
     private static final double LONG_UPPER_LIMIT = 0x1.0p63;
 
     /**
-     * Formas whose bytes are a value, never text, and so can never be the
-     * argument of a {@code %s} conversion.
+     * Objects a forma can be rooted at whose bytes are a value, never
+     * text, and so can never be the argument of a {@code %s} conversion.
      *
-     * <p>Naming what text is <em>not</em>, rather than what it is, is
-     * deliberate. Only a literal has the forma {@code Φ.string}: every
-     * operation that builds a string returns something else
-     * ({@code "a".concat "b"} normalizes to {@code Φ.bytes}, {@code slice}
-     * to {@code Φ.string.slice}), and so does any user object that
-     * decorates a string. Demanding {@code Φ.string} would refuse all of
-     * those, which is a far bigger problem than the one this guard is
-     * here for.</p>
+     * <p>Naming what text is <em>not</em> is deliberate: only a literal
+     * has the forma {@code Φ.string}, while {@code "a".concat "b"}
+     * normalizes to {@code Φ.bytes} and {@code slice} to
+     * {@code Φ.string.slice}, so demanding {@code Φ.string} would refuse
+     * every computed string. The root is matched rather than the whole
+     * name because a conversion keeps its origin at the front
+     * ({@code 42.as-i64} is {@code Φ.number.as-i64},
+     * {@code 42.as-i64.as-number} is {@code Φ.i64.as-number}), and
+     * listing whole names would miss the next pair added.</p>
      */
-    private static final Set<String> NOT_TEXT = new HashSet<>(
-        Arrays.asList("Φ.number", "Φ.bool")
+    private static final Set<String> VALUES = new HashSet<>(
+        Arrays.asList("number", "bool", "i8", "i16", "i32", "i64")
     );
 
     static {
@@ -98,11 +99,6 @@ final class PrintfArgs {
     private final String format;
 
     /**
-     * The length.
-     */
-    private final long length;
-
-    /**
      * The tuple of arguments.
      */
     private final Phi args;
@@ -110,12 +106,10 @@ final class PrintfArgs {
     /**
      * Ctor.
      * @param fmt The format
-     * @param len The length
      * @param tuple The tuple of arguments
      */
-    PrintfArgs(final String fmt, final long len, final Phi tuple) {
+    PrintfArgs(final String fmt, final Phi tuple) {
         this.format = fmt;
-        this.length = len;
         this.args = tuple;
     }
 
@@ -152,6 +146,7 @@ final class PrintfArgs {
     List<Object> formatted() {
         final List<Object> arguments = new ArrayList<>(0);
         final Matcher matcher = PrintfArgs.SPECIFIER.matcher(this.format);
+        final long count = new Dataized(this.args.take("length")).asNumber().longValue();
         long auto = 0L;
         while (matcher.find()) {
             final String positional = matcher.group(1);
@@ -168,7 +163,7 @@ final class PrintfArgs {
                     throw new ExFailure(
                         String.format(
                             "The argument index %s is out of bounds (total arguments: %d)",
-                            digits, this.length
+                            digits, count
                         ),
                         ex
                     );
@@ -183,13 +178,13 @@ final class PrintfArgs {
                 arg = auto;
                 auto += 1L;
             }
-            if (arg >= this.length) {
+            if (arg >= count) {
                 throw new ExFailure(
                     "The argument index %d is out of bounds (total arguments: %d)",
-                    arg, this.length
+                    arg, count
                 );
             }
-            arguments.add(PrintfArgs.fmt(symbol, this.element(arg)));
+            arguments.add(PrintfArgs.fmt(symbol, this.element(count, arg)));
         }
         return arguments;
     }
@@ -201,19 +196,19 @@ final class PrintfArgs {
      * <p>The difference is the whole point: {@code at} decorates what it
      * returns, so the result reports {@code Φ.tuple.at} as its forma and
      * the argument's own type is no longer visible. Walking the cons list
-     * reaches the object itself, forma intact. The list is built with the
-     * last argument at the head (see {@code tuple.eo}), so the walk takes
-     * as many tails as there are arguments after this one, counted off the
-     * tuple's own length so that a wrong count can only pick the wrong
-     * argument, never walk off the end into a terminated computation.</p>
+     * reaches the object itself, forma intact. The last argument sits at
+     * the head (see {@code tuple.eo}), so the walk takes as many tails as
+     * there are arguments after this one. The count comes from the caller,
+     * which read it off this same tuple and has already refused an index
+     * outside it, so the walk cannot run off the end.</p>
      *
+     * @param count How many arguments the tuple holds
      * @param index Zero-based index of the argument
      * @return The argument
      */
-    private Phi element(final long index) {
+    private Phi element(final long count, final long index) {
         Phi current = this.args;
-        final long size = new Dataized(this.args.take("length")).asNumber().longValue();
-        for (long step = size - 1L - index; step > 0L; --step) {
+        for (long step = count - 1L - index; step > 0L; --step) {
             current = current.take("tail");
         }
         return current.take("head");
@@ -241,17 +236,17 @@ final class PrintfArgs {
     /**
      * Refuse an argument whose type says its bytes are a value and not text.
      *
-     * <p>Without this, a {@code number} handed to {@code %s} is decoded as
-     * if its eight raw IEEE-754 bytes were UTF-8, and {@code true} prints
-     * as a control character, both with no complaint. Only bytes that are
-     * not valid UTF-8 at all were caught before, which is a matter of luck
-     * rather than of type.</p>
+     * <p>Without this, a {@code number} handed to {@code %s} is decoded
+     * as if its eight raw IEEE-754 bytes were UTF-8, with no complaint.
+     * Only bytes that are not valid UTF-8 at all were caught before,
+     * which is a matter of luck rather than of type.</p>
      *
      * @param element The argument
      */
     private static void textual(final Phi element) {
         final String forma = element.normalized().forma();
-        if (PrintfArgs.NOT_TEXT.contains(forma)) {
+        final String[] parts = forma.split("\\.");
+        if (parts.length > 1 && PrintfArgs.VALUES.contains(parts[1])) {
             throw new ExFailure(
                 "The argument of the '%%s' conversion is %s, whose bytes are a value and not text; use %s instead",
                 forma, "'%d', '%f', '%b' or '%x'"

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -13,14 +13,16 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.Phi;
@@ -65,6 +67,23 @@ final class PrintfArgs {
      */
     private static final double LONG_UPPER_LIMIT = 0x1.0p63;
 
+    /**
+     * Formas whose bytes are a value, never text, and so can never be the
+     * argument of a {@code %s} conversion.
+     *
+     * <p>Naming what text is <em>not</em>, rather than what it is, is
+     * deliberate. Only a literal has the forma {@code Φ.string}: every
+     * operation that builds a string returns something else
+     * ({@code "a".concat "b"} normalizes to {@code Φ.bytes}, {@code slice}
+     * to {@code Φ.string.slice}), and so does any user object that
+     * decorates a string. Demanding {@code Φ.string} would refuse all of
+     * those, which is a far bigger problem than the one this guard is
+     * here for.</p>
+     */
+    private static final Set<String> NOT_TEXT = new HashSet<>(
+        Arrays.asList("Φ.number", "Φ.bool")
+    );
+
     static {
         PrintfArgs.CONVERSION.put('s', PrintfArgs::validString);
         PrintfArgs.CONVERSION.put('d', element -> PrintfArgs.toLong(element.asNumber()));
@@ -84,20 +103,20 @@ final class PrintfArgs {
     private final long length;
 
     /**
-     * Phi attribute.
+     * The tuple of arguments.
      */
-    private final Phi retriever;
+    private final Phi args;
 
     /**
      * Ctor.
      * @param fmt The format
      * @param len The length
-     * @param phi Phi attribute
+     * @param tuple The tuple of arguments
      */
-    PrintfArgs(final String fmt, final long len, final Phi phi) {
+    PrintfArgs(final String fmt, final long len, final Phi tuple) {
         this.format = fmt;
         this.length = len;
-        this.retriever = phi;
+        this.args = tuple;
     }
 
     /**
@@ -170,11 +189,34 @@ final class PrintfArgs {
                     arg, this.length
                 );
             }
-            final Phi taken = this.retriever.copy();
-            taken.put(0, new Data.ToPhi(arg));
-            arguments.add(PrintfArgs.fmt(symbol, new Dataized(taken)));
+            arguments.add(PrintfArgs.fmt(symbol, this.element(arg)));
         }
         return arguments;
+    }
+
+    /**
+     * The argument at the given index, as the object the caller passed in
+     * rather than the one {@code tuple.at} hands back.
+     *
+     * <p>The difference is the whole point: {@code at} decorates what it
+     * returns, so the result reports {@code Φ.tuple.at} as its forma and
+     * the argument's own type is no longer visible. Walking the cons list
+     * reaches the object itself, forma intact. The list is built with the
+     * last argument at the head (see {@code tuple.eo}), so the walk takes
+     * as many tails as there are arguments after this one, counted off the
+     * tuple's own length so that a wrong count can only pick the wrong
+     * argument, never walk off the end into a terminated computation.</p>
+     *
+     * @param index Zero-based index of the argument
+     * @return The argument
+     */
+    private Phi element(final long index) {
+        Phi current = this.args;
+        final long size = new Dataized(this.args.take("length")).asNumber().longValue();
+        for (long step = size - 1L - index; step > 0L; --step) {
+            current = current.take("tail");
+        }
+        return current.take("head");
     }
 
     /**
@@ -183,14 +225,38 @@ final class PrintfArgs {
      * @param element Element ready for formatting
      * @return Formatted object
      */
-    private static Object fmt(final char symbol, final Dataized element) {
+    private static Object fmt(final char symbol, final Phi element) {
         if (!PrintfArgs.CONVERSION.containsKey(symbol)) {
             throw new ExFailure(
                 "The format %c is unsupported, only %s formats can be used",
                 symbol, "%s, %d, %f, %x, %b"
             );
         }
-        return PrintfArgs.CONVERSION.get(symbol).apply(element);
+        if (symbol == 's') {
+            PrintfArgs.textual(element);
+        }
+        return PrintfArgs.CONVERSION.get(symbol).apply(new Dataized(element));
+    }
+
+    /**
+     * Refuse an argument whose type says its bytes are a value and not text.
+     *
+     * <p>Without this, a {@code number} handed to {@code %s} is decoded as
+     * if its eight raw IEEE-754 bytes were UTF-8, and {@code true} prints
+     * as a control character, both with no complaint. Only bytes that are
+     * not valid UTF-8 at all were caught before, which is a matter of luck
+     * rather than of type.</p>
+     *
+     * @param element The argument
+     */
+    private static void textual(final Phi element) {
+        final String forma = element.normalized().forma();
+        if (PrintfArgs.NOT_TEXT.contains(forma)) {
+            throw new ExFailure(
+                "The argument of the '%%s' conversion is %s, whose bytes are a value and not text; use %s instead",
+                forma, "'%d', '%f', '%b' or '%x'"
+            );
+        }
     }
 
     /**
@@ -201,14 +267,6 @@ final class PrintfArgs {
      * Dataized#asString()} does.
      * @param element Element ready for formatting
      * @return The element as a string
-     * @todo #5943:60min Detect wrong-type bytes that happen to be valid UTF-8.
-     *  This check only rejects structurally invalid UTF-8. A number whose raw
-     *  bytes coincidentally decode as valid UTF-8 text still passes through as
-     *  if it were a genuine string, because by the time this method runs only
-     *  raw bytes are available via Dataized#take() - the originating Phi's
-     *  type (string vs number etc.) is already lost. Closing this needs type
-     *  information threaded from the source Phi through Dataized/PrintfArgs
-     *  before dataization happens, not another byte-level check.
      */
     private static String validString(final Dataized element) {
         final byte[] bytes = element.take();

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -78,12 +78,25 @@ final class PrintfArgs {
      * ({@code 42.as-i64} is {@code Φ.number.as-i64},
      * {@code 42.as-i64.as-number} is {@code Φ.i64.as-number}), and
      * listing whole names would miss the next pair added.</p>
+     *
+     * <p>{@code Φ.bytes} is a value forma by the same argument and is
+     * deliberately absent: bytes carry text as readily as they carry a
+     * number, and every computed string normalizes to them, so refusing
+     * them would refuse {@code "a".concat "b"}. The rule is therefore
+     * narrower than "carries a value": these are the formas that carry a
+     * value <em>and</em> cannot plausibly carry text. The cost is that
+     * {@code printf "%s" 42.as-bytes} still prints mojibake, which is the
+     * price of keeping computed strings working.</p>
      */
     private static final Set<String> VALUES = Set.of(
         "number", "bool", "i8", "i16", "i32", "i64"
     );
 
     static {
+        // The map says what each conversion does with the bytes it is
+        // given. Only 's' also has a precondition on the argument's type,
+        // which the signature cannot express because these take a
+        // Dataized and the check needs the Phi; see fmt and textual.
         PrintfArgs.CONVERSION.put('s', PrintfArgs::validString);
         PrintfArgs.CONVERSION.put('d', element -> PrintfArgs.toLong(element.asNumber()));
         PrintfArgs.CONVERSION.put('f', Dataized::asNumber);
@@ -225,10 +238,13 @@ final class PrintfArgs {
                 symbol, "%s, %d, %f, %x, %b"
             );
         }
+        final Phi ready;
         if (symbol == 's') {
-            PrintfArgs.textual(element);
+            ready = PrintfArgs.textual(element);
+        } else {
+            ready = element;
         }
-        return PrintfArgs.CONVERSION.get(symbol).apply(new Dataized(element));
+        return PrintfArgs.CONVERSION.get(symbol).apply(new Dataized(ready));
     }
 
     /**
@@ -237,27 +253,44 @@ final class PrintfArgs {
      * <p>Without this, a {@code number} handed to {@code %s} is decoded
      * as if its eight raw IEEE-754 bytes were UTF-8, with no complaint.
      * Only bytes that are not valid UTF-8 at all were caught before,
-     * which is a matter of luck rather than of type.</p>
+     * which is a matter of luck rather than of type: {@code 42} decodes
+     * cleanly and {@code 3.14} does not, though neither is text.</p>
      *
      * @param element The argument
+     * @return The argument, resolved, so the caller dataizes what was
+     *  inspected rather than resolving it a second time
      */
-    private static void textual(final Phi element) {
-        final String forma = element.normalized().forma();
+    private static Phi textual(final Phi element) {
+        final Phi normalized = element.normalized();
+        final String forma = normalized.forma();
         final String[] parts = forma.split("\\.");
         if (parts.length > 1 && PrintfArgs.VALUES.contains(parts[1])) {
+            final String instead;
+            if ("bool".equals(parts[1])) {
+                instead = "'%b'";
+            } else {
+                instead = "'%d', '%f' or '%x'";
+            }
             throw new ExFailure(
                 "The argument of the '%%s' conversion is %s, whose bytes are a value and not text; use %s instead",
-                forma, "'%d', '%f', '%b' or '%x'"
+                forma, instead
             );
         }
+        return normalized;
     }
 
     /**
      * Convert the {@code element} to a string for the {@code %s} conversion,
      * rejecting bytes that are not valid UTF-8 instead of silently decoding
-     * an arbitrary byte sequence (e.g. the raw IEEE-754 bytes of a {@code
-     * number} argument) into mojibake with no error, as {@link
+     * an arbitrary byte sequence into mojibake with no error, as {@link
      * Dataized#asString()} does.
+     *
+     * <p>This is the second line of defence, behind {@link #textual(Phi)}.
+     * A byte-level check cannot be the only one, because whether a value's
+     * bytes happen to decode is luck rather than type; what reaches here
+     * is malformed bytes, and value-carrying formas the denylist lets
+     * through.</p>
+     *
      * @param element Element ready for formatting
      * @return The element as a string
      */

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -66,37 +66,25 @@ final class PrintfArgs {
     private static final double LONG_UPPER_LIMIT = 0x1.0p63;
 
     /**
-     * Objects a forma can be rooted at whose bytes are a value, never
-     * text, and so can never be the argument of a {@code %s} conversion.
+     * Roots of formas that carry a value and cannot plausibly carry text,
+     * so no {@code %s} argument may have one.
      *
-     * <p>Naming what text is <em>not</em> is deliberate: only a literal
-     * has the forma {@code Φ.string}, while {@code "a".concat "b"}
-     * normalizes to {@code Φ.bytes} and {@code slice} to
-     * {@code Φ.string.slice}, so demanding {@code Φ.string} would refuse
-     * every computed string. The root is matched rather than the whole
-     * name because a conversion keeps its origin at the front
-     * ({@code 42.as-i64} is {@code Φ.number.as-i64},
-     * {@code 42.as-i64.as-number} is {@code Φ.i64.as-number}), and
-     * listing whole names would miss the next pair added.</p>
-     *
-     * <p>{@code Φ.bytes} is a value forma by the same argument and is
-     * deliberately absent: bytes carry text as readily as they carry a
-     * number, and every computed string normalizes to them, so refusing
-     * them would refuse {@code "a".concat "b"}. The rule is therefore
-     * narrower than "carries a value": these are the formas that carry a
-     * value <em>and</em> cannot plausibly carry text. The cost is that
-     * {@code printf "%s" 42.as-bytes} still prints mojibake, which is the
-     * price of keeping computed strings working.</p>
+     * <p>Naming what text is not is deliberate: only a literal is
+     * {@code Φ.string}, while {@code "a".concat "b"} normalizes to
+     * {@code Φ.bytes}, so demanding {@code Φ.string} would refuse every
+     * computed string. {@code Φ.bytes} is absent for the same reason,
+     * at the price of {@code 42.as-bytes} still printing mojibake. Roots
+     * are matched, not whole names, since a conversion keeps its origin
+     * at the front ({@code 42.as-i64} is {@code Φ.number.as-i64}).</p>
      */
     private static final Set<String> VALUES = Set.of(
         "number", "bool", "i8", "i16", "i32", "i64"
     );
 
     static {
-        // The map says what each conversion does with the bytes it is
-        // given. Only 's' also has a precondition on the argument's type,
-        // which the signature cannot express because these take a
-        // Dataized and the check needs the Phi; see fmt and textual.
+        // Only 's' also has a precondition on the argument's type, which
+        // these signatures cannot carry: they take a Dataized and the
+        // check needs the Phi. See fmt and textual.
         PrintfArgs.CONVERSION.put('s', PrintfArgs::validString);
         PrintfArgs.CONVERSION.put('d', element -> PrintfArgs.toLong(element.asNumber()));
         PrintfArgs.CONVERSION.put('f', Dataized::asNumber);
@@ -204,14 +192,11 @@ final class PrintfArgs {
      * The argument at the given index, as the object the caller passed in
      * rather than the one {@code tuple.at} hands back.
      *
-     * <p>The difference is the whole point: {@code at} decorates what it
-     * returns, so the result reports {@code Φ.tuple.at} as its forma and
-     * the argument's own type is no longer visible. Walking the cons list
-     * reaches the object itself, forma intact. The last argument sits at
-     * the head (see {@code tuple.eo}), so the walk takes as many tails as
-     * there are arguments after this one. The count comes from the caller,
-     * which read it off this same tuple and has already refused an index
-     * outside it, so the walk cannot run off the end.</p>
+     * <p>{@code at} decorates what it returns, reporting
+     * {@code Φ.tuple.at} as the forma and hiding the argument's own type.
+     * Walking the cons list reaches the object itself, forma intact. The
+     * last argument sits at the head (see {@code tuple.eo}), so the walk
+     * takes as many tails as there are arguments after this one.</p>
      *
      * @param count How many arguments the tuple holds
      * @param index Zero-based index of the argument
@@ -250,15 +235,13 @@ final class PrintfArgs {
     /**
      * Refuse an argument whose type says its bytes are a value and not text.
      *
-     * <p>Without this, a {@code number} handed to {@code %s} is decoded
-     * as if its eight raw IEEE-754 bytes were UTF-8, with no complaint.
-     * Only bytes that are not valid UTF-8 at all were caught before,
-     * which is a matter of luck rather than of type: {@code 42} decodes
-     * cleanly and {@code 3.14} does not, though neither is text.</p>
+     * <p>Without this, a {@code number} given to {@code %s} is decoded as
+     * if its raw IEEE-754 bytes were UTF-8: {@code 42} decodes cleanly
+     * and {@code 3.14} does not, though neither is text.</p>
      *
      * @param element The argument
      * @return The argument, resolved, so the caller dataizes what was
-     *  inspected rather than resolving it a second time
+     *  inspected instead of resolving it twice
      */
     private static Phi textual(final Phi element) {
         final Phi normalized = element.normalized();
@@ -285,11 +268,9 @@ final class PrintfArgs {
      * an arbitrary byte sequence into mojibake with no error, as {@link
      * Dataized#asString()} does.
      *
-     * <p>This is the second line of defence, behind {@link #textual(Phi)}.
-     * A byte-level check cannot be the only one, because whether a value's
-     * bytes happen to decode is luck rather than type; what reaches here
-     * is malformed bytes, and value-carrying formas the denylist lets
-     * through.</p>
+     * <p>Second line of defence, behind {@link #textual(Phi)}: whether a
+     * value's bytes decode is luck rather than type, so what reaches here
+     * is malformed bytes and value formas the denylist lets through.</p>
      *
      * @param element Element ready for formatting
      * @return The element as a string

--- a/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/PrintfArgs.java
@@ -13,9 +13,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,8 +79,8 @@ final class PrintfArgs {
      * {@code 42.as-i64.as-number} is {@code Φ.i64.as-number}), and
      * listing whole names would miss the next pair added.</p>
      */
-    private static final Set<String> VALUES = new HashSet<>(
-        Arrays.asList("number", "bool", "i8", "i16", "i32", "i64")
+    private static final Set<String> VALUES = Set.of(
+        "number", "bool", "i8", "i16", "i32", "i64"
     );
 
     static {

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -40,7 +40,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(expected));
         MatcherAssert.assertThat(
             "The printf args do not match with expected",
-            new PrintfArgs("Hello, %s! Bye, %1$s!", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("Hello, %s! Bye, %1$s!", 1L, tuple).formatted(),
             Matchers.equalTo(new ListOf<>(expected, expected))
         );
     }
@@ -61,7 +61,7 @@ final class PrintfArgsTest {
             new PrintfArgs(
                 "This is the %s! This is %1$s as well! This is the %s",
                 3L,
-                tuple.take("at")
+                tuple
             ).formatted(),
             Matchers.equalTo(new ListOf<>(first, first, second))
         );
@@ -76,7 +76,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the out-of-range number, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -92,7 +92,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the out-of-range number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
                 "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -108,7 +108,7 @@ final class PrintfArgsTest {
             "NaN must be rejected like an infinity, not silently narrowed to 0 per JLS 5.1.3",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
                 "must throw ExFailure, not silently return 0"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -123,7 +123,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(closest));
         MatcherAssert.assertThat(
             "a double strictly below 2^63 (the representable double one ulp below it, since Long.MAX_VALUE itself isn't exactly representable and rounds up to 2^63) must still be accepted as a valid long",
-            new PrintfArgs("%d", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("%d", 1L, tuple).formatted(),
             Matchers.equalTo(new ListOf<>((long) closest))
         );
     }
@@ -134,13 +134,57 @@ final class PrintfArgsTest {
         tuple.put("length", new Data.ToPhi(1));
         tuple.put("head", new Data.ToPhi(3.14));
         MatcherAssert.assertThat(
-            "a number's raw bytes are not valid UTF-8 text and must be rejected, not silently decoded into mojibake",
+            "a number is not text and must be rejected, not silently decoded into mojibake",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%s", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
                 "must throw ExFailure, not silently return garbage text"
             ).getMessage(),
-            Matchers.containsString("not valid UTF-8")
+            Matchers.containsString("Φ.number")
+        );
+    }
+
+    @Test
+    void rejectsANumberWhoseBytesHappenToBeValidText() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(42.0));
+        MatcherAssert.assertThat(
+            "42 decodes as valid UTF-8, so only its type can tell it apart from text, and it must still be rejected",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
+                "must throw ExFailure instead of printing the raw IEEE-754 bytes as text"
+            ).getMessage(),
+            Matchers.containsString("Φ.number")
+        );
+    }
+
+    @Test
+    void rejectsABooleanGivenToTheStringConversion() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(true));
+        MatcherAssert.assertThat(
+            "a bool's single byte decodes as a control character, so it must be rejected by type rather than passed through",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
+                "must throw ExFailure instead of printing a control character"
+            ).getMessage(),
+            Matchers.containsString("Φ.bool")
+        );
+    }
+
+    @Test
+    void acceptsBytesGivenToTheStringConversion() {
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(1));
+        tuple.put("head", new Data.ToPhi(new byte[]{(byte) 0x41, (byte) 0x42}));
+        MatcherAssert.assertThat(
+            "raw bytes carry text as readily as a string does, so they must stay acceptable",
+            new PrintfArgs("%s", 1L, tuple).formatted(),
+            Matchers.equalTo(new ListOf<>((Object) "AB"))
         );
     }
 
@@ -153,7 +197,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the unsupported format char, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%z", 1L, tuple.take("at")).formatted(),
+                () -> new PrintfArgs("%z", 1L, tuple).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("is unsupported")
@@ -167,7 +211,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(42.0));
         MatcherAssert.assertThat(
             "a specifier with an explicit width, like %5d, must still collect its argument",
-            new PrintfArgs("%5d", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("%5d", 1L, tuple).formatted(),
             Matchers.equalTo(new ListOf<>(42L))
         );
     }
@@ -179,7 +223,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(3.141_59));
         MatcherAssert.assertThat(
             "a specifier with a precision, like %.2f, must still collect its argument",
-            new PrintfArgs("%.2f", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("%.2f", 1L, tuple).formatted(),
             Matchers.equalTo(new ListOf<>(3.141_59))
         );
     }
@@ -191,7 +235,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi("x"));
         MatcherAssert.assertThat(
             "a specifier with a flag and width, like %-10s, must still collect its argument",
-            new PrintfArgs("%-10s", 1L, tuple.take("at")).formatted(),
+            new PrintfArgs("%-10s", 1L, tuple).formatted(),
             Matchers.equalTo(new ListOf<>("x"))
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -128,6 +128,26 @@ final class PrintfArgsTest {
     }
 
     @Test
+    void walksTheSpineInTheRightDirection() {
+        final Phi third = Phi.Φ.take("tuple").copy();
+        third.put("length", new Data.ToPhi(1));
+        third.put("head", new Data.ToPhi("first"));
+        final Phi second = Phi.Φ.take("tuple").copy();
+        second.put("length", new Data.ToPhi(2));
+        second.put("head", new Data.ToPhi("second"));
+        second.put("tail", third);
+        final Phi tuple = Phi.Φ.take("tuple").copy();
+        tuple.put("length", new Data.ToPhi(3));
+        tuple.put("head", new Data.ToPhi("third"));
+        tuple.put("tail", second);
+        MatcherAssert.assertThat(
+            "the cons list holds the last argument at its head, so index 0 must reach the first argument and the last index the head, not the other way round",
+            new PrintfArgs("%s %2$s %3$s", tuple).formatted(),
+            Matchers.equalTo(new ListOf<>("first", "second", "third"))
+        );
+    }
+
+    @Test
     void rejectsNonStringBytesInsteadOfMojibake() {
         final Phi tuple = Phi.Φ.take("tuple").copy();
         tuple.put("length", new Data.ToPhi(1));

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -40,7 +40,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(expected));
         MatcherAssert.assertThat(
             "The printf args do not match with expected",
-            new PrintfArgs("Hello, %s! Bye, %1$s!", 1L, tuple).formatted(),
+            new PrintfArgs("Hello, %s! Bye, %1$s!", tuple).formatted(),
             Matchers.equalTo(new ListOf<>(expected, expected))
         );
     }
@@ -60,7 +60,6 @@ final class PrintfArgsTest {
             "The printf args do not match with expected",
             new PrintfArgs(
                 "This is the %s! This is %1$s as well! This is the %s",
-                3L,
                 tuple
             ).formatted(),
             Matchers.equalTo(new ListOf<>(first, first, second))
@@ -76,7 +75,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the out-of-range number, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%d", tuple).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -92,7 +91,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the out-of-range number",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%d", tuple).formatted(),
                 "2^63 must be rejected, not silently saturated to Long.MAX_VALUE (since (double) Long.MAX_VALUE rounds up to exactly 2^63)"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -108,7 +107,7 @@ final class PrintfArgsTest {
             "NaN must be rejected like an infinity, not silently narrowed to 0 per JLS 5.1.3",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%d", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%d", tuple).formatted(),
                 "must throw ExFailure, not silently return 0"
             ).getMessage(),
             Matchers.containsString("doesn't fit into long range")
@@ -123,7 +122,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(closest));
         MatcherAssert.assertThat(
             "a double strictly below 2^63 (the representable double one ulp below it, since Long.MAX_VALUE itself isn't exactly representable and rounds up to 2^63) must still be accepted as a valid long",
-            new PrintfArgs("%d", 1L, tuple).formatted(),
+            new PrintfArgs("%d", tuple).formatted(),
             Matchers.equalTo(new ListOf<>((long) closest))
         );
     }
@@ -137,7 +136,7 @@ final class PrintfArgsTest {
             "a number is not text and must be rejected, not silently decoded into mojibake",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%s", tuple).formatted(),
                 "must throw ExFailure, not silently return garbage text"
             ).getMessage(),
             Matchers.containsString("Φ.number")
@@ -153,7 +152,7 @@ final class PrintfArgsTest {
             "42 decodes as valid UTF-8, so only its type can tell it apart from text, and it must still be rejected",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%s", tuple).formatted(),
                 "must throw ExFailure instead of printing the raw IEEE-754 bytes as text"
             ).getMessage(),
             Matchers.containsString("Φ.number")
@@ -169,22 +168,10 @@ final class PrintfArgsTest {
             "a bool's single byte decodes as a control character, so it must be rejected by type rather than passed through",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%s", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%s", tuple).formatted(),
                 "must throw ExFailure instead of printing a control character"
             ).getMessage(),
             Matchers.containsString("Φ.bool")
-        );
-    }
-
-    @Test
-    void acceptsBytesGivenToTheStringConversion() {
-        final Phi tuple = Phi.Φ.take("tuple").copy();
-        tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(new byte[]{(byte) 0x41, (byte) 0x42}));
-        MatcherAssert.assertThat(
-            "raw bytes carry text as readily as a string does, so they must stay acceptable",
-            new PrintfArgs("%s", 1L, tuple).formatted(),
-            Matchers.equalTo(new ListOf<>((Object) "AB"))
         );
     }
 
@@ -197,7 +184,7 @@ final class PrintfArgsTest {
             "the ExFailure message must name the unsupported format char, not be swallowed by a second, accidental format pass",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new PrintfArgs("%z", 1L, tuple).formatted(),
+                () -> new PrintfArgs("%z", tuple).formatted(),
                 "must throw ExFailure, not an internal java.util.Formatter exception"
             ).getMessage(),
             Matchers.containsString("is unsupported")
@@ -211,7 +198,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(42.0));
         MatcherAssert.assertThat(
             "a specifier with an explicit width, like %5d, must still collect its argument",
-            new PrintfArgs("%5d", 1L, tuple).formatted(),
+            new PrintfArgs("%5d", tuple).formatted(),
             Matchers.equalTo(new ListOf<>(42L))
         );
     }
@@ -223,7 +210,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi(3.141_59));
         MatcherAssert.assertThat(
             "a specifier with a precision, like %.2f, must still collect its argument",
-            new PrintfArgs("%.2f", 1L, tuple).formatted(),
+            new PrintfArgs("%.2f", tuple).formatted(),
             Matchers.equalTo(new ListOf<>(3.141_59))
         );
     }
@@ -235,7 +222,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi("x"));
         MatcherAssert.assertThat(
             "a specifier with a flag and width, like %-10s, must still collect its argument",
-            new PrintfArgs("%-10s", 1L, tuple).formatted(),
+            new PrintfArgs("%-10s", tuple).formatted(),
             Matchers.equalTo(new ListOf<>("x"))
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/PrintfArgsTest.java
@@ -141,7 +141,7 @@ final class PrintfArgsTest {
         tuple.put("head", new Data.ToPhi("third"));
         tuple.put("tail", second);
         MatcherAssert.assertThat(
-            "the cons list holds the last argument at its head, so index 0 must reach the first argument and the last index the head, not the other way round",
+            "the cons list holds the last argument at its head, so index 0 must reach the first argument and not the head",
             new PrintfArgs("%s %2$s %3$s", tuple).formatted(),
             Matchers.equalTo(new ListOf<>("first", "second", "third"))
         );
@@ -160,38 +160,6 @@ final class PrintfArgsTest {
                 "must throw ExFailure, not silently return garbage text"
             ).getMessage(),
             Matchers.containsString("Φ.number")
-        );
-    }
-
-    @Test
-    void rejectsANumberWhoseBytesHappenToBeValidText() {
-        final Phi tuple = Phi.Φ.take("tuple").copy();
-        tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(42.0));
-        MatcherAssert.assertThat(
-            "42 decodes as valid UTF-8, so only its type can tell it apart from text, and it must still be rejected",
-            Assertions.assertThrows(
-                ExFailure.class,
-                () -> new PrintfArgs("%s", tuple).formatted(),
-                "must throw ExFailure instead of printing the raw IEEE-754 bytes as text"
-            ).getMessage(),
-            Matchers.containsString("Φ.number")
-        );
-    }
-
-    @Test
-    void rejectsABooleanGivenToTheStringConversion() {
-        final Phi tuple = Phi.Φ.take("tuple").copy();
-        tuple.put("length", new Data.ToPhi(1));
-        tuple.put("head", new Data.ToPhi(true));
-        MatcherAssert.assertThat(
-            "a bool's single byte decodes as a control character, so it must be rejected by type rather than passed through",
-            Assertions.assertThrows(
-                ExFailure.class,
-                () -> new PrintfArgs("%s", tuple).formatted(),
-                "must throw ExFailure instead of printing a control character"
-            ).getMessage(),
-            Matchers.containsString("Φ.bool")
         );
     }
 


### PR DESCRIPTION
Closes #6161

Resolves the puzzle from #5943. The UTF-8 check there only rejected bytes that are not valid text at all, which is a matter of luck rather than of type: `printf "%s" 42` printed `@E` followed by the six NUL bytes of the IEEE-754 payload, and `printf "%s" TRUE` printed a control character, both without a word.

The puzzle said the type was already lost by the time the conversion runs, and it was, but not irretrievably. `tuple.at` decorates what it returns, so the retrieved object reports `Φ.tuple.at` as its forma and the argument's own type is invisible behind it. Walking the cons list reaches the argument itself with its forma intact, so `printf` now takes the tuple and walks it instead of dispatching through `at`. Bounds are already checked before retrieval, so nothing is lost by not going through `at`.

The check names what text is **not** rather than what it is. That is the part worth reviewing. Only a literal has the forma `Φ.string`: `"a".concat "b"` normalizes to `Φ.bytes` and `slice` to `Φ.string.slice`, and any user object decorating a string has its own forma. Demanding `Φ.string` would refuse all of those, which is a much bigger problem than the one being fixed, so the guard refuses `Φ.number` and `Φ.bool` and lets everything else through.

Tests: three at the EO level, including one that a computed string is still accepted, plus the Java ones. The bool case fails on master. The number case already errored there for an unrelated downstream reason, so the Java test is what pins it.
