### PR TITLE
#6354: agree on part[1] for a multi-part +package meta in set-locators.xsl

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
@@ -33,7 +33,7 @@
           <xsl:value-of select="$eo:program"/>
           <xsl:if test="root($o)/object/metas/meta[head='package']">
             <xsl:text>.</xsl:text>
-            <xsl:value-of select="root($o)/object/metas/meta[head='package']/tail"/>
+            <xsl:value-of select="root($o)/object/metas/meta[head='package']/part[1]"/>
           </xsl:if>
         </xsl:otherwise>
       </xsl:choose>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-part-package-meta-picks-first-part-consistently.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-part-package-meta-picks-first-part-consistently.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='app' and @loc='Φ.foo.app']
+input: |
+  +package foo bar
+
+  [] > app
+    42 > x


### PR DESCRIPTION
Closes #6354.

set-locators.xsl read +package as the whole tail text (e.g. "foo bar" for +package foo bar), while add-default-package.xsl and build-fqns.xsl already read only part[1] ("foo"). With a multi-part +package this produced a locator with an embedded space (Φ.foo bar.app), which fails XMIR.xsd validation.

Changed set-locators.xsl to part[1] so all three sheets agree on the same interpretation, matching what two of the three already did.

Added a declarative YAML test (multi-part-package-meta-picks-first-part-consistently.yaml) with +package foo bar, asserting @loc equals Φ.foo.app with no space. Verified manually: fails without the fix, passes with it.
