### PR TITLE
#6212: probe @type and @atom candidates, not just @args

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
@@ -57,10 +57,12 @@
       </part>
     </meta>
   </xsl:function>
-  <!-- Every probe candidate: every non-abstract, non-void base; every
+  <!--
+  Every probe candidate: every non-abstract, non-void base; every
   callback arg-type on a void attribute; every void's own type
   annotation; every atom's return signature. Shared by both entry
-  points below so the two can't drift on which sources are probed. -->
+  points below so the two can't drift on which sources are probed.
+  -->
   <xsl:template name="eo:candidates" as="element()*">
     <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
     <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
@@ -96,10 +98,12 @@
       </xsl:for-each>
     </xsl:copy>
   </xsl:template>
-  <!-- Every cumulative dotted prefix of a forma, shortest first, e.g.
+  <!--
+  Every cumulative dotted prefix of a forma, shortest first, e.g.
   "Φ.org.number" yields "Φ", "Φ.org", "Φ.org.number". Shared by every
   place below that walks a dotted forma into probe candidates, so a
-  change to how a forma is split only has one place to happen. -->
+  change to how a forma is split only has one place to happen.
+  -->
   <xsl:template name="eo:dotted-prefixes" as="element()*">
     <xsl:param name="forma" as="xs:string?"/>
     <xsl:variable name="parts" select="tokenize($forma, '\.')"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
@@ -57,13 +57,20 @@
       </part>
     </meta>
   </xsl:function>
+  <!-- Every probe candidate: every non-abstract, non-void base; every
+  callback arg-type on a void attribute; every void's own type
+  annotation; every atom's return signature. Shared by both entry
+  points below so the two can't drift on which sources are probed. -->
+  <xsl:template name="eo:candidates" as="element()*">
+    <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
+    <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
+    <xsl:apply-templates select="//o[@type]" mode="type"/>
+    <xsl:apply-templates select="//o[@atom]" mode="atom"/>
+  </xsl:template>
   <!-- ENTRY POINT 1 - no metas -->
   <xsl:template match="/object[not(metas)]">
     <xsl:variable name="candidates" as="element()*">
-      <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
-      <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
-      <xsl:apply-templates select="//o[@type]" mode="type"/>
-      <xsl:apply-templates select="//o[@atom]" mode="atom"/>
+      <xsl:call-template name="eo:candidates"/>
     </xsl:variable>
     <xsl:variable name="probes" select="distinct-values($candidates/text())[not(eo:contains-any-of(., ('ξ', 'ρ', 'φ'))) and not(.='Φ') and not(.='Φ̇')]"/>
     <xsl:copy>
@@ -80,10 +87,7 @@
   <!-- ENTRY POINT 2 - metas exists -->
   <xsl:template match="/object/metas">
     <xsl:variable name="candidates" as="element()*">
-      <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
-      <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
-      <xsl:apply-templates select="//o[@type]" mode="type"/>
-      <xsl:apply-templates select="//o[@atom]" mode="atom"/>
+      <xsl:call-template name="eo:candidates"/>
     </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
@@ -92,19 +96,29 @@
       </xsl:for-each>
     </xsl:copy>
   </xsl:template>
+  <!-- Every cumulative dotted prefix of a forma, shortest first, e.g.
+  "Φ.org.number" yields "Φ", "Φ.org", "Φ.org.number". Shared by every
+  place below that walks a dotted forma into probe candidates, so a
+  change to how a forma is split only has one place to happen. -->
+  <xsl:template name="eo:dotted-prefixes" as="element()*">
+    <xsl:param name="forma" as="xs:string?"/>
+    <xsl:variable name="parts" select="tokenize($forma, '\.')"/>
+    <xsl:for-each select="$parts">
+      <xsl:variable name="pos" select="position()"/>
+      <a>
+        <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
+      </a>
+    </xsl:for-each>
+  </xsl:template>
   <!-- Callback arg-types annotation on a void attribute -->
   <!-- The `@args` value is a single-space separated list of type atoms; -->
   <!-- homed formas start with `Φ`, generic type variables (A-F) do not -->
   <!-- and must be skipped, since they are not real objects to probe. -->
   <xsl:template match="o" mode="args" as="element()*">
     <xsl:for-each select="tokenize(@args, ' ')[starts-with(., 'Φ')]">
