### PR TITLE
#6231: keep continueTextBlock's stack in sync with its rollback

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -338,12 +338,14 @@ final class Eo implements Iterable<Directive> {
         final Span span, final Stack stack, final Globals globals, final Emit emit
     ) {
         if (Eo.closesTextBlock(span, globals)) {
+            stack.popDeeperThan(span.indent());
             final int tstartsen = emit.savepoint();
+            final int frame = stack.size();
             try {
-                stack.popDeeperThan(span.indent());
                 new LnTextBlock(span).into(stack, globals, emit);
             } catch (final ParseError err) {
                 emit.rollback(tstartsen);
+                stack.silentTruncate(frame);
                 emit.error(err.line(), err.pos(), err.getMessage());
             }
         } else {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-misplace-ms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-misplace-ms.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[@ms]
+  - /object[not(.//o[@ms])]
+  - /object/errors/error[contains(text(),'garbage')]
+input: |
+  [] > app
+    seq > s
+      42
+    """
+    body
+    """ oops


### PR DESCRIPTION
`Eo.dispatch` takes its emit savepoint and stack-size frame after `popDeeperThan`, and only wraps the line's own parsing in the try, so a failure rolls back just what that parsing did and truncates the stack to match. `Eo.continueTextBlock` had the pop and the savepoint in the opposite order and no stack truncation at all, so a parse error on a text block's closing line could leave the emitted XML and the in-memory stack disagreeing about how deep the cursor actually is, misplacing the final `ms` attribute onto a nested `<o>` instead of the root `<object>` (invalid against XMIR.xsd, since `ms` is only declared there).

Reordered `continueTextBlock` to match `dispatch` exactly: pop first, then take the savepoint and record the frame, then wrap only `LnTextBlock.into` in the try, truncating the stack to the recorded frame in the catch.

Note this PR does not touch the separate "unclosed text block" phantom-error bug also present in this method (already reported and fixed independently in #6227); the syntax test added here still shows that error, since #6227's fix isn't part of this branch.

Added a syntax test reproducing the issue's exact example (a `seq`/nested-number pair followed by a text block whose closer line has trailing garbage), asserting `ms` lands on `/object` and no nested `<o>` carries it. Confirmed it fails on the unfixed code with `ms` on the `app` object, exactly as described in the issue, and passes with the fix. Full eo-parser test suite and qulice are clean.

Closes #6231
