### PR TITLE
#5978: advance past a zero-width match when iterating

### DIFF
--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -35,6 +35,13 @@
         next. >> matched
           target.match reinit
 
+  eq. ++> can-replace-a-nullable-pattern-like-java
+    replaced
+      "abc"
+      regex "/x*/"
+      "-"
+    "-a-b-c-"
+
   eq. ++> can-replace-a-windows-separator-with-a-slash
     replaced
       "C:\\Windows\\Users\\AppLocal\\shrek"


### PR DESCRIPTION
Closes #5978
Closes #6143

The two issues are one bug. `replaced` never terminates for a nullable pattern because `matched.next` does not move: it searches from the previous `to`, and for a zero-width match `from == to`, so the same match comes back forever and `rec-replaced` recurses until it dies. #6143 is the same loop seen directly, through the iterator rather than through `replaced`.

`next` now starts one character further on when the match was zero-width, and reports a non-existent block when a zero-width match sits at the end of the text and there is nowhere further to go.

That last part is why the change is not a one-liner. `matched-from-index` refuses a `start` past the text length, and `rejectsStartIndexAfterTextEnd` pins that, so the terminal case cannot be expressed by advancing the index; the block is built directly instead, with `start` at -1 and terminators in `from`, `to` and `groups`, mirroring what the atom's own `blank` does.

Nothing in `replaced.eo` changed. With the iterator advancing, its existing algorithm produces what Java does: `"abc"` with `/x*/` gives `-a-b-c-`, matching `String.replaceAll`.

Two EO tests, both failing on master: `cannot-iterate-past-a-terminal-zero-width-match` for the iterator, `can-replace-a-nullable-pattern-like-java` for the substitution. On master the second does not merely fail, it takes the JUnit container down, which is what unbounded recursion looks like from outside.
