### PR TITLE
#6238: fix premature overflow in number.degrees and number.radians

### DIFF
--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -9,11 +9,18 @@
 +spdx SPDX-License-Identifier: MIT
 
 [num] > degrees
-  div. > @
-    times.
+  times. > @
+    div.
       number num.as-bytes
-      180
-    pi
+      pi
+    180
+
+  lt. ++> can-convert-a-large-value-without-overflow
+    abs
+      minus.
+        degrees 1.0e306
+        5.729577951308232e307
+    1.0e294
 
   lt. ++> can-convert-minus-pi-to-degrees
     abs

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -9,11 +9,11 @@
 +spdx SPDX-License-Identifier: MIT
 
 [num] > radians
-  div. > @
-    times.
+  times. > @
+    div.
       number num.as-bytes
-      pi
-    180
+      180
+    pi
 
   lt. ++> can-convert-a-full-turn-to-radians
     abs
@@ -28,6 +28,13 @@
         radians 180
         pi
     1.0E-4
+
+  lt. ++> can-convert-a-large-value-without-overflow
+    abs
+      minus.
+        radians 1.0e308
+        1.7453292519943295e306
+    1.0e293
 
   lt. ++> can-convert-a-negative-half-turn-to-radians
     abs


### PR DESCRIPTION
`degrees` computed `(num * 180) / pi` and `radians` computed `(num * pi) / 180`. Both multiply first, so the intermediate product overflows to `Infinity` for large but still finite inputs whose true converted value stays well within `double` range, for example `degrees 1e306` (true value about 5.73e307, well under `Double.MAX_VALUE`).

Divide before multiplying instead, so the intermediate never exceeds the magnitude of the final result: `(num / pi) * 180` for degrees, `(num / 180) * pi` for radians.

Added a regression test to each file checking a large input stays finite and close to the reference value, and confirmed the existing tests and the full eo-runtime test module still pass.

Closes #6238
