### PR TITLE
fix(#6218): put object name before URL in missing-object message

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -99,8 +99,8 @@ final class OyRemote implements Objectionary {
                 throw new IOException(
                     String.format(
                         "EO object '%s' is not found in this GitHub repository: https://github.com/objectionary/home by url: %s. This means that you either misspelled the name of it or simply referred to your own local object somewhere in your code as if it was an object of 'org.eolang' package. Check the sources and make sure you always use +alias meta when you refer to an object outside of 'org.eolang', even if this object belongs to your package.",
-                        url,
-                        name
+                        name,
+                        url
                     ),
                     input
                 );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -160,27 +160,10 @@ final class OyRemoteTest {
                 "http://127.0.0.1:%d/%%s/%%s.eo", port
             );
             final String name = "org.eolang.txt.sprintf";
-            MatcherAssert.assertThat(
-                "Missing-object message should put the object name first and the URL after 'by url:'",
-                Assertions.assertThrows(
-                    IOException.class,
-                    () -> new OyRemote(
-                        new OyRemote.UrlOy(tpl, "deadbeef"),
-                        new OyRemote.UrlOy(tpl, "deadbeef")
-                    ).get(name).stream(),
-                    "Expected an IOException when the remote object is missing"
-                ).getMessage(),
-                Matchers.allOf(
-                    Matchers.startsWith(
-                        String.format("EO object '%s' is not found", name)
-                    ),
-                    Matchers.containsString(
-                        String.format(
-                            "by url: http://127.0.0.1:%d/deadbeef/txt/sprintf.eo.",
-                            port
-                        )
-                    )
-                )
+            Assertions.assertThrows(
+                IOException.class,
+                () -> OyRemoteTest.missing(tpl, name, port),
+                "Expected an IOException when the remote object is missing"
             );
         } finally {
             server.stop(0);
@@ -203,5 +186,40 @@ final class OyRemoteTest {
             ).isDirectory(directory),
             Matchers.is(true)
         );
+    }
+
+    /**
+     * Pull a missing object and verify 404 message order.
+     * @param template URL template with hash and path placeholders
+     * @param name Object name
+     * @param port Local HTTP port used in the expected URL fragment
+     * @throws Exception Always, when remote returns 404 with a correct message
+     */
+    private static void missing(final String template, final String name, final int port)
+        throws Exception {
+        try {
+            new OyRemote(
+                new OyRemote.UrlOy(template, "deadbeef"),
+                new OyRemote.UrlOy(template, "deadbeef")
+            ).get(name).stream();
+        } catch (final IOException exception) {
+            final String message = exception.getMessage();
+            if (!message.startsWith(String.format("EO object '%s' is not found", name))
+                || !message.contains(
+                    String.format(
+                        "by url: http://127.0.0.1:%d/deadbeef/txt/sprintf.eo.",
+                        port
+                    )
+                )) {
+                throw new AssertionError(
+                    String.format(
+                        "Missing-object message should put the object name first and the URL after 'by url:', but was: %s",
+                        message
+                    ),
+                    exception
+                );
+            }
+            throw exception;
+        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -144,6 +144,50 @@ final class OyRemoteTest {
     }
 
     @Test
+    void putsObjectNameBeforeUrlInMissingObjectMessage() throws Exception {
+        final HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+            "/",
+            exchange -> {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+            }
+        );
+        server.start();
+        try {
+            final int port = server.getAddress().getPort();
+            final String tpl = String.format(
+                "http://127.0.0.1:%d/%%s/%%s.eo", port
+            );
+            final String name = "org.eolang.txt.sprintf";
+            MatcherAssert.assertThat(
+                "Missing-object message should put the object name first and the URL after 'by url:'",
+                Assertions.assertThrows(
+                    IOException.class,
+                    () -> new OyRemote(
+                        new OyRemote.UrlOy(tpl, "deadbeef"),
+                        new OyRemote.UrlOy(tpl, "deadbeef")
+                    ).get(name).stream(),
+                    "Expected an IOException when the remote object is missing"
+                ).getMessage(),
+                Matchers.allOf(
+                    Matchers.startsWith(
+                        String.format("EO object '%s' is not found", name)
+                    ),
+                    Matchers.containsString(
+                        String.format(
+                            "by url: http://127.0.0.1:%d/deadbeef/txt/sprintf.eo.",
+                            port
+                        )
+                    )
+                )
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfDirectoryWithNarrowHash() throws IOException {
         final String directory = "tuple";


### PR DESCRIPTION
Closes #6218

@yegor256

## Summary
`OyRemote.get` built the \"object not found\" message with `String.format` arguments in the wrong order (`url`, `name` instead of `name`, `url`). The URL appeared in the object-name slot and the object name appeared after `by url:`.

## Change
- Pass `name` then `url` to match the format string.
- Add a local HTTP 404 regression test that asserts the message order.

## Test plan
- [x] `mvn -pl eo-maven-plugin -Dtest=OyRemoteTest test` — 10/10 GREEN
- [x] `mvn -pl eo-maven-plugin -Pqulice qulice:check -DskipTests` — GREEN