### PR TITLE
#6293: validate a >> file-local handle starts lowercase like > name

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -482,6 +482,9 @@ final class Suffix {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
+        if (!handle.isEmpty()) {
+            Suffix.checkLowercaseStart(handle, span, home, begin);
+        }
         if (!cnst && rest < tail.length() && tail.charAt(rest) == '!') {
             cnst = true;
             rest = rest + 1;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-lowercase.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/auto-handle-lowercase.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:7] error: 'name must start with a lowercase letter'
+    ? >> H
+         ^
+input: |
+  [] > f
+    ? >> H


### PR DESCRIPTION
Fixes #6293.

The `> name` suffix validates the first character via `checkLowercaseStart`, but the `>> handle` path (`auto()`) only refused scope tokens and the cactus emoji, so an uppercase-first handle (`? >> H`, `? >> Foo`) or a digit-first handle (`? >> 1x`) was accepted even though the parallel `> name` rejects the same names.

The fix mirrors `named()` and calls `checkLowercaseStart` on a non-empty handle, leaving a bare `? >>` (empty handle) valid. Verified against `EoSyntax`:

```
? >> h   ? >>   -> ok
? >> H   ? >> Foo   ? >> 1x   -> error: name must start with a lowercase letter
```

Full `EoSyntaxTest` (1050 cases) stays green. Added the `auto-handle-lowercase.yaml` regression.
