### PR TITLE
#6209: return nan from number.mod when the divisor is nan

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -18,7 +18,7 @@
     cant-mod
       "cannot calculate mod by zero"
     divisor.is-finite.not.if
-      x
+      divisor.is-nan.if nan x
       if.
         gt.
           number x.as-bytes >> dividend
@@ -31,6 +31,11 @@
               floor.
                 absx.div absy
         abs-mod.neg
+
+  is-nan. ++> can-return-nan-when-the-divisor-is-nan
+    mod
+      5
+      nan
 
   ++> can-stay-compatible-with-division
     eq. > @


### PR DESCRIPTION
Fixes #6209.

`number.mod` returned the dividend unchanged for a `nan` divisor, disagreeing with Java's `%` and IEEE remainder (both yield `NaN` when either operand is `NaN`). The `is-finite.not.if x` branch added in #5979 for infinite divisors over-generalized: `is-finite` is false for both infinity and `nan`, so `nan` fell into the "return x" path.

Fix splits the `nan` case out so infinity still returns the dividend while `nan` returns `nan`:

```
divisor.is-finite.not.if
  divisor.is-nan.if nan x
  ...
```

Verified by probing `org.eolang.EO_number.EOmod` against Java `x % y`: `mod 5 nan`, `mod -5 nan`, `mod 0 nan` now return `nan`, while every control stays unchanged (`mod nan 5` = `nan`, `mod 5 pinf` = `5`, `mod -5 ninf` = `-5`, `mod -13 5` = `-3`, `mod 16 -200` = `16`). Added a regression test `can-return-nan-when-the-divisor-is-nan`.