### PR TITLE
#6218: fix swapped name/url format arguments in object-not-found message

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -99,8 +99,8 @@ final class OyRemote implements Objectionary {
                 throw new IOException(
                     String.format(
                         "EO object '%s' is not found in this GitHub repository: https://github.com/objectionary/home by url: %s. This means that you either misspelled the name of it or simply referred to your own local object somewhere in your code as if it was an object of 'org.eolang' package. Check the sources and make sure you always use +alias meta when you refer to an object outside of 'org.eolang', even if this object belongs to your package.",
-                        url,
-                        name
+                        name,
+                        url
                     ),
                     input
                 );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -23,11 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 final class OyRemoteTest {
 
-    /**
-     * The object name used by the "not found" message tests.
-     */
-    private static final String MISSING_OBJECT = "org.eolang.txt.sprintf";
-
     @Test
     void buildsCorrectUrlForProgram() throws Exception {
         MatcherAssert.assertThat(
@@ -153,9 +148,7 @@ final class OyRemoteTest {
         MatcherAssert.assertThat(
             "The object name must show up in the 'EO object' slot of the message",
             OyRemoteTest.notFoundMessage(),
-            Matchers.containsString(
-                String.format("EO object '%s'", OyRemoteTest.MISSING_OBJECT)
-            )
+            Matchers.containsString("EO object 'org.eolang.txt.sprintf'")
         );
     }
 
@@ -213,7 +206,7 @@ final class OyRemoteTest {
                 () -> new OyRemote(
                     new OyRemote.UrlOy(tpl, "stub"),
                     new OyRemote.UrlOy(tpl, "stub")
-                ).get(OyRemoteTest.MISSING_OBJECT).stream(),
+                ).get("org.eolang.txt.sprintf").stream(),
                 "Expected an IOException reporting the object as not found"
             ).getMessage();
         } finally {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -23,6 +23,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 final class OyRemoteTest {
 
+    /**
+     * The object name used by the "not found" message tests.
+     */
+    private static final String MISSING_OBJECT = "org.eolang.txt.sprintf";
+
     @Test
     void buildsCorrectUrlForProgram() throws Exception {
         MatcherAssert.assertThat(
@@ -144,6 +149,26 @@ final class OyRemoteTest {
     }
 
     @Test
+    void reportsNameInTheEoObjectSlotWhenObjectNotFound() throws Exception {
+        MatcherAssert.assertThat(
+            "The object name must show up in the 'EO object' slot of the message",
+            OyRemoteTest.notFoundMessage(),
+            Matchers.containsString(
+                String.format("EO object '%s'", OyRemoteTest.MISSING_OBJECT)
+            )
+        );
+    }
+
+    @Test
+    void reportsUrlInTheByUrlSlotWhenObjectNotFound() throws Exception {
+        MatcherAssert.assertThat(
+            "The URL must show up in the 'by url' slot of the message",
+            OyRemoteTest.notFoundMessage(),
+            Matchers.containsString("by url: http://127.0.0.1")
+        );
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
     void checksPresenceOfDirectoryWithNarrowHash() throws IOException {
         final String directory = "tuple";
@@ -159,5 +184,40 @@ final class OyRemoteTest {
             ).isDirectory(directory),
             Matchers.is(true)
         );
+    }
+
+    /**
+     * Drive {@link OyRemote#get(String)} against a local server that always
+     * answers 404, and return the "not found" message it fails with.
+     * @return The exception message
+     * @throws Exception If the test setup itself fails
+     */
+    private static String notFoundMessage() throws Exception {
+        final HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+            "/",
+            exchange -> {
+                final byte[] body = "404: Not Found".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(404, body.length);
+                exchange.getResponseBody().write(body);
+                exchange.close();
+            }
+        );
+        server.start();
+        try {
+            final String tpl = String.format(
+                "http://127.0.0.1:%d/%%s/%%s.eo", server.getAddress().getPort()
+            );
+            return Assertions.assertThrows(
+                IOException.class,
+                () -> new OyRemote(
+                    new OyRemote.UrlOy(tpl, "stub"),
+                    new OyRemote.UrlOy(tpl, "stub")
+                ).get(OyRemoteTest.MISSING_OBJECT).stream(),
+                "Expected an IOException reporting the object as not found"
+            ).getMessage();
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
The "not found" message's format string is `"EO object '%s' ... by url: %s"`, but the call passed `(url, name)` instead of `(name, url)`, so the URL showed up in the object-name slot and the object name showed up in the url slot.

Swapped the two arguments to match the format string.

Added a test driving `OyRemote.get` against a local server that always answers 404, asserting the object name shows up after "EO object" and the URL shows up after "by url". Confirmed it fails on the unfixed code (the name assertion fails, since the URL appears there instead) and passes with the fix. Full eo-maven-plugin test suite and qulice are clean.

Closes #6218
