### PR TITLE
#6373: remove obsolete generated Java tests

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -51,8 +51,12 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
         if (clazz.element("java").text().isPresent()) {
             this.footprint.apply(Paths.get(""), this.target);
         }
-        if (tests && JavaPlaced.testsPresent(clazz)) {
-            this.placeJavaTests(clazz);
+        if (tests) {
+            if (JavaPlaced.testsPresent(clazz)) {
+                this.placeJavaTests(clazz);
+            } else {
+                this.removeJavaTests(clazz);
+            }
         }
     }
 
@@ -94,6 +98,38 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
             content = clazz.element("tests").text().get();
         }
         new Saved(content, resulted).value();
+        this.removeJavaTests(clazz, resulted);
+    }
+
+    /**
+     * Remove Java tests that are no longer generated.
+     * @param clazz Transpiled class
+     * @throws IOException If I/O fails
+     */
+    private void removeJavaTests(final Xnav clazz) throws IOException {
+        this.removeJavaTests(clazz, null);
+    }
+
+    /**
+     * Remove Java tests except the one currently generated.
+     * @param clazz Transpiled class
+     * @param retained Generated test to retain, if any
+     * @throws IOException If I/O fails
+     */
+    private void removeJavaTests(final Xnav clazz, final Path retained) throws IOException {
+        final String[] parts = clazz.attribute("java-name").text().get().split("\\.");
+        final Path base = Arrays.stream(parts, 0, parts.length - 1).reduce(
+            this.generated.getParent().resolve("generated-test-sources"),
+            Path::resolve,
+            Path::resolve
+        );
+        final String name = parts[parts.length - 1];
+        for (final String suffix : new String[]{"Test.java", "EOAtomTest.java"}) {
+            final Path test = base.resolve(String.format("%s%s", name, suffix));
+            if (!test.equals(retained)) {
+                Files.deleteIfExists(test);
+            }
+        }
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.github.lombrozo.xnav.Xnav;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.text.TextOf;
@@ -103,5 +104,54 @@ final class JavaPlacedTest {
             ).asString(),
             Matchers.equalTo(expected)
         );
+    }
+
+    @Test
+    void removesObsoleteJavaCompanions(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("target");
+        final Path generated = target.resolve("generated-sources");
+        final Path utest = target.resolve("FooTest.java");
+        final JavaPlaced placed = new JavaPlaced(
+            new FpJavaGenerated(this.clazz("@Test"), generated, utest), utest, generated
+        );
+        placed.exec(this.clazz("@Test"), true);
+        final Path test = target.resolve("generated-test-sources").resolve("FooTest.java");
+        final boolean created = Files.exists(test);
+        placed.exec(this.clazz(""), true);
+        MatcherAssert.assertThat(
+            "Obsolete Java test was not removed", created && Files.notExists(test)
+        );
+    }
+
+    @Test
+    void removesObsoleteAtomJavaCompanions(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("target");
+        final Path generated = target.resolve("generated-sources");
+        final Path utest = target.resolve("FooTest.java");
+        final JavaPlaced placed = new JavaPlaced(
+            new FpJavaGenerated(this.clazz("@Test"), generated, utest), utest, generated
+        );
+        Files.createDirectories(temp.resolve("src/test/java"));
+        new Saved("", temp.resolve("src/test/java/FooTest.java")).value();
+        placed.exec(this.clazz("@Test"), true);
+        final Path atom = target.resolve("generated-test-sources").resolve("FooEOAtomTest.java");
+        final boolean created = Files.exists(atom);
+        placed.exec(this.clazz(""), true);
+        MatcherAssert.assertThat(
+            "Obsolete atom Java test was not removed", created && Files.notExists(atom)
+        );
+    }
+
+    /**
+     * Create transpiled class.
+     * @param tests Test code
+     * @return Class XML
+     */
+    private Xnav clazz(final String tests) throws Exception {
+        return new Xnav(
+            new Xembler(
+                new Directives().add("class").attr("java-name", "Foo").add("tests").set(tests)
+            ).xml()
+        ).element("class");
     }
 }


### PR DESCRIPTION
Fixes #6373.

## What changed

- JavaPlaced removes generated test sources when the current XMIR no longer contains tests.
- Cleanup covers both normal test names and the EO atom collision variant.
- When the collision status changes, the obsolete alternative test path is removed after generating the current one.
- Added focused regressions for ordinary and collision-based stale tests.

## Why

Incremental transpilation previously wrote a generated test when one existed, but left it behind after the source test was removed or renamed. Maven could then compile or execute a test absent from the current EO source. The generated-test tree now converges with the current XMIR.

## Verification

JavaPlacedTest passed in a single-core Maven run with JUnit parallel execution disabled.