### PR TITLE
#6379: preserve out-of-range integral numeral values

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Numeral.java
+++ b/eo-runtime/src/main/java/org/eolang/Numeral.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.function.Supplier;
+
+/**
+ * A number value rendered as a φ-term.
+ *
+ * <p>A whole value inside the {@code long} range prints without a
+ * fraction, so {@code 42} rather than {@code 42.0}. Everything else —
+ * fractional, infinite, or beyond {@code long} — keeps its full
+ * {@code double} spelling: casting an out-of-range value to {@code long}
+ * would saturate and denote a different number.</p>
+ *
+ * @since 0.73.3
+ */
+final class Numeral implements Supplier<String> {
+
+    /**
+     * The number.
+     */
+    private final double value;
+
+    /**
+     * Ctor.
+     * @param num The number
+     */
+    Numeral(final double num) {
+        this.value = num;
+    }
+
+    @Override
+    public String get() {
+        final String txt;
+        if (
+            this.value == Math.floor(this.value)
+                && !Double.isInfinite(this.value)
+                && Long.MIN_VALUE <= this.value
+                && this.value < Long.MAX_VALUE
+        ) {
+            txt = Long.toString((long) this.value);
+        } else {
+            txt = Double.toString(this.value);
+        }
+        return txt;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -99,7 +99,9 @@ public final class PhApplication extends PhOnce {
         if (string != null) {
             result = string;
         } else if (literal && "Φ.number".equals(head)) {
-            result = PhDefault.numeral(new BytesOf(PhApplication.bytes(data.group(1))).asNumber());
+            result = new Numeral(
+                new BytesOf(PhApplication.bytes(data.group(1))).asNumber()
+            ).get();
         } else {
             result = String.format("%s(%s)", head, body);
         }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -338,32 +338,12 @@ public class PhDefault implements Phi, Cloneable {
             if ("string".equals(name)) {
                 result = new Quoted(raw).get();
             } else {
-                result = PhDefault.numeral(new BytesOf(raw).asNumber());
+                result = new Numeral(new BytesOf(raw).asNumber()).get();
             }
         } else {
             result = this.structural();
         }
         return result;
-    }
-
-    /**
-     * Render a number value as a φ-term.
-     * @param value The number
-     * @return Whole values without a fraction, decimals otherwise
-     */
-    static String numeral(final double value) {
-        final String txt;
-        if (
-            value == Math.floor(value)
-                && !Double.isInfinite(value)
-                && Long.MIN_VALUE <= value
-                && value < Long.MAX_VALUE
-        ) {
-            txt = Long.toString((long) value);
-        } else {
-            txt = Double.toString(value);
-        }
-        return txt;
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -353,7 +353,12 @@ public class PhDefault implements Phi, Cloneable {
      */
     static String numeral(final double value) {
         final String txt;
-        if (value == Math.floor(value) && !Double.isInfinite(value)) {
+        if (
+            value == Math.floor(value)
+                && !Double.isInfinite(value)
+                && Long.MIN_VALUE <= value
+                && value < Long.MAX_VALUE
+        ) {
             txt = Long.toString((long) value);
         } else {
             txt = Double.toString(value);

--- a/eo-runtime/src/test/java/org/eolang/NumeralTest.java
+++ b/eo-runtime/src/test/java/org/eolang/NumeralTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Numeral}.
+ * @since 0.73.3
+ */
+final class NumeralTest {
+
+    @Test
+    void printsPositiveIntegralNumberOutsideLongRange() {
+        final double number = Math.scalb(1.0d, 63);
+        MatcherAssert.assertThat(
+            "Positive integral double outside long range must retain its value in φ-term",
+            new Numeral(number).get(),
+            Matchers.equalTo(Double.toString(number))
+        );
+    }
+
+    @Test
+    void printsNegativeIntegralNumberOutsideLongRange() {
+        final double number = -Math.scalb(1.0d, 64);
+        MatcherAssert.assertThat(
+            "Negative integral double outside long range must retain its value in φ-term",
+            new Numeral(number).get(),
+            Matchers.equalTo(Double.toString(number))
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -67,22 +67,6 @@ final class PhDefaultTest {
     }
 
     @Test
-    void printsOutOfRangeIntegralNumbersWithoutSaturation() {
-        final double positive = Math.scalb(1.0d, 63);
-        final double negative = -Math.scalb(1.0d, 64);
-        MatcherAssert.assertThat(
-            "Positive integral double outside long range must retain its value in φ-term",
-            PhDefault.numeral(positive),
-            Matchers.equalTo(Double.toString(positive))
-        );
-        MatcherAssert.assertThat(
-            "Negative integral double outside long range must retain its value in φ-term",
-            PhDefault.numeral(negative),
-            Matchers.equalTo(Double.toString(negative))
-        );
-    }
-
-    @Test
     void printsUnsetNumberStructurally() {
         MatcherAssert.assertThat(
             "Number without injected bytes must fall back to its structural φ-term, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -67,6 +67,22 @@ final class PhDefaultTest {
     }
 
     @Test
+    void printsOutOfRangeIntegralNumbersWithoutSaturation() {
+        final double positive = Math.scalb(1.0d, 63);
+        final double negative = -Math.scalb(1.0d, 64);
+        MatcherAssert.assertThat(
+            "Positive integral double outside long range must retain its value in φ-term",
+            PhDefault.numeral(positive),
+            Matchers.equalTo(Double.toString(positive))
+        );
+        MatcherAssert.assertThat(
+            "Negative integral double outside long range must retain its value in φ-term",
+            PhDefault.numeral(negative),
+            Matchers.equalTo(Double.toString(negative))
+        );
+    }
+
+    @Test
     void printsUnsetNumberStructurally() {
         MatcherAssert.assertThat(
             "Number without injected bytes must fall back to its structural φ-term, but it didnt",


### PR DESCRIPTION
Fixes #6379.

## What changed

- PhDefault.numeral() now uses integer spelling only when a whole double fits in the long range.
- Integral doubles at or beyond the long bounds retain their Double.toString() representation instead of being narrowed to Long.MAX_VALUE or Long.MIN_VALUE.
- Added regressions for positive and negative values outside the representable long range.

## Why

Casting an out-of-range double to long saturates it. The earlier integral-value branch then emitted that saturated long, so distinct φ-terms collapsed to a boundary value. Keeping the double representation preserves the original numeric value.

## Verification

PhDefaultTest passed with one CPU, 1 GB heap, and JUnit parallel execution disabled.