### PR TITLE
#6110: collapse under-indented blank text-block lines to empty

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -246,7 +246,9 @@ final class Globals {
      */
     void appendTextLine(final String raw) {
         final String stripped;
-        if (raw.length() >= this.tindent
+        if (raw.chars().allMatch(c -> c == ' ')) {
+            stripped = "";
+        } else if (raw.length() >= this.tindent
             && raw.substring(0, Math.min(this.tindent, raw.length()))
                 .chars().allMatch(c -> c == ' ')) {
             stripped = raw.substring(Math.min(this.tindent, raw.length()));

--- a/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
@@ -94,6 +94,18 @@ final class GlobalsTest {
     }
 
     @Test
+    void collapsesUnderIndentedBlankLineToEmpty() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 6);
+        globals.appendTextLine("  ");
+        MatcherAssert.assertThat(
+            "a blank line shorter than the opener's indent must collapse to an empty line",
+            globals.tbody(),
+            Matchers.contains("")
+        );
+    }
+
+    @Test
     void closesTextBlockState() {
         final Globals globals = new Globals();
         globals.openTextBlock(3);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# yamllint disable rule:trailing-spaces
 sheets: []
 asserts:
   - //o[@base='Φ.string' and o/o[text()='48-69-2C-20-74-68-65-72-65-0A-41-64-69-C3-B3-73']]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# yamllint disable rule:trailing-spaces
 sheets: []
 asserts:
   - //o[@base='Φ.string' and o/o[text()='48-69-2C-20-74-68-65-72-65-0A-41-64-69-C3-B3-73']]
@@ -10,28 +9,10 @@ asserts:
   - //o[@base='Φ.string' and o/o[text()='20-20-20-74-68-69-72-64']]
   - //o[@base='Φ.string' and o/o[text()='0A-73-65-63-6F-6E-64']]
   - //o[@name='blank-under-indented']//o[@base='Φ.string' and o/o[text()='0A-73-65-63-6F-6E-64']]
-input: |
-  [] > main
-    """
-    Hi, there
-    Adiós
-    """ > txt
-    stdout > marg
-      """
-      first
-       second
-      """
-    stdout > mrg
-      """
-         third
-      """
-    stdout > blank
-      """
-
-      second
-      """
-    stdout > blank-under-indented
-      """
-    
-      second
-      """
+# The "blank-under-indented" case needs a literal blank line whose
+# indentation (2 spaces) is less than the text-block marker's (4 spaces).
+# A YAML block scalar would put those 2 spaces at the end of a physical
+# line, where any trailing-whitespace pre-commit tool would strip them
+# and silently break this test. Encoding the whole input as one quoted
+# scalar with explicit \n keeps the meaningful spaces mid-line instead.
+input: "[] > main\n  \"\"\"\n  Hi, there\n  Adiós\n  \"\"\" > txt\n  stdout > marg\n    \"\"\"\n    first\n     second\n    \"\"\"\n  stdout > mrg\n    \"\"\"\n       third\n    \"\"\"\n  stdout > blank\n    \"\"\"\n\n    second\n    \"\"\"\n  stdout > blank-under-indented\n    \"\"\"\n  \n    second\n    \"\"\"\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block.yaml
@@ -8,6 +8,7 @@ asserts:
   - //o[@base='Φ.string' and o/o[text()='66-69-72-73-74-0A-20-73-65-63-6F-6E-64']]
   - //o[@base='Φ.string' and o/o[text()='20-20-20-74-68-69-72-64']]
   - //o[@base='Φ.string' and o/o[text()='0A-73-65-63-6F-6E-64']]
+  - //o[@name='blank-under-indented']//o[@base='Φ.string' and o/o[text()='0A-73-65-63-6F-6E-64']]
 input: |
   [] > main
     """
@@ -26,5 +27,10 @@ input: |
     stdout > blank
       """
 
+      second
+      """
+    stdout > blank-under-indented
+      """
+    
       second
       """


### PR DESCRIPTION
Closes #6110.

`Globals.appendTextLine` only stripped a text-block body line when its length was at least the opener's indent. A blank line shorter than that (a few stray leading spaces, no content) fell into the else branch and was appended unstripped, so the stray spaces survived into the assembled string literal.

Fix: check `raw.chars().allMatch(c -> c == ' ')` first and collapse any such line to an empty string, before falling back to the existing length/prefix check for non-blank lines.

Added a direct `GlobalsTest` case that reproduces the reported scenario (`openTextBlock` at indent 6, `appendTextLine("  ")`), and confirmed it fails without the fix and passes with it.
