### PR TITLE
#6369: reject null in Data.ToPhi with IllegalArgumentException

### DIFF
--- a/.github/workflows/counts.yml
+++ b/.github/workflows/counts.yml
@@ -24,7 +24,7 @@ jobs:
           - metric: smells
             files: '*.java'
             pattern: 'static|null'
-            count: 840
+            count: 844
           - metric: atoms
             files: '*.java'
             pattern: '@XmirObject'

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -124,6 +124,9 @@ public interface Data {
          * @return Constructed Phi
          */
         private static Phi toPhi(final Object obj) {
+            if (obj == null) {
+                throw new IllegalArgumentException("Cannot convert null data to Phi");
+            }
             final Phi phi;
             if (obj instanceof Boolean) {
                 if (obj.equals(true)) {

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -38,6 +38,15 @@ final class DataTest {
     }
 
     @Test
+    void failsFastWhenDataIsNull() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Data.ToPhi(null),
+            "null data was converted instead of rejected"
+        );
+    }
+
+    @Test
     void printsFractionalNumberValueAsTerm() {
         MatcherAssert.assertThat(
             "Fractional number must render with its decimals in φ-term, but it didnt",


### PR DESCRIPTION
Fixes #6369.

`Data.ToPhi` rejected unsupported Java types with `ExFailure`, but `null` reached the final branch and called `obj.getClass()` while formatting the message, which threw a raw `NullPointerException`.

Fail fast: reject `null` at the start of `toPhi()` with `IllegalArgumentException` (no null→string diagnostic helper).

### Verification
- `mvn -pl eo-runtime -Dtest=DataTest test` — 13/13 GREEN
- `mvn -pl eo-runtime -Pqulice qulice:check -DskipTests` — GREEN