### PR TITLE
#6545: resolve xslMeasures to an absolute path before taking parent

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -195,7 +195,7 @@ final class Transpilation {
      * @return Measured train
      */
     private Train<Shift> measured(final Train<Shift> base) {
-        final Path parent = this.xslMeasures.getParent();
+        final Path parent = this.xslMeasures.toAbsolutePath().getParent();
         if (parent.toFile().mkdirs()) {
             Logger.debug(this, "Directory created for %[file]s", this.xslMeasures);
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Transpilation}.
+ * @since 0.74
+ */
+final class TranspilationTest {
+
+    @Test
+    void buildsSourceFunctionForParentlessMeasuresPath() {
+        Assertions.assertDoesNotThrow(
+            () -> new Transpilation(
+                "1.0-SNAPSHOT",
+                new Tracking(false, false),
+                false,
+                "PhDefault",
+                Paths.get("xsl-measures.csv"),
+                Paths.get("target")
+            ).forSource("foo"),
+            "forSource() must not throw when eo.xslMeasuresFile is a bare relative path with no parent directory"
+        );
+    }
+}


### PR DESCRIPTION
`Transpilation.measured()` took `this.xslMeasures.getParent()` and dereferenced the result on the next line. `xslMeasures` comes from the `eo.xslMeasuresFile` Maven parameter, whose default value has a parent directory, so the problem stays hidden in normal use. A relative, single-segment override has no parent, though:

```
mvn eo:transpile -Deo.xslMeasuresFile=measures.json
```

`Paths.get("measures.json").getParent()` returns nothing, so the following `parent.toFile().mkdirs()` throws a raw `NullPointerException` on the first transpiled source, with no message identifying the cause.

## Fix

Resolve `xslMeasures` to an absolute path before taking its parent (`toAbsolutePath().getParent()`), which is always present. This mirrors the fix already applied to the same class of bug in `Saved` (#6441) and `MjAtomsTable` (#6447).

## Verification

- Added `TranspilationTest.buildsSourceFunctionForParentlessMeasuresPath`, which builds the source function for a parentless measures path. It fails on `master` with a `NullPointerException` at `Transpilation.forSource` and passes with this change.
- `mvn -pl eo-maven-plugin clean verify -DskipTests -Pqulice` passes locally on JDK 21.

Closes #6545

@yegor256
