### PR TITLE
#6228: stop double-escaping the <listing> element, drop XML-forbidden characters instead

### DIFF
--- a/.github/workflows/counts.yml
+++ b/.github/workflows/counts.yml
@@ -24,7 +24,7 @@ jobs:
           - metric: smells
             files: '*.java'
             pattern: 'static|null'
-            count: 847
+            count: 848
           - metric: atoms
             files: '*.java'
             pattern: '@XmirObject'

--- a/.github/workflows/counts.yml
+++ b/.github/workflows/counts.yml
@@ -24,7 +24,7 @@ jobs:
           - metric: smells
             files: '*.java'
             pattern: 'static|null'
-            count: 848
+            count: 850
           - metric: atoms
             files: '*.java'
             pattern: '@XmirObject'

--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -5,7 +5,7 @@
 package org.eolang.parser;
 
 import java.util.Iterator;
-import org.apache.commons.text.StringEscapeUtils;
+import java.util.regex.Pattern;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -13,9 +13,22 @@ import org.xembly.Directives;
  * Source-text {@code <listing>} directive — wraps the original EO
  * source as an {@code Iterable<Directive>} that appends a
  * {@code <listing>…</listing>} element under {@code /object}.
+ *
+ * <p>The text is set as is, without any manual escaping: the XML writer
+ * escapes it exactly once, so the text value of {@code /object/listing}
+ * equals the source. Only the characters that XML forbids in text nodes
+ * are dropped, since they can't be represented there at all.</p>
+ *
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
+
+    /**
+     * Characters that are not allowed inside an XML text node.
+     */
+    private static final Pattern FORBIDDEN = Pattern.compile(
+        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
+    );
 
     /**
      * Raw EO source text to embed verbatim under {@code <listing>}.
@@ -36,7 +49,7 @@ final class Listing implements Iterable<Directive> {
             .xpath("/object")
             .strict(1)
             .add("listing")
-            .set(StringEscapeUtils.escapeXml11(this.source))
+            .set(Listing.FORBIDDEN.matcher(this.source).replaceAll(""))
             .iterator();
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -132,7 +132,7 @@ final class EoSyntaxTest {
             ),
             XhtmlMatchers.hasXPaths(
                 "/object/errors/error",
-                String.format("/object[listing='%s']", StringEscapeUtils.escapeXml11(src))
+                String.format("/object[listing='%s']", src)
             )
         );
     }
@@ -154,7 +154,25 @@ final class EoSyntaxTest {
                     )
                 ).inner()
             ).element("object").element("listing").text().get(),
-            Matchers.containsString(StringEscapeUtils.escapeXml11(src))
+            Matchers.equalTo(src)
+        );
+    }
+
+    @Test
+    void keepsListingVerbatimWithXmlSpecialCharacters() throws Exception {
+        final String src = String.join(
+            System.lineSeparator(),
+            "# Sample.",
+            "[] > app",
+            "  \"a < b & c > d\" > x",
+            ""
+        );
+        MatcherAssert.assertThat(
+            "listing must hold the source verbatim, not XML-escaped",
+            new Xnav(
+                new EoSyntax(new InputOf(src)).parsed().inner()
+            ).element("object").element("listing").text().get(),
+            Matchers.equalTo(src)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XMLDocument;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Listing}.
+ * @since 0.1
+ */
+final class ListingTest {
+
+    @ParameterizedTest
+    @MethodSource("sources")
+    void keepsSourceVerbatim(final String source) {
+        MatcherAssert.assertThat(
+            "the text of <listing> must be equal to the source, not escaped twice",
+            ListingTest.listing(source),
+            Matchers.equalTo(source)
+        );
+    }
+
+    @Test
+    void dropsCharactersForbiddenInXml() {
+        MatcherAssert.assertThat(
+            "characters that XML text nodes can't hold must be dropped",
+            ListingTest.listing(
+                String.format(
+                    "[] > x%c%c%c%c",
+                    (char) 0x01,
+                    (char) 0x07,
+                    (char) 0x1F,
+                    (char) 0x7F
+                )
+            ),
+            Matchers.equalTo("[] > x")
+        );
+    }
+
+    @Test
+    void doesNotThrowExceptionOnEmptySource() {
+        Assertions.assertDoesNotThrow(
+            () -> ListingTest.listing(""),
+            "an empty source must not break the <listing> element"
+        );
+    }
+
+    @Test
+    void buildsListingForEmptySource() {
+        MatcherAssert.assertThat(
+            "An empty source must produce an empty listing",
+            ListingTest.listing(""),
+            Matchers.emptyString()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        ints = {
+            0x00,
+            0x01,
+            0x08,
+            0x0B,
+            0x0C,
+            0x0E,
+            0x1F,
+            0xFFFE,
+            0xFFFF,
+            0x7F,
+            0x80,
+            0x84,
+            0x86,
+            0x9F
+        }
+    )
+    void removesForbiddenCharacters(final int codepoint) {
+        final String source = new String(Character.toChars(codepoint));
+        MatcherAssert.assertThat(
+            String.format(
+                "Character '%s' (%s code) must be removed from EO listing", source, codepoint
+            ),
+            ListingTest.listing(source),
+            Matchers.emptyString()
+        );
+    }
+
+    /**
+     * Sources to embed into {@code <listing>}.
+     * @return Stream of sources
+     */
+    private static Stream<Arguments> sources() {
+        return Stream.of(
+            "[] > foo",
+            String.join(
+                System.lineSeparator(),
+                "[] > app",
+                "  \"a < b & c > d\" > x",
+                ""
+            ),
+            String.join(
+                System.lineSeparator(),
+                "# Comment with 'quotes' and \"double quotes\".",
+                "[] > bar",
+                ""
+            ),
+            String.join(
+                System.lineSeparator(),
+                "[] > x",
+                "  Q.io.stdout \"守规矩\" > @",
+                ""
+            )
+        ).map(Arguments::of);
+    }
+
+    /**
+     * Read the text of {@code /object/listing} built for the given source.
+     * @param source The EO source text
+     * @return The text of the {@code listing} element
+     */
+    private static String listing(final String source) {
+        return new Xnav(
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("object").up().append(new Listing(source))
+                ).xmlQuietly()
+            ).inner()
+        ).element("object").element("listing").text().orElse("");
+    }
+}


### PR DESCRIPTION
Listing.java called StringEscapeUtils.escapeXml11 on the source before setting it on the listing directive. The XML writer then escapes the already-escaped text a second time, so /object/listing held double-escaped text (e.g. > became &amp;gt; instead of &gt;) instead of the documented verbatim source.

Fixed by setting the raw source directly and letting the XML writer escape it exactly once. The only characters actually dropped are the ones XML text nodes cannot represent at all (C0/C1 control characters and a couple of noncharacters), since those cannot round-trip through XML regardless of escaping.

Updated the two existing tests that baked in the double-escaped expectation, added a case with the literal <, &, and characters from the reported repro, and added ListingTest.java covering the character-dropping behavior directly.

Closes #6228
