### PR TITLE
#6506: log the cache path, not the unused source, in FpUpdateFromCache

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/FpUpdateFromCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/FpUpdateFromCache.java
@@ -31,11 +31,12 @@ final class FpUpdateFromCache implements Footprint {
 
     @Override
     public Path apply(final Path source, final Path target) throws IOException {
+        final Path cached = this.cache.get();
         Logger.debug(
             FpUpdateFromCache.class,
             "Updating only target %[file]s from cache %[file]s",
-            target, source
+            target, cached
         );
-        return new Saved(new TextOf(this.cache.get()), target).value();
+        return new Saved(new TextOf(cached), target).value();
     }
 }


### PR DESCRIPTION
FpUpdateFromCache.apply logged "cache %[file]s" but passed source, the argument it never reads. The content actually comes from this.cache.get(); source is unused (the test already passes Paths.get("/dev/null") for it).

Fix: bind final Path cached = this.cache.get() once and use it both in the log message and in the copy, matching how FpUpdateBoth already binds and logs its cache path.


Closes #6506
