### PR TITLE
#6364: recognize all JUnit test entry-point annotations

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import org.cactoos.BiProc;
 
 /**
@@ -17,6 +18,14 @@ import org.cactoos.BiProc;
  * @since 0.56.7
  */
 final class JavaPlaced implements BiProc<Xnav, Boolean> {
+
+    /**
+     * JUnit annotations that mark a method as a test entry point.
+     * @see <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests">JUnit 5 user guide</a>
+     */
+    private static final List<String> TEST_ANNOTATIONS = List.of(
+        "@Test", "@ParameterizedTest", "@RepeatedTest", "@TestFactory", "@TestTemplate"
+    );
 
     /**
      * The footprint.
@@ -101,6 +110,8 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
      * @return True or False
      */
     private static boolean testsPresent(final Xnav clazz) {
-        return clazz.element("tests").text().map(s -> s.contains("@Test")).orElse(false);
+        return clazz.element("tests").text()
+            .map(s -> JavaPlaced.TEST_ANNOTATIONS.stream().anyMatch(s::contains))
+            .orElse(false);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -10,7 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 import org.cactoos.BiProc;
 
 /**
@@ -18,14 +18,6 @@ import org.cactoos.BiProc;
  * @since 0.56.7
  */
 final class JavaPlaced implements BiProc<Xnav, Boolean> {
-
-    /**
-     * JUnit annotations that mark a method as a test entry point.
-     * @see <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests">JUnit 5 user guide</a>
-     */
-    private static final List<String> TEST_ANNOTATIONS = List.of(
-        "@Test", "@ParameterizedTest", "@RepeatedTest", "@TestFactory", "@TestTemplate"
-    );
 
     /**
      * The footprint.
@@ -110,8 +102,10 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
      * @return True or False
      */
     private static boolean testsPresent(final Xnav clazz) {
-        return clazz.element("tests").text()
-            .map(s -> JavaPlaced.TEST_ANNOTATIONS.stream().anyMatch(s::contains))
-            .orElse(false);
+        return clazz.element("tests").text().map(
+            s -> Stream.of(
+                "@Test", "@ParameterizedTest", "@RepeatedTest", "@TestFactory", "@TestTemplate"
+            ).anyMatch(s::contains)
+        ).orElse(false);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -76,8 +76,7 @@ final class JavaPlacedTest {
     }
 
     @Test
-    @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
-    void placesJavaTestsWithParameterizedTestOnly(@Mktmp final Path temp) throws Exception {
+    void placesClassMarkedOnlyWithParameterized(@Mktmp final Path temp) throws Exception {
         final String expected = String.join(
             System.lineSeparator(),
             "final class FooTest {",
@@ -98,8 +97,7 @@ final class JavaPlacedTest {
             new FpJavaGenerated(java, generated, utest), utest, generated
         ).exec(java, true);
         MatcherAssert.assertThat(
-            "A generated test class using only @ParameterizedTest must not be "
-                + "silently skipped, but it was",
+            "A generated class marked only with @ParameterizedTest was silently skipped",
             new TextOf(
                 target.resolve("generated-test-sources").resolve("FooTest.java")
             ).asString(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -74,4 +74,36 @@ final class JavaPlacedTest {
             Matchers.equalTo(expected)
         );
     }
+
+    @Test
+    @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
+    void placesJavaTestsWithParameterizedTestOnly(@Mktmp final Path temp) throws Exception {
+        final String expected = String.join(
+            System.lineSeparator(),
+            "final class FooTest {",
+            "  @ParameterizedTest",
+            "  @ValueSource(ints = {1, 2})",
+            "  void testsSomething(final int arg) {}",
+            "}"
+        );
+        final Path target = temp.resolve("target");
+        final Path generated = target.resolve("generated-sources");
+        final Path utest = target.resolve("FooTest.java");
+        final Xnav java = new Xnav(
+            new Xembler(
+                new Directives().add("class").attr("java-name", "Foo").add("tests").set(expected)
+            ).xml()
+        ).element("class");
+        new JavaPlaced(
+            new FpJavaGenerated(java, generated, utest), utest, generated
+        ).exec(java, true);
+        MatcherAssert.assertThat(
+            "A generated test class using only @ParameterizedTest must not be "
+                + "silently skipped, but it was",
+            new TextOf(
+                target.resolve("generated-test-sources").resolve("FooTest.java")
+            ).asString(),
+            Matchers.equalTo(expected)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #6364.

`JavaPlaced.testsPresent()` decided whether to write generated test source by checking only for the literal substring `@Test`. A generated JUnit class using `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`, or `@TestTemplate` instead does not contain that substring, so it was silently skipped even when test generation was enabled. Maven then reported a green build without running the intended EO test.

`testsPresent()` now checks for any of the five JUnit test entry-point annotations.

Added a test with a generated class using only `@ParameterizedTest`, checking the file is written like the existing `@Test` case.
