### PR TITLE
#6227: close text block after an error on its closing line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -345,6 +345,7 @@ final class Eo implements Iterable<Directive> {
             } catch (final ParseError err) {
                 emit.rollback(tstartsen);
                 emit.error(err.line(), err.pos(), err.getMessage());
+                globals.closeTextBlock();
             }
         } else {
             final String raw = span.text();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-swallow-rest-of-file.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-swallow-rest-of-file.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unicode')]
+  - /object[not(errors/error[contains(text(),'unclosed')])]
+  - //o[@name='y']
+  - //o[@name='z']
+input: |
+  [] > app
+    """
+    \uZZZZ
+    """ > x
+    42 > y
+    43 > z


### PR DESCRIPTION
`Eo.continueTextBlock` catches a `ParseError` thrown while processing a text block's closing line (from the suffix, the escape decoder, or the transition), rolls the emit back, and reports the error, but never clears the `inTextBlock` flag. Every following line then gets silently absorbed as text-block body content instead of being parsed, and a phantom "unclosed text block" error appears at EOF even though the closer line was actually reached.

Added `globals.closeTextBlock()` to the catch block, right after the error is reported. This only clears state going forward; it does not affect the already-reported error or anything already rolled back.

Added a syntax test reproducing the issue's example (a bad unicode escape inside a text block, closing line, followed by two more object lines), asserting the real error is still present, no "unclosed" error appears, and the following lines still parse into real objects. Confirmed it fails on the unfixed code with "passed without exceptions" (the follow-on lines silently vanish) and passes with the fix. Full eo-parser test suite and qulice are clean.

Closes #6227
