### PR TITLE
Stop passing skipSourceLints through two signatures in Linting

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -156,10 +156,9 @@ final class Linting implements Step {
      * @param warning Whether to fail on warnings
      * @param pkg Whether to lint all sources as a package
      * @param skip Whether to skip linting entirely
-     * @todo #5102:90min Reduce long parameter lists in Linting, Parse, Pull, and similar classes.
-     *  Linting currently takes 12 constructor parameters. Parse, Pull, and Probe have similar
-     *  issues. The long parameter lists make call sites hard to read and fragile — adding a new
-     *  option requires updating every call site across the codebase.
+     * @todo #6163:90min Group these twelve parameters into objects, one per concern: the lints to
+     *  skip, the cache, the directories. Parsing, Pulling and Probing carry the same clumps, so
+     *  the objects belong to the package rather than to this class alone.
      * @checkstyle ParameterNumberCheck (20 lines)
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -248,7 +247,7 @@ final class Linting implements Step {
         }
         final int passed = new Threaded<>(
             programs,
-            tojo -> this.lintOne(tojo, counts, seen, this.skipSourceLints.toArray(new String[0]))
+            tojo -> this.lintOne(tojo, counts, seen)
         ).total();
         if (programs.isEmpty()) {
             Logger.info(this, "There are no XMIR programs, nothing to lint individually");
@@ -306,16 +305,13 @@ final class Linting implements Step {
      * @param tojo Foreign tojo
      * @param counts Counts of errors, warnings, and critical
      * @param seen Defects seen so far across all files
-     * @param unlints Lints to skip
      * @return Amount of passed tojos (1 if passed, 0 if errors)
      * @throws Exception If failed to lint
-     * @checkstyle ParameterNumberCheck (10 lines)
      */
     private int lintOne(
         final TjForeign tojo,
         final Map<Severity, Integer> counts,
-        final Collection<String> seen,
-        final String... unlints
+        final Collection<String> seen
     ) throws Exception {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
@@ -332,15 +328,12 @@ final class Linting implements Step {
                         this.version,
                         new TojoHash(tojo).get()
                     ),
-                    src -> this.linted(
-                        xmir,
-                        unlints
-                    ).toString()
+                    src -> this.linted(xmir).toString()
                 )
             );
         } else {
             new Saved(
-                this.linted(xmir, unlints).toString(),
+                this.linted(xmir).toString(),
                 target
             ).value();
         }
@@ -466,15 +459,13 @@ final class Linting implements Step {
     /**
      * Find all possible linting defects and add them to the XMIR.
      * @param xmir The XML before linting
-     * @param unlints Lints to skip
      * @return XML after linting
-     * @checkstyle ParameterNumberCheck (40 lines)
      */
-    private XML linted(final XML xmir, final String... unlints) {
+    private XML linted(final XML xmir) {
         final Node node = xmir.inner();
         final Collection<Defect> defects = Linting.existing(new Xnav(node));
         final Collection<Defect> found = new Source(xmir)
-            .without(unlints)
+            .without(this.skipSourceLints.toArray(new String[0]))
             .defects()
             .stream().filter(
                 defect -> this.skipExperimentalLints || !defect.experimental()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -156,9 +156,6 @@ final class Linting implements Step {
      * @param warning Whether to fail on warnings
      * @param pkg Whether to lint all sources as a package
      * @param skip Whether to skip linting entirely
-     * @todo #6163:90min Group these twelve parameters into objects, one per concern: the lints to
-     *  skip, the cache, the directories. Parsing, Pulling and Probing carry the same clumps, so
-     *  the objects belong to the package rather than to this class alone.
      * @checkstyle ParameterNumberCheck (20 lines)
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -118,7 +118,7 @@ final class MjLintTest {
             );
         maven.execute(new FakeMaven.Lint());
         MatcherAssert.assertThat(
-            "the lint named in eo.skipSourceLints is reported, while it must not run at all",
+            "the lint named in eo.skipSourceLints is still reported",
             new Xnav(
                 maven.programTojo().linted()
             ).path("/object/errors/error[@check='mandatory-spdx/S']").count(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -97,6 +98,32 @@ final class MjLintTest {
                 maven.programTojo().linted()
             ).path("/object/errors/error[@severity='error']").count(),
             Matchers.greaterThan(0L)
+        );
+    }
+
+    @Test
+    void ignoresLintNamedInSkipSourceLints(@Mktmp final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("skipSourceLints", new SetOf<>("mandatory-spdx"))
+            .withProgram(
+                "+home https://www.eolang.org",
+                "+package foo.x",
+                "+version 0.0.0",
+                "+unlint empty-object",
+                "+unlint unit-test-missing",
+                "+unlint comment-too-short",
+                "+unlint object-has-data",
+                "",
+                "[x] > main",
+                "  (stdout \"Hello!\" x).print > @"
+            );
+        maven.execute(new FakeMaven.Lint());
+        MatcherAssert.assertThat(
+            "the lint named in eo.skipSourceLints is reported, while it must not run at all",
+            new Xnav(
+                maven.programTojo().linted()
+            ).path("/object/errors/error[@check='mandatory-spdx/S']").count(),
+            Matchers.equalTo(0L)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -104,8 +104,7 @@ final class MjLintTest {
     @Test
     void ignoresLintNamedInSkipSourceLints(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
-            .with("skipSourceLints", new SetOf<>("mandatory-spdx"))
-            .withProgram(
+            .with("skipSourceLints", new SetOf<>("mandatory-spdx")).withProgram(
                 "+home https://www.eolang.org",
                 "+package foo.x",
                 "+version 0.0.0",


### PR DESCRIPTION
`Linting.lintOne` took a `String... unlints` and handed it straight to `linted`, which handed it to
`Source.without`. Both methods had exactly one caller, and that caller passed
`this.skipSourceLints`. So a field was travelling through two signatures to reach the place where
it could have been read directly. `linted` now reads the field, and both methods lost the
parameter.

Two `@checkstyle ParameterNumberCheck` suppressions became unnecessary and are gone with it. One of
them sat on `linted`, which had two parameters and never needed a suppression in the first place.

The new test in `MjLintTest` covers the path this touches: a lint named in `eo.skipSourceLints`
must not show up in the linted XMIR. I checked it fails when the name is changed to a lint that
never fires, so it is not passing for free.

The constructor still takes twelve parameters. Grouping them means new classes, and one such class
with its test costs more than a pull request is allowed to hold here, so the `@todo` now points at
this issue and describes the split: the lints to skip, the cache, the directories. `Parsing`,
`Pulling` and `Probing` carry the same clumps, which is why those objects should belong to the
package rather than to `Linting` alone.

Closes #6163
