### PR TITLE
Hash directories through Sha instead of Cache

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -5,15 +5,9 @@
 package org.eolang.maven;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-import java.util.Comparator;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import org.cactoos.Func;
 import org.cactoos.func.UncheckedFunc;
 
@@ -120,51 +114,11 @@ final class Cache {
      * @return Base64-encoded SHA-256 hash of the file or directory contents
      */
     private String sha(final Path any) {
-        final String result;
-        if (Files.isDirectory(any)) {
-            result = this.dirSha(any);
-        } else if (Files.isRegularFile(any)) {
-            result = new Sha(any).toString();
-        } else {
+        if (!Files.isDirectory(any) && !Files.isRegularFile(any)) {
             throw new IllegalArgumentException(
                 String.format("Path '%s' is neither a regular file nor a directory", any)
             );
         }
-        return result;
-    }
-
-    /**
-     * Calculate SHA-256 hash of a directory by hashing all regular files inside it.
-     * @param dir Directory path
-     * @return Base64-encoded SHA-256 hash of the directory contents
-     * @todo #5254:30min Hash directories through Sha instead of here.
-     *  This method now frames every file the same way Sha does, so the two
-     *  digests agree, yet it stays because Sha hashes every file it walks
-     *  while this one drops the ones the filter rejects. Teach Sha to take
-     *  that filter and let this method delegate the whole walk to it.
-     */
-    private String dirSha(final Path dir) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            try (Stream<Path> stream = Files.walk(dir)) {
-                stream.filter(Files::isRegularFile)
-                    .filter(this.filter)
-                    .sorted(Comparator.comparing(Path::toString))
-                    .map(p -> String.format("%s\0%s", dir.relativize(p), new Sha(p)))
-                    .map(s -> s.getBytes(StandardCharsets.UTF_8))
-                    .forEach(digest::update);
-            }
-            return Base64.getEncoder().encodeToString(digest.digest());
-        } catch (final NoSuchAlgorithmException exception) {
-            throw new IllegalStateException(
-                "SHA-256 algorithm is not available for dir hashing",
-                exception
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("Failed to read directory '%s' for hashing", dir),
-                exception
-            );
-        }
+        return new Sha(any, this.filter).toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -14,11 +14,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
  * SHA-256 hash of a file or directory.
- * For a directory, hashes every file sorted by its relative path, framed by that path and by
+ * For a directory, hashes the accepted files, sorted by relative path, framed by that path and by
  * the amount of bytes read from it, so that trees differing in file names or in file boundaries
  * never collide. Only files speak into the digest, hence a directory holding none of them stays
  * invisible to the hash, the way Git also sees it.
@@ -32,11 +33,26 @@ final class Sha {
     private final Path path;
 
     /**
+     * Files that speak into the digest.
+     */
+    private final Predicate<Path> filter;
+
+    /**
      * Ctor.
      * @param path File or directory to hash
      */
     Sha(final Path path) {
+        this(path, file -> true);
+    }
+
+    /**
+     * Ctor.
+     * @param path File or directory to hash
+     * @param filter Files that speak into the digest
+     */
+    Sha(final Path path, final Predicate<Path> filter) {
         this.path = path;
+        this.filter = filter;
     }
 
     @Override
@@ -49,7 +65,7 @@ final class Sha {
     }
 
     /**
-     * Hashes all regular files reachable from the path, sorted by relative path.
+     * Hashes the accepted regular files reachable from the path, sorted by relative path.
      * A file of a directory is framed by its relative path and length, a lone file is not.
      * @return Base64-encoded SHA-256 hash
      * @throws IOException If reading fails
@@ -59,6 +75,7 @@ final class Sha {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
         try (Stream<Path> walk = Files.walk(this.path)) {
             walk.filter(Files::isRegularFile)
+                .filter(this.filter)
                 .sorted(Comparator.comparing(this::relative))
                 .forEach(file -> this.feed(digest, file));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -208,7 +208,7 @@ final class CacheTest {
     @Test
     void generatesCorrectHashForEntireFolderWithSeveralFiles(
         @Mktmp final Path temp
-    ) throws IOException, NoSuchAlgorithmException {
+    ) throws IOException {
         final Path cache = temp.resolve("cache");
         Files.createDirectories(cache);
         final Path source = temp.resolve("folder");
@@ -222,22 +222,13 @@ final class CacheTest {
             temp.resolve("out.txt"),
             source.getFileName()
         );
-        final MessageDigest instance = MessageDigest.getInstance("SHA-256");
-        instance.update(
-            String.format("file1.txt\0%s", CacheTest.hash(first))
-                .getBytes(StandardCharsets.UTF_8)
-        );
-        instance.update(
-            String.format("file2.txt\0%s", CacheTest.hash(second))
-                .getBytes(StandardCharsets.UTF_8)
-        );
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for folder with several files",
             Files.readString(
                 cache.resolve("folder.sha256"),
                 StandardCharsets.UTF_8
             ),
-            Matchers.equalTo(Base64.getEncoder().encodeToString(instance.digest()))
+            Matchers.equalTo(new Sha(source).toString())
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.function.Predicate;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -108,6 +109,21 @@ final class ShaTest {
             String.format("hashes of two identical dirs differ, seed=%d", seed),
             new Sha(temp.resolve("first")).toString(),
             Matchers.equalTo(new Sha(temp.resolve("second")).toString())
+        );
+    }
+
+    @Test
+    void keepsRejectedFilesOutOfDirHash(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        final String text = String.format("%s-Ωμέγα-съешь", Long.toHexString(seed));
+        final Predicate<Path> filter = file -> file.getFileName().toString().endsWith(".xmir");
+        new Saved(text, temp.resolve("first/a.xmir")).value();
+        new Saved(text, temp.resolve("first/nested/b.txt")).value();
+        new Saved(text, temp.resolve("second/a.xmir")).value();
+        MatcherAssert.assertThat(
+            String.format("hash of a filtered dir counts the rejected file, seed=%d", seed),
+            new Sha(temp.resolve("first"), filter).toString(),
+            Matchers.equalTo(new Sha(temp.resolve("second"), filter).toString())
         );
     }
 }


### PR DESCRIPTION
`Cache` carried its own directory hashing next to `Sha`, which already knew how to walk a tree. The two existed side by side only because `Sha` hashed every file it reached, while `Cache` had to drop the ones its filter rejected.

`Sha` now takes that filter as a second attribute and applies it during the walk, so `Cache.dirSha` is gone and `Cache.sha` hands the whole job over. Hashing a tree lives in one place again.

The digest of a directory changes shape as a result, since `Sha` frames each file by its relative path, its bytes and its length, where the old code framed it by the path and the per-file digest. Nothing persists across versions here beyond the cache itself, so the worst of it is one cold pass after the upgrade.

`CacheTest` used to spell out the old recipe byte for byte; it now asserts what `Cache` actually promises, that the marker holds the `Sha` of the source. A new test in `ShaTest` pins the filter down: a directory hashed with a filter matches a directory holding only the files that filter accepts.

Closes #6552
