### PR TITLE
#6290: reject a malformed dotted atom signature

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -619,6 +619,12 @@ final class Suffix {
                 "atom signature requires a name"
             );
         }
+        if (raw.startsWith(".") || raw.endsWith(".") || raw.contains("..")) {
+            throw new ParseError(
+                span.line(), home + after,
+                "atom signature must be a dotted name with no leading, trailing, or empty segment"
+            );
+        }
         return Suffix.typeAtom(raw, span, home + after);
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/atom-sig-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/atom-sig-dot.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:8] error: 'atom signature must be a dotted name with no leading, trailing, or empty segment'
+  [] > f /Q.
+          ^
+input: |
+  [] > f /Q.


### PR DESCRIPTION
Fixes #6290.

`Suffix.signature()` validated only emptiness, a stray `?`, and a bare `Q`, and `typeAtom()` promoted a leading `Q.` without checking the dot structure. So a leading dot (`/.x`), a trailing dot (`/Q.`, `/Q.number.`), or an empty segment (`/Q..x`, `/.`) all parsed, emitting a malformed `sig` (`Φ.`, `.x`, `Φ..x`).

The fix rejects a raw signature that starts with `.`, ends with `.`, or contains `..`, before promotion. Verified against `EoSyntax`:

```
/Q.number  /A  /Q.number.power   -> ok
/Q.  /.x  /Q.number.  /Q..x  /.  -> error: atom signature must be a dotted name with no leading, trailing, or empty segment
```

Full `EoSyntaxTest` (1050 cases) stays green. Added the `atom-sig-dot.yaml` regression.
