### PR TITLE
#6366: delete the binary before marking its tojo unplaced

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
@@ -161,10 +161,10 @@ final class Unplacing implements Step {
      * @throws IOException If fails to delete binary
      */
     private static int unplaced(final TjPlaced tojo, final Path path) throws IOException {
-        tojo.unplace();
         if (Files.deleteIfExists(path)) {
             Logger.debug(Unplacing.class, "Deleted binary %s", path);
         }
+        tojo.unplace();
         return 1;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
@@ -8,14 +8,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Set;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -37,6 +37,7 @@ final class UnplacingTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void keepsCatalogEntryWhenDeletionFails(@TempDir final Path temp) throws IOException {
         final Path classes = temp.resolve("classes");
         Files.createDirectories(classes);
@@ -44,7 +45,6 @@ final class UnplacingTest {
         Files.write(binary, "class-bytes".getBytes(StandardCharsets.UTF_8));
         final TjsPlaced placed = new TjsPlaced(temp.resolve("placed.json"));
         placed.placeClass(binary, "Foo.class", "dep");
-        final Set<PosixFilePermission> writable = Files.getPosixFilePermissions(classes);
         Files.setPosixFilePermissions(classes, PosixFilePermissions.fromString("r-xr-xr-x"));
         try {
             Assertions.assertThrows(
@@ -53,11 +53,10 @@ final class UnplacingTest {
                 "a deletion failure must surface as an exception, not be swallowed"
             );
         } finally {
-            Files.setPosixFilePermissions(classes, writable);
+            Files.setPosixFilePermissions(classes, PosixFilePermissions.fromString("rwxr-xr-x"));
         }
         MatcherAssert.assertThat(
-            "the catalog entry must remain placed after a failed deletion, "
-                + "so a later run can retry",
+            "the catalog entry must remain placed after a failed deletion",
             placed.classes().iterator().next().placed(),
             Matchers.is(true)
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
@@ -4,8 +4,16 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import org.cactoos.set.SetOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,6 +33,33 @@ final class UnplacingTest {
                 new SetOf<>()
             ).exec(),
             "Unplacing must skip gracefully when the placed catalog is empty"
+        );
+    }
+
+    @Test
+    void keepsCatalogEntryWhenDeletionFails(@TempDir final Path temp) throws IOException {
+        final Path classes = temp.resolve("classes");
+        Files.createDirectories(classes);
+        final Path binary = classes.resolve("Foo.class");
+        Files.write(binary, "class-bytes".getBytes(StandardCharsets.UTF_8));
+        final TjsPlaced placed = new TjsPlaced(temp.resolve("placed.json"));
+        placed.placeClass(binary, "Foo.class", "dep");
+        final Set<PosixFilePermission> writable = Files.getPosixFilePermissions(classes);
+        Files.setPosixFilePermissions(classes, PosixFilePermissions.fromString("r-xr-xr-x"));
+        try {
+            Assertions.assertThrows(
+                Exception.class,
+                () -> new Unplacing(placed, classes, new SetOf<>()).exec(),
+                "a deletion failure must surface as an exception, not be swallowed"
+            );
+        } finally {
+            Files.setPosixFilePermissions(classes, writable);
+        }
+        MatcherAssert.assertThat(
+            "the catalog entry must remain placed after a failed deletion, "
+                + "so a later run can retry",
+            placed.classes().iterator().next().placed(),
+            Matchers.is(true)
         );
     }
 }


### PR DESCRIPTION
Fixes #6366.

`Unplacing.unplaced()` called `tojo.unplace()` before `Files.deleteIfExists(path)`. If deletion failed (locked file, read-only directory), the method threw after the catalog had already forgotten the binary. A later `unplace` run had no catalog entry left to retry the deletion, leaving a stale class in the output directory permanently.

The binary is now deleted first; the tojo is marked unplaced only after deletion succeeds (or is confirmed already absent).

Added a test that makes the output directory read-only to force a deletion failure, and checks the catalog entry stays marked as placed afterward.
