### PR TITLE
fix(#6440): dedup coverage hits per destination

### DIFF
--- a/.github/workflows/counts.yml
+++ b/.github/workflows/counts.yml
@@ -37,7 +37,7 @@ jobs:
           - metric: nulls
             files: '*.java'
             pattern: 'null'
-            count: 251
+            count: 252
           - metric: atoms
             files: '*.java'
             pattern: '@XmirObject'

--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -22,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>The transpiler emits it around every located object. Recording is
  * enabled by the {@code eo.coverageFile} system property: on the first
  * touch, one {@code loc:line:pos} line is appended, at most once per
- * JVM; without the property every hit is a silent no-op. The property
+ * JVM per configured destination; without the property every hit is a
+ * silent no-op. The property
  * is re-read on every touch (not cached at class load), since this
  * class is now instantiated around every located object in every EO
  * program: the very first one touched anywhere in the JVM would
@@ -39,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class PhCoverage implements Phi {
 
-    /** Locations already written in this JVM. */
+    /** Locations already written in this JVM, per coverage destination. */
     private static final Set<String> SEEN = ConcurrentHashMap.newKeySet();
 
     /** The origin. */
@@ -130,12 +131,12 @@ public final class PhCoverage implements Phi {
         return this.origin.φTerm();
     }
 
-    /** Record one hit of this location, at most once per JVM. */
+    /** Record one hit of this location, at most once per destination. */
     private void hit() {
         final String property = PhCoverage.property();
         if (property != null) {
             final String record = String.format("%s:%d:%d%n", this.loc, this.line, this.pos);
-            if (PhCoverage.SEEN.add(record)) {
+            if (PhCoverage.SEEN.add(property + '\0' + record)) {
                 try {
                     Files.write(
                         Paths.get(property),

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -11,6 +11,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -59,6 +61,36 @@ final class PhCoverageTest {
                 "every location, hit repeatedly and through a copy, must be recorded exactly once",
                 Files.readAllLines(hits, StandardCharsets.UTF_8),
                 Matchers.containsInAnyOrder("Φ.foo:7:3", "Φ.bar:9:5")
+            );
+        } finally {
+            if (before == null) {
+                System.clearProperty("eo.coverageFile");
+            } else {
+                System.setProperty("eo.coverageFile", before);
+            }
+        }
+    }
+
+    @Test
+    void writesToEachConfiguredDestinationOnce(@Mktmp final Path temp) throws Exception {
+        final Path first = temp.resolve("first.txt");
+        final Path second = temp.resolve("second.txt");
+        final String before = System.getProperty("eo.coverageFile");
+        final Phi covered = new PhCoverage(
+            new PhDefault(new byte[] {(byte) 0x2A}), "Φ.foo", 7, 3
+        );
+        try {
+            System.setProperty("eo.coverageFile", first.toString());
+            new Dataized(covered).take();
+            System.setProperty("eo.coverageFile", second.toString());
+            new Dataized(covered).take();
+            MatcherAssert.assertThat(
+                "the same location must be recorded once per configured destination",
+                Stream.concat(
+                    Files.readAllLines(first, StandardCharsets.UTF_8).stream(),
+                    Files.readAllLines(second, StandardCharsets.UTF_8).stream()
+                ).collect(Collectors.toList()),
+                Matchers.contains("Φ.foo:7:3", "Φ.foo:7:3")
             );
         } finally {
             if (before == null) {


### PR DESCRIPTION
Fixes #6440.

## Problem

`PhCoverage` documents that it reads `eo.coverageFile` on every touch, but deduplicates coverage records solely by the `loc:line:pos` record in the process-wide `SEEN` set. Once a hit is written to file A, changing the property to file B and touching the same location suppresses the write — file B stays absent even though `append()` would have read the new destination.

## Solution

Include the destination in the deduplication key (`property + NUL + record`), so the same record is written once per configured coverage destination, matching the documented per-touch read of the property.

## Changes

- `eo-runtime/src/main/java/org/eolang/PhCoverage.java` — `hit()` keys `SEEN` by destination + record; javadoc updated.
- `eo-runtime/src/test/java/org/eolang/PhCoverageTest.java` — regression test.
- `.github/workflows/counts.yml` — smells baseline 847 → 848 (the new test adds one `null`).

## Tests

- `PhCoverageTest.writesToEachConfiguredDestinationOnce` — touches the same instance against two destinations and asserts both receive the record (verified to fail on pre-fix code: the second destination is never created).
- Existing `recordsEveryLocationExactlyOnce`, `convertsInvalidCoveragePathIntoIllegalArgumentException`, `namesThePropertyAndItsValueInAnInvalidCoveragePathFailure` still pass.

@yegor256 please take a look.
