### PR TITLE
#6449: reject a negative requested size in posix.read and win32.read

### DIFF
--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -118,6 +118,23 @@
           "127.0.0.1"
       16777343
 
+  --> stops-on-read-size-being-negative
+    os.is-windows.if > @
+      1.div 0
+      seq *
+        code.
+          posix *1
+            "read"
+            fd
+            -1
+        true
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        0
+        0
+
   --> stops-on-write-size-being-negative
     os.is-windows.if > @
       1.div 0

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -61,6 +61,23 @@
           "127.0.0.1"
       16777343
 
+  --> stops-on-read-size-being-negative
+    os.is-windows.not.if > @
+      1.div 0
+      seq *
+        code.
+          win32 *1
+            "_read"
+            fd
+            -1
+        true
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        0
+        0
+
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @
       1.div 0

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -7,6 +7,7 @@ package org.eolang.posix;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,6 +33,9 @@ public final class ReadSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure("Can't read a negative number of bytes: %d", size);
+        }
         final Phi result = this.posix.take("return").copy();
         final byte[] buf = new byte[size];
         final int count = CStdLib.INSTANCE.read(

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,6 +33,9 @@ public final class ReadFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure("Can't read a negative number of bytes: %d", size);
+        }
         final byte[] buf = new byte[size];
         final int count = Msvcrt.INSTANCE._read(
             new Dataized(params[0]).asNumber().intValue(), buf, size

--- a/eo-runtime/src/test/java/org/eolang/posix/ReadSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/ReadSyscallTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ReadSyscall}.
+ * @since 0.1
+ */
+final class ReadSyscallTest {
+
+    @Test
+    void rejectsNegativeSizeBeforeAllocatingTheBuffer() {
+        final Phi posix = Phi.Φ.take("posix");
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadSyscall(posix).make(new Data.ToPhi(0), new Data.ToPhi(-1)),
+            "a negative size must fail through the controlled EO failure path, not a raw JVM exception"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/ReadFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/ReadFuncCallTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ReadFuncCall}.
+ * @since 0.1
+ */
+final class ReadFuncCallTest {
+
+    @Test
+    void rejectsNegativeSizeBeforeAllocatingTheBuffer() {
+        final Phi win = Phi.Φ.take("win32");
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadFuncCall(win).make(new Data.ToPhi(0), new Data.ToPhi(-1)),
+            "a negative size must fail through the controlled EO failure path, not a raw JVM exception"
+        );
+    }
+}


### PR DESCRIPTION
Closes #6449.

ReadSyscall.make() and ReadFuncCall.make() allocated a buffer from an unvalidated size argument. A negative EO argument escaped as a raw NegativeArraySizeException instead of the runtime's controlled EO failure path, matching the check WriteSyscall already does for its own size argument.

Added the same style of check, before the buffer is allocated or the native function is called.

Added an EO-level test to each of posix.eo/win32.eo mirroring the existing stops-on-write-size-being-negative precedent, plus a focused Java test per class. The EO --> test only asserts "throws something" (the transpiler generates Assertions.assertThrows(Exception.class, ...)), so it cannot tell a controlled ExFailure apart from the original NegativeArraySizeException. The Java tests assert the specific exception type and fail on the un-fixed code with exactly the NegativeArraySizeException the issue reports.
