### PR TITLE
Make directory report is-directory from a syscall

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -13,7 +13,6 @@
 
 [file] > directory
   file > @
-  true > is-directory
   [dir time process random] > retried
     [index] >> attempted
       if. > @
@@ -187,6 +186,23 @@
     mktemp.tmpfile.deleted.as-path.as-dir.made > parent
     created.as-bytes.eq expected.as-bytes > valid!
 
+  ++> can-tell-that-a-deleted-directory-is-no-longer-a-directory
+    not. > @
+      d.deleted.is-directory false
+    made. > d
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "gone"
+
+  is-directory. ++> can-tell-that-a-directory-is-a-directory
+    directory
+      Q.file "."
+    false
+
+  not. ++> can-tell-that-a-regular-file-is-not-a-directory
+    is-directory.
+      directory mktemp.tmpfile
+      true
+
   ++> can-walk-recursively
     seq * > @
       made.
@@ -228,9 +244,16 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  is-directory. ++> rejects-checking-an-absent-directory
+    directory mktemp.tmpfile.deleted
+    true
+
   tmpfile. --> on-tmpfile-touching-absent-directory
     @.
       mktemp.tmpfile.deleted.as-path.resolved "child"
+
+  is-directory. --> stops-on-checking-an-absent-directory
+    directory mktemp.tmpfile.deleted
 
   walk. --> stops-on-walking-a-path-with-a-nul-character
     directory


### PR DESCRIPTION
The `directory` object decorates a `file`, but it also declared `true > is-directory`,
which shadowed the check it inherits. Any `directory` therefore claimed to be a
directory even when its path pointed at a regular file or at nothing at all. The
`is-directory` in `file` does the real work: it stats the path and reads the mode
bits, falling back to `cant-check` when the syscall fails.

Dropping that one line lets the decorator delegate, so the answer now comes from
the file system instead of from a constant. Every place that already calls
`is-directory` without an argument sits behind an `exists` check, so the fallback
is never dataized there and those call sites keep working. Two existing tests
gain meaning from this: the assertion in `directory.made` and the one in `mktemp`
were both satisfied by the constant before and now depend on a syscall.

The new tests cover a real directory, a regular file, a directory that was made
and then deleted, and an absent path both with and without the fallback.

I could not run the suite locally to completion, so I am leaning on CI here and
will follow up on whatever it reports.

Closes #5440
