### PR TITLE
Fix #6174: probe FQNs from void `@args` annotations

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
@@ -61,6 +61,7 @@
   <xsl:template match="/object[not(metas)]">
     <xsl:variable name="candidates" as="element()*">
       <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
+      <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
     </xsl:variable>
     <xsl:variable name="probes" select="distinct-values($candidates/text())[not(eo:contains-any-of(., ('ξ', 'ρ', 'φ'))) and not(.='Φ') and not(.='Φ̇')]"/>
     <xsl:copy>
@@ -78,6 +79,7 @@
   <xsl:template match="/object/metas">
     <xsl:variable name="candidates" as="element()*">
       <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
+      <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
     </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
@@ -85,6 +87,21 @@
         <xsl:copy-of select="eo:meta(.)"/>
       </xsl:for-each>
     </xsl:copy>
+  </xsl:template>
+  <!-- Callback arg-types annotation on a void attribute -->
+  <!-- The `@args` value is a single-space separated list of type atoms; -->
+  <!-- homed formas start with `Φ`, generic type variables (A-F) do not -->
+  <!-- and must be skipped, since they are not real objects to probe. -->
+  <xsl:template match="o" mode="args" as="element()*">
+    <xsl:for-each select="tokenize(@args, ' ')[starts-with(., 'Φ')]">
+      <xsl:variable name="parts" select="tokenize(., '\.')"/>
+      <xsl:for-each select="$parts">
+        <xsl:variable name="pos" select="position()"/>
+        <a>
+          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
+        </a>
+      </xsl:for-each>
+    </xsl:for-each>
   </xsl:template>
   <!-- Composite base -->
   <xsl:template match="o[not(starts-with(@base, '.'))]" mode="create" as="element()*">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-args.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-args.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A callback arg-types annotation on a void attribute (`/{Q.chunk}`) must be
+# probed too, otherwise objects referenced only there (like `chunk` in
+# `malloc.eo`) are never pulled and transpiled. See #6174.
+probes:
+  - 'chunk'
+eo: |
+  +package custom
+  +version 0.0.0
+
+  [] > foo /Q.bytes
+    ? > size /Q.number
+    ? > scope /{Q.chunk}


### PR DESCRIPTION
Closes #6174.

## Problem

`EOmalloc$EOof.java` resolves `Φ.chunk` at runtime, but the only mention of `chunk` in `malloc.eo` is the callback arg-types annotation on the void `scope`:

```
? > scope /{Q.chunk}
```

The parser emits this as an `@args` attribute on the void object. `add-probes.xsl` never looks at `@args`: its candidate set is `//o[not(eo:abstract(.)) and not(eo:void(.))]` (void objects are excluded outright) and it only tokenizes `@base`. So no probe was emitted for `Φ.chunk`, `chunk` never entered `eo-foreign.json`, `objects/chunk.eo` was never pulled, and `org.eolang.EOchunk` was never transpiled. Any program touching `malloc` then failed with:

```
Couldn't find object 'Φ.chunk' ... Caused by: java.lang.ClassNotFoundException: org.eolang.EOchunk
```

## Fix

Extend the candidate collection in `add-probes.xsl` to also walk void objects that carry an `@args` annotation (`//o[eo:void(.) and @args]`). The new `args` mode tokenizes each homed forma in the space-separated `@args` list the same way composite bases are tokenized, so `Φ.chunk` becomes a probe. Generic type variables (`A`–`F`), which are not real objects, are skipped by keeping only `Φ`-prefixed members; bare `Φ` is dropped by the existing downstream filter.

This is the root-cause fix suggested in the issue, so no throwaway `Q.chunk` reference in `malloc.eo` is needed.

## Tests

Added `probe-packs/add-probes-from-void-args.yaml` covering an atom whose void carries `/{Q.chunk}`, asserting `chunk` is now probed. `ProbesTest` passes (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7prTPGBmFdnj31jZzhxbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7prTPGBmFdnj31jZzhxbb)_