### PR TITLE
#6309: double underscores in JavaPath to match the transpiler encoding

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/JavaPath.java
+++ b/eo-runtime/src/main/java/org/eolang/JavaPath.java
@@ -74,7 +74,9 @@ final class JavaPath {
                 prefix = "EO_";
             }
             out.append('.').append(prefix)
-                .append(parts[idx].replace("$", "$EO").replace("-", "_"));
+                .append(
+                    parts[idx].replace("_", "__").replace("-", "_").replace("$", "$EO")
+                );
         }
         return out.toString();
     }

--- a/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/JavaPathTest.java
@@ -24,7 +24,10 @@ class JavaPathTest {
         "Φ.obj.sub, org.eolang.EO_obj.EOsub",
         "Φ.obj.sub$attr, org.eolang.EO_obj.EOsub$EOattr",
         "Φ.obj.sub-dashed$attr, org.eolang.EO_obj.EOsub_dashed$EOattr",
-        "Φ.obj.sub-dashed$attr-dashed, org.eolang.EO_obj.EOsub_dashed$EOattr_dashed"
+        "Φ.obj.sub-dashed$attr-dashed, org.eolang.EO_obj.EOsub_dashed$EOattr_dashed",
+        "Φ.foo_bar, org.eolang.EOfoo__bar",
+        "Φ.obj.sub_under, org.eolang.EO_obj.EOsub__under",
+        "Φ.a_b-c, org.eolang.EOa__b_c"
     })
     void convertsToString(final String name, final String expected) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Fixes #6309.

`to-java.xsl` escapes an EO identifier as `replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), ...)))`, so `_` is doubled before `-` becomes `_` (the `underscore-to-java.yaml` pack asserts `foo_underscore` -> class `EOfoo__underscore`). `JavaPath` only did `-` -> `_`, so it resolved `Φ.foo_bar` to `EOfoo_bar`, a class the transpiler never emits. It also collided `foo_bar` and `foo-bar` onto the same Java name.

Confirmed at runtime before the fix:

```
Φ.foo_bar -> org.eolang.EOfoo_bar   (transpiler emits EOfoo__bar)
Φ.a_b-c   -> org.eolang.EOa_b_c     (transpiler emits EOa__b_c)
```

The fix applies `_` -> `__` before `-` -> `_`, matching the stylesheet order, so the mapping is reversible again. Added `foo_bar`, `sub_under`, and mixed `a_b-c` cases to `JavaPathTest`.
