### PR TITLE
#6382: reject null writes to AtVoid and AtRho

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -5,6 +5,7 @@
 
 package org.eolang;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -53,6 +54,7 @@ final class AtRho implements Attribute {
 
     @Override
     public void put(final Phi phi) {
+        Objects.requireNonNull(phi, "Attribute value can't be null");
         this.rho.compareAndSet(null, phi);
     }
 

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -5,6 +5,7 @@
 
 package org.eolang;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -71,6 +72,7 @@ public final class AtVoid implements Attribute {
 
     @Override
     public void put(final Phi phi) {
+        Objects.requireNonNull(phi, "Attribute value can't be null");
         if (!this.object.compareAndSet(null, phi)) {
             throw new ExReadOnly(
                 String.format(

--- a/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
@@ -69,4 +69,16 @@ final class AtRhoTest {
             Matchers.equalTo(obj)
         );
     }
+
+    @Test
+    void rejectsNullValue() {
+        MatcherAssert.assertThat(
+            "AtRho must reject null instead of silently keeping rho unset",
+            Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new AtRho().put(null)
+            ).getMessage(),
+            Matchers.containsString("can't be null")
+        );
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
@@ -88,6 +88,18 @@ final class AtVoidTest {
     }
 
     @Test
+    void rejectsNullValue() {
+        MatcherAssert.assertThat(
+            "AtVoid must reject null instead of leaving the attribute vacant",
+            Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new AtVoid("void").put(null)
+            ).getMessage(),
+            Matchers.containsString("can't be null")
+        );
+    }
+
+    @Test
     void isVacantWhenUnset() {
         MatcherAssert.assertThat(
             "Unset void attribute must be vacant, but it wasn't",


### PR DESCRIPTION
Fixes #6382.

## What changed

- AtVoid.put() now rejects a null Phi before its atomic compare-and-set operation, preventing a null-to-null write from being reported as successful.
- AtRho.put() applies the same validation, so both sentinel-backed attributes preserve their write-once invariant.
- Added focused regression coverage in AtVoidTest and AtRhoTest. Each test verifies both the exception type and that the diagnostic states the invalid null contract.

## Why

Both classes represent an unset value with null. Passing null to AtomicReference.compareAndSet(null, null) succeeds without changing the state, allowing a later non-null write. Rejecting null at the public boundary prevents this silent no-op and makes the misuse explicit.

## Verification

- git diff --check
- Direct compilation of eo-runtime main sources passed with one CPU and 1 GB heap.
- The targeted test compilation is currently blocked by pre-existing missing generated classes EOnop and EOnumber in PhPackageTest, PhDefaultTest, and DataTest; this is unrelated to the four files changed here.