### PR TITLE
perf(parser): build locators top-down in set-locators (~2.5x)

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/set-locators.xsl
@@ -8,69 +8,68 @@
   Here we go through all objects and add @loc attributes
   to all of them. The value of the attribute is a unique locator
   of the object.
-  The locator function takes the object only and reaches the
-  program through it, instead of taking the program as a second
-  argument. Saxon 13.0 binds the arguments of a multi-argument
-  function to the wrong values, once in a while, when one compiled
-  stylesheet transforms many documents in parallel threads (which is
-  what the "parse" goal does).
+  The locator of an object is the locator of its parent plus one more
+  segment, so we build them top-down: every "o" receives the locator
+  already built for its parent through the "eo:parent" tunnel parameter
+  and only appends its own segment. Reaching the program from every
+  object instead re-derives all of its ancestors, which costs O(depth)
+  per object rather than O(1), and hits the limit on nested calls that
+  Saxon imposes once objects nest a few hundred levels deep (#6509).
+  The "Φ.package" prefix is likewise computed once, on the "object"
+  element, and tunnelled down, instead of being looked up again for
+  every object in the document.
+  Both values travel as template parameters, not as extra arguments of
+  a locator function. Saxon 13.0 binds the arguments of a
+  multi-argument function to the wrong values, once in a while, when
+  one compiled stylesheet transforms many documents in parallel threads
+  (which is what the "parse" goal does), so eo:segment below stays
+  single-argument. Nothing here reads the global context item either,
+  since that item is absent when the stylesheet is driven through
+  xsl:apply-templates rather than through a whole-document transform.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:import href="/org/eolang/parser/_specials.xsl"/>
-  <xsl:function name="eo:locator" as="xs:string">
-    <xsl:param name="o" as="node()"/>
-    <xsl:if test="name($o) != 'o'">
-      <xsl:message terminate="yes">
-        <xsl:text>Only 'o' XML elements are accepted here</xsl:text>
-      </xsl:message>
-    </xsl:if>
-    <xsl:variable name="ret">
-      <xsl:choose>
-        <xsl:when test="$o/parent::o">
-          <xsl:value-of select="eo:locator($o/parent::o)"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$eo:program"/>
-          <xsl:if test="root($o)/object/metas/meta[head='package']">
-            <xsl:text>.</xsl:text>
-            <xsl:value-of select="root($o)/object/metas/meta[head='package']/part[1]"/>
-          </xsl:if>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:text>.</xsl:text>
-      <xsl:choose>
-        <xsl:when test="$o/@name">
-          <xsl:choose>
-            <xsl:when test="$o/@name = '@'">
-              <xsl:value-of select="$eo:phi"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$o/@name"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:choose>
-            <xsl:when test="$o/@as">
-              <xsl:value-of select="$o/@as"/>
-            </xsl:when>
-            <xsl:when test="starts-with($o/parent::o/@base, '.') and not($o/preceding-sibling::o)">
-              <xsl:value-of select="$eo:rho"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$eo:alpha"/>
-              <xsl:value-of select="count($o/preceding-sibling::o) - count($o/parent::o[starts-with(@base, '.')])"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:value-of select="$ret"/>
+  <!--
+  The trailing segment of the locator of the given object, without the
+  dot that joins it to the locator of its parent.
+  -->
+  <xsl:function name="eo:segment" as="xs:string">
+    <xsl:param name="o" as="element(o)"/>
+    <xsl:variable name="dotted" as="xs:boolean" select="starts-with($o/parent::o/@base, '.')"/>
+    <xsl:choose>
+      <xsl:when test="$o/@name = '@'">
+        <xsl:sequence select="$eo:phi"/>
+      </xsl:when>
+      <xsl:when test="$o/@name">
+        <xsl:sequence select="string($o/@name)"/>
+      </xsl:when>
+      <xsl:when test="$o/@as">
+        <xsl:sequence select="string($o/@as)"/>
+      </xsl:when>
+      <xsl:when test="$dotted and not($o/preceding-sibling::o)">
+        <xsl:sequence select="$eo:rho"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="concat($eo:alpha, count($o/preceding-sibling::o) - (if ($dotted) then 1 else 0))"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
-  <xsl:template match="o">
+  <xsl:template match="object">
+    <xsl:variable name="pkg" select="metas/meta[head='package'][1]/part[1]"/>
     <xsl:copy>
-      <xsl:attribute name="loc" select="eo:locator(.)"/>
-      <xsl:apply-templates select="node()|@* except @loc"/>
+      <xsl:apply-templates select="node()|@*">
+        <xsl:with-param name="eo:parent" as="xs:string" tunnel="yes" select="if ($pkg) then concat($eo:program, '.', $pkg) else $eo:program"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="o">
+    <xsl:param name="eo:parent" as="xs:string" select="$eo:program" tunnel="yes"/>
+    <xsl:variable name="loc" as="xs:string" select="concat($eo:parent, '.', eo:segment(.))"/>
+    <xsl:copy>
+      <xsl:attribute name="loc" select="$loc"/>
+      <xsl:apply-templates select="node()|@* except @loc">
+        <xsl:with-param name="eo:parent" as="xs:string" tunnel="yes" select="$loc"/>
+      </xsl:apply-templates>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="node()|@*">


### PR DESCRIPTION
Closes #6509.

`set-locators.xsl` is the 3rd most expensive stylesheet in the build (**12786 ms, 8.09%** of the README benchmark total). The cost is algorithmic: `eo:locator()` reached the program from every object separately by walking `parent::o` upwards, so each locator cost O(depth) and the pass cost O(objects x depth).

Over the 170 eo-runtime documents this stylesheet actually receives, **36,675 objects triggered 240,586 `eo:locator()` calls**. Each of those calls also materialised a result tree fragment (`<xsl:variable name="ret">` has no `as=`), and the base case re-scanned `metas/meta[head='package']` twice per object — 73,350 scans for a value that is constant per document.

## Change

Locators are prefix-computable, so build them in one top-down pass: every `<o>` receives its parent's finished locator through a tunnel parameter and appends a single segment, making each locator O(1). The `Φ.package` prefix is computed once on the `object` element and tunnelled down with it. `count($o/parent::o[starts-with(@base, '.')])` becomes a plain `if`.

Two constraints the implementation deliberately respects:

- **The accumulator rides on template parameters, not function arguments.** The comment already in this file records that Saxon 13.0 binds multi-argument function arguments to the wrong values when one compiled stylesheet transforms documents in parallel threads — which is what the `parse` goal does. A tunnel template parameter is a different mechanism, and `eo:segment` stays single-argument.
- **Nothing reads the global context item.** Hoisting the prefix into a global `<xsl:variable select="/object/...">` is faster to write and works under the JAXP path production uses, but fails with `XPDY0002 the context item is absent` when the stylesheet is driven through `xsl:apply-templates`. Computing it on the `object` element works under both, and measured the same.

## Results

Saxon-HE 13.0 behind the same JAXP `DOMSource` -> `DOMResult` path `jcabi-xml` uses, single thread, ms per pass over all 170 documents:

| variant | rounds (ms) |
|---|---|
| before | 1662, 1708, 1684 |
| drop the RTF + hoist the prefix, ancestor walk retained | 1128, 1077, 1163 |
| **after (this PR)** | **683, 663, 650** |

**2.4-2.6x** single-threaded, **4.4x** on the 4-thread parallel path. About a third of the saving is the RTF plus the repeated prefix lookup; the rest is removing the walk.

The win scales with nesting — holding object count constant at 2400 and varying only chain depth:

| nesting depth | 10 | 25 | 50 | 100 | 200 |
|---|---|---|---|---|---|
| speedup | 2.5x | 2.7x | 3.5x | 5.6x | 9.8x |

## Correctness

- **Byte-identical output on all 170 eo-runtime documents** (36,675 `@loc` attributes), diffed against the current stylesheet. Inputs were generated by running the real `Canonical` pipeline and stopping before `set-locators`, so they are exactly what it sees in a build — packaged and unpackaged files, nesting up to 52 levels.
- `eo-parser`: 1684 tests pass (including `StrictXmirTest`, which validates `@loc` against the `locator` type in `XMIR.xsd`).
- `eo-maven-plugin`: `MjTranspileTest` (52, covering the three `transpile-packs/locators` packs), `MjParseTest` (13), `MjInferenceTest` (2) pass.
- `xcop` clean.

## Side effect: more depth headroom

Deep nesting previously *failed* rather than merely slowed — past ~215 levels the recursion tripped `SXLM0001 Too many nested function calls`. The top-down version reaches ~460 before hitting the same limit. eo-runtime's deepest file is 52 levels, so this is headroom rather than a live bug fix, and a tree walk cannot remove the ceiling entirely.

#6509 also records a larger, orthogonal finding from the same profiling run: the W3C DOM source tree costs ~2.5x versus Saxon's native TinyTree, independent of the stylesheet, which would affect every XSL in the pipeline. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DcQkPHQetxHrf2vjw7zkX

---
_Generated by [Claude Code](https://claude.ai/code/session_014DcQkPHQetxHrf2vjw7zkX)_