### PR TITLE
#6573: correct scanf out-of-range diagnostic

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -64,7 +64,8 @@
                 digits-lte normalized "9223372036854775808"
                 digits-lte normalized "9223372036854775807"
         T
-          "The number doesn't fit into long range for the '%%d' conversion"
+          "The number doesn't fit into long range for the '%%d' conversion".printf
+            *
         negative.if negated folded
       [a b] > digits-lte
         if. > [index] >> rec

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.ExAbstract;
+import org.eolang.PhApplication;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link EOscanf} diagnostics.
+ * @since 0.61.0
+ */
+final class EOscanfDiagnosticTest {
+
+    @Test
+    void reportsSinglePercentForOversizedInteger() {
+        final Phi scanf = new PhApplication(
+            new PhApplication(
+                new PhApplication(
+                    Phi.Φ.take("string.scanf").copy(),
+                    "format", new Data.ToPhi("%d")
+                ),
+                "read", new Data.ToPhi("99999999999999999999")
+            ).take("at").copy(),
+            "i", new Data.ToPhi(0)
+        );
+        MatcherAssert.assertThat(
+            "scanf must report the %d conversion with one percent sign",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(scanf).take()
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString(
+                    "The number doesn't fit into long range for the '%d' conversion"
+                ),
+                Matchers.not(Matchers.containsString("%%d"))
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link EOscanf} diagnostics.
  * @since 0.61.0
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 final class EOscanfDiagnosticTest {
 
     @Test


### PR DESCRIPTION
## Summary

- format the `scanf` out-of-range diagnostic before it reaches the bottom object
- add regression coverage for the visible `%d` conversion text

## Testing

- `mvn -Dmaven.repo.local=target/m2-issue-6573 -o -pl eo-runtime -Dtest=org.eolang.EO_string.EOscanfDiagnosticTest,org.eolang.EO_string.EOscanfTest -DskipITs test` — 26 tests passed
- Full `eo-runtime verify` on this Windows host was blocked by the unrelated TEST-NET assumption tracked in #6584

Closes #6573