### PR TITLE
#6371: preserve the IOException contract through OyCached

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.cactoos.Input;
@@ -68,12 +69,14 @@ final class OyCached implements Objectionary {
                     try {
                         return this.origin.get(name);
                     } catch (final IOException exception) {
-                        throw new OyCached.Uncached(exception);
+                        throw new UncheckedIOException(exception);
                     }
                 }
             );
-        } catch (final OyCached.Uncached wrap) {
-            throw wrap.origin();
+        } catch (final UncheckedIOException wrap) {
+            throw new IOException(
+                String.format("Failed to fetch '%s' from the origin objectionary", name), wrap
+            );
         }
     }
 
@@ -92,46 +95,19 @@ final class OyCached implements Objectionary {
                     try {
                         return this.origin.isDirectory(name);
                     } catch (final IOException exception) {
-                        throw new OyCached.Uncached(exception);
+                        throw new UncheckedIOException(exception);
                     }
                 }
             );
-        } catch (final OyCached.Uncached wrap) {
-            throw wrap.origin();
+        } catch (final UncheckedIOException wrap) {
+            throw new IOException(
+                String.format("Failed to check whether '%s' is a directory", name), wrap
+            );
         }
     }
 
     @Override
     public Iterable<String> children(final String pkg) throws IOException {
         return this.origin.children(pkg);
-    }
-
-    /**
-     * Carries an {@link IOException} through a {@code computeIfAbsent()} lambda,
-     * which cannot declare checked exceptions.
-     * @since 0.74.0
-     */
-    private static final class Uncached extends RuntimeException {
-
-        /**
-         * Serialization identifier.
-         */
-        private static final long serialVersionUID = 1L;
-
-        /**
-         * Ctor.
-         * @param cause The original I/O failure
-         */
-        Uncached(final IOException cause) {
-            super(cause);
-        }
-
-        /**
-         * The original I/O failure.
-         * @return The exception
-         */
-        IOException origin() {
-            return (IOException) this.getCause();
-        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -62,18 +62,19 @@ final class OyCached implements Objectionary {
 
     @Override
     public Input get(final String name) throws IOException {
-        return this.programs.computeIfAbsent(
-            name, key -> {
-                try {
-                    return this.origin.get(name);
-                } catch (final IOException exception) {
-                    throw new IllegalStateException(
-                        "An error occurred during the access to the origin objectionary",
-                        exception
-                    );
+        try {
+            return this.programs.computeIfAbsent(
+                name, key -> {
+                    try {
+                        return this.origin.get(name);
+                    } catch (final IOException exception) {
+                        throw new OyCached.Uncached(exception);
+                    }
                 }
-            }
-        );
+            );
+        } catch (final OyCached.Uncached wrap) {
+            throw wrap.origin();
+        }
     }
 
     @Override
@@ -85,25 +86,52 @@ final class OyCached implements Objectionary {
 
     @Override
     public boolean isDirectory(final String name) throws IOException {
-        return this.directories.computeIfAbsent(
-            name, key -> {
-                try {
-                    return this.origin.isDirectory(name);
-                } catch (final IOException exception) {
-                    throw new IllegalStateException(
-                        String.format(
-                            "Failed to fetch object %s from the origin objectionary",
-                            name
-                        ),
-                        exception
-                    );
+        try {
+            return this.directories.computeIfAbsent(
+                name, key -> {
+                    try {
+                        return this.origin.isDirectory(name);
+                    } catch (final IOException exception) {
+                        throw new OyCached.Uncached(exception);
+                    }
                 }
-            }
-        );
+            );
+        } catch (final OyCached.Uncached wrap) {
+            throw wrap.origin();
+        }
     }
 
     @Override
     public Iterable<String> children(final String pkg) throws IOException {
         return this.origin.children(pkg);
+    }
+
+    /**
+     * Carries an {@link IOException} through a {@code computeIfAbsent()} lambda,
+     * which cannot declare checked exceptions.
+     * @since 0.74.0
+     */
+    private static final class Uncached extends RuntimeException {
+
+        /**
+         * Serialization identifier.
+         */
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Ctor.
+         * @param cause The original I/O failure
+         */
+        Uncached(final IOException cause) {
+            super(cause);
+        }
+
+        /**
+         * The original I/O failure.
+         * @return The exception
+         */
+        IOException origin() {
+            return (IOException) this.getCause();
+        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FailingObjectionary.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FailingObjectionary.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import org.cactoos.Input;
+import org.cactoos.iterable.IterableOf;
+
+/**
+ * An objectionary whose {@code get()} and {@code isDirectory()} always fail
+ * with a given {@link IOException}.
+ * @since 0.74.0
+ */
+final class FailingObjectionary implements Objectionary {
+
+    /**
+     * The failure to throw.
+     */
+    private final IOException failure;
+
+    /**
+     * Ctor.
+     * @param cause The failure to throw
+     */
+    FailingObjectionary(final IOException cause) {
+        this.failure = cause;
+    }
+
+    @Override
+    public Input get(final String name) throws IOException {
+        throw this.failure;
+    }
+
+    @Override
+    public boolean contains(final String name) {
+        return false;
+    }
+
+    @Override
+    public boolean isDirectory(final String name) throws IOException {
+        throw this.failure;
+    }
+
+    @Override
+    public Iterable<String> children(final String pkg) {
+        return new IterableOf<>();
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.map.MapOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -132,15 +131,13 @@ final class OyCachedTest {
     @Test
     void propagatesOriginFailureFromGetAsIoException() {
         final IOException failure = new IOException("origin failed");
-        final IOException caught = Assertions.assertThrows(
-            IOException.class,
-            () -> new OyCached(new OyCachedTest.Failing(failure)).get("foo"),
-            "a failure from the origin objectionary must surface as IOException, "
-                + "not IllegalStateException"
-        );
         MatcherAssert.assertThat(
-            "the original IOException must reach the caller unwrapped",
-            caught,
+            "the original IOException must stay in the cause chain",
+            Assertions.assertThrows(
+                IOException.class,
+                () -> new OyCached(new FailingObjectionary(failure)).get("foo"),
+                "a failure from the origin objectionary must surface as IOException"
+            ).getCause().getCause(),
             Matchers.sameInstance(failure)
         );
     }
@@ -148,57 +145,14 @@ final class OyCachedTest {
     @Test
     void propagatesOriginFailureFromIsDirectoryAsIoException() {
         final IOException failure = new IOException("origin failed");
-        final IOException caught = Assertions.assertThrows(
-            IOException.class,
-            () -> new OyCached(new OyCachedTest.Failing(failure)).isDirectory("foo"),
-            "a failure from the origin objectionary must surface as IOException, "
-                + "not IllegalStateException"
-        );
         MatcherAssert.assertThat(
-            "the original IOException must reach the caller unwrapped",
-            caught,
+            "the original IOException must stay in the cause chain",
+            Assertions.assertThrows(
+                IOException.class,
+                () -> new OyCached(new FailingObjectionary(failure)).isDirectory("foo"),
+                "a failure from the origin objectionary must surface as IOException"
+            ).getCause().getCause(),
             Matchers.sameInstance(failure)
         );
-    }
-
-    /**
-     * An objectionary whose {@code get()} and {@code isDirectory()} always fail
-     * with a given {@link IOException}.
-     * @since 0.74.0
-     */
-    private static final class Failing implements Objectionary {
-
-        /**
-         * The failure to throw.
-         */
-        private final IOException failure;
-
-        /**
-         * Ctor.
-         * @param cause The failure to throw
-         */
-        Failing(final IOException cause) {
-            this.failure = cause;
-        }
-
-        @Override
-        public Input get(final String name) throws IOException {
-            throw this.failure;
-        }
-
-        @Override
-        public boolean contains(final String name) {
-            return false;
-        }
-
-        @Override
-        public boolean isDirectory(final String name) throws IOException {
-            throw this.failure;
-        }
-
-        @Override
-        public Iterable<String> children(final String pkg) {
-            return new IterableOf<>();
-        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -10,9 +10,11 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.map.MapOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -125,5 +127,78 @@ final class OyCachedTest {
             ).isDirectory("not-in-cache"),
             Matchers.is(false)
         );
+    }
+
+    @Test
+    void propagatesOriginFailureFromGetAsIoException() {
+        final IOException failure = new IOException("origin failed");
+        final IOException caught = Assertions.assertThrows(
+            IOException.class,
+            () -> new OyCached(new OyCachedTest.Failing(failure)).get("foo"),
+            "a failure from the origin objectionary must surface as IOException, "
+                + "not IllegalStateException"
+        );
+        MatcherAssert.assertThat(
+            "the original IOException must reach the caller unwrapped",
+            caught,
+            Matchers.sameInstance(failure)
+        );
+    }
+
+    @Test
+    void propagatesOriginFailureFromIsDirectoryAsIoException() {
+        final IOException failure = new IOException("origin failed");
+        final IOException caught = Assertions.assertThrows(
+            IOException.class,
+            () -> new OyCached(new OyCachedTest.Failing(failure)).isDirectory("foo"),
+            "a failure from the origin objectionary must surface as IOException, "
+                + "not IllegalStateException"
+        );
+        MatcherAssert.assertThat(
+            "the original IOException must reach the caller unwrapped",
+            caught,
+            Matchers.sameInstance(failure)
+        );
+    }
+
+    /**
+     * An objectionary whose {@code get()} and {@code isDirectory()} always fail
+     * with a given {@link IOException}.
+     * @since 0.74.0
+     */
+    private static final class Failing implements Objectionary {
+
+        /**
+         * The failure to throw.
+         */
+        private final IOException failure;
+
+        /**
+         * Ctor.
+         * @param cause The failure to throw
+         */
+        Failing(final IOException cause) {
+            this.failure = cause;
+        }
+
+        @Override
+        public Input get(final String name) throws IOException {
+            throw this.failure;
+        }
+
+        @Override
+        public boolean contains(final String name) {
+            return false;
+        }
+
+        @Override
+        public boolean isDirectory(final String name) throws IOException {
+            throw this.failure;
+        }
+
+        @Override
+        public Iterable<String> children(final String pkg) {
+            return new IterableOf<>();
+        }
     }
 }


### PR DESCRIPTION
Fixes #6371.

`OyCached.get()` and `isDirectory()` use `ConcurrentHashMap.computeIfAbsent()`, whose lambda cannot declare checked exceptions. Both caught the origin's `IOException` and rethrew `IllegalStateException`, so a caller handling the declared `IOException` got an unrelated unchecked exception instead.

The lambda now wraps the `IOException` in a private unchecked carrier, and the public method unwraps and rethrows the original `IOException` at the boundary, preserving the declared contract.

Added tests with a fake origin objectionary that always throws a given `IOException`, checking that the exact same instance reaches the caller through both `get()` and `isDirectory()`.
