### PR TITLE
#6443: fix StrictXmir.copied() NullPointerException for filename-only cache path

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/StrictXmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StrictXmir.java
@@ -214,11 +214,11 @@ public final class StrictXmir implements XML {
      * @return Where it was saved
      */
     private static File copied(final String uri, final Path path) {
-        final File file = path.toFile();
+        final File abs = path.toFile().getAbsoluteFile();
         StrictXmir.LOCK.lock();
         try {
-            if (!file.exists()) {
-                if (file.getParentFile().mkdirs()) {
+            if (!abs.exists()) {
+                if (abs.getParentFile().mkdirs()) {
                     Logger.debug(StrictXmir.class, "Directory for %[file]s created", path);
                 }
                 try {
@@ -239,7 +239,7 @@ public final class StrictXmir implements XML {
         } finally {
             StrictXmir.LOCK.unlock();
         }
-        return file;
+        return abs;
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
@@ -12,6 +12,8 @@ import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.Together;
 import com.yegor256.WeAreOnline;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
@@ -127,6 +129,28 @@ final class StrictXmirTest {
             ).toFile().exists(),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    void validatesXmirWithLocalSchemaAndEmptyCacheDirectory() throws IOException {
+        try {
+            Assertions.assertDoesNotThrow(
+                new StrictXmir(
+                    StrictXmirTest.xmir(
+                        String.format(
+                            "https://www.eolang.org/xsd/XMIR-%s.xsd",
+                            StrictXmirTest.version()
+                        )
+                    ),
+                    Path.of("")
+                )::inner,
+                "validation should not fail on a cache directory with no parent"
+            );
+        } finally {
+            Files.deleteIfExists(
+                Path.of(String.format("XMIR-%s.xsd", StrictXmirTest.version()))
+            );
+        }
     }
 
     @RepeatedTest(20)


### PR DESCRIPTION
StrictXmir.copied() called path.toFile().getParentFile().mkdirs() on the raw (possibly relative) path. When the cache directory resolves to an empty relative path (Path.of("")), the file it produces has no parent component, and getParentFile() returns null before the schema is ever copied. The sibling downloaded() method already avoids this by resolving to an absolute file first, so copied() now does the same.


Closes #6443
