### PR TITLE
#6310: validate the as-char code is a byte in [0, 255]

### DIFF
--- a/eo-runtime/src/main/eo/number/as-char.eo
+++ b/eo-runtime/src/main/eo/number/as-char.eo
@@ -1,5 +1,7 @@
 # Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
-# The number is read as a 64-bit integer and its least-significant byte is taken.
+# The receiver must be an integer within the range [0, 255]; any other value
+# (negative, above 255, or fractional) terminates the computation instead of
+# being silently truncated to its least-significant byte.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,9 +11,17 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > as-char
-  ^.as-i64.as-bytes.slice > @
-    7
-    1
+  if. > @
+    or.
+      or.
+        0.gt ^
+        ^.gt 255
+      ^.is-integer.not
+    T
+      "The receiver of as-char must be an integer within the range [0, 255]"
+    ^.as-i64.as-bytes.slice
+      7
+      1
 
   eq. ++> can-round-trip-through-as-ascii
     "!"
@@ -40,3 +50,9 @@
   eq. ++> can-write-the-byte-of-the-zero-digit
     "0"
     string 48.as-char
+
+  256.as-char --> stops-on-a-code-past-the-byte-range
+
+  3.5.as-char --> stops-on-a-fractional-code
+
+  -1.as-char --> stops-on-a-negative-code


### PR DESCRIPTION
Fixes #6310.

`string.as-char` took the least-significant byte of `code.as-i64.as-bytes` with no validation, so out-of-domain inputs were silently truncated modulo 256. Confirmed at runtime:

```
as-char 0    -> 00
as-char 255  -> FF
as-char 256  -> 00   (collides with 0)
as-char -1   -> FF   (collides with 255)
as-char 3.5  -> 03   (fractional truncated)
as-char 300  -> 2C
```

The fix rejects any `code` that is not an integer in `[0, 255]`, failing through the normal EO error path instead of truncating. Valid codes keep their previous single-byte result. Confirmed after the fix that `256`, `-1`, `3.5`, `300` raise `ExFailure` while `0`, `65`, `255` still succeed.

Added `AsCharDomainTest` asserting the reject/accept boundaries (a hand-written JUnit case, since an EO `-->` example cannot distinguish a genuine failure from `asBool` throwing on the old truncated string).
