### PR TITLE
test(eo-runtime): #6169 assert os families are mutually exclusive

### DIFF
--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -36,3 +36,10 @@
   or. ++> can-check-the-os-family
     os.is-windows.or os.is-macos
     os.is-linux
+
+  not. ++> cannot-belong-to-two-os-families-at-once
+    or.
+      or.
+        os.is-linux.and os.is-macos
+        os.is-linux.and os.is-windows
+      os.is-macos.and os.is-windows


### PR DESCRIPTION
Closes #6169.

## What #6169 reports

Dataizing the `os` platform predicates (`is-linux`, `is-macos`, `is-windows`) terminates, because the OS `name` is bound both as the `φ` of `os` and as the argument of `match`, so the same object is asked to attach `ρ` twice. The reproduction used **eo-maven-plugin 0.62.0 and home tag 0.62.0**.

## What I found on `master`

The termination does **not** reproduce against the current runtime:

- `EOosTest.can_check_the_os_family` — the `++>` object in `os.eo` that dataizes `os.is-windows.or os.is-macos` together with `os.is-linux` — passes. It is part of the suite, so a real termination here would already be turning `master` CI red.
- `Q.stdout "Hello, world!\n"` compiles, links and prints `Hello, world!`; `console` and repeated `stdout` writes dataize cleanly.
- Each predicate dataizes to a boolean, and asking one `os` for all three in a row does not terminate.

The reason is `AtWithRho`: when an attribute's value has no `ρ` yet, it is **copied** before `ρ` is attached (`AtWithRho#get`), so each reference to the shared `name` gets its own copy and no object receives `ρ` twice on the current runtime. The reported break was in the 0.62.0 runtime that shipped with that plugin, not in the objects on `master`.

## On the suggested `$.name` change

Rewriting the bare `name` to `$.name` is a no-op: both resolve to `ξ.name` during parsing, so `eo:format` canonicalises `$.name` straight back to `name` (a build with `$.name` fails the format check for exactly this reason). It neither changes the compiled graph nor fixes anything, so `os.eo`'s predicates are left untouched.

## This PR

The predicates are already covered at the EO level by `can-check-the-os-family`, which asserts that **at least one** family holds. This adds the complementary `++>` regression that **no two** hold at once:

```
not. ++> cannot-belong-to-two-os-families-at-once
  or.
    or.
      os.is-linux.and os.is-macos
      os.is-linux.and os.is-windows
    os.is-macos.and os.is-windows
```

Together the two objects pin the family down to exactly one, and both dataize every predicate, so the termination path stays covered from both directions. It is platform-independent (exactly one family is true on Linux, macOS and Windows runners).

A Java-level test was not added: `jtcop`'s `RuleEveryTestHasProductionClass` requires each test class to map to a production class, and the predicates are formations rather than atoms (there is no `EOos$EOis_macos`), so the coverage belongs in `os.eo` as a `++>` object.

`os.eo`'s predicates are unchanged. `EOosTest` (both `can_check_the_os_family` and `cannot_belong_to_two_os_families_at_once`) is green, and `eo:format` reports the source canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)