### PR TITLE
#6501: remove three MainTest tests that only assert JDK stream behavior

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/MainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MainTest.java
@@ -7,11 +7,6 @@ package org.eolang;
 import com.yegor256.Jaxec;
 import com.yegor256.Jhome;
 import com.yegor256.Result;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.channels.Channels;
-import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -116,59 +111,6 @@ final class MainTest {
             "Fails with the proper error message",
             MainTest.stderr("unavailable-name"),
             Matchers.containsString("Couldn't find object 'Φ.unavailable-name'")
-        );
-    }
-
-    @Test
-    void readsStreamCorrectly() throws IOException {
-        MatcherAssert.assertThat(
-            "Reading stream should produce a non-empty line, but it didn't",
-            new BufferedReader(
-                Channels.newReader(
-                    Channels.newChannel(
-                        new ByteArrayInputStream(
-                            ">> ··𝔸('text' for EOorgEOio.EOstdoutν2) ➜ ΦSFN".getBytes(
-                                StandardCharsets.UTF_8
-                            )
-                        )
-                    ),
-                    StandardCharsets.UTF_8.name()
-                )
-            ).readLine().length(),
-            Matchers.greaterThan(0)
-        );
-    }
-
-    @Test
-    void readsSimpleStreamCorrectly() throws IOException {
-        MatcherAssert.assertThat(
-            "Reading stream should produce a line longer then 1 character, but it didn't",
-            new BufferedReader(
-                Channels.newReader(
-                    Channels.newChannel(
-                        new ByteArrayInputStream(
-                            "abc".getBytes(
-                                StandardCharsets.UTF_8
-                            )
-                        )
-                    ),
-                    StandardCharsets.UTF_8.name()
-                )
-            ).readLine().length(),
-            Matchers.greaterThan(1)
-        );
-    }
-
-    @Test
-    void readsBytesCorrectly() {
-        MatcherAssert.assertThat(
-            "Reading stream should produce a byte of next character, but it didn't",
-            new ByteArrayInputStream(
-                "··𝔸➜Φ".getBytes(
-                    StandardCharsets.UTF_8
-                )
-            ).read(),
-            Matchers.greaterThan(0)
         );
     }
 


### PR DESCRIPTION
readsStreamCorrectly, readsSimpleStreamCorrectly and readsBytesCorrectly in MainTest.java never touched Main or anything in org.eolang. They wrapped an inline ByteArrayInputStream and asserted properties of BufferedReader/ByteArrayInputStream that only the JDK controls, so they carried no relationship to the class the file is named for and could only fail if the JDK itself was broken. The first two also left their BufferedReader unclosed.

Removed the three and the now-unused imports (BufferedReader, ByteArrayInputStream, IOException, Channels, StandardCharsets). deliversCleanOutput already covers Main's output through Main itself.


Closes #6501
