### PR TITLE
fix(#6497): report ρ presence truthfully in PhPackage

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -56,7 +56,7 @@ final class PhPackage implements Phi {
 
     @Override
     public boolean hasRho() {
-        return true;
+        return this.objects.containsKey(Phi.RHO);
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -55,6 +55,26 @@ final class PhPackageTest {
     }
 
     @Test
+    void reportsNoRhoOnGlobalObject() {
+        MatcherAssert.assertThat(
+            "hasRho() must agree with take(RHO) and report the global object as lacking ρ",
+            Phi.Φ.hasRho(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void reportsRhoOnceBound() {
+        final Phi pckg = new PhPackage("test-rho");
+        pckg.put(Phi.RHO, Phi.Φ);
+        MatcherAssert.assertThat(
+            "hasRho() must turn true as soon as ρ is bound into the package",
+            pckg.hasRho(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void setsRhoToObject() {
         final Phi pckg = Phi.Φ;
         MatcherAssert.assertThat(


### PR DESCRIPTION
Fixes #6497.

## Problem

`PhPackage.hasRho()` is hardcoded to `return true` regardless of whether ρ was ever bound in the package's `objects` map. This contradicts `take(Phi.RHO)` (which correctly throws `ExUnset` when ρ is absent) and the class's own test `PhPackageTest.doesNotSetRhoToGlobalObject` — the global package `Phi.Φ` never has ρ bound, yet reports `hasRho() == true`.

`AtWithRho#get()` relies on the `hasRho()` contract to decide whether to copy an object and bind ρ to it. For any `Phi` that resolves to a `PhPackage`, the hardcoded `true` skips binding even when ρ is genuinely unset, silently violating the invariant `AtWithRho` depends on.

## Solution

Make `hasRho()` mirror the check `take(Phi.RHO)` already performs: `return this.objects.containsKey(Phi.RHO);`.

## Changes

- `eo-runtime/src/main/java/org/eolang/PhPackage.java` — `hasRho()` now reports actual ρ presence.
- `eo-runtime/src/test/java/org/eolang/PhPackageTest.java` — regression tests.

## Tests

- `PhPackageTest.reportsNoRhoOnGlobalObject` — `Phi.Φ.hasRho()` is `false` (was `true`; verified to fail on pre-fix code).
- `PhPackageTest.reportsRhoOnceBound` — `hasRho()` turns `true` once ρ is bound into a package.
- Existing `doesNotSetRhoToGlobalObject`, `setsRhoToObject`, `AtWithRhoTest`, `PhNestTest`, `PhDefaultTest` still pass (108 targeted tests).

@yegor256 please take a look.