-      <xsl:variable name="parts" select="tokenize(., '\.')"/>
-      <xsl:for-each select="$parts">
-        <xsl:variable name="pos" select="position()"/>
-        <a>
-          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
-        </a>
-      </xsl:for-each>
+      <xsl:call-template name="eo:dotted-prefixes">
+        <xsl:with-param name="forma" select="."/>
+      </xsl:call-template>
     </xsl:for-each>
   </xsl:template>
   <!-- A void's own type annotation (`? > name /Q.foo`, optionally `/Q.foo?`). -->
@@ -113,13 +127,9 @@
   <xsl:template match="o" mode="type" as="element()*">
     <xsl:variable name="forma" select="replace(@type, '\?$', '')"/>
     <xsl:if test="starts-with($forma, 'Φ')">
-      <xsl:variable name="parts" select="tokenize($forma, '\.')"/>
-      <xsl:for-each select="$parts">
-        <xsl:variable name="pos" select="position()"/>
-        <a>
-          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
-        </a>
-      </xsl:for-each>
+      <xsl:call-template name="eo:dotted-prefixes">
+        <xsl:with-param name="forma" select="$forma"/>
+      </xsl:call-template>
     </xsl:if>
   </xsl:template>
   <!-- An atom's own return signature (`[] > name /Q.foo`). -->
@@ -127,24 +137,16 @@
   <!-- must be skipped, since they are not real objects to probe. -->
   <xsl:template match="o" mode="atom" as="element()*">
     <xsl:if test="starts-with(@atom, 'Φ')">
-      <xsl:variable name="parts" select="tokenize(@atom, '\.')"/>
-      <xsl:for-each select="$parts">
-        <xsl:variable name="pos" select="position()"/>
-        <a>
-          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
-        </a>
-      </xsl:for-each>
+      <xsl:call-template name="eo:dotted-prefixes">
+        <xsl:with-param name="forma" select="@atom"/>
+      </xsl:call-template>
     </xsl:if>
   </xsl:template>
   <!-- Composite base -->
   <xsl:template match="o[not(starts-with(@base, '.'))]" mode="create" as="element()*">
-    <xsl:variable name="parts" select="tokenize(@base, '\.')"/>
-    <xsl:for-each select="$parts">
-      <xsl:variable name="pos" select="position()"/>
-      <a>
-        <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
-      </a>
-    </xsl:for-each>
+    <xsl:call-template name="eo:dotted-prefixes">
+      <xsl:with-param name="forma" select="@base"/>
+    </xsl:call-template>
     <xsl:apply-templates select="o" mode="create"/>
   </xsl:template>
   <!-- Method base -->

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/probe/add-probes.xsl
@@ -62,6 +62,8 @@
     <xsl:variable name="candidates" as="element()*">
       <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
       <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
+      <xsl:apply-templates select="//o[@type]" mode="type"/>
+      <xsl:apply-templates select="//o[@atom]" mode="atom"/>
     </xsl:variable>
     <xsl:variable name="probes" select="distinct-values($candidates/text())[not(eo:contains-any-of(., ('ξ', 'ρ', 'φ'))) and not(.='Φ') and not(.='Φ̇')]"/>
     <xsl:copy>
@@ -80,6 +82,8 @@
     <xsl:variable name="candidates" as="element()*">
       <xsl:apply-templates select="//o[not(eo:abstract(.)) and not(eo:void(.))]" mode="create"/>
       <xsl:apply-templates select="//o[eo:void(.) and @args]" mode="args"/>
+      <xsl:apply-templates select="//o[@type]" mode="type"/>
+      <xsl:apply-templates select="//o[@atom]" mode="atom"/>
     </xsl:variable>
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
@@ -102,6 +106,35 @@
         </a>
       </xsl:for-each>
     </xsl:for-each>
