### PR TITLE
#6229: add pos to error complexType so parser syntax errors validate against XMIR.xsd

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -144,7 +144,7 @@
       <xs:annotation>
         <xs:appinfo>The position in the code line where the object has been seen</xs:appinfo>
         <xs:documentation>
-          The attribute contains the position in the code line (starting from 1),
+          The attribute contains the position in the code line (0-indexed),
           where the object has been met during the scanning of the source code.
         </xs:documentation>
       </xs:annotation>
@@ -262,7 +262,7 @@
           <xs:annotation>
             <xs:appinfo>The position in the code line where the error was found</xs:appinfo>
             <xs:documentation>
-              The attribute contains the position in the code line (starting from 1),
+              The attribute contains the position in the code line (0-indexed),
               where the error was found. If the element is omitted, the problem
               is not related to any particular column in the line.
             </xs:documentation>

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -258,6 +258,16 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="pos" type="whole">
+          <xs:annotation>
+            <xs:appinfo>The position in the code line where the error was found</xs:appinfo>
+            <xs:documentation>
+              The attribute contains the position in the code line (starting from 1),
+              where the error was found. If the element is omitted, the problem
+              is not related to any particular column in the line.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="severity" use="required">
           <xs:annotation>
             <xs:appinfo>The severity of the error</xs:appinfo>

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/error-pos.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/error-pos.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+errors: 0
+document: |
+  <object author="eo-parser">
+    <errors>
+      <error line="4" pos="6" severity="error">something went wrong</error>
+    </errors>
+  </object>


### PR DESCRIPTION
`Emit.java` sets a `pos` attribute on `<error>` elements, but `XMIR.xsd`'s `error` complex type only declares `check`, `line`, and `severity`. Any `.eo` file with a plain parser syntax error produces XMIR that fails validation against the repository's own schema.

The parser spec's R-9.1.2 / section 9.6 calls for reporting the error's column, which is what `pos` conveys, so this adds `pos` to the schema (type `whole`, matching how `pos` is already declared on `o`) rather than dropping it from the parser.

Added a case to `EoSyntaxTest.checksXsdMistakes` with a raw `<error pos="...">` element expecting zero schema violations, confirmed it fails against the unfixed schema with the same `cvc-complex-type.3.2.2` message from the issue, and passes with the fix. Full eo-parser test suite is green.

Closes #6229
