### PR TITLE
#6450: escape quotes, backslashes and control chars in PhDefault.phiTerm()

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -333,7 +333,9 @@ public class PhDefault implements Phi, Cloneable {
         if (this.literal(name)) {
             final byte[] raw = this.loaded().get("as-bytes").get().delta();
             if ("string".equals(name)) {
-                result = String.format("\"%s\"", new String(raw, StandardCharsets.UTF_8));
+                result = String.format(
+                    "\"%s\"", this.escaped(new String(raw, StandardCharsets.UTF_8))
+                );
             } else {
                 result = PhDefault.numeral(new BytesOf(raw).asNumber());
             }
@@ -356,6 +358,35 @@ public class PhDefault implements Phi, Cloneable {
             txt = Double.toString(value);
         }
         return txt;
+    }
+
+    /**
+     * Escape a string for safe embedding inside a double-quoted φ-term
+     * literal: a quote or backslash is escaped so it cannot be mistaken
+     * for the literal's own delimiter or escape marker, and a control
+     * character is escaped so the term stays on one visual line.
+     * @param raw The unescaped string
+     * @return The same string, safe to wrap in double quotes
+     * @checkstyle NonStaticMethodCheck (2 lines)
+     */
+    private String escaped(final String raw) {
+        final StringBuilder out = new StringBuilder(raw.length());
+        for (final char chr : raw.toCharArray()) {
+            if (chr == '"' || chr == '\\') {
+                out.append('\\').append(chr);
+            } else if (chr == '\n') {
+                out.append("\\n");
+            } else if (chr == '\r') {
+                out.append("\\r");
+            } else if (chr == '\t') {
+                out.append("\\t");
+            } else if (chr < 0x20 || chr == 0x7F) {
+                out.append(String.format("\\u%04x", (int) chr));
+            } else {
+                out.append(chr);
+            }
+        }
+        return out.toString();
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -65,6 +65,15 @@ final class DataTest {
     }
 
     @Test
+    void escapesQuotesBackslashesAndControlCharsInTerm() {
+        MatcherAssert.assertThat(
+            "A quote, a backslash and a control character must be escaped in φ-term",
+            new Data.ToPhi("a\"b\\c".concat(String.valueOf('\n'))).φTerm(),
+            Matchers.equalTo("\"a\\\"b\\\\c\\n\"")
+        );
+    }
+
+    @Test
     void distinguishesDifferentNumbersInTerm() {
         MatcherAssert.assertThat(
             "Different numbers must produce different φ-terms, but they didnt",


### PR DESCRIPTION
Closes #6450.

PhDefault.phiTerm() wrapped a string value's raw UTF-8 bytes in double quotes with no escaping, so a quote in the value ended the rendered literal early, a backslash came through raw, and a newline broke the term across lines. The printed phi-term could be syntactically invalid or represent a different string entirely.

Added an escape pass: a quote or backslash gets a backslash prefix, newline/carriage-return/tab get their short forms, and any other control character gets a \u escape, matching the shorthand VerboseBytesAsString already uses for the general case.

This does not touch PhApplication.phiTerm(), which has the same gap (#6375). Separate object, separate issue.

Added a test with the issue's exact repro (a quote, a backslash and a newline in one string) asserting the correctly escaped output.
