### PR TITLE
#6425: give Eo.dispatch's rollback a real way to undo Stack.replace

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -341,12 +341,12 @@ final class Eo implements Iterable<Directive> {
         if (Eo.closesTextBlock(span, globals)) {
             stack.popDeeperThan(span.indent());
             final int tstartsen = emit.savepoint();
-            final int frame = stack.size();
+            final java.util.List<Level> frame = stack.snapshot();
             try {
                 new LnTextBlock(span).into(stack, globals, emit);
             } catch (final ParseError err) {
                 emit.rollback(tstartsen);
-                stack.silentTruncate(frame);
+                stack.restore(frame);
                 emit.error(err.line(), err.pos(), err.getMessage());
                 globals.closeTextBlock();
             }
@@ -409,13 +409,13 @@ final class Eo implements Iterable<Directive> {
             stack.popDeeperThan(span.indent());
         }
         final int tstartsen = emit.savepoint();
-        final int frame = stack.size();
+        final java.util.List<Level> frame = stack.snapshot();
         boolean failed = false;
         try {
             Eo.classify(span).into(stack, globals, emit);
         } catch (final ParseError err) {
             emit.rollback(tstartsen);
-            stack.silentTruncate(frame);
+            stack.restore(frame);
             emit.error(err.line(), err.pos(), err.getMessage());
             failed = true;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -73,7 +73,7 @@ final class Recovery {
             idx = idx + 1;
         }
         if (idx < this.spans.size()) {
-            idx = this.rewound(idx, failed);
+            idx = this.rewound(idx, from - 1);
         }
         return idx;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -108,26 +108,30 @@ final class Stack {
     }
 
     /**
-     * Current number of entries on the stack — savepoint for per-line
-     * rollback (R-7.3).
-     * @return Entry count
+     * A copy of the current levels — savepoint for per-line rollback
+     * (R-7.3). A plain entry count cannot serve as that savepoint:
+     * {@link #replace(int, Kind, Openness)} removes one entry and adds
+     * one back, so the count is unchanged even though the top entry
+     * itself is a different object. Snapshotting the entries themselves
+     * survives that case.
+     * @return Snapshot of the levels, bottom-to-top
      */
-    int size() {
-        return this.levels.size();
+    List<Level> snapshot() {
+        return new ArrayList<>(this.levels);
     }
 
     /**
-     * Pop entries silently until {@code size()} equals {@code target}.
-     * Used by {@link Eo} to undo {@link #push} / {@link #replace} side
-     * effects of a line that threw a {@link ParseError} (R-7.3) — the
-     * closer is <em>not</em> invoked here because the rolled-back open
-     * directives never reached the sink.
-     * @param target Target stack size
+     * Restore the levels to a previously taken {@link #snapshot()},
+     * discarding whatever {@link #push} / {@link #replace} side effects
+     * happened since. Used by {@link Eo} to undo those side effects for
+     * a line that threw a {@link ParseError} (R-7.3) — the closer is
+     * <em>not</em> invoked here because the rolled-back open directives
+     * never reached the sink.
+     * @param snapshot A snapshot taken earlier via {@link #snapshot()}
      */
-    void silentTruncate(final int target) {
-        while (this.levels.size() > target) {
-            this.levels.remove(this.levels.size() - 1);
-        }
+    void restore(final List<Level> snapshot) {
+        this.levels.clear();
+        this.levels.addAll(snapshot);
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -201,7 +201,7 @@ final class StackTest {
     }
 
     @Test
-    void restoreReinstatesTheEntryDisplacedByReplace() {
+    void reinstatesTheEntryDisplacedByReplaceOnRestore() {
         final Stack stack = new Stack();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
         final Level displaced = stack.push(2, 2, Kind.HEAD, Openness.OPEN);

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -200,6 +200,22 @@ final class StackTest {
         );
     }
 
+    @Test
+    void restoreReinstatesTheEntryDisplacedByReplace() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        final Level displaced = stack.push(2, 2, Kind.HEAD, Openness.OPEN);
+        final List<Level> snapshot = stack.snapshot();
+        stack.replace(3, Kind.COMPACT_TUPLE, Openness.OPEN);
+        stack.restore(snapshot);
+        MatcherAssert.assertThat(
+            "restore must bring back the exact entry replace displaced"
+                .concat(", not merely one at the same indent"),
+            stack.top(),
+            Matchers.sameInstance(displaced)
+        );
+    }
+
     /**
      * Trigger the first-push-at-non-zero-indent violation and capture it.
      * @return The thrown error

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-level-rollback-does-not-crash.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-level-rollback-does-not-crash.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'invalid unicode or octal escape')]
+input: |
+  [] > pl
+    b > child
+      "x"
+      "r\c" > [m]


### PR DESCRIPTION
Closes #6425.

Eo.dispatch recovers from a ParseError with emit.rollback(savepoint) + stack.silentTruncate(frame), where frame was stack.size() taken before the line ran. That assumes a failed line's only stack side effect is a net change in entry count. push fits that assumption; replace does not, since it removes the old top and pushes a new one at the same indent, leaving size() unchanged even though the top is now a different Level. silentTruncate was then a no-op: the replacement level stayed on the stack with no matching directives in the rolled-back emit stream, so its own eventual close overshot or undershot the sink's cursor, producing the reported ClassCastException or schema-invalid XMIR depending on which way the owed-close count differed between the two kinds.

Replaced the size-based savepoint with Stack.snapshot()/restore(), which capture and reinstate the actual Level list by identity, so a replace's rollback puts the original Level back instead of leaving the replacement in place. size() and silentTruncate had no other callers, so removed rather than left dead.

Added a yaml pack test (replaced-level-rollback-does-not-crash.yaml) using the issue's own minimal repro, and a direct unit test in StackTest asserting restore() reinstates the exact Level replace displaced (by identity, not just by indent). Verified both fail with the reported ClassCastException on the pre-fix code and pass with the fix.
