### PR TITLE
#6563: preserve labels across inline printer layouts

### DIFF
--- a/docs/superpowers/plans/2026-08-11-inline-label-binding.md
+++ b/docs/superpowers/plans/2026-08-11-inline-label-binding.md
@@ -1,0 +1,81 @@
+# Inline Label Binding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve an inline `:label` on its owning application when XMIR is printed and reparsed.
+
+**Architecture:** Keep the existing line-tree model and penalty selector. Remove the unsafe horizontal candidate only when a non-leaf node's tail starts with `:`, allowing the existing vertical renderer to place the label next to its owner.
+
+**Tech Stack:** Java 17+, Maven, JUnit 5 parameterized tests, EO printer YAML fixtures
+
+---
+
+### Task 1: Preserve labels on nested applications
+
+**Files:**
+- Create: `eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding.yaml`
+- Modify: `eo-printer/src/main/java/org/eolang/printer/Pretty.java:274-297`
+
+- [ ] **Step 1: Add the regression fixture**
+
+```yaml
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  a (b c):lbl > x
+
+printed: |
+  a > x
+    b:lbl
+      c
+```
+
+- [ ] **Step 2: Run the exact-output test and verify RED**
+
+Run: `mvn -pl eo-printer test "-Dtest=XmirTest#printsToEo" "-Dinvoker.skip=true" --batch-mode --no-transfer-progress`
+
+Expected: FAIL for `inline-label-binding.yaml`, showing actual output `b c:lbl` instead of the expected vertical `b:lbl` with child `c`.
+
+- [ ] **Step 3: Reject the unsafe horizontal candidate**
+
+In `Pretty.horizontal()`, replace the leaf-only guard with:
+
+```java
+        } else if (node.children.isEmpty() || node.tail.startsWith(":")) {
+            result = Optional.empty();
+```
+
+Extend the method Javadoc to state that a `:label` tail cannot follow inlined arguments because it would bind to the last argument rather than the node.
+
+- [ ] **Step 4: Verify GREEN and round-trip behavior**
+
+Run: `mvn -pl eo-printer test "-Dtest=XmirTest" "-Dinvoker.skip=true" --batch-mode --no-transfer-progress`
+
+Expected: BUILD SUCCESS; the fixture passes `printsToEo` and `printsToParseableEo`, proving exact safe output and stable reparsing.
+
+- [ ] **Step 5: Run module verification**
+
+Run: `mvn -pl eo-printer -am clean install "-Dinvoker.skip=true" "-DskipITs=true" --batch-mode --no-transfer-progress`
+
+Run: `mvn -pl eo-printer -am verify -PskipTests -Pqulice "-Dinvoker.skip=true" --batch-mode --no-transfer-progress`
+
+Expected: both commands finish with BUILD SUCCESS.
+
+- [ ] **Step 6: Check scope and commit**
+
+Run: `git diff --check && git diff --numstat`
+
+Expected: only the fixture and `Pretty.java` are modified, and total additions plus deletions for the complete branch remain at or below 200.
+
+```bash
+git add eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding.yaml eo-printer/src/main/java/org/eolang/printer/Pretty.java
+git commit -m "#6563: preserve inline label binding"
+```

