### PR TITLE
Fix #6213: strip org.eolang. prefix in ObjectsIndex.children()

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
@@ -89,7 +89,14 @@ final class ObjectsIndex {
      * @throws Exception If the index can't be read
      */
     Iterable<String> children(final String pkg) throws Exception {
-        final String prefix = String.format("%s.", pkg);
+        final String pfx = "org.eolang.";
+        final String target;
+        if (pkg.startsWith(pfx)) {
+            target = pkg.substring(pfx.length());
+        } else {
+            target = pkg;
+        }
+        final String prefix = String.format("%s.", target);
         return new Filtered<>(
             name -> name.startsWith(prefix) && name.indexOf('.', prefix.length()) < 0,
             this.objects.value()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -93,6 +93,25 @@ final class ObjectsIndexTest {
     }
 
     @Test
+    void listsDirectChildrenOfPackageWithOrgEolangPrefix() throws Exception {
+        MatcherAssert.assertThat(
+            "The index must strip org.eolang. prefix when listing children of package",
+            new ObjectsIndex(
+                new ScalarOf<>(
+                    () -> new SetOf<>(
+                        "tuple",
+                        "tuple.each",
+                        "tuple.eachi",
+                        "tuple.inner.deep",
+                        "math.abs"
+                    )
+                )
+            ).children("org.eolang.tuple"),
+            Matchers.containsInAnyOrder("tuple.each", "tuple.eachi")
+        );
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
     void downloadsAndChecksFromRealSource() throws Exception {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #6213
- **Prefix Normalization in `ObjectsIndex.children()`**: Updated `ObjectsIndex.children(pkg)` to strip the leading `org.eolang.` prefix if present, aligning its package matching behavior with `ObjectsIndex.contains(name)`.
- **Unit Test**: Added `listsDirectChildrenOfPackageWithOrgEolangPrefix()` in `ObjectsIndexTest` to verify that `children("org.eolang.tuple")` successfully strips the prefix and      
  matches direct package objects.

@yegor256 please take a look