### PR TITLE
#6236: fold a fingerprint of parse-stage XSLs into the parse cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -50,6 +50,41 @@ final class Parsing implements Step {
     static final String ZERO = "0.0.0";
 
     /**
+     * Classpath resources of the canonical parse-stage XSLs applied by
+     * {@link org.eolang.parser.Canonical}, plus the shared libraries they
+     * {@code xsl:import}, folded into the parse cache key's fingerprint (see
+     * {@link #parsed(TjForeign, UnaryOperator, String)}) so that editing any
+     * of them invalidates previously cached XMIR for the same source, the
+     * same way {@link Transpilation#XSLS}/{@link Transpilation#IMPORTS} are
+     * folded into the transpile cache key. This list must be kept in sync
+     * with {@code Canonical.Pipeline.value()}.
+     */
+    static final String[] PARSE_XSLS = {
+        "/org/eolang/parser/parse/wrap-applications.xsl",
+        "/org/eolang/parser/parse/resolve-self.xsl",
+        "/org/eolang/parser/parse/resolve-local-names.xsl",
+        "/org/eolang/parser/parse/validate-before-stars.xsl",
+        "/org/eolang/parser/parse/resolve-before-stars.xsl",
+        "/org/eolang/parser/parse/fragile-dispatch.xsl",
+        "/org/eolang/parser/parse/wrap-method-calls.xsl",
+        "/org/eolang/parser/parse/const-to-dataized.xsl",
+        "/org/eolang/parser/parse/stars-to-tuples.xsl",
+        "/org/eolang/parser/parse/vars-float-up.xsl",
+        "/org/eolang/parser/parse/move-voids-up.xsl",
+        "/org/eolang/parser/parse/validate-objects-count.xsl",
+        "/org/eolang/parser/parse/build-fqns.xsl",
+        "/org/eolang/parser/parse/expand-aliases.xsl",
+        "/org/eolang/parser/parse/resolve-aliases.xsl",
+        "/org/eolang/parser/parse/add-default-package.xsl",
+        "/org/eolang/parser/parse/roll-bases.xsl",
+        "/org/eolang/parser/parse/cti-adds-errors.xsl",
+        "/org/eolang/parser/parse/mandatory-as.xsl",
+        "/org/eolang/parser/parse/set-locators.xsl",
+        "/org/eolang/parser/_funcs.xsl",
+        "/org/eolang/parser/_specials.xsl",
+    };
+
+    /**
      * The directory where to parse to.
      */
     static final String DIR = "1-parse";
@@ -162,6 +197,23 @@ final class Parsing implements Step {
     }
 
     /**
+     * Cache-key version segment: the plugin version combined with a
+     * fingerprint of the canonical parse-stage XSLs and the libraries they
+     * {@code xsl:import}, plus the digest of the set of known objects.
+     * Folding the XSL content in means that editing a parse stylesheet
+     * invalidates any previously cached XMIR for the same source, the same
+     * way {@link Transpilation#version()} does for the transpile cache
+     * (see #6236).
+     * @param digest Digest of the set of known objects (part of the cache key)
+     * @return The version segment for {@link CachePath}
+     */
+    String version(final String digest) {
+        return String.format(
+            "%s-%s-%s", this.version, new Fingerprint(Parsing.PARSE_XSLS).get(), digest
+        );
+    }
+
+    /**
      * Parse all the given sources to XMIRs, concurrently.
      * @param sources The sources to parse
      * @param pipeline The canonical parsing transform to apply
@@ -201,7 +253,7 @@ final class Parsing implements Step {
                 new Cache(
                     new CachePath(
                         this.cacheDir.resolve(Parsing.CACHE),
-                        String.format("%s-%s", this.version, digest),
+                        this.version(digest),
                         new TojoHash(tojo).get()
                     ),
                     src -> {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -56,33 +56,11 @@ final class Parsing implements Step {
      * {@link #parsed(TjForeign, UnaryOperator, String)}) so that editing any
      * of them invalidates previously cached XMIR for the same source, the
      * same way {@link Transpilation#XSLS}/{@link Transpilation#IMPORTS} are
-     * folded into the transpile cache key. This list must be kept in sync
-     * with {@code Canonical.Pipeline.value()}.
+     * folded into the transpile cache key. Delegates to {@link Canonical#XSLS},
+     * the same list the real pipeline is built from, so the two cannot drift
+     * apart the way two independently maintained copies could.
      */
