### PR TITLE
Fix atom detection when generating Java files

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -95,7 +95,7 @@ final class JavaFiles {
             final Xnav object = new Xnav(target).element("object");
             final Collection<Xnav> classes = object.elements(Filter.withName("class"))
                 .collect(Collectors.toList());
-            final boolean atom = object.path("/object/o/o[@name='λ']").findAny().isPresent();
+            final boolean atom = object.path("o/o[@name='λ']").findAny().isPresent();
             for (final Xnav clazz : classes) {
                 final String jname = clazz.attribute("java-name").text().get();
                 if (!atom || jname.endsWith("Test")) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
@@ -75,5 +76,57 @@ final class JavaFilesTest {
             ),
             Matchers.equalTo(Arrays.asList(false, true))
         );
+    }
+
+    @Test
+    void writesExactlyOneFileForAtom(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "only a test class of an atom must be written",
+            JavaFilesTest.generateAtom(temp),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void skipsAtomImplementationClass(@Mktmp final Path temp) throws IOException {
+        JavaFilesTest.generateAtom(temp);
+        MatcherAssert.assertThat(
+            "an atom implementation class must not be written",
+            Files.exists(temp.resolve("generated/EOatom.java")),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void writesCompanionClassForAtom(@Mktmp final Path temp) throws IOException {
+        JavaFilesTest.generateAtom(temp);
+        MatcherAssert.assertThat(
+            "an atom test class must be written",
+            Files.exists(temp.resolve("generated/EOatomTest.java")),
+            Matchers.equalTo(true)
+        );
+    }
+
+    /**
+     * Transpile a single-atom XMIR and report how many files were written.
+     * @param temp Temp directory to write into
+     * @return Number of files written
+     * @throws IOException If fails to save or transpile
+     */
+    private static int generateAtom(final Path temp) throws IOException {
+        final Path xmir = temp.resolve("main.xmir");
+        new Saved(
+            String.join(
+                "",
+                "<object><o><o name='λ'/></o>",
+                "<class java-name='EOatom'><java>class EOatom {}</java></class>",
+                "<class java-name='EOatomTest'><java>class EOatomTest {}</java></class>",
+                "</object>"
+            ),
+            xmir
+        ).value();
+        return new JavaFiles(
+            temp.resolve("generated"), temp.resolve("cache").resolve("1.0-SNAPSHOT"), false
+        ).total(true, xmir, "", false);
     }
 }


### PR DESCRIPTION
## What changed

`JavaFiles` now evaluates the atom marker relative to the XMIR `<object>` element it already selected. This makes the `o/o[@name='λ']` check match the shape produced by the parser instead of looking for a second nested `<object>`.

## Why

The previous absolute-looking expression, `/object/o/o[@name='λ']`, was evaluated by `Xnav` from the current `<object>` node. It therefore never detected an ordinary atom, leaving `atom` false and causing production Java classes to be written for atoms.

## Verification

`JavaFilesTest` now creates an atom XMIR with both an implementation class and a test class. It verifies that only the `*Test` class is generated and that the implementation class is absent.

Tested with:

```text
MAVEN_OPTS='-XX:ActiveProcessorCount=1 -Xmx1g' mvn -q -ntp -T 1 -pl eo-maven-plugin test -Dtest=JavaFilesTest -DfailIfNoTests=false -Djunit.jupiter.execution.parallel.enabled=false -DforkCount=1
```

Fixes #6247