### PR TITLE
#6141: fix drive-relative win32 path incorrectly classified as absolute

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -78,9 +78,7 @@
                 number index
       string > text
         basename >> base!
-    is-root-relative.or > is-absolute
-      drive.size.gt 0
-    and. > is-root-relative
+    and. > is-absolute
       driveless.size.gt 0
       eq.
         driveless.slice 0 1
@@ -106,7 +104,7 @@
           concat.
             concat.
               drive.concat
-                is-root-relative.if separator --
+                is-absolute.if separator --
               string.joined >> body!
                 separator
                 tuple.reduced
@@ -119,7 +117,7 @@
                         accum.length.gt 0
                         not. (accum.head.eq "..")
                       accum.tail
-                      is-root-relative.not.if (accum.with segment) accum
+                      is-absolute.not.if (accum.with segment) accum
                     if.
                       or.
                         segment.eq "."
@@ -196,6 +194,10 @@
           string (string.replaced pth (regex "/\\//") separator)!
         string ubts > pth
       ^.separator > separator
+
+  not. ++> can-detect-a-drive-relative-win32-path-as-not-absolute
+    is-absolute.
+      path.win32 "C:foo"
 
   and. ++> can-detect-an-absolute-posix-path
     is-absolute.


### PR DESCRIPTION
`path.win32.is-absolute` was `is-root-relative.or (drive.size.gt 0)`. Since `win32.drive` returns a non-empty drive letter for both `C:foo` and `C:\foo`, the `.or` clause alone forced `is-absolute` to `true` for any drive-qualified path, even a drive-relative one like `C:foo` that has no root separator after the drive.

`is-root-relative` already contains the exact distinction needed (whether the part after the drive starts with the separator), so folding the drive-presence check into `is-absolute` was redundant and wrong for the drive-relative case. Made `is-absolute` equal to what `is-root-relative` computed directly (dropping the extra `.or` condition), and removed the now-redundant `is-root-relative` name entirely (qulice's `anemic-getter` lint flagged a bare rename as dead weight), updating the two internal call sites that referenced it (`normalized`'s separator and `..`-collapsing logic) to use `is-absolute` instead, since after this fix they are the exact same value.

Added the issue's own regression case, `path.win32 "C:foo"` reporting `is-absolute` as `false`, alongside the existing `can-detect-an-absolute-win32-path` test that already covers the rooted (`C:\Windows\Users`, `\Windows\Users`) and plain-relative (`temp\var`) cases. Confirmed the new test fails on the unfixed code (`is-absolute` incorrectly `true`) and passes with the fix. Full eo-runtime test suite is clean.

Closes #6141
