### PR TITLE
#6513: fix two non-existent stylesheet paths in XslBench

### DIFF
--- a/eo-parser/src/test/java/benchmarks/XslBench.java
+++ b/eo-parser/src/test/java/benchmarks/XslBench.java
@@ -45,11 +45,11 @@ public class XslBench {
         new TrClasspath<>(
             "/org/eolang/parser/parse/move-voids-up.xsl",
             "/org/eolang/parser/parse/validate-before-stars.xsl",
-            "/org/eolang/parser/parse/resolve-before-star.xsl",
+            "/org/eolang/parser/parse/resolve-before-stars.xsl",
             "/org/eolang/parser/parse/wrap-method-calls.xsl",
             "/org/eolang/parser/parse/const-to-dataized.xsl",
             "/org/eolang/parser/parse/stars-to-tuples.xsl",
-            "/org/eolang/parser/shake/build-fqns.xsl"
+            "/org/eolang/parser/parse/build-fqns.xsl"
         ).back()
     );
 


### PR DESCRIPTION
XslBench.LINE listed two stylesheet paths that never existed: resolve-before-star.xsl (real file is resolve-before-stars.xsl, plural) and shake/build-fqns.xsl (real file is parse/build-fqns.xsl, no shake/ directory). TrClasspath resolves eagerly, so the static initializer threw before any benchmark ran, mvn jmh:benchmark still exited 0, and benchmark.json came out as an empty array. That is why the Performance Regression Check bot has been posting "one of the benchmarks is missing" on every PR.

Fixed both paths. Verified with mvn jmh:benchmark -pl eo-parser -Djmh.rf=json -Djmh.rff=benchmark.json: before the fix, benchmark.json is []; after, it holds a real result for XslBench.manySheetsOnLargeXmir.


Closes #6513
