### PR TITLE
#6450: escape string literals rendered in φ-terms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Escaped.java
+++ b/eo-runtime/src/main/java/org/eolang/Escaped.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.function.Supplier;
+
+/**
+ * One glyph spelled the way an EO string literal carries it.
+ *
+ * <p>A quote, a backslash and a control character cannot stand inside a
+ * literal as they are: the quote closes it, the backslash swallows its
+ * neighbour, and a line feed breaks the literal in two. Each of them turns
+ * into the escape sequence the parser decodes back into the very same
+ * glyph (R-9.7), while everything else stays verbatim.</p>
+ *
+ * <p>The glyphs from {@code 0x08} to {@code 0x0D} carry the one-letter
+ * spellings of {@code "btnvfr"}, except the vertical tab {@code 0x0B},
+ * which EO has no letter for and which goes out as a unicode escape.</p>
+ *
+ * @since 0.73.3
+ */
+final class Escaped implements Supplier<String> {
+
+    /**
+     * The glyph.
+     */
+    private final char glyph;
+
+    /**
+     * Ctor.
+     * @param glyph The glyph
+     */
+    Escaped(final char glyph) {
+        this.glyph = glyph;
+    }
+
+    @Override
+    public String get() {
+        final int code = this.glyph;
+        final String text;
+        if (code == '"' || code == '\\') {
+            text = String.format("\\%c", this.glyph);
+        } else if (code >= 0x08 && code <= 0x0D && code != 0x0B) {
+            text = String.format("\\%c", "btnvfr".charAt(code - 0x08));
+        } else if (code < 0x20 || code == 0x7F) {
+            text = String.format("\\u%04x", code);
+        } else {
+            text = String.valueOf(this.glyph);
+        }
+        return text;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -333,7 +333,7 @@ public class PhDefault implements Phi, Cloneable {
         if (this.literal(name)) {
             final byte[] raw = this.loaded().get("as-bytes").get().delta();
             if ("string".equals(name)) {
-                result = String.format("\"%s\"", new String(raw, StandardCharsets.UTF_8));
+                result = new Quoted(raw).get();
             } else {
                 result = PhDefault.numeral(new BytesOf(raw).asNumber());
             }

--- a/eo-runtime/src/main/java/org/eolang/Quoted.java
+++ b/eo-runtime/src/main/java/org/eolang/Quoted.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+/**
+ * UTF-8 bytes rendered as an EO string literal.
+ *
+ * <p>The text lands between double quotes, with every glyph spelled by
+ * {@link Escaped}. Without the escaping, a quote inside the text closes
+ * the literal early and a line feed splits it across lines, so the
+ * printed φ-term denotes a string other than the one it came from.</p>
+ *
+ * @since 0.73.3
+ */
+final class Quoted implements Supplier<String> {
+
+    /**
+     * The bytes of the text.
+     */
+    private final byte[] data;
+
+    /**
+     * Ctor.
+     * @param data The bytes
+     */
+    Quoted(final byte[] data) {
+        this.data = Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public String get() {
+        final StringBuilder out = new StringBuilder("\"");
+        for (final char glyph : new String(this.data, StandardCharsets.UTF_8).toCharArray()) {
+            out.append(new Escaped(glyph).get());
+        }
+        return out.append('"').toString();
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -65,6 +65,15 @@ final class DataTest {
     }
 
     @Test
+    void printsStringWithSpecialCharactersAsTerm() {
+        MatcherAssert.assertThat(
+            "String with quotes, backslashes and control chars must render escaped, but it didnt",
+            new Data.ToPhi(String.format("a\"b\\c%cd%ce%cf", 0x09, 0x0D, 0x0A)).φTerm(),
+            Matchers.equalTo("\"a\\\"b\\\\c\\td\\re\\nf\"")
+        );
+    }
+
+    @Test
     void distinguishesDifferentNumbersInTerm() {
         MatcherAssert.assertThat(
             "Different numbers must produce different φ-terms, but they didnt",

--- a/eo-runtime/src/test/java/org/eolang/EscapedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EscapedTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link Escaped}.
+ * @since 0.73.3
+ */
+final class EscapedTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "0x22, '\\\"'",
+        "0x5C, '\\\\'",
+        "0x08, '\\b'",
+        "0x0C, '\\f'",
+        "0x0A, '\\n'",
+        "0x0D, '\\r'",
+        "0x09, '\\t'",
+        "0x07, '\\u0007'",
+        "0x0B, '\\u000b'",
+        "0x7F, '\\u007f'"
+    })
+    void spellsSpecialGlyph(final int code, final String expected) {
+        MatcherAssert.assertThat(
+            String.format("Glyph 0x%02X must be spelled as an escape sequence, but it wasnt", code),
+            new Escaped((char) code).get(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void keepsOrdinaryGlyphIntact() {
+        MatcherAssert.assertThat(
+            "Ordinary glyph must stay verbatim, but it didnt",
+            new Escaped('ж').get(),
+            Matchers.equalTo("ж")
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/QuotedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/QuotedTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Quoted}.
+ * @since 0.73.3
+ */
+final class QuotedTest {
+
+    @Test
+    void quotesPlainText() {
+        MatcherAssert.assertThat(
+            "Text without special glyphs must be quoted as it is, but it wasnt",
+            new Quoted("Привет, мир".getBytes(StandardCharsets.UTF_8)).get(),
+            Matchers.equalTo("\"Привет, мир\"")
+        );
+    }
+
+    @Test
+    void escapesQuoteAndBackslash() {
+        MatcherAssert.assertThat(
+            "Quote and backslash must not break out of the literal, but they did",
+            new Quoted("say \"hi\\bye\"".getBytes(StandardCharsets.UTF_8)).get(),
+            Matchers.equalTo("\"say \\\"hi\\\\bye\\\"\"")
+        );
+    }
+
+    @Test
+    void escapesDeleteCharacter() {
+        MatcherAssert.assertThat(
+            "Delete character must be spelled as a unicode escape, but it wasnt",
+            new Quoted(String.format("%c", 0x7F).getBytes(StandardCharsets.UTF_8)).get(),
+            Matchers.equalTo("\"\\u007f\"")
+        );
+    }
+}


### PR DESCRIPTION
Closes #6450.

`PhDefault.φTerm()` wrapped raw UTF-8 text in quotes, so a quote closed the literal early, a backslash stayed raw and a line feed broke the term across lines.

Now the text goes through `Quoted`, which spells every glyph with `Escaped` (`\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t`, `\uXXXX` for the rest of the control characters), matching what the parser decodes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)