### PR TITLE
#5796: refuse a scope token as a file-local handle

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -4,8 +4,6 @@
  */
 package org.eolang.parser;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -61,9 +59,7 @@ final class Suffix {
      * {@link #test(String, int, Span, int, Form)} already refuses
      * {@code @} for a test attribute.
      */
-    private static final Set<String> SCOPES = new HashSet<>(
-        Arrays.asList("@", "^", "$")
-    );
+    private static final Set<String> SCOPES = Set.of("@", "^", "$");
 
     /**
      * Suffix form.

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -4,6 +4,10 @@
  */
 package org.eolang.parser;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A parsed name suffix — §3.10 of the spec.
  *
@@ -48,6 +52,18 @@ final class Suffix {
      * {@link #terminates} so dotted FQNs are still consumed whole.
      */
     private static final String NAME_BOUNDARIES = ",.|':;?[]{}()";
+
+    /**
+     * Scope tokens, which name a place rather than an object: the
+     * {@code φ} decoratee, the {@code ρ} parent and {@code ξ} itself.
+     * A {@code >>} handle is a name a later reference can be written
+     * with, so none of these can serve as one, the same way
+     * {@link #test(String, int, Span, int, Form)} already refuses
+     * {@code @} for a test attribute.
+     */
+    private static final Set<String> SCOPES = new HashSet<>(
+        Arrays.asList("@", "^", "$")
+    );
 
     /**
      * Suffix form.
@@ -409,6 +425,14 @@ final class Suffix {
         final int begin = Suffix.skipSpace(tail, idx);
         int rest = Suffix.skipName(tail, begin);
         final String handle = tail.substring(begin, rest);
+        if (Suffix.SCOPES.contains(handle)) {
+            throw new ParseError(
+                span.line(), home + begin,
+                String.format(
+                    "file-local handle must be an identifier, not %s", handle
+                )
+            );
+        }
         if (handle.codePoints().anyMatch(cp -> cp == 0x1F335)) {
             throw new ParseError(
                 span.line(), home + begin,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-dollar-token.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-dollar-token.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "file-local handle must be an identifier"
+input: |
+  [] > app
+    42 >> $

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-hat-token.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-hat-token.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "file-local handle must be an identifier"
+input: |
+  [] > app
+    42 >> ^

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-scope-token.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-is-not-a-scope-token.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "file-local handle must be an identifier"
+input: |
+  [] > app
+    42 >> @


### PR DESCRIPTION
Closes #5796

`>> @`, `>> ^` and `>> $` parsed cleanly and produced `local="@"` and friends, which is not a name anything can be written with. `Suffix.test` already refuses `@` for a test attribute; the `>>` path had no equivalent, so this adds one for all three tokens.

Three typo packs, one per token, all failing on master.
