### PR TITLE
perf(printer): index `merge-monikers` lookups with `xsl:key`

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -37,6 +37,45 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
+  The `ξ.` prefix every local reference carries, built once instead of at each
+  of the many `starts-with`/`substring-after` calls below. Saxon does not fold
+  `concat($eo:xi, '.')` into a constant, since `$eo:xi` is a global variable
+  rather than a literal, so leaving it inline rebuilds the same two-character
+  string for every reference the sheet looks at.
+  -->
+  <xsl:variable name="eo:xi-dot" select="concat($eo:xi, '.')"/>
+  <!--
+  Every reference that resolves to an attribute name (`eo:resolved-ref`),
+  indexed by the formation that owns it and the name it resolves to. The
+  lookups below all ask the same question — "which references in this
+  formation name this binding?" — which as a `$owner//o[...]` scan costs a walk
+  of the whole subtree per binding, and so a walk of the document per node
+  once every node asks it. The index answers it in constant time, and, being a
+  key, still hands the references back in document order, which is what makes
+  "the first hosting reference" mean the same thing as before.
+  -->
+  <xsl:key name="moniker-ref" match="o[eo:resolved-ref(.) != '']" use="concat(generate-id(ancestor::o[eo:abstract(.)][1]), ' ', eo:resolved-ref(.))"/>
+  <!--
+  Every applied reference (`eo:applied-refs`) — a bare `ξ.<name>` carrying
+  arguments and no name of its own — indexed by owning formation and receiver
+  name, the applied twin of `moniker-ref` above.
+  -->
+  <xsl:key name="applied-ref" match="o[exists(@base) and starts-with(@base, $eo:xi-dot) and exists(o) and not(exists(@name))]" use="concat(generate-id(ancestor::o[eo:abstract(.)][1]), ' ', substring-after(@base, $eo:xi-dot))"/>
+  <!--
+  Every eligible binding (`eo:moniker-binding`) indexed by its owning formation
+  and name, so a reference reaches the binding it resolves to without scanning
+  the formation's attributes.
+  -->
+  <xsl:key name="moniker-binding" match="o[eo:moniker-binding(.)]" use="concat(generate-id(..), ' ', @name)"/>
+  <!--
+  The same bindings indexed by name alone, for the two "kept reference"
+  lookups, which climb the ancestor formations looking for whichever one
+  declares a segment of the reference's base. Cactus names are auto-generated
+  and effectively unique, so this bucket holds one node and the climb becomes a
+  parentage check on it rather than a scan of every ancestor's attributes.
+  -->
+  <xsl:key name="moniker-name" match="o[eo:moniker-binding(.)]" use="@name"/>
+  <!--
   The single attribute name a hostable `ξ.<name>` reference resolves to, or
   the empty string for anything that is not hostable. Two shapes host a
   binding: a bare reference `ξ.<name>` (no trailing path, no arguments) and a
@@ -49,8 +88,8 @@
   -->
   <xsl:function name="eo:resolved-ref" as="xs:string">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="tail" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, concat($eo:xi, '.')) and not(contains($tail, '.')) and not($ref/o)) then $tail else if (eo:dispatch-seg($ref) != '') then substring-before($tail, '.') else ''"/>
+    <xsl:variable name="tail" select="substring-after($ref/@base, $eo:xi-dot)"/>
+    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, $eo:xi-dot) and not(contains($tail, '.')) and not($ref/o)) then $tail else if (eo:dispatch-seg($ref) != '') then substring-before($tail, '.') else ''"/>
   </xsl:function>
   <!--
   The trailing dispatch chain of a hostable dispatch reference
@@ -64,8 +103,8 @@
   -->
   <xsl:function name="eo:dispatch-seg" as="xs:string">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="tail" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, concat($eo:xi, '.')) and contains($tail, '.') and substring-before($tail, '.') != '') then substring-after($tail, '.') else ''"/>
+    <xsl:variable name="tail" select="substring-after($ref/@base, $eo:xi-dot)"/>
+    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, $eo:xi-dot) and contains($tail, '.') and substring-before($tail, '.') != '') then substring-after($tail, '.') else ''"/>
   </xsl:function>
   <!--
   Whether `$attr` is a restored recursive `&gt;&gt; name` handle: an abstract
