### PR TITLE
#6306: validate tuple length before allocating the array

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/TupleToArray.java
+++ b/eo-runtime/src/main/java/org/eolang/TupleToArray.java
@@ -28,7 +28,15 @@ public final class TupleToArray implements Supplier<Phi[]> {
 
     @Override
     public Phi[] get() {
-        final int length = new Dataized(this.tuple.take("length")).asNumber().intValue();
+        final double raw = new Dataized(this.tuple.take("length")).asNumber().doubleValue();
+        if (!Double.isFinite(raw) || raw < 0.0 || Math.rint(raw) != raw
+            || raw > Integer.MAX_VALUE) {
+            throw new ExFailure(
+                "The tuple length must be a finite non-negative integer within int range, but it was %s",
+                raw
+            );
+        }
+        final int length = (int) raw;
         final Phi[] arguments = new Phi[length];
         Phi tup = this.tuple;
         for (int idx = length - 1; idx >= 0; --idx) {

--- a/eo-runtime/src/test/java/org/eolang/TupleToArrayTest.java
+++ b/eo-runtime/src/test/java/org/eolang/TupleToArrayTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link TupleToArray}.
+ * @since 0.57
+ */
+final class TupleToArrayTest {
+
+    @Test
+    void rejectsNegativeLengthWithFailure() {
+        MatcherAssert.assertThat(
+            "a negative tuple length must raise an EO failure, not a Java array exception",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new TupleToArray(TupleToArrayTest.withLength(-1.0)).get(),
+                "a tuple whose length is -1 must fail with a proper message"
+            ).getMessage(),
+            Matchers.containsString("finite non-negative integer")
+        );
+    }
+
+    @Test
+    void rejectsNonFiniteLengthWithFailure() {
+        Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new TupleToArray(TupleToArrayTest.withLength(Double.POSITIVE_INFINITY)).get(),
+            "an infinite tuple length must fail instead of exhausting memory"
+        );
+    }
+
+    @Test
+    void rejectsFractionalLengthWithFailure() {
+        Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new TupleToArray(TupleToArrayTest.withLength(2.7)).get(),
+            "a fractional tuple length must fail rather than being silently truncated"
+        );
+    }
+
+    /**
+     * A tuple-like object whose {@code length} dataizes to the given value.
+     * @param length The length to expose
+     * @return Phi with a bound {@code length} attribute
+     */
+    private static Phi withLength(final double length) {
+        final Phi tuple = new PhDefault(
+            new Attrs(new Attr("length", new AtVoid("length")))
+        ).copy();
+        tuple.put("length", new Data.ToPhi(length));
+        return tuple;
+    }
+}


### PR DESCRIPTION
Fixes #6306.

`TupleToArray` narrowed the `length` attribute to `int` and allocated `new Phi[length]` with no validation. Confirmed at runtime with a tuple-like object whose `length` dataizes to a bad value:

```
length = -1        -> NegativeArraySizeException
length = +Infinity -> OutOfMemoryError (array size exceeds VM limit)
length = 2.7       -> silently truncated to 2
length = NaN       -> silently treated as 0
```

Since `TupleToArray` is the bridge behind the generic `posix`/`win32` dispatchers, these leak raw JVM exceptions instead of an EO failure.

The fix validates the length before allocation: it must be finite, integral, non-negative, and within `int` range, otherwise it raises `ExFailure`. Added `TupleToArrayTest` covering the negative, non-finite, and fractional cases.
