### PR TITLE
#6232: reject empty name suffix when / or ! sits right after the space

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -398,13 +398,15 @@ final class Suffix {
     }
 
     /**
-     * Reject a {@code > name} suffix whose name came out empty because a
-     * name-terminating character ({@code /} or {@code !}) sat immediately
-     * after the single skipped space, e.g. {@code > /sig} or {@code > !}.
-     * A second space (rather than a real terminator) is left alone here:
-     * that case falls through to {@link #endsClean}, which reports the
-     * more specific "trailing garbage" once whatever follows the extra
-     * space is reached.
+     * Reject a {@code > name} suffix whose name came out empty because
+     * {@link #skipName} stopped right where it started — any character
+     * {@link #endsName} treats as a boundary sat immediately after the
+     * single skipped space, not just {@code /} and {@code !} but also
+     * the separators in {@link #NAME_BOUNDARIES}, e.g. {@code > /sig},
+     * {@code > !}, or {@code > .foo}. A second space (rather than a real
+     * boundary character) is left alone here: that case falls through to
+     * {@link #endsClean}, which reports the more specific "trailing
+     * garbage" once whatever follows the extra space is reached.
      * @param tail Tail substring
      * @param begin Index where the name was expected to start
      * @param idx Index {@link #skipName} stopped at
@@ -415,8 +417,7 @@ final class Suffix {
     private static void checkNamePresent(
         final String tail, final int begin, final int idx, final Span span, final int home
     ) {
-        if (begin == idx && begin < tail.length()
-            && tail.charAt(begin) != ' ' && tail.charAt(begin) != '\t') {
+        if (begin == idx && tail.charAt(begin) != ' ' && tail.charAt(begin) != '\t') {
             throw new ParseError(
                 span.line(), home + begin,
                 "name suffix requires a name"

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -398,6 +398,33 @@ final class Suffix {
     }
 
     /**
+     * Reject a {@code > name} suffix whose name came out empty because a
+     * name-terminating character ({@code /} or {@code !}) sat immediately
+     * after the single skipped space, e.g. {@code > /sig} or {@code > !}.
+     * A second space (rather than a real terminator) is left alone here:
+     * that case falls through to {@link #endsClean}, which reports the
+     * more specific "trailing garbage" once whatever follows the extra
+     * space is reached.
+     * @param tail Tail substring
+     * @param begin Index where the name was expected to start
+     * @param idx Index {@link #skipName} stopped at
+     * @param span Source span
+     * @param home Source column where tail begins
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private static void checkNamePresent(
+        final String tail, final int begin, final int idx, final Span span, final int home
+    ) {
+        if (begin == idx && begin < tail.length()
+            && tail.charAt(begin) != ' ' && tail.charAt(begin) != '\t') {
+            throw new ParseError(
+                span.line(), home + begin,
+                "name suffix requires a name"
+            );
+        }
+    }
+
+    /**
      * Parse a {@code >>} (auto) suffix, optionally carrying a trailing
      * file-local handle ({@code >> name}, §3.10) kept as the label, and a
      * {@code !} const marker (R-9.4) either right after {@code >>}
@@ -470,6 +497,7 @@ final class Suffix {
         }
         final int begin = Suffix.skipSpace(tail, from);
         int idx = Suffix.skipName(tail, begin);
+        Suffix.checkNamePresent(tail, begin, idx, span, home);
         final String name = tail.substring(begin, idx);
         if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
             throw new ParseError(

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -281,6 +281,30 @@ final class SuffixTest {
     }
 
     @Test
+    void rejectsAtomSignatureRightAfterSkippedSpace() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " > /org.eolang.foo",
+                new Span("[] > /org.eolang.foo", 1), 2
+            ),
+            "`> /sig` with no name between `>` and `/` must be rejected"
+        );
+    }
+
+    @Test
+    void rejectsConstMarkerRightAfterSkippedSpace() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(
+                " > !",
+                new Span("[] > !", 1), 2
+            ),
+            "`> !` with no name between `>` and `!` must be rejected"
+        );
+    }
+
+    @Test
     void rejectsPlusGreaterWithPhi() {
         Assertions.assertThrows(
             ParseError.class,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-atom-signature-with-no-name-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-atom-signature-with-no-name-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'name suffix requires a name')]
+input: |
+  [] > main
+    42 > /number

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-boundary-char-with-no-name-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-boundary-char-with-no-name-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'name suffix requires a name')]
+input: |
+  [] > main
+    42 > .foo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-const-marker-with-no-name-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-const-marker-with-no-name-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'name suffix requires a name')]
+input: |
+  [] > main
+    42 > !


### PR DESCRIPTION
`Suffix.named` skips exactly one space after `>` and then reads the name up to the next terminator. If a terminator (`/` or `!`) sits right at that position, `skipName` doesn't advance and the name comes out empty with no error, for example `42 > /org.eolang.foo` or `42 > !`. #6150 only rejected a tail that is entirely blank; it did not cover a terminator landing immediately after the single skipped space.

Added a check right after computing the name bounds, mirroring the same check `Suffix.test` already does. It only fires when the character at that position is not itself a space or tab, so the pre-existing double-space typo case (`[] >  foo`) still falls through to the existing "trailing garbage" error instead of getting the new message.

Extracted the check into its own method (`checkNamePresent`) to keep `named`'s cyclomatic complexity under qulice's limit.

Added tests for both triggers mentioned in the issue (`> /sig` and `> !`) and confirmed the full eo-parser test suite and qulice still pass.

Closes #6232
