### PR TITLE
#6395: don't crash on multiple +package metas

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/add-default-package.xsl
@@ -59,7 +59,7 @@
   -->
   <xsl:param name="objects" as="xs:string" select="''"/>
   <!-- The package of the current program (empty if there is no "+package" meta). -->
-  <xsl:variable name="package" select="string(/object/metas/meta[head='package']/part[1])"/>
+  <xsl:variable name="package" select="string((/object/metas/meta[head='package']/part[1])[1])"/>
   <!-- Qualified names of all local package objects as a sequence. -->
   <xsl:variable name="known" select="tokenize($objects, '\s+')[. != '']"/>
   <!--

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multiple-package-metas-do-not-crash.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multiple-package-metas-do-not-crash.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+input: |
+  +package test
+  +package sandbox
+
+  [] > main
+    (stdout "Hello, world!").print > @


### PR DESCRIPTION
Fixes #6395.

`add-default-package.xsl` computed the current package with `string(/object/metas/meta[head='package']/part[1])`. When a source has more than one `+package` meta, this node-set holds one `<part>` per meta, and Saxon's `fn:string()` throws on a sequence of more than one item instead of returning a value. The compiler crashed with a raw Saxon exception rather than letting parsing continue (the duplicate meta itself is a job for lints, not a hard parser failure).

The variable now selects only the first meta's part before calling `string()`, keeping the existing single-package behavior unchanged.

Added a declarative parser test (`eo-syntax` pack) with two `+package` metas in one source, checking parsing produces no errors.
