### PR TITLE
#6504: use different xml per thread in doesNotFailWithDifferentXmlInMultipleThreads

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
@@ -49,10 +49,16 @@ final class StrictXmirTest {
         Assertions.assertDoesNotThrow(
             new Together<>(
                 thread -> {
-                    return new StrictXmir(
-                        StrictXmirTest.xmir("https://www.eolang.org/XMIR.xsd"),
-                        tmp
-                    ).inner();
+                    final String schema;
+                    if (thread % 2 == 0) {
+                        schema = "https://www.eolang.org/XMIR.xsd";
+                    } else {
+                        schema = String.format(
+                            "https://www.eolang.org/xsd/XMIR-%s.xsd",
+                            StrictXmirTest.version()
+                        );
+                    }
+                    return new StrictXmir(StrictXmirTest.xmir(schema), tmp).inner();
                 }
             )::asList,
             "StrictXmir should not fail in different threads with different xmls"


### PR DESCRIPTION
doesNotFailWithDifferentXmlInMultipleThreads built every thread the same XMIR against the same schema URL, so it was really testing the same-xml case a second time under a name that promises different xmls. doesNotFailOnTheSameOperation already covers that case seventeen lines below.

Now each thread alternates between the remote schema and the local version-specific schema, so threads validate genuinely different documents concurrently.


Closes #6504
