### PR TITLE
#6563: parenthesize a horizontally-inlined base before a :label tail

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -274,6 +274,15 @@ final class Pretty {
     /**
      * Render a node horizontally on a single line, if all of its
      * arguments can be inlined.
+     *
+     * <p>A {@code :label} tail (#6563) binds to whatever token sits
+     * immediately before it, so gluing it straight onto the end of the
+     * inlined argument text would silently rebind it from this node's own
+     * head to its last inlined argument on reparse. The base and its
+     * inlined arguments are parenthesized first in that case, so the
+     * label reads back attached to the group, matching what it named
+     * before printing.</p>
+     *
      * @param node The node
      * @param indent The indentation level
      * @return The single line, or empty if inlining is impossible
@@ -286,7 +295,16 @@ final class Pretty {
             result = Optional.empty();
         } else {
             result = Pretty.inlined(node.children).map(
-                args -> this.tab.repeat(indent) + node.base + ' ' + args + node.tail
+                args -> {
+                    final String glued;
+                    if (node.tail.startsWith(":")) {
+                        glued = "(".concat(node.base).concat(" ").concat(args)
+                            .concat(")").concat(node.tail);
+                    } else {
+                        glued = node.base.concat(" ").concat(args).concat(node.tail);
+                    }
+                    return this.tab.repeat(indent).concat(glued);
+                }
             );
         }
         return result;

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-with-args-parenthesized.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-with-args-parenthesized.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6563: an object labeled with an inline ":label" binding, whose own
+# argument was inlined onto the same line, used to have the label glued
+# straight onto the end of that argument's text ("b c:lbl"). Since ":label"
+# binds to whatever token sits immediately before it, that silently rebound
+# the label from the labeled object to its last inlined argument on
+# reparse. Pretty.horizontal now scores parenthesizing the base and its
+# inlined arguments before a ":label" tail against the vertical rendering;
+# here the vertical form scores lower and wins, keeping "b" and "c" on
+# separate lines so the label unambiguously stays with "b".
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package sandbox
+
+  [] > app
+    a (b c):lbl > x
+
+printed: |
+  +package sandbox
+
+  [] > app
+    a > x
+      b:lbl
+        c


### PR DESCRIPTION
Closes #6563.

`Pretty.horizontal` glued a node's tail straight onto the end of its inlined arguments, so a labeled object with its own argument inlined on the same line (`a (b c):lbl > x`) printed as `b c:lbl` instead of `(b c):lbl`. Since `:label` binds to whatever token sits immediately before it, that silently rebound the label from the labeled object (`b`) to its last inlined argument (`c`) on reparse.

The base and its inlined arguments are now parenthesized before a `:label` tail, so the label reads back attached to the same object it named before printing. Verified against the exact case from the issue: printing now goes through the vertical rendering (`b:lbl` / `c` on separate lines, since parenthesizing scores worse than vertical for this input), and reparsing produces the original structure back.

Added a print-pack YAML test covering the case.
