### PR TITLE
#6439: reject non-IPv4 addresses in win32.inet_addr instead of throwing

### DIFF
--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -61,6 +61,14 @@
           "127.0.0.1"
       16777343
 
+  os.is-windows.not.or ++> rejects-an-ipv6-address-as-invalid
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "::1"
+      win32.invalid
+
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @
       1.div 0

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -36,15 +36,18 @@ public final class InetAddrFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
+        byte[] address;
         try {
-            final ByteBuffer buffer = ByteBuffer.allocate(4);
-            buffer.put(
-                InetAddress.getByName(
-                    new Dataized(params[0]).asString()
-                ).getAddress()
-            );
-            result.put(0, new Data.ToPhi(Integer.reverseBytes(buffer.getInt(0))));
+            address = InetAddress.getByName(new Dataized(params[0]).asString()).getAddress();
         } catch (final UnknownHostException exception) {
+            address = new byte[0];
+        }
+        if (address.length == 4) {
+            result.put(
+                0,
+                new Data.ToPhi(Integer.reverseBytes(ByteBuffer.wrap(address).getInt(0)))
+            );
+        } else {
             Winsock.INSTANCE.WSASetLastError(Winsock.WSAEINVAL);
             result.put(0, new Data.ToPhi(-1));
         }


### PR DESCRIPTION
InetAddrFuncCall allocated a 4-byte ByteBuffer and put() the resolved address into it directly. For an IPv6 input like ::1, InetAddress.getByName resolves to 16 bytes, so the put() overflowed the 4-byte buffer and threw BufferOverflowException instead of returning the existing invalid-address result (-1 with WSAEINVAL) that an unresolvable host already gets.

Now the resolved address length is checked before use: only a 4-byte (IPv4) result is converted, anything else (including the unresolvable-host case, which now yields a 0-length array) falls into the existing invalid-address branch.

Added an EO test in win32.eo next to the existing localhost test, following the same os.is-windows guard, asserting win32 inet_addr on "::1" returns win32.invalid.

Refs #6439
