### PR TITLE
#6376: configure the EO logger only once

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -56,6 +57,16 @@ public final class Main {
      * EO app-wide logger.
      */
     private static final Logger EOLOG = Logger.getLogger("org.eolang");
+
+    /**
+     * Handler for EO runtime logs.
+     */
+    private static final Handler HANDLER = Main.handler();
+
+    /**
+     * Lock guarding the EO runtime logger configuration.
+     */
+    private static final ReentrantLock LOCK = new ReentrantLock();
 
     /**
      * Not for instantiation.
@@ -142,6 +153,24 @@ public final class Main {
      * Setup logs.
      */
     private static void setup() {
+        Main.LOCK.lock();
+        try {
+            if (Arrays.stream(Main.EOLOG.getHandlers()).noneMatch(
+                handler -> handler == Main.HANDLER
+            )) {
+                Main.EOLOG.addHandler(Main.HANDLER);
+            }
+        } finally {
+            Main.LOCK.unlock();
+        }
+        Main.EOLOG.setUseParentHandlers(false);
+    }
+
+    /**
+     * Make a handler for EO runtime logs.
+     * @return Configured handler
+     */
+    private static Handler handler() {
         final Handler handler = new ConsoleHandler();
         handler.setFormatter(
             new Formatter() {
@@ -151,8 +180,7 @@ public final class Main {
                 }
             }
         );
-        Main.EOLOG.addHandler(handler);
-        Main.EOLOG.setUseParentHandlers(false);
+        return handler;
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -7,6 +7,7 @@ package org.eolang;
 import com.yegor256.Jaxec;
 import com.yegor256.Jhome;
 import com.yegor256.Result;
+import java.util.logging.Logger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -124,6 +125,17 @@ final class MainTest {
                 Matchers.containsString("at org.eolang.PhPackage.take"),
                 Matchers.containsString("at org.eolang.Main.run")
             )
+        );
+    }
+
+    @Test
+    void configuresRuntimeLoggerOnlyOnce() throws Exception {
+        Main.main("--version");
+        Main.main("--version");
+        MatcherAssert.assertThat(
+            "Repeated Main.main calls must not add another EO log handler",
+            Logger.getLogger("org.eolang").getHandlers().length,
+            Matchers.equalTo(1)
         );
     }
 


### PR DESCRIPTION
Fixes #6376.

## What changed

- Main creates its formatted EO log handler once and reuses it on later calls to Main.main().
- setup() synchronizes handler installation and checks identity, so repeated or concurrent in-process entry-point calls cannot attach duplicate handlers.
- Added a regression to MainTest that invokes Main.main() twice and verifies the logger handler count remains stable.

## Why

Main.setup() previously constructed and appended a ConsoleHandler every time. Each later invocation then emitted every EO log record through all accumulated handlers. The setup is now idempotent while preserving any separately configured handlers.

## Verification

- git diff --check
- eo-runtime main Java sources compiled successfully with one CPU and 1 GB heap.
- Full test compilation remains blocked by unrelated missing EOnop and EOnumber generated classes in the current local base.