### PR TITLE
#6353: reject a bare '+package' meta with no argument

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -75,6 +75,12 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
+        if ("package".equals(head) && parts.isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+package' directive requires exactly one argument"
+            );
+        }
         Comments.seal(globals, emit, this.span);
         globals.markMeta();
         globals.clearBlanks();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bare-package-meta-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bare-package-meta-is-rejected.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'package')]
+input: |
+  +package
+
+  [] > app
+    42 > x


### PR DESCRIPTION
Fixes #6353.

`set-locators.xsl` tests only whether a `meta[head='package']` is present, then appends `"." + tail` to every locator unconditionally. A bare `+package` with no argument has an empty `tail`, so every locator in the file got a doubled dot (e.g. `loc="Phi..app"`), which fails `XMIR.xsd`'s own locator pattern.

`LnMeta` now rejects a `+package` meta with no argument at parse time with a `ParseError`, the same way a nameless meta (`+` alone) is already rejected, instead of letting it silently reach the locator-building stage.

Added a declarative parser test with a bare `+package` line, checking parsing reports an error mentioning `package`.
