### PR TITLE
#6294: validate a meta directive name against the NAME grammar

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -69,6 +69,20 @@ final class LnMeta implements Line {
                 body.substring(space + 1), this.span, space + 1
             );
         }
+        this.checkHead(head, parts);
+        Comments.seal(globals, emit, this.span);
+        globals.markMeta();
+        globals.clearBlanks();
+        emit.meta(this.span.line(), head, parts);
+    }
+
+    /**
+     * Validate the meta directive name against the NAME grammar and the
+     * {@code +package} arity rule.
+     * @param head The meta directive name
+     * @param parts The directive arguments
+     */
+    private void checkHead(final String head, final List<String> parts) {
         if (head.isEmpty()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
@@ -87,10 +101,6 @@ final class LnMeta implements Line {
                 "'+package' directive requires exactly one argument"
             );
         }
-        Comments.seal(globals, emit, this.span);
-        globals.markMeta();
-        globals.clearBlanks();
-        emit.meta(this.span.line(), head, parts);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -75,6 +75,12 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
+        if (!head.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()]*")) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + 1,
+                "meta name must be a NAME starting with a lowercase letter"
+            );
+        }
         if ("package".equals(head) && parts.isEmpty()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-not-lowercase.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-not-lowercase.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:1] error: 'meta name must be a NAME starting with a lowercase letter'
+  +Package foo
+   ^
+input: |
+  # doc.
+
+  +Package foo
+
+  [] > f


### PR DESCRIPTION
Fixes #6294.

`LnMeta.into()` took the meta head (between `+` and the first space) and checked only that it is non-empty, so a head starting with an uppercase letter (`+Package`, `+PACKAGE`) or containing a NAME terminator such as `.` (`+p.x`) was accepted, even though §2.3 defines the head as a `NAME`.

The fix validates the head against the NAME grammar (first char `[a-z]`, no terminators) after the emptiness check, leaving the free-form meta parts untouched. Verified against `EoSyntax`:

```
+package foo   +alias foo   +rt jvm a.b.c   -> ok
+Package foo   +PACKAGE foo   +p.x foo       -> error: meta name must be a NAME starting with a lowercase letter
```

Full `EoSyntaxTest` (1050 cases) stays green. Added the `meta-name-not-lowercase.yaml` regression.
