### PR TITLE
#6449: reject a negative size in posix and win32 read

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -7,6 +7,7 @@ package org.eolang.posix;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,6 +33,12 @@ public final class ReadSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure(
+                "Can't read a negative number of bytes '%d'",
+                size
+            );
+        }
         final Phi result = this.posix.take("return").copy();
         final byte[] buf = new byte[size];
         final int count = CStdLib.INSTANCE.read(

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,6 +33,12 @@ public final class ReadFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure(
+                "Can't read a negative number of bytes '%d'",
+                size
+            );
+        }
         final byte[] buf = new byte[size];
         final int count = Msvcrt.INSTANCE._read(
             new Dataized(params[0]).asNumber().intValue(), buf, size

--- a/eo-runtime/src/test/java/org/eolang/ReadSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ReadSyscallTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.eolang.posix.ReadSyscall;
+import org.eolang.win32.ReadFuncCall;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@code read} system calls.
+ * @since 0.40.0
+ */
+final class ReadSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsNegativeSizeOnPosixRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(-7)
+            ),
+            "A negative posix read size must fail with ExFailure, not NegativeArraySizeException"
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsNegativeSizeOnWindowsRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(-7)
+            ),
+            "A negative win32 read size must fail with ExFailure, not NegativeArraySizeException"
+        );
+    }
+}


### PR DESCRIPTION
@yegor256 please review.

Closes #6449.

`posix.read` and `win32.read` allocated `new byte[size]` before validating it, so a negative EO argument escaped as `NegativeArraySizeException`. Both adapters now fail with `ExFailure` before allocating, like `WriteSyscall`/`SendSyscall` already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)