--- a/docs/superpowers/specs/2026-08-11-inline-label-binding-design.md
+++ b/docs/superpowers/specs/2026-08-11-inline-label-binding-design.md
@@ -1,0 +1,39 @@
+# Inline Label Binding Design
+
+Issue: [#6563](https://github.com/objectionary/eo/issues/6563)
+
+## Problem
+
+The printer stores an object's `:label` in the line-tree node's `tail`.
+`Pretty.horizontal()` currently emits the node's base, then its inlined
+arguments, and finally that tail. For `b` with argument `c` and label `lbl`,
+this produces `b c:lbl`; reparsing binds `lbl` to `c` instead of `b`.
+
+## Considered Approaches
+
+1. Reject horizontal layout for an application whose tail starts with `:`.
+   The existing vertical layout then emits `b:lbl` with `c` below it. This is
+   the smallest change and uses an output form explicitly accepted by #6563.
+2. Reorder the label before horizontal arguments. This would produce
+   `b:lbl c`, but introduces another canonical surface form that is not the
+   issue's requested output and needs broader grammar validation.
+3. Split labels from other suffixes in the line-tree model and teach the
+   printer to reconstruct `(b c):lbl`. This preserves compact spelling but is
+   substantially broader and risks exceeding the project's 200-line PR limit.
+
+Approach 1 is selected.
+
+## Implementation
+
+Add a printer fixture for `a (b c):lbl > x` that expects the safe vertical
+form. Confirm that it fails because the current printer emits `b c:lbl`.
+Then make `Pretty.horizontal()` return no horizontal candidate when the node
+has children and its tail begins with `:`. The penalty selector will retain
+the existing vertical candidate without changing unrelated suffix handling.
+
+## Verification
+
+The new fixture must pass both exact-output and reprint/idempotency checks in
+`XmirTest`. Run the complete `eo-printer` module build with its dependencies,
+then run Qulice for the affected module. The final PR must remain below 200
+changed lines.

--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -223,16 +223,24 @@ final class Node {
      * #5624). With {@code N >= 1} the count sits on the head's line, so
      * the {@code *N} marker round-trips after a dotted dispatch too
      * ({@code string.sprintf *1}) and a dotted base is allowed
-     * (issue #5648).</p>
+     * (issue #5648). A labeled application is also excluded because placing
+     * the marker before its label would bind the label to the marker instead
+     * of the application.</p>
      *
      * @return True when the trailing-star hybrid form is applicable
      */
     boolean tuply() {
-        final int size = this.children.size();
-        return size > 0
-            && this.marked()
-            && this.children.get(size - 1).stars()
-            && this.absorbed(size);
+        final boolean result;
+        if (this.tail.startsWith(":")) {
+            result = false;
+        } else {
+            final int size = this.children.size();
+            result = size > 0
+                && this.marked()
+                && this.children.get(size - 1).stars()
+                && this.absorbed(size);
+        }
+        return result;
     }
 
     /**

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -430,7 +430,9 @@ final class Pretty {
      * result is only a candidate: {@link #shaped} keeps it only when its
      * penalty beats the plain vertical and horizontal renderings, so a short
      * tuple whose one-line {@code * 1 2} form is no worse than the vertical one
-     * stays inline as that bare tuple rather than the hybrid star.</p>
+     * stays inline as that bare tuple rather than the hybrid star. A labeled
+     * node cannot use this form because the marker would separate its label
+     * from the node's head.</p>
      *
      * @param node The node
      * @param indent The indentation level

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -274,6 +274,11 @@ final class Pretty {
     /**
      * Render a node horizontally on a single line, if all of its
      * arguments can be inlined.
+     *
+     * <p>A label tail cannot follow inlined arguments: {@code b c:lbl}
+     * binds {@code lbl} to {@code c}, not {@code b}. Such a node keeps its
+     * vertical rendering, where the label stays next to its owner.</p>
+     *
      * @param node The node
      * @param indent The indentation level
      * @return The single line, or empty if inlining is impossible
@@ -282,7 +287,7 @@ final class Pretty {
         final Optional<String> result;
         if (node.abstractt) {
             result = this.phi(node, indent);
-        } else if (node.children.isEmpty()) {
+        } else if (node.children.isEmpty() || node.tail.startsWith(":")) {
             result = Optional.empty();
         } else {
             result = Pretty.inlined(node.children).map(

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding-before-star.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding-before-star.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  a (b c (* d)):lbl > x
+
+printed: |
+  a > x
+    b:lbl
+      c
+      * d

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inline-label-binding.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  a (b c):lbl > x
+
+printed: |
+  a > x
+    b:lbl
+      c


### PR DESCRIPTION
Closes #6563.

## Summary

- prevent labeled applications from using a horizontal form that would move the label from the application to its last argument;
- exclude labeled applications from the compact trailing-star form, which can otherwise print `b *1:lbl` and bind `:lbl` to the tuple marker;
- add print-pack coverage for both the original reproducer and the trailing-star variant.

## Root cause

The printer appended a node's `:label` tail after its horizontally inlined children. For `a (b c):lbl > x`, this produced `b c:lbl`, so reparsing attached the label to `c` instead of `b`.

The compact trailing-star candidate bypassed the normal horizontal candidate and had the same problem. For example, `a (b c (* d)):lbl > x` could become `b *1:lbl`, again changing what the label names.

This PR keeps labeled applications in a safe vertical layout in both paths, preserving the original structure after printing and reparsing.

## Difference from #6578

#6578 addresses the original horizontal example by parenthesizing that candidate. This competing draft also covers the independent compact trailing-star path selected before the horizontal guard, with a regression fixture for that case.

## Validation

- `mvn -pl eo-printer -am clean install -Dinvoker.skip=true -DskipITs=true --batch-mode --no-transfer-progress`
  - `eo-parser`: 1,723 tests, 0 failures, 0 errors, 9 skipped
  - `eo-printer`: 348 tests, 0 failures, 0 errors
- `mvn -pl eo-printer -am verify -PskipTests -Pqulice -Dinvoker.skip=true --batch-mode --no-transfer-progress`
- `git diff --check`

The complete PR contains 186 changed lines, below the repository's 200-line limit.
