### PR TITLE
#6442: reject a trailing separator in a void type list

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1391,6 +1391,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Type variable outside A–F | `type variable must be one of A-F` |
 | `?` optional marker on an atom return signature | `optional marker ? is allowed only on a void attribute` |
 | `?` inside a `/{…}` argument list | `? is not allowed inside a /{…} argument list` |
+| Empty member in a `/{…}` argument list: a double space, or a separator with no type after it (e.g. `/{string }`) | `types in a /{…} list must be separated by exactly one space` |
 | Type annotation on a void outside an atom | `a void type annotation is allowed only inside an atom` |
 | Two type annotations on one void | `a void attribute may carry at most one type annotation` |
 | Unexpected odd character after a name suffix | `unexpected content after name suffix` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -198,8 +198,8 @@ final class LnVoid implements Line {
     /**
      * Split a brace argument list on single spaces, promoting each type
      * atom (variable verbatim, forma {@code Q.} promoted to {@code Φ.})
-     * and rejecting empty entries, double spaces, and the {@code ?}
-     * optional marker.
+     * and rejecting empty entries, double spaces, a trailing space with
+     * no member after it, and the {@code ?} optional marker.
      * @param inside The text inside the braces
      * @param span The source span (for errors)
      * @return The space-separated promoted arguments
@@ -236,6 +236,12 @@ final class LnVoid implements Line {
             }
             out.append(Suffix.typeAtom(member, span, span.indent()));
             idx = end + 1;
+            if (idx == inside.length()) {
+                throw new ParseError(
+                    span.line(), span.indent(),
+                    "types in a `/{…}` list must be separated by exactly one space"
+                );
+            }
         }
         return out.toString();
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "types in a `/{…}` list must be separated by exactly one space"
+input: |
+  [] > fopen /file
+    ? > missing /{string }


### PR DESCRIPTION
Closes #6442.

`LnVoid.members()` walks the text inside `/{…}` by scanning to the next space, promoting the member it just read, and then setting `idx = end + 1` to step over the separator. When the separator is the last character, that step lands `idx` exactly on `inside.length()`, the `while` guard fails, and the loop exits without ever noticing that the separator had no member after it. So `? > missing /{string }` parsed clean and emitted `args="string"`, even though the list ends on an empty entry. A double space (`/{a  b}`) was already rejected, because there the next iteration starts on a space and `end == idx` fires the existing check; only a trailing separator slipped through.

Now the loop rejects the list as soon as stepping over a separator reaches the end of the text, reusing the message the double-space case already uses, since both are the same defect: a separator with no type on one side of it. Nothing else changes — a well-formed list still ends with `idx` one past `inside.length()`, so it never trips the new check.

Added `trailing-space-in-void-args.yaml` to the `eo-typos` pack with the exact input from the issue; it fails on master and passes here. Also added the condition to the error table in `PARSER_SPEC.md`, next to the other `/{…}` rows, which did not mention this message at all.

Local gate: `mvn -pl eo-parser clean test -Dtest=EoSyntaxTest` is 1066 tests / 0 failures with the change and 1064 / 0 on master (the two new ones are the pack above). `mvn -pl eo-parser clean verify -PskipTests -Pqulice` passes, and a full reactor `mvn clean install -DskipTests -PskipITs` is green, so the stricter check does not reject any `.eo` source in the repo — no `/{…}` list in the tree ends on a space.