@@ -124,7 +163,7 @@
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
-    <xsl:variable name="refs" select="$owner//o[eo:resolved-ref(.) = $attr/@name and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
+    <xsl:variable name="refs" select="key('moniker-ref', concat(generate-id($owner), ' ', $attr/@name), root($attr))[not(ancestor::o[. is $attr])]"/>
     <xsl:variable name="dispatch" as="element()*">
       <xsl:perform-sort select="$refs[eo:dispatch-seg(.) != '']">
         <xsl:sort select="count(tokenize(eo:dispatch-seg(.), '\.'))" data-type="number" order="ascending"/>
@@ -154,7 +193,7 @@
   <xsl:function name="eo:hosted-binding" as="element()*">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
-    <xsl:variable name="binding" select="$owner/o[@name = eo:resolved-ref($ref) and eo:moniker-binding(.)][1]"/>
+    <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', eo:resolved-ref($ref)), root($ref))[1]"/>
     <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
@@ -195,7 +234,7 @@
   <xsl:function name="eo:applied-refs" as="element()*">
     <xsl:param name="attr" as="element()*"/>
     <xsl:variable name="owner" select="$attr/.."/>
-    <xsl:sequence select="$owner//o[exists(@base) and starts-with(@base, concat($eo:xi, '.')) and substring-after(@base, concat($eo:xi, '.')) = $attr/@name and exists(o) and not(exists(@name)) and (ancestor::o[eo:abstract(.)][1] is $owner) and not(ancestor::o[. is $attr])]"/>
+    <xsl:sequence select="if (empty($attr)) then () else key('applied-ref', concat(generate-id($owner), ' ', $attr/@name), root($attr))[not(ancestor::o[. is $attr])]"/>
   </xsl:function>
   <!--
   Whether the applied reference `$ref` sits in a dispatch-receiver slot: the
@@ -229,9 +268,9 @@
   <xsl:function name="eo:applied-handle" as="element()*">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
