### PR TITLE
#6499: fix cachesPhiViaNewRecursively to check its own counter

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -961,7 +961,6 @@ final class PhDefaultTest {
         /**
          * Count.
          */
-        @SuppressWarnings("PMD.UnusedPrivateField")
         private static int count;
 
         /**
@@ -978,7 +977,7 @@ final class PhDefaultTest {
                             rho -> {
                                 --PhDefaultTest.RecursivePhiViaNew.count;
                                 final Phi result;
-                                if (PhDefaultTest.RecursivePhi.count <= 0) {
+                                if (PhDefaultTest.RecursivePhiViaNew.count <= 0) {
                                     result = new Data.ToPhi(0L);
                                 } else {
                                     result = new Data.ToPhi(


### PR DESCRIPTION
Fixes the recursion check in `cachesPhiViaNewRecursively`.

The `RecursivePhiViaNew` fixture decremented `RecursivePhiViaNew.count`, but the termination check on the next line read `RecursivePhi.count`, the sibling fixture's counter. That counter defaults to 0, so the fixture returned `new Data.ToPhi(0L)` on the first call without ever recursing, and the test's assertion held either way.

Fix: read `RecursivePhiViaNew.count` in the termination check, so the counter the test sets actually governs the recursion. Also dropped the now-stale `@SuppressWarnings("PMD.UnusedPrivateField")` on `count`, since it is genuinely read now.


Closes #6499
