### PR TITLE
Let a pack describe a program of several files

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -15,7 +15,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
 import org.eolang.xax.XtSticky;
@@ -53,10 +55,13 @@ final class InferringTest {
     @ClasspathSource(value = "org/eolang/maven/inference-packs/", glob = "**.yaml")
     void understandsProgramOfPack(final String yaml) throws IOException {
         final Xtory pack = new XtSticky(new XtYaml(yaml));
-        Files.writeString(
-            Files.createDirectories(this.dir.resolve("parsed")).resolve("main.xmir"),
-            new EoSyntax(pack.map().get("eo").toString()).parsed().toString()
-        );
+        final Path parsed = Files.createDirectories(this.dir.resolve("parsed"));
+        for (final Map.Entry<String, String> source : this.sources(pack).entrySet()) {
+            Files.writeString(
+                parsed.resolve(source.getKey()),
+                new EoSyntax(source.getValue()).parsed().toString()
+            );
+        }
         new Inferring(
             this.dir.resolve("parsed"), this.dir.resolve("pre"), this.dir.resolve("tables")
         ).exec();
@@ -136,6 +141,24 @@ final class InferringTest {
     }
 
     /**
+     * The files of the program the pack describes, named as they are on disk,
+     * since one table covers all of them and a locator names one object of
+     * one file.
+     * @param pack The pack
+     * @return The sources, by the name their XMIR takes
+     */
+    private Map<String, String> sources(final Xtory pack) {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<?, ?> entry : ((Map<?, ?>) pack.map().get("eo")).entrySet()) {
+            found.put(
+                entry.getKey().toString().replace(".eo", ".xmir"),
+                entry.getValue().toString()
+            );
+        }
+        return found;
+    }
+
+    /**
      * The XPaths of the pack that match nothing, each named by the document it
      * was asked of.
      * @param pack The pack
@@ -145,13 +168,46 @@ final class InferringTest {
      */
     private Collection<String> unmatched(final Xtory pack, final Path temp) throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
-        for (final String key : Arrays.asList("xmir", "provides", "needs", "links")) {
-            if (pack.map().containsKey(key)) {
-                final XML written = this.written(temp, key);
-                for (final String xpath : (List<String>) pack.map().get(key)) {
-                    if (written.nodes(xpath).isEmpty()) {
-                        failed.add(String.format("%s: %s", key, xpath));
-                    }
+        for (final String table : Arrays.asList("provides", "needs", "links")) {
+            if (pack.map().containsKey(table)) {
+                failed.addAll(
+                    this.absent(
+                        new XMLDocument(temp.resolve("tables").resolve(table.concat(".xml"))),
+                        table,
+                        (List<String>) pack.map().get(table)
+                    )
+                );
+            }
+        }
+        failed.addAll(this.unprepared(pack, temp));
+        return failed;
+    }
+
+    /**
+     * The XPaths the pack asks of the XMIR prepared for the rules, which is
+     * per file, that match nothing.
+     * @param pack The pack
+     * @param temp The directory the clues have just written into
+     * @return The XPaths that failed, and every file named that the program
+     *  does not have
+     * @throws IOException If a document cannot be read
+     */
+    private Collection<String> unprepared(final Xtory pack, final Path temp) throws IOException {
+        final Collection<String> failed = new ArrayList<>(0);
+        if (pack.map().containsKey("xmir")) {
+            final Map<String, String> sources = this.sources(pack);
+            for (final Map.Entry<?, ?> entry : ((Map<?, ?>) pack.map().get("xmir")).entrySet()) {
+                final String name = entry.getKey().toString().replace(".eo", ".xmir");
+                if (sources.containsKey(name)) {
+                    failed.addAll(
+                        this.absent(
+                            new XMLDocument(temp.resolve("pre").resolve(name)),
+                            entry.getKey().toString(),
+                            (List<String>) entry.getValue()
+                        )
+                    );
+                } else {
+                    failed.add(String.format("unknown file: %s", entry.getKey()));
                 }
             }
         }
@@ -159,19 +215,21 @@ final class InferringTest {
     }
 
     /**
-     * The document the given key of a pack talks about.
-     * @param temp The directory the clues have just written into
-     * @param key The key, either {@code xmir} or the name of a table
-     * @return The document
-     * @throws IOException If it cannot be read
+     * The XPaths that match nothing in the given document.
+     * @param document The document
+     * @param about What the document is, for the message
+     * @param xpaths The XPaths
+     * @return The XPaths that failed
      */
-    private XML written(final Path temp, final String key) throws IOException {
-        final Path path;
-        if ("xmir".equals(key)) {
-            path = temp.resolve("pre").resolve("main.xmir");
-        } else {
-            path = temp.resolve("tables").resolve(String.format("%s.xml", key));
+    private Collection<String> absent(
+        final XML document, final String about, final List<String> xpaths
+    ) {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final String xpath : xpaths) {
+            if (document.nodes(xpath).isEmpty()) {
+                failed.add(String.format("%s: %s", about, xpath));
+            }
         }
-        return new XMLDocument(path);
+        return failed;
     }
 }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/application-provides-nothing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/application-provides-nothing.yaml
@@ -4,11 +4,12 @@
 # An application provides nothing of its own: what it has is what the object it
 # copies has, which is the business of the links table. So it gets no row of its
 # own, while the attribute it is bound to does.
-eo: |
-  [] > lamp
-    bulb 1 > @
-    [n] > bulb
-      n > @
+eo:
+  lamp.eo: |
+    [] > lamp
+      bulb 1 > @
+      [n] > bulb
+        n > @
 provides:
   - "/provides[not(type[@id='Φ.lamp.φ.α0'])]"
   - "/provides/type[@id='Φ.lamp']/attr[@name='φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-is-not-complete.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-is-not-complete.yaml
@@ -3,8 +3,9 @@
 ---
 # An atom hides its body in Java, which this prototype cannot read, so the
 # object is not complete and nothing about it will ever be reported.
-eo: |
-  [] > tick /Q.number
-    ? > x /Q.number
+eo:
+  tick.eo: |
+    [] > tick /Q.number
+      ? > x /Q.number
 provides:
   - "/provides/type[@id='Φ.tick' and @complete='false']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/data-provides-nothing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/data-provides-nothing.yaml
@@ -3,8 +3,9 @@
 ---
 # Bytes carry their value as text and are not a formation, so they provide
 # nothing and get no row.
-eo: |
-  [] > two
-    01- > @
+eo:
+  two.eo: |
+    [] > two
+      01- > @
 provides:
   - "/provides/type[@id='Φ.two']/attr[@name='φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-asks-receiver-not-argument.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-asks-receiver-not-argument.yaml
@@ -3,9 +3,10 @@
 ---
 # The attribute is taken from the receiver, never from an argument: `x.plus 5`
 # asks `x` for `plus` and asks the `5` for nothing.
-eo: |
-  [x] > sum
-    x.plus 5 > @
+eo:
+  sum.eo: |
+    [x] > sum
+      x.plus 5 > @
 needs:
   - "/needs/type[@id='Φ.sum.φ.ρ']/attr[@name='plus']"
   - "/needs[not(type[@id='Φ.sum.φ.α0'])]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-reaches-into-another-file.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-reaches-into-another-file.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The object a dispatch takes from may live in another file, and the two
+# rows still meet: `plus` is asked of something the links table knows to be
+# the `number` of the other file, which does provide it.
+eo:
+  sum.eo: |
+    [] > sum
+      number.plus > @
+  number.eo: |
+    [] > number
+      [] > plus
+needs:
+  - "/needs/type[@id='Φ.sum.φ.ρ']/attr[@name='plus']"
+links:
+  - "/links/type[@id='Φ.sum.φ.ρ' and @copy='Φ.number']"
+provides:
+  - "/provides/type[@id='Φ.number']/attr[@name='plus']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-is-complete.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-is-complete.yaml
@@ -4,7 +4,8 @@
 # "Complete" means the whole formation has been seen, so there is nothing in it
 # besides the attributes listed. It is what later keeps the checker honest: a
 # missing attribute is a mistake only on an object that is complete.
-eo: |
-  [] > lid
+eo:
+  lid.eo: |
+    [] > lid
 provides:
   - "/provides/type[@id='Φ.lid' and @complete='true']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-lists-attributes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-lists-attributes.yaml
@@ -3,10 +3,11 @@
 ---
 # A formation shows its attributes in the code, so every one of them gets a row
 # without any thinking. Two attributes, two rows.
-eo: |
-  [] > kettle
-    [] > steam
-    [] > whistle
+eo:
+  kettle.eo: |
+    [] > kettle
+      [] > steam
+      [] > whistle
 provides:
   - "/provides/type[@id='Φ.kettle' and count(attr)=2]"
   - "/provides/type[@id='Φ.kettle']/attr[@name='steam']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/locators-on-split.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/locators-on-split.yaml
@@ -4,8 +4,10 @@
 # The objects born from splitting a chain have no locator of their own, so the
 # locators are set again afterwards - every row of every table points into the
 # prepared XMIR, and a row pointing at nothing would be worthless.
-eo: |
-  [x] > box
-    x.lid.hinge > @
+eo:
+  box.eo: |
+    [x] > box
+      x.lid.hinge > @
 xmir:
-  - "//o[@base='ξ.x' and @loc='Φ.box.φ.ρ.ρ']"
+  box.eo:
+    - "//o[@base='ξ.x' and @loc='Φ.box.φ.ρ.ρ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -6,15 +6,17 @@
 # `x.next.foo` asks for something that will never be there. Nobody reports it
 # yet: the tables only write down what is known, and comparing them is the job
 # of the checking loop.
-eo: |
-  [] > app
-    inc t > @
-    [] > t
-      [] > next
-    [x] > inc
-      x.next.foo > @
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+      [] > t
+        [] > next
+      [x] > inc
+        x.next.foo > @
 xmir:
-  - "//o[@base='.foo']/o[@base='.next']/o[@base='ξ.x']"
+  app.eo:
+    - "//o[@base='.foo']/o[@base='.next']/o[@base='ξ.x']"
 provides:
   - "/provides/type[@id='Φ.app.t']/attr[@name='next' and @type='Φ.app.t.next']"
   - "/provides/type[@id='Φ.app.t.next' and @complete='true' and not(attr)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
@@ -7,13 +7,15 @@
 # resolve - no formation binds `ρ` as an attribute. It is the whole of what
 # stays unlinked in the runtime, and the checking loop, which knows what
 # object it is inside of, is where it belongs.
-eo: |
-  [] > outer
-    [] > held
-    [] > inner
-      held > @
+eo:
+  outer.eo: |
+    [] > outer
+      [] > held
+      [] > inner
+        held > @
 xmir:
-  - "//o[@base='.held']/o[@base='ξ.ρ']"
+  outer.eo:
+    - "//o[@base='.held']/o[@base='ξ.ρ']"
 needs:
   - "/needs/type[@id='Φ.outer.inner.φ.ρ']/attr[@name='held']"
 links:

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-reaches-into-another-file.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-reaches-into-another-file.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An object in one file is used by objects in others, which is the reason a
+# clue is given the whole program: on its own, `two.eo` cannot say what
+# `number` is, and the link would be missing.
+eo:
+  two.eo: |
+    [] > two
+      number > @
+  number.eo: |
+    [] > number
+      [] > plus
+links:
+  - "/links/type[@id='Φ.two.φ' and @copy='Φ.number']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-stays-whole.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-stays-whole.yaml
@@ -3,9 +3,11 @@
 ---
 # A reference takes no attribute from anything, so the splitting leaves it
 # alone: one name after the head is not a dispatch.
-eo: |
-  [] > tap
-    water > @
-    [] > water
+eo:
+  tap.eo: |
+    [] > tap
+      water > @
+      [] > water
 xmir:
-  - "//o[@base='ξ.water']"
+  tap.eo:
+    - "//o[@base='ξ.water']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-to-root-object.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-to-root-object.yaml
@@ -3,9 +3,10 @@
 ---
 # A name the whole program knows is a reference to a root object, and the
 # locator it points at is the base itself.
-eo: |
-  [] > tworef
-    number > @
-  [] > number
+eo:
+  tworef.eo: |
+    [] > tworef
+      number > @
+    [] > number
 links:
   - "/links/type[@id='Φ.tworef.φ' and @copy='Φ.number']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-files-are-one-program.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-files-are-one-program.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A program is a directory, not a file. One table covers both of these,
+# because a locator names one object of one file and no other, so nothing
+# has to be merged or renamed to put them together.
+eo:
+  kettle.eo: |
+    [] > kettle
+      [] > steam
+  cup.eo: |
+    [] > cup
+      [] > handle
+provides:
+  - "/provides/type[@id='Φ.kettle']/attr[@name='steam']"
+  - "/provides/type[@id='Φ.cup']/attr[@name='handle']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unknown-name-is-left-alone.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unknown-name-is-left-alone.yaml
@@ -4,8 +4,9 @@
 # A name that resolves to nothing gets no row and no complaint. A missing
 # row leaves a later check undecided, while a wrong row would make it
 # decide wrongly.
-eo: |
-  [] > jarref
-    nowhere > @
+eo:
+  jarref.eo: |
+    [] > jarref
+      nowhere > @
 links:
   - "/links[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-is-marked.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-is-marked.yaml
@@ -4,8 +4,9 @@
 # A void provides nothing until something is put into it, and the row says so.
 # The order of voids decides what an application binds to what, which is why
 # the rows remember when they were written.
-eo: |
-  [x] > pipe
-    x > @
+eo:
+  pipe.eo: |
+    [x] > pipe
+      x > @
 provides:
   - "/provides/type[@id='Φ.pipe']/attr[@name='x' and @void='true']"


### PR DESCRIPTION
A pack described a one-file program, because the runner wrote whatever `eo`
held into a single `main.xmir`. That hid the property the tables are built
around: the clues read a *world*, one table covers the whole program, and an
object in one file is used by objects in others. On the runtime that is 170
files feeding four tables; in the packs it was always one.

The `eo` key now names its files:

```yaml
eo:
  two.eo: |
    [] > two
      number > @
  number.eo: |
    [] > number
      [] > plus
links:
  - "/links/type[@id='Φ.two.φ' and @copy='Φ.number']"
```

The table keys are untouched — they were program-wide from the start, so
`provides`, `needs` and `links` say exactly what they said before. Only `xmir`
had to grow a name, since the XMIR prepared for the rules is per file:

```yaml
xmir:
  box.eo:
    - "//o[@base='ξ.x' and @loc='Φ.box.φ.ρ.ρ']"
```

All thirteen existing packs are converted to the named form; there is one way
to write a pack, not two.

Three packs are new, and each says something no pack could say before: two
files landing in one table, a reference reaching into another file, and a
dispatch whose receiver was built in another file — where all three tables
meet across a file boundary. `reference-to-root-object.yaml` keeps its
single-file program on purpose: a sibling object in the same file is a
different case from one next door.

Two guards worth naming. A pack that names a file the program does not have
fails rather than passing quietly:

```
Expected: an empty collection
     but: <[unknown file: nope.eo]>
```

And I mutated a cross-file assertion to confirm the new packs actually bite
before trusting them green.

Closes: #6553
