### PR TITLE
#6214: fold compile-scope XMIR fingerprint into the WPA lint cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+/**
+ * Fingerprint of a set of compile-scope tojos, keyed on each one's
+ * identifier and the content of its XMIR.
+ *
+ * <p>Used to fold the compile-scope XMIRs a whole-program-analysis pass
+ * reads into that pass's cache key, so a change confined to a compile-scope
+ * dependency's XMIR invalidates the cached verdict the same way a change in
+ * the project's own sources already does (see {@link Linting}, #6214).</p>
+ *
+ * @since 0.64
+ */
+final class CompileScopeFingerprint implements Supplier<String> {
+
+    /**
+     * The compile-scope tojos to fingerprint.
+     */
+    private final Collection<TjForeign> tojos;
+
+    /**
+     * Ctor.
+     * @param compile Compile-scope tojos
+     */
+    CompileScopeFingerprint(final Collection<TjForeign> compile) {
+        this.tojos = compile;
+    }
+
+    @Override
+    public String get() {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            this.tojos.stream()
+                .sorted(Comparator.comparing(TjForeign::identifier)).forEach(
+                    tojo -> digest.update(
+                        String.format("%s:%s%n", tojo.identifier(), new Sha(tojo.xmir()))
+                            .getBytes(StandardCharsets.UTF_8)
+                    )
+                );
+            final StringBuilder hex = new StringBuilder(64);
+            for (final byte octet : digest.digest()) {
+                hex.append(String.format("%02x", octet));
+            }
+            return hex.toString();
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
@@ -20,12 +20,11 @@ import java.util.function.Supplier;
  * dependency's XMIR invalidates the cached verdict the same way a change in
  * the project's own sources already does (see {@link Linting}, #6214).</p>
  *
- * <p>{@link #get()} joins each entry with a fixed LF character, not the
- * platform line separator, so the fingerprint is the same on every OS
+ * <p>{@link #get()} frames each entry with a zero byte rather than any
+ * textual separator, so the fingerprint carries no platform line separator
  * and a cache built on one machine stays valid on another.</p>
  *
  * @since 0.64
- * @checkstyle ProhibitLineSeparatorInStringsCheck (60 lines)
  */
 final class CompileScopeFingerprint implements Supplier<String> {
 
@@ -48,10 +47,13 @@ final class CompileScopeFingerprint implements Supplier<String> {
             final MessageDigest digest = MessageDigest.getInstance("SHA-256");
             this.tojos.stream()
                 .sorted(Comparator.comparing(TjForeign::identifier)).forEachOrdered(
-                    tojo -> digest.update(
-                        String.format("%s:%s\n", tojo.identifier(), new Sha(tojo.xmir()))
-                            .getBytes(StandardCharsets.UTF_8)
-                    )
+                    tojo -> {
+                        digest.update(
+                            String.format("%s:%s", tojo.identifier(), new Sha(tojo.xmir()))
+                                .getBytes(StandardCharsets.UTF_8)
+                        );
+                        digest.update((byte) 0);
+                    }
                 );
             final StringBuilder hex = new StringBuilder(64);
             for (final byte octet : digest.digest()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CompileScopeFingerprint.java
@@ -20,7 +20,12 @@ import java.util.function.Supplier;
  * dependency's XMIR invalidates the cached verdict the same way a change in
  * the project's own sources already does (see {@link Linting}, #6214).</p>
  *
+ * <p>{@link #get()} joins each entry with a fixed LF character, not the
+ * platform line separator, so the fingerprint is the same on every OS
+ * and a cache built on one machine stays valid on another.</p>
+ *
  * @since 0.64
+ * @checkstyle ProhibitLineSeparatorInStringsCheck (60 lines)
  */
 final class CompileScopeFingerprint implements Supplier<String> {
 
@@ -42,9 +47,9 @@ final class CompileScopeFingerprint implements Supplier<String> {
         try {
             final MessageDigest digest = MessageDigest.getInstance("SHA-256");
             this.tojos.stream()
-                .sorted(Comparator.comparing(TjForeign::identifier)).forEach(
+                .sorted(Comparator.comparing(TjForeign::identifier)).forEachOrdered(
                     tojo -> digest.update(
-                        String.format("%s:%s%n", tojo.identifier(), new Sha(tojo.xmir()))
+                        String.format("%s:%s\n", tojo.identifier(), new Sha(tojo.xmir()))
                             .getBytes(StandardCharsets.UTF_8)
                     )
                 );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -370,6 +370,24 @@ final class Linting implements Step {
     }
 
     /**
+     * Cache-key version segment for the whole-program-analysis cache: the
+     * plugin version combined with a fingerprint of the compile-scope
+     * XMIRs the pass reads, so a change confined to a compile-scope
+     * dependency's XMIR invalidates the cached verdict the same way a
+     * change in the project's own sources already does (#6214). The
+     * {@code 3-lint} directory the cache otherwise hashes is written only
+     * by {@link #lintOne}, which never touches compile-scope tojos, so
+     * their content would otherwise be invisible to the cache key.
+     * @return The version segment for {@link Linting#CACHE}
+     */
+    private String wpaCacheVersion() {
+        return String.format(
+            "%s-%s",
+            this.version, new CompileScopeFingerprint(this.compile.withXmir()).get()
+        );
+    }
+
+    /**
      * Lint all XMIR files together.
      * @param counts Counts of errors, warnings, and critical
      * @param seen Defects seen so far across all files
@@ -403,7 +421,7 @@ final class Linting implements Step {
             this.guard.apply(
                 base, target, wpa,
                 new Cache(
-                    this.cacheDir.resolve(Linting.CACHE).resolve(this.version),
+                    this.cacheDir.resolve(Linting.CACHE).resolve(this.wpaCacheVersion()),
                     root -> {
                         Logger.info(this, "Linting a package");
                         final Directives all = new Directives().add("defects");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -26,6 +26,32 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class LintingTest {
 
+    /**
+     * Whether caching is enabled, for {@link #lintAsPackage}.
+     */
+    private static final boolean CACHE_ENABLED = true;
+
+    /**
+     * Whether to skip experimental lints, for {@link #lintAsPackage}.
+     */
+    private static final boolean SKIP_EXPERIMENTAL = false;
+
+    /**
+     * Whether to fail on warnings, for {@link #lintAsPackage}.
+     */
+    private static final boolean FAIL_ON_WARNING = false;
+
+    /**
+     * Whether to lint all sources as a package (WPA), for
+     * {@link #lintAsPackage}.
+     */
+    private static final boolean LINT_AS_PACKAGE = true;
+
+    /**
+     * Whether to skip linting entirely, for {@link #lintAsPackage}.
+     */
+    private static final boolean SKIP_LINTING = false;
+
     @Test
     void summarizesAllThreeSeveritiesTogether() {
         final Map<Severity, Integer> counts = new EnumMap<>(Severity.class);
@@ -97,14 +123,14 @@ final class LintingTest {
             compile,
             target,
             cache,
-            true,
+            LintingTest.CACHE_ENABLED,
             "0.0.0",
             Collections.emptyList(),
             Collections.emptyList(),
-            false,
-            false,
-            true,
-            false
+            LintingTest.SKIP_EXPERIMENTAL,
+            LintingTest.FAIL_ON_WARNING,
+            LintingTest.LINT_AS_PACKAGE,
+            LintingTest.SKIP_LINTING
         ).exec();
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -4,10 +4,15 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eolang.lints.Severity;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -54,5 +59,72 @@ final class LintingTest {
             ).exec(),
             "Linting must be fully skipped when skipLinting is TRUE"
         );
+    }
+
+    @Test
+    void changesWpaCacheKeyWhenCompileScopeXmirChanges(@TempDir final Path temp)
+        throws IOException {
+        final Path cache = temp.resolve("cache");
+        final Path target = temp.resolve("target");
+        final Path dep = temp.resolve("dep.xmir");
+        Files.writeString(dep, "<object><o line=\"1\" name=\"one\"/></object>");
+        final TjsForeign compile = new TjsForeign();
+        compile.add("dep").withXmir(dep).withScope("compile");
+        LintingTest.lintAsPackage(compile, target, cache);
+        final Set<String> first = LintingTest.wpaCacheEntries(cache);
+        Files.writeString(dep, "<object><o line=\"1\" name=\"two\"/></object>");
+        LintingTest.lintAsPackage(compile, target, cache);
+        MatcherAssert.assertThat(
+            "changing a compile-scope XMIR's content must produce a new WPA cache entry, not reuse the stale one",
+            LintingTest.wpaCacheEntries(cache),
+            Matchers.not(Matchers.equalTo(first))
+        );
+    }
+
+    /**
+     * Run linting as a package, with a fresh, empty tojos set of the
+     * project's own sources, over the given compile-scope tojos.
+     * @param compile Compile-scope tojos to analyze
+     * @param target Target directory
+     * @param cache Cache directory
+     * @throws IOException If linting fails
+     */
+    private static void lintAsPackage(
+        final TjsForeign compile, final Path target, final Path cache
+    ) throws IOException {
+        new Linting(
+            new TjsForeign(),
+            compile,
+            target,
+            cache,
+            true,
+            "0.0.0",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            false,
+            false,
+            true,
+            false
+        ).exec();
+    }
+
+    /**
+     * The set of WPA cache entry directory names under the given cache
+     * directory.
+     * @param cache Cache directory
+     * @return Directory names, one per distinct cache key seen so far
+     * @throws IOException If the directory can't be listed
+     */
+    private static Set<String> wpaCacheEntries(final Path cache) throws IOException {
+        final Path wpa = cache.resolve(Linting.CACHE);
+        final Set<String> entries;
+        if (Files.exists(wpa)) {
+            try (Stream<Path> list = Files.list(wpa)) {
+                entries = list.map(p -> p.getFileName().toString()).collect(Collectors.toSet());
+            }
+        } else {
+            entries = Collections.emptySet();
+        }
+        return entries;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -26,32 +26,6 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class LintingTest {
 
-    /**
-     * Whether caching is enabled, for {@link #lintAsPackage}.
-     */
-    private static final boolean CACHE_ENABLED = true;
-
-    /**
-     * Whether to skip experimental lints, for {@link #lintAsPackage}.
-     */
-    private static final boolean SKIP_EXPERIMENTAL = false;
-
-    /**
-     * Whether to fail on warnings, for {@link #lintAsPackage}.
-     */
-    private static final boolean FAIL_ON_WARNING = false;
-
-    /**
-     * Whether to lint all sources as a package (WPA), for
-     * {@link #lintAsPackage}.
-     */
-    private static final boolean LINT_AS_PACKAGE = true;
-
-    /**
-     * Whether to skip linting entirely, for {@link #lintAsPackage}.
-     */
-    private static final boolean SKIP_LINTING = false;
-
     @Test
     void summarizesAllThreeSeveritiesTogether() {
         final Map<Severity, Integer> counts = new EnumMap<>(Severity.class);
@@ -123,15 +97,59 @@ final class LintingTest {
             compile,
             target,
             cache,
-            LintingTest.CACHE_ENABLED,
+            LintingTest.cacheEnabled(),
             "0.0.0",
             Collections.emptyList(),
             Collections.emptyList(),
-            LintingTest.SKIP_EXPERIMENTAL,
-            LintingTest.FAIL_ON_WARNING,
-            LintingTest.LINT_AS_PACKAGE,
-            LintingTest.SKIP_LINTING
+            LintingTest.skipExperimentalLints(),
+            LintingTest.failOnWarning(),
+            LintingTest.asPackage(),
+            LintingTest.skipLinting()
         ).exec();
+    }
+
+    /**
+     * Whether caching is enabled, for {@link #lintAsPackage(TjsForeign, Path, Path)}.
+     * @return True
+     */
+    private static boolean cacheEnabled() {
+        return true;
+    }
+
+    /**
+     * Whether to skip experimental lints, for
+     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
+     * @return False
+     */
+    private static boolean skipExperimentalLints() {
+        return false;
+    }
+
+    /**
+     * Whether to fail on warnings, for
+     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
+     * @return False
+     */
+    private static boolean failOnWarning() {
+        return false;
+    }
+
+    /**
+     * Whether to lint all sources as a package (WPA), for
+     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
+     * @return True
+     */
+    private static boolean asPackage() {
+        return true;
+    }
+
+    /**
+     * Whether to skip linting entirely, for
+     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
+     * @return False
+     */
+    private static boolean skipLinting() {
+        return false;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LintingTest.java
@@ -70,13 +70,13 @@ final class LintingTest {
         Files.writeString(dep, "<object><o line=\"1\" name=\"one\"/></object>");
         final TjsForeign compile = new TjsForeign();
         compile.add("dep").withXmir(dep).withScope("compile");
-        LintingTest.lintAsPackage(compile, target, cache);
-        final Set<String> first = LintingTest.wpaCacheEntries(cache);
+        this.lintAsPackage(compile, target, cache);
+        final Set<String> first = this.wpaCacheEntries(cache);
         Files.writeString(dep, "<object><o line=\"1\" name=\"two\"/></object>");
-        LintingTest.lintAsPackage(compile, target, cache);
+        this.lintAsPackage(compile, target, cache);
         MatcherAssert.assertThat(
             "changing a compile-scope XMIR's content must produce a new WPA cache entry, not reuse the stale one",
-            LintingTest.wpaCacheEntries(cache),
+            this.wpaCacheEntries(cache),
             Matchers.not(Matchers.equalTo(first))
         );
     }
@@ -89,7 +89,7 @@ final class LintingTest {
      * @param cache Cache directory
      * @throws IOException If linting fails
      */
-    private static void lintAsPackage(
+    private void lintAsPackage(
         final TjsForeign compile, final Path target, final Path cache
     ) throws IOException {
         new Linting(
@@ -97,59 +97,15 @@ final class LintingTest {
             compile,
             target,
             cache,
-            LintingTest.cacheEnabled(),
+            true,
             "0.0.0",
             Collections.emptyList(),
             Collections.emptyList(),
-            LintingTest.skipExperimentalLints(),
-            LintingTest.failOnWarning(),
-            LintingTest.asPackage(),
-            LintingTest.skipLinting()
+            false,
+            false,
+            true,
+            false
         ).exec();
-    }
-
-    /**
-     * Whether caching is enabled, for {@link #lintAsPackage(TjsForeign, Path, Path)}.
-     * @return True
-     */
-    private static boolean cacheEnabled() {
-        return true;
-    }
-
-    /**
-     * Whether to skip experimental lints, for
-     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
-     * @return False
-     */
-    private static boolean skipExperimentalLints() {
-        return false;
-    }
-
-    /**
-     * Whether to fail on warnings, for
-     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
-     * @return False
-     */
-    private static boolean failOnWarning() {
-        return false;
-    }
-
-    /**
-     * Whether to lint all sources as a package (WPA), for
-     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
-     * @return True
-     */
-    private static boolean asPackage() {
-        return true;
-    }
-
-    /**
-     * Whether to skip linting entirely, for
-     * {@link #lintAsPackage(TjsForeign, Path, Path)}.
-     * @return False
-     */
-    private static boolean skipLinting() {
-        return false;
     }
 
     /**
@@ -159,7 +115,7 @@ final class LintingTest {
      * @return Directory names, one per distinct cache key seen so far
      * @throws IOException If the directory can't be listed
      */
-    private static Set<String> wpaCacheEntries(final Path cache) throws IOException {
+    private Set<String> wpaCacheEntries(final Path cache) throws IOException {
         final Path wpa = cache.resolve(Linting.CACHE);
         final Set<String> entries;
         if (Files.exists(wpa)) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -8,6 +8,7 @@ import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -246,11 +247,12 @@ final class MjLintTest {
             );
         maven.execute(new FakeMaven.Lint());
         MatcherAssert.assertThat(
-            "WPA results must be saved to cache",
-            cache.resolve(Linting.CACHE)
-                .resolve(FakeMaven.pluginVersion())
-                .resolve("wpa.xmir").toFile(),
-            FileMatchers.anExistingFile()
+            "WPA results must be saved to a version-keyed cache entry containing wpa.xmir",
+            cache.resolve(Linting.CACHE).toFile().listFiles(
+                (dir, name) -> name.startsWith(FakeMaven.pluginVersion())
+                    && new File(dir, name).toPath().resolve("wpa.xmir").toFile().exists()
+            ),
+            Matchers.arrayWithSize(1)
         );
     }
 


### PR DESCRIPTION
Depends on #6292 (merge that first). This PR's diff includes #6292's `LintTarget` extraction only because GitHub can't target a base branch that lives on a fork; once #6292 merges to master, I'll rebase this branch and the diff will shrink to just the actual fix below, under the 200-line PR-size limit. Until then the `pr-size` check on this PR will stay red, only because of that duplicated prep-work diff, not this fix's own size.

`Linting.lintAll`'s whole-program-analysis (WPA) pass reads XMIRs from both the project's own tojos and compile-scope tojos. Only `lintOne` (run over the project's own tojos) writes into the `3-lint` cache directory that the WPA cache key hashes. So a change confined to a compile-scope dependency's XMIR leaves that hashed directory byte-identical between builds, and the cached WPA verdict from before the dependency changed gets reused instead of recomputed. Same class of bug as #6030 (a constant cache key), narrower: here the key does capture the project's own sources, it just misses the compile-scope inputs.

Added `CompileScopeFingerprint`, a small `Supplier<String>` that hashes each compile-scope tojo's identifier plus its XMIR content (sorted by identifier for determinism), hex-encoded (not base64 — base64's standard alphabet can emit `/`, which would silently split the fingerprint into extra path segments when used as a cache directory name; caught this in testing). Folded it into the WPA cache key alongside the plugin version, mirroring the pattern `Parsing`'s `Fingerprint`-based key and `Linting`'s own per-file `skipSourceLints`/`skipExperimentalLints` folding already use.

Folding this fingerprint in pushed `Linting`'s qulice `ClassFanOutComplexity` (already at the 30-max ceiling) over the limit, which is why #6292 (extracting `LintTarget`) exists as prep.

Added a `LintingTest` case constructing `Linting` directly with an in-memory compile-scope tojo, running it twice with the same cache directory but different XMIR content the second time, and asserting the WPA cache produces a different directory entry (not the stale one). Confirmed it fails on the unfixed code (same directory both times) and passes with the fix. Updated `MjLintTest.savesForWholeProgramAnalysisResultsToCache`, whose hardcoded cache-path assertion no longer matches the new key shape, to look for the version-keyed directory that actually contains `wpa.xmir` instead. Full eo-maven-plugin test suite, qulice, and jtcop are clean.

Fixes #6214 (once #6292 is merged and this is rebased on top).
