### PR TITLE
#6352: validate cti severity is a critical/error/warning string

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/cti-adds-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/cti-adds-errors.xsl
@@ -28,10 +28,7 @@
   <!-- A severity argument that is a string literal with one of the three legal values. -->
   <xsl:function name="eo:cti-has-valid-severity" as="xs:boolean">
     <xsl:param name="cti" as="element()"/>
-    <xsl:sequence select="
-      $cti/o[last() - 1]/@base = 'Φ.string'
-      and eo:bytes-to-string($cti/o[last() - 1]/o[1]/o[1]/text()) = ('critical', 'error', 'warning')
-      "/>
+    <xsl:sequence select="$cti/o[last() - 1]/@base = 'Φ.string' and eo:bytes-to-string($cti/o[last() - 1]/o[1]/o[1]/text()) = ('critical', 'error', 'warning')"/>
   </xsl:function>
   <xsl:template match="o[@base='Φ.cti' and count(o) &lt; 2]" mode="create">
     <error>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/cti-adds-errors.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/cti-adds-errors.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="cti-adds-errors" version="2.0" exclude-result-prefixes="eo">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="cti-adds-errors" version="2.0" exclude-result-prefixes="eo">
   <!--
   For every cti objects add error messages.
   -->
@@ -25,7 +25,43 @@
       </xsl:if>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="o[@base='Φ.cti']" mode="create">
+  <!-- A severity argument that is a string literal with one of the three legal values. -->
+  <xsl:function name="eo:cti-has-valid-severity" as="xs:boolean">
+    <xsl:param name="cti" as="element()"/>
+    <xsl:sequence select="
+      $cti/o[last() - 1]/@base = 'Φ.string'
+      and eo:bytes-to-string($cti/o[last() - 1]/o[1]/o[1]/text()) = ('critical', 'error', 'warning')
+      "/>
+  </xsl:function>
+  <xsl:template match="o[@base='Φ.cti' and count(o) &lt; 2]" mode="create">
+    <error>
+      <xsl:attribute name="check">
+        <xsl:text>cti</xsl:text>
+      </xsl:attribute>
+      <xsl:attribute name="line">
+        <xsl:value-of select="@line"/>
+      </xsl:attribute>
+      <xsl:attribute name="severity">
+        <xsl:text>error</xsl:text>
+      </xsl:attribute>
+      <xsl:text>cti requires two arguments: a severity and a message</xsl:text>
+    </error>
+  </xsl:template>
+  <xsl:template match="o[@base='Φ.cti' and count(o) &gt;= 2 and not(eo:cti-has-valid-severity(.))]" mode="create">
+    <error>
+      <xsl:attribute name="check">
+        <xsl:text>cti</xsl:text>
+      </xsl:attribute>
+      <xsl:attribute name="line">
+        <xsl:value-of select="@line"/>
+      </xsl:attribute>
+      <xsl:attribute name="severity">
+        <xsl:text>error</xsl:text>
+      </xsl:attribute>
+      <xsl:text>cti severity must be a string literal, one of "critical", "error", "warning"</xsl:text>
+    </error>
+  </xsl:template>
+  <xsl:template match="o[@base='Φ.cti' and count(o) &gt;= 2 and eo:cti-has-valid-severity(.)]" mode="create">
     <error>
       <xsl:attribute name="check">
         <xsl:text>cti</xsl:text>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/cti-with-non-string-severity-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/cti-with-non-string-severity-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@check='cti']
+  - /object/errors/error[contains(text(),'severity')]
+input: |
+  [] > app
+    cti 1 2 > x


### PR DESCRIPTION
Fixes #6352.

`cti-adds-errors.xsl` decoded whatever bytes sit at the severity argument's data-literal position as UTF-8 and wrote them straight into the `severity` XML attribute, with no check that the argument is actually a string, let alone one of the three legal values. Passing a number there decoded its raw IEEE-754 payload into the attribute, producing XMIR that `XMIR.xsd`'s own enumeration rejects, while the parser itself reported zero errors.

Added `eo:cti-has-valid-severity()`, checking the severity argument is a `Phi.string` literal whose decoded value is `critical`, `error` or `warning`. A `cti` call that fails this now gets a normal `<error>` entry instead of garbage output.

This touches the same file as #6351 (missing-arguments crash) and reuses the same `count(o) < 2` guard, so the two PRs will need a rebase against whichever lands first.

Added a declarative parser test with `cti 1 2 > x` (numeric severity), checking the error mentions "severity", and verified the existing valid-severity case (`cti` with a `"warning"` string) still emits the correct attribute.
