### PR TITLE
#6372: replace unplaced binaries even at equal length

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -197,7 +197,7 @@ final class Placing implements Step {
             final boolean res;
             if (tojo.isPresent()
                 && Files.exists(target)
-                && (this.sameLength(target, file) || !tojo.get().unplaced())
+                && !tojo.get().unplaced()
             ) {
                 Logger.debug(
                     this,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
@@ -200,12 +200,12 @@ final class MjPlaceTest {
     }
 
     @Test
-    void placesAgainIfWasUnplaced(@Mktmp final Path temp) throws Exception {
+    void placesAgainIfWasUnplacedWithSameLength(@Mktmp final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp);
         final String binary = "some.class";
-        MjPlaceTest.saveBinary(temp, "with old content", binary);
+        MjPlaceTest.saveBinary(temp, "old content", binary);
         maven.execute(MjPlace.class).result();
-        final String updated = "with some new content";
+        final String updated = "new content";
         MjPlaceTest.saveBinary(temp, updated, binary);
         maven.placed().unplaceAll();
         maven.execute(MjPlace.class).result();


### PR DESCRIPTION
Fixes #6372.

## What changed

- Placing no longer treats an unplaced target as current merely because the replacement binary has the same size.
- The regression now replaces old content with different content of exactly the same byte length after unplaceAll().

## Why

An unplaced catalog entry means the binary must be restored from the resolved dependency. The former size shortcut skipped that restoration when byte lengths matched, leaving stale class contents in target/classes. The placement decision now follows the catalog state rather than an insufficient length heuristic.

## Verification

MjPlaceTest passed in a single-core Maven run with JUnit parallel execution disabled.