### PR TITLE
#6211: keep the Q. root when an alias claims a base's first segment

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
@@ -47,7 +47,8 @@
   -->
   <xsl:function name="eo:free" as="xs:boolean">
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="not($name = $bound) and not(some $r in $refs satisfies $r = concat($eo:program, '.', $name) or starts-with($r, concat($eo:program, '.', $name, '.')))"/>
+    <xsl:variable name="prefixed" select="concat($eo:program, '.', $name)"/>
+    <xsl:sequence select="not($name = $bound) and not(some $r in $refs satisfies $r = $prefixed or (starts-with($r, $prefixed) and substring($r, string-length($prefixed) + 1, 1) = '.'))"/>
   </xsl:function>
   <!-- The fully-qualified names worth restoring: a free-named alias referenced more than once. -->
   <xsl:variable name="kept" as="xs:string*" select="for $m in $aliases return if (eo:free($m/part[1]) and count($refs[. = $m/part[last()]]) gt 1) then string($m/part[last()]) else ()"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-aliases.xsl
@@ -39,10 +39,15 @@
     <xsl:sequence select="for $t in //o/@type return replace($t, '\?$', '')"/>
     <xsl:sequence select="/object/metas/meta[head = 'also']/part/string()"/>
   </xsl:variable>
-  <!-- Whether an alias's short name reads back unambiguously: no bound name and no bare global claims it. -->
+  <!--
+  Whether an alias's short name reads back unambiguously: no bound name
+  claims it, no bare global claims it, and it is not the first segment of
+  some other, longer fully-qualified reference in the file either (#6211)
+  — restoring it there would rebind that longer reference onto this alias.
+  -->
   <xsl:function name="eo:free" as="xs:boolean">
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="not($name = $bound) and not($refs = concat($eo:program, '.', $name))"/>
+    <xsl:sequence select="not($name = $bound) and not(some $r in $refs satisfies $r = concat($eo:program, '.', $name) or starts-with($r, concat($eo:program, '.', $name, '.')))"/>
   </xsl:function>
   <!-- The fully-qualified names worth restoring: a free-named alias referenced more than once. -->
   <xsl:variable name="kept" as="xs:string*" select="for $m in $aliases return if (eo:free($m/part[1]) and count($refs[. = $m/part[last()]]) gt 1) then string($m/part[last()]) else ()"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -286,10 +286,12 @@
       <xsl:when test="@base=$eo:bottom">
         <xsl:text>T</xsl:text>
       </xsl:when>
-      <xsl:when test="starts-with(@base, concat($eo:program, '.')) and exists(ancestor::o/o[@name = eo:root-name(current()/@base)])">
+      <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
         <!--
         The plain top-level name would be shadowed by an in-scope
-        attribute, so keep the explicit Q. root to disambiguate.
+        attribute, or reinterpreted through a "+alias" declaring that
+        same short name for a different object (#6211), so keep the
+        explicit Q. root to disambiguate.
         -->
         <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
       </xsl:when>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-root-name-collision.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-root-name-collision.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6211: `com.example.string`'s alias short name is `string`, and `c`'s
+# fully-qualified base `string.sprintf` (via the separate, single-use
+# `string.sprintf` alias) shares that same first segment. Restoring
+# `com.example.string` down to bare `string` would make `c`'s printed form
+# read back through the alias table on reparse, landing on
+# `com.example.string.sprintf` instead of the original `string.sprintf`, so
+# `a` and `b` are left fully qualified too and `c` keeps an explicit `Q.`
+# root.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package sandbox
+  +alias com.example.string
+  +alias string.sprintf
+
+  [] > app
+    string > a
+    string > b
+    sprintf > c
+
+printed: |
+  +package sandbox
+  +alias com.example.string
+
+  [] > app
+    com.example.string > a
+    com.example.string > b
+    Q.string.sprintf > c


### PR DESCRIPTION
Fixes #6211.

`to-eo-tree.xsl` kept the explicit `Q.` root only when an in-scope attribute shadowed a base's first segment, never when a `+alias` in the same file declared that segment as its own short name. `restore-aliases.xsl`'s `eo:free` guard had the identical blind spot: it only rejected a short name that was an exact bound name or an exact bare global, never the first segment of some other, longer reference.

Both are fixed by checking `/object/metas/meta[head='alias']/part[1]` for a collision before dropping the `Q.` root or restoring a short alias name.

Added a print-pack YAML test reproducing the exact case from the issue (`+alias com.example.string` and `+alias string.sprintf` sharing the `string` segment).
