### PR TITLE
#6445: reject a negative write offset in Heaps

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -197,6 +197,14 @@ final class Heaps {
                     )
                 );
             }
+            if (offset < 0) {
+                throw new ExFailure(
+                    String.format(
+                        "Block '%d': can't write at negative offset '%d'",
+                        identifier, offset
+                    )
+                );
+            }
             final long end = (long) offset + data.length;
             if (end > Integer.MAX_VALUE) {
                 throw new ExFailure(

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -85,6 +85,34 @@ final class HeapsTest {
     }
 
     @Test
+    void failsCleanlyOnWriteWithNegativeOffset() {
+        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10);
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.write(idx, -1, new byte[] {0x01}),
+            "Heaps must reject a negative write offset with a clean ExFailure, not a raw JVM exception"
+        );
+        Heaps.INSTANCE.free(idx);
+    }
+
+    @Test
+    void keepsBlockIntactAfterWriteWithNegativeOffset() {
+        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 3);
+        Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.write(idx, -2, new byte[] {1, 2}),
+            "Heaps must reject a negative write offset before touching the block, but it didn't"
+        );
+        MatcherAssert.assertThat(
+            "Heaps must leave the block untouched after a rejected negative-offset write, but it didn't",
+            Heaps.INSTANCE.read(idx, 0, 3),
+            Matchers.equalTo(new byte[] {7, 8, 9})
+        );
+        Heaps.INSTANCE.free(idx);
+    }
+
+    @Test
     void failsOnReadFromEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,


### PR DESCRIPTION
Closes #6445.

`Heaps.write()` validated only the upper bound, so a negative offset slipped through to `System.arraycopy()` and leaked `ArrayIndexOutOfBoundsException`. Reads already reject a negative offset via `fits()`.

Now `write()` fails with `ExFailure` before touching the block, same contract as `resize()` and `read()`.

@yegor256 please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)