### PR TITLE
#6401: report the top comment's own line, not the sealing meta's

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -56,7 +56,7 @@ final class Comments {
             );
         }
         if (!pending.isEmpty()) {
-            emit.comment(pending, span.line());
+            emit.comment(pending, pending.get(pending.size() - 1).line());
             globals.clearComments();
         }
         globals.seal();

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -151,7 +151,7 @@ final class Emit {
      * navigation in {@code push}/{@code pop}.</p>
      *
      * @param spans Comment line spans, in source order
-     * @param target Line of the named object the comment attaches to
+     * @param target Line of the last comment span in the block
      */
     void comment(final List<Span> spans, final int target) {
         if (spans.isEmpty()) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/optional-comments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/optional-comments.yaml
@@ -6,7 +6,7 @@ sheets: []
 asserts:
   - /object[not(errors)]
   - //o[not(@base) and @name='app' and o[@base='Φ.stdout' and @name='φ']]
-  - /object/comments/comment[@line='3' and text()='Application entry point.']
+  - /object/comments/comment[@line='1' and text()='Application entry point.']
 input: |
   # Application entry point.
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/top-comment-reports-its-own-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/top-comment-reports-its-own-line.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/comments/comment[@line='1' and text()='Hello.']
+input: |
+  # Hello.
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > hello


### PR DESCRIPTION
Fixes #6401.

`Comments.seal()` flushed the pending top comment block with `span.line()`, the line of the meta or object that closes the header zone, instead of the comment block's own line. A comment on line 1 followed by metas further down was reported at the sealing meta's line instead of its own.

`Eo.java`'s separate EOF flush path (for a comment-only file) already used the last comment span's line, matching `Emit.comment()`'s own javadoc ("the reported line number is the line of the last comment line in the block"). `Comments.seal()` now does the same.

Added a declarative parser test with a one-line top comment followed by two `+spdx` metas, checking the emitted `<comment>` reports line 1.
