### PR TITLE
#6299: guard recv against a negative received count on both platforms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -41,7 +41,7 @@ public final class RecvSyscall implements Syscall {
             new Dataized(params[2]).asNumber().intValue()
         );
         result.put(0, new Data.ToPhi(received));
-        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, received)));
+        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(received, 0))));
         return result;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -42,7 +42,7 @@ public final class RecvFuncCall implements Syscall {
             new Dataized(params[2]).asNumber().intValue()
         );
         result.put(0, new Data.ToPhi(received));
-        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, received)));
+        result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(received, 0))));
         return result;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.posix.CStdLib;
+import org.eolang.posix.RecvSyscall;
+import org.eolang.win32.RecvFuncCall;
 import org.eolang.win32.WSAStartupFuncCall;
 import org.eolang.win32.Winsock;
 import org.hamcrest.MatcherAssert;
@@ -218,6 +220,25 @@ final class SyscallTest {
                 this.cleanup();
                 server.stop();
             }
+        }
+
+        @Test
+        void receivesNothingWithoutCrashingOnFailedRecvViaSyscall() {
+            final Phi result = new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(-1),
+                new Data.ToPhi(16),
+                new Data.ToPhi(0)
+            );
+            MatcherAssert.assertThat(
+                "A failed recv must report code -1 instead of throwing NegativeArraySizeException",
+                new Dataized(result.take("code")).asNumber().intValue(),
+                Matchers.equalTo(-1)
+            );
+            MatcherAssert.assertThat(
+                "A failed recv must expose an empty byte sequence as its output",
+                ((byte[]) new Dataized(result.take("output")).take()).length,
+                Matchers.equalTo(0)
+            );
         }
 
         @RepeatedIfExceptionsTest(repeats = 3)
@@ -560,6 +581,25 @@ final class SyscallTest {
                 this.closeSocket(socket);
                 server.stop();
             }
+        }
+
+        @Test
+        void receivesNothingWithoutCrashingOnFailedRecvViaSyscall() {
+            final Phi result = new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(-1),
+                new Data.ToPhi(16),
+                new Data.ToPhi(0)
+            );
+            MatcherAssert.assertThat(
+                "A failed recv must report code -1 instead of throwing NegativeArraySizeException",
+                new Dataized(result.take("code")).asNumber().intValue(),
+                Matchers.equalTo(-1)
+            );
+            MatcherAssert.assertThat(
+                "A failed recv must expose an empty byte sequence as its output",
+                ((byte[]) new Dataized(result.take("output")).take()).length,
+                Matchers.equalTo(0)
+            );
         }
 
         @RepeatedIfExceptionsTest(repeats = 3)

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -21,8 +21,6 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.posix.CStdLib;
-import org.eolang.posix.RecvSyscall;
-import org.eolang.win32.RecvFuncCall;
 import org.eolang.win32.WSAStartupFuncCall;
 import org.eolang.win32.Winsock;
 import org.hamcrest.MatcherAssert;
@@ -220,25 +218,6 @@ final class SyscallTest {
                 this.cleanup();
                 server.stop();
             }
-        }
-
-        @Test
-        void receivesNothingWithoutCrashingOnFailedRecvViaSyscall() {
-            final Phi result = new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
-                new Data.ToPhi(-1),
-                new Data.ToPhi(16),
-                new Data.ToPhi(0)
-            );
-            MatcherAssert.assertThat(
-                "A failed recv must report code -1 instead of throwing NegativeArraySizeException",
-                new Dataized(result.take("code")).asNumber().intValue(),
-                Matchers.equalTo(-1)
-            );
-            MatcherAssert.assertThat(
-                "A failed recv must expose an empty byte sequence as its output",
-                ((byte[]) new Dataized(result.take("output")).take()).length,
-                Matchers.equalTo(0)
-            );
         }
 
         @RepeatedIfExceptionsTest(repeats = 3)
@@ -581,25 +560,6 @@ final class SyscallTest {
                 this.closeSocket(socket);
                 server.stop();
             }
