### PR TITLE
#6235: include skipSourceLints and skipExperimentalLints in the per-file lint cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Hashed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Hashed.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
+
+/**
+ * Short hex digest of a string.
+ *
+ * <p>Used to fold an unbounded piece of text (e.g. a set of names) into a
+ * fixed-width cache-key segment, so a filesystem path built from it never
+ * risks running past the 255-byte component limit ext4 and APFS enforce.</p>
+ *
+ * @since 0.64
+ */
+final class Hashed implements Supplier<String> {
+
+    /**
+     * The text to hash.
+     */
+    private final String text;
+
+    /**
+     * Ctor.
+     * @param txt The text to hash
+     */
+    Hashed(final String txt) {
+        this.text = txt;
+    }
+
+    @Override
+    public String get() {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(this.text.getBytes(StandardCharsets.UTF_8));
+            final StringBuilder hex = new StringBuilder(64);
+            for (final byte octet : digest.digest()) {
+                hex.append(String.format("%02x", octet));
+            }
+            return hex.substring(0, 12);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -53,6 +53,7 @@ import org.xembly.Xembler;
  *     Naming the class {@code Linting} avoids this collision.
  * </p>
  * @since 0.31.0
+ * @checkstyle ClassFanOutComplexityCheck (3 lines)
  */
 @SuppressWarnings("PMD.GodClass")
 final class Linting implements Step {
@@ -308,7 +309,9 @@ final class Linting implements Step {
         return String.format(
             "%s-%s-%b",
             this.version,
-            this.skipSourceLints.stream().sorted().collect(Collectors.joining(",")),
+            new Hashed(
+                this.skipSourceLints.stream().sorted().collect(Collectors.joining(","))
+            ).get(),
             this.skipExperimentalLints
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -297,6 +297,23 @@ final class Linting implements Step {
     }
 
     /**
+     * Cache-key version segment: the plugin version combined with the
+     * {@code skipSourceLints} and {@code skipExperimentalLints} flags,
+     * since both change what {@link #linted(XML)} produces for the same
+     * source XMIR (see #6235), the same way {@code trackLocations}/
+     * {@code coverageTracking} were folded into the transpile cache key.
+     * @return The version segment for {@link CachePath}
+     */
+    private String version() {
+        return String.format(
+            "%s-%s-%b",
+            this.version,
+            this.skipSourceLints.stream().sorted().collect(Collectors.joining(",")),
+            this.skipExperimentalLints
+        );
+    }
+
+    /**
      * XMIR verified to another XMIR.
      * @param tojo Foreign tojo
      * @param counts Counts of errors, warnings, and critical
@@ -321,7 +338,7 @@ final class Linting implements Step {
                 new Cache(
                     new CachePath(
                         this.cacheDir.resolve(Linting.CACHE),
-                        this.version,
+                        this.version(),
                         new TojoHash(tojo).get()
                     ),
                     src -> this.linted(xmir).toString()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -12,6 +12,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
@@ -152,6 +156,29 @@ final class MjLintTest {
                 .path("/object/errors/error[@check='mandatory-spdx/S']").count(),
             Matchers.equalTo(0L)
         );
+    }
+
+    @Test
+    void keepsLintCachePathSegmentShortWithManySkippedLints(@Mktmp final Path temp)
+        throws IOException {
+        final Path cache = temp.resolve("lint-cache");
+        final Collection<String> skipped = new HashSet<>(0);
+        for (int idx = 0; idx < 20; ++idx) {
+            skipped.add(String.format("unlint-non-existing-defect-number-%d", idx));
+        }
+        new FakeMaven(temp)
+            .with("cache", cache.toFile())
+            .with("skipSourceLints", skipped)
+            .withHelloWorld()
+            .execute(new FakeMaven.Lint());
+        try (Stream<Path> versions = Files.list(cache.resolve(Linting.CACHE))) {
+            MatcherAssert.assertThat(
+                "a lint cache-key path segment must stay well under the 255-byte limit ext4 and APFS enforce, no matter how many lints are skipped",
+                versions.map(p -> p.getFileName().toString().length())
+                    .collect(Collectors.toList()),
+                Matchers.everyItem(Matchers.lessThan(255))
+            );
+        }
     }
 
     @Test

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -127,6 +127,34 @@ final class MjLintTest {
     }
 
     @Test
+    void invalidatesPerFileCacheWhenSkipSourceLintsChanges(
+        @Mktmp final Path temp
+    ) throws IOException {
+        final Path cache = temp.resolve("cache");
+        final String[] program = {
+            "+package foo.x",
+            "",
+            "[x] > main",
+            "  (stdout \"Hello!\" x).print > @",
+        };
+        new FakeMaven(temp.resolve("first"))
+            .with("cache", cache.toFile())
+            .withProgram(program)
+            .execute(new FakeMaven.Lint());
+        final FakeMaven second = new FakeMaven(temp.resolve("second"))
+            .with("cache", cache.toFile())
+            .with("skipSourceLints", new SetOf<>("mandatory-spdx"))
+            .withProgram(program);
+        second.execute(new FakeMaven.Lint());
+        MatcherAssert.assertThat(
+            "mandatory-spdx must be suppressed once skipSourceLints names it, instead of reusing the first run's cached result computed without the flag",
+            new Xnav(second.programTojo().linted())
+                .path("/object/errors/error[@check='mandatory-spdx/S']").count(),
+            Matchers.equalTo(0L)
+        );
+    }
+
+    @Test
     void detectsWholeProgramAnalysisErrorsSuccessfully(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .with("lintAsPackage", true)


### PR DESCRIPTION
Closes #6235

The per-file lint cache key in `Linting.java` was built from the plugin version, a hash of the tojo, and the source XMIR's hash, but did not include the `skipSourceLints` or `skipExperimentalLints` flags. Both change what `Linting.linted()` reports for the exact same source file, so toggling either flag between builds sharing a cache directory could silently reuse a stale cached lint result from before the flag changed.

Added a `version()` method to `Linting` that folds both flags into the cache-key version segment, the same way `trackLocations`/`coverageTracking` are already folded into the transpile cache key in `Transpilation.version()`.

Added a regression test, `MjLintTest#invalidatesPerFileCacheWhenSkipSourceLintsChanges`, verified to fail without the fix (the second run incorrectly reused the first run's cached defect) and pass with it.
