### PR TITLE
#6357: reject magnitudes 2^53 or larger in string.as-decimal

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -13,29 +13,32 @@
     T
       "Can't write a non-finite number as decimal"
     if.
-      n.lt 0
-      if. > [m] >> negative
-        m.floor.eq 0
-        digits m
-        "-".as-bytes.concat
+      n.abs.gte 9007199254740992
+      T
+        "Can't write this number as decimal digits exactly: its magnitude is 2^53 or larger, past the largest integer a double can hold exactly"
+      if.
+        n.lt 0
+        if. > [m] >> negative
+          m.floor.eq 0
           digits m
-      | (n.times -1)
-      [n] >> digits
-        if. > @
-          n.lt 10
-          as-char
-            n.floor.plus 48
-          concat.
-            digits q
+          "-".as-bytes.concat
+            digits m
+        | (n.times -1)
+        [n] >> digits
+          if. > @
+            n.lt 10
             as-char
-              plus.
-                floor.
-                  n.minus
-                    q.times 10
-                48
-        floor. > q
-          n.div 10
-      | n
+              n.floor.plus 48
+            concat.
+              digits q
+              as-char
+                plus.
+                  floor.
+                    n.minus (q.times 10)
+                  48
+          floor. > q
+            n.div 10
+        | n
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"
@@ -77,10 +80,19 @@
     string
       as-decimal 7
 
+  eq. ++> can-write-the-largest-exactly-representable-magnitude
+    "9007199254740991"
+    string
+      as-decimal 9007199254740991
+
   eq. ++> can-write-zero
     "0"
     string
       as-decimal 0
+
+  as-decimal 9007199254740992 --> stops-on-a-magnitude-of-two-to-the-53rd
+
+  as-decimal 1.0e30 --> stops-on-a-magnitude-too-large-to-represent-exactly
 
   as-decimal nan --> stops-on-nan
 


### PR DESCRIPTION
Fixes #6357.

as-decimal computes each decimal digit as floor(n - floor(n/10)*10), one division at a time. A double only holds integers exactly up to 2^53; past that, rounding error in this loop can push a single "digit" outside [0, 9], and as-char then writes that out-of-range value as a raw byte, producing an invalid non-UTF-8 string (confirmed: as-decimal 1e30 emits a stray 0xB0 byte instead of a digit).

Added a magnitude guard: n.abs.gte 9007199254740992 (2^53) now fails with a clear domain-error message instead of silently emitting corrupted output. 2^53 is the largest integer a double represents exactly, so it's the natural, non-arbitrary cutoff rather than a guessed threshold.

Added 3 EO tests: the largest value the guard still allows (2^53 - 1, checked against its correct digit string), the smallest value it now rejects (2^53 exactly), and the originally reported 1e30.
