### PR TITLE
#6375: escape string literals rendered in φ-terms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -5,7 +5,11 @@
 
 package org.eolang;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,15 +84,55 @@ public final class PhApplication extends PhOnce {
         final String body = PhApplication.body(binds);
         final Matcher data = PhApplication.DATA.matcher(body);
         final boolean literal = binds.length == 1 && data.find();
-        final String result;
+        final String string;
         if (literal && "Φ.string".equals(head)) {
-            result = String.format(
-                "\"%s\"", new String(PhApplication.bytes(data.group(1)), StandardCharsets.UTF_8)
-            );
+            string = PhApplication.string(PhApplication.bytes(data.group(1)));
+        } else {
+            string = null;
+        }
+        final String result;
+        if (string != null) {
+            result = string;
         } else if (literal && "Φ.number".equals(head)) {
             result = PhDefault.numeral(new BytesOf(PhApplication.bytes(data.group(1))).asNumber());
         } else {
             result = String.format("%s(%s)", head, body);
+        }
+        return result;
+    }
+
+    /**
+     * Render UTF-8 bytes as an EO string literal.
+     * @param bytes Bytes to render
+     * @return Escaped literal, or null if bytes are not valid UTF-8
+     */
+    private static String string(final byte[] bytes) {
+        Optional<String> text;
+        try {
+            text = Optional.of(
+                StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes)).toString()
+            );
+        } catch (final CharacterCodingException ignored) {
+            text = Optional.empty();
+        }
+        final String result;
+        if (text.isPresent()) {
+            result = String.format(
+                "\"%s\"",
+                text.get()
+                    .replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\b", "\\b")
+                    .replace("\f", "\\f")
+                    .replace(String.valueOf('\n'), "\\n")
+                    .replace(String.valueOf('\r'), "\\r")
+                    .replace("\t", "\\t")
+            );
+        } else {
+            result = null;
         }
         return result;
     }

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -116,6 +116,38 @@ final class PhApplicationTest {
     }
 
     @Test
+    void escapesStringLiteralCharacters() {
+        MatcherAssert.assertThat(
+            "String φ-term must escape EO string literal characters",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "string"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"), 0,
+                    new PhDefault(
+                        new byte[] {'a', '"', '\\', '\b', '\f', '\n', '\r', '\t'}
+                    )
+                )
+            ).φTerm(),
+            Matchers.equalTo("\"a\\\"\\\\\\b\\f\\n\\r\\t\"")
+        );
+    }
+
+    @Test
+    void rendersInvalidUtfAsBytes() {
+        MatcherAssert.assertThat(
+            "Invalid UTF-8 must not be rendered as a misleading string literal",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "string"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"), 0,
+                    new PhDefault(new byte[] {(byte) 0xC3, (byte) 0x28})
+                )
+            ).φTerm(),
+            Matchers.equalTo("Φ.string(0->Φ.bytes(0->[D> C3-28]))")
+        );
+    }
+
+    @Test
     void rendersPositionalBindingAsTerm() {
         MatcherAssert.assertThat(
             "PhApplication must render positional binding in φ-term, but it didnt",


### PR DESCRIPTION
Fixes #6375.

## What changed

- PhApplication now decodes string-literal bytes with strict UTF-8 validation.
- Valid strings escape backslash, quote, backspace, form feed, line feed, carriage return, and tab before being rendered as a quoted φ-term.
- Invalid UTF-8 no longer becomes a replacement-character string literal; it retains the unambiguous byte-based application representation.
- Added regressions for literal metacharacters and malformed UTF-8.

## Why

The prior rendering inserted decoded text directly between quotes. Quotes could terminate the literal, backslashes were ambiguous, and control characters produced invalid multi-line terms. The new renderer preserves the exact literal structure used in runtime diagnostics.

## Verification

- git diff --check
- eo-runtime main Java sources compiled successfully with one CPU and 1 GB heap.
- Full test compilation remains blocked by unrelated missing EOnop and EOnumber generated classes in the current local base.