### PR TITLE
#6423: apply recovery to tab and odd-indent lines like any other rejected line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -24,10 +24,6 @@ import org.xembly.Directive;
  * with no parser-grammar dependency: classification, validation, and
  * emission all happen here against the spec rules directly.</p>
  *
- * <p>The classifier in this initial implementation covers the three
- * trivial line shapes — blank, comment, meta. Other shapes from §3.1
- * fall through to a placeholder error pending later additions.</p>
- *
  * @since 0.1
  */
 final class Eo implements Iterable<Directive> {
@@ -312,8 +308,10 @@ final class Eo implements Iterable<Directive> {
             Eo.continueTextBlock(span, stack, globals, emit);
         } else if (span.tab()) {
             emit.error(span.line(), 0, "tab character in leading whitespace");
+            failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");
+            failed = true;
         } else if (Eo.opensTextBlock(span)) {
             globals.openTextBlock(span.line(), span.indent());
             globals.markEmitted();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-odd-indent.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-odd-indent.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'unexpected odd indent')]
+input: |
+  [] > example
+   [] > bad
+     one > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-tab.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-tab.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'tab character')]
+input: "[] > example\n\t[] > bad\n    one > x\n"


### PR DESCRIPTION
Closes #6423.

Eo.process handled a tab-character or odd-indent line differently from every other rejected line: only the Eo.dispatch branch (a real ParseError) set failed = true. The tab() and odd-indent branches called emit.error(...) directly and left failed at false. In the main loop, recovery.after(idx) only runs when failed is true, so the block nested under a tab or odd-indent line was not skipped, unlike every other kind of rejected line. This contradicts the class's own documented contract ("the block nested under the failed line is skipped") and PARSER_SPEC.md section 7.

Added failed = true to both branches, routing them through the same recovery path as ParseError.

Added two declarative YAML tests (a tab-indented line and an odd-indent line, each with one nested child), asserting count(error)=1 - no cascade. Also removed a stale class-level javadoc paragraph claiming the parser "covers the three trivial line shapes", long untrue given the file's current size - needed to fit under the 1000-line FileLengthCheck limit.
