### PR TITLE
#6428: resolve the fan-out suppression puzzle in MjSafe.java

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Caching.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Caching.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+
+/**
+ * The cache of one step, as configured by the user.
+ *
+ * <p>This is the only place where {@code eo.cacheEnabled} is read, so that no
+ * step has to know that the option exists. Kept out of {@link MjSafe} on
+ * purpose: its two possible outcomes ({@link GlobalCache} and
+ * {@link GcShared}) are exactly the two types that pushed that class over
+ * its class-fan-out limit.</p>
+ *
+ * @since 0.1
+ */
+final class Caching {
+
+    /**
+     * Whether the machine-wide cache is enabled.
+     */
+    private final boolean enabled;
+
+    /**
+     * Directory of the machine-wide cache.
+     */
+    private final Path cache;
+
+    /**
+     * Version of the compiler, folded into the cache key.
+     */
+    private final String version;
+
+    /**
+     * Ctor.
+     * @param enabled Whether the machine-wide cache is enabled
+     * @param cache Directory of the machine-wide cache
+     * @param version Version of the compiler, folded into the cache key
+     */
+    Caching(final boolean enabled, final Path cache, final String version) {
+        this.enabled = enabled;
+        this.cache = cache;
+        this.version = version;
+    }
+
+    /**
+     * The cache of one step.
+     * @param sub Directory of that step inside the machine-wide cache
+     * @return The cache of that step
+     */
+    GlobalCache store(final String sub) {
+        final GlobalCache result;
+        if (this.enabled) {
+            result = new GcShared(this.cache.resolve(sub), this.version);
+        } else {
+            result = new GlobalCache.GcFresh();
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -46,7 +46,9 @@ public final class MjParse extends MjSafe {
             this.scopedTojos(),
             this.targetDir.toPath(),
             this.sourcesDir.toPath(),
-            this.caching(Parsing.CACHE)
+            this.cacheEnabled,
+            this.cache.toPath(),
+            this.plugin.getVersion()
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -27,16 +27,6 @@ import org.slf4j.impl.StaticLoggerBinder;
 /**
  * Abstract Mojo for all others.
  * @since 0.1
- * @todo #6125:60min Take the fan-out suppression below off again.
- *  This class sat at exactly 30 referenced types, the maximum, so naming
- *  {@link GlobalCache} and {@link GcShared} in {@link #caching(String)}
- *  pushed it to 32 and the suppression had to be added. Unload the class
- *  instead, the way the puzzle about the tojos lifecycle below asks, and
- *  the suppression can go, together with the {@code @SuppressWarnings}
- *  for the field count right below it, which the same unloading fixes.
- *  Until then no further step can be moved to {@link GlobalCache}
- *  without making this worse.
- * @checkstyle ClassFanOutComplexityCheck (5 lines)
  */
 @SuppressWarnings("PMD.TooManyFields")
 abstract class MjSafe extends AbstractMojo {
@@ -546,7 +536,9 @@ abstract class MjSafe extends AbstractMojo {
                     this.scopedTojos(),
                     this.targetDir.toPath(),
                     this.sourcesDir.toPath(),
-                    this.caching(Parsing.CACHE)
+                    this.cacheEnabled,
+                    this.cache.toPath(),
+                    this.plugin.getVersion()
                 )
             ),
             new Timed(
@@ -566,25 +558,6 @@ abstract class MjSafe extends AbstractMojo {
                 )
             )
         );
-    }
-
-    /**
-     * The cache of one step, as configured by the user. This is the only
-     * place where {@code eo.cacheEnabled} is read, so that no step below
-     * has to know that the option exists.
-     * @param sub Directory of that step inside the machine-wide cache
-     * @return The cache of that step
-     */
-    GlobalCache caching(final String sub) {
-        final GlobalCache store;
-        if (this.cacheEnabled) {
-            store = new GcShared(
-                this.cache.toPath().resolve(sub), this.plugin.getVersion()
-            );
-        } else {
-            store = new GlobalCache.GcFresh();
-        }
-        return store;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -80,25 +80,30 @@ final class Parsing implements Step {
     /**
      * Where the results of earlier builds are looked for and kept.
      */
-    private final GlobalCache cache;
+    private final Caching cache;
 
     /**
      * Constructor.
      * @param srcs Foreign tojos catalog
      * @param target Target directory
      * @param sources EO sources directory
-     * @param store Where the results of earlier builds are looked for and kept
+     * @param enabled Whether the machine-wide cache is enabled
+     * @param store Directory of the machine-wide cache
+     * @param version Version of the compiler, folded into the cache key
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
     Parsing(
         final TjsForeign srcs,
         final Path target,
         final Path sources,
-        final GlobalCache store
+        final boolean enabled,
+        final Path store,
+        final String version
     ) {
         this.tojos = srcs;
         this.targetDir = target;
         this.sourcesDir = sources;
-        this.cache = store;
+        this.cache = new Caching(enabled, store, version);
     }
 
     @Override
@@ -113,7 +118,7 @@ final class Parsing implements Step {
         final int total = this.parsed(
             sources,
             new Canonical(objects),
-            this.cache.with(
+            this.cache.store(Parsing.CACHE).with(
                 new Fingerprint(
                     Stream.concat(
                         Canonical.XSLS.stream(), Canonical.IMPORTS.stream()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -27,7 +27,9 @@ final class CompilingTest {
                         new TjsForeign(),
                         temp,
                         temp,
-                        new GlobalCache.GcFresh()
+                        false,
+                        temp,
+                        Parsing.ZERO
                     ),
                     new Probing(new TjsForeign(), new Objectionary.Fake(), false),
                     new Pulling(


### PR DESCRIPTION
Closes #6428.

The puzzle 6125-d751ea55 flagged MjSafe.caching(String): its GlobalCache return type and GcShared/GlobalCache.GcFresh construction pushed the class from 30 referenced types, the checkstyle limit, to 32, forcing a ClassFanOutComplexityCheck suppression.

Extracting caching() into its own Caching class only recovered one of the two points: MjSafe stopped referencing GcShared but picked up a reference to Caching itself, landing at 31, still over.

The remaining point belonged to Parsing, the only real consumer of the cache. Moved Caching's construction there, so MjSafe and MjParse now just pass the three primitives they already had (cache enabled flag, cache directory, compiler version) and never mention Caching, GlobalCache or GcShared by name. Parsing already owned a GlobalCache field for its own reasons, so the type nesting belongs there.

Caching.store(String) is resolved lazily at Parsing's one use site rather than in its constructor, per qulice's ConstructorsCodeFreeCheck (constructors assign fields only, no method calls).

Fan-out on MjSafe is back at 30. Both the suppression and its @todo puzzle are removed. No behavior changed, this is a pure move; existing coverage (MjParseTest, MjSafeTest, CompilingTest) confirms it, no new test needed.
