### PR TITLE
#6607: restructure Deadline to satisfy PMD PreserveStackTrace

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/Deadline.java
+++ b/eo-runtime/src/test/java/org/eolang/Deadline.java
@@ -20,10 +20,9 @@ public final class Deadline implements TestExecutionExceptionHandler {
     @Override
     public void handleTestExecutionException(final ExtensionContext context,
         final Throwable error) throws Throwable {
-        try {
-            throw error;
-        } catch (final TimeoutException ex) {
-            throw new TestAbortedException(ex.getMessage(), ex);
+        if (error instanceof TimeoutException) {
+            throw new TestAbortedException(error.getMessage(), error);
         }
+        throw error;
     }
 }


### PR DESCRIPTION
Closes #6607.

`qulice:check -Pqulice` on `eo-runtime` was failing on master for everyone, unrelated to whatever a PR actually touches. PMD's `PreserveStackTrace` flagged `Deadline.handleTestExecutionException`, even though the caught exception was already passed as the cause. The `throw error; catch (TimeoutException ex)` idiom (rethrow-then-catch, used to narrow a checked `Throwable` down to one type) seems to confuse that PMD rule's pattern matching.

Rewrote it with a plain `instanceof` check instead, same behavior: a `TimeoutException` becomes a `TestAbortedException` with the same message and cause, anything else propagates unchanged. No suppression needed, PMD is satisfied by the restructured control flow.

Verified locally: `mvn -pl eo-runtime qulice:check -Pqulice` is BUILD SUCCESS with this change (it fails on unmodified master with the exact PMD violation quoted in the issue).
