### PR TITLE
fix(#6569): return positive zero for zero dividend modulo

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -30,7 +30,7 @@
       divisor.is-finite.not.if
         divisor.is-nan.if nan x
         if.
-          gt.
+          gte.
             number x.as-bytes >> dividend
             0
           [] >> abs-mod
@@ -68,6 +68,16 @@
     mod
       5
       nan
+
+  eq. ++> can-return-positive-zero-when-dividend-is-zero
+    as-bytes.
+      0.mod 3
+    0.as-bytes
+
+  eq. ++> can-return-positive-zero-when-dividend-is-zero-and-divisor-is-negative
+    as-bytes.
+      0.mod -3
+    0.as-bytes
 
   ++> can-stay-compatible-with-division
     eq. > @
@@ -131,10 +141,22 @@
       7
     -1
 
+  eq. ++> can-take-a-modulo-of-minus-seven-by-three
+    mod
+      -7
+      3
+    -1
+
   eq. ++> can-take-a-modulo-of-one-by-two
     mod
       1
       2
+    1
+
+  eq. ++> can-take-a-modulo-of-seven-by-three
+    mod
+      7
+      3
     1
 
   eq. ++> can-take-a-modulo-of-sixteen-by-a-large-negative


### PR DESCRIPTION
## Summary

Fixes `number.mod` returning negative zero when the dividend is zero.

The sign branch used `gt` to determine whether the result should be negated. For a zero dividend, `0 > 0` is false, so the zero magnitude was sent through `.neg`, producing `-0.0`.

The condition now uses `gte`, so zero dividends stay on the non-negative path and return `+0.0`.

Closes #6569.

## Changes

- Change the sign condition in `number.mod` from `gt` to `gte`.
- Add byte-level regression coverage for:
  - `0 mod 3`
  - `0 mod -3`
- Add normal positive/negative modulo regression checks:
  - `7 mod 3`
  - `-7 mod 3`

## Testing

Verified locally with Java 17 and Maven 3.9.16.

Passed:

- CI-equivalent Maven build:
  `mvn -ntp -PskipITs --errors --batch-mode -Deo.coverageTracking=false -Deo.transpileTests=false clean install`
- Targeted EO modulo tests:
  `mvn test -pl eo-runtime -Dtest=EOmodTest`
- Reverse verification:
  temporarily restoring `gt` reproduces the regression; restoring `gte` makes the tests pass again.

Note:

`-Pqulice` was not run locally because the profile requires Java 21+, while the available environment has Java 17. The non-qulice CI-equivalent build and targeted EO tests both passed.

@yegor256 please take a look.
