### PR TITLE
#6316: declare opentest4j and sisu.plexus explicitly for qulice classpath

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -121,6 +121,19 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!--
+      Provides ComponentSetDescriptor, the superclass of MjSafe's
+      PluginDescriptor field. maven-core brings it in transitively, but
+      qulice resolves its Checkstyle/PMD type-checking classpath from
+      directly declared dependencies only (#6316), so it must be
+      declared explicitly here too.
+      -->
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>3.15.2</version>
@@ -178,6 +191,11 @@
     <dependency>
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
+    <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
       <!-- version from parent POM -->
     </dependency>
     <dependency>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Objectionary.java
@@ -77,10 +77,7 @@ interface Objectionary {
         Fake() {
             this(
                 s -> new InputOf(
-                    String.join(
-                        System.lineSeparator(),
-                        "[] > sprintf".concat(System.lineSeparator())
-                    )
+                    "[] > sprintf".concat(System.lineSeparator())
                 )
             );
         }

--- a/eo-parser/pom.xml
+++ b/eo-parser/pom.xml
@@ -95,6 +95,11 @@
       <!-- version from parent POM -->
     </dependency>
     <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <!-- version from parent POM -->

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -84,10 +84,7 @@ final class EoSyntaxTest {
         try {
             Assertions.assertDoesNotThrow(
                 new EoSyntax(
-                    String.join(
-                        System.lineSeparator(),
-                        "[] > x-н, 1".concat(System.lineSeparator())
-                    )
+                    "[] > x-н, 1".concat(System.lineSeparator())
                 )::parsed,
                 "EO syntax should not fail in debug mode when program has errors"
             );
@@ -123,10 +120,7 @@ final class EoSyntaxTest {
 
     @Test
     void printsProperListingEvenWhenSyntaxIsBroken() throws Exception {
-        final String src = String.join(
-            System.lineSeparator(),
-            "[] > x-н, 1".concat(System.lineSeparator())
-        );
+        final String src = "[] > x-н, 1".concat(System.lineSeparator());
         MatcherAssert.assertThat(
             "EO syntax is broken, but listing should be printed",
             XhtmlMatchers.xhtml(
@@ -530,10 +524,7 @@ final class EoSyntaxTest {
                 new String(
                     new EoSyntax(
                         new InputOf(
-                            String.join(
-                                System.lineSeparator(),
-                                "[] > foo🌵bar".concat(System.lineSeparator())
-                            )
+                            "[] > foo🌵bar".concat(System.lineSeparator())
                         )
                     ).parsed().toString().getBytes(StandardCharsets.UTF_8),
                     StandardCharsets.UTF_8

--- a/eo-printer/pom.xml
+++ b/eo-printer/pom.xml
@@ -82,6 +82,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <!-- version from parent POM -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <!-- version from parent POM -->

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,19 @@
       </dependency>
       <dependency>
         <!--
+        junit-jupiter's Assumptions.assumeTrue(...) throws this; it is
+        already on the classpath transitively, but qulice resolves its
+        Checkstyle/PMD type-checking classpath from directly declared
+        dependencies only (since the 0.29.0 upgrade), so it must be
+        declared explicitly here too (#6316).
+        -->
+        <groupId>org.opentest4j</groupId>
+        <artifactId>opentest4j</artifactId>
+        <version>1.3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <!--
         We don't use this dependency anywhere in the code. It must
         be removed in future releases. Try to remove it as soon as possible.
         -->


### PR DESCRIPTION
Closes #6316.

Since the qulice 0.29.0 upgrade, it resolves the classpath for Checkstyle/PMD/ErrorProne type-checking from directly declared dependencies only, not transitive ones. opentest4j (needed for Assumptions.assumeTrue, used in EoSyntaxTest/XmirTest/MjTranspileTest) and org.eclipse.sisu.plexus (provides ComponentSetDescriptor, the superclass of PluginDescriptor in MjSafe.java) are still available transitively, but were not resolvable for qulice, so the whole check failed deterministically.

Declared opentest4j explicitly (test scope) in eo-parser, eo-printer and eo-maven-plugin, and org.eclipse.sisu.plexus (provided scope, the version already resolved transitively) in eo-maven-plugin.

Side effect: while these types could not be resolved, ErrorProne could not fully analyze several files and stayed silent about real bugs in them. With the fix, 4 no-op String.join(separator, singleElement) calls surfaced (single-element String.join performs no joining, it just returns the argument unchanged) - 3 in EoSyntaxTest.java, 1 in Objectionary.java. Removed the redundant wrapper in all four, keeping the direct expression, matching ErrorProne's own suggested fix.

Verified manually: qulice is now clean on all three modules, EoSyntaxTest and OyIndexedTest (which uses the affected Objectionary.Fake) pass.
