### PR TITLE
#6552: hash directories through Sha instead of Cache's own loop

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -5,15 +5,9 @@
 package org.eolang.maven;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-import java.util.Comparator;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import org.cactoos.Func;
 import org.cactoos.func.UncheckedFunc;
 
@@ -137,34 +131,8 @@ final class Cache {
      * Calculate SHA-256 hash of a directory by hashing all regular files inside it.
      * @param dir Directory path
      * @return Base64-encoded SHA-256 hash of the directory contents
-     * @todo #5254:30min Hash directories through Sha instead of here.
-     *  This method now frames every file the same way Sha does, so the two
-     *  digests agree, yet it stays because Sha hashes every file it walks
-     *  while this one drops the ones the filter rejects. Teach Sha to take
-     *  that filter and let this method delegate the whole walk to it.
      */
     private String dirSha(final Path dir) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            try (Stream<Path> stream = Files.walk(dir)) {
-                stream.filter(Files::isRegularFile)
-                    .filter(this.filter)
-                    .sorted(Comparator.comparing(Path::toString))
-                    .map(p -> String.format("%s\0%s", dir.relativize(p), new Sha(p)))
-                    .map(s -> s.getBytes(StandardCharsets.UTF_8))
-                    .forEach(digest::update);
-            }
-            return Base64.getEncoder().encodeToString(digest.digest());
-        } catch (final NoSuchAlgorithmException exception) {
-            throw new IllegalStateException(
-                "SHA-256 algorithm is not available for dir hashing",
-                exception
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("Failed to read directory '%s' for hashing", dir),
-                exception
-            );
-        }
+        return new Sha(dir, this.filter).toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -14,6 +14,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -32,11 +33,26 @@ final class Sha {
     private final Path path;
 
     /**
+     * Files filter, applied only when hashing a directory.
+     */
+    private final Predicate<Path> filter;
+
+    /**
      * Ctor.
      * @param path File or directory to hash
      */
     Sha(final Path path) {
+        this(path, p -> true);
+    }
+
+    /**
+     * Ctor.
+     * @param path File or directory to hash
+     * @param filter Files filter, applied only when hashing a directory
+     */
+    Sha(final Path path, final Predicate<Path> filter) {
         this.path = path;
+        this.filter = filter;
     }
 
     @Override
@@ -59,6 +75,7 @@ final class Sha {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
         try (Stream<Path> walk = Files.walk(this.path)) {
             walk.filter(Files::isRegularFile)
+                .filter(this.filter)
                 .sorted(Comparator.comparing(this::relative))
                 .forEach(file -> this.feed(digest, file));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -223,14 +223,8 @@ final class CacheTest {
             source.getFileName()
         );
         final MessageDigest instance = MessageDigest.getInstance("SHA-256");
-        instance.update(
-            String.format("file1.txt\0%s", CacheTest.hash(first))
-                .getBytes(StandardCharsets.UTF_8)
-        );
-        instance.update(
-            String.format("file2.txt\0%s", CacheTest.hash(second))
-                .getBytes(StandardCharsets.UTF_8)
-        );
+        CacheTest.frame(instance, "file1.txt", first);
+        CacheTest.frame(instance, "file2.txt", second);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for folder with several files",
             Files.readString(
@@ -356,6 +350,23 @@ final class CacheTest {
             MessageDigest.getInstance("SHA-256")
                 .digest(content.getBytes(StandardCharsets.UTF_8))
         );
+    }
+
+    /**
+     * Feed a digest with a single file's contents, framed by its relative
+     * path and its byte length, the same way {@link Sha} frames a file
+     * inside a directory.
+     * @param digest Digest to feed
+     * @param relative Relative path of the file
+     * @param content File content
+     */
+    private static void frame(
+        final MessageDigest digest, final String relative, final String content
+    ) {
+        final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        digest.update(String.format("%s\0", relative).getBytes(StandardCharsets.UTF_8));
+        digest.update(bytes);
+        digest.update(String.format("\0%d\0", bytes.length).getBytes(StandardCharsets.UTF_8));
     }
 
     /**


### PR DESCRIPTION
Closes #6552.

Resolves the puzzle in `Cache.dirSha`. That method used to walk a directory, hash each file separately with `Sha`, then combine those per-file hashes with its own second-level digest. `Sha` already had its own directory-hashing algorithm, so the two lived side by side and only agreed by coincidence.

Gave `Sha` a second constructor that takes a files filter, applied only when walking a directory. `Cache.dirSha` now just delegates: `new Sha(dir, this.filter).toString()`. `Cache.java` no longer needs its own digest/walk code, so the unused imports went with it.

This changes the exact byte layout of directory hashes (single-level framing by relative path and byte length, same as `Sha` already does for the cases that went through it directly), so `CacheTest.generatesCorrectHashForEntireFolderWithSeveralFiles` now builds its expected digest the same way `Sha` frames a file, instead of hardcoding the old two-level scheme.

Ran `CacheTest`, `ShaTest`, and the other cache-consumer tests (`ConcurrentCacheTest`, `GlobalCacheTest`, `ChCachedTest`, `OyCachedTest`, `Fp*CacheTest`) locally, all green. `qulice:check -Pqulice` on `eo-maven-plugin` is clean.
