### PR TITLE
#6096: compile each source glob once and report a bad one as configuration

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
@@ -8,10 +8,12 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.list.ListEnvelope;
@@ -52,11 +54,12 @@ final class Walk extends ListEnvelope<Path> {
      */
     @SuppressWarnings("PMD.LooseCoupling")
     Walk includes(final Collection<String> globs) {
+        final Collection<PathMatcher> matchers = Walk.compiled(globs);
         return new Walk(
             this.home,
             this.stream().filter(
-                file -> globs.stream().anyMatch(
-                    glob -> this.matches(glob, file)
+                file -> matchers.stream().anyMatch(
+                    matcher -> matcher.matches(this.relative(file))
                 )
                 )
                 .collect(Collectors.toList())
@@ -70,11 +73,12 @@ final class Walk extends ListEnvelope<Path> {
      */
     @SuppressWarnings("PMD.LooseCoupling")
     Walk excludes(final Collection<String> globs) {
+        final Collection<PathMatcher> matchers = Walk.compiled(globs);
         return new Walk(
             this.home,
             this.stream().filter(
-                file -> globs.stream().noneMatch(
-                    glob -> this.matches(glob, file)
+                file -> matchers.stream().noneMatch(
+                    matcher -> matcher.matches(this.relative(file))
                 )
                 )
                 .collect(Collectors.toList())
@@ -115,17 +119,50 @@ final class Walk extends ListEnvelope<Path> {
     }
 
     /**
-     * Create glob matcher from text.
-     * @param text The pattern, e.g. "**&#47;*.java"
-     * @param file The file to match
+     * Compile every glob once, up front.
+     *
+     * <p>Compiling here rather than inside the filter matters twice over.
+     * It turns one compilation per glob per file into one per glob, and it
+     * moves the failure of a glob that cannot be compiled out of the walk
+     * and onto the configuration that named it, so the report can say
+     * which pattern is at fault and where it came from instead of
+     * arriving as a regex error from inside a file scan.</p>
+     *
+     * @param globs The patterns, e.g. "**&#47;*.java"
+     * @return Matchers, in the order given
+     */
+    private static Collection<PathMatcher> compiled(final Collection<String> globs) {
+        return globs.stream().map(Walk::matcher).collect(Collectors.toList());
+    }
+
+    /**
+     * Compile one glob.
+     * @param glob The pattern
      * @return Matcher
      */
-    private boolean matches(final String text, final Path file) {
-        return FileSystems.getDefault().getPathMatcher(String.format("glob:%s", text)).matches(
-            Paths.get(
-                file.toAbsolutePath().toString().substring(
-                    this.home.toAbsolutePath().toString().length() + 1
-                )
+    private static PathMatcher matcher(final String glob) {
+        try {
+            return FileSystems.getDefault().getPathMatcher(String.format("glob:%s", glob));
+        } catch (final PatternSyntaxException ex) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The glob '%s', configured to select sources, is not a valid glob pattern",
+                    glob
+                ),
+                ex
+            );
+        }
+    }
+
+    /**
+     * The file's path relative to the directory being walked.
+     * @param file The file
+     * @return Relative path
+     */
+    private Path relative(final Path file) {
+        return Paths.get(
+            file.toAbsolutePath().toString().substring(
+                this.home.toAbsolutePath().toString().length() + 1
             )
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WalkTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WalkTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -34,6 +35,24 @@ final class WalkTest {
             ),
             new Walk(temp).includes(new ListOf<>(pattern)),
             Matchers.iterableWithSize(count)
+        );
+    }
+
+    @Test
+    void namesTheMalformedGlobInsteadOfLeakingARegexError(@Mktmp final Path temp) throws Exception {
+        new Saved("", temp.resolve("EOxxx/bar")).value();
+        final String glob = "**/[a-.eo";
+        MatcherAssert.assertThat(
+            "the message must say the glob comes from source selection, which the JDK's own regex error does not, even though it does quote the pattern",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Walk(temp).includes(new ListOf<>(glob)),
+                "a malformed glob must be reported, not thrown as a raw regex error"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString(glob),
+                Matchers.containsString("configured to select sources")
+            )
         );
     }
 }


### PR DESCRIPTION
Closes #6096

First, a correction to my own issue text: it says the error "never names the offending glob", and that is wrong. `getPathMatcher` reports on the glob, not on the translated regex, so `**/[a-.eo` already comes back as `Invalid range near index 4` with the pattern quoted underneath. I checked before writing the fix.

What is missing is the context. The exception arrives as a regex error from inside a file scan, with nothing saying it came from a glob the build was configured with. It is now wrapped so the message says which pattern is at fault and that it was configured to select sources. `Walk` is reached from four places with different parameter names (`MjRegister`, `Placing`, `Unspiling`, `Unplacing`), so the message names the role rather than one parameter.

The second half of the issue is done as well, and it is what shapes the change: each glob is compiled once in `includes`/`excludes` instead of once per file. For N files and M globs that was N*M compilations. Compiling up front is also what moves the failure off the walk and onto the configuration, so the two halves are one change rather than two.

The test fails on master.
