### PR TITLE
Align eo-maven-plugin test fixtures with objectionary/home 0.62.0 layout

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjProbeTest.java
@@ -30,7 +30,7 @@ final class MjProbeTest {
             new ResourceOf("org/eolang/maven/commits/tags.txt"),
             temp.resolve("tags.txt")
         ).value();
-        final String expected = "7";
+        final String expected = "6";
         MatcherAssert.assertThat(
             String.format(
                 "Number of objects that we should find during the probing phase should be equal %s",
@@ -53,7 +53,7 @@ final class MjProbeTest {
      */
     @Test
     void findsProbesInOyRemote(@Mktmp final Path temp) throws IOException {
-        final String tag = "0.23.15";
+        final String tag = "0.62.0";
         final String expected = "3";
         final String found = new FakeMaven(temp)
             .with("tag", tag).with(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPullTest.java
@@ -51,7 +51,7 @@ final class MjPullTest {
         new FakeMaven(temp).withProgram(
             String.format("+package foo.x%n"),
             "[] > main",
-            "  Q.io.stdout > @",
+            "  Q.stdout > @",
             "    \"I am 18 years old\""
             )
             .with("objectionary", new ScalarOf<>(() -> new OyRemote(new ChRemote("master"))))
@@ -126,7 +126,7 @@ final class MjPullTest {
             .with("offline", true)
             .execute(new FakeMaven.Pull())
             .result();
-        final String stdout = "org/eolang/io/stdout.eo";
+        final String stdout = "org/eolang/stdout.eo";
         final String string = "org/eolang/string.eo";
         MatcherAssert.assertThat(
             String.format(
@@ -240,7 +240,7 @@ final class MjPullTest {
      * Returns the stdout path.
      */
     private String stdout() {
-        return "io.stdout";
+        return "stdout";
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -77,7 +77,7 @@ final class ObjectsIndexTest {
     void downloadsAndChecksFromRealSource() throws Exception {
         MatcherAssert.assertThat(
             "The index must contain the default value",
-            new ObjectsIndex().contains("io.stdout"),
+            new ObjectsIndex().contains("stdout"),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
@@ -51,7 +51,7 @@ final class OyIndexedTest {
             "OyIndexed with fake index must contain stdout object, but it doesn't",
             new OyIndexed(
                 new Objectionary.Fake(),
-                new ObjectsIndex(() -> Collections.singleton("io.stdout"))
+                new ObjectsIndex(() -> Collections.singleton("stdout"))
             ).contains(this.stdout()),
             Matchers.is(true)
         );
@@ -117,6 +117,6 @@ final class OyIndexedTest {
      * Returns the stdout path.
      */
     private String stdout() {
-        return "io.stdout";
+        return "stdout";
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -80,7 +80,7 @@ final class OyRemoteTest {
     void checksPresenceOfProgram() throws IOException {
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the program in Objectionary",
-            new OyRemote(new ChRemote("master")).contains("io.stdout"),
+            new OyRemote(new ChRemote("master")).contains("stdout"),
             Matchers.is(true)
         );
     }
@@ -90,7 +90,7 @@ final class OyRemoteTest {
     void checksPresenceOfDirectory() throws IOException {
         MatcherAssert.assertThat(
             "OyRemote positively checks the presence of the directory in Objectionary",
-            new OyRemote(new ChRemote("master")).contains("ms"),
+            new OyRemote(new ChRemote("master")).isDirectory("number"),
             Matchers.is(true)
         );
     }
@@ -98,7 +98,7 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfProgramWithNarrowHash() throws IOException {
-        final String stdout = "io.stdout";
+        final String stdout = "stdout";
         MatcherAssert.assertThat(
             String.format(
                 "OyRemote with narrow hash should have contained program %s, but it didn't",
@@ -146,17 +146,17 @@ final class OyRemoteTest {
     @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfDirectoryWithNarrowHash() throws IOException {
-        final String stdout = "ss";
+        final String directory = "tuple";
         MatcherAssert.assertThat(
             String.format(
                 "OyRemote with narrow hash should have contained directory %s, but it didn't",
-                stdout
+                directory
             ),
             new OyRemote(
                 new ChNarrow(
                     new ChRemote("master")
                 )
-            ).contains(stdout),
+            ).isDirectory(directory),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -35,7 +35,7 @@ final class ProbingTest {
         MatcherAssert.assertThat(
             "Probe should have found and registered objects from the objectionary",
             tojos.size(),
-            Matchers.equalTo(8)
+            Matchers.equalTo(7)
         );
     }
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
@@ -1,4 +1,4 @@
-+alias stdout org.eolang.io.stdout
++alias stdout org.eolang.stdout
 +home https://www.eolang.org
 +package foo.x
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com


### PR DESCRIPTION
Eight network-facing tests in `eo-maven-plugin` fail on every CI run since yesterday (see [run 30587184764](https://github.com/objectionary/eo/actions/runs/30587184764/job/91021235896)): the `objectionary/home` repository was updated to the EO 0.62.0 layout in [objectionary/home@52bb0e9](https://github.com/objectionary/home/commit/52bb0e9dfc), which moved `objects/io/stdout.eo` to `objects/stdout.eo`, replaced the `ms`/`ss` packages with `number`/`tuple`, regenerated `objectionary.lst`, and pruned `tags.txt` down to tags 0.40.5 and newer. The tests kept probing the old names, so this isn't a transient outage — the failures are permanent until the fixtures move too.

This updates the object names in `OyRemoteTest`, `OyIndexedTest`, `ObjectsIndexTest`, `MjPullTest`, and the shared `hello-world.eo` fixture (whose alias now points at `org.eolang.stdout`, shrinking its probe count by one in `MjProbeTest` and `ProbingTest`), and replaces the pruned `0.23.15` tag with `0.62.0`. The two directory-presence tests now call `isDirectory()` instead of `contains()`, because in the new layout every package directory has a same-named `.eo` file, so `contains()` would succeed on the program URL and never reach the directory branch it was meant to cover.

The whole `eo-maven-plugin` suite passes locally (512 tests, 0 failures). This fixes the immediate breakage behind #6168; the broader concern raised there — that remote-Objectionary tests can fail unrelated PRs — is left for a separate discussion.