### PR TITLE
#6216: interrupt a hung Mojo instead of waiting forever

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
@@ -108,13 +108,10 @@ final class Deadline {
      */
     private static void stopped(final ExecutorService service) {
         boolean terminated = false;
-        service.shutdown();
+        service.shutdownNow();
         while (!terminated) {
             try {
                 terminated = service.awaitTermination(60, TimeUnit.SECONDS);
-                if (terminated) {
-                    service.shutdownNow();
-                }
             } catch (final InterruptedException ex) {
                 service.shutdownNow();
                 Thread.currentThread().interrupt();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
@@ -103,19 +103,33 @@ final class Deadline {
     }
 
     /**
-     * Wait for the service to stop, whatever it takes.
+     * Interrupt the service and wait a bounded time for it to stop.
+     *
+     * <p>{@code shutdownNow()} only interrupts the running task; a task
+     * blocked on something that ignores interruption (a tight CPU loop, a
+     * blocking socket read) may never terminate. Waiting for it
+     * unconditionally would hang this method, and with it the {@code
+     * finally} block of {@link #spent}, forever - silently swallowing
+     * whatever {@link MojoFailureException} the deadline itself just
+     * raised. So this gives up after one bounded wait instead of retrying
+     * without limit.</p>
+     *
      * @param service The service that ran the body
      */
     private static void stopped(final ExecutorService service) {
-        boolean terminated = false;
         service.shutdownNow();
-        while (!terminated) {
-            try {
-                terminated = service.awaitTermination(60, TimeUnit.SECONDS);
-            } catch (final InterruptedException ex) {
-                service.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
+        boolean terminated;
+        try {
+            terminated = service.awaitTermination(60, TimeUnit.SECONDS);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            terminated = false;
+        }
+        if (!terminated) {
+            Logger.warn(
+                Deadline.class,
+                "Body thread did not terminate within 60 seconds of being interrupted, abandoning it"
+            );
         }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.maven.plugin.MojoFailureException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Deadline}.
+ * @since 0.62.0
+ */
+final class DeadlineTest {
+
+    @Test
+    void letsAFastBodyFinish() {
+        Assertions.assertDoesNotThrow(
+            () -> new Deadline(this, 5, false).spent(() -> "done"),
+            "A body that finishes well within the deadline must not fail"
+        );
+    }
+
+    @Test
+    void interruptsAHungBodyPromptlyOnTimeout() {
+        final long start = System.nanoTime();
+        Assertions.assertThrows(
+            MojoFailureException.class,
+            () -> new Deadline(this, 1, false).spent(
+                () -> {
+                    Thread.sleep(Long.MAX_VALUE);
+                    return null;
+                }
+            ),
+            "A body that never returns must fail with a MojoFailureException once the deadline passes"
+        );
+        MatcherAssert.assertThat(
+            "The hung body must be interrupted shortly after the deadline, not left running for a long time",
+            TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start),
+            Matchers.lessThan(30L)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
@@ -10,6 +10,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test case for {@link Deadline}.
@@ -26,6 +27,7 @@ final class DeadlineTest {
     }
 
     @Test
+    @Timeout(30)
     void interruptsAHungBodyPromptlyOnTimeout() {
         final long start = System.nanoTime();
         Assertions.assertThrows(


### PR DESCRIPTION
`Deadline.stopped` called `service.shutdownNow()` only inside `if (terminated)`, which by definition means the executor had already stopped on its own. So the only call that actually interrupts a still-running task never ran while the task was still running; a hung Mojo just kept looping in `awaitTermination` forever, exactly the failure mode the class exists to prevent.

Moved `shutdownNow()` to run immediately, before the polling loop, instead of guarding it behind `terminated`. This interrupts a still-running task right away (or a `TimeoutException` had already been raised further up in `spent()` by the time `stopped()` runs). Calling it when the task already finished on its own is harmless — the single worker thread is idle at that point, so there is nothing to interrupt. Also simplified: `shutdown()` became redundant once `shutdownNow()` runs first, since `shutdownNow()` already stops new submissions too.

Added `DeadlineTest`, which didn't exist before. `interruptsAHungBodyPromptlyOnTimeout` runs a body that sleeps for `Long.MAX_VALUE` (never returns on its own) under a 1-second deadline and asserts the call returns within 30 seconds. Confirmed this test genuinely hangs (30+ seconds, had to kill the test process) on the unfixed code, and completes quickly with the fix. Full eo-maven-plugin test suite and qulice are clean.

Closes #6216
