### PR TITLE
#6485: fix undefined 'failed' variable in Recovery.skip, broken build

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Recovery.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Recovery.java
@@ -73,7 +73,7 @@ final class Recovery {
             idx = idx + 1;
         }
         if (idx < this.spans.size()) {
-            idx = this.rewound(idx, failed);
+            idx = this.rewound(idx, from - 1);
         }
         return idx;
     }


### PR DESCRIPTION
Fixes #6485.

`Recovery.skip(from, indent)` called `this.rewound(idx, failed)` with an undefined `failed` variable, a plain compile error on current master (confirmed with `mvn -pl eo-parser compile -DskipTests`). This came from PR #6467, which pulled `skip` out of `after(failed)` as a standalone primitive but left the old `failed` reference instead of `from - 1`, its equivalent boundary.

Fix is one line: `idx = this.rewound(idx, from - 1);`.

Verified: `eo-parser` compiles clean, and `RecoveryTest`, `EoTest`, `EoSyntaxTest` pass (1149 tests, 0 failures).
