### PR TITLE
Filter the directory walk while it walks

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -94,7 +94,6 @@
       number.random clock
   [glob] > walk
     [accum prefix dir] >> walked
-      dir.listed >> names
       [rest] >> stepped
         if. > @
           rest.length.eq 0
@@ -103,8 +102,8 @@
             child.as-file.is-directory false
             walked earlier sub child.as-dir
             picked earlier sub
-        stepped rest.tail > earlier
         dir.as-path.resolved name > child
+        stepped rest.tail > earlier
         rest.head > name
         if. > sub
           prefix.length.eq 0
@@ -113,7 +112,7 @@
             path.separator
             prefix
             name
-      | names > @
+      | dir.listed > @
     | > @
       *
       ""

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -9,10 +9,10 @@
 # @todo #5751:30min Stop descending into a symbolic link to a directory. The
 #  `walk` below asks stat, which follows the link, so a link to its own ancestor
 #  recurses forever, while the `Files.walk` it replaced only listed such a link.
-# @todo #5751:60min Walk a directory without growing the EO call stack. The
-#  `stepped` below recurses once per entry and `walked` once per level, so a
-#  directory with many entries overflows the stack the way `string.repeated`
-#  does in #6239, while the `Files.walk` they replace iterated instead.
+# @todo #6484:60min Walk a directory in constant stack space. The `stepped`
+#  below still costs one frame per entry, because every loop EO has grows the
+#  stack: `while` nests a frame per cycle and `tuple.reducedi` one per element,
+#  so a directory of a few thousand entries still overflows.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -93,41 +93,36 @@
             *
       number.random clock
   [glob] > walk
-    tuple.reduced > @
-      [accum prefix dir] >> walked
-        dir.listed >> names
-        [index acc] >> stepped
-          if. > @
-            index.gte names.length
-            acc
-            stepped
-              index.plus 1
-              if.
-                child.as-file.is-directory false
-                walked acc sub child.as-dir
-                acc.with sub
-          dir.as-path.resolved name > child
-          names.at index > name
-          if. > sub
-            prefix.length.eq 0
+    [accum prefix dir] >> walked
+      dir.listed >> names
+      [rest] >> stepped
+        if. > @
+          rest.length.eq 0
+          picked accum prefix
+          if.
+            child.as-file.is-directory false
+            walked earlier sub child.as-dir
+            picked earlier sub
+        stepped rest.tail > earlier
+        dir.as-path.resolved name > child
+        rest.head > name
+        if. > sub
+          prefix.length.eq 0
+          name
+          string.joined *1
+            path.separator
+            prefix
             name
-            string.joined *1
-              path.separator
-              prefix
-              name
-        | > @
-          0
-          accum.with prefix
-      |
-        *
-        ""
-        ^
+      | names > @
+    | > @
       *
-      if. > [accum rel] >>
-        matched rel
-        accum.with
-          Q.file (base.resolved rel).as-bytes
-        accum
+      ""
+      ^
+    if. > [accum rel] >> picked
+      matched rel
+      accum.with
+        Q.file (base.resolved rel).as-bytes
+      accum
     ^.as-path >> base
     if. > [char] >> escaped
       string.contains ".+()|^$\\" char
@@ -332,6 +327,29 @@
     is-directory.
       directory mktemp.tmpfile
       true
+
+  ++> can-walk-a-directory-before-its-children
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/b.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "**b*"
+        string.joined *1
+          ","
+          d.resolved "sub"
+          d.resolved "sub/b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
 
   ++> can-walk-recursively
     seq * > @


### PR DESCRIPTION
`directory.walk` used to build the whole tree first and filter it afterwards. `walked` collected every relative path into a tuple, and a `tuple.reduced` on top of it threw away the ones the glob did not match. Two full recursions over the same entries, one nested inside the other, and the inner one paid for `names.at index` at every step — a lookup that peels one tail per index, so a directory of `n` entries cost `n` more frames at the deepest point and quadratic time overall.

Now the glob is applied where the entry is produced. `picked` appends a path to the accumulator only when `matched` says yes, and `walked` hands the accumulator down the tree, so nothing is collected that is later discarded and the second pass is gone. `stepped` walks the listing by `head` and `tail` instead of by index, which drops the quadratic lookups; it recurses on the earlier entries first and appends the last one, so the pre-order that `directory.deleted` relies on is unchanged. The new test pins that order: a directory comes back before the file inside it.

This makes the walk cheaper, not free. A puzzle stays behind for the rest, because it is not really a problem of this file. EO has no loop that does not grow the stack — `while` nests a frame per cycle and `tuple.reducedi` one per element — so any traversal written here still costs a frame per entry. Removing that needs an iterative primitive in the runtime, not another rewrite of `walk`.

Closes #6484
