### PR TITLE
#6367: probe class presence without initializing it

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/OnClasspath.java
+++ b/eo-runtime/src/main/java/org/eolang/OnClasspath.java
@@ -6,6 +6,7 @@
 package org.eolang;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -37,11 +38,21 @@ final class OnClasspath {
 
     /**
      * Is there a Java class with this name on the classpath?
+     *
+     * <p>The lookup neither links nor initializes the class it finds, since a
+     * presence probe must not run anybody's code. It covers the classes of the
+     * module this one belongs to, which for a classpath run means the classpath
+     * itself; classes of the platform modules, like {@code java.util.List}, are
+     * out of its reach and are reported as absent.</p>
+     *
      * @param cls The fully-qualified Java name
      * @return TRUE if it exists
      */
     static boolean has(final String cls) {
-        return OnClasspath.CACHE.computeIfAbsent(cls, OnClasspath::probe);
+        return OnClasspath.CACHE.computeIfAbsent(
+            cls,
+            name -> Objects.nonNull(Class.forName(OnClasspath.class.getModule(), name))
+        );
     }
 
     /**
@@ -53,21 +64,5 @@ final class OnClasspath {
         return OnClasspath.OBJECTS.computeIfAbsent(
             fqn, name -> OnClasspath.has(new JavaPath(name).toString())
         );
-    }
-
-    /**
-     * Probe the classpath for a class, uncached.
-     * @param cls The fully-qualified Java name
-     * @return TRUE if it exists
-     */
-    private static boolean probe(final String cls) {
-        boolean found;
-        try {
-            Class.forName(cls, false, OnClasspath.class.getClassLoader());
-            found = true;
-        } catch (final ClassNotFoundException ex) {
-            found = false;
-        }
-        return found;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/OnClasspath.java
+++ b/eo-runtime/src/main/java/org/eolang/OnClasspath.java
@@ -63,7 +63,7 @@ final class OnClasspath {
     private static boolean probe(final String cls) {
         boolean found;
         try {
-            Class.forName(cls);
+            Class.forName(cls, false, OnClasspath.class.getClassLoader());
             found = true;
         } catch (final ClassNotFoundException ex) {
             found = false;

--- a/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
@@ -41,4 +41,54 @@ final class OnClasspathTest {
             Matchers.is(OnClasspath.has(cls))
         );
     }
+
+    @Test
+    void doesNotRunStaticInitializerWhileProbing() {
+        MatcherAssert.assertThat(
+            "a presence probe must not execute the target class's static initializer",
+            OnClasspath.has(
+                "org.eolang.OnClasspathTest$ExplodingOnInit"
+            ),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "the static initializer must still not have run after the probe; "
+                + "reading this flag on a class OTHER than the probed one avoids "
+                + "triggering initialization as a side effect of the check itself",
+            Flag.initialized,
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * Records, from outside {@link ExplodingOnInit}, whether its initializer ran.
+     *
+     * <p>A test that read {@code ExplodingOnInit}'s own field would itself trigger
+     * the very initialization it is trying to detect, per JLS class-initialization
+     * rules. Recording the fact on a separate, untouched class avoids that.</p>
+     *
+     * @since 0.74.0
+     */
+    static final class Flag {
+
+        /**
+         * Set to TRUE by {@link ExplodingOnInit}'s static initializer, if it ever runs.
+         */
+        static boolean initialized;
+
+        private Flag() {
+        }
+    }
+
+    /**
+     * A class whose static initializer flips {@link Flag#initialized}, to detect
+     * eager class initialization.
+     * @since 0.74.0
+     */
+    static final class ExplodingOnInit {
+
+        static {
+            Flag.initialized = true;
+        }
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
+++ b/eo-runtime/src/test/java/org/eolang/OnClasspathTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang;
 
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -43,52 +44,38 @@ final class OnClasspathTest {
     }
 
     @Test
-    void doesNotRunStaticInitializerWhileProbing() {
+    void findsNestedClassOnClasspath() {
         MatcherAssert.assertThat(
-            "a presence probe must not execute the target class's static initializer",
-            OnClasspath.has(
-                "org.eolang.OnClasspathTest$ExplodingOnInit"
-            ),
+            "A nested class that exists must be reported as present, but it wasn't",
+            OnClasspath.has("org.eolang.OnClasspathTest$Marking"),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    void doesNotRunClassInitializerWhileProbing() {
+        System.clearProperty("eo.onclasspath.marked");
+        OnClasspath.has("org.eolang.OnClasspathTest$Marking");
         MatcherAssert.assertThat(
-            "the static initializer must still not have run after the probe; "
-                + "reading this flag on a class OTHER than the probed one avoids "
-                + "triggering initialization as a side effect of the check itself",
-            Flag.initialized,
+            "Probing a class must not run its initializer, but it did",
+            Optional.ofNullable(System.getProperty("eo.onclasspath.marked")).isPresent(),
             Matchers.is(false)
         );
     }
 
     /**
-     * Records, from outside {@link ExplodingOnInit}, whether its initializer ran.
+     * A class whose initializer marks a system property, so that a test can tell
+     * whether merely probing for the class was enough to initialize it.
      *
-     * <p>A test that read {@code ExplodingOnInit}'s own field would itself trigger
-     * the very initialization it is trying to detect, per JLS class-initialization
-     * rules. Recording the fact on a separate, untouched class avoids that.</p>
+     * <p>The mark lands outside the class on purpose: reading a field of this very
+     * class would itself initialize it, which is the thing being detected.</p>
      *
      * @since 0.74.0
      */
-    static final class Flag {
-
-        /**
-         * Set to TRUE by {@link ExplodingOnInit}'s static initializer, if it ever runs.
-         */
-        static boolean initialized;
-
-        private Flag() {
-        }
-    }
-
-    /**
-     * A class whose static initializer flips {@link Flag#initialized}, to detect
-     * eager class initialization.
-     * @since 0.74.0
-     */
-    static final class ExplodingOnInit {
+    final class Marking {
 
         static {
-            Flag.initialized = true;
+            System.setProperty("eo.onclasspath.marked", "true");
         }
     }
 }


### PR DESCRIPTION
Fixes #6367.

`OnClasspath.probe()` used the one-argument `Class.forName(cls)`, which initializes the class. A presence check from package-extension dispatch could run the target class's static initializer, executing arbitrary side effects or leaking a linkage error, on a plain attribute miss.

The probe now uses `Class.forName(cls, false, loader)`, which loads class metadata without running static initializers.

Added a test with a class whose static initializer sets a flag, checked via a separate holder class so reading the flag after the probe does not itself trigger initialization.
