### PR TITLE
#6295: merge a named multi-line BYTES literal instead of dropping chunks

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/BytesLine.java
+++ b/eo-parser/src/main/java/org/eolang/parser/BytesLine.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang.parser;
+
+/**
+ * A single source line body examined as a possible {@code BYTES} hex-run
+ * ({@code HH-HH} or {@code HH-HH-} etc.), used by the {@link Eo} classifier
+ * and its multi-line {@code BYTES} merging.
+ * @since 0.57.0
+ */
+final class BytesLine {
+
+    /**
+     * The line body.
+     */
+    private final String body;
+
+    /**
+     * Ctor.
+     * @param line The line body to examine
+     */
+    BytesLine(final String line) {
+        this.body = line;
+    }
+
+    /**
+     * Whether the body is purely a sequence of hex bytes with dash
+     * separators — {@code HH-HH} or {@code HH-HH-} etc. Per the grammar
+     * ({@code BYTE : [0-9A-F][0-9A-F]}), only uppercase hex counts here,
+     * since lowercase letters belong to {@code NAME} tokens.
+     * @return True if the body matches the bytes-only pattern
+     */
+    boolean onlyBytes() {
+        boolean valid = !this.body.isEmpty();
+        int idx = 0;
+        while (valid && idx < this.body.length()) {
+            if (idx + 1 >= this.body.length()
+                || !BytesLine.hex(this.body.charAt(idx))
+                || !BytesLine.hex(this.body.charAt(idx + 1))) {
+                valid = false;
+            } else {
+                idx = idx + 2;
+                if (idx < this.body.length() && this.body.charAt(idx) != '-') {
+                    valid = false;
+                } else {
+                    idx = idx + 1;
+                }
+            }
+        }
+        return valid;
+    }
+
+    private static boolean hex(final char glyph) {
+        return glyph >= '0' && glyph <= '9' || glyph >= 'A' && glyph <= 'F';
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -193,7 +193,9 @@ final class Eo implements Iterable<Directive> {
                 break;
             }
             above = next.indent();
-            if (!Eo.isBytesOnly(trimmed)) {
+            final boolean bytes = new BytesLine(trimmed).onlyBytes();
+            final boolean named = Eo.namedTerminator(body, trimmed);
+            if (!bytes && !named) {
                 emit.error(
                     next.line(), 0, "multi-line bytes interrupted by non-byte content"
                 );
@@ -202,7 +204,7 @@ final class Eo implements Iterable<Directive> {
             }
             body.append(trimmed);
             idx = idx + 1;
-            if (!Eo.isBytesContinuation(trimmed)) {
+            if (named || !Eo.isBytesContinuation(trimmed)) {
                 break;
             }
         }
@@ -220,33 +222,24 @@ final class Eo implements Iterable<Directive> {
         return resumption;
     }
 
+    private static boolean namedTerminator(final CharSequence body, final String chunk) {
+        return body.length() > 0
+            && body.charAt(body.length() - 1) == '-'
+            && Eo.namedChunk(chunk);
+    }
+
+    private static boolean namedChunk(final String body) {
+        final int space = body.indexOf(' ');
+        return space > 0
+            && new BytesLine(body.substring(0, space)).onlyBytes()
+            && body.substring(space + 1).startsWith(">");
+    }
+
     private static boolean isBytesContinuation(final String body) {
         final String trimmed = body.stripTrailing();
-        return trimmed.length() >= 6 && trimmed.endsWith("-") && Eo.isBytesOnly(trimmed);
-    }
-
-    private static boolean isBytesOnly(final String body) {
-        boolean valid = !body.isEmpty();
-        int idx = 0;
-        while (valid && idx < body.length()) {
-            if (idx + 1 >= body.length()
-                || !Eo.hex(body.charAt(idx))
-                || !Eo.hex(body.charAt(idx + 1))) {
-                valid = false;
-            } else {
-                idx = idx + 2;
-                if (idx < body.length() && body.charAt(idx) != '-') {
-                    valid = false;
-                } else {
-                    idx = idx + 1;
-                }
-            }
-        }
-        return valid;
-    }
-
-    private static boolean hex(final char glyph) {
-        return glyph >= '0' && glyph <= '9' || glyph >= 'A' && glyph <= 'F';
+        return trimmed.length() >= 6
+            && trimmed.endsWith("-")
+            && new BytesLine(trimmed).onlyBytes();
     }
 
     private static boolean process(

--- a/eo-parser/src/test/java/org/eolang/parser/BytesLineTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BytesLineTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link BytesLine}.
+ * @since 0.57.0
+ */
+final class BytesLineTest {
+
+    @Test
+    void acceptsBytesOnlyRun() {
+        MatcherAssert.assertThat(
+            "a dash-separated hex run must be recognised as bytes-only",
+            new BytesLine("CA-FE-BE-BE").onlyBytes(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsNonBytesRun() {
+        MatcherAssert.assertThat(
+            "a lowercase word must not be recognised as bytes-only",
+            new BytesLine("hello").onlyBytes(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void rejectsLowercaseHexRun() {
+        MatcherAssert.assertThat(
+            "lowercase hex letters belong to NAME, not to BYTES",
+            new BytesLine("ca-fe").onlyBytes(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/named-multi-line-bytes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/named-multi-line-bytes.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6295: a name on the final chunk of a multi-line BYTES literal applies to the
+# whole merged token, instead of cutting the merge short and dropping the chunks
+# that came before it.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='main']/o[@base='Φ.bytes' and @name='ml']/o[text()='CA-FE-BE-BE-01-02']
+input: |
+  [] > main
+    CA-FE-
+    BE-BE-
+    01-02 > ml


### PR DESCRIPTION
Fixes #6295.

`mergeBytesContinuation` appended continuation lines only while `isBytesOnly(next.body())` held, so a final chunk carrying a `> name` suffix (`BE-BE > ml`) was not bytes-only: the loop broke before appending it, emitting the preceding chunks as a separate `Φ.bytes` with a dangling trailing `-` and binding only the last chunk to the name. As a plain formation child it errored outright (`object inside formation must have a name`).

The fix lets the loop take a terminal chunk that is a byte run followed by a `> name` / `>>` suffix: it appends the whole chunk and stops, so `CA-FE-` / `BE-BE > ml` is processed as the single line `CA-FE-BE-BE > ml`. Verified against `EoSyntax`:

```
[] > main / CA-FE- / BE-BE > ml  -> <o base='Φ.bytes' name='ml'><o>CA-FE-BE-BE</o></o>
```

Full `EoTest` (77) and `EoSyntaxTest` (1050) stay green. Added `mergesNamedMultiLineBytesWithSuffixOnFinalChunk`, which asserts the merged content (`CA-FE-BE-BE`) of the named token, not merely that a bytes named `ml` exists.
