### PR TITLE
test(#6425): add ms-integrity regression for replaced only-phi rollback

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-only-phi-rollback-keeps-ms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-only-phi-rollback-keeps-ms.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[@ms='0']
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'invalid unicode or octal escape')]
+input: |
+  [] > pl
+    b > child
+      "x" > [m]
+      "r\c"


### PR DESCRIPTION
Related to #6425 (already fixed by #6468).

## Problem

The merged fix (#6468) added a regression pack for the primary symptom of #6425 — a failed only-phi line replacing a plain sibling, which used to crash with `ClassCastException`. The issue also documents the reverse shape — a failed plain line replacing an only-phi sibling — which used to land the `ms` attribute on a child `<o>` (schema-invalid XMIR). That shape is not covered by any test.

## Solution

Add one eo-syntax pack covering the reverse shape and asserting `ms` stays on `/object`, plus the expected parser error.

## Changes

- `eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-only-phi-rollback-keeps-ms.yaml` — new pack.

## Tests

- The pack fails on pre-fix code with `FAIL: /object[@ms='0']` (verified against `98647bd6e`) and passes on master with the #6468 fix.