-    <xsl:variable name="name" select="substring-after($ref/@base, concat($eo:xi, '.'))"/>
-    <xsl:variable name="binding" select="$owner/o[@name = $name and eo:moniker-binding(.) and eo:applied-hosted(.)][1]"/>
-    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, concat($eo:xi, '.')) and $name != '' and not(contains($name, '.')) and exists($ref/o) and exists($binding) and (eo:applied-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:variable name="name" select="substring-after($ref/@base, $eo:xi-dot)"/>
+    <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', $name), root($ref))[eo:applied-hosted(.)][1]"/>
+    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, $eo:xi-dot) and $name != '' and not(contains($name, '.')) and exists($ref/o) and exists($binding) and (eo:applied-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
   <!--
   Whether `$attr` is a const file-local handle (`a &gt;&gt; b!`, R-3.10.12):
@@ -265,7 +304,7 @@
   -->
   <xsl:function name="eo:kept-const-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and eo:const-handle(.) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
+    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[eo:const-handle(.)][some $anc in $ref/ancestor::o satisfies $anc is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
@@ -327,7 +366,7 @@
   -->
   <xsl:function name="eo:kept-local-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="$ref/ancestor::o[eo:abstract(.)]/o[eo:moniker-binding(.) and not(eo:const-handle(.)) and exists(@local) and (some $seg in tokenize($ref/@base, '\.') satisfies $seg = @name)]"/>
+    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[not(eo:const-handle(.)) and exists(@local)][some $anc in $ref/ancestor::o satisfies $anc is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -304,7 +304,7 @@
   -->
   <xsl:function name="eo:kept-const-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[eo:const-handle(.)][some $anc in $ref/ancestor::o satisfies $anc is ..]"/>
+    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[eo:const-handle(.)][some $scope in $ref/ancestor::o satisfies $scope is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>
@@ -366,7 +366,7 @@
   -->
   <xsl:function name="eo:kept-local-ref" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[not(eo:const-handle(.)) and exists(@local)][some $anc in $ref/ancestor::o satisfies $anc is ..]"/>
+    <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[not(eo:const-handle(.)) and exists(@local)][some $scope in $ref/ancestor::o satisfies $scope is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
   </xsl:function>


### PR DESCRIPTION
Fixes part of #6512.

`merge-monikers.xsl` answers the same question from every node it visits —
"which references in this formation name this binding?" — and answered it with
a `$owner//o[...]` descendant scan. Since those lookups are reached from
template *patterns*, which Saxon evaluates against every `o` node, a document
of N nodes walked its own subtree N times. Print time therefore grew
quadratically, and in the outermost formation `$owner//o` is the whole
document.

## What changed

Four lookups are now backed by `xsl:key` indexes:

| key | replaces |
| --- | --- |
| `moniker-ref` | the `$owner//o[...]` scan in `eo:moniker-refs` |
| `applied-ref` | the `$owner//o[...]` scan in `eo:applied-refs` |
| `moniker-binding` | the `$owner/o[...]` sibling scan in `eo:hosted-binding` and `eo:applied-handle` |
| `moniker-name` | the `$ref/ancestor::o[eo:abstract(.)]/o[...]` climb in `eo:kept-const-ref` and `eo:kept-local-ref` |

The first three are keyed on `generate-id()` of the owning formation plus the
name, so a lookup keeps the "same formation, no intervening formation" scoping
the scans enforced by hand. Keys hand their nodes back in document order, so
"the first hosting reference" still means what it meant before — which is what
keeps #5739's first-reference rule and #5890's ordering intact.

`concat($eo:xi, '.')` is hoisted into a global `$eo:xi-dot`. Saxon does not
fold it, because `$eo:xi` is a global variable rather than a literal, so
leaving it inline rebuilt the same two-character string at each of the seven
call sites; string concatenation was the largest single group of samples in a
JFR profile of the old sheet.

No behaviour changes. The sheet's semantics, its comments and its function
signatures are untouched — only how the four lookups find their nodes.

## Results

Saxon-HE 13.0 (the pinned version), best of several runs, on synthetic XMIR of
the shape the sheet sees:

| `<o>` nodes | before | after | speedup |
| ---: | ---: | ---: | ---: |
| 502 | 782 ms | 112 ms | 7× |
| 1002 | 2421 ms | 67 ms | 36× |
| 2002 | 10170 ms | 90 ms | 113× |
| 4002 | 41427 ms | 199 ms | 208× |
| 16002 | (over 10 min) | 558 ms | — |

On real `eo-runtime` sources, taken from `target/eo/1-parse` and pushed through
the five print sheets that precede this one, so the input is exactly what
`merge-monikers` receives:

| file | `<o>` nodes | before | after | speedup |
| --- | ---: | ---: | ---: | ---: |
| `string/printf.eo` | 1151 | 440 ms | 95 ms | 4.6× |
| `path.eo` | 1021 | 205 ms | 81 ms | 2.5× |
| `file.eo` | 810 | 127 ms | 71 ms | 1.8× |
| `map.eo` | 741 | 108 ms | 64 ms | 1.7× |
| `tuple.eo` | 719 | 97 ms | 55 ms | 1.8× |
| `directory.eo` | 684 | 111 ms | 62 ms | 1.8× |

Runtime sources gain less because their formations are small; the quadratic
term is driven by the size of the largest formation, not the file. To be
explicit about the limit of that: a full `mvn -pl eo-runtime process-sources`
takes 250 s before and 252 s after, which is to say no measurable difference —
`eo-runtime` is not where this hurts, since the goal's time goes to linting,
inference and `to-java`. The win is on files whose cactus bindings concentrate
in one scope, where the sheet currently spends tens of seconds. Holding a
synthetic document at ~3000 nodes and only redistributing the same 600
bindings shows the effect on its own: 1046 ms across 100 formations against
22224 ms in a single one, and a flat ~160 ms either way after this change.

## Verification

- Output is byte-identical to `master` on every input tried: all six real
  `eo-runtime` files above, the three `print-packs` fixtures, and eleven
  synthetic documents covering bare references, single- and multi-segment
  dispatch chains, const handles, named handles, applied formation handles,
  recursive handles, shared handles and references from nested formations.
- All 334 `eo-printer` tests pass, including the 293 `XmirTest` pack tests.
- Given #6091 (Saxon-HE 13.0 miscomputing `xsl:function` arguments when one
  compiled stylesheet is shared across threads), the keys were checked under
  the same conditions the printer uses: one shared `Templates`, 24 threads,
  4320 transforms — zero mismatches. Keys are built per source document by the
  per-transformation `KeyManager`, so they add no shared mutable state, and
  this change introduces no new multi-argument `xsl:function`.

Remaining optimization opportunities — memoizing the functions that are still
evaluated once in a pattern and again in a body, and the same scan shape in
`inline-cactoos.xsl` and `restore-local-names.xsl` — are listed in #6512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgyCtxMVnZq4qnDXedksSu