### PR TITLE
#6426: run recovery for a rejected multi-line BYTES literal

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -76,8 +76,7 @@ final class Eo implements Iterable<Directive> {
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
             if (!globals.inTextBlock() && Eo.isBytesContinuation(span.body())) {
-                final int next = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit);
-                idx = next;
+                idx = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit, recovery);
             } else if (Eo.process(span, stack, globals, emit)) {
                 idx = recovery.after(idx);
             } else {
@@ -200,12 +199,13 @@ final class Eo implements Iterable<Directive> {
      * @param stack Indent stack
      * @param globals Global parser state
      * @param emit Directives sink
-     * @return Next index to process (past the merged region)
+     * @param recovery Where the walk resumes if the merged line fails
+     * @return Next index to process
      * @checkstyle ParameterNumberCheck (3 lines)
      */
     private static int mergeBytesContinuation(
-        final java.util.List<Span> spans, final int start,
-        final Stack stack, final Globals globals, final Emit emit
+        final java.util.List<Span> spans, final int start, final Stack stack,
+        final Globals globals, final Emit emit, final Recovery recovery
     ) {
         final Span head = spans.get(start);
         final StringBuilder body = new StringBuilder(head.body());
@@ -221,13 +221,16 @@ final class Eo implements Iterable<Directive> {
                 break;
             }
         }
-        Eo.process(
-            new Span(
-                " ".repeat(head.indent()).concat(body.toString()), head.line()
-            ),
+        final int resumption;
+        if (Eo.process(
+            new Span(" ".repeat(head.indent()).concat(body.toString()), head.line()),
             stack, globals, emit
-        );
-        return idx;
+        )) {
+            resumption = recovery.skip(idx, head.indent());
+        } else {
+            resumption = idx;
+        }
+        return resumption;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -41,8 +41,23 @@ final class Recovery {
      * @return Index of the resumption point
      */
     int after(final int failed) {
-        final int indent = this.spans.get(failed).indent();
-        int idx = failed + 1;
+        return this.skip(failed + 1, this.spans.get(failed).indent());
+    }
+
+    /**
+     * The index the walk resumes at, skipping forward from {@code from}
+     * while a line still belongs to the block of a line at {@code indent}.
+     * Unlike {@link #after(int)}, the scan start and the reference indent
+     * are given separately — needed when the failed line's own index does
+     * not carry its indent (e.g. a merged multi-line literal, where the
+     * block belongs to the head line but scanning must start past every
+     * already-merged continuation line).
+     * @param from Index to start scanning from
+     * @param indent Indent of the line whose block is being skipped
+     * @return Index of the resumption point
+     */
+    int skip(final int from, final int indent) {
+        int idx = from;
         while (idx < this.spans.size() && this.skipped(idx, indent)) {
             idx = idx + 1;
         }

--- a/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
@@ -47,4 +47,21 @@ final class RecoveryTest {
             Matchers.equalTo(4)
         );
     }
+
+    @Test
+    void skipsFromAnIndexOtherThanTheFailedLineItself() {
+        MatcherAssert.assertThat(
+            "skip must scan from the given index using the given indent, "
+                .concat("not the indent of the line at that index"),
+            new Recovery(
+                Arrays.asList(
+                    new Span("01-02-", 1),
+                    new Span("03-04", 2),
+                    new Span("  child", 3),
+                    new Span("sibling", 4)
+                )
+            ).skip(2, 0),
+            Matchers.equalTo(3)
+        );
+    }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-bytes-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-skips-nested-block-after-bytes-continuation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'indent increased by more than one level')]
+input: |
+  # Sample.
+
+  [] > app
+        01-02-
+          q.


### PR DESCRIPTION
Closes #6426.

mergeBytesContinuation dispatches the merged multi-line BYTES literal through Eo.process but discarded the return value, so a rejected literal never called recovery.after, unlike every other call site in Eo.directives(). Any block nested under the rejected literal produced a spurious second error instead of being skipped per PARSER_SPEC.md section 7.

Recovery.after(failed) derived both the scan start and the reference indent from the same span index, which does not fit this call site: the reference indent belongs to the head line, but the scan must start past the continuation lines the merge already consumed. Added Recovery.skip(from, indent) as the decoupled primitive, rebuilt after(int) on top of it, and used skip directly in mergeBytesContinuation.

Added a yaml pack test (recovery-skips-nested-block-after-bytes-continuation.yaml) reproducing the issue's case A, and a direct unit test for Recovery.skip in RecoveryTest. Verified both fail on the pre-fix code and pass with the fix.
