### PR TITLE
#6237: preserve explicit $. reference when printing XMIR

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -265,6 +265,20 @@
     <xsl:variable name="self-prefix" select="concat($eo:program, '.', $package, '.')"/>
     <xsl:variable name="self-rest" select="substring-after(@base, $self-prefix)"/>
     <xsl:variable name="self-first" select="if (contains($self-rest, '.')) then substring-before($self-rest, '.') else $self-rest"/>
+    <!--
+    Whether some formation this reference is actually nested inside (not
+    just the innermost one - a zero-hop reference here can legitimately
+    reach a handle owned by any enclosing formation, not only the
+    nearest, since resolve-local-names.xsl already resolved it) owns
+    "hop-name" as its own file-local "&gt;&gt; hop-name" handle - mirrors
+    resolve-local-names.xsl's own "eo:captor" scoping (#5875, #5780): a
+    handle is lexically scoped to its declaring formation and the
+    formations nested inside it, so a same-named handle declared by some
+    unrelated formation elsewhere in the file (not an ancestor of this
+    reference at all) must not suppress the "$." marker here.
+    -->
+    <xsl:variable name="local-handle"
+      select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">
@@ -309,22 +323,24 @@
         -->
         <xsl:value-of select="eo:translate-path($hop-rest)"/>
       </xsl:when>
