### PR TITLE
#5721: keep an argument applied to a data literal when unhexing

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Payload.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Payload.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.printer;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * The hex byte payload of a data literal in XMIR.
+ *
+ * <p>The payload is the {@code α0} argument of the literal's wrapper element,
+ * and {@link StUnhex} folds it into the readable EO text of the same value. A
+ * bare data literal can be the head of an application, as in {@code 42 5}, and
+ * then the wrapper holds the applied argument next to the payload. The applied
+ * arguments are taken out before the wrapper is emptied and put back after,
+ * which also drops the indentation between them, and they take the places left
+ * by the payload, since the slot they were counted from is gone.</p>
+ *
+ * @since 0.73.3
+ */
+final class Payload {
+
+    /**
+     * The wrapper element of the literal.
+     */
+    private final Xnav literal;
+
+    /**
+     * Ctor.
+     * @param wrapper The {@code <o>} element of the literal
+     */
+    Payload(final Xnav wrapper) {
+        this.literal = wrapper;
+    }
+
+    /**
+     * Put the given text in place of the payload.
+     * @param text The readable EO text of the literal
+     */
+    void replace(final String text) {
+        final List<Node> args = this.literal.elements(Filter.withName("o"))
+            .skip(1)
+            .map(Xnav::node)
+            .collect(Collectors.toList());
+        final Node wrapper = this.literal.node();
+        wrapper.setTextContent(text);
+        int index = 0;
+        for (final Node arg : args) {
+            final Element elem = (Element) arg;
+            if (elem.getAttribute("as").startsWith("α")) {
+                elem.setAttribute("as", String.format("α%d", index));
+                index += 1;
+            }
+            wrapper.appendChild(arg);
+        }
+    }
+}

--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -34,7 +34,7 @@ final class StUnhex extends StEnvelope {
         StUnhex.class.getSimpleName(),
         new StXnav(
             StUnhex.BYTES,
-            xnav -> xnav.node().setTextContent(
+            xnav -> new Payload(xnav).replace(
                 xnav.element("o").text().orElse("")
             )
         ),
@@ -47,7 +47,7 @@ final class StUnhex extends StEnvelope {
                 if (buffer.remaining() == Double.BYTES) {
                     final double number = buffer.getDouble();
                     if (!Double.isNaN(number) && !Double.isInfinite(number)) {
-                        xnav.node().setTextContent(StUnhex.number(number));
+                        new Payload(xnav).replace(StUnhex.number(number));
                     }
                 }
             }
@@ -59,7 +59,7 @@ final class StUnhex extends StEnvelope {
                     StUnhex.undash(xnav.element("o").text().orElse(""))
                 ).array()
             ).ifPresent(
-                decoded -> xnav.node().setTextContent(
+                decoded -> new Payload(xnav).replace(
                     String.format("\"%s\"", StUnhex.escape(decoded))
                 )
             )

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -235,6 +235,30 @@ final class StUnhexTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void unhexesIndentedLiteralWithAnArgument(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must keep the argument of an indented literal and unhex it cleanly",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<p> <o base='Φ.number'> ",
+                        "<o as='α0' base='Φ.bytes'> <o as='α0'>40-45-00-00-00-00-00-00</o> </o> ",
+                        "<o as='α1' base='Φ.bytes'> <o as='α0'>2A-</o> </o> </o> </p>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.number' and text()='42' and o[@as='α0' and text()='2A-']]"
+            )
+        );
+    }
+
     private static Stream<Arguments> shifts() {
         return Stream.of(
             Arguments.of(StUnhex.XNAV, "xnav")

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-applied-to-data-literal.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-applied-to-data-literal.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A bare data literal may be the head of an application, so its XMIR wrapper
+# holds the applied argument next to its own byte payload. Unhexing the payload
+# must leave that argument where it is (#5721).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    42 5 > a
+    "str" 5 > b
+    01-02 5 > c
+    42 * > d
+      1
+      2
+
+printed: |
+  [] > main
+    42 5 > a
+    "str" 5 > b
+    01-02 5 > c
+    42 * > d
+      1
+      2


### PR DESCRIPTION
`StUnhex` called `setTextContent` on the wrapper element of a data literal, which deletes every child of that element. The byte payload is only the first child: a bare literal can be the head of an application, as in `42 5`, and then the applied argument sits next to the payload and was deleted with it. The argument disappeared from the printed EO without any error.

Now only the payload child is swapped for the readable text, so the argument stays. The payload is the `α0` argument of the wrapper, so the arguments that follow move up one place, otherwise `unnecessary-as.xsl` no longer sees a run starting at `α0` and the printer emits `5:1` instead of `5`.

The print-pack covers a number, a string, a bytes literal and a compact tuple as the applied argument. Without the fix it prints `42 > a`, `"str" > b`, `01-02 > c` and `42 > d`.

Closes #5721