-        }
-
-        @Test
-        void receivesNothingWithoutCrashingOnFailedRecvViaSyscall() {
-            final Phi result = new RecvSyscall(Phi.Φ.take("posix").copy()).make(
-                new Data.ToPhi(-1),
-                new Data.ToPhi(16),
-                new Data.ToPhi(0)
-            );
-            MatcherAssert.assertThat(
-                "A failed recv must report code -1 instead of throwing NegativeArraySizeException",
-                new Dataized(result.take("code")).asNumber().intValue(),
-                Matchers.equalTo(-1)
-            );
-            MatcherAssert.assertThat(
-                "A failed recv must expose an empty byte sequence as its output",
-                ((byte[]) new Dataized(result.take("output")).take()).length,
-                Matchers.equalTo(0)
-            );
         }
 
         @RepeatedIfExceptionsTest(repeats = 3)

--- a/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link RecvSyscall}.
+ * @since 0.57.0
+ */
+final class RecvSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void survivesFailedRecvWithoutCrashing() {
+        MatcherAssert.assertThat(
+            "A failed posix recv must report code -1 with empty output, not crash",
+            RecvSyscallTest.outcome(
+                new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                    new Data.ToPhi(-1), new Data.ToPhi(16), new Data.ToPhi(0)
+                )
+            ),
+            Matchers.contains(-1, 0)
+        );
+    }
+
+    /**
+     * The recv outcome as a {@code [code, output-length]} pair.
+     * @param result The dataizable recv result
+     * @return The exit code followed by the output byte count
+     */
+    private static List<Integer> outcome(final Phi result) {
+        return Arrays.asList(
+            new Dataized(result.take("code")).asNumber().intValue(),
+            ((byte[]) new Dataized(result.take("output")).take()).length
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/posix/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for posix syscalls.
+ * @since 0.57.0
+ */
+package org.eolang.posix;

--- a/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link RecvFuncCall}.
+ * @since 0.57.0
+ */
+final class RecvFuncCallTest {
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void survivesFailedRecvWithoutCrashing() {
+        MatcherAssert.assertThat(
+            "A failed win32 recv must report code -1 with empty output, not crash",
+            RecvFuncCallTest.outcome(
+                new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(-1), new Data.ToPhi(16), new Data.ToPhi(0)
+                )
+            ),
+            Matchers.contains(-1, 0)
+        );
+    }
+
+    /**
+     * The recv outcome as a {@code [code, output-length]} pair.
+     * @param result The dataizable recv result
+     * @return The exit code followed by the output byte count
+     */
+    private static List<Integer> outcome(final Phi result) {
+        return Arrays.asList(
+            new Dataized(result.take("code")).asNumber().intValue(),
+            ((byte[]) new Dataized(result.take("output")).take()).length
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for win32 socket function calls.
+ * @since 0.57.0
+ */
+package org.eolang.win32;


### PR DESCRIPTION
Fixes #6299.

Both receive wrappers copied the reported byte count straight into `Arrays.copyOf`:

```java
result.put(1, new Data.ToPhi(Arrays.copyOf(buf, received)));
```

A failed receive reports `-1`, so `Arrays.copyOf(buf, -1)` throws `NegativeArraySizeException`, hiding the status code EO callers are supposed to inspect. Confirmed by running the native call directly: `recv(-1, buf, 16, 0)` returns `-1`, after which `Arrays.copyOf(buf, -1)` throws, while `Arrays.copyOf(buf, Math.max(-1, 0))` yields an empty array.

The sibling `win32.ReadFuncCall` already guards this with `Math.max(count, 0)`; this applies the same rule to both receive wrappers:

- `posix/RecvSyscall.java`
- `win32/RecvFuncCall.java`

Now a failed receive keeps `code = -1` and exposes an empty byte sequence instead of throwing.

Added two regression tests in `SyscallTest` (one per platform, gated by the existing `@DisabledOnOs` split) that invoke the wrapper with descriptor `-1` and assert `code == -1` and an empty output, rather than a Java exception.
