### PR TITLE
#6562: accept a bare ! const marker on a vertical argument line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -309,6 +309,13 @@ final class Suffix {
 
     /**
      * Parse a suffix tail into a result struct.
+     *
+     * <p>A bare {@code !} with no name suffix — the vertical-argument
+     * counterpart of the horizontal {@code a b!} form (#5821), which
+     * {@link #named} already accepts inline but which the unnamed tail of
+     * a vertical argument line never reached (#6562) — yields
+     * {@link Form#NONE} with the const marker set.</p>
+     *
      * @param tail Tail substring
      * @param span Source span
      * @param home Source column where {@code tail} begins
@@ -327,6 +334,9 @@ final class Suffix {
             result = Suffix.auto(tail, idx + 2, span, home);
         } else if (tail.charAt(idx) == '>') {
             result = Suffix.named(tail, idx + 1, span, home);
+        } else if (tail.charAt(idx) == '!') {
+            Suffix.endsClean(tail, idx + 1, span, home);
+            result = new Suffix.Parsed(Form.NONE, "", "", true);
         } else {
             throw new ParseError(
                 span.line(), home + idx,

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -145,6 +145,24 @@ final class SuffixTest {
     }
 
     @Test
+    void reportsNoneFormForBareConstMarker() {
+        MatcherAssert.assertThat(
+            "a bare `!` with no name suffix must still yield Form.NONE",
+            new Suffix(" !", new Span("[] !", 1), 2).form(),
+            Matchers.equalTo(Suffix.Form.NONE)
+        );
+    }
+
+    @Test
+    void detectsConstMarkerOnBareTail() {
+        MatcherAssert.assertThat(
+            "a bare `!` (#6562, the vertical-argument counterpart of #5821) must report constant() == true",
+            new Suffix(" !", new Span("[] !", 1), 2).constant(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void parsesAtomSignature() {
         MatcherAssert.assertThat(
             "`> name /sig` must record the atom signature as sig()",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bare-bang-vertical-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/bare-bang-vertical-argument.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6562: the horizontal `a b! > x` form was already accepted (#5821), but the
+# same `!` written on a vertical argument line with no name suffix
+# (`b` alone, indented under `a > x`) was rejected as "trailing garbage after
+# expression" — Suffix.parse had no branch for a bare `!` with nothing after
+# it. A bare `!` must parse the same way `> name!`'s marker does, feeding the
+# same const-to-dataized rewrite.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.as-bytes' and o[@base='Φ.dataized' and o[@base='b']]]
+  - //o[@name='x']/o
+input: |
+  [] > main
+    a > x
+      b!


### PR DESCRIPTION
Closes #6562.

`Suffix.parse` only recognized the `!` const marker after `+>`, `->`, `>>`, or `>`, so a vertical argument line with no name suffix (`b` alone, indented under `a > x`) threw "trailing garbage after expression" for a trailing `!`, even though the equivalent horizontal `a b!` form already works (#5821).

A bare `!` now yields `Form.NONE` with the const flag set — same as every other form already does — so `ChainEmission` picks it up through its existing `suffix.constant()` check with no change needed there.

Added a JUnit test on `Suffix` plus an `eo-packs` YAML test confirming the bare-`!` case produces the same `const-to-dataized` rewrite as the horizontal form.
