### PR TITLE
Add cant-get callback to getenv

### DIFF
--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -1,5 +1,4 @@
-# Get environment variable as `string`.
-# If the return `string` is empty - the variable does not exist.
+# Get environment variable as `string`, or `cant-get` if it does not exist.
 #
 # See https://man7.org/linux/man-pages/man3/getenv.3.html.
 
@@ -8,14 +7,30 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 +unlint mandatory-package
 
-output. > [name] > getenv
-  os.is-windows.if
-    win32 *1
-      "getenv"
-      name
-    posix *1
-      "getenv"
-      name
+[name cant-get] > getenv
+  result.code.if > @
+    result.output
+    cant-get
+  called. > result
+    os.is-windows.if
+      win32 *1
+        "getenv"
+        name
+      posix *1
+        "getenv"
+        name
+
+  not. ++> can-read-an-existing-variable
+    eq.
+      getenv
+        "PATH"
+        "not found"
+      "not found"
+
+  eq. ++> can-use-fallback-when-variable-does-not-exist
+    getenv
+      "EO_UNSET_VARIABLE_6142"
+      "not found"
+    "not found"

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -27,9 +27,9 @@
                 if.
                   userprofile.eq empty
                   "C:\\Windows"
-                  getenv "USERPROFILE" >> userprofile!
-                getenv "TEMP" >> temp!
-              getenv "TMP" >> tmp!
+                  getenv "USERPROFILE" empty >> userprofile!
+                getenv "TEMP" empty >> temp!
+              getenv "TMP" empty >> tmp!
             if.
               tmpdir.eq empty
               if.
@@ -39,10 +39,10 @@
                   if.
                     tempdir.eq empty
                     "/tmp"
-                    getenv "TEMPDIR" >> tempdir!
+                    getenv "TEMPDIR" empty >> tempdir!
                   temp
                 tmp
-              getenv "TMPDIR" >> tmpdir!
+              getenv "TMPDIR" empty >> tmpdir!
           -- > empty
 
   mktemp.tmpfile.exists ++> can-create-a-temp-file


### PR DESCRIPTION
getenv now uses the syscall result code so an unset variable invokes cant-get while an existing empty variable remains an empty string. Embedded tests cover existing and missing environment variables. Tests: EOgetenvTest (2 passed). Closes #6142. @yegor256