### PR TITLE
#6564: fix number.mod hanging on a non-finite dividend

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -8,7 +8,8 @@
 # remainder is below twice the subtracted value, which is exact too, so the
 # answer matches the true remainder for any pair of finite numbers, however
 # far apart their magnitudes are, at the cost of two recursive steps per
-# bit of the quotient.
+# bit of the quotient. When the dividend is `nan` or infinite, the result is
+# `nan`, regardless of the divisor.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -24,32 +25,44 @@
       0
     cant-mod
       "cannot calculate mod by zero"
-    divisor.is-finite.not.if
-      divisor.is-nan.if nan x
-      if.
-        gt.
-          number x.as-bytes >> dividend
-          0
-        [] >> abs-mod
-          shrink > @
-            grow
-              abs divisor >> absy
-            abs dividend >> absx
-          if. > [chunk] > grow
-            chunk.gte absx
-            chunk
-            grow
-              chunk.plus chunk
-          if. > [chunk rest] > shrink
-            chunk.lt absy
-            rest
-            shrink
-              chunk.div 2
-              if.
-                rest.gte chunk
-                rest.minus chunk
-                rest
-        abs-mod.neg
+    dividend.is-finite.not.if
+      nan
+      divisor.is-finite.not.if
+        divisor.is-nan.if nan x
+        if.
+          gt.
+            number x.as-bytes >> dividend
+            0
+          [] >> abs-mod
+            shrink > @
+              grow
+                abs divisor >> absy
+              abs dividend >> absx
+            if. > [chunk] > grow
+              chunk.gte absx
+              chunk
+              grow
+                chunk.plus chunk
+            if. > [chunk rest] > shrink
+              chunk.lt absy
+              rest
+              shrink
+                chunk.div 2
+                if.
+                  rest.gte chunk
+                  rest.minus chunk
+                  rest
+          abs-mod.neg
+
+  is-nan. ++> can-return-nan-when-the-dividend-is-infinite
+    mod
+      pinf
+      5
+
+  is-nan. ++> can-return-nan-when-the-dividend-is-nan
+    mod
+      nan
+      5
 
   is-nan. ++> can-return-nan-when-the-divisor-is-nan
     mod


### PR DESCRIPTION
Closes #6564.

number.mod only checked whether the divisor was finite before running its abs-mod computation. When the dividend itself is nan or infinite, grow/shrink's exit conditions (chunk.gte absx, chunk.lt absy) are permanently false or permanently true against a non-finite absx, so mod never terminated, regardless of the divisor.

mod now checks the dividend's finiteness first and returns nan immediately for a non-finite dividend, matching Math.IEEEremainder/% semantics. Added two EO tests (nan and pinf dividend against a finite divisor).
