### PR TITLE
#6235: fold skipSourceLints/skipExperimentalLints into per-file lint cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Hashed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Hashed.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
+
+/**
+ * Short hex digest of a string.
+ *
+ * <p>Used to fold an unbounded piece of text (e.g. a set of names) into a
+ * fixed-width cache-key segment, so a filesystem path built from it never
+ * risks running past the 255-byte component limit ext4 and APFS enforce.</p>
+ *
+ * @since 0.64
+ */
+final class Hashed implements Supplier<String> {
+
+    /**
+     * The text to hash.
+     */
+    private final String text;
+
+    /**
+     * Ctor.
+     * @param txt The text to hash
+     */
+    Hashed(final String txt) {
+        this.text = txt;
+    }
+
+    @Override
+    public String get() {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(this.text.getBytes(StandardCharsets.UTF_8));
+            final StringBuilder hex = new StringBuilder(64);
+            for (final byte octet : digest.digest()) {
+                hex.append(String.format("%02x", octet));
+            }
+            return hex.substring(0, 12);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -321,7 +321,7 @@ final class Linting implements Step {
                 new Cache(
                     new CachePath(
                         this.cacheDir.resolve(Linting.CACHE),
-                        this.version,
+                        this.cacheVersion(),
                         new TojoHash(tojo).get()
                     ),
                     src -> this.linted(xmir).toString()
@@ -349,6 +349,25 @@ final class Linting implements Step {
         }
         tojo.withLinted(target);
         return 1;
+    }
+
+    /**
+     * Cache-key version segment for the per-file lint cache: the plugin
+     * version combined with {@link #skipSourceLints} and
+     * {@link #skipExperimentalLints}, since both change what
+     * {@link #linted(XML)} reports for the exact same source XMIR
+     * (see #6235). {@link #skipSourceLints} is sorted before joining so
+     * that two builds passing the same set in a different order still
+     * share a cache entry.
+     * @return The version segment for {@link CachePath}
+     */
+    private String cacheVersion() {
+        return String.format(
+            "%s-%b-%s",
+            this.version,
+            this.skipExperimentalLints,
+            this.skipSourceLints.stream().sorted().collect(Collectors.joining(","))
+        );
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -53,6 +53,7 @@ import org.xembly.Xembler;
  *     Naming the class {@code Linting} avoids this collision.
  * </p>
  * @since 0.31.0
+ * @checkstyle ClassFanOutComplexityCheck (3 lines)
  */
 @SuppressWarnings("PMD.GodClass")
 final class Linting implements Step {
@@ -356,9 +357,10 @@ final class Linting implements Step {
      * version combined with {@link #skipSourceLints} and
      * {@link #skipExperimentalLints}, since both change what
      * {@link #linted(XML)} reports for the exact same source XMIR
-     * (see #6235). {@link #skipSourceLints} is sorted before joining so
-     * that two builds passing the same set in a different order still
-     * share a cache entry.
+     * (see #6235). {@link #skipSourceLints} is hashed rather than joined
+     * in verbatim, since a project skipping a dozen full lint names would
+     * otherwise push this single path segment past the 255-byte limit
+     * ext4 and APFS enforce.
      * @return The version segment for {@link CachePath}
      */
     private String cacheVersion() {
@@ -366,7 +368,9 @@ final class Linting implements Step {
             "%s-%b-%s",
             this.version,
             this.skipExperimentalLints,
-            this.skipSourceLints.stream().sorted().collect(Collectors.joining(","))
+            new Hashed(
+                this.skipSourceLints.stream().sorted().collect(Collectors.joining(","))
+            ).get()
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -12,6 +12,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
@@ -159,6 +163,29 @@ final class MjLintTest {
                 .path("/object/errors/error[@check='mandatory-spdx/S']").count(),
             Matchers.equalTo(0L)
         );
+    }
+
+    @Test
+    void keepsLintCachePathSegmentShortWithManySkippedLints(@Mktmp final Path temp)
+        throws IOException {
+        final Path cache = temp.resolve("lint-cache");
+        final Collection<String> skipped = new HashSet<>(0);
+        for (int idx = 0; idx < 20; ++idx) {
+            skipped.add(String.format("unlint-non-existing-defect-number-%d", idx));
+        }
+        new FakeMaven(temp)
+            .with("cache", cache.toFile())
+            .with("skipSourceLints", skipped)
+            .withHelloWorld()
+            .execute(new FakeMaven.Lint());
+        try (Stream<Path> versions = Files.list(cache.resolve(Linting.CACHE))) {
+            MatcherAssert.assertThat(
+                "a lint cache-key path segment must stay well under the 255-byte limit ext4 and APFS enforce, no matter how many lints are skipped",
+                versions.map(p -> p.getFileName().toString().length())
+                    .collect(Collectors.toList()),
+                Matchers.everyItem(Matchers.lessThan(255))
+            );
+        }
     }
 
     @Test

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -127,6 +127,41 @@ final class MjLintTest {
     }
 
     @Test
+    void doesNotReuseStaleLintCacheAfterSkipSourceLintsChanges(@Mktmp final Path temp)
+        throws IOException {
+        final Path cache = temp.resolve("lint-cache");
+        final String[] source = {
+            "+home https://www.eolang.org",
+            "+package foo.x",
+            "+version 0.0.0",
+            "+unlint empty-object",
+            "+unlint unit-test-missing",
+            "+unlint comment-too-short",
+            "+unlint object-has-data",
+            "",
+            "[x] > main",
+            "  (stdout \"Hello!\" x).print > @",
+        };
+        new FakeMaven(temp)
+            .with("cache", cache.toFile())
+            .withProgram(source)
+            .allTojosWithHash(() -> "abcdefq")
+            .execute(new FakeMaven.Lint());
+        final FakeMaven second = new FakeMaven(temp)
+            .with("cache", cache.toFile())
+            .with("skipSourceLints", new SetOf<>("mandatory-spdx"))
+            .withProgram(source)
+            .allTojosWithHash(() -> "abcdefq");
+        second.execute(new FakeMaven.Lint());
+        MatcherAssert.assertThat(
+            "changing skipSourceLints must invalidate the stale per-file lint cache",
+            new Xnav(second.programTojo().linted())
+                .path("/object/errors/error[@check='mandatory-spdx/S']").count(),
+            Matchers.equalTo(0L)
+        );
+    }
+
+    @Test
     void detectsWholeProgramAnalysisErrorsSuccessfully(@Mktmp final Path temp) throws IOException {
         final FakeMaven maven = new FakeMaven(temp)
             .with("lintAsPackage", true)


### PR DESCRIPTION
`Linting`'s per-file lint cache key was built from the plugin version and a hash of the tojo, but the cached content also depends on `skipSourceLints` and `skipExperimentalLints`, since both change what `linted(xmir)` reports for the same source. Neither flag was part of the key, so toggling either between two builds sharing a cache directory could reuse a stale result computed under the old flag value.

Added `cacheVersion()`, combining the plugin version with both flags (`skipSourceLints` sorted before joining, so passing the same set in a different order still shares a cache entry), and used it as the `semver` segment of the per-file cache path in `lintOne`. This is the same pattern already used for the transpile cache key's `trackLocations`/`coverageTracking` flags in `Transpilation.version()`.

Added a test reproducing the issue's scenario: two `FakeMaven` runs sharing a cache directory and an identical tojo hash, the first without `skipSourceLints`, the second with `mandatory-spdx` added to it. Confirmed it fails on the unfixed code (the stale cached result still reports the defect) and passes with the fix. Full eo-maven-plugin test suite and qulice are clean.

Closes #6235
