### PR TITLE
Write down what every object is asked for

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Clues.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Clues.java
@@ -6,8 +6,8 @@ package org.eolang.inference;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Every clue the checker knows how to follow.
@@ -26,9 +26,21 @@ import java.util.Collections;
  *
  * <p>Three clues are planned, one per kind of object, and each fills a
  * table of its own: what an object certainly has ({@link Provides}), what
- * it must have judging by how it is used, and which types are copies of
- * which. Keeping the tables apart is what lets a smarter rule add rows,
- * or read them differently, without touching anything else.</p>
+ * it must have judging by how it is used ({@link Needs}), and which types
+ * are copies of which. Keeping the tables apart is what lets a smarter
+ * rule add rows, or read them differently, without touching anything
+ * else.</p>
+ *
+ * <p>Every clue reads the program as text, writing a row for an object
+ * because it is <em>there</em>, not because something reaches it. The
+ * alternative — starting from a root and following what actually runs —
+ * gives sharper answers, since every question is then asked in a context
+ * where the types are concrete, but it cannot be used here: eo-runtime is
+ * a library with no entry point, so a checker that waits to be reached
+ * has nothing to pull on and reports a clean bill of health for code it
+ * never opened. Reading the text costs precision, which the checking loop
+ * buys back later by resolving each site in its own context; reading only
+ * what runs costs coverage, which nothing buys back.</p>
  *
  * <p>Then the checks are drained one by one, each of them either
  * deciding, splitting into smaller checks, or waiting for facts that may
