### PR TITLE
Name the legacy QQ root in the parse error

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1369,6 +1369,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Malformed BYTES literal (R-3.13.1 — invalid byte form, e.g., `Z9-`, single trailing dash without prefix, odd hex run) | `invalid bytes literal` |
 | Meta after first non-meta object | `meta directive must precede all other objects` |
 | Plain child without name in formation | `object inside formation must have a name` |
+| Root identifier glued to a letter or a digit (e.g. the legacy `QQ.io.stdout`) | `<token> is not a valid object name, root <root> must be followed by a dot` (token and root substituted) |
 | Atom containing non-test child | `atom may contain only test attributes` |
 | `+>` outside indent 2 of top level | `test attribute legal only as direct child of top-level object` |
 | Bare reversed dispatch missing receiver | `reversed dispatch missing receiver` |

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -664,15 +664,17 @@ final class Tokens {
     }
 
     /**
-     * Whether the root identifier at the index is glued to a letter or
-     * a digit, as the legacy {@code QQ.io.stdout} head is.
+     * Whether the root identifier at the index is glued to a NAME
+     * character, as the legacy {@code QQ.io.stdout} head is. A root
+     * ends at a NAME terminator, so anything else standing next to it
+     * belongs to the same token.
      * @param body Body
      * @param idx Index of the root character
-     * @return True if a letter or a digit follows the root
+     * @return True if a NAME character follows the root
      */
     private static boolean glued(final String body, final int idx) {
         return idx + 1 < body.length()
-            && Character.isLetterOrDigit(body.charAt(idx + 1));
+            && !Tokens.terminates(body.charAt(idx + 1));
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -323,7 +323,10 @@ final class Tokens {
 
     /**
      * Read a root identifier at the cursor — one of {@code Q}, {@code @},
-     * {@code ^}, {@code $}. Advances past it.
+     * {@code ^}, {@code $}. Advances past it. A root glued to a letter
+     * or a digit — the legacy {@code QQ} above all — is rejected here,
+     * so that the offending token names itself instead of surfacing as
+     * trailing garbage after a one-character expression.
      * @return Root value
      */
     Value readRoot() {
@@ -334,6 +337,15 @@ final class Tokens {
             );
         }
         final int start = this.cursor;
+        if (Tokens.glued(this.body, start)) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + start,
+                String.format(
+                    "%s is not a valid object name, root %s must be followed by a dot",
+                    Tokens.token(this.body, start), this.body.charAt(start)
+                )
+            );
+        }
         this.cursor = this.cursor + 1;
         return new Value(
             Value.Kind.ROOT, String.valueOf(this.body.charAt(start)),
@@ -649,6 +661,33 @@ final class Tokens {
      */
     private static boolean rootStart(final char glyph) {
         return glyph == 'Q' || glyph == '@' || glyph == '^' || glyph == '$';
+    }
+
+    /**
+     * Whether the root identifier at the index is glued to a letter or
+     * a digit, as the legacy {@code QQ.io.stdout} head is.
+     * @param body Body
+     * @param idx Index of the root character
+     * @return True if a letter or a digit follows the root
+     */
+    private static boolean glued(final String body, final int idx) {
+        return idx + 1 < body.length()
+            && Character.isLetterOrDigit(body.charAt(idx + 1));
+    }
+
+    /**
+     * Read the whole token starting at the index, up to the first
+     * {@code NAME} terminator or the end of the body.
+     * @param body Body
+     * @param idx Index of the first character
+     * @return The token, terminator excluded
+     */
+    private static String token(final String body, final int idx) {
+        int end = idx;
+        while (end < body.length() && !Tokens.terminates(body.charAt(end))) {
+            end = end + 1;
+        }
+        return body.substring(idx, end);
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -298,6 +298,17 @@ final class EoTest {
     }
 
     @Test
+    void rejectsLegacyDoubledRoot() {
+        MatcherAssert.assertThat(
+            "the legacy `QQ` head must name itself in the error, not read as trailing garbage",
+            EoTest.render("[] > main", "  QQ.io.stdout", "    \"Hello world\""),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'QQ is not a valid object name')]"
+            )
+        );
+    }
+
+    @Test
     void allowsSameIndentSiblingFormations() {
         MatcherAssert.assertThat(
             "two top-level formations must emit as two sibling <o>s under the program root",

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -315,6 +315,15 @@ final class TokensTest {
     }
 
     @Test
+    void rejectsRootGluedToHyphen() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Tokens("Q-foo", new Span("Q-foo", 1)).readRoot(),
+            "readRoot must reject a root glued to a hyphen, which is a NAME character"
+        );
+    }
+
+    @Test
     void readsRootFollowedByDot() {
         MatcherAssert.assertThat(
             "`^.foo` must read its root and stop right before the dot",

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -297,6 +297,33 @@ final class TokensTest {
     }
 
     @Test
+    void rejectsRootGluedToLetter() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Tokens("QQ", new Span("QQ", 1)).readRoot(),
+            "readRoot must reject a root glued to a letter, as in the legacy `QQ`"
+        );
+    }
+
+    @Test
+    void rejectsRootGluedToDigit() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Tokens("$1", new Span("$1", 1)).readRoot(),
+            "readRoot must reject a root glued to a digit"
+        );
+    }
+
+    @Test
+    void readsRootFollowedByDot() {
+        MatcherAssert.assertThat(
+            "`^.foo` must read its root and stop right before the dot",
+            new Tokens("^.foo", new Span("^.foo", 1)).readRoot().raw(),
+            Matchers.equalTo("^")
+        );
+    }
+
+    @Test
     void readsEmptyBytes() {
         MatcherAssert.assertThat(
             "`--` must read as BYTES with raw `--`",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/qq.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/qq.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:3] error: 'trailing garbage after expression'
+  [2:2] error: 'QQ is not a valid object name, root Q must be followed by a dot'
     QQ.io.stdout > @
-     ^
+    ^
 input: |
   [] > foo
     QQ.io.stdout > @


### PR DESCRIPTION
The head `QQ.io.stdout` used to fail with `trailing garbage after expression`, with the caret sitting under the second `Q`. That says nothing about what is wrong: `Q` is the root token, the reader consumed exactly one character, and everything after it became garbage. Anyone porting a program written before `QQ` was dropped got a message pointing at the wrong thing.

The root reader now rejects a root glued to a letter or a digit and names the offending token: `QQ is not a valid object name, root Q must be followed by a dot`, with the caret on the `Q` that starts it. Nothing changes about what the parser accepts, only about what it says when it refuses. The canonical text is added to the table in §9.9 of `PARSER_SPEC.md`, as R-9.9.3 requires, and `eo-typos/qq.yaml` is updated to the new wording.

Two things the issue raises are already gone on master and stay untouched here. The confusing `Only one object per source file is allowed and required` no longer accompanies a parse failure, since `validate-objects-count` fires only when more than one object is present. And a plain child of a formation that carries no name already reports `object inside formation must have a name`, which is what the discussion asked for.

One rough edge remains: the following line still reports `indent increased by more than one level`, because the failed line never pushed a level and R-7.4 says the next line is processed as if it had not existed. That cascade is what the spec prescribes, so I left it alone rather than working around it.

Closes #4106
