### PR TITLE
#6125: extract GlobalCache out of Parsing

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GcShared.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GcShared.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+import org.cactoos.Func;
+
+/**
+ * The cache that lives on this machine and is reused by later builds.
+ *
+ * <p>A file is kept under {@code dir/key/hash/tail}, where the key tells the
+ * output of one version of the compiler apart from another.</p>
+ *
+ * @since 0.74
+ */
+final class GcShared implements GlobalCache {
+
+    /**
+     * Directory of this step inside the machine-wide cache.
+     */
+    private final Path dir;
+
+    /**
+     * The segment that tells one compiler output from another.
+     */
+    private final String key;
+
+    /**
+     * Guard, shared by every file of one run, see {@link ConcurrentCache}.
+     */
+    private final ConcurrentCache guard;
+
+    /**
+     * Ctor.
+     * @param dir Directory of this step inside the machine-wide cache
+     * @param key The segment that tells one compiler output from another
+     */
+    GcShared(final Path dir, final String key) {
+        this(dir, key, new ConcurrentCache());
+    }
+
+    /**
+     * Ctor.
+     * @param dir Directory of this step inside the machine-wide cache
+     * @param key The segment that tells one compiler output from another
+     * @param guard Guard shared with the cache this one was derived from
+     */
+    private GcShared(final Path dir, final String key, final ConcurrentCache guard) {
+        this.dir = dir;
+        this.key = key;
+        this.guard = guard;
+    }
+
+    @Override
+    public Footprint footprint(
+        final Path tail, final Supplier<String> hash, final Func<Path, String> compile
+    ) {
+        return (source, target) -> {
+            this.guard.apply(
+                source, target, tail,
+                new Cache(new CachePath(this.dir, this.key, hash, Paths.get(".")), compile)
+            );
+            return target;
+        };
+    }
+
+    @Override
+    public GlobalCache with(final String segment) {
+        return new GcShared(
+            this.dir, String.format("%s-%s", this.key, segment), this.guard
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import org.cactoos.Func;
+import org.cactoos.io.InputOf;
+
+/**
+ * The cache shared by every build on this machine.
+ *
+ * <p>A step asks it how one file is to be written and gets a {@link Footprint}
+ * back. Whether that footprint goes through the cache or straight past it is
+ * decided once, where the {@code eo.cacheEnabled} option is read, so no step
+ * has to know that the option exists.</p>
+ *
+ * @since 0.74
+ */
+interface GlobalCache {
+
+    /**
+     * The cache that remembers nothing, for a build that turned caching off.
+     */
+    GlobalCache NONE = new GlobalCache.GcFresh();
+
+    /**
+     * How one file is to be written.
+     * @param tail Path of that file inside the cache
+     * @param hash Hash segment of the cache path
+     * @param compile How the content of the file is produced
+     * @return The footprint that writes it
+     */
+    Footprint footprint(Path tail, Supplier<String> hash, Func<Path, String> compile);
+
+    /**
+     * The same cache, with one more segment folded into its key.
+     * @param segment The segment to fold in
+     * @return The derived cache
+     */
+    GlobalCache with(String segment);
+
+    /**
+     * The cache that remembers nothing.
+     *
+     * <p>Every file is produced and written to its target, and the cache
+     * directory is neither read nor written. This is what the build gets when
+     * {@code eo.cacheEnabled} is false.</p>
+     *
+     * @since 0.74
+     */
+    final class GcFresh implements GlobalCache {
+
+        @Override
+        public Footprint footprint(
+            final Path tail, final Supplier<String> hash, final Func<Path, String> compile
+        ) {
+            return new FpGenerated(src -> new InputOf(compile.apply(src)));
+        }
+
+        @Override
+        public GlobalCache with(final String segment) {
+            return this;
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
@@ -22,11 +22,6 @@ import org.cactoos.io.InputOf;
 interface GlobalCache {
 
     /**
-     * The cache that remembers nothing, for a build that turned caching off.
-     */
-    GlobalCache NONE = new GlobalCache.GcFresh();
-
-    /**
      * How one file is to be written.
      * @param tail Path of that file inside the cache
      * @param hash Hash segment of the cache path

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -45,10 +45,8 @@ public final class MjParse extends MjSafe {
         new Parsing(
             this.scopedTojos(),
             this.targetDir.toPath(),
-            this.cache.toPath(),
-            this.cacheEnabled,
-            this.plugin.getVersion(),
-            this.sourcesDir.toPath()
+            this.sourcesDir.toPath(),
+            this.caching(Parsing.CACHE)
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -32,8 +32,10 @@ import org.slf4j.impl.StaticLoggerBinder;
  *  {@link GlobalCache} and {@link GcShared} in {@link #caching(String)}
  *  pushed it to 32 and the suppression had to be added. Unload the class
  *  instead, the way the puzzle about the tojos lifecycle below asks, and
- *  the suppression can go. Until then no further step can be moved to
- *  {@link GlobalCache} without making this worse.
+ *  the suppression can go, together with the {@code @SuppressWarnings}
+ *  for the field count right below it, which the same unloading fixes.
+ *  Until then no further step can be moved to {@link GlobalCache}
+ *  without making this worse.
  * @checkstyle ClassFanOutComplexityCheck (5 lines)
  */
 @SuppressWarnings("PMD.TooManyFields")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -27,6 +27,14 @@ import org.slf4j.impl.StaticLoggerBinder;
 /**
  * Abstract Mojo for all others.
  * @since 0.1
+ * @todo #6125:60min Take the fan-out suppression below off again.
+ *  This class sat at exactly 30 referenced types, the maximum, so naming
+ *  {@link GlobalCache} and {@link GcShared} in {@link #caching(String)}
+ *  pushed it to 32 and the suppression had to be added. Unload the class
+ *  instead, the way the puzzle about the tojos lifecycle below asks, and
+ *  the suppression can go. Until then no further step can be moved to
+ *  {@link GlobalCache} without making this worse.
+ * @checkstyle ClassFanOutComplexityCheck (5 lines)
  */
 @SuppressWarnings("PMD.TooManyFields")
 abstract class MjSafe extends AbstractMojo {
@@ -535,10 +543,8 @@ abstract class MjSafe extends AbstractMojo {
                 new Parsing(
                     this.scopedTojos(),
                     this.targetDir.toPath(),
-                    this.cache.toPath(),
-                    this.cacheEnabled,
-                    this.plugin.getVersion(),
-                    this.sourcesDir.toPath()
+                    this.sourcesDir.toPath(),
+                    this.caching(Parsing.CACHE)
                 )
             ),
             new Timed(
@@ -558,6 +564,25 @@ abstract class MjSafe extends AbstractMojo {
                 )
             )
         );
+    }
+
+    /**
+     * The cache of one step, as configured by the user. This is the only
+     * place where {@code eo.cacheEnabled} is read, so that no step below
+     * has to know that the option exists.
+     * @param sub Directory of that step inside the machine-wide cache
+     * @return The cache of that step
+     */
+    GlobalCache caching(final String sub) {
+        final GlobalCache cche;
+        if (this.cacheEnabled) {
+            cche = new GcShared(
+                this.cache.toPath().resolve(sub), this.plugin.getVersion()
+            );
+        } else {
+            cche = GlobalCache.NONE;
+        }
+        return cche;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -582,7 +582,7 @@ abstract class MjSafe extends AbstractMojo {
                 this.cache.toPath().resolve(sub), this.plugin.getVersion()
             );
         } else {
-            store = GlobalCache.NONE;
+            store = new GlobalCache.GcFresh();
         }
         return store;
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -574,15 +574,15 @@ abstract class MjSafe extends AbstractMojo {
      * @return The cache of that step
      */
     GlobalCache caching(final String sub) {
-        final GlobalCache cche;
+        final GlobalCache store;
         if (this.cacheEnabled) {
-            cche = new GcShared(
+            store = new GcShared(
                 this.cache.toPath().resolve(sub), this.plugin.getVersion()
             );
         } else {
-            cche = GlobalCache.NONE;
+            store = GlobalCache.NONE;
         }
-        return cche;
+        return store;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -87,18 +87,18 @@ final class Parsing implements Step {
      * @param srcs Foreign tojos catalog
      * @param target Target directory
      * @param sources EO sources directory
-     * @param cche Where the results of earlier builds are looked for and kept
+     * @param store Where the results of earlier builds are looked for and kept
      */
     Parsing(
         final TjsForeign srcs,
         final Path target,
         final Path sources,
-        final GlobalCache cche
+        final GlobalCache store
     ) {
         this.tojos = srcs;
         this.targetDir = target;
         this.sourcesDir = sources;
-        this.cache = cche;
+        this.cache = store;
     }
 
     @Override
@@ -150,17 +150,17 @@ final class Parsing implements Step {
      * Parse all the given sources to XMIRs, concurrently.
      * @param sources The sources to parse
      * @param pipeline The canonical parsing transform to apply
-     * @param cche The cache, already keyed by the set of known objects
+     * @param store The cache, already keyed by the set of known objects
      * @return Amount of parsed tojos
      */
     private int parsed(
         final Collection<TjForeign> sources,
         final UnaryOperator<XML> pipeline,
-        final GlobalCache cche
+        final GlobalCache store
     ) {
         return new Threaded<>(
             new Filtered<>(TjForeign::notParsed, sources),
-            tojo -> this.parsed(tojo, pipeline, cche)
+            tojo -> this.parsed(tojo, pipeline, store)
         ).total();
     }
 
@@ -168,19 +168,19 @@ final class Parsing implements Step {
      * Parse EO file to XML.
      * @param tojo The tojo
      * @param pipeline The canonical parsing transform to apply
-     * @param cche The cache, already keyed by the set of known objects
+     * @param store The cache, already keyed by the set of known objects
      * @return Amount of parsed tojos
      * @throws Exception If fails
      */
     private int parsed(
-        final TjForeign tojo, final UnaryOperator<XML> pipeline, final GlobalCache cche
+        final TjForeign tojo, final UnaryOperator<XML> pipeline, final GlobalCache store
     ) throws Exception {
         final Path source = tojo.source();
         final String name = tojo.identifier();
         final Path base = this.targetDir.resolve(Parsing.DIR);
         final Path target = new Place(name).make(base, MjAssemble.XMIR);
         final List<Node> refs = new ArrayList<>(1);
-        cche.footprint(
+        store.footprint(
             base.relativize(target),
             new TojoHash(tojo),
             src -> {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -72,57 +72,33 @@ final class Parsing implements Step {
     private final Path targetDir;
 
     /**
-     * Base cache directory.
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final Path cacheDir;
-
-    /**
-     * Whether caching is enabled.
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final boolean cacheEnabled;
-
-    /**
-     * Plugin version.
-     */
-    private final String version;
-
-    /**
      * EO sources directory (used for logging).
      * @checkstyle MemberNameCheck (5 lines)
      */
     private final Path sourcesDir;
 
     /**
-     * Cache guard, see {@link ConcurrentCache} for why it is one per instance.
+     * Where the results of earlier builds are looked for and kept.
      */
-    private final ConcurrentCache guard;
+    private final GlobalCache cache;
 
     /**
      * Constructor.
      * @param srcs Foreign tojos catalog
      * @param target Target directory
-     * @param cache Base cache directory
-     * @param enabled Whether caching is enabled
-     * @param ver Plugin version string
      * @param sources EO sources directory
+     * @param cche Where the results of earlier builds are looked for and kept
      */
     Parsing(
         final TjsForeign srcs,
         final Path target,
-        final Path cache,
-        final boolean enabled,
-        final String ver,
-        final Path sources
+        final Path sources,
+        final GlobalCache cche
     ) {
         this.tojos = srcs;
         this.targetDir = target;
-        this.cacheDir = cache;
-        this.cacheEnabled = enabled;
-        this.version = ver;
         this.sourcesDir = sources;
-        this.guard = new ConcurrentCache();
+        this.cache = cche;
     }
 
     @Override
@@ -137,9 +113,17 @@ final class Parsing implements Step {
         final int total = this.parsed(
             sources,
             new Canonical(objects),
-            new UncheckedText(
-                new HexOf(new Sha256DigestOf(new InputOf(objects)))
-            ).asString()
+            this.cache.with(
+                new Fingerprint(
+                    Stream.concat(
+                        Canonical.XSLS.stream(), Canonical.IMPORTS.stream()
+                    ).toArray(String[]::new)
+                ).get()
+            ).with(
+                new UncheckedText(
+                    new HexOf(new Sha256DigestOf(new InputOf(objects)))
+                ).asString()
+            )
         );
         if (0 == total) {
             if (sources.isEmpty()) {
@@ -166,17 +150,17 @@ final class Parsing implements Step {
      * Parse all the given sources to XMIRs, concurrently.
      * @param sources The sources to parse
      * @param pipeline The canonical parsing transform to apply
-     * @param digest Digest of the set of known objects (part of the cache key)
+     * @param cche The cache, already keyed by the set of known objects
      * @return Amount of parsed tojos
      */
     private int parsed(
         final Collection<TjForeign> sources,
         final UnaryOperator<XML> pipeline,
-        final String digest
+        final GlobalCache cche
     ) {
         return new Threaded<>(
             new Filtered<>(TjForeign::notParsed, sources),
-            tojo -> this.parsed(tojo, pipeline, digest)
+            tojo -> this.parsed(tojo, pipeline, cche)
         ).total();
     }
 
@@ -184,48 +168,27 @@ final class Parsing implements Step {
      * Parse EO file to XML.
      * @param tojo The tojo
      * @param pipeline The canonical parsing transform to apply
-     * @param digest Digest of the set of known objects (part of the cache key)
+     * @param cche The cache, already keyed by the set of known objects
      * @return Amount of parsed tojos
      * @throws Exception If fails
      */
     private int parsed(
-        final TjForeign tojo, final UnaryOperator<XML> pipeline, final String digest
+        final TjForeign tojo, final UnaryOperator<XML> pipeline, final GlobalCache cche
     ) throws Exception {
         final Path source = tojo.source();
         final String name = tojo.identifier();
         final Path base = this.targetDir.resolve(Parsing.DIR);
         final Path target = new Place(name).make(base, MjAssemble.XMIR);
         final List<Node> refs = new ArrayList<>(1);
-        if (this.cacheEnabled) {
-            this.guard.apply(
-                source, target, base.relativize(target),
-                new Cache(
-                    new CachePath(
-                        this.cacheDir.resolve(Parsing.CACHE),
-                        String.format(
-                            "%s-%s-%s",
-                            this.version,
-                            new Fingerprint(
-                                Stream.concat(
-                                    Canonical.XSLS.stream(), Canonical.IMPORTS.stream()
-                                ).toArray(String[]::new)
-                            ).get(),
-                            digest
-                        ),
-                        new TojoHash(tojo).get()
-                    ),
-                    src -> {
-                        final Node node = this.parsed(src, name, pipeline);
-                        refs.add(node);
-                        return new XMLDocument(node).toString();
-                    }
-                )
-            );
-        } else {
-            final Node node = this.parsed(source, name, pipeline);
-            new Saved(new XMLDocument(node).toString(), target).value();
-            refs.add(node);
-        }
+        cche.footprint(
+            base.relativize(target),
+            new TojoHash(tojo),
+            src -> {
+                final Node node = this.parsed(src, name, pipeline);
+                refs.add(node);
+                return new XMLDocument(node).toString();
+            }
+        ).apply(source, target);
         tojo.withXmir(target).withVersion(Parsing.tojoVersion(target, refs));
         final List<Xnav> errors = new Xnav(target)
             .element("object")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -27,9 +27,7 @@ final class CompilingTest {
                         new TjsForeign(),
                         temp,
                         temp,
-                        false,
-                        "0.0.0",
-                        temp
+                        new GlobalCache.GcFresh()
                     ),
                     new Probing(new TjsForeign(), new Objectionary.Fake(), false),
                     new Pulling(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/GcSharedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/GcSharedTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link GcShared}.
+ * @since 0.74
+ */
+@ExtendWith(MktmpResolver.class)
+final class GcSharedTest {
+
+    @Test
+    void servesTheSecondRunFromTheCache(@Mktmp final Path temp) throws IOException {
+        final Path source = temp.resolve("source.eo");
+        Files.writeString(source, "[] > main", StandardCharsets.UTF_8);
+        final Path target = temp.resolve("target.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final GlobalCache cache = new GcShared(temp.resolve("cache"), "1.2.3");
+        for (int idx = 0; idx < 2; ++idx) {
+            cache.footprint(
+                Path.of("target.xmir"),
+                () -> "0123456789",
+                src -> String.format("compiled %d", counter.incrementAndGet())
+            ).apply(source, target);
+        }
+        MatcherAssert.assertThat(
+            "the second run must be written from the cache, not compiled again",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("compiled 1")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/GlobalCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/GlobalCacheTest.java
@@ -30,7 +30,7 @@ final class GlobalCacheTest {
         final Path target = temp.resolve("target.xmir");
         final AtomicInteger counter = new AtomicInteger(0);
         for (int idx = 0; idx < 2; ++idx) {
-            GlobalCache.NONE.footprint(
+            new GlobalCache.GcFresh().footprint(
                 Path.of("target.xmir"),
                 () -> "0123456789",
                 src -> String.format("compiled %d", counter.incrementAndGet())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/GlobalCacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/GlobalCacheTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link GlobalCache.GcFresh}.
+ * @since 0.74
+ */
+@ExtendWith(MktmpResolver.class)
+final class GlobalCacheTest {
+
+    @Test
+    void compilesAgainOnEveryRun(@Mktmp final Path temp) throws IOException {
+        final Path source = temp.resolve("source.eo");
+        Files.writeString(source, "[] > main", StandardCharsets.UTF_8);
+        final Path target = temp.resolve("target.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        for (int idx = 0; idx < 2; ++idx) {
+            GlobalCache.NONE.footprint(
+                Path.of("target.xmir"),
+                () -> "0123456789",
+                src -> String.format("compiled %d", counter.incrementAndGet())
+            ).apply(source, target);
+        }
+        MatcherAssert.assertThat(
+            "nothing must be remembered between two runs",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("compiled 2")
+        );
+    }
+}


### PR DESCRIPTION
A sketch, as asked. One class extracted, not the four.

`Parsing` and `Transpiling` hold the same four fields: the cache directory, the enabled flag, the version and the `ConcurrentCache` guard. In `Parsing` those four are used in one block and nowhere else, so that is where the cut is cleanest. `Transpiling` comes next, in another PR, together with `JavaFiles`, which keeps a third copy of the same two ideas.

`GlobalCache` answers one question: how is this one file to be written. It hands back a `Footprint`, which is the interface this module already has for that. `GcShared` goes through the machine-wide cache; `GlobalCache.NONE` does not. The `eo.cacheEnabled` option is read once, in `MjSafe`, so no step below knows the option exists.

`Parsing` loses four fields and two constructor parameters, and the `if` over the flag goes with them. The lambda that turns a source into XMIR was written twice before, once inside the cache and once in the `else`; now it is written once.

Numbers on this branch: qulice green, `MjParseTest` 13 of 13 and untouched, suppressions across the repo down from 369 to 368.

One thing I want your opinion on. `MjSafe` sat at exactly 30 referenced types, which is the `ClassFanOutComplexityCheck` maximum, so naming `GlobalCache` and `GcShared` there pushed it to 32. I tried moving the parsing step out of `MjSafe` instead, which keeps the count flat, but that spread the construction across `MjParse`, `MjAssemble` and `MjCompile` and added about 120 lines to a change that is supposed to be small. So the suppression is there for now, with a puzzle next to it. It matters beyond style: while the ceiling stands, `Transpiling` cannot move to `GlobalCache` either, since it is built in the same class.

Not closing the issue with this PR.
