### PR TITLE
#5612: drop the `oss.sonatype.org` plugin repository override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,29 +319,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <pluginRepositories>
-    <!--
-    The parent POM (com.jcabi:parent) points plugin resolution at
-    oss.sonatype.org, a host Sonatype has decommissioned. Re-declaring
-    the same id on Central shadows the dead host, since Maven merges
-    repositories by id and lets the child win. Without this, a cold
-    cache (every fork pull request) stalls on dead-host timeouts and
-    the qulice job burns its whole budget before a single check runs.
-    @todo #5284:30min Drop this override once com.jcabi:parent no
-    longer declares the decommissioned oss.sonatype.org plugin
-    repository, so plugin resolution relies on the parent again.
-    -->
-    <pluginRepository>
-      <id>oss.sonatype.org</id>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Closes #5612.

The puzzle `5284-96b32ff9` asked to drop the `<pluginRepositories>` override in the root `pom.xml` once the reason for it disappeared. It has.

### Why the override existed

#5284 found that `com.jcabi:parent` declares a plugin repository pointing at `https://oss.sonatype.org/content/groups/public`. That host had been decommissioned and no longer answered, so on a cold cache — every fork pull request — Maven waited out a connection timeout on each plugin artifact before falling back to Central, and the `qulice` job burned its whole 15-minute budget before running a single check. Re-declaring the same repository id against Central shadowed the dead host.

### Why it can go now

`oss.sonatype.org` is no longer dead: it answers with a fast redirect to Maven Central. Verified across artifact shapes, all served in about a second:

| Path | Result |
| --- | --- |
| `qulice-maven-plugin-0.30.1.pom` | 200, → `repo1.maven.org/maven2/…`, 1.10s |
| `parent-0.73.3.pom` | 200, → `repo1.maven.org/maven2/…`, 1.42s |
| `maven-clean-plugin-3.5.0.jar` | 200, → `repo1.maven.org/maven2/…`, 1.07s |
| a nonexistent artifact | clean 404, 1.59s |

The `/content/groups/public/…` prefix maps onto `/maven2/…`, so poms, jars and missing-artifact 404s all behave correctly — nothing hangs.

End-to-end check with the override removed and an empty local repository: Maven resolved **280 artifacts through the real `https://oss.sonatype.org/content/groups/public/…` URL, every one successfully, with zero timeouts, connection failures or resolution errors**, and the build finished green. `mvn validate` passes on the reactor.

### Trade-off, stated plainly

Plugin artifacts now take the redirect rather than going straight to Central. Measured over 20 real plugin artifacts with pooled connections, the extra hop costs roughly 0.36s each on my connection. That is latency, not a stall, and it is bounded by a live host rather than by a connect timeout on a dead one — which is what made #5284 fatal. Warm caches, which is the common case, are unaffected.

The upstream declaration in `com.jcabi:parent` is still there as of 0.73.3, so this leans on the redirect. The alternative was keeping a permanent override that ties this POM to the internals of one specific parent version, which is exactly what the issue title objects to.
