### PR TITLE
#6572: format signed long values exactly

### DIFF
--- a/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+++ b/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` correctly for `%d` and `%f`, while preserving truncation and deliberate failures.
 
-**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`, extract digits with exact signed `i64` quotient/remainder operations, and never negate the full input so the signed minimum remains representable.
+**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`. Render safe values below `1_000_000_000` with the original fast `number` digit loop; split larger values with exactly one signed `i64.div` by `1_000_000_000`, render the exact safe quotient and remainder through that loop, and left-pad the remainder to nine digits. Never negate the full input, so the signed minimum remains representable.
 
 **Tech Stack:** EO standard-library objects, embedded EO test declarations, Maven Surefire, Java 21.
 
@@ -12,7 +12,7 @@
 
 ## File map
 
-- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point digit extraction and the `2^53` guard with signed-long validation plus exact `i64` digit extraction; extend its embedded regression tests.
+- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point full-value digit extraction and the `2^53` guard with signed-long validation plus one exact base-`1_000_000_000` split; extend its embedded regression tests.
 - Modify `eo-runtime/src/main/eo/string/printf.eo`: add issue-level `%d` and `%f` regression tests only; production routing remains unchanged.
 - Reference `eo-runtime/src/main/eo/string/as-fixed.eo`: verify that `%f` still reaches `string.as-decimal` through its integer part; no source change is planned.
 
@@ -115,7 +115,7 @@ git commit -m '#6572: reproduce long-range printf failures'
 
 Expected: one commit containing only the two EO test files.
 
-### Task 2: Render decimal digits with exact signed `i64` arithmetic
+### Task 2: Render signed-long decimals with one exact base-`1_000_000_000` split
 
 **Files:**
 - Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:11-42`
@@ -124,57 +124,22 @@ Expected: one commit containing only the two EO test files.
 
 - [ ] **Step 1: Replace the conversion and digit routine in `as-decimal`**
 
-Replace the production body above the embedded tests with this implementation, leaving the file header and test declarations intact:
+Leave the file header and all Task 1 embedded test declarations intact. Replace only the production body with this exact algorithm:
 
-```eo
-[n] > as-decimal
-  n.is-finite.not.if > @
-    T
-      "Can't write a non-finite number as decimal"
-    if.
-      or.
-        n.gte 9.223372036854776e18
-        n.lt -9.223372036854776e18
-      T
-        "Can't write this number as decimal digits: it is outside the signed 64-bit range"
-      if.
-        integer.lt 0.as-i64
-        "-".as-bytes.concat
-          digits integer
-        digits integer
-  [n] >> digit
-    as-char
-      plus.
-        if.
-          n.lt 0.as-i64
-          n.neg.as-number
-          n.as-number
-        48
-  [n] >> digits
-    if. > @
-      q.eq 0.as-i64
-      digit remainder
-      concat.
-        digits q
-        digit remainder
-    n.div 10.as-i64 > q
-    n.minus (q.times 10.as-i64) > remainder
-  n.as-i64 > integer!
-```
+1. Reject non-finite input, `n >= 2^63`, and `n < -2^63`, in that order, before invoking `number.as-i64`.
+2. Dataize `n.as-i64` exactly once as `integer!`; redecorate every typed use as `i64 integer` because a `!` binding retains bytes rather than its decoration.
+3. Determine whether to prefix `-` from the truncated `i64`, not from `n`. This keeps negative fractions that truncate to zero unsigned.
+4. Define `small-digits` by retaining the original fast `number`-level division, floor, remainder, and ASCII conversion loop. Call it only with exact nonnegative integers below `2^53`.
+5. If `n.abs < 1_000_000_000`, render the absolute value of `(i64 integer).as-number` directly through `small-digits`.
+6. Otherwise perform exactly one signed `(i64 integer).div 1000000000.as-i64`. Cache and redecorate the quotient bytes. Cache `quotient * base`, then compute and cache the signed remainder as `integer - product`. Prefer the established two's-complement `not`-plus-one addition pattern if it keeps the EO structure clear; do not introduce repeated `i64.div` or negate the full input.
+7. Convert only the cached quotient and remainder to `number`, take their `number`-level absolute values, and render them with `small-digits`. The quotient magnitude is at most `9_223_372_036`; the remainder magnitude is at most `999_999_999`, so both paths are exact.
+8. Left-pad the tail string to exactly nine characters with zeroes and concatenate the unsigned head and tail. Prefix one minus sign only when the truncated `i64` is negative.
 
-The positive upper comparison is inclusive because the double literal is exactly `2^63`; the negative comparison is strict so exactly `-2^63` remains accepted. `digit` negates only a remainder from `-9` through `-1`, never the whole long minimum.
+The chunk boundary behavior must include `10000000000000000 -> 10000000 | 000000000`, `9007199254740992 -> 9007199 | 254740992`, `38802277692848472 -> 38802277 | 692848472`, `9223372036854774784 -> 9223372036 | 854774784`, and `-9223372036854775808 -> -9223372036 | -854775808` before magnitude rendering and the single sign prefix.
 
-- [ ] **Step 2: Run the two focused EO test classes and confirm the green state**
+Do not revive the rejected per-decimal-digit algorithm. With quotient and remainder caching, it still produced `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`; all six errors were 20-minute JUnit timeouts while the other 64 focused tests passed.
 
-Run:
-
-```powershell
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
-```
-
-Expected: `EOas_decimalTest` and `EOprintfTest` pass with zero failures and zero errors, including the existing truncation, padding, precision, non-finite, and out-of-range cases.
-
-- [ ] **Step 3: Inspect the implementation diff for accidental caller changes**
+- [ ] **Step 2: Inspect the implementation diff for accidental caller changes**
 
 Run:
 
@@ -185,17 +150,9 @@ git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/s
 
 Expected: production changes appear only in `as-decimal.eo`; `printf.eo` contains test additions only; `as-fixed.eo` has no diff.
 
-- [ ] **Step 4: Commit the exact formatter implementation**
+Do not run the complete focused classes or commit the production source yet. Task 3 applies the performance gates in increasing scope before staging the implementation.
 
-```powershell
-git add -- eo-runtime/src/main/eo/string/as-decimal.eo
-git diff --cached --check
-git commit -m '#6572: format signed long numbers exactly'
-```
-
-Expected: one commit containing the production change in `as-decimal.eo`; the `printf.eo` regression tests are already committed in Task 1.
-
-### Task 3: Verify the branch and prepare it for review
+### Task 3: Enforce the performance gate, verify the branch, and prepare it for review
 
 **Files:**
 - Verify: `eo-runtime/src/main/eo/string/as-decimal.eo`
@@ -203,27 +160,67 @@ Expected: one commit containing the production change in `as-decimal.eo`; the `p
 - Verify: `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`
 - Verify: `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`
 
-- [ ] **Step 1: Rebuild the focused tests from clean generated sources**
+- [ ] **Step 1: Inspect the generated test name and time the signed-minimum test alone**
+
+Inspect `eo-runtime/target/generated-test-sources/org/eolang/EO_string/EOas_decimalTest.java` and confirm that `can-write-the-long-minimum` generated the Java method `can_write_the_long_minimum`. Then run only that method with Java 21:
+
+```powershell
+$env:JAVA_HOME='E:\tools\ProfessionalTools\jdk21\jdk\jdk-21.0.10+7'
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+$watch=[System.Diagnostics.Stopwatch]::StartNew()
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_the_long_minimum' test -pl :eo-runtime
+$code=$LASTEXITCODE
+$watch.Stop()
+"Maven wall time: {0:N3}s" -f $watch.Elapsed.TotalSeconds
+exit $code
+```
+
+Record both the Maven wall time and the testcase duration from `eo-runtime/target/surefire-reports/TEST-org.eolang.EO_string.EOas_decimalTest.xml`.
+
+Expected: the test passes and its Surefire testcase duration is less than five minutes. If it exceeds five minutes, stop before any broader run and redesign the implementation; do not weaken the existing timeout.
+
+- [ ] **Step 2: Run the largest positive and signed-minimum methods together**
+
+After confirming that the generated method names are `can_write_the_largest_double_below_the_long_maximum` and `can_write_the_long_minimum`, run:
+
+```powershell
+$watch=[System.Diagnostics.Stopwatch]::StartNew()
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_the_largest_double_below_the_long_maximum+can_write_the_long_minimum' test -pl :eo-runtime
+$code=$LASTEXITCODE
+$watch.Stop()
+"Maven wall time: {0:N3}s" -f $watch.Elapsed.TotalSeconds
+exit $code
+```
+
+Expected: both pass under contention, and neither approaches the 20-minute JUnit timeout.
+
+- [ ] **Step 3: Run the exact focused EO suite**
 
 Run:
 
 ```powershell
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' clean test -pl :eo-runtime
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
 ```
 
-Expected: both generated EO test classes pass from a clean build with zero failures and zero errors.
+Expected: `EOas_decimalTest` reports `21` tests, zero failures, and zero errors; `EOprintfTest` reports `49` tests, zero failures, and zero errors. Record each class duration from the Surefire reports. The rejected per-digit baseline was `21/0F/5E` and `49/0F/1E`, with all six errors caused by 20-minute timeouts.
 
-- [ ] **Step 2: Run the full `eo-runtime` unit-test suite**
+- [ ] **Step 4: Stage and commit only the verified formatter implementation**
 
 Run:
 
 ```powershell
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' test -pl :eo-runtime
+git diff --check
+git diff --name-only
+git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
+git add -- eo-runtime/src/main/eo/string/as-decimal.eo
+git diff --cached --name-only
+git diff --cached --check
+git commit -m '#6572: format signed long numbers exactly'
 ```
 
-Expected on this Windows host: no regression attributable to this branch. The previously reproduced environment-specific `SyscallTest.WindowsSocketTest.refusesConnectionViaSyscall` may remain the sole failure because `192.0.2.1` accepts the connection here; record its exact counts and output separately if it recurs.
+Expected: before staging, the only uncommitted production file is `as-decimal.eo`, with no uncommitted `printf.eo` or `as-fixed.eo` diff. The commit contains only `as-decimal.eo`; the regression tests are already in Task 1.
 
-- [ ] **Step 3: Run repository hygiene checks and inspect the complete branch diff**
+- [ ] **Step 5: Run repository hygiene checks and inspect the complete branch diff**
 
 Run:
 
@@ -236,10 +233,10 @@ git log --oneline --decorate upstream/master..HEAD
 
 Expected: no whitespace errors, no uncommitted source changes, and only the design, plan, regression tests, and formatter implementation are present.
 
-- [ ] **Step 4: Request a code review and address only verified findings**
+- [ ] **Step 6: Request a code review and address only verified findings**
 
 Use `superpowers:requesting-code-review` against `upstream/master...HEAD`. Check the review against the issue scope, rerun the focused tests after any correction, and create a narrowly scoped follow-up commit only if a concrete defect is found.
 
-- [ ] **Step 5: Push and open the requested Draft PR**
+- [ ] **Step 7: Push and open the requested Draft PR**
 
 Run the publishing workflow from `github:yeet`: confirm GitHub authentication, push `agent/issue-6572-printf-long` to `origin`, and create a Draft PR against `objectionary/eo:master`. The PR body must explain the old `2^53` guard, the exact `i64` extraction, the test evidence, the known unrelated Windows baseline failure if it recurs, and include `Fixes #6572`.

--- a/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+++ b/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
@@ -1,251 +1,313 @@
-# Issue #6572 Long-Range Decimal Formatting Implementation Plan
+# Issue #6572 Native Signed-Long Decimal Formatting Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` correctly for `%d` and `%f`, while preserving truncation and deliberate failures.
+**Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` exactly and fast enough for production by delegating the already-validated `i64` bytes to one narrow JVM atom.
 
-**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`. Render safe values below a once-bound base of `1_000_000_000` with the original fast `number` digit loop. For larger values, estimate the bounded quotient with `number` arithmetic, validate and correct it at most one unit with exact `i64` multiplication and addition, render the safe exact chunks, and left-pad the remainder to nine digits. Never negate the full integer. `string.as-fixed` renders finite negative doubles at or above `2^53` directly as signed integral values and appends zero fraction digits, preserving the existing rounding path below that threshold.
+**Architecture:** Keep all non-finite/range checks and the sole `number.as-i64` conversion in `string.as-decimal`; pass the cached bytes, redecorated as `i64`, to a nested atom that decodes one Java `long` and returns its locale-independent decimal text as UTF-8 `Q.bytes`. Avoid `Long.MIN_VALUE` overflow in `string.as-fixed` with one finite-negative-large helper that renders the signed integral value directly and appends zero fraction digits. Do not change production `string.printf`.
 
-**Tech Stack:** EO standard-library objects, embedded EO test declarations, Maven Surefire, Java 21.
+**Tech Stack:** EO standard-library objects, Java runtime atoms, JUnit 5, Hamcrest, Maven Surefire, Java 21.
 
 ---
 
 ## File map
 
-- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point full-value digit extraction and the `2^53` guard with signed-long validation plus an estimated and exactly corrected base-`1_000_000_000` split; extend its embedded regression tests.
-- Modify `eo-runtime/src/main/eo/string/printf.eo`: add issue-level `%d` and `%f` regression tests only; production routing remains unchanged.
-- Modify `eo-runtime/src/main/eo/string/as-fixed.eo`: avoid negating finite negative integral doubles whose magnitude is at least `2^53`; keep ordinary rounding unchanged.
+- Modify `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`: replace the rejected estimate/chunk design with the measured JVM-atom exception, exact API, performance gate, and Node parity debt.
+- Modify `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`: define the test-first implementation and validation sequence.
+- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: retain the guards and sole `n.as-i64`, declare and call `from-i64 /Q.bytes`.
+- Modify `eo-runtime/src/main/eo/string/as-fixed.eo`: avoid whole-value negation for finite negative integral doubles at or above `2^53`.
+- Create `eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java`: exact signed-long-to-UTF-8 atom.
+- Create `eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java`: direct atom contract tests.
+- Preserve `eo-runtime/src/main/eo/string/printf.eo`: its issue regressions are already committed; no production edit is permitted.
 
-### Task 1: Add failing regressions for the documented range
+## Evidence and exception boundary
+
+Pure EO has been exhausted for this path. Per-digit exact division produced six 20-minute timeouts while 64 other focused tests passed. A single base-`1_000_000_000` `i64.div` took 58–88 seconds in isolation. The fastest quotient/chunk variants still took 21.890–23.386 seconds, and the remaining variants took 27–88 seconds. Every result exceeds the required `<10s` isolated signed-minimum testcase gate.
+
+The JVM atom is therefore a measured performance exception. Recent `dataized` and `recovered` changes establish Java-only atom precedent after the `eo2js` archive, and Maven/CI validate JVM atom metadata only. All current atom EO sources still declare both JVM and Node locators, so `as-decimal.eo` does too. This branch does not add a JavaScript counterpart: Node atom lookup remains unsupported and must be tracked in a separate Node-parity issue against the archived/runtime successor project. Do not claim Node compatibility and do not expand this branch into external `eo2js` work.
+
+### Task 1: Commit the native design decision
 
 **Files:**
-- Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:45-101`
-- Modify: `eo-runtime/src/main/eo/string/printf.eo:370-611`
 
-- [ ] **Step 1: Replace the obsolete `2^53` stopping test and add exact decimal boundary regressions**
+- Modify: `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`
+- Modify: `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`
 
-Keep the existing small-number, fraction, zero, and `9007199254740991` tests. Replace `stops-on-a-magnitude-of-two-to-the-53rd` and add these declarations beside the other `as-decimal` tests:
+- [ ] **Step 1: Replace pure-EO production experiments without losing committed tests**
 
-```eo
-  eq. ++> can-write-two-to-the-53rd
-    "9007199254740992"
-    string
-      as-decimal 9007199254740992
+Use `apply_patch` to reduce the uncommitted `as-decimal.eo` production body to the guarded cached conversion and nested declaration shown in Task 3. Retain every embedded EO test already committed in `b163d32d6`. Keep only the narrow signed-large `as-fixed` branch shown in Task 3. Leave these production files unstaged during the documentation commit.
 
-  eq. ++> can-write-ten-to-the-16th
-    "10000000000000000"
-    string
-      as-decimal 1.0e16
+- [ ] **Step 2: Record the final architecture and evidence**
 
-  eq. ++> can-write-a-large-exact-counterexample
-    "38802277692848472"
-    string
-      as-decimal 38802277692848472
+The design and this plan must state the 20-minute per-digit timeouts, 58–88 second division result, 21.890–23.386 second best range, 27–88 second remaining range, exact EO/Java API, wrong-width `ExFailure`, UTF-8 output, `<10s` gate, `as-fixed` fix, JVM-only precedent, and separate Node parity debt.
 
-  eq. ++> can-write-the-largest-double-below-the-long-maximum
-    "9223372036854774784"
-    string
-      as-decimal 9223372036854774784
+- [ ] **Step 3: Check and commit documentation only**
 
-  eq. ++> can-write-the-long-minimum
-    "-9223372036854775808"
-    string
-      as-decimal -9.223372036854776e18
-
-  as-decimal 9.223372036854776e18 --> stops-on-the-long-maximum-boundary
-
-  as-decimal -9.223372036854778e18 --> stops-below-the-long-minimum-boundary
-```
-
-- [ ] **Step 2: Add the five issue examples to `printf`**
-
-Place these declarations with the other successful formatting tests:
-
-```eo
-  eq. ++> can-format-two-to-the-53rd-as-an-integer
-    "9007199254740992"
-    printf *1
-      "%d"
-      9007199254740992
-
-  eq. ++> can-format-ten-to-the-16th-as-an-integer
-    "10000000000000000"
-    printf *1
-      "%d"
-      1.0e16
-
-  eq. ++> can-format-two-to-the-53rd-as-a-float
-    "9007199254740992.000000"
-    printf *1
-      "%f"
-      9007199254740992
-
-  eq. ++> can-format-ten-to-the-16th-with-two-fraction-digits
-    "10000000000000000.00"
-    printf *1
-      "%.2f"
-      1.0e16
-
-  eq. ++> can-format-ten-to-the-16th-without-fraction-digits
-    "10000000000000000"
-    printf *1
-      "%.0f"
-      1.0e16
-```
-
-- [ ] **Step 3: Run only the generated EO test classes and confirm the red state**
-
-Run in PowerShell:
+Run:
 
 ```powershell
-$env:JAVA_HOME='E:\tools\ProfessionalTools\jdk21\jdk\jdk-21.0.10+7'
-$env:Path="$env:JAVA_HOME\bin;$env:Path"
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
-```
-
-Expected: the command fails because the new successful cases bottom out at the current `2^53` guard. The reported cause contains `its magnitude is 2^53 or larger`; pre-existing small and failure cases remain successful.
-
-- [ ] **Step 4: Commit the red tests**
-
-```powershell
-git add -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo
+git diff --check -- docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+git add -- docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+git diff --cached --name-only
 git diff --cached --check
-git commit -m '#6572: reproduce long-range printf failures'
+git commit -m '#6572: adopt native decimal conversion design'
 ```
 
-Expected: one commit containing only the two EO test files.
+Expected: the staged file list contains exactly the design and plan; the production EO files remain uncommitted.
 
-### Task 2: Render signed-long decimals with an exact corrected base-`1_000_000_000` split
+### Task 2: Specify and observe the direct JVM atom contract
 
 **Files:**
-- Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:11-42`
-- Test: `eo-runtime/src/main/eo/string/as-decimal.eo:45-115`
-- Test: `eo-runtime/src/main/eo/string/printf.eo:370-640`
 
-- [ ] **Step 1: Replace the conversion and digit routine in `as-decimal`**
+- Create: `eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java`
 
-Leave the file header and all Task 1 embedded test declarations intact. Replace only the production body with this exact algorithm:
+- [ ] **Step 1: Add the direct test before the Java atom**
 
-1. Reject non-finite input, `n >= 2^63`, and `n < -2^63`, in that order, before invoking `number.as-i64`.
-2. Dataize `n.as-i64` exactly once as `integer!`; redecorate every typed use as `i64 integer` because a `!` binding retains bytes rather than its decoration.
-3. Determine whether to prefix `-` from the truncated `i64`, not from `n`. This keeps negative fractions that truncate to zero unsigned.
-4. Define `small-digits` by retaining the original fast `number`-level division, floor, remainder, and ASCII conversion loop. Call it only with exact nonnegative integers below `2^53`.
-5. Bind numeric base `1_000_000_000` once. If `n.abs < base`, render the absolute value of `(i64 integer).as-number` directly through `small-digits`.
-6. Otherwise compute `floor(n.abs / base)`, apply the sign using safe `number` arithmetic, convert the bounded estimate to `i64`, and cache its bytes. Do not use `i64.div` and do not negate the full integer.
-7. Cache the exact `i64` product `estimate * base`, then cache the signed remainder as `integer - product` with two's-complement `not`-plus-one addition.
-8. Correct at most one unit using exact signed-remainder invariants. Positive inputs require `0 <= remainder < base`: decrement/add-base for a negative remainder or increment/subtract-base for a remainder at least base. Negative inputs require `-base < remainder <= 0`: increment/subtract-base for a positive remainder or decrement/add-base for a remainder at or below negative base. Cache the corrected quotient and remainder bytes.
-9. Convert only the corrected quotient and remainder to `number`, take their `number`-level absolute values, and render them with `small-digits`. The quotient magnitude is at most `9_223_372_036`; the remainder magnitude is at most `999_999_999`, so both paths are exact. An overestimate near the maximum quotient cannot reach `9_223_372_037`, because the `2^63` magnitude boundary is still `145_224_192` below that base multiple, while the estimate error is sub-micro-unit.
-10. Left-pad the tail string to exactly nine characters with zeroes and concatenate the unsigned head and tail. Prefix one minus sign only when the truncated `i64` is negative.
+Create the test with `apply_patch`. The test class references the not-yet-present `EOas_decimal$EOfrom_i64` and contains this behavior:
 
-The chunk boundary behavior must include `10000000000000000 -> 10000000 | 000000000`, `9007199254740992 -> 9007199 | 254740992`, `38802277692848472 -> 38802277 | 692848472`, `9223372036854774784 -> 9223372036 | 854774784`, and `-9223372036854775808 -> -9223372036 | -854775808` before magnitude rendering and the single sign prefix.
+```java
+@ParameterizedTest
+@CsvSource({
+    "-9223372036854775808, -9223372036854775808",
+    "9223372036854775807, 9223372036854775807",
+    "0, 0",
+    "42, 42",
+    "-42, -42",
+    "38802277692848472, 38802277692848472"
+})
+void convertsSignedLongToDecimalBytes(final long input, final String expected) {
+    MatcherAssert.assertThat(
+        "signed i64 bytes must become exact decimal UTF-8 bytes",
+        new Dataized(EOas_decimalEOfrom_i64Test.application(input)).asString(),
+        Matchers.equalTo(expected)
+    );
+}
+```
 
-Do not revive either rejected division algorithm. Per-decimal-digit division produced `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`; all six errors were 20-minute timeouts while the other 64 focused tests passed. The later one-division base split was correct but still required 58–88 seconds for isolated large values and hundreds of seconds for individual contended suite cases, which is not acceptable for production formatting.
+Add a wrong-width case that passes one byte and asserts `ExFailure`, plus a result-forma case that invokes `take(Phi.LAMBDA)` and asserts `Φ.bytes`. Build applications with exact binary long bytes, never `Data.ToPhi(Long)`:
 
-- [ ] **Step 2: Inspect the implementation diff for accidental caller changes**
+```java
+private static Phi application(final long value) {
+    return EOas_decimalEOfrom_i64Test.application(
+        new Data.ToPhi(new BytesOf(value).take())
+    );
+}
+
+private static Phi application(final Phi value) {
+    return new PhApplication(
+        new EOas_decimal$EOfrom_i64(), "value", value
+    );
+}
+```
+
+- [ ] **Step 2: Run the intended RED with JDK 21**
+
+Run one owned Maven process:
+
+```powershell
+$Issue6572Jdk='E:\tools\ProfessionalTools\jdk21\jdk\jdk-21.0.10+7'
+$env:JAVA_HOME=$Issue6572Jdk
+$env:Path="$Issue6572Jdk\bin;$env:Path"
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalEOfrom_i64Test' test -pl :eo-runtime
+```
+
+Expected: test compilation fails only because `EOas_decimal$EOfrom_i64` is absent. Record the compiler diagnostic; do not create production Java before observing this RED.
+
+- [ ] **Step 3: Commit the test alone**
 
 Run:
 
 ```powershell
-git diff --check
-git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
+git add -- eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java
+git diff --cached --name-only
+git diff --cached --check
+git commit -m '#6572: cover native signed decimal conversion'
 ```
 
-Expected: production changes appear only in `as-decimal.eo` and `as-fixed.eo`; `printf.eo` contains test additions only.
+Expected: the commit contains exactly the direct Java test.
 
-Do not run the complete focused classes or commit the production source yet. Task 3 applies the performance gates in increasing scope before staging the implementation.
-
-### Task 3: Enforce the performance gate, verify the branch, and prepare it for review
+### Task 3: Implement the minimal native conversion and signed-large caller fix
 
 **Files:**
+
+- Modify: `eo-runtime/src/main/eo/string/as-decimal.eo`
+- Modify: `eo-runtime/src/main/eo/string/as-fixed.eo`
+- Create: `eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java`
+
+- [ ] **Step 1: Keep the exact EO seam**
+
+Add the standard runtime locators and use this production shape before the existing embedded tests:
+
+```eo
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
+
+[n] > as-decimal
+  n.is-finite.not.if > @
+    T
+      "Can't write a non-finite number as decimal"
+    if.
+      n.gte 9.223372036854776e18
+      T
+        "Can't write this number as decimal digits: it is outside the signed 64-bit range"
+      if.
+        n.lt -9.223372036854776e18
+        T
+          "Can't write this number as decimal digits: it is outside the signed 64-bit range"
+        from-i64
+          i64 integer
+  [] > from-i64 /Q.bytes
+    ? > value /Q.i64
+  n.as-i64 > integer!
+```
+
+There must be exactly one `n.as-i64`; `integer!` is cached bytes and must be redecorated as `i64 integer` at the application. Do not add digit loops, division, multiplication, chunks, whole-value negation, or production logic to `printf.eo`.
+
+- [ ] **Step 2: Add the exact Java atom**
+
+Create `EOas_decimal$EOfrom_i64.java` with `@XmirObject(oname = "as-decimal.from-i64")`, `public final`, `extends PhDefault`, `implements Atom`, and constructor attributes `new Attrs(new Attr("value", new AtVoid("value")))`. Its lambda is exactly:
+
+```java
+@Override
+public Phi lambda() {
+    final long value = new Dataized(this.take("value")).take(Long.class);
+    return new Data.ToPhi(new BytesOf(Long.toString(value)).take());
+}
+```
+
+Do not return `Data.ToPhi(Long)` or `Data.ToPhi(Number)`, because those paths convert through `double` and lose values above `2^53`.
+
+- [ ] **Step 3: Keep the narrow `as-fixed` helper**
+
+After places validation and before the existing signed/positive rounding path, branch only on `n.is-finite.and (n.lt 0 and n.abs.gte 9007199254740992)`. Apply this helper to signed `n`:
+
+```eo
+if. > [a] >> signed-large
+  places.eq 0
+  as-decimal a
+  concat.
+    concat.
+      as-decimal a
+      ".".as-bytes
+    rec-pad 0 places --
+| n
+```
+
+The ordinary path remains byte-for-byte equivalent below `2^53`; non-finite values do not enter the shortcut.
+
+### Task 4: Validate correctness, typing, latency, and scope
+
+**Files:**
+
+- Verify: `eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java`
 - Verify: `eo-runtime/src/main/eo/string/as-decimal.eo`
+- Verify: `eo-runtime/src/main/eo/string/as-fixed.eo`
 - Verify: `eo-runtime/src/main/eo/string/printf.eo`
-- Verify: `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`
-- Verify: `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`
 
-- [ ] **Step 1: Inspect the generated test name and time the signed-minimum test alone**
-
-Inspect `eo-runtime/target/generated-test-sources/org/eolang/EO_string/EOas_decimalTest.java` and confirm that `can-write-the-long-minimum` generated the Java method `can_write_the_long_minimum`. Then run only that method with Java 21:
+- [ ] **Step 1: Run the direct atom test**
 
 ```powershell
-$env:JAVA_HOME='E:\tools\ProfessionalTools\jdk21\jdk\jdk-21.0.10+7'
-$env:Path="$env:JAVA_HOME\bin;$env:Path"
-$watch=[System.Diagnostics.Stopwatch]::StartNew()
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalEOfrom_i64Test' test -pl :eo-runtime
+```
+
+Expected: six conversions, wrong-width rejection, and `Φ.bytes` forma all pass.
+
+- [ ] **Step 2: Enforce the isolated `<10s` gate**
+
+```powershell
+$Issue6572Watch=[System.Diagnostics.Stopwatch]::StartNew()
 mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_the_long_minimum' test -pl :eo-runtime
-$code=$LASTEXITCODE
-$watch.Stop()
-"Maven wall time: {0:N3}s" -f $watch.Elapsed.TotalSeconds
-exit $code
+$Issue6572Code=$LASTEXITCODE
+$Issue6572Watch.Stop()
+"Maven wall time: {0:N3}s" -f $Issue6572Watch.Elapsed.TotalSeconds
+exit $Issue6572Code
 ```
 
