### PR TITLE
Write decimal digits over i64 so printf reaches 2^63

### DIFF
--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -28,7 +28,7 @@
           digits m
           "-".as-bytes.concat
             digits m
-        | (n.times -1).as-i64
+        | (n.times -1).as-i64 failure
         [n] >> digits
           if. > @
             n.lt ten
@@ -41,9 +41,10 @@
                   as-number.
                     n.minus (q.times ten)
                   48
-          n.div ten > q!
-        | n.as-i64
-  10.as-i64 > ten!
+          n.div ten failure > q!
+        | n.as-i64 failure
+  T message > [message] >> failure
+  10.as-i64 failure > ten!
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -1,5 +1,9 @@
 # Writes the number `n` as signed decimal digits, truncating its fraction
 # towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
+#
+# The digits are peeled off an `i64`, where division by ten is exact, so every
+# magnitude below `2^63` is written exactly, and not only the magnitudes below
+# `2^53` that a double divides without losing a digit.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,32 +17,34 @@
     T
       "Can't write a non-finite number as decimal"
     if.
-      n.abs.gte 9007199254740992
+      gte.
+        n.abs
+        2.power 63
       T
-        "Can't write this number as decimal digits exactly: its magnitude is 2^53 or larger, past the largest integer a double can hold exactly"
+        "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"
       if.
         n.lt 0
         if. > [m] >> negative
-          m.floor.eq 0
+          m.as-number.eq 0
           digits m
           "-".as-bytes.concat
             digits m
-        | (n.times -1)
+        | (n.times -1).as-i64
         [n] >> digits
           if. > @
-            n.lt 10
+            n.lt ten
             as-char
-              n.floor.plus 48
+              n.as-number.plus 48
             concat.
               digits q
               as-char
                 plus.
-                  floor.
-                    n.minus (q.times 10)
+                  as-number.
+                    n.minus (q.times ten)
                   48
-          floor. > q
-            n.div 10
-        | n
+          n.div ten > q!
+        | n.as-i64
+  10.as-i64 > ten!
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"
@@ -59,6 +65,16 @@
     "42"
     string
       as-decimal 42.987
+
+  eq. ++> can-write-a-large-negative-magnitude
+    "-9007199254740992"
+    string
+      as-decimal -9007199254740992
+
+  eq. ++> can-write-a-magnitude-above-two-to-the-53rd
+    "9007199254740992"
+    string
+      as-decimal 9007199254740992
 
   eq. ++> can-write-a-multi-digit-number
     "31415"
@@ -85,14 +101,19 @@
     string
       as-decimal 9007199254740991
 
+  eq. ++> can-write-the-largest-magnitude-below-two-to-the-63rd
+    "9223372036854774784"
+    string
+      as-decimal 9223372036854774784
+
   eq. ++> can-write-zero
     "0"
     string
       as-decimal 0
 
-  as-decimal 9007199254740992 --> stops-on-a-magnitude-of-two-to-the-53rd
+  as-decimal 1.0e30 --> stops-on-a-magnitude-far-past-the-long-range
 
-  as-decimal 1.0e30 --> stops-on-a-magnitude-too-large-to-represent-exactly
+  as-decimal 9.223372036854776e18 --> stops-on-a-magnitude-of-two-to-the-63rd
 
   as-decimal nan --> stops-on-nan
 

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -31,7 +31,7 @@
         |
           as-i64.
             n.times -1
-          T message > [message] >> failure
+            T message > [message] >> failure
         [n] >> digits
           if. > @
             n.lt ten
@@ -44,8 +44,9 @@
                   as-number.
                     n.minus (q.times ten)
                   48
-          n.div ten failure > q!
-        | n.as-i64 failure
+          n.div ten failure > bits!
+          i64 bits > q
+        | (n.as-i64 failure)
   10.as-i64 failure > ten!
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -17,8 +17,7 @@
     T
       "Can't write a non-finite number as decimal"
     if.
-      gte.
-        n.abs
+      n.abs.gte
         2.power 63
       T
         "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -28,7 +28,10 @@
           digits m
           "-".as-bytes.concat
             digits m
-        | (n.times -1).as-i64 failure
+        |
+          as-i64.
+            n.times -1
+          T message > [message] >> failure
         [n] >> digits
           if. > @
             n.lt ten
@@ -43,7 +46,6 @@
                   48
           n.div ten failure > q!
         | n.as-i64 failure
-  T message > [message] >> failure
   10.as-i64 failure > ten!
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -4,6 +4,13 @@
 # If `places` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-print` fallback is returned, or the bottom object
 # when unbound.
+#
+# @todo #6572:30min Scale a large value without losing its last digits. The
+#  `positive` object below multiplies the value by a power of ten in double
+#  arithmetic, so a product above 2^53 is rounded and the integer part handed
+#  to `as-decimal` can be off by one, which makes `printf`'s `%f` misprint a
+#  magnitude past 2^53 that `%d` now prints exactly; split the value into its
+#  integer and fraction parts over `i64` before scaling.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -189,7 +189,7 @@
               gte.
                 number numeric
                 number limit
-              lt.
+              lte.
                 number numeric
                 times.
                   number limit
@@ -401,11 +401,29 @@
       "%s"
       "ab".concat "cd"
 
+  eq. ++> can-format-a-decimal-above-two-to-the-53rd
+    "9007199254740992"
+    printf *1
+      "%d"
+      9007199254740992
+
+  eq. ++> can-format-a-float-above-two-to-the-53rd
+    "9007199254740992.000000"
+    printf *1
+      "%f"
+      9007199254740992
+
   eq. ++> can-format-a-float-with-six-fraction-digits
     "1.250000"
     printf *1
       "%f"
       1.25
+
+  eq. ++> can-format-a-large-negative-decimal
+    "-9007199254740992"
+    printf *1
+      "%d"
+      -9007199254740992
 
   eq. ++> can-format-a-numbered-substitution
     "Hello, Jeff! Bye, Jeff!"
@@ -611,3 +629,7 @@
   printf *1 --> stops-on-formatting-nan-as-a-decimal
     "%d"
     nan
+
+  printf *1 --> stops-on-the-negative-long-boundary-as-a-decimal
+    "%d"
+    -9.223372036854776e18


### PR DESCRIPTION
`printf`'s `%d` documents its range as magnitudes below `2^63` and checks for exactly that, but the value it lets through is then handed to `as-decimal`, which refused anything at or above `2^53`. So `printf "%d" 9007199254740992` died with `as-decimal`'s message about doubles, even though the number is an exact integer that Java and C both print fine. `%f` hit the same ceiling through `as-fixed`, which asks `as-decimal` for the integer part.

The ceiling was there because `as-decimal` peeled digits off a double: above `2^53` the division by ten stops being exact and the remainder falls outside `0..9`. This peels them off an `i64` instead, where `i64/div` is exact long division, so the guard moves up to `2^63` and matches what `printf` already promised. The negative boundary `-2^63` stays out of range, because the object negates before converting, so `printf`'s own check now rejects it with `lte` rather than letting `as-decimal` do it with the wrong message.

`%f` still has a limit of its own that this doesn't touch: `as-fixed` scales the value by a power of ten in double arithmetic before splitting off the integer part, so a product above `2^53` is rounded and the last digit can be off. That is left as a puzzle in `as-fixed.eo`.

Closes #6572
