### PR TITLE
#6221: return empty scheme for a schemeless uri instead of crashing

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -55,9 +55,7 @@
       hash-idx.eq -1
     slice.
       text.slice >> rest
-        plus.
-          string.index-of text ":" >> scheme-colon
-          1
+        scheme-colon.plus 1
         text.length.minus
           number
             scheme-colon.plus 1
@@ -131,9 +129,14 @@
         number
           question-idx.plus 1
     ""
-  text.slice > scheme
-    0
-    scheme-colon
+  if. > scheme
+    eq.
+      string.index-of text ":" >> scheme-colon
+      -1
+    ""
+    text.slice
+      0
+      scheme-colon
   if. > userinfo
     not. >> has-userinfo
       userinfo-at-idx.eq -1
@@ -216,6 +219,11 @@
     scheme.
       uri "pgsql:localhost:899"
     "pgsql"
+
+  eq. ++> can-parse-the-scheme-of-a-schemeless-uri
+    scheme.
+      uri "localhost"
+    ""
 
   eq. ++> can-parse-the-scheme-of-a-triple-slash-uri
     scheme.


### PR DESCRIPTION
`uri.scheme` sliced `text` from 0 to `scheme-colon` (the index of the first `:`) with no guard for the no-colon case, where `scheme-colon` is `-1`. `text.slice 0 -1` then trips `string.slice`'s own "Length to slice must be >= 0" guard. Every sibling attribute (`has-fragment`, `has-port`, `has-query`, `has-userinfo`) already guards its own `index-of` result against `-1`; `scheme` was the one that didn't, even though a schemeless input is a legitimate RFC 3986 relative reference and every other component already parses it fine.

Added the same guard the siblings use: when `scheme-colon` is `-1`, return `""` instead of slicing.

Added a regression test for `(uri "localhost").scheme = ""`, matching the exact case from the issue. Confirmed it fails on the unfixed code with the same `ExFailure` message from the issue, and passes with the fix. Full eo-runtime test suite is clean.

Closes #6221
