### PR TITLE
#6234: validate write/send size against buffer length before native call

### DIFF
--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -114,3 +114,21 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  --> stops-on-write-size-exceeding-buffer-length
+    os.is-windows.if > @
+      1.div 0
+      seq *
+        code.
+          posix *1
+            "write"
+            fd
+            "ab"
+            4096
+        true
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly
+        0

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -115,6 +115,24 @@
           "127.0.0.1"
       16777343
 
+  --> stops-on-write-size-being-negative
+    os.is-windows.if > @
+      1.div 0
+      seq *
+        code.
+          posix *1
+            "write"
+            fd
+            "ab"
+            -1
+        true
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly
+        0
+
   --> stops-on-write-size-exceeding-buffer-length
     os.is-windows.if > @
       1.div 0

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -59,3 +59,21 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  --> stops-on-write-size-exceeding-buffer-length
+    os.is-windows.not.if > @
+      1.div 0
+      seq *
+        code.
+          win32 *1
+            "_write"
+            fd
+            "ab"
+            4096
+        true
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly
+        0

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -60,6 +60,24 @@
           "127.0.0.1"
       16777343
 
+  --> stops-on-write-size-being-negative
+    os.is-windows.not.if > @
+      1.div 0
+      seq *
+        code.
+          win32 *1
+            "_write"
+            fd
+            "ab"
+            -1
+        true
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly
+        0
+
   --> stops-on-write-size-exceeding-buffer-length
     os.is-windows.not.if > @
       1.div 0

--- a/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,14 +32,22 @@ public final class SendSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final byte[] buf = new Dataized(params[1]).take();
+        final int size = new Dataized(params[2]).asNumber().intValue();
+        if (size > buf.length) {
+            throw new ExFailure(
+                "Can't send %d bytes from a buffer of only %d bytes",
+                size, buf.length
+            );
+        }
         final Phi result = this.posix.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.send(
                     new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).take(),
-                    new Dataized(params[2]).asNumber().intValue(),
+                    buf,
+                    size,
                     new Dataized(params[3]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
@@ -34,7 +34,7 @@ public final class SendSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size > buf.length) {
+        if (size < 0 || size > buf.length) {
             throw new ExFailure(
                 "Can't send %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,14 +32,22 @@ public final class WriteSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final byte[] buf = new Dataized(params[1]).take();
+        final int size = new Dataized(params[2]).asNumber().intValue();
+        if (size > buf.length) {
+            throw new ExFailure(
+                "Can't write %d bytes from a buffer of only %d bytes",
+                size, buf.length
+            );
+        }
         final Phi result = this.posix.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.write(
                     new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).take(),
-                    new Dataized(params[2]).asNumber().intValue()
+                    buf,
+                    size
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
@@ -34,7 +34,7 @@ public final class WriteSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size > buf.length) {
+        if (size < 0 || size > buf.length) {
             throw new ExFailure(
                 "Can't write %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -6,6 +6,7 @@ package org.eolang.win32;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -32,14 +33,22 @@ public final class SendFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final byte[] buf = new Dataized(params[1]).take();
+        final int size = new Dataized(params[2]).asNumber().intValue();
+        if (size > buf.length) {
+            throw new ExFailure(
+                "Can't send %d bytes from a buffer of only %d bytes",
+                size, buf.length
+            );
+        }
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.send(
                     new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).take(),
-                    new Dataized(params[2]).asNumber().intValue(),
+                    buf,
+                    size,
                     new Dataized(params[3]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -35,7 +35,7 @@ public final class SendFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size > buf.length) {
+        if (size < 0 || size > buf.length) {
             throw new ExFailure(
                 "Can't send %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
@@ -34,7 +34,7 @@ public final class WriteFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size > buf.length) {
+        if (size < 0 || size > buf.length) {
             throw new ExFailure(
                 "Can't write %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
@@ -6,6 +6,7 @@ package org.eolang.win32;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,14 +32,22 @@ public final class WriteFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final byte[] buf = new Dataized(params[1]).take();
+        final int size = new Dataized(params[2]).asNumber().intValue();
+        if (size > buf.length) {
+            throw new ExFailure(
+                "Can't write %d bytes from a buffer of only %d bytes",
+                size, buf.length
+            );
+        }
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 Msvcrt.INSTANCE._write(
                     new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).take(),
-                    new Dataized(params[2]).asNumber().intValue()
+                    buf,
+                    size
                 )
             )
         );


### PR DESCRIPTION
Closes #6234

`WriteSyscall`/`SendSyscall` (posix) and `WriteFuncCall`/`SendFuncCall` (win32) passed the caller-supplied `size` straight to the native `write`/`send` call without checking it against the actual length of the supplied buffer. A caller could pass a small buffer with a large `size`, causing the native call to read past the end of the JNA-allocated buffer and leak adjacent JVM memory into a file or socket (or crash, depending on heap layout).

Each of the four classes now checks `size <= buf.length` and throws a clear `ExFailure` before making the native call, instead of passing the mismatched size through.

Added EO-level throwing tests to `posix.eo` and `win32.eo` (`stops-on-write-size-exceeding-buffer-length`) verifying that an oversized `size` argument is now rejected rather than silently accepted. Verified locally that the posix test fails with "Expected Exception to be thrown, but nothing was thrown" when the fix is reverted, and passes with the fix in place. The win32 test is gated to only exercise the real win32 call on Windows; it is a no-op pass on other platforms since the CI runners for other OSes don't have win32 syscalls at all.
