### PR TITLE
Bring `qulice` back to green across the reactor

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CentralMavenTest.java
@@ -9,7 +9,6 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.WeAreOnline;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -121,11 +120,12 @@ final class CentralMavenTest {
 
     @Test
     void composesWithAndThenInsteadOfThrowing() {
-        final BiConsumer<Dependency, Path> after = (dep, dest) -> {
-        };
         MatcherAssert.assertThat(
             "andThen must return a composed BiConsumer, not throw at composition time",
-            new CentralMaven().andThen(after),
+            new CentralMaven().andThen(
+                (dep, dest) -> {
+                }
+            ),
             Matchers.notNullValue()
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -615,7 +615,6 @@ final class Emissions {
      * @param head Backslash character (always {@code '\\'})
      * @param next The character after the backslash
      * @return The decoded character(s)
-     * @throws NumberFormatException If the escape is not recognised
      */
     private static String singleCharEscape(final char head, final char next) {
         final String decoded;

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -461,7 +461,7 @@ final class Suffix {
     ) {
         int idx = after;
         boolean cnst = false;
-        if (idx < tail.length() && tail.charAt(idx) == '!') {
+        if (tail.startsWith("!", idx)) {
             cnst = true;
             idx = idx + 1;
         }
@@ -485,12 +485,12 @@ final class Suffix {
         if (!handle.isEmpty()) {
             Suffix.checkLowercaseStart(handle, span, home, begin);
         }
-        if (!cnst && rest < tail.length() && tail.charAt(rest) == '!') {
+        if (!cnst && tail.startsWith("!", rest)) {
             cnst = true;
             rest = rest + 1;
         }
         final int trailing = Suffix.skipSpace(tail, rest);
-        if (trailing < tail.length() && tail.charAt(trailing) == '/') {
+        if (tail.startsWith("/", trailing)) {
             throw new ParseError(
                 span.line(), home + trailing,
                 "auto-named atom is forbidden"

--- a/eo-runtime/src/main/java/org/eolang/JavaPath.java
+++ b/eo-runtime/src/main/java/org/eolang/JavaPath.java
@@ -73,10 +73,9 @@ final class JavaPath {
             } else {
                 prefix = "EO_";
             }
-            out.append('.').append(prefix)
-                .append(
-                    parts[idx].replace("_", "__").replace("-", "_").replace("$", "$EO")
-                );
+            out.append('.').append(prefix).append(
+                parts[idx].replace("_", "__").replace("-", "_").replace("$", "$EO")
+            );
         }
         return out.toString();
     }

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -37,7 +37,9 @@ final class VerboseBytesAsStringTest {
         MatcherAssert.assertThat(
             "A hex field ending on an eight-character boundary must not carry a trailing hyphen",
             new VerboseBytesAsString(new byte[]{0, 0, 0, 0, 0, 0, 0, 0}).get(),
-            Matchers.equalTo("[0x00000000-00000000] = 0.0, or \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\"")
+            Matchers.equalTo(
+                "[0x00000000-00000000] = 0.0, or \"".concat("\\u0000".repeat(8)).concat("\"")
+            )
         );
     }
 


### PR DESCRIPTION
Seven Checkstyle and PMD violations have been failing `qulice` on
`master`, which turns the check red on every open pull request as well,
whatever it touches. They sit in three modules, and because Maven stops
at the first module that fails, `eo-parser` was hiding the rest — the
full list came out of a `--fail-at-end` run of the whole reactor.

`Emissions.singleCharEscape` documented a `NumberFormatException` that
its signature does not declare. It was the only `@throws` for an
unchecked exception in the module, and `appendOctal` and `appendUnicode`
throw the very same exception a few lines above without one, so the tag
is gone rather than the signature changed.

Two more are complexity limits on `Suffix.auto`, which asked three times
whether a given character sits at a given index and spelled each
question as a bounds check plus a comparison. The same file already asks
it in one call:

```java
if (tail.startsWith("!", idx)) {
```

`startsWith` does the bounds check itself, exactly as it already does at
line 323 for `+>` and `>>`. Cyclomatic complexity drops from 11 to 8 and
the NPath count from 288 to 36. Extracting a method would have been the
usual way to cut complexity, and it is the one way that cannot be used
here: the `thresholds` job pins the number of `static` members across
the whole codebase to master's exact count, so a new one would turn that
job red instead.

`CentralMavenTest` held a lambda in a local variable it used once, which
is what `UnnecessaryLocalRule` objects to. The last two are layout in
eo-runtime: a fluent `append` opening a block on a line of its own, and
an expected string of eight repeated escapes running to 124 characters,
now built with `repeat(8)`, which fits and says how many of them there
are.

Nothing changes behaviour. The three rewritten branches in `Suffix` are
all exercised by `SuffixTest` through `>>!`, `>> fibo!`, `>> /number`
and a bare `>>` — that last one being exactly the end-of-tail case the
explicit guard used to cover. All 1670 parser tests pass, the touched
tests in the other two modules pass, `qulice` is clean on all six
modules, and the four counts the `thresholds` job pins are untouched at
840, 364, 0 and 26.

Closes #6360
