### PR TITLE
fix(#6427): hand the trailing blank back to the walk

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -17,6 +17,17 @@ import java.util.List;
  * back at or above the indent of the one that failed. A blank line
  * carries no indent of its own and never ends the skipped block.</p>
  *
+ * <p>The blanks trailing the block are handed back, though. A blank
+ * standing between the last skipped line and the line the walk resumes
+ * at separates two objects instead of sitting inside either, and §6.5
+ * reads its rules off exactly such separators — R-6.5.4 forbids one in
+ * front of a plain object. Swallowing it would drop that diagnostic
+ * from whatever follows the failed block, since the line never reaches
+ * the blank-line bookkeeping. Blanks with skipped lines still under
+ * them are nested and stay skipped, and a block running to the end of
+ * the file keeps its trailing blanks, no object being left for them to
+ * separate.</p>
+ *
  * @since 0.1
  */
 final class Recovery {
@@ -45,6 +56,24 @@ final class Recovery {
         int idx = failed + 1;
         while (idx < this.spans.size() && this.skipped(idx, indent)) {
             idx = idx + 1;
+        }
+        if (idx < this.spans.size()) {
+            idx = this.rewound(idx, failed);
+        }
+        return idx;
+    }
+
+    /**
+     * Step back over the run of blank lines trailing the skipped block,
+     * so the walk meets them again as the separators they are.
+     * @param stop Index the skip stopped at
+     * @param failed Index of the line that failed to parse
+     * @return Index of the first blank of the trailing run
+     */
+    private int rewound(final int stop, final int failed) {
+        int idx = stop;
+        while (idx - 1 > failed && this.spans.get(idx - 1).blank()) {
+            idx = idx - 1;
         }
         return idx;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
@@ -32,6 +32,37 @@ final class RecoveryTest {
     }
 
     @Test
+    void resumesAtBlankSeparatingSibling() {
+        MatcherAssert.assertThat(
+            "the blank separating the failed block from the next object must be handed back",
+            new Recovery(
+                Arrays.asList(
+                    new Span("  bad!!!", 1),
+                    new Span("    child", 2),
+                    new Span("", 3),
+                    new Span("next", 4)
+                )
+            ).after(0),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void skipsBlanksTrailingBlockAtEndOfFile() {
+        MatcherAssert.assertThat(
+            "blanks with no object left below them separate nothing and stay skipped",
+            new Recovery(
+                Arrays.asList(
+                    new Span("bad!!!", 1),
+                    new Span("  child", 2),
+                    new Span("", 3)
+                )
+            ).after(0),
+            Matchers.equalTo(3)
+        );
+    }
+
+    @Test
     void skipsBlankLineInsideBlock() {
         MatcherAssert.assertThat(
             "a blank line inside the block of a failed line must not resume the walk",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-keeps-blank-before-next-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-keeps-blank-before-next-object.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=2]
+  - /object/errors/error[contains(text(),'expected identifier')]
+  - /object/errors/error[contains(text(),'R-6.5.4')]
+input: |
+  # Sample.
+
+  [] > app
+    x..y > z
+
+    42 > w


### PR DESCRIPTION
Recovery swallowed the blank that separates a failed line's block from the object below it, so the blank never reached Globals and R-6.5.4 went unreported on that object. 

The skip now stops at the last non-blank line it covers, unless the block runs to the end of the file.

Closes #6427 