### PR TITLE
#6560: restore the ?. fragile-dispatch marker when printing XMIR back to EO

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -32,6 +32,18 @@
     <xsl:param name="base" as="xs:string"/>
     <xsl:sequence select="if (starts-with($base, '.')) then concat(eo:translate-path(substring($base, 2)), '.') else if (starts-with($base, concat($eo:program, '.'))) then eo:translate-path(substring-after($base, concat($eo:program, '.'))) else if (starts-with($base, concat($eo:xi, '.'))) then eo:translate-path(substring-after($base, concat($eo:xi, '.'))) else if ($base = $eo:xi) then '$' else if ($base = $eo:program) then 'Q' else eo:translate-path($base)"/>
   </xsl:function>
+  <!--
+  A surface head with its last dot turned into "?." when the dispatch it
+  ends in is fragile (R-3.5 / §9.4): "foo.first" becomes "foo?.first" and
+  the reversed "first." becomes "first?.". A surface with no dot at all
+  (nothing to mark) passes through unchanged.
+  -->
+  <xsl:function name="eo:fragile-marked" as="xs:string">
+    <xsl:param name="surface" as="xs:string"/>
+    <xsl:param name="fragile" as="xs:boolean"/>
+    <xsl:variable name="last" select="tokenize($surface, '\.')[last()]"/>
+    <xsl:sequence select="if ($fragile and contains($surface, '.')) then concat(substring($surface, 1, string-length($surface) - string-length($last) - 1), '?.', $last) else $surface"/>
+  </xsl:function>
   <!-- First name segment of a program-rooted base (Φ.foo.bar -> foo). -->
   <xsl:function name="eo:root-name" as="xs:string">
     <xsl:param name="base" as="xs:string"/>
@@ -348,7 +360,7 @@
         <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="eo:surface(@base)"/>
+        <xsl:value-of select="eo:fragile-marked(eo:surface(@base), exists(@fragile))"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-restored.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-restored.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6560: the parser marks a fragile `?.` dispatch with `@fragile=""` on the
+# XMIR node, but the printer had no branch for that attribute and silently
+# dropped it, turning every fragile dispatch into a plain one on the next
+# `eo:format -Deo.autoFix`. The fix marks the last dot of the printed head
+# with `?.` whenever `@fragile` is set.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    foo?.first > x
+
+printed: |
+  [] > main
+    foo?.first > x


### PR DESCRIPTION
Closes #6560.

The parser marks a `?.` fragile dispatch with `@fragile=""` on the XMIR node, but `to-eo-tree.xsl` had no branch for that attribute, so the printer silently dropped it and turned every fragile dispatch into a plain one on the next `eo:format -Deo.autoFix`.

The BASED head template's fallback branch now runs the computed surface string through a new `eo:fragile-marked` function, which turns the last dot into `?.` when `@fragile` is set. This covers both shapes a fragile dispatch's base can take: a flattened `Φ.`-rooted dotted path (`foo?.first`) and the reversed-dispatch vertical form (`read?.` with the receiver as a nested child).

Added a print-pack YAML test for the simple case.
