### PR TITLE
#6427: treat a blank line before an unrelated sibling as a separator

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -15,7 +15,10 @@ import java.util.List;
  * standing under its parent. This object holds the lines of the program
  * and answers where the walk picks up again: the first line standing
  * back at or above the indent of the one that failed. A blank line
- * carries no indent of its own and never ends the skipped block.</p>
+ * carries no indent of its own, so it is resolved by looking past it to
+ * the next real line: genuinely nested inside the block if that line is
+ * indented deeper, but a file-level separator in front of an unrelated
+ * sibling otherwise — and a separator does not extend the skip.</p>
  *
  * <p>The blanks trailing the block are handed back, though. A blank
  * standing between the last skipped line and the line the walk resumes
@@ -102,6 +105,31 @@ final class Recovery {
      */
     private boolean skipped(final int idx, final int indent) {
         final Span span = this.spans.get(idx);
-        return span.blank() || span.indent() > indent;
+        final boolean result;
+        if (span.blank()) {
+            result = this.blankBelongsToBlock(idx, indent);
+        } else {
+            result = span.indent() > indent;
+        }
+        return result;
+    }
+
+    /**
+     * Whether a blank line at {@code idx} still belongs to the block of a
+     * line at {@code indent} — true only when the next non-blank line is
+     * itself indented deeper than {@code indent}. A blank line whose next
+     * real line stands back at or above {@code indent} is a file-level
+     * separator between the block and an unrelated sibling, not part of
+     * the block, and must not be skipped.
+     * @param idx Index of the blank line
+     * @param indent Indent of the failed line
+     * @return True when the blank line must be skipped
+     */
+    private boolean blankBelongsToBlock(final int idx, final int indent) {
+        int next = idx + 1;
+        while (next < this.spans.size() && this.spans.get(next).blank()) {
+            next = next + 1;
+        }
+        return next < this.spans.size() && this.spans.get(next).indent() > indent;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -76,7 +76,7 @@ final class Recovery {
             idx = idx + 1;
         }
         if (idx < this.spans.size()) {
-            idx = this.rewound(idx, failed);
+            idx = this.rewound(idx, from - 1);
         }
         return idx;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RecoveryTest.java
@@ -80,6 +80,23 @@ final class RecoveryTest {
     }
 
     @Test
+    void stopsAtABlankLineThatSeparatesTheBlockFromAnUnrelatedSibling() {
+        MatcherAssert.assertThat(
+            "a blank line before an unrelated sibling is a separator, not part of the block"
+                .concat(", and must not be skipped"),
+            new Recovery(
+                Arrays.asList(
+                    new Span("bad!!!", 1),
+                    new Span("  child", 2),
+                    new Span("", 3),
+                    new Span("sibling", 4)
+                )
+            ).after(0),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
     void skipsFromAnIndexOtherThanTheFailedLineItself() {
         MatcherAssert.assertThat(
             "skip must scan from the given index using the given indent, "

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-blank-line-separator-still-checked.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-blank-line-separator-still-checked.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors[count(error)=2]
+  - /object/errors/error[contains(text(),'expected identifier')]
+  - /object/errors/error[contains(text(),'blank line before a plain object is forbidden')]
+input: |
+  [] > app
+    x..y > z
+
+    42 > w


### PR DESCRIPTION
Closes #6427.

This branch is stacked on #6467 (issue #6426): both touch Recovery.java, so this diff will show both PRs' changes combined until #6467 merges. Please review/merge #6467 first; I will rebase this one afterward so it shows only its own diff.

Recovery.skipped treated every blank line as belonging to a failed line's block, unconditionally. That is correct for a blank genuinely nested inside the block, but it also swallows a blank that is really a file-level separator between the block and the next unrelated top-level object. Since the swallowed blank never reaches Eo.process, globals never records it, so Blanks.checkPlain on the following object sees no preceding blank at all and silently drops a genuine R-6.5.4 violation on it.

skipped now looks past a blank line to the next real line and bases the decision on that line's indent: still part of the block only if that line is indented deeper than the failed line, a separator otherwise. A separator is no longer skipped, so it reaches Eo.process normally and globals records it like any other blank.

Added a yaml pack test reproducing the issue's exact repro (a genuine parse error plus a blank-separated sibling that must still get its own R-6.5.4 diagnostic), and a direct unit test on Recovery.after for the same scenario. Verified both fail on the pre-fix code and pass with the fix.
