### PR TITLE
fix(#6239): repeat by doubling instead of one copy per level

### DIFF
--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -20,20 +20,19 @@
       "Can't repeat text %f times".printf
         * times
     string
-      if. >> result!
-        0.eq
-          times >> amount!
-        --
-        if. > [accum index] >> rec-repeated
-          amount.eq index
-          accum
-          rec-repeated
-            accum.concat b
-            as-number.
-              index.plus 1
-        |
-          text >> b!
-          1
+      [n] >> rec-repeated
+        if. > @
+          0.eq n
+          --
+          if.
+            0.eq
+              n.mod 2
+            twice
+            concat.
+              half.concat >> twice
+                rec-repeated (n.div 2).floor >> half!
+              text.as-bytes
+      | times
 
   eq. ++> can-format-the-error-message-of-a-negative-count
     "Can't repeat text -1.000000 times"
@@ -47,6 +46,18 @@
     repeated
       "hey"
       5
+
+  eq. ++> can-repeat-a-text-six-times
+    "zxzxzxzxzxzx"
+    repeated
+      "zx"
+      6
+
+  eq. ++> can-repeat-a-text-twenty-thousand-times
+    20000
+    size.
+      as-bytes.
+        repeated "x" 20000
 
   eq. ++> can-repeat-a-text-zero-times
     ""


### PR DESCRIPTION
Closes #6239.

`repeated` peeled one copy per recursion level, so the depth equalled the count (stack overflow at ~1000) and every level concatenated the whole growing accumulator, which is `O(n^2)` in bytes.

It now halves the count per level: `half!` is the text repeated `n/2` times, the result is `half.concat half` plus one more copy when `n` is odd. Depth is `log2(count)`, total copying is ~`2n`. The `!` marker matters — without it the two references to `half` grow the tree back to `2^depth`.

Isolated timings of the same test on macOS:

| count | before | after |
| --- | --- | --- |
| 2000 | 18.8 s | 12.1 s |
| 20000 | did not finish in 25 min | 16.2 s |

Two tests added: `can-repeat-a-text-twenty-thousand-times` (asserts through `bytes.size`, since `string.length` walks the bytes one by one and would time the wrong object) and `can-repeat-a-text-six-times` for the even branch.

@yegor256 please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)