### PR TITLE
#6307: drop the trailing hex group delimiter

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -72,7 +72,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
             chars[idx * 2] = VerboseBytesAsString.HEX_ARRAY[value >>> 4];
             chars[idx * 2 + 1] = VerboseBytesAsString.HEX_ARRAY[value & 0x0F];
         }
-        return new String(chars).replaceAll("(.{8})", "$1-");
+        return new String(chars).replaceAll("(.{8})(?=.)", "$1-");
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -27,8 +27,28 @@ final class VerboseBytesAsStringTest {
                 ByteBuffer.allocate(Double.BYTES).putDouble(12.345_67d).array()
             ).get(),
             Matchers.equalTo(
-                "[0x4028B0FB-A8826AA9-] = 12.34567, or \"@(\\ufffd\\ufffd\\ufffd\\ufffdj\\ufffd\""
+                "[0x4028B0FB-A8826AA9] = 12.34567, or \"@(\\ufffd\\ufffd\\ufffd\\ufffdj\\ufffd\""
             )
+        );
+    }
+
+    @Test
+    void groupsHexWithoutTrailingDelimiter() {
+        MatcherAssert.assertThat(
+            "A hex field ending on an eight-character boundary must not carry a trailing hyphen",
+            new VerboseBytesAsString(new byte[]{0, 0, 0, 0, 0, 0, 0, 0}).get(),
+            Matchers.equalTo("[0x00000000-00000000] = 0.0, or \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\"")
+        );
+    }
+
+    @Test
+    void groupsNineBytesWithSeparatorsBetweenGroupsOnly() {
+        MatcherAssert.assertThat(
+            "A nine-byte hex field must separate groups without a leading or trailing hyphen",
+            new VerboseBytesAsString(
+                new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9}
+            ).get(),
+            Matchers.containsString("[0x01020304-05060708-09]")
         );
     }
 


### PR DESCRIPTION
Fixes #6307.

`toHex()` grouped hex with `replaceAll("(.{8})", "$1-")`, which appends a hyphen after every complete group, including the last one when the hex length is a multiple of eight. An eight-byte value therefore rendered as `[0x00000000-00000000-]` with a dangling delimiter.

Added a `(?=.)` lookahead so a separator is inserted only when another character follows, keeping hyphens strictly between groups. Updated the eight-byte double expectation (was `A8826AA9-]`, now `A8826AA9]`) and added tests for the 8-byte boundary and a 9-byte case.
