### PR TITLE
#6358: catch ClassCastException when deserializing a compiled regex

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -261,6 +261,11 @@
             regex "/$/"
             "x"
 
+  next. --> rejects-serialized-bytes-of-the-wrong-type
+    match.
+      pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
+      "hello"
+
   compiled. --> stops-on-a-missing-closing-slash
     regex "/pattern"
 

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -78,7 +78,7 @@ public final class EOregex$EOpattern$EOmatch$EOmatched_from_index extends PhDefa
                     new Dataized(match.take(Phi.RHO).take("serialized")).take()
                 )
             ).readObject()).matcher(text);
-        } catch (final IOException | ClassNotFoundException ex) {
+        } catch (final IOException | ClassNotFoundException | ClassCastException ex) {
             throw new ExFailure("cannot deserialize the compiled regex pattern", ex);
         }
         final int start = new Expect.Natural(

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOpatternEOmatchEOmatchedfromindexTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOpatternEOmatchEOmatchedfromindexTest.java
@@ -134,23 +134,28 @@ final class EOregexEOpatternEOmatchEOmatchedfromindexTest {
         }
         final Phi pattern = Phi.Φ.take("string.regex").take("pattern").copy();
         pattern.put(0, new Data.ToPhi(baos.toByteArray()));
-        final ExAbstract failure = Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new Dataized(
-                new PhApplication(
-                    new PhApplication(
-                        pattern.take("match").copy(),
-                        "txt", new Data.ToPhi("hello")
-                    ).take("matched-from-index").copy(),
-                    new Bind(EOregexEOpatternEOmatchEOmatchedfromindexTest.position(), new Data.ToPhi(1)),
-                    new Bind(EOregexEOpatternEOmatchEOmatchedfromindexTest.start(), new Data.ToPhi(0))
-                ).take("from")
-            ).take(),
-            "bytes deserializing to the wrong type must fail with ExFailure, not a raw ClassCastException"
-        );
         MatcherAssert.assertThat(
-            "the failure must be the clean deserialize message, not a raw ClassCastException",
-            failure.toString(),
+            "a raw ClassCastException leaked instead of the clean deserialize failure",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        new PhApplication(
+                            pattern.take("match").copy(),
+                            "txt", new Data.ToPhi("hello")
+                        ).take("matched-from-index").copy(),
+                        new Bind(
+                            EOregexEOpatternEOmatchEOmatchedfromindexTest.position(),
+                            new Data.ToPhi(1)
+                        ),
+                        new Bind(
+                            EOregexEOpatternEOmatchEOmatchedfromindexTest.start(),
+                            new Data.ToPhi(0)
+                        )
+                    ).take("from")
+                ).take(),
+                "bytes of the wrong type must fail with ExFailure"
+            ).toString(),
             Matchers.containsString("cannot deserialize the compiled regex pattern")
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOpatternEOmatchEOmatchedfromindexTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOpatternEOmatchEOmatchedfromindexTest.java
@@ -8,6 +8,8 @@
  */
 package org.eolang.EO_string; // NOPMD
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import org.eolang.Bind;
 import org.eolang.Data;
 import org.eolang.Dataized;
@@ -121,6 +123,35 @@ final class EOregexEOpatternEOmatchEOmatchedfromindexTest {
                 Matchers.containsString(EOregexEOpatternEOmatchEOmatchedfromindexTest.start()),
                 Matchers.containsString("must be less than or equal to text length")
             )
+        );
+    }
+
+    @Test
+    void rejectsSerializedBytesOfTheWrongType() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject("not a pattern");
+        }
+        final Phi pattern = Phi.Φ.take("string.regex").take("pattern").copy();
+        pattern.put(0, new Data.ToPhi(baos.toByteArray()));
+        final ExAbstract failure = Assertions.assertThrows(
+            ExAbstract.class,
+            () -> new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        pattern.take("match").copy(),
+                        "txt", new Data.ToPhi("hello")
+                    ).take("matched-from-index").copy(),
+                    new Bind(EOregexEOpatternEOmatchEOmatchedfromindexTest.position(), new Data.ToPhi(1)),
+                    new Bind(EOregexEOpatternEOmatchEOmatchedfromindexTest.start(), new Data.ToPhi(0))
+                ).take("from")
+            ).take(),
+            "bytes deserializing to the wrong type must fail with ExFailure, not a raw ClassCastException"
+        );
+        MatcherAssert.assertThat(
+            "the failure must be the clean deserialize message, not a raw ClassCastException",
+            failure.toString(),
+            Matchers.containsString("cannot deserialize the compiled regex pattern")
         );
     }
 


### PR DESCRIPTION
Fixes #6358.

`string.regex.pattern` deserializes the caller-supplied `serialized` bytes with `ObjectInputStream` and casts the result to `Pattern`, with the surrounding `catch` handling only `IOException` and `ClassNotFoundException`. Bytes that deserialize successfully to some other type (a serialized `String`, for example) leaked a raw `ClassCastException` instead of the same clean `ExFailure` used for the other two failure modes.

Added `ClassCastException` to the catch clause, so a type mismatch produces the same "cannot deserialize the compiled regex pattern" `ExFailure` as a malformed stream.

This is the minimal fix the issue itself allows for; replacing Java object serialization with a safer encoding is called out there as separate, longer-term work.

Added a test that serializes a `String` (a validly-serialized object of the wrong type) and feeds it through `pattern`, checking the failure is the clean `ExFailure` message, not a raw `ClassCastException`.
