### PR TITLE
Fix the pre-transpile directory when transformation steps are tracked

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TrSpy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TrSpy.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import com.jcabi.xml.XML;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StAfter;
 import com.yegor256.xsline.StLambda;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TrSpy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TrSpy.java
@@ -13,10 +13,14 @@ import com.yegor256.xsline.TrEnvelope;
 import com.yegor256.xsline.TrLambda;
 import com.yegor256.xsline.Train;
 import java.nio.file.Path;
-import org.cactoos.Func;
 
 /**
  * Train that spies.
+ * <p>The directory is fixed for the whole train, because a document halfway
+ * through it no longer carries the name of the object it came from: after
+ * {@code classes.xsl} an XMIR holding two objects has two {@code class}
+ * elements and no {@code /object/o/@name} at all, and deriving the directory
+ * from such a document breaks the build, see #4370.</p>
  * @since 0.23
  */
 final class TrSpy extends TrEnvelope {
@@ -26,7 +30,7 @@ final class TrSpy extends TrEnvelope {
      * @param train Original one
      * @param dir The dir to save
      */
-    TrSpy(final Train<Shift> train, final Func<XML, Path> dir) {
+    TrSpy(final Train<Shift> train, final Path dir) {
         super(
             new TrLambda(
                 train,
@@ -38,7 +42,7 @@ final class TrSpy extends TrEnvelope {
                             final String log = shift.uid().replaceAll("[^A-Za-z0-9]", "-");
                             new Saved(
                                 xml.toString(),
-                                dir.apply(xml).resolve(String.format("%02d-%s.xml", pos, log))
+                                dir.resolve(String.format("%02d-%s.xml", pos, log))
                             ).value();
                             if (Logger.isDebugEnabled(TrSpy.class)) {
                                 Logger.debug(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.maven;
 
-import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.yegor256.xsline.Shift;
@@ -22,9 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.cactoos.func.StickyFunc;
-import org.eolang.parser.OnDefault;
-import org.eolang.parser.OnDetailed;
 import org.eolang.parser.TrFull;
 
 /**
@@ -180,23 +176,15 @@ final class Transpilation {
      * Build XSL transformation function for a source file.
      * If transformation steps are tracked - creates a new {@link Xsline}
      * for every XMIR in purpose of thread safety.
-     * @param source Path to source XMIR
+     * @param name Name of the object the source XMIR holds
      * @return XSL transformation function
      */
-    Function<XML, XML> forSource(final Path source) {
+    Function<XML, XML> forSource(final String name) {
         final Train<Shift> measured = this.measured(this.train());
         final Function<XML, XML> func;
         if (this.tracking.steps()) {
-            func = xml -> new Xsline(
-                new TrSpy(
-                    measured,
-                    new StickyFunc<>(
-                        doc -> new Place(
-                            new OnDetailed(new OnDefault(new Xnav(doc.inner())), source).get()
-                        ).make(this.target.resolve(Transpiling.PRE), "")
-                    )
-                )
-            ).pass(xml);
+            final Path dir = new Place(name).make(this.target.resolve(Transpiling.PRE), "");
+            func = xml -> new Xsline(new TrSpy(measured, dir)).pass(xml);
         } else {
             func = new Xsline(measured)::pass;
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -181,12 +181,11 @@ final class Transpiling implements Step {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
         final Path base = this.targetDir.resolve(Transpiling.DIR);
-        final Path target = new Place(
-            new OnDetailed(new OnDefault(new Xnav(xmir.inner())), source).get()
-        ).make(base, MjAssemble.XMIR);
+        final String name = new OnDetailed(new OnDefault(new Xnav(xmir.inner())), source).get();
+        final Path target = new Place(name).make(base, MjAssemble.XMIR);
         final Supplier<String> hsh = new TojoHash(tojo);
         final AtomicBoolean rewrite = new AtomicBoolean(false);
-        final Function<XML, XML> transform = this.train.forSource(source);
+        final Function<XML, XML> transform = this.train.forSource(name);
         final Path cdir = this.cacheDir.resolve(Transpiling.CACHE);
         final Path tail = base.relativize(target);
         if (this.cacheEnabled) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -85,18 +85,8 @@ final class MjTranspileTest {
     void tracksStepsOfProgramWithTwoObjects(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "the first tracked step of a program holding two objects did not leave its XMIR in the pre-transpile directory",
-            new FakeMaven(temp).withProgram(
-                String.join(
-                    System.lineSeparator(),
-                    "+package examples",
-                    "",
-                    "# First.",
-                    "[] > x",
-                    "",
-                    "# Second.",
-                    "[] > y"
-                )
-                ).with("trackTransformationSteps", true)
+            new FakeMaven(temp).withProgram(MjTranspileTest.pair())
+                .with("trackTransformationSteps", true)
                 .execute(MjParse.class)
                 .execute(MjTranspile.class)
                 .result(),
@@ -111,18 +101,8 @@ final class MjTranspileTest {
         throws IOException {
         MatcherAssert.assertThat(
             "the second object of a tracked program did not reach the generated Java",
-            new FakeMaven(temp).withProgram(
-                String.join(
-                    System.lineSeparator(),
-                    "+package examples",
-                    "",
-                    "# First.",
-                    "[] > x",
-                    "",
-                    "# Second.",
-                    "[] > y"
-                )
-                ).with("trackTransformationSteps", true)
+            new FakeMaven(temp).withProgram(MjTranspileTest.pair())
+                .with("trackTransformationSteps", true)
                 .execute(MjParse.class)
                 .execute(MjTranspile.class)
                 .result(),
@@ -560,6 +540,23 @@ final class MjTranspileTest {
     private static String instantiating() {
         return String.format(
             "+package foo.x%n%n[] > main%n  [] > inner%n    42 > @%n  42.plus > @%n    []"
+        );
+    }
+
+    /**
+     * The EO program holding two top-level objects.
+     * @return Source code of the program
+     */
+    private static String pair() {
+        return String.join(
+            System.lineSeparator(),
+            "+package examples",
+            "",
+            "# First.",
+            "[] > x",
+            "",
+            "# Second.",
+            "[] > y"
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -107,6 +107,30 @@ final class MjTranspileTest {
     }
 
     @Test
+    void transpilesSecondObjectOfProgramWhileTrackingSteps(@Mktmp final Path temp)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "the second object of a tracked program did not reach the generated Java",
+            new FakeMaven(temp).withProgram(
+                String.join(
+                    System.lineSeparator(),
+                    "+package examples",
+                    "",
+                    "# First.",
+                    "[] > x",
+                    "",
+                    "# Second.",
+                    "[] > y"
+                )
+                ).with("trackTransformationSteps", true)
+                .execute(MjParse.class)
+                .execute(MjTranspile.class)
+                .result(),
+            Matchers.hasKey("target/generated/org/eolang/EO_examples/EOy.java")
+        );
+    }
+
+    @Test
     void wrapsObjectsIntoPhCoverageWhenTrackingEnabled(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the generated Java must wrap located objects into PhCoverage when coverageTracking is on",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -82,6 +82,31 @@ final class MjTranspileTest {
     }
 
     @Test
+    void tracksStepsOfProgramWithTwoObjects(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the first tracked step of a program holding two objects did not leave its XMIR in the pre-transpile directory",
+            new FakeMaven(temp).withProgram(
+                String.join(
+                    System.lineSeparator(),
+                    "+package examples",
+                    "",
+                    "# First.",
+                    "[] > x",
+                    "",
+                    "# Second.",
+                    "[] > y"
+                )
+                ).with("trackTransformationSteps", true)
+                .execute(MjParse.class)
+                .execute(MjTranspile.class)
+                .result(),
+            Matchers.hasKey(
+                String.format("target/%s/examples/x/00-set-locators.xml", Transpiling.PRE)
+            )
+        );
+    }
+
+    @Test
     void wrapsObjectsIntoPhCoverageWhenTrackingEnabled(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the generated Java must wrap located objects into PhCoverage when coverageTracking is on",


### PR DESCRIPTION
With `trackTransformationSteps` on, the transpiler picked the directory for each intermediate XMIR by reading the name of the object out of that very document. That only works while the document still looks like a freshly parsed XMIR. Halfway through the train it does not: `classes.xsl` replaces `/object/o` with one `class` element per top-level object, so a `.eo` file holding two objects ends up with two of them, and `OnDefault` refuses to guess which one names the file. The build then died with `Expected 1 child nodes, but found 2` on a program that compiles fine with the option off.

The name never depended on the intermediate document in the first place. `Transpiling` already derives it from the source XMIR to place the output under `5-transpile`, so the same string now goes to `Transpilation.forSource`, the directory is computed once before the train starts, and `TrSpy` takes a plain `Path` instead of a function it has to apply to every step.

The new test in `MjTranspileTest` transpiles a two-object program with the option on and checks that the first step leaves its XMIR under `5-pre-transpile`. It fails on master with the exception from the issue.

I could not run qulice locally, since it needs Java 21 and this machine has 17. The full `eo-maven-plugin` suite passes.

Closes #4370
