### PR TITLE
#6301: split win32 drive by character length, not byte size

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -58,8 +58,8 @@
       drive.size.eq 0
       uri
       uri.slice
-        drive.size
-        uri.size.minus drive.size
+        drive.length
+        uri.length.minus drive.length
     [] > extname
       if. > @
         or.
@@ -225,6 +225,11 @@
     normalized.
       path.win32 "C:"
     "C:"
+
+  eq. ++> can-normalize-a-drive-qualified-win32-path-with-a-multibyte-segment
+    normalized.
+      path.win32 "C:\\Ж"
+    "C:\\Ж"
 
   eq. ++> can-normalize-a-drive-relative-win32-path-keeping-a-leading-dotdot
     normalized.


### PR DESCRIPTION
Fixes #6301.

`path.win32` split the drive off the URI with a character-indexed `string.slice`, but computed both slice arguments from `.size` (the UTF-8 **byte** length). For an ASCII path the two units coincide, so the bug stayed hidden. As soon as the path carried a multibyte segment the byte length exceeded the character length and the slice ran past the end of the string:

```
path.win32 "C:\Ж".driveless    -> ExFailure: Start index + length to slice (5) is out of string bounds
path.win32 "C:\Ж".normalized   -> same failure
```

(`"C:\Ж"` is 5 bytes but 4 characters, so `uri.size.minus drive.size` asked `slice` for 3 characters starting at index 2 of a 4-character string.)

The fix makes the drive split use character units throughout, matching `string.slice`:

```eo
uri.slice
  drive.length
  uri.length.minus drive.length
```

Added a regression test `can-normalize-a-drive-qualified-win32-path-with-a-multibyte-segment` asserting `path.win32 "C:\Ж".normalized` yields `C:\Ж`. All 52 `EOpathTest` cases pass locally, including the existing ASCII and posix ones.
