### PR TITLE
#6288: validate void parameter names against the NAME grammar

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -310,17 +310,16 @@ final class LnFormation implements Line {
      * @return Emitted name
      */
     private static String mapParam(final String raw, final Span span, final int pos) {
-        if ("^".equals(raw)) {
+        final String mapped;
+        if ("@".equals(raw)) {
+            mapped = "φ";
+        } else if (raw.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()]*(?:\\.\\.\\.)?")) {
+            mapped = raw;
+        } else {
             throw new ParseError(
                 span.line(), pos,
                 "parameter names in voids must be NAME or @"
             );
-        }
-        final String mapped;
-        if ("@".equals(raw)) {
-            mapped = "φ";
-        } else {
-            mapped = raw;
         }
         return mapped;
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:1] error: 'parameter names in voids must be NAME or @'
+  [a,b] > obj
+   ^
+input: |
+  [a,b] > obj
+    5 > x


### PR DESCRIPTION
Fixes #6288.

A formation's void parameters were split on the ASCII space and each token used verbatim as the parameter name; `mapParam` checked only `^` and `@`. So `[a,b]`, `[a.b]`, `[a|b]`, `[a:b]`, `[a?b]`, and a tab-separated `[a<tab>b]` all emitted a void whose `name` is not a valid `NAME` (§2.3 terminators are `" \t,.|':;!?[]{}()"`).

The fix validates each token in `mapParam`: it must start with `[a-z]` and contain no `NAME` terminator, mirroring `Tokens.readName`, with an optional trailing `...` so varargs params still parse. Verified against `EoSyntax`:

```
[a b] [m2] [minus1 minus2] [foo-bar] [foo_bar] [@ x]  -> ok
[a b... c]  (varargs)                                 -> ok
[a,b] [a.b] [a?b] [a<tab>b] [Foo]                     -> error: parameter names in voids must be NAME or @
```

Unicode identifiers are preserved (they contain no terminator), so the existing `unicode.yaml` pack still parses. Full `EoSyntaxTest` (1052 cases) stays green. Added the `void-param-name.yaml` regression.
