### PR TITLE
#6370: complete the root package for a top-level probe

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -143,13 +143,10 @@ final class Probing implements Step {
         final Path src,
         final Set<String> completed
     ) throws IOException {
-        final int split = object.lastIndexOf('.');
-        if (split > 0) {
-            final String pkg = object.substring(0, split);
-            if (completed.add(pkg)) {
-                for (final String sibling : this.objectionary.children(pkg)) {
-                    this.tojos.add(sibling).withDiscoveredAt(src);
-                }
+        final String pkg = object.substring(0, Math.max(object.lastIndexOf('.'), 0));
+        if (completed.add(pkg)) {
+            for (final String sibling : this.objectionary.children(pkg)) {
+                this.tojos.add(sibling).withDiscoveredAt(src);
             }
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -75,6 +75,37 @@ final class ProbingTest {
     }
 
     @Test
+    void completesRootPackageForTopLevelProbe(@TempDir final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > test",
+                    "  Q.foo > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(() -> new SetOf<>("foo", "bar"))
+            ),
+            true
+        ).exec();
+        MatcherAssert.assertThat(
+            "Probe should have registered the root-package sibling "
+                + "that was never probed directly",
+            tojos.contains("bar"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void skipsWhenOffline(@TempDir final Path temp) throws IOException {
         final Path xmir = temp.resolve("test.xmir");
         Files.write(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -98,8 +98,7 @@ final class ProbingTest {
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Probe should have registered the root-package sibling "
-                + "that was never probed directly",
+            "Probe must register the root-package sibling that was never probed directly",
             tojos.contains("bar"),
             Matchers.is(true)
         );


### PR DESCRIPTION
Fixes #6370.

`Probing.complete()` only pulled the remaining siblings of a probed object's package when the name contained a dot (`split > 0`). For a top-level object such as `foo`, `lastIndexOf('.')` is `-1`, so the root package was never completed, even though `ObjectsIndex.children("")` explicitly supports listing the root package's own children. A project that probes a top-level object referencing another top-level object by its bare name could fail to resolve that sibling during parsing.

The package prefix is now computed with `substring(0, Math.max(lastIndexOf('.'), 0))`, so a name with no dot resolves to the empty root package instead of skipping completion, while keeping the existing per-package de-duplication.

Added a test that probes a top-level object and checks a root-level sibling gets pulled in.
