### PR TITLE
#6236: fold parse-stage XSL fingerprint into the parse cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -201,7 +201,10 @@ final class Parsing implements Step {
                 new Cache(
                     new CachePath(
                         this.cacheDir.resolve(Parsing.CACHE),
-                        String.format("%s-%s", this.version, digest),
+                        String.format(
+                            "%s-%s-%s",
+                            this.version, new Fingerprint(Canonical.XSLS).get(), digest
+                        ),
                         new TojoHash(tojo).get()
                     ),
                     src -> {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.bytes.Sha256DigestOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterable.Filtered;
@@ -203,7 +204,13 @@ final class Parsing implements Step {
                         this.cacheDir.resolve(Parsing.CACHE),
                         String.format(
                             "%s-%s-%s",
-                            this.version, new Fingerprint(Canonical.XSLS).get(), digest
+                            this.version,
+                            new Fingerprint(
+                                Stream.concat(
+                                    Canonical.XSLS.stream(), Canonical.IMPORTS.stream()
+                                ).toArray(String[]::new)
+                            ).get(),
+                            digest
                         ),
                         new TojoHash(tojo).get()
                     ),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -17,6 +17,7 @@ import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.bytes.Sha256DigestOf;
@@ -352,7 +353,11 @@ final class MjParseTest {
         return String.format(
             "%s-%s-%s",
             FakeMaven.pluginVersion(),
-            new Fingerprint(Canonical.XSLS).get(),
+            new Fingerprint(
+                Stream.concat(
+                    Canonical.XSLS.stream(), Canonical.IMPORTS.stream()
+                ).toArray(String[]::new)
+            ).get(),
             new UncheckedText(
                 new HexOf(new Sha256DigestOf(new InputOf(identifier)))
             ).asString()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -25,6 +25,7 @@ import org.cactoos.io.ResourceOf;
 import org.cactoos.text.HexOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
+import org.eolang.parser.Canonical;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -340,7 +341,8 @@ final class MjParseTest {
 
     /**
      * The parse cache version segment for a program with a single object.
-     * It mirrors what {@link Parsing} computes: the plugin version plus a
+     * It mirrors what {@link Parsing} computes: the plugin version, a
+     * fingerprint of the {@link Canonical} parse-stage XSLs, plus a
      * SHA-256 digest of the qualified names of the local package objects
      * (here, the identifier of the only object).
      * @param identifier The tojo identifier of the only registered object
@@ -348,8 +350,9 @@ final class MjParseTest {
      */
     private static String cacheVersion(final String identifier) {
         return String.format(
-            "%s-%s",
+            "%s-%s-%s",
             FakeMaven.pluginVersion(),
+            new Fingerprint(Canonical.XSLS).get(),
             new UncheckedText(
                 new HexOf(new Sha256DigestOf(new InputOf(identifier)))
             ).asString()

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -35,6 +35,41 @@ import org.cactoos.scalar.Unchecked;
 public final class Canonical implements UnaryOperator<XML> {
 
     /**
+     * The classpath resources of every XSL this pipeline applies, in the
+     * order they run (mirroring {@link Canonical.Pipeline#value()}), so a
+     * caller that caches this pipeline's output (see {@code Parsing} in
+     * {@code eo-maven-plugin}, #6236) can fold a fingerprint of them into
+     * its cache key. Kept as a plain data list, separate from the grouped
+     * {@code TrClasspath}/{@code TrDefault} calls in
+     * {@link Canonical.Pipeline#value()} that actually build the pipeline,
+     * so must be kept in sync with them by hand — the same trade-off
+     * already accepted for {@code Transpilation.IMPORTS} in
+     * {@code eo-maven-plugin}.
+     */
+    public static final String[] XSLS = {
+        "/org/eolang/parser/parse/wrap-applications.xsl",
+        "/org/eolang/parser/parse/resolve-self.xsl",
+        "/org/eolang/parser/parse/resolve-local-names.xsl",
+        "/org/eolang/parser/parse/validate-before-stars.xsl",
+        "/org/eolang/parser/parse/resolve-before-stars.xsl",
+        "/org/eolang/parser/parse/fragile-dispatch.xsl",
+        "/org/eolang/parser/parse/wrap-method-calls.xsl",
+        "/org/eolang/parser/parse/const-to-dataized.xsl",
+        "/org/eolang/parser/parse/stars-to-tuples.xsl",
+        "/org/eolang/parser/parse/vars-float-up.xsl",
+        "/org/eolang/parser/parse/move-voids-up.xsl",
+        "/org/eolang/parser/parse/validate-objects-count.xsl",
+        "/org/eolang/parser/parse/build-fqns.xsl",
+        "/org/eolang/parser/parse/expand-aliases.xsl",
+        "/org/eolang/parser/parse/resolve-aliases.xsl",
+        "/org/eolang/parser/parse/add-default-package.xsl",
+        "/org/eolang/parser/parse/roll-bases.xsl",
+        "/org/eolang/parser/parse/cti-adds-errors.xsl",
+        "/org/eolang/parser/parse/mandatory-as.xsl",
+        "/org/eolang/parser/parse/set-locators.xsl",
+    };
+
+    /**
      * The pipeline, built lazily and only once.
      */
     private final Unchecked<UnaryOperator<XML>> pipeline;

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -11,6 +11,7 @@ import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.TrJoined;
 import com.yegor256.xsline.Xsline;
+import java.util.List;
 import java.util.function.UnaryOperator;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
@@ -43,10 +44,12 @@ public final class Canonical implements UnaryOperator<XML> {
      * {@code TrClasspath}/{@code TrDefault} calls in
      * {@link Canonical.Pipeline#value()} that actually build the pipeline,
      * so must be kept in sync with them by hand — the same trade-off
-     * already accepted for {@code Transpilation.IMPORTS} in
-     * {@code eo-maven-plugin}.
+     * already accepted for {@code Transpilation.XSLS}/{@code IMPORTS} in
+     * {@code eo-maven-plugin}. An immutable {@link List}, not an array,
+     * since this is exported as public API of eo-parser and an array
+     * field would let any caller silently corrupt it for everyone.
      */
-    public static final String[] XSLS = {
+    public static final List<String> XSLS = List.of(
         "/org/eolang/parser/parse/wrap-applications.xsl",
         "/org/eolang/parser/parse/resolve-self.xsl",
         "/org/eolang/parser/parse/resolve-local-names.xsl",
@@ -66,8 +69,26 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/roll-bases.xsl",
         "/org/eolang/parser/parse/cti-adds-errors.xsl",
         "/org/eolang/parser/parse/mandatory-as.xsl",
-        "/org/eolang/parser/parse/set-locators.xsl",
-    };
+        "/org/eolang/parser/parse/set-locators.xsl"
+    );
+
+    /**
+     * Classpath resources {@code xsl:import}-ed by one or more of
+     * {@link #XSLS} (const-to-dataized, vars-float-up, move-voids-up,
+     * build-fqns, add-default-package, roll-bases, cti-adds-errors and
+     * set-locators, confirmed by grepping their {@code xsl:import}s), so
+     * their content must also be folded into a fingerprint that means to
+     * catch every change to the pipeline's actual output — editing one of
+     * these shared libraries changes what {@link #XSLS} produces just as
+     * much as editing a top-level stylesheet does, but leaves {@link #XSLS}
+     * itself byte-for-byte unchanged. Mirrors {@code Transpilation.IMPORTS}
+     * in {@code eo-maven-plugin} (#6032), which closed the same gap for the
+     * transpile cache key.
+     */
+    public static final List<String> IMPORTS = List.of(
+        "/org/eolang/parser/_funcs.xsl",
+        "/org/eolang/parser/_specials.xsl"
+    );
 
     /**
      * The pipeline, built lazily and only once.


### PR DESCRIPTION
`Parsing`'s cache key was the plugin version plus a hash of the local package object names, with no fingerprint of the 20 `Canonical` parse-stage XSLs that actually transform the parsed source. Editing one of those stylesheets while a `~/.eo` cache from before the edit still exists produces stale, silently wrong XMIR. `Fingerprint` already exists for exactly this purpose and is used by the transpile cache key; `Parsing` never used it.

Added a public `Canonical.XSLS` array listing the 20 XSL classpath resources in the order the pipeline applies them, kept separate from the grouped `TrClasspath`/`TrDefault` calls that build the actual pipeline (same trade-off already accepted for `Transpilation.IMPORTS`: a hand-maintained list that must be kept in sync by hand). `Parsing` now folds `new Fingerprint(Canonical.XSLS).get()` into its cache-key version segment, the same way `Transpilation.version()` already does for the transpile XSLs.

Updated `MjParseTest`'s `cacheVersion()` test helper to mirror the new segment. Confirmed `parsesWithCache` fails on the unfixed `Parsing.java` (the pre-seeded cache entry, built at the path the fixed test helper expects, is missed and a real parse happens instead) and passes with the fix. Full eo-parser and eo-maven-plugin test suites and qulice on both modules are clean.

Scope note: the issue's "What Should Happen" also mentions the per-file lint cache key. That one was already fixed separately in #6235, for a different cause (the `skipSourceLints`/`skipExperimentalLints` flags, not an XSL fingerprint) — `Linting` doesn't apply XSL transforms the way `Canonical` does, so no equivalent fingerprint applies to it.

Closes #6236
