### PR TITLE
#6287: reject an unrecognised string escape instead of keeping it verbatim

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -603,10 +603,11 @@ final class Emissions {
 
     /**
      * Resolve a single-character escape sequence (e.g. {@code \n},
-     * {@code \t}). Unknown sequences are passed through verbatim.
+     * {@code \t}). An unrecognised sequence is a lexical error (R-9.7.3).
      * @param head Backslash character (always {@code '\\'})
      * @param next The character after the backslash
      * @return The decoded character(s)
+     * @throws NumberFormatException If the escape is not recognised
      */
     private static String singleCharEscape(final char head, final char next) {
         final String decoded;
@@ -623,7 +624,9 @@ final class Emissions {
         } else if (next == '"' || next == '\'' || next == '\\') {
             decoded = String.valueOf(next);
         } else {
-            decoded = new String(new char[]{head, next});
+            throw new NumberFormatException(
+                String.format("unrecognised escape sequence '%c%c'", head, next)
+            );
         }
         return decoded;
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/unknown-string-escape.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/unknown-string-escape.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:2] error: 'invalid unicode or octal escape in string literal'
+    "\q" > x
+    ^
+input: |
+  [] > app
+    "\q" > x


### PR DESCRIPTION
Fixes #6287.

`singleCharEscape` returned an unrecognised escape (`\q`, `\9`, `\x`) verbatim, so the parser silently kept a literal backslash instead of reporting the lexical error required by R-9.7.3. Every recognised escape (`\n`, `\t`, `\r`, `\b`, `\f`, `\"`, `\'`, `\`) has its own branch; the `else` arm is only reached by a sequence the spec defines as an error.

The fix throws `NumberFormatException` from that branch, which `unescape` already catches and turns into the same `ParseError` used for the `\u` / octal boundary. Verified against `EoSyntax`:

```
"\n" "\t" "\\" "\""  -> ok
"\q" "\9" "\x"        -> error: invalid unicode or octal escape in string literal
```

No `.eo` source in the repo uses an unrecognised escape (regex literals already write `\`), and the full `EoSyntaxTest` suite (1052 cases) stays green. Added the `unknown-string-escape.yaml` regression.