-Record both the Maven wall time and the testcase duration from `eo-runtime/target/surefire-reports/TEST-org.eolang.EO_string.EOas_decimalTest.xml`.
+Read `eo-runtime/target/surefire-reports/TEST-org.eolang.EO_string.EOas_decimalTest.xml`. Expected: PASS and the testcase `time` is below `10.0`; if not, stop without weakening timeouts.
 
-Expected: the test passes and its Surefire testcase duration is less than ten seconds, preferably substantially lower. If it reaches ten seconds, stop before any broader run and redesign the implementation; do not weaken the existing timeout.
-
-- [ ] **Step 2: Run the largest positive and signed-minimum methods together**
-
-After confirming that the generated method names are `can_write_the_largest_double_below_the_long_maximum` and `can_write_the_long_minimum`, run:
+- [ ] **Step 3: Run all base seams**
 
 ```powershell
-$watch=[System.Diagnostics.Stopwatch]::StartNew()
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_the_largest_double_below_the_long_maximum+can_write_the_long_minimum' test -pl :eo-runtime
-$code=$LASTEXITCODE
-$watch.Stop()
-"Maven wall time: {0:N3}s" -f $watch.Elapsed.TotalSeconds
-exit $code
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_positive_value_below_the_chunk_base+can_write_positive_value_at_the_chunk_base+can_write_positive_value_one_past_the_chunk_base+can_write_positive_value_forty_two_past_the_chunk_base+can_write_negative_value_below_the_chunk_base+can_write_negative_value_at_the_chunk_base+can_write_negative_value_one_past_the_chunk_base+can_write_negative_value_forty_two_past_the_chunk_base' test -pl :eo-runtime
 ```
 
-Expected: both pass under contention, and neither approaches the 20-minute JUnit timeout.
+Expected: eight seam methods pass.
 
-- [ ] **Step 3: Run the exact focused EO suite**
+- [ ] **Step 4: Run the paired extrema**
 
-Run:
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest#can_write_the_largest_double_below_the_long_maximum+can_write_the_long_minimum' test -pl :eo-runtime
+```
+
+Expected: both methods pass.
+
+- [ ] **Step 5: Run the exact focused classes**
 
 ```powershell
 mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOas_fixedTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
 ```
 
-Expected: all three focused classes report zero failures and zero errors. Record each class count and duration from the Surefire reports. The rejected per-digit baseline was `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`, with all six errors caused by 20-minute timeouts.
+Expected: all focused tests pass with zero failures and zero errors. Record per-class counts and times from the three Surefire XML reports.
 
-- [ ] **Step 4: Stage and commit only the verified formatter implementation**
+- [ ] **Step 6: Verify atom typing**
 
-Run:
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Deo.typing=true' '-Dtest=org.eolang.EO_string.EOas_decimalEOfrom_i64Test,org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOas_fixedTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
+```
+
+Expected: the direct and focused suites all pass while `AtomTyped` checks the nested `/Q.bytes` declaration.
+
+- [ ] **Step 7: Run module unit tests if the focused gates are green**
+
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' test -pl :eo-runtime
+```
+
+Record exact counts. If the known unrelated Windows `SyscallTest` baseline recurs, report it verbatim; do not weaken, skip, or modify that test.
+
+- [ ] **Step 8: Self-review and verify scope**
 
 ```powershell
 git diff --check
 git diff --name-only
-git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
-git add -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/as-fixed.eo
-git diff --cached --name-only
-git diff --cached --check
-git commit -m '#6572: avoid long division in decimal formatting'
+git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/as-fixed.eo eo-runtime/src/main/eo/string/printf.eo
+git status --short
 ```
 
-Expected: before staging, the only uncommitted production files are `as-decimal.eo` and `as-fixed.eo`, with `printf.eo` containing tests only. The production commit contains only `as-decimal.eo` and `as-fixed.eo`; the regressions are already committed separately.
+Confirm exact signed decoding, UTF-8 output, no `Data.ToPhi(Number)`, lazy error guards, one `n.as-i64`, `Long.MIN_VALUE`, negative-to-zero behavior, canonical EO, Java style, typing compatibility, explicit Node debt, no log artifacts, and no owned Maven process.
 
-- [ ] **Step 5: Run repository hygiene checks and inspect the complete branch diff**
+### Task 5: Commit production only and hand off for review
 
-Run:
+**Files:**
+
+- Stage: `eo-runtime/src/main/eo/string/as-decimal.eo`
+- Stage: `eo-runtime/src/main/eo/string/as-fixed.eo`
+- Stage: `eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java`
+
+- [ ] **Step 1: Stage and inspect only production files**
+
+```powershell
+git add -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/as-fixed.eo 'eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java'
+git diff --cached --name-only
+git diff --cached --check
+git diff --cached
+```
+
+Expected: exactly the two EO production files and the Java atom are staged. The direct test is already committed, and `printf.eo` has no new production diff.
+
+- [ ] **Step 2: Commit the verified implementation**
+
+```powershell
+git commit -m '#6572: format signed longs natively'
+```
+
+- [ ] **Step 3: Inspect the branch without publishing it**
 
 ```powershell
 git diff upstream/master...HEAD --check
-git status --short
+git status --short --branch
 git diff --stat upstream/master...HEAD
 git log --oneline --decorate upstream/master..HEAD
 ```
 
-Expected: no whitespace errors, no uncommitted source changes, and only the design, plan, regression tests, and formatter implementation are present.
-
-- [ ] **Step 6: Request a code review and address only verified findings**
-
-Use `superpowers:requesting-code-review` against `upstream/master...HEAD`. Check the review against the issue scope, rerun the focused tests after any correction, and create a narrowly scoped follow-up commit only if a concrete defect is found.
-
-### Review follow-up: reject pure-EO division latency and cover the signed minimum
-
-- [ ] Amend this plan and the design before source changes. Record the one-division latency, the number estimate plus exact `i64` correction, the ten-second isolated gate, the base seams, and the `as-fixed` signed-minimum path. Commit docs only as `#6572: refine decimal formatting performance design`.
-- [ ] Add positive and negative `as-decimal` regressions for `999999999`, `1000000000`, `1000000001`, and `1000000042`, plus a large fractional truncation case. Add `printf` regressions for `%d`, `%f`, and `%.0f` at `-2^63`. Run the three focused classes before production edits and verify that only the `%f` and `%.0f` signed-minimum cases fail. Commit tests only as `#6572: cover decimal chunk boundaries`.
-- [ ] Replace the general `i64.div` split with the bounded estimate and exact one-unit correction. Add the narrow finite-negative-large branch to `as-fixed`; retain its rounding path for smaller magnitudes.
-- [ ] Run the signed-minimum `as-decimal` method alone and require its testcase duration below ten seconds. Then run seam methods, the largest-positive/signed-minimum pair, and the exact three focused classes. Inspect counts and timings, production diffs, branch cleanliness, and owned processes before committing production only as `#6572: avoid long division in decimal formatting`.
-
-- [ ] **Step 7: Push and open the requested Draft PR**
-
-Run the publishing workflow from `github:yeet`: confirm GitHub authentication, push `agent/issue-6572-printf-long` to `origin`, and create a Draft PR against `objectionary/eo:master`. The PR body must explain the old `2^53` guard, the exact `i64` extraction, the test evidence, the known unrelated Windows baseline failure if it recurs, and include `Fixes #6572`.
+Expected: documentation, committed EO regressions, the direct atom test, and the three production files are present; the worktree is clean. Do not push or open a pull request from this task.

--- a/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+++ b/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` correctly for `%d` and `%f`, while preserving truncation and deliberate failures.
 
-**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`. Render safe values below `1_000_000_000` with the original fast `number` digit loop; split larger values with exactly one signed `i64.div` by `1_000_000_000`, render the exact safe quotient and remainder through that loop, and left-pad the remainder to nine digits. Never negate the full input, so the signed minimum remains representable.
+**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`. Render safe values below a once-bound base of `1_000_000_000` with the original fast `number` digit loop. For larger values, estimate the bounded quotient with `number` arithmetic, validate and correct it at most one unit with exact `i64` multiplication and addition, render the safe exact chunks, and left-pad the remainder to nine digits. Never negate the full integer. `string.as-fixed` renders finite negative doubles at or above `2^53` directly as signed integral values and appends zero fraction digits, preserving the existing rounding path below that threshold.
 
 **Tech Stack:** EO standard-library objects, embedded EO test declarations, Maven Surefire, Java 21.
 
@@ -12,9 +12,9 @@
 
 ## File map
 
-- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point full-value digit extraction and the `2^53` guard with signed-long validation plus one exact base-`1_000_000_000` split; extend its embedded regression tests.
+- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point full-value digit extraction and the `2^53` guard with signed-long validation plus an estimated and exactly corrected base-`1_000_000_000` split; extend its embedded regression tests.
 - Modify `eo-runtime/src/main/eo/string/printf.eo`: add issue-level `%d` and `%f` regression tests only; production routing remains unchanged.
-- Reference `eo-runtime/src/main/eo/string/as-fixed.eo`: verify that `%f` still reaches `string.as-decimal` through its integer part; no source change is planned.
+- Modify `eo-runtime/src/main/eo/string/as-fixed.eo`: avoid negating finite negative integral doubles whose magnitude is at least `2^53`; keep ordinary rounding unchanged.
 
 ### Task 1: Add failing regressions for the documented range
 
@@ -115,7 +115,7 @@ git commit -m '#6572: reproduce long-range printf failures'
 
 Expected: one commit containing only the two EO test files.
 
-### Task 2: Render signed-long decimals with one exact base-`1_000_000_000` split
+### Task 2: Render signed-long decimals with an exact corrected base-`1_000_000_000` split
 
 **Files:**
 - Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:11-42`
@@ -130,14 +130,16 @@ Leave the file header and all Task 1 embedded test declarations intact. Replace 
 2. Dataize `n.as-i64` exactly once as `integer!`; redecorate every typed use as `i64 integer` because a `!` binding retains bytes rather than its decoration.
 3. Determine whether to prefix `-` from the truncated `i64`, not from `n`. This keeps negative fractions that truncate to zero unsigned.
 4. Define `small-digits` by retaining the original fast `number`-level division, floor, remainder, and ASCII conversion loop. Call it only with exact nonnegative integers below `2^53`.
-5. If `n.abs < 1_000_000_000`, render the absolute value of `(i64 integer).as-number` directly through `small-digits`.
-6. Otherwise perform exactly one signed `(i64 integer).div 1000000000.as-i64`. Cache and redecorate the quotient bytes. Cache `quotient * base`, then compute and cache the signed remainder as `integer - product`. Prefer the established two's-complement `not`-plus-one addition pattern if it keeps the EO structure clear; do not introduce repeated `i64.div` or negate the full input.
-7. Convert only the cached quotient and remainder to `number`, take their `number`-level absolute values, and render them with `small-digits`. The quotient magnitude is at most `9_223_372_036`; the remainder magnitude is at most `999_999_999`, so both paths are exact.
-8. Left-pad the tail string to exactly nine characters with zeroes and concatenate the unsigned head and tail. Prefix one minus sign only when the truncated `i64` is negative.
+5. Bind numeric base `1_000_000_000` once. If `n.abs < base`, render the absolute value of `(i64 integer).as-number` directly through `small-digits`.
+6. Otherwise compute `floor(n.abs / base)`, apply the sign using safe `number` arithmetic, convert the bounded estimate to `i64`, and cache its bytes. Do not use `i64.div` and do not negate the full integer.
+7. Cache the exact `i64` product `estimate * base`, then cache the signed remainder as `integer - product` with two's-complement `not`-plus-one addition.
+8. Correct at most one unit using exact signed-remainder invariants. Positive inputs require `0 <= remainder < base`: decrement/add-base for a negative remainder or increment/subtract-base for a remainder at least base. Negative inputs require `-base < remainder <= 0`: increment/subtract-base for a positive remainder or decrement/add-base for a remainder at or below negative base. Cache the corrected quotient and remainder bytes.
+9. Convert only the corrected quotient and remainder to `number`, take their `number`-level absolute values, and render them with `small-digits`. The quotient magnitude is at most `9_223_372_036`; the remainder magnitude is at most `999_999_999`, so both paths are exact. An overestimate near the maximum quotient cannot reach `9_223_372_037`, because the `2^63` magnitude boundary is still `145_224_192` below that base multiple, while the estimate error is sub-micro-unit.
+10. Left-pad the tail string to exactly nine characters with zeroes and concatenate the unsigned head and tail. Prefix one minus sign only when the truncated `i64` is negative.
 
 The chunk boundary behavior must include `10000000000000000 -> 10000000 | 000000000`, `9007199254740992 -> 9007199 | 254740992`, `38802277692848472 -> 38802277 | 692848472`, `9223372036854774784 -> 9223372036 | 854774784`, and `-9223372036854775808 -> -9223372036 | -854775808` before magnitude rendering and the single sign prefix.
 
-Do not revive the rejected per-decimal-digit algorithm. With quotient and remainder caching, it still produced `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`; all six errors were 20-minute JUnit timeouts while the other 64 focused tests passed.
+Do not revive either rejected division algorithm. Per-decimal-digit division produced `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`; all six errors were 20-minute timeouts while the other 64 focused tests passed. The later one-division base split was correct but still required 58–88 seconds for isolated large values and hundreds of seconds for individual contended suite cases, which is not acceptable for production formatting.
 
 - [ ] **Step 2: Inspect the implementation diff for accidental caller changes**
 
@@ -148,7 +150,7 @@ git diff --check
 git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
 ```
 
-Expected: production changes appear only in `as-decimal.eo`; `printf.eo` contains test additions only; `as-fixed.eo` has no diff.
+Expected: production changes appear only in `as-decimal.eo` and `as-fixed.eo`; `printf.eo` contains test additions only.
 
 Do not run the complete focused classes or commit the production source yet. Task 3 applies the performance gates in increasing scope before staging the implementation.
 
@@ -177,7 +179,7 @@ exit $code
 
 Record both the Maven wall time and the testcase duration from `eo-runtime/target/surefire-reports/TEST-org.eolang.EO_string.EOas_decimalTest.xml`.
 
-Expected: the test passes and its Surefire testcase duration is less than five minutes. If it exceeds five minutes, stop before any broader run and redesign the implementation; do not weaken the existing timeout.
+Expected: the test passes and its Surefire testcase duration is less than ten seconds, preferably substantially lower. If it reaches ten seconds, stop before any broader run and redesign the implementation; do not weaken the existing timeout.
 
 - [ ] **Step 2: Run the largest positive and signed-minimum methods together**
 
@@ -199,10 +201,10 @@ Expected: both pass under contention, and neither approaches the 20-minute JUnit
 Run:
 
 ```powershell
-mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOas_fixedTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
 ```
 
-Expected: `EOas_decimalTest` reports `21` tests, zero failures, and zero errors; `EOprintfTest` reports `49` tests, zero failures, and zero errors. Record each class duration from the Surefire reports. The rejected per-digit baseline was `21/0F/5E` and `49/0F/1E`, with all six errors caused by 20-minute timeouts.
+Expected: all three focused classes report zero failures and zero errors. Record each class count and duration from the Surefire reports. The rejected per-digit baseline was `EOas_decimalTest 21/0F/5E` and `EOprintfTest 49/0F/1E`, with all six errors caused by 20-minute timeouts.
 
 - [ ] **Step 4: Stage and commit only the verified formatter implementation**
 
@@ -212,13 +214,13 @@ Run:
 git diff --check
 git diff --name-only
 git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
-git add -- eo-runtime/src/main/eo/string/as-decimal.eo
+git add -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/as-fixed.eo
 git diff --cached --name-only
 git diff --cached --check
-git commit -m '#6572: format signed long numbers exactly'
+git commit -m '#6572: avoid long division in decimal formatting'
 ```
 
-Expected: before staging, the only uncommitted production file is `as-decimal.eo`, with no uncommitted `printf.eo` or `as-fixed.eo` diff. The commit contains only `as-decimal.eo`; the regression tests are already in Task 1.
+Expected: before staging, the only uncommitted production files are `as-decimal.eo` and `as-fixed.eo`, with `printf.eo` containing tests only. The production commit contains only `as-decimal.eo` and `as-fixed.eo`; the regressions are already committed separately.
 
 - [ ] **Step 5: Run repository hygiene checks and inspect the complete branch diff**
 
@@ -236,6 +238,13 @@ Expected: no whitespace errors, no uncommitted source changes, and only the desi
 - [ ] **Step 6: Request a code review and address only verified findings**
 
 Use `superpowers:requesting-code-review` against `upstream/master...HEAD`. Check the review against the issue scope, rerun the focused tests after any correction, and create a narrowly scoped follow-up commit only if a concrete defect is found.
+
+### Review follow-up: reject pure-EO division latency and cover the signed minimum
+
+- [ ] Amend this plan and the design before source changes. Record the one-division latency, the number estimate plus exact `i64` correction, the ten-second isolated gate, the base seams, and the `as-fixed` signed-minimum path. Commit docs only as `#6572: refine decimal formatting performance design`.
+- [ ] Add positive and negative `as-decimal` regressions for `999999999`, `1000000000`, `1000000001`, and `1000000042`, plus a large fractional truncation case. Add `printf` regressions for `%d`, `%f`, and `%.0f` at `-2^63`. Run the three focused classes before production edits and verify that only the `%f` and `%.0f` signed-minimum cases fail. Commit tests only as `#6572: cover decimal chunk boundaries`.
+- [ ] Replace the general `i64.div` split with the bounded estimate and exact one-unit correction. Add the narrow finite-negative-large branch to `as-fixed`; retain its rounding path for smaller magnitudes.
+- [ ] Run the signed-minimum `as-decimal` method alone and require its testcase duration below ten seconds. Then run seam methods, the largest-positive/signed-minimum pair, and the exact three focused classes. Inspect counts and timings, production diffs, branch cleanliness, and owned processes before committing production only as `#6572: avoid long division in decimal formatting`.
 
 - [ ] **Step 7: Push and open the requested Draft PR**
 

--- a/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+++ b/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` exactly and fast enough for production by delegating the already-validated `i64` bytes to one narrow JVM atom.
 
-**Architecture:** Keep all non-finite/range checks and the sole `number.as-i64` conversion in `string.as-decimal`; pass the cached bytes, redecorated as `i64`, to a nested atom that decodes one Java `long` and returns its locale-independent decimal text as UTF-8 `Q.bytes`. Avoid `Long.MIN_VALUE` overflow in `string.as-fixed` with one finite-negative-large helper that renders the signed integral value directly and appends zero fraction digits. Do not change production `string.printf`.
+**Architecture:** Keep all non-finite/range checks and the sole `number.as-i64` conversion in `string.as-decimal`; pass the cached bytes, redecorated as `i64`, to a nested atom that decodes one Java `long` and returns its locale-independent decimal text as UTF-8 `Q.bytes`. Route every finite value whose magnitude is at least `2^53` through one `string.as-fixed` helper that renders the integral value directly and appends zero fraction digits, avoiding both positive-value double scaling drift and `Long.MIN_VALUE` negation overflow. Do not change production `string.printf`.
 
 **Tech Stack:** EO standard-library objects, Java runtime atoms, JUnit 5, Hamcrest, Maven Surefire, Java 21.
 
@@ -15,7 +15,7 @@
 - Modify `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`: replace the rejected estimate/chunk design with the measured JVM-atom exception, exact API, performance gate, and Node parity debt.
 - Modify `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`: define the test-first implementation and validation sequence.
 - Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: retain the guards and sole `n.as-i64`, declare and call `from-i64 /Q.bytes`.
-- Modify `eo-runtime/src/main/eo/string/as-fixed.eo`: avoid whole-value negation for finite negative integral doubles at or above `2^53`.
+- Modify `eo-runtime/src/main/eo/string/as-fixed.eo`: render finite positive and negative integral doubles whose magnitude is at least `2^53` directly, avoiding positive double scaling drift and whole-value negation of `Long.MIN_VALUE`.
 - Create `eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java`: exact signed-long-to-UTF-8 atom.
 - Create `eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java`: direct atom contract tests.
 - Preserve `eo-runtime/src/main/eo/string/printf.eo`: its issue regressions are already committed; no production edit is permitted.
@@ -35,7 +35,7 @@ The JVM atom is therefore a measured performance exception. Recent `dataized` an
 
 - [ ] **Step 1: Replace pure-EO production experiments without losing committed tests**
 
-Use `apply_patch` to reduce the uncommitted `as-decimal.eo` production body to the guarded cached conversion and nested declaration shown in Task 3. Retain every embedded EO test already committed in `b163d32d6`. Keep only the narrow signed-large `as-fixed` branch shown in Task 3. Leave these production files unstaged during the documentation commit.
+Use `apply_patch` to reduce the uncommitted `as-decimal.eo` production body to the guarded cached conversion and nested declaration shown in Task 3. Retain every embedded EO test already committed in `b163d32d6`. Keep only the narrow finite-large `as-fixed` branch shown in Task 3. Leave these production files unstaged during the documentation commit.
 
 - [ ] **Step 2: Record the final architecture and evidence**
 
@@ -179,7 +179,7 @@ Do not return `Data.ToPhi(Long)` or `Data.ToPhi(Number)`, because those paths co
 
 - [ ] **Step 3: Keep the narrow `as-fixed` helper**
 
-After places validation and before the existing signed/positive rounding path, branch only on `n.is-finite.and (n.lt 0 and n.abs.gte 9007199254740992)`. Apply this helper to signed `n`:
+After places validation and before the existing signed/positive rounding path, branch on `n.is-finite.and n.abs.gte 9007199254740992`. Every such value is integral on the IEEE-754 grid, so apply this helper directly to positive or negative `n`; this avoids positive-value double scaling drift as well as whole-value negation of `Long.MIN_VALUE`:
 
 ```eo
 if. > [a] >> signed-large

--- a/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
+++ b/docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md
@@ -1,0 +1,245 @@
+# Issue #6572 Long-Range Decimal Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `string.printf` render finite signed-long `number` values above `2^53` correctly for `%d` and `%f`, while preserving truncation and deliberate failures.
+
+**Architecture:** Keep `string.as-decimal` as the shared integer-rendering path for `%d` and `string.as-fixed`. Convert each accepted `number` once to `i64`, extract digits with exact signed `i64` quotient/remainder operations, and never negate the full input so the signed minimum remains representable.
+
+**Tech Stack:** EO standard-library objects, embedded EO test declarations, Maven Surefire, Java 21.
+
+---
+
+## File map
+
+- Modify `eo-runtime/src/main/eo/string/as-decimal.eo`: replace floating-point digit extraction and the `2^53` guard with signed-long validation plus exact `i64` digit extraction; extend its embedded regression tests.
+- Modify `eo-runtime/src/main/eo/string/printf.eo`: add issue-level `%d` and `%f` regression tests only; production routing remains unchanged.
+- Reference `eo-runtime/src/main/eo/string/as-fixed.eo`: verify that `%f` still reaches `string.as-decimal` through its integer part; no source change is planned.
+
+### Task 1: Add failing regressions for the documented range
+
+**Files:**
+- Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:45-101`
+- Modify: `eo-runtime/src/main/eo/string/printf.eo:370-611`
+
+- [ ] **Step 1: Replace the obsolete `2^53` stopping test and add exact decimal boundary regressions**
+
+Keep the existing small-number, fraction, zero, and `9007199254740991` tests. Replace `stops-on-a-magnitude-of-two-to-the-53rd` and add these declarations beside the other `as-decimal` tests:
+
+```eo
+  eq. ++> can-write-two-to-the-53rd
+    "9007199254740992"
+    string
+      as-decimal 9007199254740992
+
+  eq. ++> can-write-ten-to-the-16th
+    "10000000000000000"
+    string
+      as-decimal 1.0e16
+
+  eq. ++> can-write-a-large-exact-counterexample
+    "38802277692848472"
+    string
+      as-decimal 38802277692848472
+
+  eq. ++> can-write-the-largest-double-below-the-long-maximum
+    "9223372036854774784"
+    string
+      as-decimal 9223372036854774784
+
+  eq. ++> can-write-the-long-minimum
+    "-9223372036854775808"
+    string
+      as-decimal -9.223372036854776e18
+
+  as-decimal 9.223372036854776e18 --> stops-on-the-long-maximum-boundary
+
+  as-decimal -9.223372036854778e18 --> stops-below-the-long-minimum-boundary
+```
+
+- [ ] **Step 2: Add the five issue examples to `printf`**
+
+Place these declarations with the other successful formatting tests:
+
+```eo
+  eq. ++> can-format-two-to-the-53rd-as-an-integer
+    "9007199254740992"
+    printf *1
+      "%d"
+      9007199254740992
+
+  eq. ++> can-format-ten-to-the-16th-as-an-integer
+    "10000000000000000"
+    printf *1
+      "%d"
+      1.0e16
+
+  eq. ++> can-format-two-to-the-53rd-as-a-float
+    "9007199254740992.000000"
+    printf *1
+      "%f"
+      9007199254740992
+
+  eq. ++> can-format-ten-to-the-16th-with-two-fraction-digits
+    "10000000000000000.00"
+    printf *1
+      "%.2f"
+      1.0e16
+
+  eq. ++> can-format-ten-to-the-16th-without-fraction-digits
+    "10000000000000000"
+    printf *1
+      "%.0f"
+      1.0e16
+```
+
+- [ ] **Step 3: Run only the generated EO test classes and confirm the red state**
+
+Run in PowerShell:
+
+```powershell
+$env:JAVA_HOME='E:\tools\ProfessionalTools\jdk21\jdk\jdk-21.0.10+7'
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
+```
+
+Expected: the command fails because the new successful cases bottom out at the current `2^53` guard. The reported cause contains `its magnitude is 2^53 or larger`; pre-existing small and failure cases remain successful.
+
+- [ ] **Step 4: Commit the red tests**
+
+```powershell
+git add -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo
+git diff --cached --check
+git commit -m '#6572: reproduce long-range printf failures'
+```
+
+Expected: one commit containing only the two EO test files.
+
+### Task 2: Render decimal digits with exact signed `i64` arithmetic
+
+**Files:**
+- Modify: `eo-runtime/src/main/eo/string/as-decimal.eo:11-42`
+- Test: `eo-runtime/src/main/eo/string/as-decimal.eo:45-115`
+- Test: `eo-runtime/src/main/eo/string/printf.eo:370-640`
+
+- [ ] **Step 1: Replace the conversion and digit routine in `as-decimal`**
+
+Replace the production body above the embedded tests with this implementation, leaving the file header and test declarations intact:
+
+```eo
+[n] > as-decimal
+  n.is-finite.not.if > @
+    T
+      "Can't write a non-finite number as decimal"
+    if.
+      or.
+        n.gte 9.223372036854776e18
+        n.lt -9.223372036854776e18
+      T
+        "Can't write this number as decimal digits: it is outside the signed 64-bit range"
+      if.
+        integer.lt 0.as-i64
+        "-".as-bytes.concat
+          digits integer
+        digits integer
+  [n] >> digit
+    as-char
+      plus.
+        if.
+          n.lt 0.as-i64
+          n.neg.as-number
+          n.as-number
+        48
+  [n] >> digits
+    if. > @
+      q.eq 0.as-i64
+      digit remainder
+      concat.
+        digits q
+        digit remainder
+    n.div 10.as-i64 > q
+    n.minus (q.times 10.as-i64) > remainder
+  n.as-i64 > integer!
+```
+
+The positive upper comparison is inclusive because the double literal is exactly `2^63`; the negative comparison is strict so exactly `-2^63` remains accepted. `digit` negates only a remainder from `-9` through `-1`, never the whole long minimum.
+
+- [ ] **Step 2: Run the two focused EO test classes and confirm the green state**
+
+Run:
+
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' test -pl :eo-runtime
+```
+
+Expected: `EOas_decimalTest` and `EOprintfTest` pass with zero failures and zero errors, including the existing truncation, padding, precision, non-finite, and out-of-range cases.
+
+- [ ] **Step 3: Inspect the implementation diff for accidental caller changes**
+
+Run:
+
+```powershell
+git diff --check
+git diff -- eo-runtime/src/main/eo/string/as-decimal.eo eo-runtime/src/main/eo/string/printf.eo eo-runtime/src/main/eo/string/as-fixed.eo
+```
+
+Expected: production changes appear only in `as-decimal.eo`; `printf.eo` contains test additions only; `as-fixed.eo` has no diff.
+
+- [ ] **Step 4: Commit the exact formatter implementation**
+
+```powershell
+git add -- eo-runtime/src/main/eo/string/as-decimal.eo
+git diff --cached --check
+git commit -m '#6572: format signed long numbers exactly'
+```
+
+Expected: one commit containing the production change in `as-decimal.eo`; the `printf.eo` regression tests are already committed in Task 1.
+
+### Task 3: Verify the branch and prepare it for review
+
+**Files:**
+- Verify: `eo-runtime/src/main/eo/string/as-decimal.eo`
+- Verify: `eo-runtime/src/main/eo/string/printf.eo`
+- Verify: `docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md`
+- Verify: `docs/superpowers/plans/2026-08-11-issue-6572-printf-long.md`
+
+- [ ] **Step 1: Rebuild the focused tests from clean generated sources**
+
+Run:
+
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' '-Dtest=org.eolang.EO_string.EOas_decimalTest,org.eolang.EO_string.EOprintfTest' clean test -pl :eo-runtime
+```
+
+Expected: both generated EO test classes pass from a clean build with zero failures and zero errors.
+
+- [ ] **Step 2: Run the full `eo-runtime` unit-test suite**
+
+Run:
+
+```powershell
+mvn -o -ntp -PskipITs --errors --batch-mode '-Deo.coverageTracking=false' test -pl :eo-runtime
+```
+
+Expected on this Windows host: no regression attributable to this branch. The previously reproduced environment-specific `SyscallTest.WindowsSocketTest.refusesConnectionViaSyscall` may remain the sole failure because `192.0.2.1` accepts the connection here; record its exact counts and output separately if it recurs.
+
+- [ ] **Step 3: Run repository hygiene checks and inspect the complete branch diff**
+
+Run:
+
+```powershell
+git diff upstream/master...HEAD --check
+git status --short
+git diff --stat upstream/master...HEAD
+git log --oneline --decorate upstream/master..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted source changes, and only the design, plan, regression tests, and formatter implementation are present.
+
+- [ ] **Step 4: Request a code review and address only verified findings**
+
+Use `superpowers:requesting-code-review` against `upstream/master...HEAD`. Check the review against the issue scope, rerun the focused tests after any correction, and create a narrowly scoped follow-up commit only if a concrete defect is found.
+
+- [ ] **Step 5: Push and open the requested Draft PR**
+
+Run the publishing workflow from `github:yeet`: confirm GitHub authentication, push `agent/issue-6572-printf-long` to `origin`, and create a Draft PR against `objectionary/eo:master`. The PR body must explain the old `2^53` guard, the exact `i64` extraction, the test evidence, the known unrelated Windows baseline failure if it recurs, and include `Fixes #6572`.

