### PR TITLE
fix(#6138): translate invalid directory paths

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOwalk.java
@@ -42,7 +42,9 @@ public final class EOdirectory$EOwalk extends PhDefault implements Atom {
             path = Paths.get(raw).toAbsolutePath();
         } catch (final InvalidPathException ex) {
             throw new ExFailure(
-                String.format("'%s' is not a valid path", raw),
+                String.format(
+                    "'%s' is not a valid path: %s", raw, ex.getReason()
+                ),
                 ex
             );
         }

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
@@ -5,6 +5,9 @@
 
 package org.eolang;
 
+import java.nio.file.InvalidPathException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,19 +37,53 @@ final class EOdirectoryEOwalkTest {
 
     @Test
     void wrapsInvalidPathIntoExFailure() {
-        final Phi file = Phi.Φ.take("file").copy();
-        file.put(0, new Data.ToPhi(String.format("/tmp/%cinvalid", (char) 0)));
-        final Phi dir = Phi.Φ.take("directory").copy();
-        dir.put(0, file);
         Assertions.assertThrows(
             ExFailure.class,
-            () -> new Dataized(
-                new PhApplication(
-                    new PhApplication(new EOdirectory$EOwalk(), Phi.RHO, dir),
-                    "glob", new Data.ToPhi("*")
-                )
-            ).take(),
+            () -> new Dataized(EOdirectoryEOwalkTest.invalidPathWalk()).take(),
             "a path with a NUL character must fail with ExFailure, not a raw InvalidPathException"
         );
+    }
+
+    @Test
+    void includesInvalidPathReason() {
+        final ExFailure failure = EOdirectoryEOwalkTest.failure(
+            EOdirectoryEOwalkTest.invalidPathWalk()
+        );
+        MatcherAssert.assertThat(
+            "failure must identify why parsing failed",
+            failure.getMessage(),
+            Matchers.containsString(
+                ((InvalidPathException) failure.getCause()).getReason()
+            )
+        );
+    }
+
+    /**
+     * Make a directory walk application with an invalid path.
+     * @return Directory walk application
+     */
+    private static Phi invalidPathWalk() {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi(String.format("/tmp/%cinvalid", (char) 0)));
+        final Phi directory = Phi.Φ.take("directory").copy();
+        directory.put(0, file);
+        return new PhApplication(
+            new PhApplication(new EOdirectory$EOwalk(), Phi.RHO, directory),
+            "glob", new Data.ToPhi("*")
+        );
+    }
+
+    /**
+     * Get a failure from the directory walk application.
+     * @param walk Directory walk application
+     * @return Failure raised by the atom
+     */
+    private static ExFailure failure(final Phi walk) {
+        try {
+            new Dataized(walk).take();
+        } catch (final ExFailure err) {
+            return err;
+        }
+        throw new IllegalStateException("Invalid path must fail");
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOwalkTest.java
@@ -39,15 +39,15 @@ final class EOdirectoryEOwalkTest {
     void wrapsInvalidPathIntoExFailure() {
         Assertions.assertThrows(
             ExFailure.class,
-            () -> new Dataized(EOdirectoryEOwalkTest.invalidPathWalk()).take(),
+            () -> new Dataized(this.invalidPathWalk()).take(),
             "a path with a NUL character must fail with ExFailure, not a raw InvalidPathException"
         );
     }
 
     @Test
     void includesInvalidPathReason() {
-        final ExFailure failure = EOdirectoryEOwalkTest.failure(
-            EOdirectoryEOwalkTest.invalidPathWalk()
+        final ExFailure failure = this.failure(
+            this.invalidPathWalk()
         );
         MatcherAssert.assertThat(
             "failure must identify why parsing failed",
@@ -62,7 +62,7 @@ final class EOdirectoryEOwalkTest {
      * Make a directory walk application with an invalid path.
      * @return Directory walk application
      */
-    private static Phi invalidPathWalk() {
+    private Phi invalidPathWalk() {
         final Phi file = Phi.Φ.take("file").copy();
         file.put(0, new Data.ToPhi(String.format("/tmp/%cinvalid", (char) 0)));
         final Phi directory = Phi.Φ.take("directory").copy();
@@ -78,7 +78,7 @@ final class EOdirectoryEOwalkTest {
      * @param walk Directory walk application
      * @return Failure raised by the atom
      */
-    private static ExFailure failure(final Phi walk) {
+    private ExFailure failure(final Phi walk) {
         try {
             new Dataized(walk).take();
         } catch (final ExFailure err) {


### PR DESCRIPTION
Closes #6138

## What changed

`directory.walk` now translates `InvalidPathException` raised while parsing
`file.path` into `ExFailure` at the atom boundary. The message identifies the
malformed path and the original exception remains available as the cause.

A regression test invokes the atom directly with an invalid path and verifies
both the EO-facing failure type and the preserved Java cause.

## Verification

- `mvn -pl eo-runtime -DskipITs -Dtest=EOdirectoryEOwalkTest test`
  - 2 tests, 0 failures, 0 errors
- `mvn -pl eo-runtime clean test -DskipITs`
  - 1819 tests, 0 failures, 0 errors, 10 skipped
- `mvn -pl eo-runtime -Pqulice -DskipTests qulice:check` (JDK 21)
  - Qulice quality check completed
- `mvn -pl eo-runtime -Pqulice com.github.volodya-lombrozo:jtcop-maven-plugin:1.4.3:check`
  - All tests are valid
