### PR TITLE
#6407: raise eo-runtime test method timeout from 10m to 20m

### DIFF
--- a/eo-runtime/src/test/resources/junit-platform.properties
+++ b/eo-runtime/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 
-junit.jupiter.execution.timeout.test.method.default = 10m
+junit.jupiter.execution.timeout.test.method.default = 20m


### PR DESCRIPTION
Closes #6407.

EOdirectoryTest and EO_directory.EOdeletedTest methods already run close to the 10-minute ceiling on green runs (up to 774.6s observed on macos-15-intel). Any slow runner crosses it and fails master with a timeout, not a real assertion failure.

Raised junit.jupiter.execution.timeout.test.method.default from 10m to 20m in eo-runtime/src/test/resources/junit-platform.properties. This is a global default (JUnit5 config properties do not support per-class overrides), so it also gives more headroom to the rest of the suite, not just these two classes.

No new test: this is a CI-stability config change, nothing new to assert against.
