### PR TITLE
fix(#6573): unescape %% in the scanf out-of-range message

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -64,7 +64,8 @@
                 digits-lte normalized "9223372036854775808"
                 digits-lte normalized "9223372036854775807"
         T
-          "The number doesn't fit into long range for the '%%d' conversion"
+          "The number doesn't fit into long range for the '%%d' conversion".printf
+            *
         negative.if negated folded
       [a b] > digits-lte
         if. > [index] >> rec
@@ -372,9 +373,12 @@
     "hello%"
     "hello"
 
-  scanf --> stops-on-an-oversized-integer
-    "%d"
-    "99999999999999999999"
+  eq. ++> stops-on-an-oversized-integer
+    recovered
+      head.
+        scanf "%d" "99999999999999999999"
+      42
+    42
 
   gt. ++> can-scan-a-nineteen-digit-value-at-long-max
     head.
@@ -386,17 +390,26 @@
       scanf "%d" "-9223372036854775808"
     -9000000000000000000
 
-  scanf --> stops-on-a-nineteen-digit-value-above-long-max
-    "%d"
-    "9223372036854775808"
+  eq. ++> stops-on-a-nineteen-digit-value-above-long-max
+    recovered
+      head.
+        scanf "%d" "9223372036854775808"
+      42
+    42
 
-  scanf --> stops-on-a-nineteen-digit-value-below-long-min
-    "%d"
-    "-9223372036854775809"
+  eq. ++> stops-on-a-nineteen-digit-value-below-long-min
+    recovered
+      head.
+        scanf "%d" "-9223372036854775809"
+      42
+    42
 
-  scanf --> stops-on-a-zero-padded-integer-above-long-max
-    "%d"
-    "00009223372036854775808"
+  eq. ++> stops-on-a-zero-padded-integer-above-long-max
+    recovered
+      head.
+        scanf "%d" "00009223372036854775808"
+      42
+    42
 
   scanf --> stops-on-a-wrong-format
     "%l"


### PR DESCRIPTION
The out-of-range diagnostic in `string.scanf` carried a doubled percent
meant to escape to a literal `%d`, but the string was handed straight to
`T` and never went through `.printf`, so the escaping never happened.
`PhTerminator.delta()` deliberately does not format-expand the reason
(`throw new ExFailure("%s", reason)`, the fix for #6139), which means the
collapsing has to happen at the call site.

The reason is now passed through `.printf` with an empty argument tuple,
the same way every other `%%`-carrying diagnostic in `scanf.eo` and
`printf.eo` already is.

Before:

```
scanf "%d" "99999999999999999999"
  -> ExFailure: ... for the '%%d' conversion
```

After:

```
scanf "%d" "99999999999999999999"
  -> ExFailure: The number doesn't fit into long range for the '%d' conversion
```

Verified by building `eo-runtime` and driving the error path directly:
the reason string now renders with a single `%`. All 25 of `scanf.eo`'s
own `++>`/`-->` tests pass unchanged.

Closes #6573
