### PR TITLE
Skip the benchmark comment when the benchmark run did not succeed

### DIFF
--- a/.github/workflows/post-comment.yml
+++ b/.github/workflows/post-comment.yml
@@ -10,13 +10,10 @@ name: Post Benchmark Comment
       - completed
 jobs:
   post-comment:
+    if: github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - name: Download PR Number and Benchmark Comment
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The `post-comment` job listens for every `completed` event of `Performance Regression Check`, whatever that run concluded with. A benchmark run that fails or exceeds its 15-minute timeout uploads no artifacts, so `actions/download-artifact` reports `Found 0 artifact(s)` and exits happily with an empty workspace. The next step then runs `cat pr-number/pr-number`, exits 1, and `Post Benchmark Comment` goes red on master for a reason that has nothing to do with the pull request being measured.

Run 31176478059 is the clearest example: its trigger, run 31175425819, hit the 15-minute limit, the download logged `Total of 0 artifact(s) downloaded`, and the job died on `cat: pr-number/pr-number: No such file or directory`. Thirteen of the last hundred runs of this workflow failed, and every one that was not a GitHub outage failed exactly this way.

Guarding the job with `if: github.event.workflow_run.conclusion == 'success'` lets it skip quietly when there is nothing to download, which is what GitHub documents for `workflow_run` listeners. A benchmark that produced no numbers has no comment to post.

The same commit drops the `Dump GitHub context` step. It echoed the whole `github` object into the log on every run, which is debug output that no longer earns its place now that the failure mode it was there to explain is fixed.

Worth noting separately: the 15-minute timeout on `Performance Regression Check` is what those runs keep hitting, and this change makes that quieter rather than solving it.
