### PR TITLE
#6308: clamp the withi insertion index to avoid duplicating elements

### DIFF
--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -10,11 +10,46 @@
 [list index item] > withi
   concat > @
     with.
-      front list index
+      front list bounded
       item
     back
       list
-      list.length.minus index
+      list.length.minus bounded
+  if. > bounded
+    0.gt index
+    0
+    if.
+      index.gt list.length
+      list.length
+      index
+
+  eq. ++> can-clamp-a-negative-index-to-the-front-without-duplicating
+    withi
+      *
+        1
+        2
+        3
+      -1
+      9
+    *
+      9
+      1
+      2
+      3
+
+  eq. ++> can-clamp-an-index-beyond-the-end-without-duplicating
+    withi
+      *
+        1
+        2
+        3
+      5
+      9
+    *
+      1
+      2
+      3
+      9
 
   eq. ++> can-insert-at-a-zero-index
     withi


### PR DESCRIPTION
Fixes #6308.

`tuple.withi` split the tuple with the raw `index` for both halves. A negative index left both `front` and `back` returning overlapping slices, so the result duplicated existing elements. Confirmed at runtime on `* 1 2 3`:

```
withi (* 1 2 3) -1 9  ->  * 3 9 1 2 3   (5 elements, "3" duplicated)
```

(The oversized-index example from the report, `withi (* 1 2 3) 5 9`, already yields `* 1 2 3 9` on master because `back` clamps its negative count to empty; the actual defect is the negative side.)

The fix normalizes the split point once, clamping it to `[0, list.length]`, and uses it for both `front` and `back`:

```
if. > bounded
  0.gt index
  0
  if.
    index.gt list.length
    list.length
    index
```

Now a negative index inserts a single item at the front and an oversized index at the end, with no duplication. Added regression tests for both boundaries.
