### PR TITLE
#6568: make regex matches backtrack across the full text

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -83,8 +83,34 @@
         and.
           found.to.eq txt.length
           found.from.eq 0
+      "/(?:%s)(?![\\s\\S])/%s".printf > anchored
+        *
+          parsed.group 1
+          parsed.group 2
+      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented
+        *
+          parsed.group 1
+          parsed.group 2
       next. > found
-        match txt
+        match.
+          compile.
+            regex anchored
+            retry-commented
+          txt
+      next. > parsed
+        match.
+          compiled.
+            regex "/^\\/([\\s\\S]*)\\/([dimsux]*)$/"
+          expression
+      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
+        *
+          parsed.group 1
+          parsed.group 2
+      compile. > [message] > retry-commented
+        regex commented
+        retry-quoted
+      compile. > [message] > retry-quoted
+        regex quoted
 
   eq. ++> can-advance-after-a-zero-width-match
     1

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOcompileTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOcompileTest.java
@@ -30,6 +30,13 @@ final class EOregexEOcompileTest {
     @CsvSource({
         "/a|ab/, ab, true",
         "/a+?/, aaa, true",
+        "/a|ab/i, AB, true",
+        "/([0-9]) #ignore this comment/x, 4, true",
+        "/(?x)([0-9]) #ignore this comment/, 4, true",
+        "/a(?x) #tail/, a, true",
+        "/(?x)a(?-x)/, a, true",
+        "/\\Qa|ab/, a|ab, true",
+        "/a/b|a/bc/, a/bc, true",
         "/[a-z]+/, 1abc, false"
     })
     void matchesEntireTextAfterBacktracking(

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOcompileTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOregexEOcompileTest.java
@@ -17,12 +17,38 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Test case for {@link EOregex$EOcompile}.
  * @since 0.57.4
  */
 final class EOregexEOcompileTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "/a|ab/, ab, true",
+        "/a+?/, aaa, true",
+        "/[a-z]+/, 1abc, false"
+    })
+    void matchesEntireTextAfterBacktracking(
+        final String expression, final String text, final boolean expected
+    ) {
+        MatcherAssert.assertThat(
+            String.format("regex %s must match the entire text %s", expression, text),
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        Phi.Φ.take("string.regex").copy(),
+                        "expression", new Data.ToPhi(expression)
+                    ).take("compiled").take("matches").copy(),
+                    "txt", new Data.ToPhi(text)
+                )
+            ).asBool(),
+            Matchers.equalTo(expected)
+        );
+    }
 
     @Test
     void compilesRegexWithSlashes() {


### PR DESCRIPTION
Closes #6568

@yegor256 please take a look.

## Summary

- make `string.regex.pattern.matches` compile an end-constrained form of the original expression, so the regex engine can backtrack beyond a successful prefix
- keep the implementation in EO so JVM and Node use the same matching path
- preserve comments-mode and JVM `\Q` end-of-pattern behavior through lazy compile fallbacks
- add regressions for shorter alternation branches, lazy quantifiers, flags, comments mode, inline flag changes, embedded slashes, quoted patterns, and non-zero match starts

## Verification

- `mvn surefire:test '-Dtest=EOregexTest,EOregexEOcompileTest,EOregexEOpatternEOmatchEOmatchedfromindexTest'` — 57 tests passed
- `mvn -Pqulice com.qulice:qulice-maven-plugin:0.30.7:check` — passed
- independent code review — ready to merge, no Critical/Important findings
- `mvn verify -Pqulice` — did not complete locally: the build spent about 14 minutes in the existing `eo:inference` path (`Needs.follow -> TjDefault.add`) before it was stopped; it had not reached the test phase
