### PR TITLE
#6444: reject a negative malloc size in Heaps

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -218,6 +218,12 @@ final class Heaps {
      * @return The identifier of pointer to the block in memory
      */
     private int malloc(final Phi phi, final int size) {
+        if (size < 0) {
+            throw new ExFailure(
+                "Can't allocate block in memory with negative size '%d'",
+                size
+            );
+        }
         final int identifier = phi.hashCode();
         this.lock.lock();
         try {

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -40,6 +40,21 @@ final class HeapsTest {
     }
 
     @Test
+    void failsCleanlyOnMallocWithNegativeSize() {
+        final Phi phi = new HeapsTest.PhFake();
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.malloc(phi, -1, idx -> idx),
+            "Heaps must reject a negative malloc size with a clean ExFailure, not a raw JVM exception"
+        );
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.size(phi.hashCode()),
+            "Heaps must not leave a block allocated after a rejected negative malloc, but it did"
+        );
+    }
+
+    @Test
     void allocatesAndReadsEmptyBytes() {
         MatcherAssert.assertThat(
             "Heaps should return empty bytes after memory allocation, but it didn't",


### PR DESCRIPTION
## Summary
- `Heaps.malloc` now rejects a negative size with `ExFailure` before `new byte[size]`, matching the existing contract of `Heaps.resize`.
- Without this check, `Heaps.INSTANCE.malloc(phi, -1)` leaked `NegativeArraySizeException`.
- Regression test asserts `ExFailure` and that no block is left allocated for that identifier.

Fixes #6444

## Test plan
- [x] `mvn -pl eo-runtime compiler:compile compiler:testCompile surefire:test -Dtest=HeapsTest` — 26/26 GREEN
- [x] `mvn -pl eo-runtime compiler:testCompile surefire:test -Dtest=HeapsTest,EOmallocEOofTest` — 30/30 GREEN
- [x] `mvn -pl eo-runtime -Pqulice qulice:check -DskipTests` — BUILD SUCCESS