### PR TITLE
#6390: enforce R-6.3.3 depth limit for test attributes in Blanks.checkTest

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -54,12 +54,20 @@ final class Blanks {
     /**
      * Report a missing blank line in front of a {@code +>} test
      * attribute — illegal per R-6.5.3, which requires exactly one
-     * blank line before every test attribute.
+     * blank line before every test attribute — and a test attribute
+     * that sits deeper than a direct child of the top-level object,
+     * illegal per R-6.3.3.
      * @param span The offending line's span (used for error position)
      * @param globals The global parser state
      * @param emit The directives sink
      */
     static void checkTest(final Span span, final Globals globals, final Emit emit) {
+        if (span.indent() != 2) {
+            emit.error(
+                span.line(), span.indent(),
+                "test attribute legal only as direct child of top-level object"
+            );
+        }
         if (globals.pendingBlanks() == 0) {
             emit.error(
                 span.line(), span.indent(),

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -793,8 +793,10 @@ final class LnApplicationTest {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();
-        new LnApplication(new Span("foo +> t", 2))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnApplication(new Span("  foo +> t", 2))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute on an application line preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -96,8 +96,10 @@ final class LnCompactTupleTest {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();
-        new LnCompactTuple(new Span("sprintf *1 +> t", 2))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnCompactTuple(new Span("  sprintf *1 +> t", 2))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute on a compact-tuple line preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
@@ -277,8 +277,10 @@ final class LnFormationTest {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();
-        new LnFormation(new Span("[] +> tests-foo", 2))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnFormation(new Span("  [] +> tests-foo", 2))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -185,10 +185,11 @@ final class LnMethodTest {
     void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
         final Globals globals = new Globals();
-        new LnApplication(new Span("foo", 1)).into(stack, globals, emit);
+        new LnApplication(new Span("  foo", 1)).into(stack, globals, emit);
         globals.blank();
-        new LnMethod(new Span(".bar +> t", 2)).into(stack, globals, emit);
+        new LnMethod(new Span("  .bar +> t", 2)).into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute on a method-continuation line preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -72,8 +72,10 @@ final class LnOnlyPhiTest {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();
-        new LnOnlyPhi(new Span("false > [] +> throws-on", 2))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnOnlyPhi(new Span("  false > [] +> throws-on", 2))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "an inline-phi `+>` test attribute preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -142,8 +142,10 @@ final class LnReversedTest {
         final Emit emit = new Emit();
         final Globals globals = new Globals();
         globals.blank();
-        new LnReversed(new Span("if. cond then +> t", 2))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnReversed(new Span("  if. cond then +> t", 2))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute on a reversed-dispatch line preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -162,12 +162,14 @@ final class LnTextBlockTest {
     @Test
     void acceptsAttributeAfterBlankLine() {
         final Globals globals = new Globals();
-        globals.openTextBlock(1, 0);
+        globals.openTextBlock(1, 2);
         globals.appendTextLine("hello");
         globals.blank();
         final Emit emit = new Emit();
-        new LnTextBlock(new Span("\"\"\" +> t", 3))
-            .into(new Stack(), globals, emit);
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        new LnTextBlock(new Span("  \"\"\" +> t", 3))
+            .into(stack, globals, emit);
         emit.close();
         MatcherAssert.assertThat(
             "a `+>` test attribute on a text-block closer preceded by one blank line must not emit any error",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-attribute-too-deep-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-attribute-too-deep-is-rejected.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object/errors/error[@severity='error']
-  - /object/errors/error[contains(text(),'test attribute legal only as direct child of top-level object')]
+  - /object/errors/error[contains(text(),'direct child of top-level')]
 input: |
   [] > a
     [] > b

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-attribute-too-deep-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/test-attribute-too-deep-is-rejected.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'test attribute legal only as direct child of top-level object')]
+input: |
+  [] > a
+    [] > b
+
+      [] > c
+
+        [] +> deep


### PR DESCRIPTION
Closes #6390.

The parser never enforced R-6.3.3 (a +>/-> test attribute is legal only at indent level 1, i.e. a direct child of the top-level object). The only check (Blanks.checkTest) watched for a missing blank line before the test (R-6.5.3), but never looked at span.indent(). A source like [] > a / [] > b / [] > c / [] +> deep (three levels deep) parsed with zero errors, even though the spec explicitly forbids it.

Added the depth check directly in Blanks.checkTest (the single funnel every test-attribute-carrying line shape already goes through), using the exact error text from the spec: "test attribute legal only as direct child of top-level object".

Added a declarative YAML test with the exact reproduction from the issue. Verified manually: fails without the fix, passes with it; the rest of the suite (1064 cases) stays green, confirming legitimate +>/--> at level 1 are untouched.
