### PR TITLE
#6374: preserve raw bytes in octal string escapes

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -266,6 +266,15 @@ final class Emissions {
     }
 
     /**
+     * Decode a string body to its raw byte representation.
+     * @param inner Source body without surrounding quotes
+     * @return Decoded bytes
+     */
+    static byte[] unescapeBytes(final String inner) {
+        return Emissions.unescapeRawBytes(inner);
+    }
+
+    /**
      * Open the {@code <o>} for a value that carries no data of its own —
      * a star, a root or self token, a term, a group, or a plain base
      * reference — where the kind alone picks the {@code base}.
@@ -542,7 +551,7 @@ final class Emissions {
      * @param inner Source body without surrounding quotes
      * @return Decoded bytes
      */
-    static byte[] unescapeBytes(final String inner) {
+    private static byte[] unescapeRawBytes(final String inner) {
         final ByteArrayOutputStream out = new ByteArrayOutputStream(inner.length());
         final StringBuilder text = new StringBuilder(inner.length());
         int idx = 0;
@@ -557,24 +566,7 @@ final class Emissions {
             if (next == 'u') {
                 idx = Emissions.appendUnicode(text, inner, idx + 1);
             } else if (next >= '0' && next <= '7') {
-                Emissions.appendText(out, text);
-                int cursor = idx + 1;
-                int value = 0;
-                while (cursor < inner.length() && cursor < idx + 4
-                    && inner.charAt(cursor) >= '0' && inner.charAt(cursor) <= '7') {
-                    value = value * 8 + inner.charAt(cursor) - '0';
-                    cursor = cursor + 1;
-                }
-                if (value > Emissions.MAX_OCTAL_BYTE) {
-                    throw new NumberFormatException(
-                        String.format(
-                            "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
-                            inner.substring(idx + 1, cursor), value
-                        )
-                    );
-                }
-                out.write(value);
-                idx = cursor;
+                idx = Emissions.rawOctal(out, text, inner, idx + 1);
             } else {
                 text.append(Emissions.singleCharEscape(glyph, next));
                 idx = idx + 2;
@@ -582,6 +574,39 @@ final class Emissions {
         }
         Emissions.appendText(out, text);
         return out.toByteArray();
+    }
+
+    /**
+     * Append one octal escape as a raw byte.
+     * @param out Output bytes
+     * @param text Text waiting for encoding
+     * @param body Whole string body
+     * @param start First octal digit
+     * @return Index past the octal escape
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    private static int rawOctal(
+        final ByteArrayOutputStream out, final StringBuilder text,
+        final String body, final int start
+    ) {
+        Emissions.appendText(out, text);
+        int cursor = start;
+        int value = 0;
+        while (cursor < body.length() && cursor < start + 3
+            && body.charAt(cursor) >= '0' && body.charAt(cursor) <= '7') {
+            value = value * 8 + body.charAt(cursor) - '0';
+            cursor = cursor + 1;
+        }
+        if (value > Emissions.MAX_OCTAL_BYTE) {
+            throw new NumberFormatException(
+                String.format(
+                    "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
+                    body.substring(start, cursor), value
+                )
+            );
+        }
+        out.write(value);
+        return cursor;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -4,7 +4,9 @@
  */
 package org.eolang.parser;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 
@@ -353,9 +355,11 @@ final class Emissions {
         final Emit emit, final String name, final Value value, final int line
     ) {
         emit.object(name, "Φ.string", line, value.pos());
-        final String unescaped;
+        final byte[] unescaped;
         try {
-            unescaped = Emissions.unescape(value.raw());
+            unescaped = Emissions.unescapeBytes(
+                value.raw().substring(1, value.raw().length() - 1)
+            );
         } catch (final NumberFormatException ex) {
             final ParseError error = new ParseError(
                 line, value.pos(), "invalid unicode or octal escape in string literal"
@@ -532,14 +536,66 @@ final class Emissions {
     }
 
     /**
-     * Unescape a string literal's body. The {@code raw} text is the
-     * source form including surrounding quotes; the returned string is
-     * the decoded content.
-     * @param raw Source text including the surrounding quotes
-     * @return Decoded text
+     * Decode a string body to its byte representation. Text and Unicode
+     * escapes are UTF-8 encoded, while octal escapes contribute their raw
+     * one-byte values.
+     * @param inner Source body without surrounding quotes
+     * @return Decoded bytes
      */
-    private static String unescape(final String raw) {
-        return Emissions.unescapeBody(raw.substring(1, raw.length() - 1));
+    static byte[] unescapeBytes(final String inner) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(inner.length());
+        final StringBuilder text = new StringBuilder(inner.length());
+        int idx = 0;
+        while (idx < inner.length()) {
+            final char glyph = inner.charAt(idx);
+            if (glyph != '\\' || idx + 1 >= inner.length()) {
+                text.append(glyph);
+                idx = idx + 1;
+                continue;
+            }
+            final char next = inner.charAt(idx + 1);
+            if (next == 'u') {
+                idx = Emissions.appendUnicode(text, inner, idx + 1);
+            } else if (next >= '0' && next <= '7') {
+                Emissions.appendText(out, text);
+                int cursor = idx + 1;
+                int value = 0;
+                while (cursor < inner.length() && cursor < idx + 4
+                    && inner.charAt(cursor) >= '0' && inner.charAt(cursor) <= '7') {
+                    value = value * 8 + inner.charAt(cursor) - '0';
+                    cursor = cursor + 1;
+                }
+                if (value > Emissions.MAX_OCTAL_BYTE) {
+                    throw new NumberFormatException(
+                        String.format(
+                            "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
+                            inner.substring(idx + 1, cursor), value
+                        )
+                    );
+                }
+                out.write(value);
+                idx = cursor;
+            } else {
+                text.append(Emissions.singleCharEscape(glyph, next));
+                idx = idx + 2;
+            }
+        }
+        Emissions.appendText(out, text);
+        return out.toByteArray();
+    }
+
+    /**
+     * Append valid UTF-16 text as UTF-8 bytes and clear the text buffer.
+     * @param out Output bytes
+     * @param text Text waiting for encoding
+     */
+    private static void appendText(
+        final ByteArrayOutputStream out, final StringBuilder text
+    ) {
+        Emissions.rejectLoneSurrogates(text);
+        final byte[] bytes = text.toString().getBytes(StandardCharsets.UTF_8);
+        out.write(bytes, 0, bytes.length);
+        text.setLength(0);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -59,9 +59,9 @@ final class LnTextBlock implements Line {
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }
-        final String joined;
+        final byte[] joined;
         try {
-            joined = Emissions.unescapeBody(
+            joined = Emissions.unescapeBytes(
                 String.join(String.valueOf('\n'), globals.tbody())
             );
         } catch (final NumberFormatException ex) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -72,7 +72,7 @@ final class LnTextBlockTest {
     }
 
     @Test
-    void emitsOctalHighByteWithoutUtf8Expansion() {
+    void emitsHighOctalByteWithoutUnicodeExpansion() {
         final Globals globals = new Globals();
         globals.openTextBlock(1, 0);
         globals.appendTextLine("\\377");

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -72,6 +72,24 @@ final class LnTextBlockTest {
     }
 
     @Test
+    void emitsOctalHighByteWithoutUtf8Expansion() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 0);
+        globals.appendTextLine("\\377");
+        final Emit emit = new Emit();
+        new LnTextBlock(new Span("\"\"\" > bytes", 3))
+            .into(new Stack(), globals, emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "an octal escape in a text block must contribute its raw byte",
+            LnTextBlockTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='bytes']/o[@base='Φ.bytes']/o[text()='FF-']"
+            )
+        );
+    }
+
+    @Test
     void resetsTextBlockStateAfterEmission() {
         final Globals globals = new Globals();
         globals.openTextBlock(1, 0);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/octal-high-byte-escape.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/octal-high-byte-escape.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.string' and o[@base='Φ.bytes' and o[text()='FF-']]]
+input: |
+  [] > foo
+    "\377" > @


### PR DESCRIPTION
Fixes #6374.

## What changed

- Octal escapes now append their raw byte value instead of first converting it to a UTF-16 character and then UTF-8 encoding it.
- Normal text and Unicode escapes continue to use UTF-8 encoding.
- The behavior is applied consistently to ordinary string literals and text blocks.
- Added regressions proving that octal \377 produces the single byte FF.

## Why

The parser accepted octal values through 0o377 as one-byte escapes but encoded values above 0o177 as two UTF-8 bytes. Keeping octal input on the byte path restores the documented one-byte contract.

## Verification

EoSyntaxTest and LnTextBlockTest passed in a single-core Maven run; the focused jtcop check also passed.