### PR TITLE
Fix regex next after zero-width matches

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -59,13 +59,21 @@
         ? > position /Q.number
         ? > start /Q.number
       [] > missing
+        T > count
+          "Matched block does not exist, can't get count"
         start.gte 0 > exists
         T > from
           "Matched block does not exist, can't get 'from' position"
+        T > [index] > group
+          "Matched block does not exist, can't get group"
         T > groups
           "Matched block does not exist, can't get groups"
+        T > next
+          "Matched block does not exist, can't get next"
         0 > position
         -1 > start
+        T > text
+          "Matched block does not exist, can't get text"
         T > to
           "Matched block does not exist, can't get 'to' position"
       matched. > next
@@ -242,6 +250,14 @@
   compile. --> stops-on-compiling-an-invalid-pattern
     regex "/[a-z/"
 
+  group. --> stops-on-taking-a-group-of-a-terminal-zero-width-match
+    next.
+      next.
+        match.
+          regex "/$/"
+          "x"
+    1
+
   group. --> stops-on-taking-a-group-of-an-unmatched-block
     next.
       match.
@@ -255,6 +271,13 @@
         regex "/[a-z]+/"
         "123"
 
+  count. --> stops-on-taking-the-group-count-of-a-terminal-zero-width-match
+    next.
+      next.
+        match.
+          regex "/$/"
+          "x"
+
   count. --> stops-on-taking-the-group-count-of-an-unmatched-block
     next.
       match.
@@ -267,6 +290,13 @@
         regex "/[a-z]+/"
         "123"
 
+  next. --> stops-on-taking-the-next-of-a-terminal-zero-width-match
+    next.
+      next.
+        match.
+          regex "/$/"
+          "x"
+
   next. --> stops-on-taking-the-next-of-an-unmatched-block
     next.
       match.
@@ -278,6 +308,13 @@
       match.
         regex "/[a-z]+/"
         "123"
+
+  text. --> stops-on-taking-the-text-of-a-terminal-zero-width-match
+    next.
+      next.
+        match.
+          regex "/$/"
+          "x"
 
   text. --> stops-on-taking-the-text-of-an-unmatched-block
     next.

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -93,7 +93,7 @@
         next.
           match.
             regex "/a*/"
-            "ba"
+            "xa"
 
   ++> can-expose-groups-on-each-matched-block
     and. > @

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -37,10 +37,18 @@
         groups.at index > [index] > group
         $ > matched
         exists.if > next
-          matched.
-            matched-from-index
-              position.plus 1
-              to
+          if.
+            and.
+              from.eq to
+              to.eq txt.length
+            missing
+            matched.
+              matched-from-index
+                position.plus 1
+                if.
+                  from.eq to
+                  to.plus 1
+                  to
           T
             "Matched block does not exist, can't get next"
         exists.if > text
@@ -50,6 +58,16 @@
       [] > matched-from-index /Q.string.regex.pattern.match.matched
         ? > position /Q.number
         ? > start /Q.number
+      [] > missing
+        start.gte 0 > exists
+        T > from
+          "Matched block does not exist, can't get 'from' position"
+        T > groups
+          "Matched block does not exist, can't get groups"
+        0 > position
+        -1 > start
+        T > to
+          "Matched block does not exist, can't get 'to' position"
       matched. > next
         matched-from-index 1 0
     [txt] > matches
@@ -59,6 +77,15 @@
           found.from.eq 0
       next. > found
         match txt
+
+  eq. ++> can-advance-after-a-zero-width-match
+    1
+    from.
+      next.
+        next.
+          match.
+            regex "/a*/"
+            "ba"
 
   ++> can-expose-groups-on-each-matched-block
     and. > @
@@ -197,6 +224,14 @@
     compile.
       regex "/[a-z/"
       "recovered" > [message]
+
+  not. ++> stops-on-a-terminal-zero-width-match
+    exists.
+      next.
+        next.
+          match.
+            regex "/$/"
+            "x"
 
   compiled. --> stops-on-a-missing-closing-slash
     regex "/pattern"


### PR DESCRIPTION
## Summary

- stop `string.regex.match.next` from repeating terminal zero-width matches
- advance the matcher by one character after non-terminal zero-width matches
- add regression tests for both behaviors

The previous implementation reused `to` as the next matcher start, so Java's matcher could return the same zero-width match indefinitely. Terminal zero-width matches now produce a non-existent result, while non-terminal zero-width matches advance by one character.

Fixes #6143

## Test plan

- `mvn -pl :eo-runtime "-Dtest=EOregexTest,EOregexEOpatternEOmatchEOmatchedfromindexTest" test -ntp`