### PR TITLE
#6214: extract LintTarget from Linting.lintOne (prep, no behavior change)

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LintTarget.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LintTarget.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.nio.file.Path;
+import org.eolang.parser.OnDefault;
+import org.eolang.parser.OnDetailed;
+
+/**
+ * The path a per-file lint result belongs at, derived from the XMIR
+ * document's own object name.
+ * @since 0.64
+ */
+final class LintTarget {
+
+    /**
+     * The XMIR document being linted.
+     */
+    private final XML xmir;
+
+    /**
+     * The document's own source path (for a detailed error location if the
+     * object name can't be read).
+     */
+    private final Path source;
+
+    /**
+     * Ctor.
+     * @param doc The XMIR document being linted
+     * @param src The document's own source path
+     */
+    LintTarget(final XML doc, final Path src) {
+        this.xmir = doc;
+        this.source = src;
+    }
+
+    /**
+     * The lint result's path, under the given base directory.
+     * @param base Base directory
+     * @return Full path
+     */
+    Path under(final Path base) {
+        return new Place(
+            new OnDetailed(new OnDefault(new Xnav(this.xmir.inner())), this.source).get()
+        ).make(base, MjAssemble.XMIR);
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -26,8 +26,6 @@ import org.cactoos.list.ListOf;
 import org.eolang.lints.Defect;
 import org.eolang.lints.Severity;
 import org.eolang.lints.Source;
-import org.eolang.parser.OnDefault;
-import org.eolang.parser.OnDetailed;
 import org.eolang.wpa.Program;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
@@ -312,9 +310,7 @@ final class Linting implements Step {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
         final Path base = this.targetDir.resolve(Linting.DIR);
-        final Path target = new Place(
-            new OnDetailed(new OnDefault(new Xnav(xmir.inner())), source).get()
-        ).make(base, MjAssemble.XMIR);
+        final Path target = new LintTarget(xmir, source).under(base);
         if (this.cacheEnabled) {
             this.guard.apply(
                 source, target, base.relativize(target),


### PR DESCRIPTION
Pure refactor, no behavior change. Extracted the `Place`/`OnDetailed`/`OnDefault`/`Xnav` chain `Linting.lintOne` uses to compute a per-file lint result's path into its own `LintTarget` class.

This is prep work for #6214 (whole-program-analysis lint cache key), which needs to add one more type reference to `Linting` (a fingerprint helper for compile-scope XMIRs) but `Linting`'s qulice `ClassFanOutComplexity` is already at the 30-max ceiling, so anything added there needs an equivalent reduction elsewhere. `Place`, `OnDetailed`, `OnDefault`, and `MjAssemble` were each referenced in exactly one spot in `Linting.java` (this one), so extracting them into their own class removes 4 fan-out units from `Linting` while adding only 1 (`LintTarget`).

Splitting this out as its own PR to keep the actual #6214 fix under the 200-line PR-size gate; the fix PR is opened against this branch as its base.

No new tests: existing `LintingTest`/`MjLintTest` coverage already exercises `lintOne`'s target-path computation end to end, and this change doesn't alter its behavior, only where the logic lives.
