### PR TITLE
Skip the block nested under a failed line during recovery

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -16,7 +16,9 @@ import org.xembly.Directive;
  * of the spec, then dispatched into the shared {@link Stack},
  * {@link Globals}, and {@link Emit} state. Recovery (§7) is line-local
  * — a {@link ParseError} is caught, the line's directives are rolled
- * back to a {@link Emit#savepoint()}, and the error is emitted.</p>
+ * back to a {@link Emit#savepoint()}, the error is emitted, and the
+ * block nested under the failed line is skipped up to the first line
+ * back at its indent.</p>
  *
  * <p>This is the analogue of {@code EoSyntax} on the ANTLR side, but
  * with no parser-grammar dependency: classification, validation, and
@@ -79,8 +81,9 @@ final class Eo implements Iterable<Directive> {
             if (!globals.inTextBlock() && Eo.isBytesContinuation(span.body())) {
                 final int next = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit);
                 idx = next;
+            } else if (Eo.process(span, stack, globals, emit)) {
+                idx = Eo.resume(spans, idx + 1, span.indent());
             } else {
-                Eo.process(span, stack, globals, emit);
                 idx = idx + 1;
             }
         }
@@ -297,11 +300,13 @@ final class Eo implements Iterable<Directive> {
      * @param stack The indent stack
      * @param globals The global parser state
      * @param emit The directives sink
+     * @return True when the line failed to parse
      * @checkstyle ParameterNumberCheck (3 lines)
      */
-    private static void process(
+    private static boolean process(
         final Span span, final Stack stack, final Globals globals, final Emit emit
     ) {
+        boolean failed = false;
         if (globals.inTextBlock()) {
             Eo.continueTextBlock(span, stack, globals, emit);
         } else if (span.tab()) {
@@ -313,8 +318,31 @@ final class Eo implements Iterable<Directive> {
             globals.markEmitted();
             globals.clearBlanks();
         } else {
-            Eo.dispatch(span, stack, globals, emit);
+            failed = Eo.dispatch(span, stack, globals, emit);
         }
+        return failed;
+    }
+
+    /**
+     * The index the walk resumes at after a line failed — the first
+     * line standing at or above the failed line's indent (§7). The
+     * lines in between belong to the failed line, so parsing them on
+     * their own would only pile up errors the source never made. A
+     * blank line carries no indent of its own and never resumes.
+     * @param spans Materialised list of source spans
+     * @param from Index right after the failed line
+     * @param indent Indent of the failed line
+     * @return Index of the resumption point
+     */
+    private static int resume(
+        final java.util.List<Span> spans, final int from, final int indent
+    ) {
+        int idx = from;
+        while (idx < spans.size()
+            && (spans.get(idx).blank() || spans.get(idx).indent() > indent)) {
+            idx = idx + 1;
+        }
+        return idx;
     }
 
     /**
@@ -387,10 +415,11 @@ final class Eo implements Iterable<Directive> {
      * @param stack The indent stack
      * @param globals The global parser state
      * @param emit The directives sink
+     * @return True when the line failed to parse
      * @checkstyle ParameterNumberCheck (3 lines)
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static void dispatch(
+    private static boolean dispatch(
         final Span span, final Stack stack, final Globals globals, final Emit emit
     ) {
         if (!span.blank() && span.head() != '#') {
@@ -398,13 +427,16 @@ final class Eo implements Iterable<Directive> {
         }
         final int tstartsen = emit.savepoint();
         final int frame = stack.size();
+        boolean failed = false;
         try {
             Eo.classify(span).into(stack, globals, emit);
         } catch (final ParseError err) {
             emit.rollback(tstartsen);
             stack.silentTruncate(frame);
             emit.error(err.line(), err.pos(), err.getMessage());
+            failed = true;
         }
+        return failed;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -17,8 +17,8 @@ import org.xembly.Directive;
  * {@link Globals}, and {@link Emit} state. Recovery (§7) is line-local
  * — a {@link ParseError} is caught, the line's directives are rolled
  * back to a {@link Emit#savepoint()}, the error is emitted, and the
- * block nested under the failed line is skipped up to the first line
- * back at its indent.</p>
+ * block nested under the failed line is skipped up to the point
+ * {@link Recovery} names.</p>
  *
  * <p>This is the analogue of {@code EoSyntax} on the ANTLR side, but
  * with no parser-grammar dependency: classification, validation, and
@@ -75,6 +75,7 @@ final class Eo implements Iterable<Directive> {
         );
         final java.util.List<Span> spans = new java.util.ArrayList<>(16);
         new Source(this.source).forEach(spans::add);
+        final Recovery recovery = new Recovery(spans);
         int idx = 0;
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
@@ -82,7 +83,7 @@ final class Eo implements Iterable<Directive> {
                 final int next = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit);
                 idx = next;
             } else if (Eo.process(span, stack, globals, emit)) {
-                idx = Eo.resume(spans, idx + 1, span.indent());
+                idx = recovery.after(idx);
             } else {
                 idx = idx + 1;
             }
@@ -321,28 +322,6 @@ final class Eo implements Iterable<Directive> {
             failed = Eo.dispatch(span, stack, globals, emit);
         }
         return failed;
-    }
-
-    /**
-     * The index the walk resumes at after a line failed — the first
-     * line standing at or above the failed line's indent (§7). The
-     * lines in between belong to the failed line, so parsing them on
-     * their own would only pile up errors the source never made. A
-     * blank line carries no indent of its own and never resumes.
-     * @param spans Materialised list of source spans
-     * @param from Index right after the failed line
-     * @param indent Indent of the failed line
-     * @return Index of the resumption point
-     */
-    private static int resume(
-        final java.util.List<Span> spans, final int from, final int indent
-    ) {
-        int idx = from;
-        while (idx < spans.size()
-            && (spans.get(idx).blank() || spans.get(idx).indent() > indent)) {
-            idx = idx + 1;
-        }
-        return idx;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.List;
+
+/**
+ * The place where the walk carries on after a line failed to parse — §7.
+ *
+ * <p>Every line indented deeper than a failed one belongs to it. Parsing
+ * such a line on its own only piles up errors the source never made,
+ * since an orphaned child collides with the indent stack instead of
+ * standing under its parent. This object holds the lines of the program
+ * and answers where the walk picks up again: the first line standing
+ * back at or above the indent of the one that failed. A blank line
+ * carries no indent of its own and never ends the skipped block.</p>
+ *
+ * @since 0.1
+ */
+final class Recovery {
+
+    /**
+     * All lines of the program, in source order.
+     */
+    private final List<Span> spans;
+
+    /**
+     * Ctor.
+     * @param lines All lines of the program, in source order
+     */
+    Recovery(final List<Span> lines) {
+        this.spans = lines;
+    }
+
+    /**
+     * The index the walk resumes at, having failed on the line at
+     * {@code failed}.
+     * @param failed Index of the line that failed to parse
+     * @return Index of the resumption point
+     */
+    int after(final int failed) {
+        final int indent = this.spans.get(failed).indent();
+        int idx = failed + 1;
+        while (idx < this.spans.size() && this.skipped(idx, indent)) {
+            idx = idx + 1;
+        }
+        return idx;
+    }
+
+    /**
+     * Whether the line at {@code idx} still belongs to the block of a
+     * line that failed at {@code indent}.
+     * @param idx Index of the line
+     * @param indent Indent of the failed line
+     * @return True when the line must be skipped
+     */
+    private boolean skipped(final int idx, final int indent) {
+        final Span span = this.spans.get(idx);
+        return span.blank() || span.indent() > indent;
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -126,6 +126,57 @@ final class EoTest {
     }
 
     @Test
+    void skipsBlockOfFailedLine() {
+        MatcherAssert.assertThat(
+            "the block nested under a failed line must not raise errors of its own",
+            EoTest.render(
+                "[] > example",
+                "  [x] +++ bad",
+                "    one",
+                "      two",
+                "  [] > good",
+                "    one > first"
+            ),
+            XhtmlMatchers.hasXPath("/object/errors[count(error)=1]")
+        );
+    }
+
+    @Test
+    void parsesSiblingAfterFailedLine() {
+        MatcherAssert.assertThat(
+            "the sibling standing at the indent of a failed line must still be parsed",
+            EoTest.render(
+                "[] > example",
+                "  [x] +++ bad",
+                "    one",
+                "      two",
+                "  [] > good",
+                "    one > first"
+            ),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='example']/o[@name='good']/o[@name='first']"
+            )
+        );
+    }
+
+    @Test
+    void skipsBlockOfFailedLineAcrossBlanks() {
+        MatcherAssert.assertThat(
+            "a blank line inside the block of a failed line must not resume parsing",
+            EoTest.render(
+                "[] > example",
+                "  [x] +++ bad",
+                "    one",
+                "",
+                "    two",
+                "  [] > good",
+                "    one > first"
+            ),
+            XhtmlMatchers.hasXPath("/object/errors[count(error)=1]")
+        );
+    }
+
+    @Test
     void parsesWithUnixAndWindowsLineEndings() {
         final String carriage = String.valueOf((char) 13);
         MatcherAssert.assertThat(

--- a/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Recovery}.
+ * @since 0.1
+ */
+final class RecoveryTest {
+
+    @Test
+    void resumesAtSiblingOfFailedLine() {
+        MatcherAssert.assertThat(
+            "the walk must resume at the first line back at the indent of the failed one",
+            new Recovery(
+                Arrays.asList(
+                    new Span("  über! ☃", 1),
+                    new Span("    क्ष", 2),
+                    new Span("      deeper", 3),
+                    new Span("  sibling", 4)
+                )
+            ).after(0),
+            Matchers.equalTo(3)
+        );
+    }
+
+    @Test
+    void skipsBlankLineInsideBlock() {
+        MatcherAssert.assertThat(
+            "a blank line inside the block of a failed line must not resume the walk",
+            new Recovery(
+                Arrays.asList(
+                    new Span("bad!!!", 1),
+                    new Span("  child", 2),
+                    new Span("", 3),
+                    new Span("  child", 4),
+                    new Span("next", 5)
+                )
+            ).after(0),
+            Matchers.equalTo(4)
+        );
+    }
+}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/o[@name='example']/o[@name='good']/o[@name='first']
+input: |
+  [] > example
+    [x] +++ bad
+      one
+        two
+    [] > good
+      one > first


### PR DESCRIPTION
When a line fails to parse, the parser reported the error and then went
on to parse the lines nested under it. Those lines have lost their
parent, so they collided with the indent stack and produced errors of
their own — the snippet in #4140 raised three errors where the source
had made one, and the object that followed never made it into the XMIR.

The walk now resumes at the first line standing back at the failed
line's indent. Everything in between belonged to the failed line and is
skipped. Blank lines carry no indent of their own, so they do not resume
parsing either. The sibling that follows the skipped block is parsed as
usual, which is what the issue asks for.

Closes #4140
