### PR TITLE
#6365: escape the dot in the .eo extension pattern

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplace.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplace.java
@@ -17,7 +17,7 @@ final class Unplace {
     /**
      * Pattern to catch .eo files.
      */
-    private static final Pattern EO = Pattern.compile(".eo$");
+    private static final Pattern EO = Pattern.compile("\\.eo$");
 
     /**
      * The parent dir.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplaceTest.java
@@ -19,7 +19,9 @@ final class UnplaceTest {
     @ParameterizedTest
     @CsvSource({
         "/tmp/foo/bar, /tmp/foo/bar/a/b/c.eo, a.b.c",
-        "/tmp/foo/bar, /tmp/foo/bar/a/b/.cd.ef.eo, a.b..cd.ef"
+        "/tmp/foo/bar, /tmp/foo/bar/a/b/.cd.ef.eo, a.b..cd.ef",
+        "/tmp/foo/bar, /tmp/foo/bar/demo/foxeo, demo.foxeo",
+        "/tmp/foo/bar, /tmp/foo/bar/demo/foo.java, demo.foo.java"
     })
     void makesName(
         final String base,


### PR DESCRIPTION
Fixes #6365.

`Unplace` compiled its extension-stripping pattern as `.eo$`. In a Java regex the unescaped leading dot matches any character, not just a literal `.`. A path like `demo/foxeo` had its trailing `xeo` stripped as if it were a `.eo` extension, producing the wrong program name (`demo.fo` instead of `demo.foxeo`).

The pattern is now `\.eo$`, matching only a literal `.eo` suffix.

Added cases distinguishing a name ending in the literal bytes `eo` with no dot, and a non-`.eo` extension, from an actual `.eo` file.
