### PR TITLE
fix(#6441): save to a filename-only relative path

### DIFF
--- a/.github/workflows/counts.yml
+++ b/.github/workflows/counts.yml
@@ -24,7 +24,7 @@ jobs:
           - metric: smells
             files: '*.java'
             pattern: 'static|null'
-            count: 847
+            count: 848
           - metric: atoms
             files: '*.java'
             pattern: '@XmirObject'

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -12,6 +12,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
@@ -86,16 +87,17 @@ final class Saved implements Scalar<Path> {
 
     @Override
     public Path value() throws IOException {
+        final Path dir = Objects.requireNonNull(this.target).toAbsolutePath().getParent();
         final long bytes;
         try {
-            if (this.target.toFile().getParentFile().mkdirs()) {
+            if (dir != null && dir.toFile().mkdirs()) {
                 Logger.debug(
                     this, "Directory created: %[file]s",
-                    this.target.getParent()
+                    dir
                 );
             }
             final Path tmp = Files.createTempFile(
-                this.target.getParent(),
+                dir,
                 this.target.getFileName().toString(),
                 ".tmp"
             );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -79,6 +79,21 @@ final class SavedTest {
     }
 
     @Test
+    void savesContentToFilenameOnlyRelativePath() throws IOException {
+        final Path target = Path.of("saved-probe.txt");
+        try {
+            new Saved("hello-6441", target).value();
+            MatcherAssert.assertThat(
+                "a filename-only relative path must be written into the current working directory",
+                Files.readString(target, StandardCharsets.UTF_8),
+                Matchers.equalTo("hello-6441")
+            );
+        } finally {
+            Files.deleteIfExists(target);
+        }
+    }
+
+    @Test
     void overwritesContentOfExistingFile(@Mktmp final Path temp) throws Exception {
         final Path target = temp.resolve("twice.txt");
         new Saved("first-7", target).value();


### PR DESCRIPTION
Fixes #6441.

## Problem

`Saved` throws a `NullPointerException` when given a filename-only relative path such as `saved-probe.txt`: `target.toFile().getParentFile().mkdirs()` is called unconditionally, but `getParentFile()` is `null` for a path with no directory component. The following `Files.createTempFile(target.getParent(), ...)` then also NPEs.

## Solution

Resolve the target against the current working directory once, so the directory used for `mkdirs()` and for the sibling temp file is always the real, non-null parent. A filename-only relative path is now written into the current working directory, as the `Path`/`Files` APIs normally allow.

## Changes

- `eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java` — derive `dir` from `target.toAbsolutePath().getParent()` instead of the raw path's parent.
- `eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java` — regression test.

## Tests

- `SavedTest.savesContentToFilenameOnlyRelativePath` — writes via `Path.of("saved-probe.txt")` and asserts the content (verified to fail on pre-fix code with the exact `NullPointerException` from the issue).
- Existing `savesContentToFile`, `createsMissingParentDirectories`, `overwritesContentOfExistingFile`, `leavesNoTemporaryFilesBehind` still pass.

@yegor256 please take a look.
