### PR TITLE
#6355: reject a compact-tuple count that overflows int

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -80,7 +80,7 @@ final class LnCompactTuple implements Line {
             );
         }
         tokens.seek(tokens.cursor() + 1);
-        final int count = LnCompactTuple.readCount(tokens);
+        final int count = LnCompactTuple.readCount(tokens, this.span);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
@@ -112,23 +112,31 @@ final class LnCompactTuple implements Line {
      * Read the {@code N} count after {@code *}. Defaults to 0 when
      * absent.
      * @param tokens Token reader (cursor just past the {@code *})
+     * @param span Source span, for a ParseError on overflow
      * @return The N value
      */
-    private static int readCount(final Tokens tokens) {
-        int count = 0;
+    private static int readCount(final Tokens tokens, final Span span) {
+        long count = 0;
         boolean any = false;
+        final int start = tokens.cursor();
         while (!tokens.atEnd()) {
             final char glyph = tokens.current();
             if (glyph < '0' || glyph > '9') {
                 break;
             }
             count = count * 10 + glyph - '0';
+            if (count > Integer.MAX_VALUE) {
+                throw new ParseError(
+                    span.line(), span.indent() + start,
+                    "compact tuple count is too large"
+                );
+            }
             tokens.seek(tokens.cursor() + 1);
             any = true;
         }
         if (!any) {
             count = 0;
         }
-        return count;
+        return (int) count;
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-overflow-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-overflow-is-rejected.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'too large')]
+input: |
+  [] > app
+    seq *4294967297 > x
+      y
+      z
+      w


### PR DESCRIPTION
Fixes #6355.

`LnCompactTuple.readCount` accumulated the `*N` digits into a plain 32-bit `int` with no range check, so a count above `Integer.MAX_VALUE` silently wrapped instead of being rejected, and the wrapped value changed how the line parsed. `Eo.closeCompactTuple` compares the wrapped count against the real child count by equality, so a count that happened to wrap to the actual child count was accepted as if nothing were wrong, and a negative wrap disabled the feature outright with no error anywhere.

`readCount` now accumulates into a `long` and throws a `ParseError` the moment the running total would exceed `Integer.MAX_VALUE`, pointing at the start of the digit run.

Added a declarative parser test with `seq *4294967297` (the smallest overflowing count from the issue), checking parsing reports a "too large" error instead of silently wrapping.
