### PR TITLE
#6209: return nan (not the dividend) when number.mod divisor is nan

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -18,7 +18,7 @@
     cant-mod
       "cannot calculate mod by zero"
     divisor.is-finite.not.if
-      x
+      divisor.is-nan.if nan x
       if.
         gt.
           number x.as-bytes >> dividend
@@ -40,6 +40,11 @@
       dividend
     -13 > dividend
     5 > divisor
+
+  is-nan. ++> can-take-a-modulo-by-nan
+    mod
+      5
+      nan
 
   eq. ++> can-take-a-modulo-by-one
     mod


### PR DESCRIPTION
`number.mod` returned the dividend unchanged for any non-finite divisor, treating `+-inf` and `nan` the same way. That's correct for infinity (`x mod inf = x`), but wrong for `nan`, where the result must be `nan`, matching Java's `%` and IEEE remainder semantics. This was a follow-on from #5979, which added the `is-finite.not.if x` branch to fix the infinity case and over-generalized it to also catch `nan`.

Split the `nan` case out: when the divisor is non-finite, check `is-nan` first and return `nan`, otherwise return `x` as before (still correct for infinity).

Added a regression test for `mod 5 nan` returning `nan`. Confirmed it fails on the unfixed code (`mod` returns `5` instead of `nan`) and passes with the fix. Full eo-runtime test suite is clean.

Closes #6209
