### PR TITLE
#6200: restore-aliases.xsl drops +alias for +also-only references

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
@@ -31,12 +31,13 @@
   <xsl:variable name="aliases" select="/object/metas/meta[head = 'alias']"/>
   <!-- Every name already bound in the file, so an alias short name that clashes with one is left alone. -->
   <xsl:variable name="bound" select="distinct-values((//o/@name, //o/@local))"/>
-  <!-- Every reference string, counted with multiplicity, across the four spots resolve-aliases rewrote. -->
+  <!-- Every reference string, counted with multiplicity, across the five spots resolve-aliases rewrote. -->
   <xsl:variable name="refs" as="xs:string*">
     <xsl:sequence select="//o/@base/string()"/>
     <xsl:sequence select="//o/@atom/string()"/>
     <xsl:sequence select="for $a in //o/@args, $t in tokenize($a, ' ')[. != ''] return $t"/>
     <xsl:sequence select="for $t in //o/@type return replace($t, '\?$', '')"/>
+    <xsl:sequence select="/object/metas/meta[head = 'also']/part/string()"/>
   </xsl:variable>
   <!-- Whether an alias's short name reads back unambiguously: no bound name and no bare global claims it. -->
   <xsl:function name="eo:free" as="xs:boolean">
@@ -62,6 +63,12 @@
   <xsl:template match="o/@type">
     <xsl:variable name="opt" select="ends-with(., '?')"/>
     <xsl:attribute name="type" select="concat(eo:shorten(replace(., '\?$', '')), if ($opt) then '?' else '')"/>
+  </xsl:template>
+  <xsl:template match="metas/meta[head = 'also']/part/text()">
+    <xsl:value-of select="eo:shorten(.)"/>
+  </xsl:template>
+  <xsl:template match="metas/meta[head = 'also']/tail/text()">
+    <xsl:value-of select="string-join(for $p in ../../part return eo:shorten($p), ' ')"/>
   </xsl:template>
   <!-- Drop a dead or single-use alias whose short name was free to restore; a clashing alias is left in place. -->
   <xsl:template match="metas/meta[head = 'alias' and eo:free(part[1]) and not(part[last()] = $kept)]"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-referenced-via-also.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-referenced-via-also.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# "restore-aliases" (#6184) counts how many times an alias's target is
+# referenced before deciding whether to keep the `+alias` or drop it. It used
+# to scan only `@base`, `@atom`, `@args` and `@type`, never the resolved value
+# of a `+also` meta, even though the parser's own "resolve-aliases" resolves
+# `+also X` through the exact same alias table. So a target referenced once as
+# a normal object and once via `+also` looked "referenced once" and its
+# `+alias` was dropped instead of kept (#6200). `appellation` here is used both
+# as `+also appellation` and as `a`'s value, so it must round-trip unchanged.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +alias eo3.pardon.appellation
+  +also appellation
+  +package eo3.skeptic
+
+  [] > human
+    appellation > a
+
+printed: |
+  +alias eo3.pardon.appellation
+  +also appellation
+  +package eo3.skeptic
+
+  [] > human
+    appellation > a


### PR DESCRIPTION
`restore-aliases.xsl` decides whether to keep an `+alias` by counting how many times its target is referenced, but it only scanned `@base`, `@atom`, `@args` and `@type`. It never scanned the resolved value of a `+also` meta, even though the parser's own `resolve-aliases.xsl` resolves `+also X` through the same alias table. So a target referenced once as a normal object and once via `+also` looked "referenced once" and its `+alias` was dropped instead of kept.

This adds the resolved `+also` parts to the reference count, and adds a print-side template so the `+also` meta itself is shortened back to the alias name when the alias is kept (it was staying fully qualified even before this bug, since nothing restored it).

Added `alias-referenced-via-also.yaml` reproducing the exact case from the issue. Confirmed it fails on unpatched code with the same output shown in the issue, and passes with the fix.

Closes #6200
