### PR TITLE
Correct the pull request size bylaw to 100 hits of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ A few rules we ask you to follow:
 
 * name your branch after the issue you are working on, e.g. `42`
 * prefix your commit messages with `fix(#42):` followed by a short description
-* keep your pull request small — no more than 200 lines added and deleted
-  combined, so it stays easy to review; split bigger changes into
-  puzzles using [PDD]
+* keep your pull request between 40 and 100 hits of code, counted as
+  lines added plus lines deleted, so it stays easy to review; split
+  bigger changes into puzzles using [PDD]
 * mention the issue your pull request resolves, e.g. `Closes #42`,
   so it links automatically
 * ping @yegor256 in the pull request description so he notices it


### PR DESCRIPTION
The bylaw we added to "How to Contribute" said a pull request should stay
under 200 hits of code. That number is wrong. The bot that scores our work
starts taking points away at 100, and the lower bound of 40 was missing
from the text altogether.

The evidence is a penalty one of our own pull requests collected:
https://github.com/objectionary/eo/pull/6134#issuecomment-5137235107 —
"-4 for too many hits-of-code (141 >= 100)". A contributor following the
README as written would land at 199 and lose points for obeying it.

So the rule now reads 40 to 100 hits of code, counted as lines added plus
lines deleted, with anything bigger split into puzzles.
