### PR TITLE
Clamp a negative shift in tuple.shifted

### DIFF
--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -41,7 +41,7 @@
       6
     *
 
-  eq. ++> dont-shift-by-a-negative-number
+  eq. ++> can-ignore-a-negative-shift
     shifted
       *
         "привет"
@@ -55,7 +55,7 @@
       0
       "ξ"
 
-  eq. ++> dont-shift-by-a-number-below-the-negative-length
+  eq. ++> can-ignore-a-shift-below-the-negative-length
     shifted
       *
         82.42
@@ -67,7 +67,7 @@
       ""
       "日本"
 
-  eq. ++> dont-shift-by-zero
+  eq. ++> can-ignore-a-zero-shift
     shifted
       *
         "a"

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -16,31 +16,6 @@
       shift
     list.length
 
-  eq. ++> can-shift-by-less-than-the-length
-    shifted
-      *
-        8
-        2
-        3
-        4
-        5
-      2
-    *
-      3
-      4
-      5
-
-  eq. ++> can-shift-by-more-than-the-length
-    shifted
-      *
-        8
-        2
-        3
-        4
-        5
-      6
-    *
-
   eq. ++> can-ignore-a-negative-shift
     shifted
       *
@@ -78,3 +53,28 @@
       "a"
       -0.5
       "Ω"
+
+  eq. ++> can-shift-by-less-than-the-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      2
+    *
+      3
+      4
+      5
+
+  eq. ++> can-shift-by-more-than-the-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      6
+    *

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -1,4 +1,4 @@
-# Drop the first `shift` elements of `list`.
+# Drop the first `shift` elements of `list` (a negative `shift` drops nothing).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -10,7 +10,10 @@
 [list shift] > shifted
   slice > @
     list
-    shift
+    if.
+      shift.lt 0
+      0
+      shift
     list.length
 
   eq. ++> can-shift-by-less-than-the-length
@@ -37,3 +40,41 @@
         5
       6
     *
+
+  eq. ++> dont-shift-by-a-negative-number
+    shifted
+      *
+        "привет"
+        -42
+        0
+        "ξ"
+      -1
+    *
+      "привет"
+      -42
+      0
+      "ξ"
+
+  eq. ++> dont-shift-by-a-number-below-the-negative-length
+    shifted
+      *
+        82.42
+        ""
+        "日本"
+      -9
+    *
+      82.42
+      ""
+      "日本"
+
+  eq. ++> dont-shift-by-zero
+    shifted
+      *
+        "a"
+        -0.5
+        "Ω"
+      0
+    *
+      "a"
+      -0.5
+      "Ω"


### PR DESCRIPTION
`tuple.shifted` handed `shift` straight to `tuple.slice`, and `slice` wraps a negative index around to the end of the list. So `shifted` did the opposite of what its docstring promises: `(tuple 1 2 3).shifted -1` returned `[3]` rather than dropping nothing.

A negative shift is now clamped to zero, so the whole list comes back unchanged. Rejecting it outright was the other option the issue offered, but nothing in the `tuple` package raises an error for an out-of-range index — `slice`, `back` and `front` all clamp or wrap — so clamping keeps `shifted` in line with its siblings. The docstring now says so too.

Three tests cover the boundary: a shift of `-1`, a shift below the negative length, and a shift of zero, which nothing tested before.

Closes #6570
