### PR TITLE
#6441: fix Saved NullPointerException on relative filename without parent

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -38,7 +38,8 @@ import org.cactoos.scalar.LengthOf;
 final class Saved implements Scalar<Path> {
 
     /**
-     * Absolute path to save content to.
+     * Path to save content to, absolute or relative to the current
+     * working directory.
      */
     private final Path target;
 
@@ -77,7 +78,7 @@ final class Saved implements Scalar<Path> {
     /**
      * Ctor.
      * @param content Content as lambda
-     * @param target Absolute path to save content to
+     * @param target Path to save content to
      */
     Saved(final Input content, final Path target) {
         this.content = content;
@@ -86,16 +87,14 @@ final class Saved implements Scalar<Path> {
 
     @Override
     public Path value() throws IOException {
+        final Path dir = this.target.toAbsolutePath().getParent();
         final long bytes;
         try {
-            if (this.target.toFile().getParentFile().mkdirs()) {
-                Logger.debug(
-                    this, "Directory created: %[file]s",
-                    this.target.getParent()
-                );
+            if (dir.toFile().mkdirs()) {
+                Logger.debug(this, "Directory created: %[file]s", dir);
             }
             final Path tmp = Files.createTempFile(
-                this.target.getParent(),
+                dir,
                 this.target.getFileName().toString(),
                 ".tmp"
             );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -88,9 +88,10 @@ final class Saved implements Scalar<Path> {
 
     @Override
     public Path value() throws IOException {
+        final Path abs = Objects.requireNonNull(this.target, "target").toAbsolutePath();
         final Path dir = Objects.requireNonNull(
-            this.target.toAbsolutePath().getParent(),
-            () -> String.format("%s has no parent directory", this.target)
+            abs.getParent(),
+            () -> String.format("%s has no parent directory", abs)
         );
         final long bytes;
         try {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -12,6 +12,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
@@ -87,7 +88,10 @@ final class Saved implements Scalar<Path> {
 
     @Override
     public Path value() throws IOException {
-        final Path dir = this.target.toAbsolutePath().getParent();
+        final Path dir = Objects.requireNonNull(
+            this.target.toAbsolutePath().getParent(),
+            () -> String.format("%s has no parent directory", this.target)
+        );
         final long bytes;
         try {
             if (dir.toFile().mkdirs()) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -37,6 +38,21 @@ final class SavedTest {
             Files.readString(target, StandardCharsets.UTF_8),
             Matchers.equalTo("hello")
         );
+    }
+
+    @Test
+    void savesContentToRelativeFilenameWithoutParentDirectory() throws IOException {
+        final Path target = Path.of(String.format("saved-%s.tmp", UUID.randomUUID()));
+        try {
+            new Saved("hello", target).value();
+            MatcherAssert.assertThat(
+                "a relative filename with no parent directory must be saved as-is",
+                Files.readString(target, StandardCharsets.UTF_8),
+                Matchers.equalTo("hello")
+            );
+        } finally {
+            Files.deleteIfExists(target);
+        }
     }
 
     @Test


### PR DESCRIPTION
Saved.value() called this.target.toFile().getParentFile().mkdirs() unconditionally, and getParentFile() returns null for a relative path with no directory component (e.g. Path.of("saved-probe.txt")), so a plain relative filename threw NullPointerException before any data was written. The following createTempFile call had the same problem with target.getParent().

Fixed by resolving the target to an absolute path once and using its parent for both the mkdirs call and the temp file location. An absolute path always has a parent, so no null check is needed. The returned path is still the original this.target, unchanged.


Closes #6441
