### PR TITLE
fix(#5737): reject binding on a reversed receiver chain

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -74,6 +74,25 @@ final class Bindings {
     }
 
     /**
+     * Reject a binding that a same-indent {@code .method} chain
+     * continuation would attach through a bare-reversed receiver host —
+     * R-6.6.3. When the chain being extended is the receiver of a
+     * reversed dispatch, a binding on a later link names the whole
+     * reversed expression, which is the same as binding the receiver.
+     * @param below The chain head's parent (what the upgrade would
+     *  touch), or {@code null} when there is none
+     * @param span Source span of the continuation line
+     */
+    static void checkReceiverUpgrade(final Level below, final Span span) {
+        if (below != null && below.kind() == Kind.BARE_REVERSED) {
+            throw new ParseError(
+                span.line(), span.indent(),
+                "reversed-dispatch receiver cannot carry a binding"
+            );
+        }
+    }
+
+    /**
      * Observe a freshly-pushed child line's outer binding against its
      * parent context — cross-line R-6.6.2 / R-6.6.3 / R-3.12.3.
      *

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -80,8 +80,11 @@ final class LnMethod implements Line {
             Blanks.checkPlain(this.span, globals, emit);
         }
         Comments.seal(globals, emit, this.span);
-        if (outer != null && stack.below() != null) {
-            stack.below().upgradeArgBinding();
+        if (outer != null) {
+            Bindings.checkReceiverUpgrade(stack.below(), this.span);
+            if (stack.below() != null) {
+                stack.below().upgradeArgBinding();
+            }
         }
         emit.close();
         emit.object(

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -841,42 +841,6 @@ final class EoTest {
     }
 
     @Test
-    void rejectsBindingOnReversedReceiverChain() {
-        MatcherAssert.assertThat(
-            "a binding on a later link of a reversed receiver's chain must surface R-6.6.3",
-            EoTest.render(
-                "foo > main",
-                "  if.",
-                "    cond",
-                "    .baz:x",
-                "    then",
-                "    other"
-            ),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]"
-            )
-        );
-    }
-
-    @Test
-    void acceptsUnboundReversedReceiverChain() {
-        MatcherAssert.assertThat(
-            "a reversed receiver's chain without a binding must keep parsing",
-            EoTest.render(
-                "foo > main",
-                "  if.",
-                "    cond",
-                "    .baz",
-                "    then",
-                "    other"
-            ),
-            XhtmlMatchers.hasXPath(
-                "/object[not(errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')])]"
-            )
-        );
-    }
-
-    @Test
     void acceptsInlineVoidsOnReversedDispatch() {
         MatcherAssert.assertThat(
             "a trailing-dot object with an inline void suffix must parse with no errors and desugar to the same φ-as-reversed-dispatch shape as its two-line form",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -841,6 +841,42 @@ final class EoTest {
     }
 
     @Test
+    void rejectsBindingOnReversedReceiverChain() {
+        MatcherAssert.assertThat(
+            "a binding on a later link of a reversed receiver's chain must surface R-6.6.3",
+            EoTest.render(
+                "foo > main",
+                "  if.",
+                "    cond",
+                "    .baz:x",
+                "    then",
+                "    other"
+            ),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]"
+            )
+        );
+    }
+
+    @Test
+    void acceptsUnboundReversedReceiverChain() {
+        MatcherAssert.assertThat(
+            "a reversed receiver's chain without a binding must keep parsing",
+            EoTest.render(
+                "foo > main",
+                "  if.",
+                "    cond",
+                "    .baz",
+                "    then",
+                "    other"
+            ),
+            XhtmlMatchers.hasXPath(
+                "/object[not(errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')])]"
+            )
+        );
+    }
+
+    @Test
     void acceptsInlineVoidsOnReversedDispatch() {
         MatcherAssert.assertThat(
             "a trailing-dot object with an inline void suffix must parse with no errors and desugar to the same φ-as-reversed-dispatch shape as its two-line form",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-receiver-chain-binding.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-receiver-chain-binding.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:4] error: 'reversed-dispatch receiver cannot carry a binding'
+input: |
+  foo > main
+    if.
+      cond
+      .baz:x
+      then
+      other


### PR DESCRIPTION
Fixes #5737.

## Problem

R-6.6.3 (a reversed-dispatch receiver cannot carry a binding) is bypassed when the receiver is a multi-link `.method` chain. `Bindings.observeReversedChild` only throws when the binding sits on the receiver's first line; a binding on a later chain link lands via `LnMethod.into()` → `Level.upgradeArgBinding()`, which sets `argbound` with no validation and is silently discarded because the receiver was never tracked (`argpending` stays false). So `if.` / `cond` / `.baz:x` parses cleanly and emits `<o as="x" base=".baz"/>`, while the single-line and vertical-direct equivalents correctly raise the error.

## Solution

Reject the binding at the moment it would attach through a bare-reversed receiver host. `Bindings.checkReceiverUpgrade(below, span)` throws R-6.6.3 when a `.method` continuation carries an outer binding under a `Kind.BARE_REVERSED` parent — binding a later link of the receiver's chain is the same as binding the receiver.

## Changes

- `eo-parser/src/main/java/org/eolang/parser/Bindings.java` — new `checkReceiverUpgrade` (R-6.6.3 for chain continuations).
- `eo-parser/src/main/java/org/eolang/parser/LnMethod.java` — call it before `upgradeArgBinding()`.
- `eo-parser/src/test/java/org/eolang/parser/EoTest.java` — regression tests.

## Tests

- `EoTest.rejectsBindingOnReversedReceiverChain` — the multi-link `.baz:x` shape (verified to fail on pre-fix code).
- `EoTest.acceptsUnboundReversedReceiverChain` — the same chain without a binding still parses.
- Existing `rejectsBoundReversedReceiver`, `rejectsBindingOnVerticalReceiver`, `rejectsMixedBindingsAmongReversedArgs` still pass.

@yegor256 please take a look.
