### PR TITLE
#6381: remove stale Java sources after transpiling

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -11,9 +11,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The Java files that a transpiled XMIR is written out as.
@@ -49,6 +53,15 @@ final class JavaFiles {
     private final boolean enabled;
 
     /**
+     * Java files generated during the current transpilation.
+     *
+     * <p>The collection is shared by parallel {@link #total(boolean, Path,
+     * String, boolean)} calls. It is reconciled only after all XMIRs have
+     * been processed.</p>
+     */
+    private final Collection<Path> fresh;
+
+    /**
      * Ctor.
      * @param dir Generated sources directory
      * @param cached Cache directory for this transpile version
@@ -58,6 +71,7 @@ final class JavaFiles {
         this.generated = dir;
         this.cache = cached;
         this.enabled = caching;
+        this.fresh = new ConcurrentLinkedQueue<>();
     }
 
     /**
@@ -88,6 +102,7 @@ final class JavaFiles {
                     final Path tgt = new Place(jname).make(
                         this.generated, JavaFiles.JAVA
                     );
+                    this.fresh.add(tgt);
                     final Footprint java = new FpJavaGenerated(
                         clazz, new FileGenerationReport(saved, tgt, target)
                     );
@@ -114,6 +129,37 @@ final class JavaFiles {
             );
         }
         return saved.get();
+    }
+
+    /**
+     * Delete generated Java files absent from the current XMIR collection.
+     *
+     * @throws IOException If fails to inspect or remove a generated file
+     */
+    void removeStale() throws IOException {
+        if (Files.exists(this.generated)) {
+            final Set<Path> expected = new HashSet<>(this.fresh);
+            final Set<Path> dirs = new HashSet<>();
+            for (final Path file : expected) {
+                for (Path dir = file.getParent(); dir != null && dir.startsWith(this.generated);
+                    dir = dir.getParent()) {
+                    dirs.add(dir);
+                }
+            }
+            try (Stream<Path> walk = Files.walk(this.generated)) {
+                for (final Path file : walk.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(JavaFiles.JAVA)).collect(
+                        Collectors.toList()
+                    )) {
+                    if (!expected.contains(file) && (!file.getFileName().toString().equals(
+                        "package-info.java"
+                    ) || !dirs.contains(file.getParent()))) {
+                        Files.delete(file);
+                        Logger.debug(this, "Deleted stale generated Java file %[file]s", file);
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -133,7 +133,6 @@ final class JavaFiles {
 
     /**
      * Delete generated Java files absent from the current XMIR collection.
-     *
      * @throws IOException If fails to inspect or remove a generated file
      */
     void removeStale() throws IOException {
@@ -151,8 +150,8 @@ final class JavaFiles {
                     .filter(path -> path.toString().endsWith(JavaFiles.JAVA)).collect(
                         Collectors.toList()
                     )) {
-                    if (!expected.contains(file) && (!file.getFileName().toString().equals(
-                        "package-info.java"
+                    if (!expected.contains(file) && (!"package-info.java".equals(
+                        file.getFileName().toString()
                     ) || !dirs.contains(file.getParent()))) {
                         Files.delete(file);
                         Logger.debug(this, "Deleted stale generated Java file %[file]s", file);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -180,6 +180,7 @@ final class Transpiling implements Step {
     /**
      * Transpile a single tojo.
      * @param tojo Tojo that should be transpiled
+     * @param files Generated Java files
      * @return Number of generated Java files
      * @throws IOException If any issues with I/O
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -151,13 +151,20 @@ final class Transpiling implements Step {
 
     @Override
     public void exec() throws IOException {
+        final JavaFiles files = new JavaFiles(
+            this.generatedDir,
+            this.cacheDir.resolve(Transpiling.CACHE).resolve(this.version()),
+            this.cacheEnabled
+        );
+        final int transpiled = new Threaded<>(
+            this.sources,
+            tojo -> this.transpiled(tojo, files)
+        ).total();
+        files.removeStale();
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(),
-            new Threaded<>(
-                this.sources,
-                this::transpiled
-            ).total() + new PackageInfos(this.generatedDir, this.roots).create(),
+            transpiled + new PackageInfos(this.generatedDir, this.roots).create(),
             this.generatedDir
         );
     }
@@ -176,7 +183,7 @@ final class Transpiling implements Step {
      * @return Number of generated Java files
      * @throws IOException If any issues with I/O
      */
-    private int transpiled(final TjForeign tojo) throws IOException {
+    private int transpiled(final TjForeign tojo, final JavaFiles files) throws IOException {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
         final Path base = this.targetDir.resolve(Transpiling.DIR);
@@ -216,9 +223,7 @@ final class Transpiling implements Step {
             rewrite.compareAndSet(false, true);
             new Saved(transform.apply(xmir).toString(), target).value();
         }
-        return new JavaFiles(
-            this.generatedDir, cdir.resolve(this.version()), this.cacheEnabled
-        ).total(
+        return files.total(
             rewrite.get(), target, hsh.get(), this.transpileTests && !tojo.discovered()
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -45,4 +45,36 @@ final class JavaFilesTest {
             Matchers.equalTo(1)
         );
     }
+
+    @Test
+    void removesJavaFilesNotGeneratedInCurrentRun(@Mktmp final Path temp) throws IOException {
+        final Path generated = temp.resolve("generated");
+        final Path first = temp.resolve("first.xmir");
+        final Path second = temp.resolve("second.xmir");
+        new Saved(
+            "<object><class java-name='org.eolang.EOfirst'><java>class EOfirst {}</java></class></object>",
+            first
+        ).value();
+        new Saved(
+            "<object><class java-name='org.eolang.EOsecond'><java>class EOsecond {}</java></class></object>",
+            second
+        ).value();
+        final JavaFiles initial = new JavaFiles(generated, temp.resolve("cache"), false);
+        initial.total(true, first, "", false);
+        initial.total(true, second, "", false);
+        initial.removeStale();
+        final JavaFiles current = new JavaFiles(generated, temp.resolve("cache"), false);
+        current.total(true, second, "", false);
+        current.removeStale();
+        MatcherAssert.assertThat(
+            "a Java file for an XMIR absent from the current transpilation must be deleted",
+            generated.resolve("org/eolang/EOfirst.java").toFile().exists(),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            "a Java file still generated from a current XMIR must remain",
+            generated.resolve("org/eolang/EOsecond.java").toFile().exists(),
+            Matchers.is(true)
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -8,6 +8,7 @@ import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Random;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -67,14 +68,12 @@ final class JavaFilesTest {
         current.total(true, second, "", false);
         current.removeStale();
         MatcherAssert.assertThat(
-            "a Java file for an XMIR absent from the current transpilation must be deleted",
-            generated.resolve("org/eolang/EOfirst.java").toFile().exists(),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            "a Java file still generated from a current XMIR must remain",
-            generated.resolve("org/eolang/EOsecond.java").toFile().exists(),
-            Matchers.is(true)
+            "a stale Java file must be deleted while a currently-generated one must remain",
+            Arrays.asList(
+                generated.resolve("org/eolang/EOfirst.java").toFile().exists(),
+                generated.resolve("org/eolang/EOsecond.java").toFile().exists()
+            ),
+            Matchers.equalTo(Arrays.asList(false, true))
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -445,21 +445,6 @@ final class MjTranspileTest {
     }
 
     @Test
-    void removesJavaFilesForRemovedXmirSources(@Mktmp final Path temp) throws IOException {
-        final FakeMaven maven = new FakeMaven(temp).withProgram(MjTranspileTest.program());
-        final Path java = maven.execute(new FakeMaven.Transpile()).result().get(
-            MjTranspileTest.compiled()
-        );
-        Files.delete(maven.foreignPath());
-        maven.execute(new FakeMaven.Transpile());
-        MatcherAssert.assertThat(
-            "a generated Java file without a current XMIR source must be removed",
-            Files.exists(java),
-            Matchers.is(false)
-        );
-    }
-
-    @Test
     void transpilesSimpleEoProgram(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -445,6 +445,21 @@ final class MjTranspileTest {
     }
 
     @Test
+    void removesJavaFilesForRemovedXmirSources(@Mktmp final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(MjTranspileTest.program());
+        final Path java = maven.execute(new FakeMaven.Transpile()).result().get(
+            MjTranspileTest.compiled()
+        );
+        Files.delete(maven.foreignPath());
+        maven.execute(new FakeMaven.Transpile());
+        MatcherAssert.assertThat(
+            "a generated Java file without a current XMIR source must be removed",
+            Files.exists(java),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void transpilesSimpleEoProgram(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             String.format(


### PR DESCRIPTION
Fixes #6381.

## What changed

- After all current XMIR sources are transpiled, Transpiling reconciles the generated-source directory with the classes represented in the current XMIR set.
- JavaFiles removes obsolete generated Java files and obsolete package-info.java files rather than leaving them for Maven to compile.
- Added regression coverage for stale source cleanup in JavaFilesTest and the transpilation integration path in MjTranspileTest.

## Why

Incremental transpilation previously only wrote classes that still existed. Removing an EO object or nested generated class left its old Java source under target/generated-sources, making incremental output differ from a clean build. The reconciliation step makes the generated tree converge to the current XMIR input.

## Verification

JavaFilesTest and MjTranspileTest passed in focused runs.