### PR TITLE
#6561: keep @as on the floated wrapper, not the object inside dataized

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
@@ -61,10 +61,13 @@
       <xsl:attribute name="name" select="$cname"/>
       <xsl:attribute name="line" select="@line"/>
       <xsl:attribute name="pos" select="@pos + 8"/>
+      <xsl:if test="@as">
+        <xsl:attribute name="as" select="@as"/>
+      </xsl:if>
       <o>
         <xsl:attribute name="base" select="'Φ.dataized'"/>
         <o>
-          <xsl:for-each select="@*[name()!='const' and name()!='name']">
+          <xsl:for-each select="@*[name()!='const' and name()!='name' and name()!='as']">
             <xsl:attribute name="{name()}">
               <xsl:value-of select="."/>
             </xsl:attribute>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/const-to-dataized-keeps-as.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/const-to-dataized-keeps-as.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6561: const-to-dataized.xsl copied every attribute except "const" and
+# "name" onto the object nested inside the "Φ.dataized" wrapper, including
+# "@as" - the inline binding label. That put the label on the wrong object:
+# the one inside "dataized", where it has no effect, instead of on the
+# floated ".as-bytes" wrapper that actually occupies the argument slot after
+# vars-float-up runs. The label must survive on the outer wrapper instead.
+sheets:
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+asserts:
+  - //o[@base='.as-bytes' and @as='lbl' and o[@base='Φ.dataized' and o[@base='b' and not(@as)]]]
+input: |
+  [] > foo
+    a b:lbl! > x


### PR DESCRIPTION
Closes #6561.

`const-to-dataized.xsl` copied every attribute except `const` and `name` onto the object nested inside the `Φ.dataized` wrapper, including `@as` - the inline binding label. That put the label on the wrong object: the one inside `dataized`, where it has no effect, instead of on the outer `.as-bytes` wrapper that actually occupies the argument slot after `vars-float-up` runs.

Two visible effects: the label was silently dropped (the floated reference fell back to a positional `αN` binding instead of keeping the original name), and when another argument already occupied that positional slot, the result was invalid XMIR with two attributes bound to the same position.

`@as` now stays on the outer wrapper and is excluded from the inner copy. Verified against both cases from the issue: a single labeled const argument now keeps its label end-to-end, and the two-argument collision case (`a b:1! c:0 > x`) now resolves to distinct `α0`/`α1` instead of colliding.

Added a print/parse-pack YAML test confirming the label lands on the outer `.as-bytes` node, not the inner `Φ.dataized` one.
