### PR TITLE
#6476: retry sendsAndReceivesMessageViaSocketObject on the accept-timing flake

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -113,7 +113,7 @@ final class SyscallTest {
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = 3)
     void sendsAndReceivesMessageViaSocketObject(@Ephemeral final int port)
         throws InterruptedException {
         final String msg = "Hello, Socket!";


### PR DESCRIPTION
sendsAndReceivesMessageViaSocketObject synchronizes the client connect against the server's listen with a fixed Thread.sleep(2000), guessing that two seconds is enough for the server thread to reach the actual OS-level listening state. On a loaded macos-15-intel runner that guess is sometimes wrong, and the client's connect fails with Connection refused, unrelated to the port-reservation race #6458 already fixed.

Every other socket test in this file that depends on native timing (WindowsSocketTest, PosixSocketTest) already uses @RepeatedIfExceptionsTest(repeats = 3) instead of a plain @Test for exactly this reason. This test was the one exception, still on a plain @Test. Switched it to the same idiom already established in the file, rather than inventing a new retry mechanism.

Closes #6476