+  </xsl:template>
+  <!-- A void's own type annotation (`? > name /Q.foo`, optionally `/Q.foo?`). -->
+  <!-- Homed formas start with `Φ`; generic type variables (A-F) do not and -->
+  <!-- must be skipped, since they are not real objects to probe. -->
+  <xsl:template match="o" mode="type" as="element()*">
+    <xsl:variable name="forma" select="replace(@type, '\?$', '')"/>
+    <xsl:if test="starts-with($forma, 'Φ')">
+      <xsl:variable name="parts" select="tokenize($forma, '\.')"/>
+      <xsl:for-each select="$parts">
+        <xsl:variable name="pos" select="position()"/>
+        <a>
+          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
+        </a>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:template>
+  <!-- An atom's own return signature (`[] > name /Q.foo`). -->
+  <!-- Homed formas start with `Φ`; generic type variables (A-F) do not and -->
+  <!-- must be skipped, since they are not real objects to probe. -->
+  <xsl:template match="o" mode="atom" as="element()*">
+    <xsl:if test="starts-with(@atom, 'Φ')">
+      <xsl:variable name="parts" select="tokenize(@atom, '\.')"/>
+      <xsl:for-each select="$parts">
+        <xsl:variable name="pos" select="position()"/>
+        <a>
+          <xsl:value-of select="string-join($parts[position()&lt;=$pos], '.')"/>
+        </a>
+      </xsl:for-each>
+    </xsl:if>
   </xsl:template>
   <!-- Composite base -->
   <xsl:template match="o[not(starts-with(@base, '.'))]" mode="create" as="element()*">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-atom-signature.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-atom-signature.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An atom's own return signature (`/Q.chunk`) must be probed too, the same
+# way a void's callback arg-types annotation (`/{Q.chunk}`) already is
+# (#6174). See #6212.
+probes:
+  - 'chunk'
+eo: |
+  +package custom
+  +version 0.0.0
+
+  [] > foo /Q.chunk

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-args.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-args.yaml
@@ -4,9 +4,13 @@
 # yamllint disable rule:line-length
 # A callback arg-types annotation on a void attribute (`/{Q.chunk}`) must be
 # probed too, otherwise objects referenced only there (like `chunk` in
-# `malloc.eo`) are never pulled and transpiled. See #6174.
+# `malloc.eo`) are never pulled and transpiled. See #6174. `foo`'s own atom
+# signature (`/Q.bytes`) and `size`'s plain type annotation (`/Q.number`) are
+# the exact same kind of forma reference and must be probed too (#6212).
 probes:
   - 'chunk'
+  - 'bytes'
+  - 'number'
 eo: |
   +package custom
   +version 0.0.0

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-type.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/probe-packs/add-probes-from-void-type.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A void's own type annotation (`/Q.chunk`) must be probed too, the same way
+# the callback arg-types annotation (`/{Q.chunk}`) already is (#6174).
+# `foo`'s own atom signature (`/Q.bytes`) is the exact same kind of forma
+# reference and must be probed too. See #6212.
+probes:
+  - 'chunk'
+  - 'bytes'
+eo: |
+  +package custom
+  +version 0.0.0
+
+  [] > foo /Q.bytes
+    ? > size /Q.chunk


### PR DESCRIPTION
`add-probes.xsl` only collected candidate FQNs from `@args` (a void's callback arg-types annotation, fixed for #6174). It did not collect from `@type` (a plain typed void's own type annotation) or `@atom` (an atom's own return signature), the two sibling forms the parser emits for the same `/Q.foo` syntax. A user package writing `[] > foo /Q.my.thing` referring to another package's object would hit the same `ClassNotFoundException` #6174 fixed for the `@args` case.

Added two new templates, `type` and `atom`, mirroring the existing `args` template: `type` strips the optional trailing `?` before tokenizing, `atom` tokenizes directly, both skip generic type variables (anything not starting with `Φ`) the same way `args` already does. Wired both into the candidate collection in both entry points (with and without existing metas).

This also means the existing `add-probes-from-void-args.yaml` fixture's own `[] > foo /Q.bytes` (with `? > size /Q.number`) is now correctly probed too, since the atom signature and the type annotation are exactly the same kind of reference the fix targets — updated that fixture's expected probes list to include `bytes` and `number` alongside `chunk`.

Added two new YAML packs, `add-probes-from-void-type.yaml` and `add-probes-from-atom-signature.yaml`, covering the second and third rows from the issue. Confirmed all three (the new two plus the updated existing one) fail on the unfixed XSL and pass with the fix. Full eo-maven-plugin test suite, qulice, and jtcop are clean.

Closes #6212