-      <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty(//o[@local=$hop-name])">
+      <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
         <!--
         An explicit "$.name" (zero ρ hops) whose immediate enclosing
         formation has no "name" of its own, and which is not a
-        file-local ">> name" handle either (those resolve file-wide,
-        not through ρ-scope walking, so a bare reference to one is also
-        zero-hop and must print bare), denotes a genuinely different
-        reference than a bare "name" would (which would instead resolve
-        via an implicit ρ hop into an outer scope, per the branch
-        above) — #6237. Render it with its "$." marker so reparsing
-        keeps the same meaning. When the immediate formation DOES own
-        "name", or "name" is a file-local handle, bare and "$.name"
-        resolve identically, so the otherwise branch below safely
-        prints it bare, matching a plain same-scope reference. A node
-        that itself carries "@local" is a moniker's own bound value,
-        already relocated in place of its reference site by
+        ">> name" handle owned by a formation this reference actually
+        nests inside either ("local-handle" mirrors resolve-local-names.xsl's
+        lexically-scoped "eo:captor", #5875 — a same-named handle declared
+        by some unrelated formation elsewhere in the file, one this
+        reference is not nested inside, must not count), denotes a
+        genuinely different reference than a bare "name" would (which
+        would instead resolve via an implicit ρ hop into an outer scope,
+        per the branch above) — #6237. Render it with its "$." marker so
+        reparsing keeps the same meaning. When the immediate formation
+        DOES own "name", or "name" is such an in-scope file-local handle,
+        bare and "$.name" resolve identically, so the otherwise branch
+        below safely prints it bare, matching a plain same-scope
+        reference. A node that itself carries "@local" is a moniker's own
+        bound value, already relocated in place of its reference site by
         merge-monikers.xsl, so its ancestor context here no longer
         reflects its original scope — skip it too, matching bare.
         -->

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -277,8 +277,7 @@
     unrelated formation elsewhere in the file (not an ancestor of this
     reference at all) must not suppress the "$." marker here.
     -->
-    <xsl:variable name="local-handle"
-      select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
+    <xsl:variable name="local-handle" select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
     <xsl:choose>
       <!-- NOT OPTIMIZED TUPLE -->
       <xsl:when test="@star">

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -309,6 +309,27 @@
         -->
         <xsl:value-of select="eo:translate-path($hop-rest)"/>
       </xsl:when>
+      <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty(//o[@local=$hop-name])">
+        <!--
+        An explicit "$.name" (zero ρ hops) whose immediate enclosing
+        formation has no "name" of its own, and which is not a
+        file-local ">> name" handle either (those resolve file-wide,
+        not through ρ-scope walking, so a bare reference to one is also
+        zero-hop and must print bare), denotes a genuinely different
+        reference than a bare "name" would (which would instead resolve
+        via an implicit ρ hop into an outer scope, per the branch
+        above) — #6237. Render it with its "$." marker so reparsing
+        keeps the same meaning. When the immediate formation DOES own
+        "name", or "name" is a file-local handle, bare and "$.name"
+        resolve identically, so the otherwise branch below safely
+        prints it bare, matching a plain same-scope reference. A node
+        that itself carries "@local" is a moniker's own bound value,
+        already relocated in place of its reference site by
+        merge-monikers.xsl, so its ancestor context here no longer
+        reflects its original scope — skip it too, matching bare.
+        -->
+        <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="eo:surface(@base)"/>
       </xsl:otherwise>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-application-head-kept.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-application-head-kept.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The application-head twin of `explicit-xi-reference-kept`: `$.f 1` names the
+# enclosing formation's own `f` explicitly (no `^` hop), which is a different
+# reference than a bare `f 1` (#6237). The printer must keep the `$.` prefix
+# here too, not just for a bare dispatch-free reference.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    [] > f
+      42 > @
+    [] > inner
+      $.f 1 > @
+
+printed: |
+  [] > app
+    42 > [] > f
+    $.f 1 > [] > inner

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-reference-kept-despite-unrelated-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-reference-kept-despite-unrelated-handle.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The whole-document twin of `explicit-xi-reference-kept`: a same-named
+# `>> foo` file-local handle declared by an unrelated sibling formation must
+# not suppress the `$.` marker here. Handles are lexically scoped to the
+# formation that declares them (resolve-local-names.xsl, #5875), so
+# `sibling`'s own `foo` handle has nothing to do with `inner`'s `$.foo`
+# reference to `outer`'s public `foo` attribute. The printer used to search
+# the whole document for any `@local='foo'` and treat this `$.foo` as if it
+# were itself a local-handle reference, dropping the `$.` and changing its
+# meaning on reparse (#6237).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    [] > sibling
+      42 > x
+      x >> foo
+    [] > outer
+      1 > foo
+      [] > inner
+        $.foo > @
+
+printed: |
+  [] > app
+    [] > outer
+      1 > foo
+      $.foo > [] > inner
+    [] > sibling
+      x >> foo
+      42 > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-reference-kept.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/explicit-xi-reference-kept.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An explicit `$.foo` (self, no `^` hop) denotes a different reference than a
+# bare `foo`, which resolves to `^.foo` (the enclosing formation's own scope)
+# whenever the immediate formation has no `foo` of its own. The printer used to
+# drop the `$.` prefix exactly as it correctly does for a redundant `^.`,
+# silently turning `$.foo` into a bare reference and changing its meaning on
+# reparse (#6237). The explicit `$.` must survive printing.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    42 > foo
+    [] > inner
+      $.foo > @
+
+printed: |
+  [] > app
+    42 > foo
+    $.foo > [] > inner


### PR DESCRIPTION
Closes #6237

The printer collapsed an explicit `$.foo` (base `ξ.foo`) to the same bare `foo` it prints for an ordinary same-scope reference, discarding the difference from a bare reference that resolves via an implicit `ρ` hop into an outer scope (base `ξ.ρ.foo`). Since `MjFormat`'s `-Deo.autoFix` runs the printer and writes the result back over the source file, this let the formatter silently rewrite a source into one that parses to a different meaning.

`ξ.<name>` (zero `ρ` hops) shows up in two different situations that look identical at the base-string level:
- an ordinary bare reference to a name that lives on the immediate enclosing formation itself (the common case, needs no `$.` and must keep printing bare), and
- a genuine explicit `$.name` that denotes something different only when the immediate formation does *not* have `name` of its own (the case this issue is about).

Fixed by adding a branch to the printer's `BASED` head template that checks, using the same ancestor-scope pattern the existing `ρ`-hop-drop branch already uses, whether the immediate enclosing formation actually owns the referenced name (as a plain attribute or a file-local `>> name` handle, the latter resolving file-wide rather than through `ρ`-scope walking). Only when neither is true does it keep the `$.` marker; otherwise it prints bare, matching prior (correct) behavior.

Added two print-pack tests (`explicit-xi-reference-kept`, `explicit-xi-application-head-kept`) covering the bare-reference and application-head cases from the issue. Verified against the full `XmirTest` suite (289 tests) with no regressions, and confirmed the new tests fail without the fix (4 failures: the `$.` prefix is dropped) and pass with it.
