### PR TITLE
#6221: return an empty scheme for a schemeless uri

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -55,9 +55,7 @@
       hash-idx.eq -1
     slice.
       text.slice >> rest
-        plus.
-          string.index-of text ":" >> scheme-colon
-          1
+        scheme-colon.plus 1
         text.length.minus
           number
             scheme-colon.plus 1
@@ -131,9 +129,14 @@
         number
           question-idx.plus 1
     ""
-  text.slice > scheme
-    0
-    scheme-colon
+  if. > scheme
+    eq.
+      string.index-of text ":" >> scheme-colon
+      -1
+    ""
+    text.slice
+      0
+      scheme-colon
   if. > userinfo
     not. >> has-userinfo
       userinfo-at-idx.eq -1
@@ -176,6 +179,11 @@
     query.
       uri "http://host/some/path?x=1#top"
     "x=1"
+
+  eq. ++> can-parse-an-empty-scheme-of-a-schemeless-uri
+    scheme.
+      uri "localhost"
+    ""
 
   eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
     host.


### PR DESCRIPTION
Fixes #6221.

`uri.scheme` terminated with `ExFailure: Length to slice must be >= 0, but was -1` whenever the input had no colon, even though every other component parses a schemeless input gracefully (RFC 3986 relative reference) and `(uri ":").scheme` already returns `""`.

Root cause: `scheme` did `text.slice 0 scheme-colon` where `scheme-colon` is `string.index-of text ":"`, which is `-1` when there is no colon, tripping `string.slice`'s own `>= 0` guard. The sibling attributes (`has-fragment`, `has-port`, `has-query`, `has-userinfo`) all guard their `index-of` against `-1`; `scheme` did not.

Fix guards the missing-colon case the same way, returning an empty scheme:

```
if. > scheme
  scheme-colon.eq -1
  ""
  text.slice 0 scheme-colon
```

Verified by probing `org.eolang.EOuri`: `(uri "localhost").scheme`, `(uri "").scheme` and `(uri "no-scheme/path?q#f").scheme` now return `""`, while every colon-bearing control is unchanged (`http://host:80` = `http`, `pgsql:localhost:899` = `pgsql`, `file:///etc/passwd` = `file`, `:` = `""`). Added a regression test `can-parse-an-empty-scheme-of-a-schemeless-uri`.