### PR TITLE
#6304: consume only leading CLI options, pass the rest to the object

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -19,7 +20,6 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Bridge between Java CLI and EO.
@@ -81,18 +81,21 @@ public final class Main {
      */
     public static void main(final String... args) throws Exception {
         Main.setup();
-        final List<String> opts = Arrays.stream(args)
-            .filter(Main::isOption)
-            .collect(Collectors.toList());
+        final List<String> opts = new ArrayList<>(0);
+        final List<String> arguments = new ArrayList<>(0);
+        for (final String arg : args) {
+            if (arguments.isEmpty() && Main.isOption(arg)) {
+                opts.add(arg);
+            } else {
+                arguments.add(arg);
+            }
+        }
         for (final String opt : opts) {
             if (Main.parse(opt)) {
                 return;
             }
         }
         Main.LOGGER.log(Level.FINE, String.format("EOLANG Runtime %s", Main.ver()));
-        final List<String> arguments = Arrays.stream(args)
-            .filter(Main::isArgument)
-            .collect(Collectors.toList());
         if (arguments.isEmpty()) {
             throw new ExFailure(
                 "The name of an object is expected as a command line argument"
@@ -104,15 +107,6 @@ public final class Main {
             Main.report(opts, ex);
             System.exit(1);
         }
-    }
-
-    /**
-     * Is it an argument?
-     * @param arg The arg
-     * @return TRUE if it's an argument
-     */
-    private static boolean isArgument(final String arg) {
-        return !Main.isOption(arg);
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -139,6 +139,15 @@ final class MainTest {
         );
     }
 
+    @Test
+    void treatsOptionAfterObjectNameAsArgument() {
+        MatcherAssert.assertThat(
+            "A --verbose placed after the object name must be an argument, not the verbose option, so no stacktrace is printed",
+            MainTest.stderr("org.eolang.examples.app", Main.VERBOSE),
+            Matchers.not(Matchers.containsString("at org.eolang.Main.run"))
+        );
+    }
+
     private static String stderr(final String... cmds) {
         return MainTest.exec(cmds).stderr();
     }


### PR DESCRIPTION
Fixes #6304.

`Main` filtered every `--`-prefixed token out of the argument list, wherever it appeared, so a normal EO argument like `--mode` after the object name was silently swallowed and never reached the object. The usage line already promises `[option...] class [argument...]`, i.e. options precede the class.

The fix consumes options only while no non-option (the class name) has been seen yet; once the class name is read, every remaining token, including `--mode`, `--`, and `--verbose`, is delivered to the EO object unchanged.

Added `treatsOptionAfterObjectNameAsArgument`, which asserts that a `--verbose` placed after the object name is no longer consumed as the verbose option (no stacktrace is printed), complementing the existing `printsFullStacktraceIfVerboseIsEnabled` where `--verbose` precedes the object.
