### PR TITLE
#6213: strip org.eolang. prefix in ObjectsIndex.children the same way contains does

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
@@ -76,13 +76,23 @@ final class ObjectsIndex {
     /**
      * Names of all objects located directly inside the given package, e.g.
      * {@code "tuple.each"} and {@code "tuple.eachi"} for {@code "tuple"}, but
-     * not {@code "tuple"} itself nor objects from its sub-packages.
-     * @param pkg Package name, e.g. {@code "tuple"} or {@code "math.vector"}
+     * not {@code "tuple"} itself nor objects from its sub-packages. The
+     * bare root package (stripped to an empty string) works the same way:
+     * its direct children are the top-level names with no dot at all, e.g.
+     * {@code "tuple"} and {@code "math"} themselves.
+     * @param pkg Package name, e.g. {@code "tuple"}, {@code "math.vector"}
+     *  or {@code "org.eolang"} itself
      * @return Object names that live directly in that package
      * @throws Exception If the index can't be read
      */
     Iterable<String> children(final String pkg) throws Exception {
-        final String prefix = String.format("%s.", ObjectsIndex.stripped(pkg));
+        final String stripped = ObjectsIndex.stripped(pkg);
+        final String prefix;
+        if (stripped.isEmpty()) {
+            prefix = stripped;
+        } else {
+            prefix = String.format("%s.", stripped);
+        }
         return new Filtered<>(
             name -> name.startsWith(prefix) && name.indexOf('.', prefix.length()) < 0,
             this.objects.value()
@@ -98,9 +108,12 @@ final class ObjectsIndex {
      *  name itself if it doesn't start with that prefix
      */
     private static String stripped(final String name) {
-        final String prefix = "org.eolang.";
+        final String root = "org.eolang";
+        final String prefix = String.format("%s.", root);
         final String result;
-        if (name.startsWith(prefix)) {
+        if (name.equals(root)) {
+            result = "";
+        } else if (name.startsWith(prefix)) {
             result = name.substring(prefix.length());
         } else {
             result = name;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
@@ -70,14 +70,7 @@ final class ObjectsIndex {
      * @throws Exception If something unexpected happened.
      */
     boolean contains(final String name) throws Exception {
-        final String prefix = "org.eolang.";
-        final String stripped;
-        if (name.startsWith(prefix)) {
-            stripped = name.substring(prefix.length());
-        } else {
-            stripped = name;
-        }
-        return this.objects.value().contains(stripped);
+        return this.objects.value().contains(ObjectsIndex.stripped(name));
     }
 
     /**
@@ -89,11 +82,30 @@ final class ObjectsIndex {
      * @throws Exception If the index can't be read
      */
     Iterable<String> children(final String pkg) throws Exception {
-        final String prefix = String.format("%s.", pkg);
+        final String prefix = String.format("%s.", ObjectsIndex.stripped(pkg));
         return new Filtered<>(
             name -> name.startsWith(prefix) && name.indexOf('.', prefix.length()) < 0,
             this.objects.value()
         );
+    }
+
+    /**
+     * Strip the leading {@code org.eolang.} package from a name, the same
+     * way the index itself omits it (see {@link #convert(String)}), so a
+     * name in either shape matches the same index entry.
+     * @param name Object or package name
+     * @return The name with the leading {@code org.eolang.} removed, or the
+     *  name itself if it doesn't start with that prefix
+     */
+    private static String stripped(final String name) {
+        final String prefix = "org.eolang.";
+        final String result;
+        if (name.startsWith(prefix)) {
+            result = name.substring(prefix.length());
+        } else {
+            result = name;
+        }
+        return result;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -93,6 +93,25 @@ final class ObjectsIndexTest {
     }
 
     @Test
+    void listsDirectChildrenOfPackageWithOrgEolangPrefix() throws Exception {
+        MatcherAssert.assertThat(
+            "children() must strip a leading org.eolang. package the same way contains() does",
+            new ObjectsIndex(
+                new ScalarOf<>(
+                    () -> new SetOf<>(
+                        "tuple",
+                        "tuple.each",
+                        "tuple.eachi",
+                        "tuple.inner.deep",
+                        "math.abs"
+                    )
+                )
+            ).children("org.eolang.tuple"),
+            Matchers.containsInAnyOrder("tuple.each", "tuple.eachi")
+        );
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
     void downloadsAndChecksFromRealSource() throws Exception {
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -112,6 +112,24 @@ final class ObjectsIndexTest {
     }
 
     @Test
+    void listsDirectChildrenOfTheBareRootPackage() throws Exception {
+        MatcherAssert.assertThat(
+            "children() must strip a bare org.eolang with no trailing dot the same way it strips org.eolang.",
+            new ObjectsIndex(
+                new ScalarOf<>(
+                    () -> new SetOf<>(
+                        "tuple",
+                        "tuple.each",
+                        "math",
+                        "math.abs"
+                    )
+                )
+            ).children("org.eolang"),
+            Matchers.containsInAnyOrder("tuple", "math")
+        );
+    }
+
+    @Test
     @ExtendWith(WeAreOnline.class)
     void downloadsAndChecksFromRealSource() throws Exception {
         MatcherAssert.assertThat(


### PR DESCRIPTION
`ObjectsIndex.contains(name)` strips a leading `org.eolang.` from `name` before checking the index, since the index itself stores names without that prefix. `children(pkg)` built its lookup prefix directly from the raw `pkg` argument, with no equivalent stripping, so the two methods disagreed about what normalization a package name needs. Not reachable today since every `eo-runtime` object is rooted at `Φ.<name>`, but a latent inconsistency for any future object or user package using the longer form.

Extracted the stripping logic from `contains` into a shared private `stripped` method and used it in both `contains` and `children`.

Added a test for `children("org.eolang.tuple")` returning the same result as `children("tuple")`, confirmed it fails on the unfixed code (empty result) and passes with the fix. Full eo-maven-plugin test suite, qulice, and jtcop are clean.

Closes #6213
