### PR TITLE
#6549: translate glob character classes

### DIFF
--- a/docs/superpowers/plans/2026-08-11-character-class-glob.md
+++ b/docs/superpowers/plans/2026-08-11-character-class-glob.md
@@ -1,0 +1,321 @@
+# Character Class Glob Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `directory.walk` correctly support range, negated, and metacharacter-bearing glob character classes and remove the resolved `#6482` puzzle.
+
+**Architecture:** Extend the existing recursive, single-pass glob-to-regex translator with one `classed` state flag. The same EO source file owns the translator and its embedded behavioral tests, so no public interface or additional object is introduced.
+
+**Tech Stack:** EO, `eo-maven-plugin`, Maven, embedded EO tests
+
+---
+
+## File Structure
+
+- Modify `eo-runtime/src/main/eo/directory.eo`: add embedded character-class tests, extend `translated`, and remove the resolved puzzle.
+- Keep `docs/superpowers/specs/2026-08-11-character-class-glob-design.md`: approved design record.
+- Keep `docs/superpowers/plans/2026-08-11-character-class-glob.md`: executable TDD plan.
+
+### Task 1: Prepare the focused runtime test environment
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Install the current reactor-built plugin without running the unrelated parser tests**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-DskipTests' install -pl :eo-maven-plugin -am
+```
+
+Expected: `BUILD SUCCESS`; the locally installed `eo-maven-plugin:1.0-SNAPSHOT`
+contains the current `inference` goal. The known full-reactor `XmirTest` MANIFEST
+failure is bypassed because tests are skipped only for this dependency-install step.
+
+- [ ] **Step 2: Confirm the branch contains only the approved documentation commits**
+
+Run:
+
+```powershell
+git status -sb
+git diff upstream/master...HEAD --stat
+```
+
+Expected: a clean worktree whose committed diff contains only the design and
+plan files.
+
+### Task 2: Add failing character-class behavior tests
+
+**Files:**
+- Modify and test: `eo-runtime/src/main/eo/directory.eo:394-449`
+
+- [ ] **Step 1: Add three embedded tests before the plain-glob test**
+
+Insert the following tests:
+
+```eo
+  ++> can-walk-with-a-character-class-range
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "1.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[a-z].txt"
+        d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-negated-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[!a].txt"
+        d.resolved "b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-keep-a-star-literal-inside-a-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[a*].txt"
+        d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+```
+
+- [ ] **Step 2: Run the runtime tests and verify RED**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' clean test -pl :eo-runtime
+```
+
+Expected: `BUILD FAILURE` from the newly added embedded tests because the
+existing translator sends character-class contents through wildcard and brace
+translation. Confirm the failure names or generated source point to the new
+tests, rather than an EO syntax or formatting error.
+
+### Task 3: Translate character classes in one pass
+
+**Files:**
+- Modify: `eo-runtime/src/main/eo/directory.eo:3-8`
+- Modify: `eo-runtime/src/main/eo/directory.eo:133-207`
+
+- [ ] **Step 1: Remove only the resolved puzzle**
+
+Delete the complete `# @todo #6482:45min` paragraph. Leave the `#5751` and
+`#6484` puzzle paragraphs unchanged.
+
+- [ ] **Step 2: Pass initial character-class state into the translator**
+
+Change:
+
+```eo
+                    translated 0 "" false
+```
+
+to:
+
+```eo
+                    translated 0 "" false false
+```
+
+- [ ] **Step 3: Extend `translated` with character-class state**
+
+Replace the existing `translated` object with this state-aware version:
+
+```eo
+    [index acc braced classed] >> translated
+      if. > @
+        index.gte glob.length
+        acc
+        translated
+          index.plus
+            double.if 2 1
+          string.joined *1
+            ""
+            acc
+            token
+          if.
+            classed
+            braced
+            if.
+              char.eq "{"
+              true
+              if.
+                char.eq "}"
+                false
+                braced
+          if.
+            classed
+            char.eq "]".not
+            char.eq "["
+      if. > alternated
+        classed
+        escaped char
+        if.
+          char.eq "{"
+          "("
+          if.
+            braced.and
+              char.eq "}"
+            ")"
+            if.
+              braced.and
+                char.eq ","
+              "|"
+              escaped char
+      string.at glob index > char
+      and. > double
+        classed.not
+        and.
+          char.eq "*"
+          eq.
+            string.at
+              glob
+              index.plus 1
+              "" > [message]
+            "*"
+      if. > token
+        classed
+        if.
+          and.
+            char.eq "!"
+            eq.
+              string.at glob (index.minus 1)
+              "["
+          "^"
+          escaped char
+        double.if
+          ".*"
+          if.
+            char.eq "*"
+            string.joined *1
+              ""
+              single
+              "*"
+            if.
+              char.eq "?"
+              single
+              if.
+                char.eq "/"
+                literal
+                alternated
+```
+
+The current character is translated according to the state on entry. The two
+state arguments passed recursively describe the next character: brace state is
+frozen while inside a class, and class state opens after `[` and closes after
+`]`.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' clean test -pl :eo-runtime
+```
+
+Expected: `BUILD SUCCESS`, including the three new character-class tests and
+the existing malformed `[` test.
+
+- [ ] **Step 5: Let the project formatter canonicalize the EO source**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' eo:format -pl :eo-runtime
+git diff --check
+```
+
+Expected: the formatter exits successfully and `git diff --check` reports no
+whitespace errors. If the formatter changes binding order or vertical layout,
+retain its canonical output and rerun Step 4.
+
+### Task 4: Verify scope and publish
+
+**Files:**
+- Verify: `eo-runtime/src/main/eo/directory.eo`
+- Verify: `docs/superpowers/specs/2026-08-11-character-class-glob-design.md`
+- Verify: `docs/superpowers/plans/2026-08-11-character-class-glob.md`
+
+- [ ] **Step 1: Run final runtime validation**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' clean test -pl :eo-runtime
+```
+
+Expected: `BUILD SUCCESS` with zero test failures.
+
+- [ ] **Step 2: Verify the puzzle removal and inspect the complete diff**
+
+Run:
+
+```powershell
+rg -n '#6482|character class' eo-runtime/src/main/eo/directory.eo
+git diff --check
+git status -sb
+git diff upstream/master...HEAD
+```
+
+Expected: no `#6482` puzzle remains; only the approved docs, tests, and
+translator changes are present; `git diff --check` is clean.
+
+- [ ] **Step 3: Commit the implementation**
+
+Run:
+
+```powershell
+git add eo-runtime/src/main/eo/directory.eo
+git commit -m '#6549: translate glob character classes'
+```
+
+Expected: one implementation commit containing the puzzle removal, regression
+tests, and translator change.
+
+- [ ] **Step 4: Re-run final validation after the commit**
+
+Run:
+
+```powershell
+mvn -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' test -pl :eo-runtime
+git status -sb
+```
+
+Expected: `BUILD SUCCESS`; the worktree is clean and ahead of
+`upstream/master` only by the intended commits.
+
+- [ ] **Step 5: Push and open a draft PR**
+
+Push `agent/issue-6549-character-class-glob` to the authenticated fork, then
+open a draft pull request against `objectionary/eo:master`. The PR body must
+describe the character-class state machine, the fixed range/negation/star
+behaviors, the removed puzzle, validation evidence, and the unrelated baseline
+MANIFEST limitation encountered during full-reactor testing.

--- a/docs/superpowers/specs/2026-08-11-character-class-glob-design.md
+++ b/docs/superpowers/specs/2026-08-11-character-class-glob-design.md
@@ -1,0 +1,47 @@
+# Character Class Glob Translation Design
+
+## Goal
+
+Resolve issue #6549 by making `directory.walk` translate glob character
+classes into regular-expression character classes. Remove the `#6482` puzzle
+after the behavior is covered by tests.
+
+## Scope
+
+The change is limited to `eo-runtime/src/main/eo/directory.eo`. It preserves
+the existing recursive walk, brace-group translation, wildcard behavior, and
+malformed-glob error handling. The symbolic-link and constant-stack-space
+puzzles remain untouched.
+
+## Translation
+
+Extend the existing single-pass `translated` object with character-class
+state. Outside a class, `[` opens the class. While the class is open:
+
+- a leading `!` is emitted as `^`, providing glob negation semantics;
+- range punctuation such as `-` keeps its regular-expression meaning;
+- glob metacharacters such as `*`, `?`, `{`, and `}` are emitted as class
+  characters instead of being translated as wildcards or brace groups;
+- `]` closes the class and returns translation to its existing behavior.
+
+An unmatched `[` remains unmatched in the generated regular expression, so
+the existing compilation error continues to report a malformed glob.
+
+## Tests
+
+Use the embedded EO tests in `directory.eo` and follow red-green-refactor:
+
+1. Add a failing test proving `[a-z]` matches a character in the range.
+2. Add a failing test proving `[!a]` excludes `a` and accepts another
+   character.
+3. Add a failing test proving `[*]` treats the star literally.
+4. Preserve the existing malformed `[` test.
+5. Run the focused eo-runtime checks, formatting/lint checks available for the
+   changed EO source, and inspect the final diff.
+
+## Compatibility and Errors
+
+No public object shape changes. Existing globs without character classes keep
+their current translation. Regular-expression compilation remains the single
+validation point and continues to produce the existing `Can't parse ... as a
+glob pattern` error for malformed input.

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -1,11 +1,6 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 #
-# @todo #6482:45min Translate a character class in the glob below. The
-#  `translated` object now turns a brace group into an alternation, but a class
-#  like [a-z] or [!a] reaches the regex engine neither translated nor escaped,
-#  so a negation matches nothing it should and a lone bracket refuses to
-#  compile, while a star inside a class keeps its glob meaning by mistake.
 # @todo #5751:30min Stop descending into a symbolic link to a directory. The
 #  `walk` below asks stat, which follows the link, so a link to its own ancestor
 #  recurses forever, while the `Files.walk` it replaced only listed such a link.
@@ -140,7 +135,7 @@
                   string.joined *1 >>!
                     ""
                     "/^"
-                    translated 0 "" false
+                    translated 0 "" false false
                     "$/"
                 T > [message] >>
                   "Can't parse '%s' as a glob pattern, %s".printf
@@ -151,7 +146,7 @@
       "[^"
       escaped path.separator >> literal
       "]"
-    [index acc braced] >> translated
+    [index acc braced classed] >> translated
       if. > @
         index.gte glob.length
         acc
@@ -162,49 +157,66 @@
             ""
             acc
             token
-          if.
-            char.eq "{"
-            true
+          classed.if
+            braced
             if.
-              char.eq "}"
-              false
-              braced
-      if. > alternated
-        char.eq "{"
-        "("
+              char.eq "{"
+              true
+              if.
+                char.eq "}"
+                false
+                braced
+          classed.if (char.eq "]").not (char.eq "[")
+      classed.if > alternated
+        escaped char
         if.
-          braced.and
-            char.eq "}"
-          ")"
+          char.eq "{"
+          "("
           if.
             braced.and
-              char.eq ","
-            "|"
-            escaped char
-      string.at glob index > char
-      and. > double
-        char.eq "*"
-        eq.
-          string.at
-            glob
-            index.plus 1
-            "" > [message]
-          "*"
-      double.if > token
-        ".*"
-        if.
-          char.eq "*"
-          string.joined *1
-            ""
-            single
-            "*"
-          if.
-            char.eq "?"
-            single
+              char.eq "}"
+            ")"
             if.
-              char.eq "/"
-              literal
-              alternated
+              braced.and
+                char.eq ","
+              "|"
+              escaped char
+      string.at glob index > char
+      classed.not.and > double
+        and.
+          char.eq "*"
+          eq.
+            string.at
+              glob
+              index.plus 1
+              "" > [message]
+            "*"
+      classed.if > token
+        if.
+          and.
+            char.eq "!"
+            eq.
+              string.at
+                glob
+                index.minus 1
+              "["
+          "^"
+          escaped char
+        double.if
+          ".*"
+          if.
+            char.eq "*"
+            string.joined *1
+              ""
+              single
+              "*"
+            if.
+              char.eq "?"
+              single
+              if.
+                char.eq "/"
+                literal
+                alternated
 
   ++> can-create-a-regular-tmpfile
     seq * > @
@@ -274,6 +286,23 @@
     Q.file candidate.as-bytes > next
     mktemp.tmpfile.deleted.as-path.as-dir.made > parent
     Q.file created.as-bytes > temp
+
+  ++> can-keep-a-star-literal-inside-a-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[a*].txt"
+        d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
 
   ++> can-list-only-the-direct-children-of-a-directory
     seq * > @
@@ -391,6 +420,23 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> can-walk-with-a-character-class-range
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "1.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[a-z].txt"
+        d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   ++> can-walk-with-a-comma-outside-a-glob-brace-group
     seq * > @
       touched.
@@ -423,6 +469,23 @@
         length.
           d.as-dir.walk "{привет.txt,мир.log}"
         2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-negated-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        string.joined
+          ","
+          d.as-dir.walk "[!a].txt"
+        d.resolved "b.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted


### PR DESCRIPTION
## What

- Extend glob translation with a one-pass `classed` state.
- Translate leading `[!a]` negation to the regular-expression form while keeping metacharacters such as `*`, `?`, `{`, and `}` literal inside a character class.
- Add range, negation, and literal-star regression tests and remove the resolved `#6482` puzzle.

## Why

The current translator applies wildcard and brace rules even while it is inside a character class, and it does not translate a leading `!` to regular-expression negation. As a result, valid glob classes can be interpreted incorrectly.

## Impact

`directory.walk` now supports glob character classes without changing its existing public glob API or the behavior of globs that do not use character classes.

## Validation

- RED evidence: before the translator change, `can-walk-with-a-negated-character-class` failed against the previous implementation.
- Fresh final negation run: 1 test, 0 failures, 0 errors, 0 skipped; `BUILD SUCCESS` (5:11).
- Fresh final literal-star run: 1 test, 0 failures, 0 errors, 0 skipped; `BUILD SUCCESS` (5:49).
- Task 3 also ran the range and malformed-class cases separately and both passed.
- Fresh skipped-test lifecycle build compiled all 170 EO sources, 180 generated Java files, 313 main Java sources, and 216 test sources; `BUILD SUCCESS`.
- Canonical formatter check: all 170 EO sources are formatted canonically; `BUILD SUCCESS`.
- Post-commit negation run: 1 test, 0 failures, 0 errors, 0 skipped; `BUILD SUCCESS` (5:36).

The combined EO test suite is resource-intensive because composed EO execution has high memory use, so the bug-specific cases were deliberately run separately; this does not claim a full combined-suite run.

Closes #6549