### PR TITLE
Leave a formation that delegates through φ incomplete

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -86,12 +86,10 @@ final class Provides implements Clue {
         int seen = 0;
         for (final XML formation : new Xmirs(xmirs).formations()) {
             final String owner = formation.xpath("@loc").get(0);
+            final boolean whole = formation.nodes("o[@name='λ' or @name='φ']").isEmpty();
             rows.add(owner)
                 .set("index", Integer.toString(seen))
-                .set(
-                    "complete",
-                    Boolean.toString(formation.nodes("o[@name='λ' or @name='φ']").isEmpty())
-                );
+                .set("complete", Boolean.toString(whole));
             seen = seen + 1;
             for (final XML attr : formation.nodes("o[@name and not(@name='λ')]")) {
                 final String name = attr.xpath("@name").get(0);

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -51,7 +51,9 @@ import java.nio.file.Path;
  * the checker honest later: a missing attribute is a mistake only when
  * the object that misses it is complete. An atom is not complete, since
  * its {@code λ} attribute stands for a body written in Java, which this
- * module cannot read.</p>
+ * module cannot read. Neither is a formation that binds {@code φ}: what
+ * it delegates to answers for every name it does not bind itself, and
+ * that object is the business of the links table, not of this one.</p>
  *
  * <p>Three kinds of objects are deliberately absent from this table.
  * Applications and references (anything with a {@code @base}) provide
@@ -63,6 +65,18 @@ import java.nio.file.Path;
  * outside one day, and until they are, the checker simply knows less.</p>
  *
  * @since 0.67.0
+ * @todo #6565:35min Account for attributes reached through the package.
+ *  An attribute of {@code Φ.number} like {@code minus} lives in the same
+ *  package as a top-level object {@code Φ.number.minus}, so it never
+ *  shows up among the children of the formation and this table calls the
+ *  object complete while listing a strict subset of what it has. Either
+ *  write those package members down as attributes of their owner, or
+ *  leave the owner incomplete until they are.
+ * @todo #6565:35min Write down the {@code ρ} every object has. An outer
+ *  name lowers to a dispatch of {@code ρ}, so the needs table asks for
+ *  it, while no row here ever lists it and the owner is called complete
+ *  all the same. Give every type a {@code ρ} attribute, or say in this
+ *  table that {@code ρ} is not a name the checker judges.
  */
 final class Provides implements Clue {
 
@@ -74,7 +88,10 @@ final class Provides implements Clue {
             final String owner = formation.xpath("@loc").get(0);
             rows.add(owner)
                 .set("index", Integer.toString(seen))
-                .set("complete", Boolean.toString(formation.nodes("o[@name='λ']").isEmpty()));
+                .set(
+                    "complete",
+                    Boolean.toString(formation.nodes("o[@name='λ' or @name='φ']").isEmpty())
+                );
             seen = seen + 1;
             for (final XML attr : formation.nodes("o[@name and not(@name='λ')]")) {
                 final String name = attr.xpath("@name").get(0);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-is-not-complete.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-is-not-complete.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A formation that binds `φ` answers every name it does not bind itself through
+# the object it delegates to, and that object is nowhere in this table. Here
+# `holder.extra` resolves at runtime through `φ → base → extra`, while the row
+# of `holder` lists only `φ` and `base`, so the object is not complete and
+# nothing about it will ever be reported.
+eo:
+  app.eo: |
+    [] > app
+      holder.extra > @
+      [] > holder
+        base > @
+        [] > base
+          [] > extra
+provides:
+  - "/provides/type[@id='Φ.app.holder' and @complete='false']"
+  - "/provides/type[@id='Φ.app.holder.base.extra' and @complete='true']"


### PR DESCRIPTION
`Provides` decided that a formation is complete by looking for a `λ` child alone, so any formation that delegates through `φ` was written down as complete while its row listed only the attributes it binds itself. In the snippet from the issue, `Φ.app.holder` came out complete with `φ` and `base` on it, and the checker would call `holder.extra` a mistake even though it resolves at runtime through `φ → base → extra`.

Now a formation is complete only when it binds neither `λ` nor `φ`. What sits behind the decoratee is the business of the links table, so until the checker follows those links, an object that delegates says nothing and the checker stays silent about it rather than wrong.

Two parts of the report are left as puzzles: attributes that live in the owner's package as top-level objects (`Φ.number.minus` and friends), and the `ρ` that every object has but no row lists.

Closes #6565
