### PR TITLE
#6233: enforce mandatory blank line before +>/--> test attribute on non-formation lines

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -57,7 +57,6 @@ final class LnApplication implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.checkPlain(this.span, globals, emit);
         final Tokens tokens = new Tokens(this.span.body(), this.span);
         final Value head = tokens.readValue();
         final List<MethodChain> chain = tokens.readChain();
@@ -67,6 +66,11 @@ final class LnApplication implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        } else {
+            Blanks.checkPlain(this.span, globals, emit);
+        }
         if (head.kind() == Value.Kind.GROUP
             && chain.isEmpty() && args.isEmpty() && outer == null) {
             throw new ParseError(

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -58,7 +58,6 @@ final class LnCompactTuple implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.checkPlain(this.span, globals, emit);
         final Tokens tokens = new Tokens(this.span.body(), this.span);
         final Value head = tokens.readValue();
         final List<MethodChain> chain;
@@ -85,6 +84,11 @@ final class LnCompactTuple implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        } else {
+            Blanks.checkPlain(this.span, globals, emit);
+        }
         final Level level = this.transition(stack, suffix);
         level.compact(count);
         globals.clearBlanks();

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -62,7 +62,6 @@ final class LnMethod implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.checkPlain(this.span, globals, emit);
         this.precheck(stack);
         final Level top = stack.top();
         final Tokens tokens = this.dottedTokens();
@@ -74,6 +73,11 @@ final class LnMethod implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        } else {
+            Blanks.checkPlain(this.span, globals, emit);
+        }
         Comments.seal(globals, emit, this.span);
         if (outer != null && stack.below() != null) {
             stack.below().upgradeArgBinding();

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -59,7 +59,6 @@ final class LnReversed implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.checkPlain(this.span, globals, emit);
         final Tokens tokens = new Tokens(this.span.body(), this.span);
         final Value head = LnReversed.readHead(tokens);
         if (tokens.atEnd() || !tokens.dispatchAhead()) {
@@ -80,6 +79,11 @@ final class LnReversed implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        } else {
+            Blanks.checkPlain(this.span, globals, emit);
+        }
         Comments.seal(globals, emit, this.span);
         final Kind kind;
         final Openness openness;

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -40,7 +40,6 @@ final class LnTextBlock implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.checkPlain(this.span, globals, emit);
         final String body = this.span.body();
         if (!body.startsWith("\"\"\"")) {
             throw new ParseError(
@@ -54,6 +53,11 @@ final class LnTextBlock implements Line {
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
+        if (suffix.test()) {
+            Blanks.checkTest(this.span, globals, emit);
+        } else {
+            Blanks.checkPlain(this.span, globals, emit);
+        }
         final String joined;
         try {
             joined = Emissions.unescapeBody(

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -776,7 +776,7 @@ final class LnApplicationTest {
     }
 
     @Test
-    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+    void rejectsAttributeWithoutPrecedingBlankLine() {
         final Emit emit = new Emit();
         new LnApplication(new Span("foo +> t", 2))
             .into(new Stack(), new Globals(), emit);
@@ -789,7 +789,7 @@ final class LnApplicationTest {
     }
 
     @Test
-    void acceptsTestAttributeAfterBlankLine() {
+    void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -775,6 +775,34 @@ final class LnApplicationTest {
         );
     }
 
+    @Test
+    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        new LnApplication(new Span("foo +> t", 2))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on an application line with no blank line above must emit an R-6.5.3 error",
+            LnApplicationTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsTestAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Globals globals = new Globals();
+        globals.blank();
+        new LnApplication(new Span("foo +> t", 2))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on an application line preceded by one blank line must not emit any error",
+            LnApplicationTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
     /**
      * Parse one application line into a fresh stack and emit.
      * @param body Line body

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -78,6 +78,34 @@ final class LnCompactTupleTest {
         );
     }
 
+    @Test
+    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        new LnCompactTuple(new Span("sprintf *1 +> t", 2))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a compact-tuple line with no blank line above must emit an R-6.5.3 error",
+            LnCompactTupleTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsTestAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Globals globals = new Globals();
+        globals.blank();
+        new LnCompactTuple(new Span("sprintf *1 +> t", 2))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a compact-tuple line preceded by one blank line must not emit any error",
+            LnCompactTupleTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -79,7 +79,7 @@ final class LnCompactTupleTest {
     }
 
     @Test
-    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+    void rejectsAttributeWithoutPrecedingBlankLine() {
         final Emit emit = new Emit();
         new LnCompactTuple(new Span("sprintf *1 +> t", 2))
             .into(new Stack(), new Globals(), emit);
@@ -92,7 +92,7 @@ final class LnCompactTupleTest {
     }
 
     @Test
-    void acceptsTestAttributeAfterBlankLine() {
+    void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -166,6 +166,37 @@ final class LnMethodTest {
         );
     }
 
+    @Test
+    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        final Stack stack = new Stack();
+        final Globals globals = new Globals();
+        new LnApplication(new Span("foo", 1)).into(stack, globals, emit);
+        new LnMethod(new Span(".bar +> t", 2)).into(stack, globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a method-continuation line with no blank line above must emit an R-6.5.3 error",
+            LnMethodTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsTestAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Stack stack = new Stack();
+        final Globals globals = new Globals();
+        new LnApplication(new Span("foo", 1)).into(stack, globals, emit);
+        globals.blank();
+        new LnMethod(new Span(".bar +> t", 2)).into(stack, globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a method-continuation line preceded by one blank line must not emit any error",
+            LnMethodTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -167,7 +167,7 @@ final class LnMethodTest {
     }
 
     @Test
-    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+    void rejectsAttributeWithoutPrecedingBlankLine() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();
         final Globals globals = new Globals();
@@ -182,7 +182,7 @@ final class LnMethodTest {
     }
 
     @Test
-    void acceptsTestAttributeAfterBlankLine() {
+    void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();
         final Globals globals = new Globals();

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -125,7 +125,7 @@ final class LnReversedTest {
     }
 
     @Test
-    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+    void rejectsAttributeWithoutPrecedingBlankLine() {
         final Emit emit = new Emit();
         new LnReversed(new Span("if. cond then +> t", 2))
             .into(new Stack(), new Globals(), emit);
@@ -138,7 +138,7 @@ final class LnReversedTest {
     }
 
     @Test
-    void acceptsTestAttributeAfterBlankLine() {
+    void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -124,6 +124,34 @@ final class LnReversedTest {
         );
     }
 
+    @Test
+    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("if. cond then +> t", 2))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a reversed-dispatch line with no blank line above must emit an R-6.5.3 error",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='2']")
+        );
+    }
+
+    @Test
+    void acceptsTestAttributeAfterBlankLine() {
+        final Emit emit = new Emit();
+        final Globals globals = new Globals();
+        globals.blank();
+        new LnReversed(new Span("if. cond then +> t", 2))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a reversed-dispatch line preceded by one blank line must not emit any error",
+            LnReversedTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -143,6 +143,39 @@ final class LnTextBlockTest {
         );
     }
 
+    @Test
+    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("hello");
+        final Emit emit = new Emit();
+        new LnTextBlock(new Span("\"\"\" +> t", 3))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a text-block closer with no blank line above must emit an R-6.5.3 error",
+            LnTextBlockTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/errors/error[@line='3']")
+        );
+    }
+
+    @Test
+    void acceptsTestAttributeAfterBlankLine() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("hello");
+        globals.blank();
+        final Emit emit = new Emit();
+        new LnTextBlock(new Span("\"\"\" +> t", 3))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `+>` test attribute on a text-block closer preceded by one blank line must not emit any error",
+            LnTextBlockTest.render(emit),
+            Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -144,7 +144,7 @@ final class LnTextBlockTest {
     }
 
     @Test
-    void rejectsTestAttributeWithoutPrecedingBlankLine() {
+    void rejectsAttributeWithoutPrecedingBlankLine() {
         final Globals globals = new Globals();
         globals.openTextBlock(1, 0);
         globals.appendTextLine("hello");
@@ -160,7 +160,7 @@ final class LnTextBlockTest {
     }
 
     @Test
-    void acceptsTestAttributeAfterBlankLine() {
+    void acceptsAttributeAfterBlankLine() {
         final Globals globals = new Globals();
         globals.openTextBlock(1, 0);
         globals.appendTextLine("hello");

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
@@ -11,8 +11,11 @@ asserts:
   - /object/o[@name='foo']/o[@base='.eq' and @name='+compares-something']
 input: |-
   [] > foo
+
     true +> test-works
+
     false +> always-fails
+
     eq. +> compares-something
       "foo"
       "bar"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
@@ -9,6 +9,7 @@ asserts:
   - /object/o[@name='foo']/o[@name='λ']
 input: |-
   [] > foo /bytes
+
     eq. +> test-1
       foo
       "fox"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tests.yaml
@@ -20,6 +20,7 @@ input: |
       eq. > @
         7
         fibo 5
+
     eq. +> fibo-2nd-equals-to-one
       1
       fibo 2


### PR DESCRIPTION
Closes #6233

`LnApplication`, `LnMethod`, `LnReversed`, `LnCompactTuple`, and `LnTextBlock` all called `Blanks.checkPlain` unconditionally, before their suffix was even parsed, so a `+>`/`-->` test attribute on any of these line kinds never got the mandatory-blank-line check (R-6.5.3) that `LnFormation` and `LnOnlyPhi` already enforce, and instead got the opposite rule (blank line forbidden).

Moved the blank check to after the suffix is parsed and branch on `suffix.test()`, calling `Blanks.checkTest` instead of `Blanks.checkPlain` when the line carries a test attribute, mirroring `LnFormation`/`LnOnlyPhi` exactly.

Also fixed three existing `eo-syntax` fixtures (`tests.yaml`, `atoms-with-inner-tests.yaml`, `application-in-tests.yaml`) that had test attributes on application/reversed-dispatch lines with no blank line above them. These previously passed only because of this bug; they now need the blank line the rule always required.

Added reject/accept unit test pairs to all 5 `Ln*Test` classes, matching the existing pattern in `LnFormationTest`.
