### PR TITLE
#6505: fix PenaltyKey.BRACKET javadoc to describe nesting depth

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
+++ b/eo-printer/src/main/java/org/eolang/printer/PenaltyKey.java
@@ -24,8 +24,8 @@ public enum PenaltyKey {
     INDENT(2),
 
     /**
-     * Points charged per opening parenthesis, progressively: the k-th
-     * parenthesis on a line costs k times this weight.
+     * Points charged per opening parenthesis, progressively: a parenthesis
+     * nested k levels deep costs k plus one times this weight.
      */
     BRACKET(19),
 


### PR DESCRIPTION
PenaltyKey.BRACKET's javadoc said the k-th parenthesis on a line costs k times the weight, a per-line ordinal. Penalty.brackets actually charges depth + 1, where depth is how many parentheses are still open (nesting), not how many have appeared on the line so far. The two diverge on sibling groups: in "foo (a) (b)" the second "(" is second on the line but at depth zero, so it costs one unit, not two.

Reworded the enum javadoc to match Penalty's own class javadoc, which already describes the depth rule correctly.


Closes #6505
