### PR TITLE
fix(#6140): preserve failed POSIX read result

### DIFF
--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -73,12 +73,18 @@
               buffer > @
               [size] > read
                 seq * > @
-                  output. >> chunk!
-                    win32 *1
-                      "_read"
-                      win32.stdin
-                      size
+                  if. >> chunk!
+                    received.code.eq -1
+                    T
+                      "Failed to read from standard input"
+                    received.output
+                  received
                   input-block chunk
+                called. > received
+                  win32 *1
+                    "_read"
+                    win32.stdin
+                    size
             | --
             size
       [buffer] > write
@@ -103,12 +109,18 @@
               buffer > @
               [size] > read
                 seq * > @
-                  output. >> chunk!
-                    posix *1
-                      "read"
-                      posix.stdin
-                      size
+                  if. >> chunk!
+                    received.code.eq -1
+                    T
+                      "Failed to read from standard input"
+                    received.output
+                  received
                   input-block chunk
+                called. > received
+                  posix *1
+                    "read"
+                    posix.stdin
+                    size
             | --
             size
       [buffer] > write

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -130,7 +130,6 @@
                       received.output
                     received
                     input-block chunk
-                    received
                 called. > received
                   syscall.read
                     * descriptor size

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -123,10 +123,17 @@
                     "Can't read from file with provided access mode '%s'".printf
                       * access
                   seq *
-                    output. >> chunk!
-                      syscall.read
-                        * descriptor size
+                    if. >> chunk!
+                      received.code.eq -1
+                      T
+                        "Failed to read from file"
+                      received.output
+                    received
                     input-block chunk
+                    received
+                called. > received
+                  syscall.read
+                    * descriptor size
           [buffer] > write
             output-block.write buffer > @
             [] > output-block

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -38,7 +38,7 @@ public final class ReadSyscall implements Syscall {
             new Dataized(params[0]).asNumber().intValue(), buf, size
         );
         result.put(0, new Data.ToPhi(count));
-        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, count)));
+        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(count, 0))));
         return result;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -73,7 +73,7 @@ final class EOposixEOφTest {
     void preservesFailureCodeWhenReadFails() {
         MatcherAssert.assertThat(
             "Failed \"read\" should preserve its code",
-            new Dataized(EOposixEOφTest.failedRead().take("code"))
+            new Dataized(this.failedRead().take("code"))
                 .asNumber().intValue(),
             Matchers.equalTo(-1)
         );
@@ -84,7 +84,7 @@ final class EOposixEOφTest {
     void returnsEmptyOutputWhenReadFails() {
         MatcherAssert.assertThat(
             "Failed \"read\" should return empty output",
-            new Dataized(EOposixEOφTest.failedRead().take("output")).take().length,
+            new Dataized(this.failedRead().take("output")).take().length,
             Matchers.equalTo(0)
         );
     }
@@ -94,7 +94,7 @@ final class EOposixEOφTest {
      *
      * @return Failed read result
      */
-    private static Phi failedRead() {
+    private Phi failedRead() {
         return new PhApplication(
             new PhApplication(
                 Phi.Φ.take("posix").copy(),

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -5,7 +5,6 @@
 package org.eolang;
 
 import java.lang.management.ManagementFactory;
-import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -71,8 +70,32 @@ final class EOposixEOφTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    void preservesFailureCodeWhenReadFails() {
+        MatcherAssert.assertThat(
+            "Failed \"read\" should preserve its code",
+            new Dataized(EOposixEOφTest.failedRead().take("code"))
+                .asNumber().intValue(),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
     void returnsEmptyOutputWhenReadFails() {
-        final Phi read = new PhApplication(
+        MatcherAssert.assertThat(
+            "Failed \"read\" should return empty output",
+            new Dataized(EOposixEOφTest.failedRead().take("output")).take().length,
+            Matchers.equalTo(0)
+        );
+    }
+
+    /**
+     * Reads from an invalid descriptor.
+     *
+     * @return Failed read result
+     */
+    private static Phi failedRead() {
+        return new PhApplication(
             new PhApplication(
                 Phi.Φ.take("posix").copy(),
                 "name",
@@ -86,13 +109,5 @@ final class EOposixEOφTest {
                 }
             )
         ).take("called");
-        MatcherAssert.assertThat(
-            "Failed \"read\" should preserve its code and return empty output",
-            List.of(
-                new Dataized(read.take("code")).asNumber().intValue(),
-                new Dataized(read.take("output")).take().length
-            ),
-            Matchers.equalTo(List.of(-1, 0))
-        );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -85,7 +85,7 @@ final class EOposixEOφTest {
                     new Data.ToPhi(1),
                 }
             )
-        );
+        ).take("called");
         MatcherAssert.assertThat(
             "Failed \"read\" should preserve its code and return empty output",
             List.of(

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -91,7 +91,6 @@ final class EOposixEOφTest {
 
     /**
      * Reads from an invalid descriptor.
-     *
      * @return Failed read result
      */
     private Phi failedRead() {

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -67,4 +67,33 @@ final class EOposixEOφTest {
             Matchers.containsString("No such file")
         );
     }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void returnsEmptyOutputWhenReadFails() {
+        final Phi read = new PhApplication(
+            new PhApplication(
+                Phi.Φ.take("posix").copy(),
+                "name",
+                new Data.ToPhi("read")
+            ),
+            "args",
+            new Data.ToPhi(
+                new Phi[]{
+                    new Data.ToPhi(-1),
+                    new Data.ToPhi(1),
+                }
+            )
+        );
+        MatcherAssert.assertThat(
+            "Failed \"read\" should preserve the POSIX error code",
+            new Dataized(read.take("code")).asNumber().intValue(),
+            Matchers.equalTo(-1)
+        );
+        MatcherAssert.assertThat(
+            "Failed \"read\" should return empty output",
+            new Dataized(read.take("output")).take(),
+            Matchers.equalTo(new byte[0])
+        );
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOposixEOφTest.java
@@ -5,6 +5,7 @@
 package org.eolang;
 
 import java.lang.management.ManagementFactory;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -86,14 +87,12 @@ final class EOposixEOφTest {
             )
         );
         MatcherAssert.assertThat(
-            "Failed \"read\" should preserve the POSIX error code",
-            new Dataized(read.take("code")).asNumber().intValue(),
-            Matchers.equalTo(-1)
-        );
-        MatcherAssert.assertThat(
-            "Failed \"read\" should return empty output",
-            new Dataized(read.take("output")).take(),
-            Matchers.equalTo(new byte[0])
+            "Failed \"read\" should preserve its code and return empty output",
+            List.of(
+                new Dataized(read.take("code")).asNumber().intValue(),
+                new Dataized(read.take("output")).take().length
+            ),
+            Matchers.equalTo(List.of(-1, 0))
         );
     }
 }


### PR DESCRIPTION
Closes #6140.

## Summary
- preserve the native negative status returned by a failed POSIX `read`
- return an empty byte sequence instead of passing a negative length to `Arrays.copyOf`
- test the failed-status code and the empty output independently
- make every file/console `read` consumer check the status before using the output, so a failure cannot be treated as EOF

## Root cause
`ReadSyscall` used the native `read(2)` result both as the EO status code and as the output-array length. POSIX uses `-1` for errors, while Java rejects negative array lengths.

## Impact
Successful reads and EOF behavior are unchanged. Failed reads now follow the existing `posix.return` contract and match the Win32 adapter's behavior. File and console input now stop on a failed read instead of interpreting its empty output as end-of-file.

## Testing
- RED: [the new Linux regression test failed with `NegativeArraySizeException: -1`](https://github.com/objectionary/eo/actions/runs/30642208218/job/91194696576)
- GREEN: [the same test passes after clamping only the copied output length](https://github.com/objectionary/eo/actions/runs/30643937079/job/91200508562)
- current CI: running for the latest review-fix commit