### PR TITLE
#6226: reduce ln in bounded steps instead of one factor of e at a time

### DIFF
--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -1,8 +1,10 @@
 # Natural logarithm of `num` with base `e` as `org.eolang.number`. The argument
-# is folded into [1/e, e] by peeling whole factors of `e` and counting them,
-# then the remainder is summed with the area-hyperbolic-tangent series. The
-# limiting cases follow the usual conventions: zero is negative infinity, a
-# negative number and negative infinity are nan, and positive infinity stays.
+# is folded into [1/e, e] by peeling powers of `e` that double at each step
+# (e, e^2, e^4, ..., e^512), so the depth is bounded regardless of how large
+# the argument is, then the remainder is summed with the area-hyperbolic-
+# tangent series. The limiting cases follow the usual conventions: zero is
+# negative infinity, a negative number and negative infinity are nan, and
+# positive infinity stays.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -26,18 +28,50 @@
   [p] > lnp
     if. > @
       p.gte e
-      plus.
-        lnp
-          p.div e
-        1
+      climb 9 p
       if.
         p.lt
           1.div e
-        minus.
-          lnp
-            p.times e
-          1
+        descend 9 p
         series p
+    if. > [level p] > climb
+      level.lt 0
+      series p
+      if.
+        p.gte
+          epow level
+        plus.
+          climb
+            level.minus 1
+            p.div
+              epow level
+          step level
+        climb
+          level.minus 1
+          p
+    if. > [level p] > descend
+      level.lt 0
+      series p
+      if.
+        p.lt
+          1.div
+            epow level
+        minus.
+          descend
+            level.minus 1
+            p.times
+              epow level
+          step level
+        descend
+          level.minus 1
+          p
+    [level] > epow
+      if. > @
+        level.eq 0
+        e
+        prev.times prev
+      epow > prev
+        level.minus 1
     [m] > series
       2.times > @
         t.times
@@ -57,6 +91,13 @@
       div. > t
         m.minus 1
         m.plus 1
+    [level] > step
+      if. > @
+        level.eq 0
+        1
+        prev.plus prev
+      step > prev
+        level.minus 1
   number num.as-bytes > n
 
   lt. ++> can-stay-monotonic
@@ -69,6 +110,20 @@
         ln 0.5
         -0.6931471805599453
     1.0E-11
+
+  lt. ++> can-take-a-logarithm-of-a-very-large-number-without-overflowing-the-stack
+    abs
+      minus.
+        ln 1.0e300
+        690.7755278982137
+    1.0E-9
+
+  lt. ++> can-take-a-logarithm-of-a-very-small-fraction-without-overflowing-the-stack
+    abs
+      minus.
+        ln 1.0E-300
+        -690.7755278982137
+    1.0E-9
 
   eq. ++> can-take-a-logarithm-of-e
     ln e


### PR DESCRIPTION
Closes #6226.

ln folded the argument into [1/e, e] by peeling ONE factor of e per recursion level: depth grew as O(ln p), about 115 for 1e50, 230 for 1e100, 690 for 1e300. sqrt and fractional power route through ln, so they overflowed the stack on the same inputs.

Replaced the peeling with a ladder of doubling powers of e (e, e^2, e^4, ..., e^512), tested from the largest down. Starting from a high enough level (9, i.e. e^512, which covers the whole finite double range) guarantees exactly one peel per level, so the recursion depth is a fixed ~10 regardless of how large the argument is.

epow/step compute powers of e and powers of 2 through their own bounded squaring/doubling recursion (also ~10 levels), not literal constants.

Added tests at 1e300 and 1e-300 (the magnitudes from the issue), checked against Math.log to within 1e-9.
