### PR TITLE
#6588: fix number.mod negative zero for infinite divisor

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -28,7 +28,9 @@
     dividend.is-finite.not.if
       nan
       divisor.is-finite.not.if
-        divisor.is-nan.if nan x
+        divisor.is-nan.if
+          nan
+          x.plus 0
         if.
           gte.
             number x.as-bytes >> dividend
@@ -68,6 +70,16 @@
     mod
       5
       nan
+
+  eq. ++> can-return-positive-zero-for-negative-zero-dividend-and-negative-infinite-divisor
+    as-bytes.
+      0.neg.mod ninf
+    0.as-bytes
+
+  eq. ++> can-return-positive-zero-for-negative-zero-dividend-and-positive-infinite-divisor
+    as-bytes.
+      0.neg.mod pinf
+    0.as-bytes
 
   eq. ++> can-return-positive-zero-when-dividend-is-zero
     as-bytes.


### PR DESCRIPTION
Fixes #6588.

`number.mod` returned the dividend unchanged when the divisor is infinite. For a negative-zero dividend that meant the sign stayed negative, which contradicts the invariant #6569 already set for the finite-divisor case (zero dividend always yields positive zero).

Fix: normalize the sign with `x.plus 0` in that branch, same trick used for the finite case. IEEE-754 addition of `+0` turns `-0.0` into `+0.0` and is a no-op for every other finite value.

Added two tests that check the raw bytes of `0.neg.mod pinf` and `0.neg.mod ninf`, since plain `number.eq` treats `+0`/`-0` as equal and would hide the bug.