--- a/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
@@ -1,0 +1,97 @@
+# Issue #6572: long-range decimal formatting
+
+## Context
+
+[`string.printf`](https://github.com/objectionary/eo/issues/6572) documents `%d` around the signed 64-bit range, but both `%d` and `%f` delegate integer rendering to `string.as-decimal`. That object currently rejects every magnitude at or above `2^53`, so exactly representable `number` values between `2^53` and `2^63` fail before formatting.
+
+The `2^53` guard was introduced to prevent the existing floating-point digit extraction from emitting incorrect or non-digit bytes. Removing or widening the guard without replacing that algorithm would reintroduce corruption. For example, repeated floating-point division and subtraction can render an exactly representable integer such as `38802277692848472` incorrectly.
+
+## Scope
+
+This change will:
+
+- render finite values accepted by the signed 64-bit contract through `%d`;
+- allow `%f`, `%.2f`, and `%.0f` to render large integer-valued doubles below `2^63`;
+- preserve truncation toward zero in `string.as-decimal`;
+- preserve explicit failures for non-finite and out-of-range inputs;
+- add regression coverage for the `2^53` boundary, representative large values, a value the old floating algorithm misrenders, and signed boundaries.
+
+This change will not address the separate one-ULP rounding artifact reported for `printf "%.2f" 123456789012345.67`.
+
+## Selected approach
+
+`string.as-decimal` will remain the single decimal-integer rendering primitive used by `printf` and `string.as-fixed`, but its digit extraction will operate on `i64` values instead of `number` arithmetic.
+
+The alternatives were rejected as follows:
+
+- A `printf`-local formatter would duplicate `string.as-decimal` and require a second path through `string.as-fixed` for `%f`.
+- Merely widening the existing guard to `2^63` would allow known floating-point digit corruption.
+
+## Design
+
+### Conversion and range handling
+
+`string.as-decimal` will first reject non-finite input as it does today. It will then enforce the signed 64-bit bounds before converting the truncated value with `number.as-i64`. The range check must preserve the existing `%d` contract: positive `2^63` is rejected, values below it are accepted, and the negative lower boundary is handled without overflowing an absolute-value operation.
+
+The conversion will not rely on the fallback message inside `number.as-i64`, because that message formats the rejected number through `%f` and would recurse back into this formatting path.
+
+### Exact digit extraction
+
+The internal digit routine will use exact `i64` operations:
+
+1. Divide the current signed integer by `10.as-i64`; `i64.div` truncates toward zero.
+2. Compute the signed remainder as `current - quotient * 10`.
+3. Negate only the single-digit remainder when it is negative, then convert that value to `number` and add the ASCII offset.
+4. If the quotient is zero, return that digit; otherwise recurse on the quotient and append the digit, producing most-significant-first order.
+
+The algorithm deliberately does not negate the complete input. A minus sign is prefixed only when the original input is negative and its truncated `i64` value is nonzero. This allows the signed minimum value to render without overflowing `i64`, while a negative fraction that truncates to zero remains `0`.
+
+Fractional inputs continue to truncate toward zero because `number.as-i64` already defines that behavior.
+
+### Callers
+
+No new formatting branch will be added to `string.printf`:
+
+- `%d` continues to apply its long-range guard and delegates to `string.as-decimal`.
+- `%f` continues through `string.as-fixed`; its integer part reaches the corrected `string.as-decimal` implementation.
+
+This keeps width, zero padding, precision parsing, and failure propagation unchanged.
+
+## Error behavior
+
+- `nan`, positive infinity, and negative infinity terminate with the existing non-finite decimal error.
+- Positive values at or above `2^63` and values below `-2^63` terminate before `number.as-i64` is invoked.
+- `%d` retains its existing long-range diagnostic.
+- `%f` continues to propagate the decimal conversion failure through `string.as-fixed` when its integer part is outside the supported range.
+
+No fallback will silently round an out-of-range value or emit a partial string.
+
+## Tests
+
+Tests will be added before the implementation and observed failing for the current `2^53` guard.
+
+`string.as-decimal` coverage will include:
+
+- `2^53` and `1e16` rendering successfully;
+- an exactly representable value that the old floating-point digit loop renders incorrectly;
+- a value near the positive `2^63` boundary;
+- the signed lower boundary without whole-value negation overflow;
+- continued truncation of positive and negative fractions;
+- rejection of non-finite and out-of-range values.
+
+`string.printf` coverage will include the issue examples:
+
+- `%d` with `9007199254740992` and `1.0e16`;
+- `%f` with `9007199254740992`;
+- `%.2f` and `%.0f` with `1.0e16`.
+
+Verification will use targeted `eo-runtime` tests first, followed by the module-level build. The clean `master` baseline has one unrelated Windows environment failure in `SyscallTest`: this machine accepts a connection to `192.0.2.1` where the test expects refusal. That failure will be recorded separately from any regression introduced by this change.
+
+## Acceptance criteria
+
+- All issue examples below `2^63` produce the expected decimal strings.
+- The known old-algorithm counterexample renders every digit correctly.
+- Existing small-number formatting, truncation, padding, and precision behavior remains unchanged.
+- Non-finite and out-of-range cases still fail deliberately.
+- Targeted tests pass with no failures or errors.
+- Module verification introduces no failures beyond the documented `SyscallTest` baseline failure.

--- a/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
@@ -6,6 +6,8 @@
 
 The `2^53` guard was introduced to prevent the existing floating-point digit extraction from emitting incorrect or non-digit bytes. Removing or widening the guard without replacing that algorithm would reintroduce corruption. For example, repeated floating-point division and subtraction can render an exactly representable integer such as `38802277692848472` incorrectly.
 
+The first exact signed-long implementation split large integers with one pure-EO `i64.div` by `1_000_000_000`. It produced correct digits, but isolated large cases took 58–88 seconds and contended suite cases took hundreds of seconds. It also exposed a caller defect: `string.as-fixed` negated every negative input before rendering, so the signed minimum became the out-of-range positive value `2^63` for `%f` and `%.0f`.
+
 ## Scope
 
 This change will:
@@ -14,6 +16,7 @@ This change will:
 - allow `%f`, `%.2f`, and `%.0f` to render large integer-valued doubles below `2^63`;
 - preserve truncation toward zero in `string.as-decimal`;
 - preserve explicit failures for non-finite and out-of-range inputs;
+- render the signed minimum through `%f` without negating the whole value;
 - add regression coverage for the `2^53` boundary, representative large values, a value the old floating algorithm misrenders, and signed boundaries.
 
 This change will not address the separate one-ULP rounding artifact reported for `printf "%.2f" 123456789012345.67`.
@@ -23,16 +26,19 @@ This change will not address the separate one-ULP rounding artifact reported for
 `string.as-decimal` will remain the single decimal-integer rendering primitive used by `printf` and `string.as-fixed`. It will convert an accepted value to `i64` once, but it will not perform one expensive `i64` operation per decimal digit. Instead, it will use a hybrid base-`1_000_000_000` representation:
 
 - magnitudes below the base use the original fast `number`-level digit loop after the signed-long conversion;
-- larger magnitudes perform exactly one signed `i64.div` by the base, then render the quotient and remainder with that same fast loop;
+- larger magnitudes estimate the quotient with bounded `number` arithmetic, convert that small signed estimate to `i64`, and validate and, when necessary, correct it with exact `i64` multiplication and addition;
 - the remainder is left-padded to exactly nine decimal characters before it is appended to the quotient.
 
-This split is exact because the absolute quotient is at most `9_223_372_036`, and the absolute remainder is at most `999_999_999`. Both values and every intermediate in their decimal digit loops are below `2^53` and therefore exactly representable as `number`.
+The numeric base is bound once so the estimate, product, correction, threshold, and padding cannot drift to different literals. The estimated quotient magnitude is `floor(abs(n) / base)`. It is at most `9_223_372_036`, so both it and its signed form are exact `number` values and safe to convert to `i64`. IEEE-754 division at a quotient magnitude near `10^10` has a sub-micro-unit ULP, while exact quotient boundaries are one unit apart and the input grid contributes steps of `10^-9` quotient units. The estimate can therefore cross at most one boundary. Exact signed-remainder checks correct that possible one-unit error.
+
+After correction, positive inputs satisfy `0 <= remainder < base`; negative inputs satisfy `-base < remainder <= 0`. The absolute corrected quotient is at most `9_223_372_036`, and the absolute corrected remainder is at most `999_999_999`. Both chunks and every intermediate in their decimal digit loops are below `2^53` and therefore exactly representable as `number`. The exact `i64` product is also in range: any one-unit overestimate can occur only next to an in-range base multiple, while the `2^63` magnitude boundary is still `145_224_192` integers below the next multiple, far beyond the floating estimate error, so the estimate cannot become `9_223_372_037`.
 
 The alternatives were rejected as follows:
 
 - A `printf`-local formatter would duplicate `string.as-decimal` and require a second path through `string.as-fixed` for `%f`.
 - Merely widening the existing guard to `2^63` would allow known floating-point digit corruption.
 - Repeated signed `i64.div 10` is semantically plausible but too slow in pure EO. Even after quotient and remainder caching, five large `EOas_decimalTest` cases and one `EOprintfTest` case each hit the 20-minute JUnit timeout. The other 64 focused tests passed, isolating the problem to the intrinsic cost of per-digit `i64` division rather than range or formatting semantics.
+- One signed pure-EO `i64.div 1_000_000_000` per large value is functionally correct but still production-unacceptable: isolated large cases require 58–88 seconds, and individual cases take hundreds of seconds under suite contention. Correctness alone does not satisfy the formatter's latency requirement.
 
 ## Design
 
@@ -49,11 +55,12 @@ After the range guards, `n.as-i64` is dataized and cached once as `integer!`. Ev
 The internal digit routine works as follows:
 
 1. Determine the sign from the truncated `i64` value. A minus sign is emitted only when `i64 integer` is negative, so a negative fraction that truncates to zero remains `0`.
-2. When the accepted magnitude is below `1_000_000_000`, convert the safe truncated integer to `number`, take its `number`-level absolute value, and render it with the original division-by-ten digit loop.
-3. Otherwise, divide `i64 integer` exactly once by `1_000_000_000.as-i64` and cache the quotient bytes.
-4. Compute the signed remainder exactly as `integer - quotient * 1_000_000_000`, caching and redecorating typed intermediates. An established two's-complement `not`-plus-one subtraction pattern may be used instead of `i64.minus` to avoid its multiply-by-minus-one implementation.
-5. Convert only the quotient and remainder to `number`, take their `number`-level absolute values, and render each through the fast small-number digit loop.
-6. Left-pad the rendered remainder to exactly nine characters with zeroes and concatenate `head + tail`. Prefix the sign once around the completed unsigned string.
+2. Bind the numeric base once. When the accepted magnitude is below the base, convert the safe truncated integer to `number`, take its `number`-level absolute value, and render it with the original division-by-ten digit loop.
+3. Otherwise, compute `floor(n.abs / base)`, apply the sign with safe `number` arithmetic, convert that bounded value to `i64`, and cache the estimated quotient bytes. No full-width integer is negated.
+4. Compute and cache `estimated quotient * base` exactly in `i64`, then compute the signed remainder exactly as `integer - product` with two's-complement `not`-plus-one addition.
+5. Correct at most one quotient unit from the exact remainder. For a positive integer, a negative remainder decrements the quotient and adds the base; a remainder at least the base increments the quotient and subtracts the base. For a negative integer, a positive remainder increments the quotient and subtracts the base; a remainder at or below negative base decrements the quotient and adds the base. Cache the corrected quotient and remainder bytes.
+6. Convert only the corrected quotient and remainder to `number`, take their `number`-level absolute values, and render each through the fast small-number digit loop.
+7. Left-pad the rendered remainder to exactly nine characters with zeroes and concatenate `head + tail`. Prefix the sign once around the completed unsigned string.
 
 For example, `9223372036854774784` splits into `9223372036 | 854774784`, `38802277692848472` into `38802277 | 692848472`, `10000000000000000` into `10000000 | 000000000`, and `9007199254740992` into `9007199 | 254740992`. The signed minimum splits into `-9223372036 | -854775808`; the chunks are rendered by magnitude and the result receives one leading minus sign.
 
@@ -66,7 +73,7 @@ Fractional inputs continue to truncate toward zero because `number.as-i64` alrea
 No new formatting branch will be added to `string.printf`:
 
 - `%d` continues to apply its long-range guard and delegates to `string.as-decimal`.
-- `%f` continues through `string.as-fixed`; its integer part reaches the corrected `string.as-decimal` implementation.
+- `%f` continues through `string.as-fixed`. After validating `places`, a finite negative value with magnitude at least `2^53` is already integral as a double, so `as-fixed` renders that signed integer directly through `string.as-decimal` and appends a decimal point plus exactly `places` zeroes when `places > 0`. A zero precision returns only the signed integer. Smaller magnitudes retain the existing rounding path.
 
 This keeps width, zero padding, precision parsing, and failure propagation unchanged.
 
@@ -76,6 +83,7 @@ This keeps width, zero padding, precision parsing, and failure propagation uncha
 - Positive values at or above `2^63` and values below `-2^63` terminate before `number.as-i64` is invoked.
 - `%d` retains its existing long-range diagnostic.
 - `%f` continues to propagate the decimal conversion failure through `string.as-fixed` when its integer part is outside the supported range.
+- `nan` and infinities still reach deliberate non-finite handling; the signed-large shortcut is restricted to finite values.
 
 No fallback will silently round an out-of-range value or emit a partial string.
 
@@ -90,15 +98,18 @@ Tests will be added before the implementation and observed failing for the curre
 - a value near the positive `2^63` boundary;
 - the signed lower boundary without whole-value negation overflow;
 - continued truncation of positive and negative fractions;
-- rejection of non-finite and out-of-range values.
+- rejection of non-finite and out-of-range values;
+- positive and negative seams at `999_999_999`, `1_000_000_000`, `1_000_000_001`, and `1_000_000_042`;
+- fractional truncation on the large path.
 
 `string.printf` coverage will include the issue examples:
 
 - `%d` with `9007199254740992` and `1.0e16`;
 - `%f` with `9007199254740992`;
-- `%.2f` and `%.0f` with `1.0e16`.
+- `%.2f` and `%.0f` with `1.0e16`;
+- `%d`, `%f`, and `%.0f` with `-2^63`.
 
-Performance verification is an acceptance gate, not only a correctness check. After generated test names are inspected, the signed-minimum regression will run alone and its Surefire testcase duration must be below five minutes. The largest positive and signed-minimum regressions will then run together to expose contention; both must pass without approaching the 20-minute JUnit limit. Only after those gates pass will the exact focused `EOas_decimalTest` and `EOprintfTest` command run. It must report `21` and `49` tests respectively, with zero failures and zero errors.
+Performance verification is an acceptance gate, not only a correctness check. After generated test names are inspected, the signed-minimum regression will run alone and its Surefire testcase duration must be below ten seconds, with a substantially lower result preferred. The seam regressions and the largest-positive/signed-minimum pair will then run before the exact focused `EOas_decimalTest`, `EOas_fixedTest`, and `EOprintfTest` classes. The timeout will not be weakened to accommodate the implementation.
 
 The rejected per-digit experiment established the baseline for this gate: `EOas_decimalTest` reported `21` tests with `5` errors, and `EOprintfTest` reported `49` tests with `1` error; all six errors were 20-minute timeouts. The other 64 focused tests passed. The timeout will not be weakened to accommodate the implementation.
 
@@ -109,6 +120,7 @@ The rejected per-digit experiment established the baseline for this gate: `EOas_
 - Existing small-number formatting, truncation, padding, and precision behavior remains unchanged.
 - Chunk tails are padded to exactly nine digits, including an all-zero tail.
 - The signed minimum renders correctly without whole-value negation.
+- The quotient/remainder seams render correctly on both sides of zero, and a large fraction still truncates toward zero.
 - Non-finite and out-of-range cases still fail deliberately.
-- The signed-minimum testcase completes in less than five minutes, and the paired positive/negative boundary run completes comfortably below the existing 20-minute per-test timeout.
-- The focused suite reports `EOas_decimalTest` as `21/0F/0E` and `EOprintfTest` as `49/0F/0E` without weakening timeouts.
+- The signed-minimum testcase completes in less than ten seconds, and the seam and paired boundary runs pass without weakening timeouts.
+- The focused `EOas_decimalTest`, `EOas_fixedTest`, and `EOprintfTest` classes pass with zero failures and zero errors.

--- a/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
@@ -85,7 +85,7 @@ The atom must never return `new Data.ToPhi(value)` or any other `Number`. `Data.
 
 ### `string.as-fixed`
 
-Places validation remains first. After it succeeds, one narrow helper handles a finite negative value whose magnitude is at least `2^53`. Such a value is integral on the IEEE-754 grid, so the helper passes the signed `n` directly to `as-decimal`. It returns only those digits for `places = 0`; otherwise it appends `.` and exactly `places` zeroes. The helper never evaluates `n.times -1`.
+Places validation remains first. After it succeeds, one narrow helper handles every finite value whose magnitude is at least `2^53`. Such a value is integral on the IEEE-754 grid, so the helper passes `n` directly to `as-decimal`. It returns only those digits for `places = 0`; otherwise it appends `.` and exactly `places` zeroes. This common positive-and-negative path avoids both double scaling drift for large positive values and whole-value negation of `Long.MIN_VALUE`.
 
 All smaller magnitudes retain the existing rounding path and sign-dropping behavior for values that round to zero. The shortcut is explicitly finite, so `nan` and infinities continue through the deliberate existing non-finite path.
 

--- a/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
@@ -2,125 +2,131 @@
 
 ## Context
 
-[`string.printf`](https://github.com/objectionary/eo/issues/6572) documents `%d` around the signed 64-bit range, but both `%d` and `%f` delegate integer rendering to `string.as-decimal`. That object currently rejects every magnitude at or above `2^53`, so exactly representable `number` values between `2^53` and `2^63` fail before formatting.
+[`string.printf`](https://github.com/objectionary/eo/issues/6572) documents `%d` around the signed 64-bit range, and both `%d` and `%f` ultimately render integer digits through `string.as-decimal`. The old implementation rejected every magnitude at or above `2^53` because its floating-point digit loop could emit incorrect digits. Merely widening that guard is unsafe: the exactly representable value `38802277692848472`, for example, is misrendered by repeated floating-point division and subtraction.
 
-The `2^53` guard was introduced to prevent the existing floating-point digit extraction from emitting incorrect or non-digit bytes. Removing or widening the guard without replacing that algorithm would reintroduce corruption. For example, repeated floating-point division and subtraction can render an exactly representable integer such as `38802277692848472` incorrectly.
+The committed regressions establish the desired signed-long contract. In the focused baseline, all 30 `as-decimal` seam, range, and truncation cases pass with the exact pure-EO split, as does signed-minimum `%d`; the only errors are signed-minimum `%f` and `%.0f`, both caused by `string.as-fixed` negating `Long.MIN_VALUE` to the out-of-range positive value `2^63`.
 
-The first exact signed-long implementation split large integers with one pure-EO `i64.div` by `1_000_000_000`. It produced correct digits, but isolated large cases took 58–88 seconds and contended suite cases took hundreds of seconds. It also exposed a caller defect: `string.as-fixed` negated every negative input before rendering, so the signed minimum became the out-of-range positive value `2^63` for `%f` and `%.0f`.
+## Exhausted pure-EO approaches
+
+The signed-long algorithms were correct but failed the formatter's production latency requirement:
+
+- Repeated exact `i64.div 10` caused five `EOas_decimalTest` cases and one `EOprintfTest` case to reach the existing 20-minute JUnit timeout. The other 64 focused cases passed, isolating the failure to conversion cost rather than decimal semantics.
+- One exact signed `i64.div 1_000_000_000` per large value produced correct digits but required 58–88 seconds for isolated large cases and hundreds of seconds for contended suite cases.
+- Bounded-quotient and chunk-rendering variants removed general full-width division. Exhaustive isolated trials still measured 21.890–23.386 seconds for the fastest variant, while the other variants measured 27–88 seconds.
+
+Every pure-EO route therefore exceeds the explicit `<10s` isolated-test gate, including the fastest result by more than two times. Further micro-optimization of the same object graph has no evidence of reaching the gate. The narrow JVM atom below is an exception justified by measured latency, not by convenience.
+
+The repository already accepts Java-only atom changes, including the recent `dataized` and `recovered` atoms after the `eo2js` repository was archived. The Maven build, generated atom metadata, and current CI validate the JVM runtime only. This precedent makes a JVM atom an appropriately scoped fix for issue #6572.
 
 ## Scope
 
 This change will:
 
-- render finite values accepted by the signed 64-bit contract through `%d`;
-- allow `%f`, `%.2f`, and `%.0f` to render large integer-valued doubles below `2^63`;
-- preserve truncation toward zero in `string.as-decimal`;
-- preserve explicit failures for non-finite and out-of-range inputs;
-- render the signed minimum through `%f` without negating the whole value;
-- add regression coverage for the `2^53` boundary, representative large values, a value the old floating algorithm misrenders, and signed boundaries.
+- render every finite value accepted by the signed 64-bit contract through `%d`;
+- allow `%f`, `%.2f`, and `%.0f` to render large integer-valued doubles below positive `2^63`;
+- preserve truncation toward zero in `string.as-decimal`, including negative fractions that truncate to unsigned zero;
+- preserve deliberate failures for non-finite and out-of-range values;
+- render `Long.MIN_VALUE` without negating the whole value;
+- add direct JVM coverage of exact signed-long decoding, UTF-8 decimal output, wrong-width rejection, and the declared `Q.bytes` result;
+- retain all committed EO range, seam, and `printf` regressions.
 
-This change will not address the separate one-ULP rounding artifact reported for `printf "%.2f" 123456789012345.67`.
+This change will not alter production code in `string.printf`, address the separate one-ULP rounding artifact reported for `printf "%.2f" 123456789012345.67`, or implement the corresponding Node atom.
 
-## Selected approach
+## Selected architecture
 
-`string.as-decimal` will remain the single decimal-integer rendering primitive used by `printf` and `string.as-fixed`. It will convert an accepted value to `i64` once, but it will not perform one expensive `i64` operation per decimal digit. Instead, it will use a hybrid base-`1_000_000_000` representation:
+`string.as-decimal` remains the sole decimal-integer rendering primitive used by `%d` and `string.as-fixed`. It owns all semantic guards and converts the accepted `number` exactly once:
 
-- magnitudes below the base use the original fast `number`-level digit loop after the signed-long conversion;
-- larger magnitudes estimate the quotient with bounded `number` arithmetic, convert that small signed estimate to `i64`, and validate and, when necessary, correct it with exact `i64` multiplication and addition;
-- the remainder is left-padded to exactly nine decimal characters before it is appended to the quotient.
+1. Lazily reject a non-finite value before evaluating range conversion.
+2. Reject `n >= 2^63`.
+3. Reject `n < -2^63`.
+4. Evaluate and cache the sole `n.as-i64` expression as `integer!`.
+5. Redecorate those cached bytes as `i64 integer` at the typed atom application.
+6. Return the atom's signed decimal UTF-8 bytes directly.
 
-The numeric base is bound once so the estimate, product, correction, threshold, and padding cannot drift to different literals. The estimated quotient magnitude is `floor(abs(n) / base)`. It is at most `9_223_372_036`, so both it and its signed form are exact `number` values and safe to convert to `i64`. IEEE-754 division at a quotient magnitude near `10^10` has a sub-micro-unit ULP, while exact quotient boundaries are one unit apart and the input grid contributes steps of `10^-9` quotient units. The estimate can therefore cross at most one boundary. Exact signed-remainder checks correct that possible one-unit error.
+There is no whole-value absolute operation, negation, quotient estimate, chunk split, exact division, multiplication, or EO digit recursion on the accepted value. `number.as-i64` continues to define truncation toward zero, so `-0.9` becomes the eight-byte representation of zero and the atom emits `0`. `Long.MIN_VALUE` is passed unchanged.
 
-After correction, positive inputs satisfy `0 <= remainder < base`; negative inputs satisfy `-base < remainder <= 0`. The absolute corrected quotient is at most `9_223_372_036`, and the absolute corrected remainder is at most `999_999_999`. Both chunks and every intermediate in their decimal digit loops are below `2^53` and therefore exactly representable as `number`. The exact `i64` product is also in range: any one-unit overestimate can occur only next to an in-range base multiple, while the `2^63` magnitude boundary is still `145_224_192` integers below the next multiple, far beyond the floating estimate error, so the estimate cannot become `9_223_372_037`.
+### EO API
 
-The alternatives were rejected as follows:
+The nested atom is private to `string.as-decimal` and has this exact signature:
 
-- A `printf`-local formatter would duplicate `string.as-decimal` and require a second path through `string.as-fixed` for `%f`.
-- Merely widening the existing guard to `2^63` would allow known floating-point digit corruption.
-- Repeated signed `i64.div 10` is semantically plausible but too slow in pure EO. Even after quotient and remainder caching, five large `EOas_decimalTest` cases and one `EOprintfTest` case each hit the 20-minute JUnit timeout. The other 64 focused tests passed, isolating the problem to the intrinsic cost of per-digit `i64` division rather than range or formatting semantics.
-- One signed pure-EO `i64.div 1_000_000_000` per large value is functionally correct but still production-unacceptable: isolated large cases require 58–88 seconds, and individual cases take hundreds of seconds under suite contention. Correctness alone does not satisfy the formatter's latency requirement.
+```eo
+[] > from-i64 /Q.bytes
+  ? > value /Q.i64
+```
 
-## Design
+The guarded call uses the cached bytes with their `i64` decoration restored:
 
-### Conversion and range handling
+```eo
+from-i64
+  i64 integer
+```
 
-`string.as-decimal` will first reject non-finite input as it does today. It will then enforce the signed 64-bit bounds before converting the truncated value with `number.as-i64`. The range check must preserve the existing `%d` contract: positive `2^63` is rejected, values below it are accepted, and the negative lower boundary is handled without overflowing an absolute-value operation.
+`as-decimal.eo` declares the standard runtime metadata used by existing atom EO sources:
 
-The conversion will not rely on the fallback message inside `number.as-i64`, because that message formats the rejected number through `%f` and would recurse back into this formatting path.
+```eo
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
+```
 
-### Exact digit extraction
+The Node locator is retained because all current atom EO sources declare both runtimes; it does not imply that this branch supplies a Node implementation.
 
-After the range guards, `n.as-i64` is dataized and cached once as `integer!`. Every typed use redecorates those cached bytes as `i64 integer`; the implementation must not accidentally invoke `n.as-i64` again.
+### JVM API and data path
 
-The internal digit routine works as follows:
+The implementation is `org.eolang.EO_string.EOas_decimal$EOfrom_i64`, annotated as `as-decimal.from-i64`, extending `PhDefault`, and implementing `Atom`. Its constructor exposes one void attribute named `value`. Its complete conversion is:
 
-1. Determine the sign from the truncated `i64` value. A minus sign is emitted only when `i64 integer` is negative, so a negative fraction that truncates to zero remains `0`.
-2. Bind the numeric base once. When the accepted magnitude is below the base, convert the safe truncated integer to `number`, take its `number`-level absolute value, and render it with the original division-by-ten digit loop.
-3. Otherwise, compute `floor(n.abs / base)`, apply the sign with safe `number` arithmetic, convert that bounded value to `i64`, and cache the estimated quotient bytes. No full-width integer is negated.
-4. Compute and cache `estimated quotient * base` exactly in `i64`, then compute the signed remainder exactly as `integer - product` with two's-complement `not`-plus-one addition.
-5. Correct at most one quotient unit from the exact remainder. For a positive integer, a negative remainder decrements the quotient and adds the base; a remainder at least the base increments the quotient and subtracts the base. For a negative integer, a positive remainder increments the quotient and subtracts the base; a remainder at or below negative base decrements the quotient and adds the base. Cache the corrected quotient and remainder bytes.
-6. Convert only the corrected quotient and remainder to `number`, take their `number`-level absolute values, and render each through the fast small-number digit loop.
-7. Left-pad the rendered remainder to exactly nine characters with zeroes and concatenate `head + tail`. Prefix the sign once around the completed unsigned string.
+```java
+final long value = new Dataized(this.take("value")).take(Long.class);
+return new Data.ToPhi(new BytesOf(Long.toString(value)).take());
+```
 
-For example, `9223372036854774784` splits into `9223372036 | 854774784`, `38802277692848472` into `38802277 | 692848472`, `10000000000000000` into `10000000 | 000000000`, and `9007199254740992` into `9007199 | 254740992`. The signed minimum splits into `-9223372036 | -854775808`; the chunks are rendered by magnitude and the result receives one leading minus sign.
+`Dataized.take(Long.class)` requires exactly eight bytes and decodes them as a signed Java `long`; wrong-width input raises `ExFailure`. `Long.toString(long)` is locale-independent and handles both signed extrema without an intermediate negation. `BytesOf(String)` produces UTF-8, and `Data.ToPhi(byte[])` returns an object compatible with the declared `Q.bytes` forma.
 
-The algorithm deliberately never negates the complete input, so `-9223372036854775808` remains representable throughout.
+The atom must never return `new Data.ToPhi(value)` or any other `Number`. `Data.ToPhi(Number)` converts through `doubleValue()`, which would destroy precision above `2^53` and defeat the purpose of the atom.
 
-Fractional inputs continue to truncate toward zero because `number.as-i64` already defines that behavior.
+### `string.as-fixed`
 
-### Callers
+Places validation remains first. After it succeeds, one narrow helper handles a finite negative value whose magnitude is at least `2^53`. Such a value is integral on the IEEE-754 grid, so the helper passes the signed `n` directly to `as-decimal`. It returns only those digits for `places = 0`; otherwise it appends `.` and exactly `places` zeroes. The helper never evaluates `n.times -1`.
 
-No new formatting branch will be added to `string.printf`:
+All smaller magnitudes retain the existing rounding path and sign-dropping behavior for values that round to zero. The shortcut is explicitly finite, so `nan` and infinities continue through the deliberate existing non-finite path.
 
-- `%d` continues to apply its long-range guard and delegates to `string.as-decimal`.
-- `%f` continues through `string.as-fixed`. After validating `places`, a finite negative value with magnitude at least `2^53` is already integral as a double, so `as-fixed` renders that signed integer directly through `string.as-decimal` and appends a decimal point plus exactly `places` zeroes when `places > 0`. A zero precision returns only the signed integer. Smaller magnitudes retain the existing rounding path.
-
-This keeps width, zero padding, precision parsing, and failure propagation unchanged.
+No production branch is added to `string.printf`; its width, zero-padding, precision parsing, and failure propagation remain unchanged.
 
 ## Error behavior
 
 - `nan`, positive infinity, and negative infinity terminate with the existing non-finite decimal error.
 - Positive values at or above `2^63` and values below `-2^63` terminate before `number.as-i64` is invoked.
-- `%d` retains its existing long-range diagnostic.
-- `%f` continues to propagate the decimal conversion failure through `string.as-fixed` when its integer part is outside the supported range.
-- `nan` and infinities still reach deliberate non-finite handling; the signed-large shortcut is restricted to finite values.
+- `%d` retains its existing range diagnostic.
+- `%f` continues to propagate decimal conversion failure through `string.as-fixed` for an unsupported integer part.
+- A direct atom application with anything other than eight bytes raises `ExFailure` during `take(Long.class)`.
+- No fallback rounds an out-of-range value, emits partial digits, or converts through `double` after the `i64` boundary.
 
-No fallback will silently round an out-of-range value or emit a partial string.
+## Node parity debt
 
-## Tests
+This branch intentionally implements only `EOas_decimal$EOfrom_i64.java`. The archived `eo2js` runtime would require a separate `string/as-decimal$from-i64` JavaScript atom using `BigInt` decoding and string output. Without that file, executing this object under Node will fail atom lookup even though the conventional `+rt node` metadata remains present.
 
-Tests will be added before the implementation and observed failing for the current `2^53` guard.
+That cross-runtime gap is explicit debt and must be tracked and resolved in a separate Node-parity issue against the archived/runtime successor project. It is excluded here because it requires changes outside this repository, package publication, and restored parity testing. This JVM-only branch must not be presented as Node-compatible.
 
-`string.as-decimal` coverage will include:
+## Tests and performance gates
 
-- `2^53` and `1e16` rendering successfully;
-- an exactly representable value that the old floating-point digit loop renders incorrectly;
-- a value near the positive `2^63` boundary;
-- the signed lower boundary without whole-value negation overflow;
-- continued truncation of positive and negative fractions;
-- rejection of non-finite and out-of-range values;
-- positive and negative seams at `999_999_999`, `1_000_000_000`, `1_000_000_001`, and `1_000_000_042`;
-- fractional truncation on the large path.
+Direct Java tests are written and committed before the Java atom exists. They cover `Long.MIN_VALUE`, `Long.MAX_VALUE`, zero, ordinary positive and negative values, `38802277692848472`, rejection of a non-eight-byte input with `ExFailure`, and a returned forma of `Φ.bytes`. The same direct test and focused EO classes run once with `-Deo.typing=true` so the `/Q.bytes` declaration is checked.
 
-`string.printf` coverage will include the issue examples:
+Validation proceeds in increasing scope under JDK 21:
 
-- `%d` with `9007199254740992` and `1.0e16`;
-- `%f` with `9007199254740992`;
-- `%.2f` and `%.0f` with `1.0e16`;
-- `%d`, `%f`, and `%.0f` with `-2^63`.
-
-Performance verification is an acceptance gate, not only a correctness check. After generated test names are inspected, the signed-minimum regression will run alone and its Surefire testcase duration must be below ten seconds, with a substantially lower result preferred. The seam regressions and the largest-positive/signed-minimum pair will then run before the exact focused `EOas_decimalTest`, `EOas_fixedTest`, and `EOprintfTest` classes. The timeout will not be weakened to accommodate the implementation.
-
-The rejected per-digit experiment established the baseline for this gate: `EOas_decimalTest` reported `21` tests with `5` errors, and `EOprintfTest` reported `49` tests with `1` error; all six errors were 20-minute timeouts. The other 64 focused tests passed. The timeout will not be weakened to accommodate the implementation.
+1. Run the direct Java atom test.
+2. Run `EOas_decimalTest#can_write_the_long_minimum` alone. It must pass and its Surefire testcase duration must be less than ten seconds; the timeout is not weakened.
+3. Run the positive and negative base-seam methods and the largest-positive/signed-minimum pair.
+4. Run exactly `EOas_decimalTest`, `EOas_fixedTest`, and `EOprintfTest` and record their counts and timings.
+5. Run the direct atom test plus those three focused classes with `-Deo.typing=true`.
+6. If practical, run the module unit suite and record any unrelated Windows `SyscallTest` baseline failure without weakening or hiding it.
 
 ## Acceptance criteria
 
-- All issue examples below `2^63` produce the expected decimal strings.
-- The known old-algorithm counterexample renders every digit correctly.
-- Existing small-number formatting, truncation, padding, and precision behavior remains unchanged.
-- Chunk tails are padded to exactly nine digits, including an all-zero tail.
-- The signed minimum renders correctly without whole-value negation.
-- The quotient/remainder seams render correctly on both sides of zero, and a large fraction still truncates toward zero.
-- Non-finite and out-of-range cases still fail deliberately.
-- The signed-minimum testcase completes in less than ten seconds, and the seam and paired boundary runs pass without weakening timeouts.
-- The focused `EOas_decimalTest`, `EOas_fixedTest`, and `EOprintfTest` classes pass with zero failures and zero errors.
+- All issue examples below positive `2^63` produce the exact expected decimal string.
+- The known old-algorithm counterexample and both signed extrema are exact.
+- Existing small-number formatting, truncation, padding, precision, and deliberate failures remain unchanged.
+- A negative fraction truncating to zero renders `0`.
+- The direct atom rejects wrong-width input and returns UTF-8 bytes with forma `Φ.bytes`.
+- The isolated signed-minimum testcase is below ten seconds.
+- All focused classes pass in ordinary and typing modes.
+- Production changes are limited to `as-decimal.eo`, `as-fixed.eo`, and the new Java atom; `printf.eo` contains only its already committed tests.
+- The JVM-only exception and separate Node parity debt remain explicit in the design, plan, and review handoff.

--- a/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-6572-printf-long-design.md
@@ -20,12 +20,19 @@ This change will not address the separate one-ULP rounding artifact reported for
 
 ## Selected approach
 
-`string.as-decimal` will remain the single decimal-integer rendering primitive used by `printf` and `string.as-fixed`, but its digit extraction will operate on `i64` values instead of `number` arithmetic.
+`string.as-decimal` will remain the single decimal-integer rendering primitive used by `printf` and `string.as-fixed`. It will convert an accepted value to `i64` once, but it will not perform one expensive `i64` operation per decimal digit. Instead, it will use a hybrid base-`1_000_000_000` representation:
+
+- magnitudes below the base use the original fast `number`-level digit loop after the signed-long conversion;
+- larger magnitudes perform exactly one signed `i64.div` by the base, then render the quotient and remainder with that same fast loop;
+- the remainder is left-padded to exactly nine decimal characters before it is appended to the quotient.
+
+This split is exact because the absolute quotient is at most `9_223_372_036`, and the absolute remainder is at most `999_999_999`. Both values and every intermediate in their decimal digit loops are below `2^53` and therefore exactly representable as `number`.
 
 The alternatives were rejected as follows:
 
 - A `printf`-local formatter would duplicate `string.as-decimal` and require a second path through `string.as-fixed` for `%f`.
 - Merely widening the existing guard to `2^63` would allow known floating-point digit corruption.
+- Repeated signed `i64.div 10` is semantically plausible but too slow in pure EO. Even after quotient and remainder caching, five large `EOas_decimalTest` cases and one `EOprintfTest` case each hit the 20-minute JUnit timeout. The other 64 focused tests passed, isolating the problem to the intrinsic cost of per-digit `i64` division rather than range or formatting semantics.
 
 ## Design
 
@@ -37,14 +44,20 @@ The conversion will not rely on the fallback message inside `number.as-i64`, bec
 
 ### Exact digit extraction
 
-The internal digit routine will use exact `i64` operations:
+After the range guards, `n.as-i64` is dataized and cached once as `integer!`. Every typed use redecorates those cached bytes as `i64 integer`; the implementation must not accidentally invoke `n.as-i64` again.
 
-1. Divide the current signed integer by `10.as-i64`; `i64.div` truncates toward zero.
-2. Compute the signed remainder as `current - quotient * 10`.
-3. Negate only the single-digit remainder when it is negative, then convert that value to `number` and add the ASCII offset.
-4. If the quotient is zero, return that digit; otherwise recurse on the quotient and append the digit, producing most-significant-first order.
+The internal digit routine works as follows:
 
-The algorithm deliberately does not negate the complete input. A minus sign is prefixed only when the original input is negative and its truncated `i64` value is nonzero. This allows the signed minimum value to render without overflowing `i64`, while a negative fraction that truncates to zero remains `0`.
+1. Determine the sign from the truncated `i64` value. A minus sign is emitted only when `i64 integer` is negative, so a negative fraction that truncates to zero remains `0`.
+2. When the accepted magnitude is below `1_000_000_000`, convert the safe truncated integer to `number`, take its `number`-level absolute value, and render it with the original division-by-ten digit loop.
+3. Otherwise, divide `i64 integer` exactly once by `1_000_000_000.as-i64` and cache the quotient bytes.
+4. Compute the signed remainder exactly as `integer - quotient * 1_000_000_000`, caching and redecorating typed intermediates. An established two's-complement `not`-plus-one subtraction pattern may be used instead of `i64.minus` to avoid its multiply-by-minus-one implementation.
+5. Convert only the quotient and remainder to `number`, take their `number`-level absolute values, and render each through the fast small-number digit loop.
+6. Left-pad the rendered remainder to exactly nine characters with zeroes and concatenate `head + tail`. Prefix the sign once around the completed unsigned string.
+
+For example, `9223372036854774784` splits into `9223372036 | 854774784`, `38802277692848472` into `38802277 | 692848472`, `10000000000000000` into `10000000 | 000000000`, and `9007199254740992` into `9007199 | 254740992`. The signed minimum splits into `-9223372036 | -854775808`; the chunks are rendered by magnitude and the result receives one leading minus sign.
+
+The algorithm deliberately never negates the complete input, so `-9223372036854775808` remains representable throughout.
 
 Fractional inputs continue to truncate toward zero because `number.as-i64` already defines that behavior.
 
@@ -85,13 +98,17 @@ Tests will be added before the implementation and observed failing for the curre
 - `%f` with `9007199254740992`;
 - `%.2f` and `%.0f` with `1.0e16`.
 
-Verification will use targeted `eo-runtime` tests first, followed by the module-level build. The clean `master` baseline has one unrelated Windows environment failure in `SyscallTest`: this machine accepts a connection to `192.0.2.1` where the test expects refusal. That failure will be recorded separately from any regression introduced by this change.
+Performance verification is an acceptance gate, not only a correctness check. After generated test names are inspected, the signed-minimum regression will run alone and its Surefire testcase duration must be below five minutes. The largest positive and signed-minimum regressions will then run together to expose contention; both must pass without approaching the 20-minute JUnit limit. Only after those gates pass will the exact focused `EOas_decimalTest` and `EOprintfTest` command run. It must report `21` and `49` tests respectively, with zero failures and zero errors.
+
+The rejected per-digit experiment established the baseline for this gate: `EOas_decimalTest` reported `21` tests with `5` errors, and `EOprintfTest` reported `49` tests with `1` error; all six errors were 20-minute timeouts. The other 64 focused tests passed. The timeout will not be weakened to accommodate the implementation.
 
 ## Acceptance criteria
 
 - All issue examples below `2^63` produce the expected decimal strings.
 - The known old-algorithm counterexample renders every digit correctly.
 - Existing small-number formatting, truncation, padding, and precision behavior remains unchanged.
+- Chunk tails are padded to exactly nine digits, including an all-zero tail.
+- The signed minimum renders correctly without whole-value negation.
 - Non-finite and out-of-range cases still fail deliberately.
-- Targeted tests pass with no failures or errors.
-- Module verification introduces no failures beyond the documented `SyscallTest` baseline failure.
+- The signed-minimum testcase completes in less than five minutes, and the paired positive/negative boundary run completes comfortably below the existing 20-minute per-test timeout.
+- The focused suite reports `EOas_decimalTest` as `21/0F/0E` and `EOprintfTest` as `49/0F/0E` without weakening timeouts.

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -60,6 +60,11 @@
     string
       as-decimal 42.987
 
+  eq. ++> can-write-a-large-exact-counterexample
+    "38802277692848472"
+    string
+      as-decimal 38802277692848472
+
   eq. ++> can-write-a-multi-digit-number
     "31415"
     string
@@ -80,17 +85,37 @@
     string
       as-decimal 7
 
+  eq. ++> can-write-ten-to-the-16th
+    "10000000000000000"
+    string
+      as-decimal 10000000000000000
+
+  eq. ++> can-write-the-largest-double-below-the-long-maximum
+    "9223372036854774784"
+    string
+      as-decimal 9223372036854774784
+
   eq. ++> can-write-the-largest-exactly-representable-magnitude
     "9007199254740991"
     string
       as-decimal 9007199254740991
+
+  eq. ++> can-write-the-long-minimum
+    "-9223372036854775808"
+    string
+      as-decimal -9.223372036854776e18
+
+  eq. ++> can-write-two-to-the-53rd
+    "9007199254740992"
+    string
+      as-decimal 9007199254740992
 
   eq. ++> can-write-zero
     "0"
     string
       as-decimal 0
 
-  as-decimal 9007199254740992 --> stops-on-a-magnitude-of-two-to-the-53rd
+  as-decimal -9.223372036854778e18 --> stops-below-the-long-minimum-boundary
 
   as-decimal 1.0e30 --> stops-on-a-magnitude-too-large-to-represent-exactly
 
@@ -99,3 +124,5 @@
   as-decimal ninf --> stops-on-negative-infinity
 
   as-decimal pinf --> stops-on-positive-infinity
+
+  as-decimal 9.223372036854776e18 --> stops-on-the-long-maximum-boundary

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -13,32 +13,55 @@
     T
       "Can't write a non-finite number as decimal"
     if.
-      n.abs.gte 9007199254740992
+      or.
+        n.gte 9.223372036854776e18
+        n.lt -9.223372036854776e18
       T
-        "Can't write this number as decimal digits exactly: its magnitude is 2^53 or larger, past the largest integer a double can hold exactly"
+        "Can't write this number as decimal digits: it is outside the signed 64-bit range"
       if.
-        n.lt 0
-        if. > [m] >> negative
-          m.floor.eq 0
-          digits m
-          "-".as-bytes.concat
-            digits m
-        | (n.times -1)
-        [n] >> digits
-          if. > @
-            n.lt 10
-            as-char
-              n.floor.plus 48
-            concat.
-              digits q
-              as-char
-                plus.
-                  floor.
-                    n.minus (q.times 10)
-                  48
-          floor. > q
-            n.div 10
-        | n
+        lt.
+          i64 integer
+          0.as-i64
+        "-".as-bytes.concat unsigned
+        unsigned
+  n.as-i64 > integer!
+  times. > product!
+    i64 quotient
+    1000000000.as-i64
+  div. > quotient!
+    i64 integer
+    1000000000.as-i64
+  plus. > remainder!
+    i64 integer
+    plus.
+      i64 (i64 product).as-bytes.not
+      1.as-i64
+  if. > unsigned
+    n.abs.lt 1000000000
+    [value] >> small-digits
+      if. > @
+        value.lt 10
+        as-char
+          value.floor.plus 48
+        concat.
+          small-digits q
+          as-char
+            plus.
+              floor.
+                value.minus
+                  q.times 10
+              48
+      floor. > q
+        value.div 10
+    | (i64 integer).as-number.abs
+    concat.
+      small-digits (i64 quotient).as-number.abs
+      as-bytes.
+        padded-left
+          string
+            small-digits (i64 remainder).as-number.abs
+          9
+          "0"
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -4,6 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -13,55 +15,18 @@
     T
       "Can't write a non-finite number as decimal"
     if.
-      or.
-        n.gte 9.223372036854776e18
-        n.lt -9.223372036854776e18
+      n.gte 9.223372036854776e18
       T
         "Can't write this number as decimal digits: it is outside the signed 64-bit range"
       if.
-        lt.
+        n.lt -9.223372036854776e18
+        T
+          "Can't write this number as decimal digits: it is outside the signed 64-bit range"
+        from-i64
           i64 integer
-          0.as-i64
-        "-".as-bytes.concat unsigned
-        unsigned
+  [] > from-i64 /Q.bytes
+    ? > value /Q.i64
   n.as-i64 > integer!
-  times. > product!
-    i64 quotient
-    1000000000.as-i64
-  div. > quotient!
-    i64 integer
-    1000000000.as-i64
-  plus. > remainder!
-    i64 integer
-    plus.
-      i64 (i64 product).as-bytes.not
-      1.as-i64
-  if. > unsigned
-    n.abs.lt 1000000000
-    [value] >> small-digits
-      if. > @
-        value.lt 10
-        as-char
-          value.floor.plus 48
-        concat.
-          small-digits q
-          as-char
-            plus.
-              floor.
-                value.minus
-                  q.times 10
-              48
-      floor. > q
-        value.div 10
-    | (i64 integer).as-number.abs
-    concat.
-      small-digits (i64 quotient).as-number.abs
-      as-bytes.
-        padded-left
-          string
-            small-digits (i64 remainder).as-number.abs
-          9
-          "0"
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"

--- a/eo-runtime/src/main/eo/string/as-decimal.eo
+++ b/eo-runtime/src/main/eo/string/as-decimal.eo
@@ -73,6 +73,11 @@
     string
       as-decimal -0.5
 
+  eq. ++> can-truncate-a-large-positive-fraction
+    "1000000042"
+    string
+      as-decimal 1.00000004275E9
+
   eq. ++> can-truncate-a-negative-fraction
     "-7"
     string
@@ -107,6 +112,46 @@
     "7"
     string
       as-decimal 7
+
+  eq. ++> can-write-negative-value-at-the-chunk-base
+    "-1000000000"
+    string
+      as-decimal -1000000000
+
+  eq. ++> can-write-negative-value-below-the-chunk-base
+    "-999999999"
+    string
+      as-decimal -999999999
+
+  eq. ++> can-write-negative-value-forty-two-past-the-chunk-base
+    "-1000000042"
+    string
+      as-decimal -1000000042
+
+  eq. ++> can-write-negative-value-one-past-the-chunk-base
+    "-1000000001"
+    string
+      as-decimal -1000000001
+
+  eq. ++> can-write-positive-value-at-the-chunk-base
+    "1000000000"
+    string
+      as-decimal 1000000000
+
+  eq. ++> can-write-positive-value-below-the-chunk-base
+    "999999999"
+    string
+      as-decimal 999999999
+
+  eq. ++> can-write-positive-value-forty-two-past-the-chunk-base
+    "1000000042"
+    string
+      as-decimal 1000000042
+
+  eq. ++> can-write-positive-value-one-past-the-chunk-base
+    "1000000001"
+    string
+      as-decimal 1000000001
 
   eq. ++> can-write-ten-to-the-16th
     "10000000000000000"

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -21,40 +21,54 @@
       "Can't write a fixed-point decimal with %f fraction places".printf
         * places
     if.
-      n.lt 0
-      if. > [a] >> signed
-        eq.
-          floor.
-            plus.
-              a.times
-                pow10 places
-              0.5
-          0
-        positive a
-        "-".as-bytes.concat
-          positive a
-      | (n.times -1)
-      [a] >> positive
-        if. > @
-          places.eq 0
-          as-decimal ip
+      n.is-finite.and
+        and.
+          n.lt 0
+          n.abs.gte 9007199254740992
+      if. > [a] >> signed-large
+        places.eq 0
+        as-decimal a
+        concat.
           concat.
-            concat.
-              as-decimal ip
-              ".".as-bytes
-            rec-pad
-              m.minus
-                ip.times scale
-              places
-              --
-        floor. > ip
-          m.div scale
-        floor. > m
-          plus.
-            a.times scale
-            0.5
-        pow10 places > scale
+            as-decimal a
+            ".".as-bytes
+          rec-pad 0 places --
       | n
+      if.
+        n.lt 0
+        if. > [a] >> signed
+          eq.
+            floor.
+              plus.
+                a.times
+                  pow10 places
+                0.5
+            0
+          positive a
+          "-".as-bytes.concat
+            positive a
+        | (n.times -1)
+        [a] >> positive
+          if. > @
+            places.eq 0
+            as-decimal ip
+            concat.
+              concat.
+                as-decimal ip
+                ".".as-bytes
+              rec-pad
+                m.minus
+                  ip.times scale
+                places
+                --
+          floor. > ip
+            m.div scale
+          floor. > m
+            plus.
+              a.times scale
+              0.5
+          pow10 places > scale
+        | n
   if. > [p] >> pow10
     p.eq 0
     1

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -22,9 +22,7 @@
         * places
     if.
       n.is-finite.and
-        and.
-          n.lt 0
-          n.abs.gte 9007199254740992
+        n.abs.gte 9007199254740992
       if. > [a] >> signed-large
         places.eq 0
         as-decimal a

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -462,6 +462,36 @@
       "first"
       "second"
 
+  eq. ++> can-format-ten-to-the-16th-as-an-integer
+    "10000000000000000"
+    printf *1
+      "%d"
+      10000000000000000
+
+  eq. ++> can-format-ten-to-the-16th-with-two-fraction-digits
+    "10000000000000000.00"
+    printf *1
+      "%.2f"
+      10000000000000000
+
+  eq. ++> can-format-ten-to-the-16th-without-fraction-digits
+    "10000000000000000"
+    printf *1
+      "%.0f"
+      10000000000000000
+
+  eq. ++> can-format-two-to-the-53rd-as-a-float
+    "9007199254740992.000000"
+    printf *1
+      "%f"
+      9007199254740992
+
+  eq. ++> can-format-two-to-the-53rd-as-an-integer
+    "9007199254740992"
+    printf *1
+      "%d"
+      9007199254740992
+
   eq. ++> can-ignore-extra-arguments
     "Hey"
     printf *1

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -480,6 +480,24 @@
       "%.0f"
       10000000000000000
 
+  eq. ++> can-format-the-long-minimum-as-a-float
+    "-9223372036854775808.000000"
+    printf *1
+      "%f"
+      -9.223372036854776e18
+
+  eq. ++> can-format-the-long-minimum-as-an-integer
+    "-9223372036854775808"
+    printf *1
+      "%d"
+      -9.223372036854776e18
+
+  eq. ++> can-format-the-long-minimum-without-fraction-digits
+    "-9223372036854775808"
+    printf *1
+      "%.0f"
+      -9.223372036854776e18
+
   eq. ++> can-format-two-to-the-53rd-as-a-float
     "9007199254740992.000000"
     printf *1

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -439,6 +439,12 @@
       "%f"
       0
 
+  eq. ++> can-format-large-positive-integer-exactly-as-float
+    "1369471683233246720.000000"
+    printf *1
+      "%f"
+      1369471683233246720
+
   eq. ++> can-format-left-justified-with-trailing-spaces
     "x         "
     printf *1

--- a/eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java
+++ b/eo-runtime/src/main/java/org/eolang/EO_string/EOas_decimal$EOfrom_i64.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD
+
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Attrs;
+import org.eolang.BytesOf;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * String.as-decimal.from-i64 object.
+ * @since 0.74.0
+ * @checkstyle IllegalIdentifierNameCheck (6 lines)
+ * @checkstyle TypeNameCheck (5 lines)
+ */
+@XmirObject(oname = "as-decimal.from-i64")
+@SuppressWarnings("PMD.AvoidDollarSigns")
+public final class EOas_decimal$EOfrom_i64 extends PhDefault implements Atom {
+
+    /**
+     * Ctor.
+     */
+    public EOas_decimal$EOfrom_i64() {
+        super(new Attrs(new Attr("value", new AtVoid("value"))));
+    }
+
+    @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    public Phi lambda() {
+        final long value = new Dataized(this.take("value")).take(Long.class);
+        return new Data.ToPhi(new BytesOf(Long.toString(value)).take());
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOas_decimalEOfrom_i64Test.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD
+
+import org.eolang.BytesOf;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.ExFailure;
+import org.eolang.PhApplication;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link EOas_decimal$EOfrom_i64}.
+ * @since 0.74.0
+ */
+final class EOas_decimalEOfrom_i64Test {
+
+    @ParameterizedTest
+    @CsvSource({
+        "-9223372036854775808, -9223372036854775808",
+        "9223372036854775807, 9223372036854775807",
+        "0, 0",
+        "42, 42",
+        "-42, -42",
+        "38802277692848472, 38802277692848472"
+    })
+    void convertsSignedLongToDecimalBytes(final long input, final String expected) {
+        MatcherAssert.assertThat(
+            "signed i64 bytes must become exact decimal UTF-8 bytes",
+            new Dataized(EOas_decimalEOfrom_i64Test.application(input)).asString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void rejectsWrongWidthInput() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new Dataized(
+                EOas_decimalEOfrom_i64Test.application(
+                    new Data.ToPhi(new byte[]{0x00})
+                )
+            ).take(),
+            "an i64 atom must reject input that is not exactly eight bytes"
+        );
+    }
+
+    @Test
+    void returnsBytes() {
+        MatcherAssert.assertThat(
+            "the atom result must honor its declared Q.bytes forma",
+            EOas_decimalEOfrom_i64Test.application(42L).take(Phi.LAMBDA).forma(),
+            Matchers.equalTo("Φ.bytes")
+        );
+    }
+
+    /**
+     * Apply the atom to exact signed-long bytes.
+     * @param value Signed long
+     * @return Atom application
+     */
+    private static Phi application(final long value) {
+        return EOas_decimalEOfrom_i64Test.application(
+            new Data.ToPhi(new BytesOf(value).take())
+        );
+    }
+
+    /**
+     * Apply the atom to the provided object.
+     * @param value Value object
+     * @return Atom application
+     */
+    private static Phi application(final Phi value) {
+        return new PhApplication(
+            new EOas_decimal$EOfrom_i64(), "value", value
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- replace the `2^53` decimal-formatting cliff with an exact signed-`i64` to UTF-8 decimal JVM atom
- preserve finite/range/truncation guards and format large positive and negative integers without precision-losing double scaling
- add regressions for `2^53`, signed-long seams and extrema, the reported counterexample, `%d`, `%f`, and `%.0f`

## Root cause

`string.as-decimal` rejected every magnitude at or above `2^53`, although many such doubles represent exact signed 64-bit integers. In addition, `string.as-fixed` scaled large positive values through double multiplication/division, which could change their integer part. Pure-EO `i64` decimal conversion variants were exact but too slow for runtime formatting, so this change keeps EO validation and uses a narrow JVM atom for the final `long` conversion.

Fixes #6572.

## Validation

- JDK 21 typing-enabled focused suite: 107 tests, 0 failures, 0 errors
- isolated signed-long minimum decimal case: 0.344 s
- positive `%f` regression verified RED as `+256` drift, then GREEN after the fix
- final diff and worktree hygiene checks pass
- wider module run completed 1,483 tests before the external 30-minute Windows limit; its only failure was the existing Windows `SyscallTest` behavior

Qulice currently reports one PMD `PreserveStackTrace` violation in `Deadline.java`; that file is byte-identical to `upstream/master` and comes from upstream commit `a5b94c92`, not this PR.

## Compatibility note

This PR implements the atom for the JVM runtime. The corresponding eo2js/Node atom is not included, so cross-runtime parity remains follow-up work and is not claimed here.