-    static final String[] PARSE_XSLS = {
-        "/org/eolang/parser/parse/wrap-applications.xsl",
-        "/org/eolang/parser/parse/resolve-self.xsl",
-        "/org/eolang/parser/parse/resolve-local-names.xsl",
-        "/org/eolang/parser/parse/validate-before-stars.xsl",
-        "/org/eolang/parser/parse/resolve-before-stars.xsl",
-        "/org/eolang/parser/parse/fragile-dispatch.xsl",
-        "/org/eolang/parser/parse/wrap-method-calls.xsl",
-        "/org/eolang/parser/parse/const-to-dataized.xsl",
-        "/org/eolang/parser/parse/stars-to-tuples.xsl",
-        "/org/eolang/parser/parse/vars-float-up.xsl",
-        "/org/eolang/parser/parse/move-voids-up.xsl",
-        "/org/eolang/parser/parse/validate-objects-count.xsl",
-        "/org/eolang/parser/parse/build-fqns.xsl",
-        "/org/eolang/parser/parse/expand-aliases.xsl",
-        "/org/eolang/parser/parse/resolve-aliases.xsl",
-        "/org/eolang/parser/parse/add-default-package.xsl",
-        "/org/eolang/parser/parse/roll-bases.xsl",
-        "/org/eolang/parser/parse/cti-adds-errors.xsl",
-        "/org/eolang/parser/parse/mandatory-as.xsl",
-        "/org/eolang/parser/parse/set-locators.xsl",
-        "/org/eolang/parser/_funcs.xsl",
-        "/org/eolang/parser/_specials.xsl",
-    };
+    static final List<String> PARSE_XSLS = Canonical.XSLS;
 
     /**
      * The directory where to parse to.
@@ -209,7 +187,8 @@ final class Parsing implements Step {
      */
     String version(final String digest) {
         return String.format(
-            "%s-%s-%s", this.version, new Fingerprint(Parsing.PARSE_XSLS).get(), digest
+            "%s-%s-%s", this.version,
+            new Fingerprint(Parsing.PARSE_XSLS.toArray(new String[0])).get(), digest
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -350,7 +350,7 @@ final class MjParseTest {
         return String.format(
             "%s-%s-%s",
             FakeMaven.pluginVersion(),
-            new Fingerprint(Parsing.PARSE_XSLS).get(),
+            new Fingerprint(Parsing.PARSE_XSLS.toArray(new String[0])).get(),
             new UncheckedText(
                 new HexOf(new Sha256DigestOf(new InputOf(identifier)))
             ).asString()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -348,8 +348,9 @@ final class MjParseTest {
      */
     private static String cacheVersion(final String identifier) {
         return String.format(
-            "%s-%s",
+            "%s-%s-%s",
             FakeMaven.pluginVersion(),
+            new Fingerprint(Parsing.PARSE_XSLS).get(),
             new UncheckedText(
                 new HexOf(new Sha256DigestOf(new InputOf(identifier)))
             ).asString()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParsingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParsingTest.java
@@ -34,6 +34,17 @@ final class ParsingTest {
         );
     }
 
+    @Test
+    void includesXslFingerprintInVersion() {
+        MatcherAssert.assertThat(
+            "the cache-key version must include the fingerprint of the canonical parse-stage XSLs, not just the plugin version and the digest",
+            ParsingTest.parsing().version("some-digest"),
+            Matchers.containsString(
+                new Fingerprint(Parsing.PARSE_XSLS.toArray(new String[0])).get()
+            )
+        );
+    }
+
     /**
      * A minimal {@link Parsing} instance for testing its private helpers.
      * @return A new instance

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ParsingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ParsingTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Parsing}.
+ * @since 0.1
+ */
+final class ParsingTest {
+
+    @Test
+    void includesDigestInVersion() {
+        MatcherAssert.assertThat(
+            "the cache-key version must end with the digest of the known objects",
+            ParsingTest.parsing().version("some-digest"),
+            Matchers.endsWith("-some-digest")
+        );
+    }
+
+    @Test
+    void changesVersionWhenDigestChanges() {
+        final Parsing parsing = ParsingTest.parsing();
+        MatcherAssert.assertThat(
+            "the cache-key version must reflect the digest of the known objects it is given",
+            parsing.version("digest-one"),
+            Matchers.not(Matchers.equalTo(parsing.version("digest-two")))
+        );
+    }
+
+    /**
+     * A minimal {@link Parsing} instance for testing its private helpers.
+     * @return A new instance
+     */
+    private static Parsing parsing() {
+        return new Parsing(
+            new TjsForeign(),
+            Paths.get("target"),
+            Paths.get("target/cache"),
+            true,
+            "1.0-SNAPSHOT",
+            Paths.get("src/main/eo")
+        );
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -11,7 +11,10 @@ import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.TrJoined;
 import com.yegor256.xsline.Xsline;
+import java.util.List;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
@@ -33,6 +36,75 @@ import org.cactoos.scalar.Unchecked;
  * @since 0.60
  */
 public final class Canonical implements UnaryOperator<XML> {
+
+    /**
+     * Classpath XSLs applied before the local-package-aware
+     * default-package stage, in pipeline order.
+     */
+    static final List<String> HEAD = List.of(
+        "/org/eolang/parser/parse/wrap-applications.xsl",
+        "/org/eolang/parser/parse/resolve-self.xsl",
+        "/org/eolang/parser/parse/resolve-local-names.xsl",
+        "/org/eolang/parser/parse/validate-before-stars.xsl",
+        "/org/eolang/parser/parse/resolve-before-stars.xsl",
+        "/org/eolang/parser/parse/fragile-dispatch.xsl",
+        "/org/eolang/parser/parse/wrap-method-calls.xsl",
+        "/org/eolang/parser/parse/const-to-dataized.xsl",
+        "/org/eolang/parser/parse/stars-to-tuples.xsl",
+        "/org/eolang/parser/parse/vars-float-up.xsl",
+        "/org/eolang/parser/parse/move-voids-up.xsl",
+        "/org/eolang/parser/parse/validate-objects-count.xsl",
+        "/org/eolang/parser/parse/build-fqns.xsl",
+        "/org/eolang/parser/parse/expand-aliases.xsl",
+        "/org/eolang/parser/parse/resolve-aliases.xsl"
+    );
+
+    /**
+     * The classpath XSL that homes a bare reference into the current
+     * package, applied with a runtime {@code objects} parameter.
+     */
+    static final String DEFAULT_PACKAGE = "/org/eolang/parser/parse/add-default-package.xsl";
+
+    /**
+     * Classpath XSLs applied after the default-package stage and before
+     * hex-string decoding, in pipeline order.
+     */
+    static final List<String> MID = List.of(
+        "/org/eolang/parser/parse/roll-bases.xsl",
+        "/org/eolang/parser/parse/cti-adds-errors.xsl",
+        "/org/eolang/parser/parse/mandatory-as.xsl"
+    );
+
+    /**
+     * The classpath XSL applied last, after hex-string decoding.
+     */
+    static final String TAIL = "/org/eolang/parser/parse/set-locators.xsl";
+
+    /**
+     * Shared library XSLs the stages above {@code xsl:import}.
+     */
+    static final List<String> IMPORTS = List.of(
+        "/org/eolang/parser/_funcs.xsl",
+        "/org/eolang/parser/_specials.xsl"
+    );
+
+    /**
+     * All classpath XSLs the canonical pipeline applies or imports, in
+     * pipeline order. Folded into the parse cache key's fingerprint by
+     * {@code org.eolang.maven.Parsing} so that editing any of them
+     * invalidates previously cached XMIR for the same source, the same
+     * way {@code Transpilation.XSLS}/{@code Transpilation.IMPORTS} are
+     * folded into the transpile cache key. Derived from the same group
+     * constants {@link Pipeline#value()} builds the real pipeline from,
+     * so the two cannot drift apart.
+     */
+    public static final List<String> XSLS = Stream.of(
+        Canonical.HEAD.stream(),
+        Stream.of(Canonical.DEFAULT_PACKAGE),
+        Canonical.MID.stream(),
+        Stream.of(Canonical.TAIL),
+        Canonical.IMPORTS.stream()
+    ).flatMap(s -> s).collect(Collectors.toUnmodifiableList());
 
     /**
      * The pipeline, built lazily and only once.
@@ -90,37 +162,19 @@ public final class Canonical implements UnaryOperator<XML> {
                 new TrFull(
                     new TrJoined<>(
                         new TrClasspath<>(
-                            "/org/eolang/parser/parse/wrap-applications.xsl",
-                            "/org/eolang/parser/parse/resolve-self.xsl",
-                            "/org/eolang/parser/parse/resolve-local-names.xsl",
-                            "/org/eolang/parser/parse/validate-before-stars.xsl",
-                            "/org/eolang/parser/parse/resolve-before-stars.xsl",
-                            "/org/eolang/parser/parse/fragile-dispatch.xsl",
-                            "/org/eolang/parser/parse/wrap-method-calls.xsl",
-                            "/org/eolang/parser/parse/const-to-dataized.xsl",
-                            "/org/eolang/parser/parse/stars-to-tuples.xsl",
-                            "/org/eolang/parser/parse/vars-float-up.xsl",
-                            "/org/eolang/parser/parse/move-voids-up.xsl",
-                            "/org/eolang/parser/parse/validate-objects-count.xsl",
-                            "/org/eolang/parser/parse/build-fqns.xsl",
-                            "/org/eolang/parser/parse/expand-aliases.xsl",
-                            "/org/eolang/parser/parse/resolve-aliases.xsl"
+                            Canonical.HEAD.toArray(new String[0])
                         ).back(),
                         new TrDefault<Shift>(
                             new StClasspath(
-                                "/org/eolang/parser/parse/add-default-package.xsl",
+                                Canonical.DEFAULT_PACKAGE,
                                 String.format("objects %s", this.objects)
                             )
                         ),
                         new TrClasspath<>(
-                            "/org/eolang/parser/parse/roll-bases.xsl",
-                            "/org/eolang/parser/parse/cti-adds-errors.xsl",
-                            "/org/eolang/parser/parse/mandatory-as.xsl"
+                            Canonical.MID.toArray(new String[0])
                         ).back(),
                         new TrDefault<>(new StHex()),
-                        new TrClasspath<>(
-                            "/org/eolang/parser/parse/set-locators.xsl"
-                        ).back()
+                        new TrClasspath<>(Canonical.TAIL).back()
                     )
                 )
             )::pass;


### PR DESCRIPTION
Closes #6236

The parse cache key in `Parsing.java` was built from the plugin version, a digest of the known object names, and a hash of the tojo, but did not include any fingerprint of the 20 canonical parse-stage XSLs (`set-locators.xsl`, `build-fqns.xsl`, etc.) that actually transform the parsed source into its final XMIR shape. Editing one of these stylesheets while a cache from before the edit still exists produced stale, silently wrong XMIR.

A `Fingerprint` class already exists for exactly this (added for #5578, hardened by #6032) and is already used by the transpile cache key in `Transpilation.version()`. `Parsing` never used it.

Added a `PARSE_XSLS` array (the parse-stage XSLs plus the `_funcs.xsl`/`_specials.xsl` libraries they `xsl:import`, matching `org.eolang.parser.Canonical`'s own pipeline) and a `version(String)` method that folds their fingerprint into the cache key, mirroring `Transpilation.version()`.

Added `ParsingTest` verifying the cache-key version reflects the digest it's given (and, since `Fingerprint` throws on a missing classpath resource, that `PARSE_XSLS` itself resolves correctly). Updated `MjParseTest#parsesWithCache`'s cache-path helper to match the new 3-part key format; verified it fails without the fix (the manually seeded cache entry is missed and the source is silently re-parsed instead) and passes with it.
