### PR TITLE
#6368: keep the logging wrapper across copy() and normalized()

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -32,7 +32,7 @@ public final class PhLogged implements Phi {
     @Override
     public Phi copy() {
         System.out.printf("%d.copy()...%n", this.hashCode());
-        final Phi ret = this.origin.copy();
+        final Phi ret = new PhLogged(this.origin.copy());
         System.out.printf("%d.copy()! -> %d%n", this.hashCode(), ret.hashCode());
         return ret;
     }
@@ -97,7 +97,7 @@ public final class PhLogged implements Phi {
 
     @Override
     public Phi normalized() {
-        return this.origin.normalized();
+        return new PhLogged(this.origin.normalized());
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -60,4 +60,22 @@ final class PhLoggedTest {
             Matchers.equalTo(phi.locator())
         );
     }
+
+    @Test
+    void keepsLoggingWrapperAfterCopy() {
+        MatcherAssert.assertThat(
+            "copy() must remain wrapped in PhLogged, so tracing continues, but it didn't",
+            new PhLogged(Phi.Φ).copy(),
+            Matchers.instanceOf(PhLogged.class)
+        );
+    }
+
+    @Test
+    void keepsLoggingWrapperAfterNormalized() {
+        MatcherAssert.assertThat(
+            "normalized() must remain wrapped in PhLogged, so tracing continues, but it didn't",
+            new PhLogged(Phi.Φ).normalized(),
+            Matchers.instanceOf(PhLogged.class)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #6368.

`PhLogged.copy()` and `normalized()` returned the raw result of the origin call instead of a new `PhLogged` around it. The first copy or normalization silently dropped the decorator, so every later operation on the returned object went unlogged even though it remained part of the traced computation. This is especially misleading since normal EO application frequently copies objects before filling their attributes.

Both methods now wrap their result in a new `PhLogged`, so tracing continues.

Added tests checking that `copy()` and `normalized()` return a `PhLogged` instance.
