### PR TITLE
Use quotient to select number.mod fast path

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -34,8 +34,10 @@
         [] >> abs-mod
           if. > @
             lt.
-              abs dividend >> absx
-              4503599627370496
+              div.
+                abs dividend >> absx
+                absy
+              9007199254740992
             absx.minus
               times.
                 abs divisor >> absy


### PR DESCRIPTION
Closes #6455.

Gate the `number.mod` fast path on the quotient instead of the dividend so larger quotients fall back to the existing reduction algorithm.
