### PR TITLE
#6356: make @loc agree with @as for bound arguments

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
@@ -51,6 +51,9 @@
         </xsl:when>
         <xsl:otherwise>
           <xsl:choose>
+            <xsl:when test="$o/@as">
+              <xsl:value-of select="$o/@as"/>
+            </xsl:when>
             <xsl:when test="starts-with($o/parent::o/@base, '.') and not($o/preceding-sibling::o)">
               <xsl:value-of select="$eo:rho"/>
             </xsl:when>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/loc-agrees-with-as-for-numeric-bindings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/loc-agrees-with-as-for-numeric-bindings.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - not(//o[@as and not(ends-with(@loc, concat('.', @as)))])
+  - //o[@as='α1' and @loc='Φ.app.x.α1']
+  - //o[@as='α0' and @loc='Φ.app.x.α0']
+input: |
+  [] > app
+    seq 1:1 2:0 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/loc-agrees-with-as-for-numeric-bindings.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/loc-agrees-with-as-for-numeric-bindings.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - not(//o[@as and not(ends-with(@loc, concat('.', @as)))])
+  - /object[not(//o[@as and not(ends-with(@loc, concat('.', @as)))])]
   - //o[@as='α1' and @loc='Φ.app.x.α1']
   - //o[@as='α0' and @loc='Φ.app.x.α0']
 input: |


### PR DESCRIPTION
Fixes #6356.

`eo:locator()` in `set-locators.xsl` computed the trailing `αN` segment purely from an argument's source position, ignoring the `@as` attribute that `mandatory-as.xsl` (or an explicit `N:value` binding) had already set on the same element. For an application with out-of-source-order numeric bindings like `seq 1:1 2:0`, `@as` and `@loc` disagreed about which attribute slot the element occupies: the first-written argument got `as="alpha1"` but `loc=".alpha0"`, and vice versa. The same mismatch happens with label bindings (`1:b 2:a`), where `@loc` never reflects the actual bound attribute name at all.

`eo:locator()` now reads `@as` directly when present, falling back to the existing rho/position logic only for the one case that never gets an `@as` from `mandatory-as.xsl` (the receiver of a reversed-dispatch method chain, e.g. `joined. *1 > x`).

Added a declarative parser test with `seq 1:1 2:0 > x`, checking every element's `@loc` trailing segment matches its `@as`.
