### PR TITLE
fix(#6303): accept exponent notation in `string.as-number`

### DIFF
--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -19,7 +19,7 @@
     not.
       matches.
         compiled.
-          regex "/^[+-]?\\d+(?:\\.\\d+)?$/"
+          regex "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/"
         text
     cant-parse
       "Can't convert text %s to number".printf
@@ -29,13 +29,25 @@
         at.
           scanf "%f" text
 
+  eq. ++> can-convert-exponent-text
+    1000
+    as-number "1e3"
+
   eq. ++> can-convert-float-text
     3.14
     as-number "3.14"
 
+  eq. ++> can-convert-fractional-exponent-text
+    150
+    as-number "1.5e+2"
+
   eq. ++> can-convert-negative-text
     -42
     as-number "-42"
+
+  eq. ++> can-convert-signed-exponent-text
+    -0.0025
+    as-number "-2.5E-3"
 
   eq. ++> can-convert-text
     5
@@ -61,10 +73,28 @@
       "1 2 3"
       42 > [message]
 
+  eq. ++> rejects-text-with-a-dangling-exponent
+    42
+    as-number
+      "1e"
+      42 > [message]
+
+  eq. ++> rejects-text-with-a-fractional-exponent
+    42
+    as-number
+      "1e2.5"
+      42 > [message]
+
   eq. ++> rejects-text-with-an-embedded-number
     42
     as-number
       "abc5"
+      42 > [message]
+
+  eq. ++> rejects-text-with-an-exponent-and-no-mantissa
+    42
+    as-number
+      "e3"
       42 > [message]
 
   eq. ++> rejects-text-with-multiple-dots

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -5,7 +5,8 @@
 # returns a `org.eolang.tuple` of formatted values (e.g. * "John").
 # Supported formatters are:
 # - %d - parse as integer and convert to `number`
-# - %f - parse as float and convert to `number`
+# - %f - parse as float and convert to `number`, in plain or exponent
+#   notation (e.g. "1e3", "-2.5E-3")
 # - %s - parse as string and convert to `string`.
 
 +architect yegor256@gmail.com
@@ -18,35 +19,60 @@
 [format read] > scanf
   [pattern specifiers] >>
     [text] > as-float
-      negative.if negated magnitude > @
-      index-of unsigned "." > dot
+      negative.if negated scaled > @
+      index-of significand "." > dot
+      if. > exponent
+        marker.eq -1
+        0
+        as-integer
+          slice
+            unsigned
+            marker.plus 1
+            unsigned.length.minus
+              marker.plus 1
       if. > magnitude
         not.
           dot.eq -1
         plus.
           fold-digits
-            slice unsigned 0 dot
+            slice significand 0 dot
           div.
             fold-digits
               slice
-                unsigned
+                significand
                 dot.plus 1
                 places
             10.power places
-        fold-digits unsigned
-      magnitude.times -1 > negated
+        fold-digits significand
+      index-of > marker
+        lower unsigned
+        "e"
+      scaled.times -1 > negated
       eq. > negative
         slice
           text
           0
           1
         "-"
-      unsigned.length.minus > places
+      significand.length.minus > places
         dot.plus 1
+      if. > scaled
+        exponent.lt 0
+        magnitude.div
+          10.power exponent.neg
+        magnitude.times
+          10.power exponent
       negative.or > signed
         eq.
           slice text 0 1
           "+"
+      if. > significand
+        marker.eq -1
+        unsigned
+        slice
+          unsigned
+          0
+          marker
       signed.if > unsigned
         slice
           text
@@ -224,7 +250,7 @@
                 position.plus 1
                 chained *1
                   accumulated
-                  "([+-]?\\d+(?:\\.\\d+)?)"
+                  "([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"
                 found.with "f"
                 false
               if.
@@ -293,6 +319,21 @@
     0.24
     head.
       scanf "%f" "0.24"
+
+  eq. ++> can-scan-a-float-in-exponent-form
+    1000
+    head.
+      scanf "%f" "1e3"
+
+  eq. ++> can-scan-a-float-with-a-negative-exponent
+    -0.0025
+    head.
+      scanf "%f" "-2.5E-3"
+
+  eq. ++> can-scan-a-float-with-a-signed-exponent
+    150
+    head.
+      scanf "%f" "1.5e+2"
 
   eq. ++> can-scan-an-integer
     33


### PR DESCRIPTION
Fixes #6303.

`as-number`'s anchored validator and `scanf`'s `%f` token both rejected `e`/`E`, so `"1e3"` and `"-2.5E-3"` took the `cant-parse` branch. Both are widened in one change, so the validator can't outrun the parser.

Widening the regex alone isn't enough: `as-float` folded the whole match digit by digit, so `'e'` would have counted as 53. It now splits the mantissa from the exponent and scales. A negative exponent divides by `10^|exp|` instead of multiplying by `10^exp` — the multiply path double-rounds and `-2.5E-3` misses `-0.0025`.

Tests: three positive cases per file, plus `"1e"`, `"e3"` and `"1e2.5"` in `as-number` as controls that the widening didn't turn into "accept anything".

🤖 Generated with [Claude Code](https://claude.com/claude-code)