### PR TITLE
translate a glob brace group into a regex alternation

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -1,11 +1,11 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 #
-# @todo #5751:45min Translate the rest of the glob syntax below. The `translated`
-#  object handles star, double star, question mark and the separator, but a brace
-#  group like {a,b} and a character class like [a-z] or [!a] reach the regex
-#  engine neither translated nor escaped, so a bracket or a brace in the glob
-#  either refuses to compile or matches the wrong entries.
+# @todo #6482:45min Translate a character class in the glob below. The
+#  `translated` object now turns a brace group into an alternation, but a class
+#  like [a-z] or [!a] reaches the regex engine neither translated nor escaped,
+#  so a negation matches nothing it should and a lone bracket refuses to
+#  compile, while a star inside a class keeps its glob meaning by mistake.
 # @todo #5751:30min Stop descending into a symbolic link to a directory. The
 #  `walk` below asks stat, which follows the link, so a link to its own ancestor
 #  recurses forever, while the `Files.walk` it replaced only listed such a link.
@@ -146,7 +146,7 @@
                   string.joined *1 >>!
                     ""
                     "/^"
-                    translated 0 ""
+                    translated 0 "" false
                     "$/"
                 T > [message] >>
                   "Can't parse '%s' as a glob pattern, %s".printf
@@ -157,7 +157,7 @@
       "[^"
       escaped path.separator >> literal
       "]"
-    [index acc] >> translated
+    [index acc braced] >> translated
       if. > @
         index.gte glob.length
         acc
@@ -168,6 +168,13 @@
             ""
             acc
             token
+          if.
+            char.eq "{"
+            true
+            if.
+              char.eq "}"
+              false
+              braced
       string.at glob index > char
       and. > double
         char.eq "*"
@@ -191,7 +198,21 @@
             if.
               char.eq "/"
               literal
-              escaped char
+              alternated
+      if. > alternated
+        char.eq "{"
+        "("
+        if.
+          and.
+            braced
+            char.eq "}"
+          ")"
+          if.
+            and.
+              braced
+              char.eq ","
+            "|"
+            escaped char
 
   ++> can-create-a-regular-tmpfile
     seq * > @
@@ -371,6 +392,42 @@
           ","
           d.as-dir.walk "*.txt"
         d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-brace-group
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "привет.txt"
+      touched.
+        as-file.
+          d.resolved "мир.log"
+      touched.
+        as-file.
+          d.resolved "c.md"
+      eq.
+        length.
+          d.as-dir.walk "{привет.txt,мир.log}"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-comma-outside-a-glob-brace-group
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a,b.txt"
+      touched.
+        as-file.
+          d.resolved "ab.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "a,b.txt"
+        d.resolved "a,b.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -175,6 +175,18 @@
               char.eq "}"
               false
               braced
+      if. > alternated
+        char.eq "{"
+        "("
+        if.
+          braced.and
+            char.eq "}"
+          ")"
+          if.
+            braced.and
+              char.eq ","
+            "|"
+            escaped char
       string.at glob index > char
       and. > double
         char.eq "*"
@@ -199,20 +211,6 @@
               char.eq "/"
               literal
               alternated
-      if. > alternated
-        char.eq "{"
-        "("
-        if.
-          and.
-            braced
-            char.eq "}"
-          ")"
-          if.
-            and.
-              braced
-              char.eq ","
-            "|"
-            escaped char
 
   ++> can-create-a-regular-tmpfile
     seq * > @
@@ -376,22 +374,19 @@
       made.
         directory mktemp.tmpfile.deleted
 
-  ++> can-walk-with-a-plain-glob-matching-direct-children-only
+  ++> can-walk-with-a-comma-outside-a-glob-brace-group
     seq * > @
       touched.
         as-file.
-          d.resolved "a.txt"
-      made.
-        as-dir.
-          d.resolved "sub"
+          d.resolved "a,b.txt"
       touched.
         as-file.
-          d.resolved "sub/b.txt"
+          d.resolved "ab.txt"
       eq.
         string.joined
           ","
-          d.as-dir.walk "*.txt"
-        d.resolved "a.txt"
+          d.as-dir.walk "a,b.txt"
+        d.resolved "a,b.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
@@ -415,19 +410,22 @@
       made.
         directory mktemp.tmpfile.deleted
 
-  ++> can-walk-with-a-comma-outside-a-glob-brace-group
+  ++> can-walk-with-a-plain-glob-matching-direct-children-only
     seq * > @
       touched.
         as-file.
-          d.resolved "a,b.txt"
+          d.resolved "a.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
       touched.
         as-file.
-          d.resolved "ab.txt"
+          d.resolved "sub/b.txt"
       eq.
         string.joined
           ","
-          d.as-dir.walk "a,b.txt"
-        d.resolved "a,b.txt"
+          d.as-dir.walk "*.txt"
+        d.resolved "a.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted


### PR DESCRIPTION
A glob like `*.{txt,log}` never reached the file system. The `translated` object escaped `.`, `+`, `(`, `)`, `|`, `^`, `$` and the backslash, but left a brace alone, so `{a,b}` arrived at the regex engine as `{a,b}` and Java read it as a repetition quantifier and refused to compile the pattern.

Now `translated` carries a `braced` flag alongside the index and the accumulator. An opening brace becomes `(` and raises the flag, a closing brace becomes `)` and lowers it, and a comma becomes `|` only while the flag is up, so a comma in a plain file name still matches itself. Two tests cover both halves: one walks a directory with a brace group over non-ASCII names, the other walks it with a literal comma in the pattern.

The character class is still untranslated, so `[a-z]` and `[!a]` behave the way the old puzzle described. That part stays as a puzzle in the same docblock, pointing at this issue.

Closes #6482
