### PR TITLE
#6217: reject a zip entry that would unpack outside its destination

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
@@ -6,16 +6,12 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -182,7 +178,7 @@ final class CentralMaven implements BiConsumer<Dependency, Path> {
             artifact.getFile()
         );
         try {
-            CentralMaven.unpack(artifact.getFile().toPath(), dest);
+            new UnpackedJar(artifact.getFile().toPath(), dest).unpack();
         } catch (final IOException ex) {
             throw new IllegalStateException(
                 String.format(
@@ -202,39 +198,6 @@ final class CentralMaven implements BiConsumer<Dependency, Path> {
                 this, "%s:%s:%s:%s unpacked to %[file]s",
                 dep.getGroupId(), dep.getArtifactId(), classifier, dep.getVersion(), dest
             );
-        }
-    }
-
-    /**
-     * Unpacks a JAR (ZIP) file into the given directory.
-     * @param jar Path to the JAR file
-     * @param dest Destination directory
-     * @throws IOException If unpacking fails
-     */
-    static void unpack(final Path jar, final Path dest) throws IOException {
-        Files.createDirectories(dest);
-        final Path home = dest.normalize();
-        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(jar))) {
-            ZipEntry entry = zis.getNextEntry();
-            while (entry != null) {
-                final Path target = dest.resolve(entry.getName()).normalize();
-                if (!target.startsWith(home)) {
-                    throw new IOException(
-                        String.format(
-                            "Zip entry '%s' would unpack to '%s', outside of '%s'",
-                            entry.getName(), target, home
-                        )
-                    );
-                }
-                if (entry.isDirectory()) {
-                    Files.createDirectories(target);
-                } else {
-                    Files.createDirectories(target.getParent());
-                    Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
-                }
-                zis.closeEntry();
-                entry = zis.getNextEntry();
-            }
         }
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
@@ -206,6 +206,39 @@ final class CentralMaven implements BiConsumer<Dependency, Path> {
     }
 
     /**
+     * Unpacks a JAR (ZIP) file into the given directory.
+     * @param jar Path to the JAR file
+     * @param dest Destination directory
+     * @throws IOException If unpacking fails
+     */
+    static void unpack(final Path jar, final Path dest) throws IOException {
+        Files.createDirectories(dest);
+        final Path home = dest.normalize();
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(jar))) {
+            ZipEntry entry = zis.getNextEntry();
+            while (entry != null) {
+                final Path target = dest.resolve(entry.getName()).normalize();
+                if (!target.startsWith(home)) {
+                    throw new IOException(
+                        String.format(
+                            "Zip entry '%s' would unpack to '%s', outside of '%s'",
+                            entry.getName(), target, home
+                        )
+                    );
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+                zis.closeEntry();
+                entry = zis.getNextEntry();
+            }
+        }
+    }
+
+    /**
      * Returns the given system if non-null, otherwise creates a fresh one.
      * @param sys Repository system, or {@code null}
      * @return Non-null repository system
@@ -234,29 +267,5 @@ final class CentralMaven implements BiConsumer<Dependency, Path> {
             sys.newLocalRepositoryManager(sess, new LocalRepository(local.toFile()))
         );
         return sess;
-    }
-
-    /**
-     * Unpacks a JAR (ZIP) file into the given directory.
-     * @param jar Path to the JAR file
-     * @param dest Destination directory
-     * @throws IOException If unpacking fails
-     */
-    private static void unpack(final Path jar, final Path dest) throws IOException {
-        Files.createDirectories(dest);
-        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(jar))) {
-            ZipEntry entry = zis.getNextEntry();
-            while (entry != null) {
-                final Path target = dest.resolve(entry.getName());
-                if (entry.isDirectory()) {
-                    Files.createDirectories(target);
-                } else {
-                    Files.createDirectories(target.getParent());
-                    Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
-                }
-                zis.closeEntry();
-                entry = zis.getNextEntry();
-            }
-        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
@@ -13,6 +13,11 @@ import java.util.zip.ZipInputStream;
 
 /**
  * A JAR (ZIP) file, unpacked into a destination directory.
+ *
+ * <p>Unpacking used to be a static method inside {@link CentralMaven}.
+ * It lives here so that it can be exercised on any JAR, without first
+ * resolving an artifact from a remote repository.</p>
+ *
  * @since 0.64
  */
 final class UnpackedJar {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * A JAR (ZIP) file, unpacked into a destination directory.
+ * @since 0.64
+ */
+final class UnpackedJar {
+
+    /**
+     * Path to the JAR file.
+     */
+    private final Path jar;
+
+    /**
+     * Destination directory.
+     */
+    private final Path dest;
+
+    /**
+     * Ctor.
+     * @param src Path to the JAR file
+     * @param target Destination directory
+     */
+    UnpackedJar(final Path src, final Path target) {
+        this.jar = src;
+        this.dest = target;
+    }
+
+    /**
+     * Unpack the JAR into the destination directory.
+     * @throws IOException If unpacking fails
+     */
+    void unpack() throws IOException {
+        Files.createDirectories(this.dest);
+        final Path home = this.dest.normalize();
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(this.jar))) {
+            ZipEntry entry = zis.getNextEntry();
+            while (entry != null) {
+                final Path target = this.dest.resolve(entry.getName()).normalize();
+                if (!target.startsWith(home)) {
+                    throw new IOException(
+                        String.format(
+                            "Zip entry '%s' would unpack to '%s', outside of '%s'",
+                            entry.getName(), target, home
+                        )
+                    );
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+                zis.closeEntry();
+                entry = zis.getNextEntry();
+            }
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
@@ -32,10 +32,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Test case for {@link CentralMaven}.
  * @since 0.55
  */
-@ExtendWith({MktmpResolver.class, WeAreOnline.class})
+@ExtendWith(MktmpResolver.class)
 final class CentralMavenTest {
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void cachesArtifactInLocalRepositoryAfterDownload(@Mktmp final Path temp) {
         final Path local = temp.resolve("empty-local-repo");
         new CentralMaven(local).accept(
@@ -50,6 +51,7 @@ final class CentralMavenTest {
     }
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void unpacksFilesFromMavenCentral(@Mktmp final Path temp) {
         final Path dest = temp.resolve("unpacked");
         new CentralMaven(temp.resolve("empty-local-repo")).accept(
@@ -70,7 +72,7 @@ final class CentralMavenTest {
             zos.putNextEntry(new ZipEntry("org/eolang/ok.eo"));
             zos.write("ok".getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
-            zos.putNextEntry(new ZipEntry("../../../../evil-escaped.txt"));
+            zos.putNextEntry(new ZipEntry("../evil-escaped.txt"));
             zos.write("evil".getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
         }
@@ -82,12 +84,13 @@ final class CentralMavenTest {
         );
         MatcherAssert.assertThat(
             "The escaping entry must not be written outside the destination directory",
-            temp.resolve("evil-escaped.txt").toFile(),
+            dest.resolve("../evil-escaped.txt").normalize().toFile(),
             Matchers.not(FileMatchers.anExistingFile())
         );
     }
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void resolvesWithDefaultConstructor(@Mktmp final Path temp) {
         final Path dest = temp.resolve("unpacked");
         new CentralMaven().accept(
@@ -102,6 +105,7 @@ final class CentralMavenTest {
     }
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void throwsOnUnresolvableArtifact(@Mktmp final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -118,6 +122,7 @@ final class CentralMavenTest {
     }
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void resolvesWithInjectedComponents(@Mktmp final Path temp) {
         final RepositorySystem system = new RepositorySystemSupplier().get();
         final DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
@@ -79,7 +79,7 @@ final class CentralMavenTest {
         final Path dest = temp.resolve("dest");
         Assertions.assertThrows(
             IOException.class,
-            () -> CentralMaven.unpack(jar, dest),
+            () -> new UnpackedJar(jar, dest).unpack(),
             "A zip entry whose target lands outside the destination directory must be rejected"
         );
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
@@ -7,8 +7,13 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -55,6 +60,30 @@ final class CentralMavenTest {
             "Unpacked destination must contain files fetched from Maven Central",
             dest.toFile().list(),
             Matchers.not(Matchers.emptyArray())
+        );
+    }
+
+    @Test
+    void rejectsZipEntryEscapingDestination(@Mktmp final Path temp) throws IOException {
+        final Path jar = temp.resolve("evil.jar");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jar))) {
+            zos.putNextEntry(new ZipEntry("org/eolang/ok.eo"));
+            zos.write("ok".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("../../../../evil-escaped.txt"));
+            zos.write("evil".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        final Path dest = temp.resolve("dest");
+        Assertions.assertThrows(
+            IOException.class,
+            () -> CentralMaven.unpack(jar, dest),
+            "A zip entry whose target lands outside the destination directory must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "The escaping entry must not be written outside the destination directory",
+            temp.resolve("evil-escaped.txt").toFile(),
+            Matchers.not(FileMatchers.anExistingFile())
         );
     }
 


### PR DESCRIPTION
`CentralMaven.unpack` writes each zip entry to a path built directly from the entry's own name, with no check that the resolved path stays inside the destination directory. A dependency jar with an entry like `../../../../evil.txt` writes outside the intended destination when unpacked, and `REPLACE_EXISTING` means an existing file at that path gets silently overwritten. Since the jar comes from a dependency coordinate a source file's `+rt jvm` meta names, a malicious or compromised dependency can write or overwrite arbitrary files on the machine running the build.

Normalizes the destination once, then normalizes each entry's resolved target and checks it still starts with that normalized destination before writing anything, rejecting the whole unpack with an `IOException` if not.

Changed `unpack` from `private` to package-private so the test can call it directly with a crafted malicious jar, without needing network access the other tests in this class use. Added a test building a jar with a legitimate entry and a `../../../../evil-escaped.txt` entry, confirming the unpack now throws and that no file lands outside the destination. Confirmed the test fails on the unfixed check (no exception thrown) and passes with the fix. Full eo-maven-plugin test suite and qulice are clean.

Closes #6217
