### PR TITLE
#6447: handle parentless atoms output

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
@@ -124,11 +124,8 @@ public final class MjAtomsTable extends MjSafe {
      * @throws IOException If write fails
      */
     private void write(final Map<String, String> table) throws IOException {
-        final Path target = this.atomsOutput.toPath();
-        final Path parent = target.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
+        final Path target = this.atomsOutput.toPath().toAbsolutePath();
+        Files.createDirectories(target.getParent());
         final StringBuilder out = new StringBuilder();
         for (final Map.Entry<String, String> entry : table.entrySet()) {
             out.append(entry.getKey())

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
@@ -125,7 +125,10 @@ public final class MjAtomsTable extends MjSafe {
      */
     private void write(final Map<String, String> table) throws IOException {
         final Path target = this.atomsOutput.toPath();
-        Files.createDirectories(target.getParent());
+        final Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
         final StringBuilder out = new StringBuilder();
         for (final Map.Entry<String, String> entry : table.entrySet()) {
             out.append(entry.getKey())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -468,7 +468,7 @@ final class FakeMaven {
      */
     private static Set<String> mojoFields(final Class<?> mojo, final Set<String> fields) {
         final Set<String> res;
-        if (mojo == null) {
+        if (Object.class.equals(mojo)) {
             res = fields;
         } else {
             Stream.of(mojo.getDeclaredFields()).map(Field::getName).forEach(fields::add);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
@@ -22,6 +22,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(MktmpResolver.class)
 final class MjAtomsTableTest {
 
+    /**
+     * Execute the parentless output scenario in an isolated working directory.
+     * @param args Temporary directory path
+     * @throws Exception If execution fails
+     */
+    public static void main(final String... args) throws Exception {
+        final Path temp = Path.of(args[0]);
+        new FakeMaven(temp)
+            .with("atomsInputDir", temp.resolve("xmir").toFile())
+            .with("atomsOutput", Path.of("atoms.csv").toFile())
+            .execute(MjAtomsTable.class);
+    }
+
     @Test
     void generatesAtomsTableFromXmir(@Mktmp final Path temp) throws Exception {
         new Saved(
@@ -69,37 +82,38 @@ final class MjAtomsTableTest {
 
     @Test
     void writesAtomsTableToParentlessFile(@Mktmp final Path temp) throws Exception {
-        final Path output = Path.of(
-            String.format("atoms-%s.csv", temp.getFileName())
-        );
-        try {
-            new Saved(
-                new EoSyntax(
-                    new InputOf(
-                        String.join(
-                            System.lineSeparator(),
-                            "+package foo",
-                            "",
-                            "[] > thing",
-                            "  [] > size /number"
-                        )
+        new Saved(
+            new EoSyntax(
+                new InputOf(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package foo",
+                        "",
+                        "[] > thing",
+                        "  [] > size /number"
                     )
-                ).parsed().toString(),
-                temp.resolve("xmir/foo/thing.xmir")
-            ).value();
-            new FakeMaven(temp)
-                .with("atomsInputDir", temp.resolve("xmir").toFile())
-                .with("atomsOutput", output.toFile())
-                .execute(MjAtomsTable.class);
-            MatcherAssert.assertThat(
-                "Parentless output must be written in the working directory",
-                Files.readString(output),
-                Matchers.equalTo(
-                    String.format("Φ.foo.thing.size,Φ.number%c", '\n')
                 )
-            );
-        } finally {
-            Files.deleteIfExists(output);
-        }
+            ).parsed().toString(),
+            temp.resolve("xmir/foo/thing.xmir")
+        ).value();
+        MatcherAssert.assertThat(
+            "Parentless output must be written in an isolated directory",
+            String.format(
+                "%d:%s",
+                new ProcessBuilder(
+                    Path.of(
+                        System.getProperty("java.home"), "bin", "java"
+                    ).toString(),
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    MjAtomsTableTest.class.getName(),
+                    temp.toString()
+                ).directory(temp.toFile()).inheritIO().start().waitFor(),
+                Files.readString(temp.resolve("atoms.csv"))
+            ),
+            Matchers.equalTo(
+                String.format("0:Φ.foo.thing.size,Φ.number%c", '\n')
+            )
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
@@ -66,4 +66,40 @@ final class MjAtomsTableTest {
             Matchers.emptyString()
         );
     }
+
+    @Test
+    void writesAtomsTableToParentlessFile(@Mktmp final Path temp) throws Exception {
+        final Path output = Path.of(
+            String.format("atoms-%s.csv", temp.getFileName())
+        );
+        try {
+            new Saved(
+                new EoSyntax(
+                    new InputOf(
+                        String.join(
+                            System.lineSeparator(),
+                            "+package foo",
+                            "",
+                            "[] > thing",
+                            "  [] > size /number"
+                        )
+                    )
+                ).parsed().toString(),
+                temp.resolve("xmir/foo/thing.xmir")
+            ).value();
+            new FakeMaven(temp)
+                .with("atomsInputDir", temp.resolve("xmir").toFile())
+                .with("atomsOutput", output.toFile())
+                .execute(MjAtomsTable.class);
+            MatcherAssert.assertThat(
+                "Parentless output must be written in the working directory",
+                Files.readString(output),
+                Matchers.equalTo(
+                    String.format("Φ.foo.thing.size,Φ.number%c", '\n')
+                )
+            );
+        } finally {
+            Files.deleteIfExists(output);
+        }
+    }
 }


### PR DESCRIPTION
Closes #6447.

Skip directory creation when `atomsOutput` has no parent, while still writing the CSV in the working directory. Added a regression test for a bare filename.

@yegor256 please review.