### PR TITLE
#6497: fix PhPackage.hasRho() to check the objects map instead of always returning true

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -56,7 +56,7 @@ final class PhPackage implements Phi {
 
     @Override
     public boolean hasRho() {
-        return true;
+        return this.objects.containsKey(Phi.RHO);
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -68,6 +68,30 @@ final class PhPackageTest {
     }
 
     @Test
+    void hasRhoReportsAbsenceOnGlobalObject() {
+        MatcherAssert.assertThat(
+            String.format(
+                "hasRho() must agree with take(%s) and report the global object as unset",
+                Phi.RHO
+            ),
+            Phi.Φ.hasRho(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void hasRhoReportsPresenceAfterDispatch() {
+        MatcherAssert.assertThat(
+            String.format(
+                "hasRho() must report %s as set once dispatch has bound it",
+                Phi.RHO
+            ),
+            Phi.Φ.take("nop").hasRho(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void findsLongClass() {
         MatcherAssert.assertThat(
             "Package should resolve class with '$' in the name, but it didn't",


### PR DESCRIPTION
PhPackage.hasRho() was hardcoded to return true regardless of whether rho was ever bound in the internal objects map. take(name) a few lines below already checks this.objects.containsKey(Phi.RHO) correctly and throws ExUnset when it's absent, so the right logic already existed, just not wired into hasRho().

This contradicted the class's own test: PhPackageTest.doesNotSetRhoToGlobalObject() asserts that Phi.Φ.take(Phi.RHO) throws ExUnset, yet Phi.Φ.hasRho() reported true for the same object. AtWithRho#get() relies on hasRho() to decide whether to copy an object and bind rho to it, so for any Phi resolving to a PhPackage this always reported "already bound" even when unset.

Fixed hasRho() to mirror take()'s check. Added two tests: hasRho() reports false on the unbound global object, and true once dispatch has bound it.

Closes #6497
