### PR TITLE
feat(#4752): add string.padded-right

### DIFF
--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -1,0 +1,126 @@
+# Returns `text` padded on the right with `fill` until it counts `width`
+# characters, so that `x` padded to five characters with a space
+# becomes `x    `. Characters are counted, and not bytes, so a multi-byte
+# character widens the text by one. A `text` of `width` characters
+# or longer is returned unchanged.
+# If `width` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), or `fill` is not a single character, the `cant-pad` fallback
+# is returned, or the bottom object when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text width fill cant-pad] > padded-right
+  if. > @
+    or.
+      or.
+        0.gt width
+        width.is-integer.not
+      not.
+        1.eq fill.length
+    cant-pad
+      "Can't pad text to %f characters with %s".printf
+        * width fill
+    if.
+      width.gt
+        text.length >> len!
+      string
+        text.as-bytes.concat
+          as-bytes.
+            repeated
+              fill
+              as-number.
+                width.minus len
+              cant-pad
+      text
+
+  eq. ++> can-count-characters-and-not-bytes
+    "Ж  "
+    padded-right
+      "Ж"
+      3
+      " "
+
+  eq. ++> can-format-the-error-message-of-a-negative-width
+    "Can't pad text to -1.000000 characters with x"
+    padded-right
+      "y"
+      -1
+      "x"
+      message > [message]
+
+  eq. ++> can-pad-a-text-with-trailing-spaces
+    "x         "
+    padded-right
+      "x"
+      10
+      " "
+
+  eq. ++> can-pad-with-trailing-zeros
+    "4200"
+    padded-right
+      "42"
+      4
+      "0"
+
+  eq. ++> can-return-a-longer-text-unchanged
+    "hello"
+    padded-right
+      "hello"
+      3
+      " "
+
+  eq. ++> can-return-a-text-of-the-exact-width-unchanged
+    "hey"
+    padded-right
+      "hey"
+      3
+      " "
+
+  eq. ++> can-return-a-text-unchanged-at-zero-width
+    "x"
+    padded-right
+      "x"
+      0
+      " "
+
+  eq. ++> rejects-a-multi-character-fill
+    "recovered"
+    padded-right
+      "y"
+      5
+      "ab"
+      "recovered" > [message]
+
+  eq. ++> rejects-a-negative-width
+    "recovered"
+    padded-right
+      "y"
+      -1
+      "x"
+      "recovered" > [message]
+
+  eq. ++> rejects-a-non-integer-width
+    "recovered"
+    padded-right
+      "y"
+      2.5
+      "x"
+      "recovered" > [message]
+
+  eq. ++> rejects-an-infinite-width
+    "recovered"
+    padded-right
+      "y"
+      pinf
+      "x"
+      "recovered" > [message]
+
+  padded-right --> stops-on-a-negative-width
+    "y"
+    -1
+    "x"


### PR DESCRIPTION
Adds `string.padded-right`, a mirror of the just-merged `string.padded-left`: it pads `text` on the right with `fill` until it counts `width` characters. Characters are counted, not bytes.

Needed by the pure-EO `printf` (#4752) for the `-` flag, e.g. `%-10s` and `%-25x`.

Invalid input (negative, fractional, `nan` or infinite `width`, or a multi-character `fill`) falls back to `cant-pad`, or to the bottom object when unbound.