### PR TITLE
fix(#6183): remove arbitrary spans capacity

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -71,7 +71,7 @@ final class Eo implements Iterable<Directive> {
             level -> Eo.checkOnClose(level, emit),
             parent -> Eo.beforeChild(parent, emit)
         );
-        final java.util.List<Span> spans = new java.util.ArrayList<>(16);
+        final java.util.List<Span> spans = new java.util.ArrayList<>(0);
         new Source(this.source).forEach(spans::add);
         int idx = 0;
         while (idx < spans.size()) {

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -71,7 +71,7 @@ final class Eo implements Iterable<Directive> {
             level -> Eo.checkOnClose(level, emit),
             parent -> Eo.beforeChild(parent, emit)
         );
-        final java.util.List<Span> spans = new java.util.ArrayList<>();
+        final java.util.List<Span> spans = new java.util.ArrayList<>(10);
         new Source(this.source).forEach(spans::add);
         int idx = 0;
         while (idx < spans.size()) {

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -71,7 +71,7 @@ final class Eo implements Iterable<Directive> {
             level -> Eo.checkOnClose(level, emit),
             parent -> Eo.beforeChild(parent, emit)
         );
-        final java.util.List<Span> spans = new java.util.ArrayList<>(0);
+        final java.util.List<Span> spans = new java.util.ArrayList<>();
         new Source(this.source).forEach(spans::add);
         int idx = 0;
         while (idx < spans.size()) {


### PR DESCRIPTION
Closes #6183.

## Summary
- replace the unexplained `ArrayList` initial capacity `16` with the explicit default capacity `10`
- keep `ArrayList` because the parser relies on indexed `get(idx)` look-ahead

## Root cause
`16` arrived with the initial `Eo.java` implementation without a comment, invariant, or benchmark. Qulice requires every `ArrayList` construction to provide a capacity; `10` matches the JDK's default first-expansion capacity while avoiding a zero-capacity list that must expand immediately.

## Impact
This changes only allocation strategy; parsing behavior and error handling are unchanged.

## Testing
- `mvn -pl eo-parser clean verify -PskipTests -Pqulice --errors --batch-mode` — BUILD SUCCESS (JDK 21)
- no new test was added because internal `ArrayList` capacity is not observable; Qulice directly verifies the required construction form.