### PR TITLE
#6523: raise runtime workflow timeout and drop redundant org/eolang cache purge

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -12,7 +12,7 @@ name: runtime
       - master
 jobs:
   runtime:
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022]
@@ -29,8 +29,5 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - uses: JesseTG/rm@v1.0.3
-        with:
-          path: ~/.m2/repository/org/eolang
       - run: mvn -ntp -PskipITs -DskipTests --errors --batch-mode '-Deo.coverageTracking=false' clean install -pl '!:eo-integration-tests'
       - run: mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' clean install -pl :eo-runtime


### PR DESCRIPTION
The runtime job caps itself at 15 minutes, then runs two full builds in a row: a whole-reactor install, then a rebuild of eo-runtime with its EO tests. On #6519 both matrix jobs hit the cap (15m6s and 15m15s), and the last hundred runs of this workflow hold no success at all (63 cancelled, 31 failed). Since mvn.yml already covers the same reactor without EO tests in 5 to 9 minutes, the EO test cycle needs a good deal more than the six minutes left in the 15-minute budget.

Raised timeout-minutes to 30. Also dropped the JesseTG/rm step that deletes ~/.m2/repository/org/eolang before the build: the first mvn command already runs clean install across the whole reactor (except eo-integration-tests), which rebuilds those same modules from source regardless of what's cached, so the deletion only adds rebuild time without changing what gets built.

Refs #6523
