### PR TITLE
fix(#6425): reinstate the level a failed line replaced

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -341,7 +341,7 @@ final class Eo implements Iterable<Directive> {
         if (Eo.closesTextBlock(span, globals)) {
             stack.popDeeperThan(span.indent());
             final int tstartsen = emit.savepoint();
-            final int frame = stack.size();
+            final int frame = stack.checkpoint();
             try {
                 new LnTextBlock(span).into(stack, globals, emit);
             } catch (final ParseError err) {
@@ -408,7 +408,7 @@ final class Eo implements Iterable<Directive> {
             stack.popDeeperThan(span.indent());
         }
         final int tstartsen = emit.savepoint();
-        final int frame = stack.size();
+        final int frame = stack.checkpoint();
         boolean failed = false;
         try {
             Eo.classify(span).into(stack, globals, emit);

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -40,6 +40,13 @@ final class Stack {
     private final List<Level> levels;
 
     /**
+     * The top level captured by the most recent {@link #checkpoint()},
+     * reinstated by {@link #silentTruncate} when a failed line
+     * {@link #replace}d it.
+     */
+    private Level saved;
+
+    /**
      * Close-time check hook, invoked whenever a level is popped or
      * replaced. Injected once at construction so per-call wiring stays
      * out of the API.
@@ -108,25 +115,52 @@ final class Stack {
     }
 
     /**
-     * Current number of entries on the stack — savepoint for per-line
-     * rollback (R-7.3).
-     * @return Entry count
+     * The top entry, or {@code null} when the stack is empty.
+     * @return Top, or null
      */
-    int size() {
+    Level topOrNull() {
+        final Level top;
+        if (this.levels.isEmpty()) {
+            top = null;
+        } else {
+            top = this.levels.get(this.levels.size() - 1);
+        }
+        return top;
+    }
+
+    /**
+     * Record the top level as the per-line rollback savepoint (R-7.3)
+     * and return the current depth. Taken before a line runs so a
+     * {@link ParseError} can undo its {@link #push} / {@link #replace}
+     * side effects.
+     * @return Stack depth at the checkpoint
+     */
+    int checkpoint() {
+        this.saved = this.topOrNull();
         return this.levels.size();
     }
 
     /**
-     * Pop entries silently until {@code size()} equals {@code target}.
-     * Used by {@link Eo} to undo {@link #push} / {@link #replace} side
-     * effects of a line that threw a {@link ParseError} (R-7.3) — the
-     * closer is <em>not</em> invoked here because the rolled-back open
-     * directives never reached the sink.
-     * @param target Target stack size
+     * Undo the structural side effects of a line that threw a
+     * {@link ParseError} (R-7.3) — the closer is <em>not</em> invoked
+     * here because the rolled-back open directives never reached the
+     * sink. Pops every entry pushed beyond {@code target} and then
+     * reconciles the top with the savepoint: a {@link #replace} leaves
+     * the depth unchanged yet swaps the level, and a replace that threw
+     * mid-way (before the fresh level landed) even leaves the depth one
+     * short, so a size-based truncation alone cannot model either — the
+     * displaced level is put back and its close-time check will fire
+     * when it genuinely closes.
+     * @param target Stack depth at the checkpoint
      */
     void silentTruncate(final int target) {
         while (this.levels.size() > target) {
             this.levels.remove(this.levels.size() - 1);
+        }
+        if (this.levels.size() < target) {
+            this.levels.add(this.saved);
+        } else if (target > 0 && this.levels.get(target - 1) != this.saved) {
+            this.levels.set(target - 1, this.saved);
         }
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -138,6 +138,62 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void recoversFromBrokenEscapeThatReplacedItsSibling() throws Exception {
+        MatcherAssert.assertThat(
+            "a failed only-phi line replacing a sibling must not corrupt the directive stream",
+            XhtmlMatchers.xhtml(
+                new String(
+                    new EoSyntax(
+                        new InputOf(
+                            String.join(
+                                System.lineSeparator(),
+                                "[] > pl",
+                                "  b",
+                                "    \"x\"",
+                                "    \"r\\c\" > [m]"
+                            )
+                        )
+                    ).parsed().toString().getBytes(StandardCharsets.UTF_8),
+                    StandardCharsets.UTF_8
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/object[@ms='0']",
+                "/object/errors/error[contains(text(),'invalid unicode or octal escape')]",
+                "/object/o[@name='pl']/o[@base='Φ.b']/o[@as='α0' and @base='Φ.string']"
+            )
+        );
+    }
+
+    @Test
+    void recoversFromBrokenEscapeReplacingAnOnlyPhi() throws Exception {
+        MatcherAssert.assertThat(
+            "a failed plain line replacing an only-phi sibling must not land ms on a child object",
+            XhtmlMatchers.xhtml(
+                new String(
+                    new EoSyntax(
+                        new InputOf(
+                            String.join(
+                                System.lineSeparator(),
+                                "[] > pl",
+                                "  b",
+                                "    \"x\" > [m]",
+                                "    \"r\\c\""
+                            )
+                        )
+                    ).parsed().toString().getBytes(StandardCharsets.UTF_8),
+                    StandardCharsets.UTF_8
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/object[@ms='0']",
+                "/object/errors/error[contains(text(),'invalid unicode or octal escape')]",
+                "/object/o[@name='pl']/o[@base='Φ.b']/o[@as='α0']"
+            )
+        );
+    }
+
+    @Test
     void copiesListingCorrectly() throws Exception {
         final String src = new TextOf(
             new ResourceOf("org/eolang/parser/factorial.eo")


### PR DESCRIPTION
Fixes #6425.

## Problem

A single-character typo in a `.eo` file produces an unhandled `ClassCastException` (or schema-invalid XMIR), because `Eo.dispatch` rollback cannot undo a `Stack.replace`: `silentTruncate` works by stack size, and a same-size replacement leaves the replacement level in place. When the failed line owed a different number of `emit.close()` calls than the level it displaced, the directive stream and the parser model diverge.

## Solution

Give the per-line rollback a real savepoint. `Stack.checkpoint()` records the top level and returns the current depth; `silentTruncate(target)` now reinstates the displaced level after truncation, covering three shapes:

- a push (stack grew beyond `target`),
- a completed replace (depth unchanged, top swapped),
- a replace that threw mid-way (e.g. in `observeVoid`), when the stack is left one level short of `target`.

## Changes

- `eo-parser/src/main/java/org/eolang/parser/Stack.java` — `checkpoint()` records the top level; `silentTruncate(int)` restores it; `topOrNull()` helper; removed the redundant `size()` (same as `depth()`).
- `eo-parser/src/main/java/org/eolang/parser/Eo.java` — both rollback call sites use `stack.checkpoint()`.

## Tests

- `EoSyntaxTest.recoversFromBrokenEscapeThatReplacedItsSibling` — a failed only-phi line replacing a plain sibling (the `ClassCastException` shape).
- `EoSyntaxTest.recoversFromBrokenEscapeReplacingAnOnlyPhi` — a failed plain line replacing an only-phi (the `ms`-lands-on-`<o>` shape).

@yegor256 please take a look.