### PR TITLE
#6302: inherit the default BiConsumer.andThen in CentralMaven

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CentralMaven.java
@@ -205,13 +205,6 @@ final class CentralMaven implements BiConsumer<Dependency, Path> {
         }
     }
 
-    @Override
-    public BiConsumer<Dependency, Path> andThen(
-        final BiConsumer<? super Dependency, ? super Path> after
-    ) {
-        throw new UnsupportedOperationException("not implemented #andThen()");
-    }
-
     /**
      * Returns the given system if non-null, otherwise creates a fresh one.
      * @param sys Repository system, or {@code null}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
@@ -9,6 +9,7 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -115,6 +116,17 @@ final class CentralMavenTest {
             "Unpacked destination must contain files when using injected resolver components",
             dest.toFile().list(),
             Matchers.not(Matchers.emptyArray())
+        );
+    }
+
+    @Test
+    void composesWithAndThenInsteadOfThrowing() {
+        final BiConsumer<Dependency, Path> after = (dep, dest) -> {
+        };
+        MatcherAssert.assertThat(
+            "andThen must return a composed BiConsumer, not throw at composition time",
+            new CentralMaven().andThen(after),
+            Matchers.notNullValue()
         );
     }
 


### PR DESCRIPTION
Fixes #6302.

`CentralMaven implements BiConsumer<Dependency, Path>` but overrode `andThen` to `throw new UnsupportedOperationException`, so ordinary `BiConsumer` composition failed at the `central.andThen(after)` call, before either consumer could run. `accept(...)` is a normal side-effecting operation, so there is no reason to forbid composition.

The fix removes the override and inherits the correct default `BiConsumer.andThen`. Added `composesWithAndThenInsteadOfThrowing`, which asserts the composition returns a consumer instead of throwing, guarding against restoring the placeholder.