@@ -50,7 +62,7 @@ public final class Clues implements Clue {
      * Ctor.
      */
     public Clues() {
-        this(Collections.singletonList(new Provides()));
+        this(Arrays.asList(new Provides(), new Needs()));
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Needs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Needs.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.yegor256.tojos.MnMemory;
+import com.yegor256.tojos.TjCached;
+import com.yegor256.tojos.TjDefault;
+import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * What every object must have, judging by how it is used.
+ *
+ * <p>This is the other half of {@link Provides}: a formation shows what its
+ * object certainly has, while a dispatch shows what somebody expects to find.
+ * In this fragment</p>
+ *
+ * <pre> &lt;o base=".next" loc="Φ.app.inc.φ.ρ"&gt;
+ *   &lt;o base="ξ.x" loc="Φ.app.inc.φ.ρ.ρ"/&gt;
+ * &lt;/o&gt;</pre>
+ *
+ * <p>somebody takes {@code next} from the object at
+ * {@code Φ.app.inc.φ.ρ.ρ}, so that object must have such an attribute, and
+ * whatever it holds is the type of the dispatch itself. That is one row. The
+ * {@code .foo} wrapped around this fragment adds another, asking the dispatch
+ * for {@code foo} in turn — the chain is walked simply by every step of it
+ * being a dispatch of its own, which is what the splitting done before any
+ * clue looks at the XMIR is for.</p>
+ *
+ * <p>The receiver is the child that is not an argument: {@code x.plus 5}
+ * takes {@code plus} from {@code x}, never from the {@code 5}. Nothing here
+ * tries to work out what the receiver actually is, or whether it really has
+ * the attribute — asking is all this clue does. Comparing the answer with
+ * what {@link Provides} wrote down is the job of the checking loop, once the
+ * links between copies are known.</p>
+ *
+ * @since 0.68.0
+ */
+final class Needs implements Clue {
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        final Tojos rows = new TjCached(new TjDefault(new MnMemory()));
+        int seen = 0;
+        for (final XML dispatch : new Xmirs(xmirs).dispatches()) {
+            final String owner = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+            rows.add(owner).set("index", Integer.toString(seen));
+            seen = seen + 1;
+            rows.add(String.join(" ", owner, dispatch.xpath("@base").get(0)))
+                .set("owner", owner)
+                .set("index", Integer.toString(seen))
+                .set("name", dispatch.xpath("@base").get(0).substring(1))
+                .set("type", dispatch.xpath("@loc").get(0));
+            seen = seen + 1;
+        }
+        Files.createDirectories(tables);
+        Files.write(
+            tables.resolve("needs.xml"),
+            new Grouped(rows, "needs").asXml().toString().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -53,13 +53,37 @@ final class Xmirs {
      * @throws IOException If a file cannot be read
      */
     Collection<XML> formations() throws IOException {
+        return this.matching(
+            "//o[not(@base) and not(@name='λ') and not(text()[normalize-space()])]"
+        );
+    }
+
+    /**
+     * Every dispatch of the program.
+     *
+     * <p>A dispatch is an object whose base begins with a dot: it takes an
+     * attribute from the object below it. Every composite base was split
+     * into one such object per step before any clue looked at the XMIR, so
+     * a chain like {@code x.next.foo} is three objects here and not one.</p>
+     *
+     * @return The dispatches, file by file, in the order they appear in
+     *  the code
+     * @throws IOException If a file cannot be read
+     */
+    Collection<XML> dispatches() throws IOException {
+        return this.matching("//o[starts-with(@base, '.')]");
+    }
+
+    /**
+     * Every object of the program the given XPath matches.
+     * @param xpath The XPath
+     * @return The objects, file by file
+     * @throws IOException If a file cannot be read
+     */
+    private Collection<XML> matching(final String xpath) throws IOException {
         final Collection<XML> found = new ArrayList<>(0);
         for (final XML xmir : this.documents()) {
-            found.addAll(
-                xmir.nodes(
-                    "//o[not(@base) and not(@name='λ') and not(text()[normalize-space()])]"
-                )
-            );
+            found.addAll(xmir.nodes(xpath));
         }
         return found;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/CluesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/CluesTest.java
@@ -42,6 +42,24 @@ final class CluesTest {
     }
 
     @Test
+    void writesTableOfWhatIsNeeded(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.cup.φ' base='.lid'>",
+                "<o loc='Φ.cup.φ.ρ' base='ξ.cup'/></o></object>"
+            )
+        );
+        new Clues().follow(temp.resolve("xmirs"), temp.resolve("tables"));
+        MatcherAssert.assertThat(
+            "the clues we know must write down what every object is asked for, but they didnt",
+            Files.exists(temp.resolve("tables").resolve("needs.xml")),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void writesTableOfWhatIsProvided(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),

--- a/eo-inference/src/test/java/org/eolang/inference/NeedsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/NeedsTest.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Needs}.
+ * @since 0.68.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class NeedsTest {
+
+    @Test
+    void recordsAttributeTakenFromReceiver(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the object a dispatch takes from must be asked for that attribute, but it isnt",
+            this.table(
+                temp,
+                String.join(
+                    "",
+                    "<object><o loc='Φ.app.inc.φ' base='.foo'>",
+                    "<o loc='Φ.app.inc.φ.ρ' base='.next'>",
+                    "<o loc='Φ.app.inc.φ.ρ.ρ' base='ξ.x'/>",
+                    "</o></o></object>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "/needs/type[@id='Φ.app.inc.φ.ρ.ρ']/attr[@name='next' and @type='Φ.app.inc.φ.ρ']"
+            )
+        );
+    }
+
+    @Test
+    void recordsEveryStepOfChain(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a dispatch on a dispatch must ask the inner one for the attribute, but it doesnt",
+            this.table(
+                temp,
+                String.join(
+                    "",
+                    "<object><o loc='Φ.app.inc.φ' base='.foo'>",
+                    "<o loc='Φ.app.inc.φ.ρ' base='.next'>",
+                    "<o loc='Φ.app.inc.φ.ρ.ρ' base='ξ.x'/>",
+                    "</o></o></object>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "/needs/type[@id='Φ.app.inc.φ.ρ']/attr[@name='foo' and @type='Φ.app.inc.φ']"
+            )
+        );
+    }
+
+    @Test
+    void asksReceiverAndNotArgument(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the attribute is taken from the receiver, not from an argument, but it wasnt",
+            this.table(
+                temp,
+                String.join(
+                    "",
+                    "<object><o loc='Φ.sum' base='.plus'>",
+                    "<o loc='Φ.sum.ρ' base='ξ.x'/>",
+                    "<o loc='Φ.sum.α0' as='α0' base='Φ.number'/>",
+                    "</o></object>"
+                )
+            ),
+            XhtmlMatchers.hasXPath("/needs/type[@id='Φ.sum.ρ']/attr[@name='plus']")
+        );
+    }
+
+    @Test
+    void skipsReference(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a reference takes nothing from anybody, so it must ask for nothing, but it asked",
+            this.table(temp, "<object><o loc='Φ.pot' base='ξ.jar'/></object>"),
+            XhtmlMatchers.hasXPath("/needs[not(type)]")
+        );
+    }
+
+    @Test
+    void putsNeedsOfManyFilesInOneTable(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the dispatches of every file must land in the same table, but they didnt",
+            this.table(
+                temp,
+                String.join(
+                    "",
+                    "<object><o loc='Φ.jar.φ' base='.lid'>",
+                    "<o loc='Φ.jar.φ.ρ' base='ξ.jar'/></o></object>"
+                ),
+                String.join(
+                    "",
+                    "<object><o loc='Φ.pot.φ' base='.handle'>",
+                    "<o loc='Φ.pot.φ.ρ' base='ξ.pot'/></o></object>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "/needs[type[@id='Φ.jar.φ.ρ'] and type[@id='Φ.pot.φ.ρ']]"
+            )
+        );
+    }
+
+    /**
+     * The table this clue writes out of the given XMIR.
+     * @param temp The temporary directory to work in
+     * @param xmirs The XMIR of the program, a document per file
+     * @return The table
+     * @throws IOException If a file cannot be read or written
+     */
+    private XML table(final Path temp, final String... xmirs) throws IOException {
+        final Path dir = Files.createDirectories(temp.resolve("xmirs"));
+        int index = 0;
+        for (final String xmir : xmirs) {
+            Files.writeString(dir.resolve(String.format("main%d.xmir", index)), xmir);
+            index = index + 1;
+        }
+        new Needs().follow(dir, temp.resolve("tables"));
+        return new XMLDocument(temp.resolve("tables").resolve("needs.xml"));
+    }
+}


### PR DESCRIPTION
Rule three of `inference.md`: a dispatch tells us what an object must have.

`Needs` sweeps every object whose base begins with a dot and writes one row
per dispatch into `needs.xml` — the owner is the receiver's locator, the name
is the attribute taken, the type is the locator of the dispatch itself. The
note's own example comes out as it does on paper:

```xml
<needs>
  <type id="Φ.app.inc.φ.ρ.ρ">
    <attr name="next" type="Φ.app.inc.φ.ρ"/>
  </type>
  <type id="Φ.app.inc.φ.ρ">
    <attr name="foo" type="Φ.app.inc.φ"/>
  </type>
</needs>
```

The row shape is the one `Provides` already uses, so `Grouped` renders the
second table without a line changed. A chain needs no walking of its own:
every step of `x.next.foo` is a dispatch object by the time a clue sees the
XMIR, so the outer one simply asks the inner one. The receiver is the child
that is not an argument — `x.plus 5` takes `plus` from `x`, never from the
`5`; all 9,848 dispatches in eo-runtime have their receiver first and carry a
locator, so the rule is total on real input.

Nothing here resolves what a receiver is or decides whether it really has the
attribute. Asking is all this clue does; comparing the two tables belongs to
the checking loop, once links between copies exist.

On eo-runtime the goal now writes 9,848 need rows next to the 2,456 types of
`provides.xml`.

`Clues` also gained a paragraph explaining why every clue reads the program as
text rather than following what runs. The reason is empirical rather than
aesthetic: eo-runtime is a library with no entry point, so a checker that
waits to be reached reports a clean bill of health for code it never opened.
Reading the text costs precision, which the checking loop can buy back by
resolving each site in its own context; reading only what runs costs coverage,
which nothing buys back.

Closes: #6469
