### PR TITLE
fix(#6547): reject a compact-tuple count that overflows int in LnOnlyPhi

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -155,7 +155,7 @@ final class LnOnlyPhi implements Line {
      * @return The φ token reader rewound to the head
      */
     private Tokens slot(final Stack stack, final Suffix suffix, final Span inner) {
-        final int stars = LnOnlyPhi.compactStar(inner.body());
+        final int stars = LnOnlyPhi.compactStar(inner.body(), inner);
         final Tokens tokens = LnOnlyPhi.reader(inner, stars);
         final Level level = this.transition(
             stack, suffix, stars >= 0 || LnOnlyPhi.bare(tokens)
@@ -294,14 +294,15 @@ final class LnOnlyPhi implements Line {
      * the LHS is not a compact-tuple head — its head must be a single
      * space-free token that is not a reversed dispatch (no trailing dot).
      * @param lhs The LHS body
+     * @param span Source span, for a ParseError on overflow
      * @return The N count, or -1 when not a compact-tuple head
      */
-    private static int compactStar(final String lhs) {
+    private static int compactStar(final String lhs, final Span span) {
         final int space = lhs.indexOf(' ');
         final int result;
         if (space > 0 && lhs.charAt(space - 1) != '.'
             && space + 1 < lhs.length() && lhs.charAt(space + 1) == '*') {
-            result = LnOnlyPhi.starCount(lhs, space + 2);
+            result = LnOnlyPhi.starCount(lhs, space + 2, span);
         } else {
             result = -1;
         }
@@ -334,24 +335,36 @@ final class LnOnlyPhi implements Line {
      * The non-negative integer {@code N} spelled from {@code from} to the
      * end of {@code lhs} (0 when empty, R-3.9.1), or -1 when any character
      * is not a digit (which also rejects trailing horizontal arguments).
+     * The digits accumulate in a {@code long} and a {@link ParseError} is
+     * thrown the moment {@code N} would exceed {@link Integer#MAX_VALUE},
+     * pointing at the digit run - mirroring {@code LnCompactTuple.readCount}
+     * for the sibling {@code *N} marker, so the count can never silently
+     * wrap and collide with the {@code -1} "not-a-digit" sentinel.
      * @param lhs The LHS body
      * @param from Index of the first character after {@code *}
+     * @param span Source span, for a ParseError on overflow
      * @return The N count, or -1 when the tail is not all digits
      */
-    private static int starCount(final String lhs, final int from) {
-        int count = 0;
+    private static int starCount(final String lhs, final int from, final Span span) {
+        long count = 0;
         boolean digits = true;
         for (int idx = from; idx < lhs.length(); idx = idx + 1) {
             final char glyph = lhs.charAt(idx);
-            if (glyph >= '0' && glyph <= '9') {
-                count = count * 10 + glyph - '0';
-            } else {
+            if (glyph < '0' || glyph > '9') {
                 digits = false;
+                break;
+            }
+            count = count * 10 + glyph - '0';
+            if (count > Integer.MAX_VALUE) {
+                throw new ParseError(
+                    span.line(), span.indent() + from,
+                    "compact tuple count is too large"
+                );
             }
         }
         final int result;
         if (digits) {
-            result = count;
+            result = (int) count;
         } else {
             result = -1;
         }

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -265,6 +265,16 @@ final class LnOnlyPhiTest {
         );
     }
 
+    @Test
+    void rejectsCompactTupleCountThatOverflowsInt() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnOnlyPhi(new Span("seq *4294967297 > [m] > bar", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a compact-tuple `*N` count above Integer.MAX_VALUE must be rejected, not silently wrapped"
+        );
+    }
+
     /**
      * Render the emit's directives under a fresh {@code <object/>}.
      * @param emit The emit

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-tuple-count-overflow-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-tuple-count-overflow-is-rejected.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'too large')]
+input: |
+  [] > app
+    seq *4294967297 > [m] > bar


### PR DESCRIPTION
Fixes #6547.

`LnOnlyPhi.starCount` accumulated the `*N` digits of an only-phi compact-tuple LHS (`head *N > [params] > name`) into a plain 32-bit `int` with no range check, so a count above `Integer.MAX_VALUE` silently wrapped instead of being rejected - the same defect fixed for the sibling `LnCompactTuple.readCount` in #6355 (PR #6420), but never ported to the only-phi path. A positive wrap changed how the line parsed, and a negative wrap collided with the existing `-1` "not-a-digit" sentinel so the whole token was misread as a bare empty-tuple horizontal argument with no error at all.

`starCount` now accumulates into a `long` and throws a `ParseError` the moment the running total would exceed `Integer.MAX_VALUE`, pointing at the start of the digit run - mirroring `LnCompactTuple.readCount` for the sibling `*N` marker.

Tests:
- declarative parser test `only-phi-compact-tuple-count-overflow-is-rejected.yaml` with `seq *4294967297` (2^32 + 1, the smallest overflowing count) on an only-phi line, asserting parsing reports a "too large" error instead of silently wrapping;
- unit test `LnOnlyPhiTest.rejectsCompactTupleCountThatOverflowsInt` asserting the `ParseError` directly.

`mvn -pl eo-parser -Pqulice test` passes (1681 tests, 0 failures); `qulice:check` and `jtcop:check` pass.

@yegor256
