### PR TITLE
#6286: give a float overflow its own message instead of suggesting Infinity

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -415,7 +415,15 @@ final class Emissions {
         final Emit emit, final String name, final Value value, final int line
     ) {
         final double parsed = Double.parseDouble(value.raw());
-        if (!Double.isFinite(parsed) || Emissions.overPrecise(value.raw(), parsed)) {
+        if (!Double.isFinite(parsed)) {
+            throw new ParseError(
+                line, value.pos(),
+                String.format(
+                    "%s is out of the finite range of a double", value.raw()
+                )
+            );
+        }
+        if (Emissions.overPrecise(value.raw(), parsed)) {
             final String canonical;
             if (value.kind() == Value.Kind.INTEGER) {
                 canonical = Emissions.canonicalInteger(parsed);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/float-overflow.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/float-overflow.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:2] error: '1.0E400 is out of the finite range of a double'
+    1.0E400 > x
+    ^
+input: |
+  [] > app
+    1.0E400 > x


### PR DESCRIPTION
Fixes #6286.

`Emissions.number()` folded the IEEE-overflow case into the over-precise case and, for a `FLOAT`, built the suggested spelling with `Double.toString(parsed)`. When the literal overflows (e.g. `1.0E400`), that is `"Infinity"` / `"-Infinity"`, neither of which is a lexable head, so following the compiler's advice produced a worse error (`line shape not yet implemented in spec parser` / `expected value`).

The fix rejects a non-finite parse with its own message that names no unparseable token, and keeps the over-precise branch (whose suggestion does re-parse) unchanged. Verified against `EoSyntax`:

```
1.0E30            -> ok
1.0E400           -> '1.0E400 is out of the finite range of a double'
-1.0E400          -> '-1.0E400 is out of the finite range of a double'
9007199254740993  -> 'over-precise, write 9007199254740992 instead'  (still actionable)
```

Added the `float-overflow.yaml` typo-message regression.
