### PR TITLE
fix: complete root-package siblings during probing

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjRegisterIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjRegisterIT.java
@@ -82,18 +82,17 @@ final class MjRegisterIT {
                 MjRegisterIT.succeeds(f);
                 final TjSmart foreign = MjRegisterIT.loadForeign(temp);
                 MatcherAssert.assertThat(
-                    "Foreign must contain only 3 references to objects, but it doesn't",
-                    foreign.size(),
-                    Matchers.equalTo(3)
-                );
-                MatcherAssert.assertThat(
-                    "Foreign must contain refs to Number, Bytes, and current object",
-                    MjRegisterIT.existences(foreign, "number", "bytes", "foo"),
+                    "Foreign must contain required objects and root-package siblings",
+                    MjRegisterIT.existences(
+                        foreign, "number", "bytes", "string", "foo"
+                    ),
                     Matchers.everyItem(Matchers.is(true))
                 );
                 MatcherAssert.assertThat(
                     "Foreign must not contain a reference to an old object",
-                    foreign.select(tojo -> "string".equals(tojo.get("id"))).isEmpty(),
+                    foreign.select(
+                        tojo -> "io.stdout".equals(tojo.get("id"))
+                    ).isEmpty(),
                     Matchers.is(true)
                 );
             }
@@ -106,7 +105,7 @@ final class MjRegisterIT {
             f -> {
                 MjRegisterIT.run(
                     f,
-                    new String[]{"  \"Hello\" > @", "  42 > @"},
+                    new String[]{"  Q.io.stdout > @", "  42 > @"},
                     "eo:register", "eo:parse", "eo:probe", "eo:pull"
                 );
                 f.exec("eo:register", "eo:parse", "eo:probe", "eo:pull");
@@ -118,7 +117,7 @@ final class MjRegisterIT {
                 );
                 MatcherAssert.assertThat(
                     "Unnecessary objects were not removed",
-                    temp.resolve("target/eo/2-pull/string.eo").toFile().exists(),
+                    temp.resolve("target/eo/2-pull/io/stdout.eo").toFile().exists(),
                     Matchers.is(false)
                 );
             }
@@ -157,7 +156,7 @@ final class MjRegisterIT {
                 "+rt jvm org.eolang:eo-runtime:0.25.0",
                 "",
                 "[] > foo",
-                "  \"42\" > @"
+                "  Q.io.stdout > @"
             )
         );
         new AppendedPlugin(farea).value();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -148,7 +148,7 @@ final class Probing implements Step {
     ) throws IOException {
         final int split = object.lastIndexOf('.');
         final String pkg = object.substring(0, Math.max(split, 0));
-        if (split > 0 && completed.add(pkg)) {
+        if (completed.add(pkg)) {
             final String root = "org.eolang.";
             final boolean rooted = object.startsWith(root);
             for (final String sibling : this.objectionary.children(pkg)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -146,8 +146,9 @@ final class Probing implements Step {
         final Path src,
         final Set<String> completed
     ) throws IOException {
-        final int split = object.lastIndexOf('.');
-        final String pkg = object.substring(0, Math.max(split, 0));
+        final String pkg = object.substring(
+            0, Math.max(object.lastIndexOf('.'), 0)
+        );
         if (completed.add(pkg)) {
             final String root = "org.eolang.";
             final boolean rooted = object.startsWith(root);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -8,15 +8,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import org.cactoos.Input;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
 
 /**
  * Test cases for {@link Probing}.
@@ -62,14 +63,15 @@ final class ProbingTest {
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Probe should register tuple.eachi from the same package",
-            tojos.contains("tuple.eachi"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Probe should register tuple.withouti from the same package",
-            tojos.contains("tuple.withouti"),
-            Matchers.is(true)
+            "Probe should register all siblings from the same package",
+            new MapOf<String, Boolean>(
+                new MapEntry<>("tuple.eachi", tojos.contains("tuple.eachi")),
+                new MapEntry<>("tuple.withouti", tojos.contains("tuple.withouti"))
+            ),
+            Matchers.allOf(
+                Matchers.hasEntry("tuple.eachi", true),
+                Matchers.hasEntry("tuple.withouti", true)
+            )
         );
     }
 
@@ -99,14 +101,15 @@ final class ProbingTest {
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Probe should register the probed root object itself",
-            tojos.contains("foo"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Probe should register a sibling from the root package",
-            tojos.contains("bar"),
-            Matchers.is(true)
+            "Probe should register the object and its root-package sibling",
+            new MapOf<String, Boolean>(
+                new MapEntry<>("foo", tojos.contains("foo")),
+                new MapEntry<>("bar", tojos.contains("bar"))
+            ),
+            Matchers.allOf(
+                Matchers.hasEntry("foo", true),
+                Matchers.hasEntry("bar", true)
+            )
         );
     }
 
@@ -126,67 +129,37 @@ final class ProbingTest {
         );
         final TjsForeign tojos = new TjsForeign();
         tojos.add("test").withXmir(xmir);
-        final Collection<String> completions = new ConcurrentLinkedQueue<>();
-        final Objectionary indexed = new OyIndexed(
-            new Objectionary.Fake(),
-            new ObjectsIndex(
-                () -> new SetOf<>("foo", "bar", "baz")
+        final Objectionary observed = Mockito.mock(
+            Objectionary.class,
+            AdditionalAnswers.delegatesTo(
+                new OyIndexed(
+                    new Objectionary.Fake(),
+                    new ObjectsIndex(
+                        () -> new SetOf<>("foo", "bar", "baz")
+                    )
+                )
             )
         );
         new Probing(
             tojos,
-            new Objectionary() {
-                @Override
-                public Input get(final String name) throws IOException {
-                    return indexed.get(name);
-                }
-
-                @Override
-                public boolean contains(final String name) throws IOException {
-                    return indexed.contains(name);
-                }
-
-                @Override
-                public boolean isDirectory(
-                    final String name
-                ) throws IOException {
-                    return indexed.isDirectory(name);
-                }
-
-                @Override
-                public Iterable<String> children(
-                    final String pkg
-                ) throws IOException {
-                    completions.add(pkg);
-                    return indexed.children(pkg);
-                }
-            },
+            observed,
             true
         ).exec();
+        Mockito.verify(observed).children("");
         MatcherAssert.assertThat(
-            "Multiple root probes should complete the root package exactly once",
-            completions,
-            Matchers.contains("")
-        );
-        MatcherAssert.assertThat(
-            "That single completion should still register every root object",
-            tojos.size(),
-            Matchers.is(4)
-        );
-        MatcherAssert.assertThat(
-            "Root object foo should be registered",
-            tojos.contains("foo"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Root object bar should be registered",
-            tojos.contains("bar"),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Root object baz should be registered",
-            tojos.contains("baz"),
-            Matchers.is(true)
+            "A single completion should register every root object",
+            new MapOf<String, Boolean>(
+                new MapEntry<>("all", tojos.size() == 4),
+                new MapEntry<>("foo", tojos.contains("foo")),
+                new MapEntry<>("bar", tojos.contains("bar")),
+                new MapEntry<>("baz", tojos.contains("baz"))
+            ),
+            Matchers.allOf(
+                Matchers.hasEntry("all", true),
+                Matchers.hasEntry("foo", true),
+                Matchers.hasEntry("bar", true),
+                Matchers.hasEntry("baz", true)
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -44,10 +44,96 @@ final class ProbingTest {
     void completesPartiallyProbedPackage(@TempDir final Path temp) throws IOException {
         final TjsForeign tojos = new TjsForeign();
         tojos.add("test").withXmir(this.caller(temp));
-        new Probing(tojos, this.tuples(), true).exec();
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(
+                    () -> new SetOf<>(
+                        "tuple.each",
+                        "tuple.eachi",
+                        "tuple.withouti",
+                        "tuple.nested.object"
+                    )
+                )
+            ),
+            true
+        ).exec();
         MatcherAssert.assertThat(
-            "Probe should have registered the siblings that were never probed directly",
-            tojos.contains("tuple.eachi") && tojos.contains("tuple.withouti"),
+            "Probe should register only direct siblings from the same package",
+            tojos.contains("tuple.eachi")
+                && tojos.contains("tuple.withouti")
+                && !tojos.contains("tuple.nested.object"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void completesRootPackage(@TempDir final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > test",
+                    "  Q.foo > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(
+                    () -> new SetOf<>("foo", "bar", "nested.object")
+                )
+            ),
+            true
+        ).exec();
+        MatcherAssert.assertThat(
+            "Probe should register the root sibling but not a nested object",
+            tojos.contains("foo")
+                && tojos.contains("bar")
+                && !tojos.contains("nested.object"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void completesRootPackageOnce(@TempDir final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > test",
+                    "  Q.foo > first",
+                    "  Q.baz > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(
+                    () -> new SetOf<>("foo", "bar", "baz", "nested.object")
+                )
+            ),
+            true
+        ).exec();
+        MatcherAssert.assertThat(
+            "Multiple root probes should produce one complete root object set",
+            tojos.size() == 4
+                && tojos.contains("foo")
+                && tojos.contains("bar")
+                && tojos.contains("baz"),
             Matchers.is(true)
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -55,8 +55,7 @@ final class ProbingTest {
                     () -> new SetOf<>(
                         "tuple.each",
                         "tuple.eachi",
-                        "tuple.withouti",
-                        "tuple.nested.object"
+                        "tuple.withouti"
                     )
                 )
             ),
@@ -71,11 +70,6 @@ final class ProbingTest {
             "Probe should register tuple.withouti from the same package",
             tojos.contains("tuple.withouti"),
             Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Probe should not register an object from a nested package",
-            tojos.contains("tuple.nested.object"),
-            Matchers.is(false)
         );
     }
 
@@ -99,7 +93,7 @@ final class ProbingTest {
             new OyIndexed(
                 new Objectionary.Fake(),
                 new ObjectsIndex(
-                    () -> new SetOf<>("foo", "bar", "nested.object")
+                    () -> new SetOf<>("foo", "bar")
                 )
             ),
             true
@@ -113,11 +107,6 @@ final class ProbingTest {
             "Probe should register a sibling from the root package",
             tojos.contains("bar"),
             Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Probe should not register an object from a nested package",
-            tojos.contains("nested.object"),
-            Matchers.is(false)
         );
     }
 
@@ -141,7 +130,7 @@ final class ProbingTest {
         final Objectionary indexed = new OyIndexed(
             new Objectionary.Fake(),
             new ObjectsIndex(
-                () -> new SetOf<>("foo", "bar", "baz", "nested.object")
+                () -> new SetOf<>("foo", "bar", "baz")
             )
         );
         new Probing(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.cactoos.Input;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
@@ -60,11 +63,19 @@ final class ProbingTest {
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Probe should register only direct siblings from the same package",
-            tojos.contains("tuple.eachi")
-                && tojos.contains("tuple.withouti")
-                && !tojos.contains("tuple.nested.object"),
+            "Probe should register tuple.eachi from the same package",
+            tojos.contains("tuple.eachi"),
             Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Probe should register tuple.withouti from the same package",
+            tojos.contains("tuple.withouti"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Probe should not register an object from a nested package",
+            tojos.contains("tuple.nested.object"),
+            Matchers.is(false)
         );
     }
 
@@ -94,11 +105,19 @@ final class ProbingTest {
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Probe should register the root sibling but not a nested object",
-            tojos.contains("foo")
-                && tojos.contains("bar")
-                && !tojos.contains("nested.object"),
+            "Probe should register the probed root object itself",
+            tojos.contains("foo"),
             Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Probe should register a sibling from the root package",
+            tojos.contains("bar"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Probe should not register an object from a nested package",
+            tojos.contains("nested.object"),
+            Matchers.is(false)
         );
     }
 
@@ -118,22 +137,66 @@ final class ProbingTest {
         );
         final TjsForeign tojos = new TjsForeign();
         tojos.add("test").withXmir(xmir);
+        final Collection<String> completions = new ConcurrentLinkedQueue<>();
+        final Objectionary indexed = new OyIndexed(
+            new Objectionary.Fake(),
+            new ObjectsIndex(
+                () -> new SetOf<>("foo", "bar", "baz", "nested.object")
+            )
+        );
         new Probing(
             tojos,
-            new OyIndexed(
-                new Objectionary.Fake(),
-                new ObjectsIndex(
-                    () -> new SetOf<>("foo", "bar", "baz", "nested.object")
-                )
-            ),
+            new Objectionary() {
+                @Override
+                public Input get(final String name) throws IOException {
+                    return indexed.get(name);
+                }
+
+                @Override
+                public boolean contains(final String name) throws IOException {
+                    return indexed.contains(name);
+                }
+
+                @Override
+                public boolean isDirectory(
+                    final String name
+                ) throws IOException {
+                    return indexed.isDirectory(name);
+                }
+
+                @Override
+                public Iterable<String> children(
+                    final String pkg
+                ) throws IOException {
+                    completions.add(pkg);
+                    return indexed.children(pkg);
+                }
+            },
             true
         ).exec();
         MatcherAssert.assertThat(
-            "Multiple root probes should produce one complete root object set",
-            tojos.size() == 4
-                && tojos.contains("foo")
-                && tojos.contains("bar")
-                && tojos.contains("baz"),
+            "Multiple root probes should complete the root package exactly once",
+            completions,
+            Matchers.contains("")
+        );
+        MatcherAssert.assertThat(
+            "That single completion should still register every root object",
+            tojos.size(),
+            Matchers.is(4)
+        );
+        MatcherAssert.assertThat(
+            "Root object foo should be registered",
+            tojos.contains("foo"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Root object bar should be registered",
+            tojos.contains("bar"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Root object baz should be registered",
+            tojos.contains("baz"),
             Matchers.is(true)
         );
     }


### PR DESCRIPTION
Derive a package key for every valid probed object: retain the existing substring for qualified names and use the empty string for top-level names. Feed that key through the existing `completed` set and `Objectionary.children(pkg)` loop so root completion has the same per-package de-duplication and tojo registration behavior as nested-package completion. `Probing.complete()` completes the containing package only when a probed object name has a dot. A top-level probe such as `foo` therefore registers `foo` but never asks the objectionary for `children("")`, even though `ObjectsIndex` already defines the empty string as the root package.

Probe a top-level `foo` while the object index contains `foo` and `bar`; verify both the direct probe and root sibling are registered in `TjsForeign`; Probe a qualified object such as `tuple.each`; verify the existing behavior still registers only the direct siblings of `tuple`, preserving nested-package completion.

Fixes #6370
