### PR TITLE
#6363: validate eo.coverageFile path inside the controlled error boundary

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Set;
@@ -132,20 +132,28 @@ public final class PhCoverage implements Phi {
 
     /** Record one hit of this location, at most once per JVM. */
     private void hit() {
-        final Path target = PhCoverage.target();
-        if (target != null) {
+        final String property = PhCoverage.property();
+        if (property != null) {
             final String record = String.format("%s:%d:%d%n", this.loc, this.line, this.pos);
             if (PhCoverage.SEEN.add(record)) {
                 try {
                     Files.write(
-                        target,
+                        Paths.get(property),
                         record.getBytes(StandardCharsets.UTF_8),
                         StandardOpenOption.CREATE,
                         StandardOpenOption.APPEND
                     );
                 } catch (final IOException ex) {
                     throw new UncheckedIOException(
-                        String.format("Failed to append a coverage hit to '%s'", target),
+                        String.format("Failed to append a coverage hit to '%s'", property),
+                        ex
+                    );
+                } catch (final InvalidPathException ex) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "Invalid path '%s' in the 'eo.coverageFile' system property",
+                            property
+                        ),
                         ex
                     );
                 }
@@ -154,16 +162,16 @@ public final class PhCoverage implements Phi {
     }
 
     /**
-     * Target file from the {@code eo.coverageFile} property.
-     * @return The path, or NULL when recording is disabled
+     * Value of the {@code eo.coverageFile} property.
+     * @return The value, or NULL when recording is disabled
      */
-    private static Path target() {
+    private static String property() {
         final String path = System.getProperty("eo.coverageFile");
-        final Path result;
+        final String result;
         if (path == null || path.isEmpty()) {
             result = null;
         } else {
-            result = Paths.get(path);
+            result = path;
         }
         return result;
     }

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -10,9 +10,9 @@ import com.yegor256.MktmpResolver;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -70,39 +70,48 @@ final class PhCoverageTest {
     }
 
     @Test
+    void convertsInvalidCoveragePathIntoIllegalArgumentException() {
+        MatcherAssert.assertThat(
+            "a raw InvalidPathException leaked through unconverted",
+            this.failure(String.format("/tmp/%cinvalid", (char) 0)).getClass(),
+            Matchers.<Class<?>>equalTo(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
     void namesThePropertyAndItsValueInAnInvalidCoveragePathFailure() {
-        final String before = System.getProperty("eo.coverageFile");
         final String bad = String.format("/tmp/%cinvalid", (char) 0);
-        System.setProperty("eo.coverageFile", bad);
+        MatcherAssert.assertThat(
+            "the failure must name the offending property and its value",
+            this.failure(bad).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("eo.coverageFile"),
+                Matchers.containsString(bad)
+            )
+        );
+    }
+
+    /**
+     * Failure raised while dataizing with the given value in the property.
+     * @param path Value to put into the {@code eo.coverageFile} property
+     * @return The exception thrown, or a placeholder if nothing was thrown
+     */
+    private RuntimeException failure(final String path) {
+        final Optional<String> before = Optional.ofNullable(System.getProperty("eo.coverageFile"));
+        System.setProperty("eo.coverageFile", path);
+        RuntimeException thrown = new IllegalStateException("nothing was thrown at all");
         try {
-            final Phi phi = new PhCoverage(
-                new PhDefault(new byte[] {(byte) 0x03}), "Φ.invalid-coverage-path", 11, 1
-            );
-            final IllegalArgumentException failure = Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> new Dataized(phi).take(),
-                "an invalid 'eo.coverageFile' value must fail with IllegalArgumentException"
-            );
-            MatcherAssert.assertThat(
-                "the failure class must be exactly IllegalArgumentException, "
-                    + "not a raw InvalidPathException leaking through unconverted",
-                failure.getClass(),
-                Matchers.<Class<?>>equalTo(IllegalArgumentException.class)
-            );
-            MatcherAssert.assertThat(
-                "the failure must name the offending property and its value",
-                failure.getMessage(),
-                Matchers.allOf(
-                    Matchers.containsString("eo.coverageFile"),
-                    Matchers.containsString(bad)
+            new Dataized(
+                new PhCoverage(
+                    new PhDefault(new byte[] {(byte) 0x03}), "Φ.invalid-coverage-path", 11, 1
                 )
-            );
+            ).take();
+        } catch (final IllegalArgumentException ex) {
+            thrown = ex;
         } finally {
-            if (before == null) {
-                System.clearProperty("eo.coverageFile");
-            } else {
-                System.setProperty("eo.coverageFile", before);
-            }
+            System.clearProperty("eo.coverageFile");
+            before.ifPresent(value -> System.setProperty("eo.coverageFile", value));
         }
+        return thrown;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -73,7 +73,7 @@ final class PhCoverageTest {
     void convertsInvalidCoveragePathIntoIllegalArgumentException() {
         MatcherAssert.assertThat(
             "a raw InvalidPathException leaked through unconverted",
-            this.failure(String.format("/tmp/%cinvalid", (char) 0)).getClass(),
+            this.failure(String.format("/tmp/%cinvalid", (char) 0), "Φ.invalid-path").getClass(),
             Matchers.<Class<?>>equalTo(IllegalArgumentException.class)
         );
     }
@@ -83,7 +83,7 @@ final class PhCoverageTest {
         final String bad = String.format("/tmp/%cinvalid", (char) 0);
         MatcherAssert.assertThat(
             "the failure must name the offending property and its value",
-            this.failure(bad).getMessage(),
+            this.failure(bad, "Φ.invalid-value").getMessage(),
             Matchers.allOf(
                 Matchers.containsString("eo.coverageFile"),
                 Matchers.containsString(bad)
@@ -93,17 +93,21 @@ final class PhCoverageTest {
 
     /**
      * Failure raised while dataizing with the given value in the property.
+     * <p>Each caller must pass its own location: {@link PhCoverage} writes a
+     * given location at most once per JVM, so a shared one would make the
+     * second test see no attempt to write at all.</p>
      * @param path Value to put into the {@code eo.coverageFile} property
+     * @param loc Location to record, unique per caller
      * @return The exception thrown, or a placeholder if nothing was thrown
      */
-    private RuntimeException failure(final String path) {
+    private RuntimeException failure(final String path, final String loc) {
         final Optional<String> before = Optional.ofNullable(System.getProperty("eo.coverageFile"));
         System.setProperty("eo.coverageFile", path);
         RuntimeException thrown = new IllegalStateException("nothing was thrown at all");
         try {
             new Dataized(
                 new PhCoverage(
-                    new PhDefault(new byte[] {(byte) 0x03}), "Φ.invalid-coverage-path", 11, 1
+                    new PhDefault(new byte[] {(byte) 0x03}), loc, 11, 1
                 )
             ).take();
         } catch (final IllegalArgumentException ex) {

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -58,6 +59,43 @@ final class PhCoverageTest {
                 "every location, hit repeatedly and through a copy, must be recorded exactly once",
                 Files.readAllLines(hits, StandardCharsets.UTF_8),
                 Matchers.containsInAnyOrder("Φ.foo:7:3", "Φ.bar:9:5")
+            );
+        } finally {
+            if (before == null) {
+                System.clearProperty("eo.coverageFile");
+            } else {
+                System.setProperty("eo.coverageFile", before);
+            }
+        }
+    }
+
+    @Test
+    void namesThePropertyAndItsValueInAnInvalidCoveragePathFailure() {
+        final String before = System.getProperty("eo.coverageFile");
+        final String bad = String.format("/tmp/%cinvalid", (char) 0);
+        System.setProperty("eo.coverageFile", bad);
+        try {
+            final Phi phi = new PhCoverage(
+                new PhDefault(new byte[] {(byte) 0x03}), "Φ.invalid-coverage-path", 11, 1
+            );
+            final IllegalArgumentException failure = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Dataized(phi).take(),
+                "an invalid 'eo.coverageFile' value must fail with IllegalArgumentException"
+            );
+            MatcherAssert.assertThat(
+                "the failure class must be exactly IllegalArgumentException, "
+                    + "not a raw InvalidPathException leaking through unconverted",
+                failure.getClass(),
+                Matchers.<Class<?>>equalTo(IllegalArgumentException.class)
+            );
+            MatcherAssert.assertThat(
+                "the failure must name the offending property and its value",
+                failure.getMessage(),
+                Matchers.allOf(
+                    Matchers.containsString("eo.coverageFile"),
+                    Matchers.containsString(bad)
+                )
             );
         } finally {
             if (before == null) {


### PR DESCRIPTION
Fixes #6363.

`PhCoverage.hit()` called `Paths.get(path)` outside the try block that catches `IOException`. An invalid `eo.coverageFile` value (for example a path with a NUL character) threw a raw `InvalidPathException` instead of a descriptive failure.

The path conversion now happens inside the same controlled error boundary as the file write. An invalid value throws `IllegalArgumentException` naming the property and its value.

Added a test that fails on the unpatched code with a raw `InvalidPathException` and passes with the fix, checking both the exact exception class and the message content.
