### PR TITLE
#6305: align one-byte boolean diagnostic with asBool

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -42,7 +42,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
             result = String.format(
                 "[0x%02X] = %s",
                 this.data[0],
-                this.data[0] != 0
+                this.data[0] == 1
             );
         } else if (this.data.length == Double.BYTES) {
             result = String.format(

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -76,8 +76,9 @@ final class VerboseBytesAsStringTest {
             ),
             Arguments.of(new byte[]{1}, "[0x01] = true"),
             Arguments.of(new byte[]{0}, "[0x00] = false"),
+            Arguments.of(new byte[]{2}, "[0x02] = false"),
             Arguments.of(new byte[]{}, "[<no bytes>]"),
-            Arguments.of(new byte[]{12}, "[0x0C] = true"),
+            Arguments.of(new byte[]{12}, "[0x0C] = false"),
             Arguments.of(
                 new byte[]{10, 11, 12, 13, 14, 15, 16, 17, -18, -19, -20, -21, 22},
                 "[0x0A0B0C0D-0E0F1011-EEEDECEB-16] = \"\\u000a\\u000b\\u000c\\u000d\\u000e\\u000f\\u0010\\u0011\\ufffd\\ufffd\\ufffd\\ufffd\\u0016\""


### PR DESCRIPTION
Fixes #6305.

The one-byte boolean diagnostic used `this.data[0] != 0`, so it disagreed with `Dataized.asBool()`, which treats only `01-` as `true`. Confirmed at runtime:

```
byte 0x00 -> printed false, asBool false
byte 0x01 -> printed true,  asBool true
byte 0x02 -> printed TRUE,  asBool false   <- mismatch
byte 0xFF -> printed TRUE,  asBool false   <- mismatch
```

Changed the predicate to `this.data[0] == 1` so the CLI diagnostic matches the runtime. Updated the existing `{12} -> true` expectation (now `false`) and added `{2} -> [0x02] = false`.
