### PR TITLE
#6241: fix incorrect returned index in tuple.index-of and tuple.last-index-of

### DIFF
--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -18,10 +18,21 @@
           next.eq -1
           if.
             tup.head.eq wanted
-            tup.tail.length
+            tup.length.minus 1
             -1
           recidx tup.tail >> next!
     | list
+
+  eq. ++> can-find-the-index-of-a-non-symmetric-match
+    1
+    index-of
+      *
+        10
+        20
+        30
+        40
+        50
+      20
 
   eq. ++> can-find-the-index-of-a-string
     1

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -14,7 +14,7 @@
     -1
     if.
       t.head.eq wanted
-      t.tail.length
+      t.length.minus 1
       rec t.tail
   | list > @
 
@@ -61,3 +61,14 @@
         "Привет"
         "こんにちわ"
       "Привет"
+
+  eq. ++> can-find-the-last-index-of-a-non-symmetric-match
+    4
+    last-index-of
+      *
+        10
+        20
+        30
+        40
+        20
+      20


### PR DESCRIPTION
The issue describes both a value bug and an order bug in `tuple.index-of` and `tuple.last-index-of`. Tracing the actual runtime behavior of `Φ.tuple` (built via `with`, which sets `tail` to the previous tuple and `head` to the newly appended value, see `tuple.eo`), `head`/`tail` walk the tuple from its last element back to its first, not first to last.

Given that, the existing recursion order in both functions was already correct for what each function needs: `index-of` recurses first and lets a deeper (closer to the start) match win, which is what finds the first occurrence when walking backward. `last-index-of` checks the current head immediately, which is what finds the last occurrence when walking backward, since the highest index is visited first.

The actual bug was only the returned value: both functions returned `X.tail.length` (count of elements after the match), not the true 0-based index. Since `tup`/`t` at any point in the recursion is always a prefix of the original list (built by stripping elements off the end), the true index of a match is `tup.length.minus 1` / `t.length.minus 1`.

Verified against the exact counter-example from the issue: `index-of (list 10 20 30 40 50) 20` now returns `1`, and confirmed by hand-tracing the recursion with the actual head/tail semantics before writing the fix. Added a non-symmetric regression test to each file, matching the ones suggested in the issue, and confirmed all existing tests plus the full `eo-runtime` test module still pass.

Closes #6241
