### PR TITLE
#6544: leave odd-length hex payloads untouched in StUnhex

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -40,27 +40,28 @@ final class StUnhex extends StEnvelope {
         ),
         new StXnav(
             StUnhex.elements("number"),
-            xnav -> {
-                final ByteBuffer buffer = StUnhex.buffer(
-                    StUnhex.undash(xnav.element("o").text().orElse(""))
-                );
-                if (buffer.remaining() == Double.BYTES) {
-                    final double number = buffer.getDouble();
-                    if (!Double.isNaN(number) && !Double.isInfinite(number)) {
-                        new Payload(xnav).replace(StUnhex.number(number));
+            xnav -> StUnhex.buffer(
+                StUnhex.undash(xnav.element("o").text().orElse(""))
+            ).ifPresent(
+                buffer -> {
+                    if (buffer.remaining() == Double.BYTES) {
+                        final double number = buffer.getDouble();
+                        if (!Double.isNaN(number) && !Double.isInfinite(number)) {
+                            new Payload(xnav).replace(StUnhex.number(number));
+                        }
                     }
                 }
-            }
+            )
         ),
         new StXnav(
             StUnhex.elements("string"),
-            xnav -> StUnhex.decode(
-                StUnhex.buffer(
-                    StUnhex.undash(xnav.element("o").text().orElse(""))
-                ).array()
+            xnav -> StUnhex.buffer(
+                StUnhex.undash(xnav.element("o").text().orElse(""))
             ).ifPresent(
-                decoded -> new Payload(xnav).replace(
-                    String.format("\"%s\"", StUnhex.escape(decoded))
+                buffer -> StUnhex.decode(buffer.array()).ifPresent(
+                    decoded -> new Payload(xnav).replace(
+                        String.format("\"%s\"", StUnhex.escape(decoded))
+                    )
                 )
             )
         )
@@ -104,18 +105,33 @@ final class StUnhex extends StEnvelope {
     }
 
     /**
-     * Make a byte buffer from a string.
+     * Make a byte buffer from a hex string.
+     *
+     * <p>Each byte is two hex characters, so a payload with an odd number of
+     * digits has a stray trailing nibble that cannot form a complete byte.
+     * Rather than reading past the end of the string and throwing, this
+     * method returns {@link Optional#empty()} for such a payload, so that
+     * callers leave the offending {@code Φ.number}/{@code Φ.string} node
+     * untouched - the same strategy the number branch already uses for a
+     * wrong byte count.</p>
+     *
      * @param txt The text
-     * @return The buffer of bytes
+     * @return The buffer of bytes, or empty if the payload has odd length
      */
-    private static ByteBuffer buffer(final String txt) {
+    private static Optional<ByteBuffer> buffer(final String txt) {
         final int len = txt.length();
-        final ByteBuffer buffer = ByteBuffer.allocate(len / 2);
-        for (int idx = 0; idx < len; idx += 2) {
-            buffer.put((byte) Integer.parseInt(txt.substring(idx, idx + 2), 16));
+        final Optional<ByteBuffer> result;
+        if (len % 2 == 0) {
+            final ByteBuffer buffer = ByteBuffer.allocate(len / 2);
+            for (int idx = 0; idx < len; idx += 2) {
+                buffer.put((byte) Integer.parseInt(txt.substring(idx, idx + 2), 16));
+            }
+            buffer.position(0);
+            result = Optional.of(buffer);
+        } else {
+            result = Optional.empty();
         }
-        buffer.position(0);
-        return buffer;
+        return result;
     }
 
     /**

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -218,6 +218,44 @@ final class StUnhexTest {
 
     @ParameterizedTest
     @MethodSource("shifts")
+    void keepsOddLengthNumberPayloadUnconverted(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must not crash on a number payload with an odd number of hex digits, but it did",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.number'><o base='Φ.bytes'><o>40-49-0F-D</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.number' and o[@base='Φ.bytes' and not(o) and text()='40-49-0F-D']]"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void keepsOddLengthStringPayloadUnconverted(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must not crash on a string payload with an odd number of hex digits, but it did",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    "<p><o base='Φ.string'><o base='Φ.bytes'><o>41-42-0</o></o></o></p>"
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.string' and o[@base='Φ.bytes' and not(o) and text()='41-42-0']]"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shifts")
     void keepsMalformedBytesUnconverted(final Shift shift, final String type) {
         MatcherAssert.assertThat(
             String.format(


### PR DESCRIPTION
## Root cause

`StUnhex.buffer(String)` parses a hex payload two characters at a time with `txt.substring(idx, idx + 2)`, but its loop runs while `idx < len`. For a payload with an odd number of hex digits (e.g. `40-49-0F-D`, which `undash` turns into the 7-char `"40490FD"`), the buffer is sized to `len / 2 = 3` bytes correctly, yet the loop still enters one final iteration at `idx == len - 1` and calls `substring(6, 8)` on a 7-character string, throwing `StringIndexOutOfBoundsException`. The exception propagates out of `Xmir.toEO()` unhandled.

Both callers were affected:
- the `number` branch already guarded `buffer.remaining() == Double.BYTES`, but that check runs *after* `buffer()` and never gets a chance on odd input;
- the `string` branch called `buffer(...).array()` with no length check at all.

## Fix

Make `StUnhex.buffer(...)` return `Optional<ByteBuffer>`, empty when the payload has an odd length (a stray trailing nibble cannot form a complete byte). Both branches now consume it with `ifPresent`, so an odd-length payload leaves the `Φ.number`/`Φ.string`/`Φ.bytes` node untouched instead of crashing.

This is the same strategy the `number` branch already uses for a wrong byte count (the fix for #6038 in #6052), and the same strategy the `string` branch already uses for invalid UTF-8, where `decode()` returns `Optional.empty()`.

## Tests

Added two parameterized regression tests to `StUnhexTest`, mirroring the existing `keepsTooFewNumberBytesUnconverted` / `keepsMalformedBytesUnconverted` style:
- `keepsOddLengthNumberPayloadUnconverted` — `Φ.number` with `40-49-0F-D` (7 hex digits);
- `keepsOddLengthStringPayloadUnconverted` — `Φ.string` with `41-42-0` (5 hex digits).

Both crash with `StringIndexOutOfBoundsException` on the unpatched `buffer()` and pass after the fix, asserting the node is left untouched (`not(o)` with the original dashed `text()` preserved).

`mvn -pl eo-printer test` — 340 tests pass. `mvn -pl eo-printer -Pqulice verify -DskipTests` — clean (checkstyle, PMD, jtcop, license headers).

Fixes #6544
