### PR TITLE
Drain the pending checks and say what is certainly missing

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Clues.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Clues.java
@@ -24,13 +24,13 @@ import java.util.Collection;
  *   [x] &gt; inc
  *     x.next.foo &gt; @</pre>
  *
- * <p>Three clues are planned, one per kind of object, and each fills a
- * table of its own: what an object certainly has ({@link Provides}), what
- * it must have judging by how it is used ({@link Needs}), and which types
- * are copies of which ({@link Links}), and what has to be checked once
- * those three are read together ({@link Checks}). Keeping the tables apart is what lets a smarter
- * rule add rows, or read them differently, without touching anything
- * else.</p>
+ * <p>There is a clue per kind of object, and each fills a table of its
+ * own: what an object certainly has ({@link Provides}), what it must have
+ * judging by how it is used ({@link Needs}), which types are copies of
+ * which ({@link Links}), and what has to be checked once those three are
+ * read together ({@link Checks}). Keeping the tables apart is what lets a
+ * smarter rule add rows, or read them differently, without touching
+ * anything else.</p>
  *
  * <p>Every clue reads the program as text, writing a row for an object
  * because it is <em>there</em>, not because something reaches it. The
@@ -43,12 +43,10 @@ import java.util.Collection;
  * buys back later by resolving each site in its own context; reading only
  * what runs costs coverage, which nothing buys back.</p>
  *
- * <p>Then the checks are drained one by one, each of them either
- * deciding, splitting into smaller checks, or waiting for facts that may
- * never come. A mistake is reported only when the object that misses an
- * attribute is complete, so that parts of the program the checker cannot
- * see — atoms, delegation through {@code φ} — make it silent rather than
- * wrong. Only the first clue is here so far.</p>
+ * <p>No clue decides anything, which is why they can be read one after
+ * another in any order. Draining the checks the last of them files is the
+ * work of {@link Concluded}, which follows all of them first and then reads
+ * their tables together.</p>
  *
  * @since 0.67.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Concluded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Concluded.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.tojos.MnMemory;
+import com.yegor256.tojos.TjDeferred;
+import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * The clues, followed and then read together.
+ *
+ * <p>A clue writes down what it understands and decides nothing, which is
+ * what keeps the rules simple and apart from one another. This is the other
+ * half: the tables they wrote are read back, the checks in them are drained,
+ * and what the checker is sure about lands in a table of its own beside them.
+ * Nothing but the four documents passes between the two halves, so a rule can
+ * change how it fills a table, or a table can gain a column, without the loop
+ * being touched.</p>
+ *
+ * <p>The mistakes are written the way every other table is written, a type
+ * with the attributes it is missing:</p>
+ *
+ * <pre> &lt;problems&gt;
+ *   &lt;type id="Φ.app.t.next"&gt;
+ *     &lt;attr name="foo" asked="Φ.app.inc.φ"/&gt;
+ *   &lt;/type&gt;
+ * &lt;/problems&gt;</pre>
+ *
+ * <p>which says that the object at {@code Φ.app.t.next} is asked for
+ * {@code foo}, at {@code Φ.app.inc.φ}, and will never have it. The document
+ * is written even when it is empty, because "nothing was found" is an answer
+ * and a missing file is not. Nothing fails the build yet: the checker is a
+ * prototype, and its verdicts are worth reading before they are worth
+ * obeying.</p>
+ *
+ * @since 0.68.0
+ */
+public final class Concluded implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the checks are drained
+     */
+    public Concluded(final Clue clues) {
+        this.origin = clues;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final Map<String, String> names = new Same(
+            new XMLDocument(tables.resolve("links.xml"))
+        ).names();
+        try (Tojos rows = new TjDeferred(new MnMemory())) {
+            new Worklist(
+                names,
+                new Provided(
+                    new Ungrouped(new XMLDocument(tables.resolve("provides.xml")), names).rows()
+                ),
+                new Ungrouped(new XMLDocument(tables.resolve("needs.xml")), names).rows(),
+                new Ungrouped(new XMLDocument(tables.resolve("checks.xml")), names).rows()
+            ).drain(rows);
+            Files.write(
+                tables.resolve("problems.xml"),
+                new Grouped(rows, "problems").asXml().toString().getBytes(StandardCharsets.UTF_8)
+            );
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What the types of a program certainly have.
+ *
+ * <p>This is the table {@link Provides} wrote, read by the name a type and
+ * its copies go by, so that a question about an argument is answered by the
+ * formation the argument is a copy of. Three questions are asked of it while
+ * the checks are drained.</p>
+ *
+ * <p>Whether the whole of a type has been seen, which is what makes a missing
+ * attribute a mistake rather than a gap. A type is whole when it says so and
+ * nothing that goes by the same name says otherwise: an argument put into a
+ * copy of an atom is as unknown as the atom.</p>
+ *
+ * <p>What the type of an attribute is, or nothing at all when the type has no
+ * such attribute. An attribute is looked for in two places, because there are
+ * two: the type itself, and its package, since an attribute nobody binds falls
+ * through to the object of that name beside it — {@code Φ.number} binds eight
+ * attributes and answers to forty, the rest of them being objects of their own
+ * in the same package, {@code Φ.number.eq} among them. A locator names both
+ * kinds the same way, so the second place costs one lookup. Delegation through
+ * {@code φ} is a third place, and is not looked into yet.</p>
+ *
+ * <p>And which of its attributes are void, in the order they were declared,
+ * because an argument fills a void by its place among them.</p>
+ *
+ * @since 0.68.0
+ */
+final class Provided {
+
+    /**
+     * The rows of the provides table, by the name their owner goes by.
+     */
+    private final Map<String, Collection<Map<String, String>>> table;
+
+    /**
+     * Ctor.
+     * @param rows The rows of the provides table, by the name of their owner
+     */
+    Provided(final Map<String, Collection<Map<String, String>>> rows) {
+        this.table = rows;
+    }
+
+    /**
+     * Has the whole of this type been seen?
+     * @param type The name the type goes by
+     * @return TRUE when nothing about the type is hidden from the checker
+     */
+    boolean complete(final String type) {
+        final Collection<Boolean> flags = new ArrayList<>(1);
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("complete")) {
+                flags.add(Boolean.parseBoolean(row.get("complete")));
+            }
+        }
+        return !flags.isEmpty() && !flags.contains(false);
+    }
+
+    /**
+     * The type of the attribute this type keeps under the given name.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @return The type of the attribute, or an empty string when this type has
+     *  no attribute of that name
+     */
+    String attribute(final String type, final String name) {
+        String found = "";
+        for (final Map<String, String> row : this.own(type)) {
+            if (name.equals(row.getOrDefault("name", ""))) {
+                found = row.getOrDefault("type", "");
+            }
+        }
+        final String member = String.join(".", type, name);
+        if (found.isEmpty() && this.table.containsKey(member)) {
+            found = member;
+        }
+        return found;
+    }
+
+    /**
+     * The types of the void attributes of this type, in the order they were
+     * declared.
+     * @param type The name the type goes by
+     * @return The types, empty when the type declares no voids
+     */
+    List<String> voids(final String type) {
+        final List<String> found = new ArrayList<>(0);
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("void")) {
+                found.add(row.getOrDefault("type", ""));
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The rows about the type of the given name.
+     * @param type The name the type goes by
+     * @return The rows, empty when the table says nothing about it
+     */
+    private Collection<Map<String, String>> own(final String type) {
+        return this.table.getOrDefault(type, Collections.emptyList());
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Row.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Row.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.w3c.dom.NamedNodeMap;
+
+/**
+ * One row of a table, as its document keeps it.
+ *
+ * <p>A row is a few named cells and nothing else, which is what
+ * {@link Cells} turns into a document and what this turns back. No column is
+ * known here by name, so a rule that starts writing a new one has it read
+ * back without anything being changed.</p>
+ *
+ * @since 0.68.0
+ */
+final class Row {
+
+    /**
+     * The element of the document the row was written as.
+     */
+    private final XML element;
+
+    /**
+     * Ctor.
+     * @param row The element of the document the row was written as
+     */
+    Row(final XML row) {
+        this.element = row;
+    }
+
+    /**
+     * The cells of the row.
+     * @return The cells, by their names, in the order the document keeps them
+     */
+    Map<String, String> cells() {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        final NamedNodeMap named = this.element.inner().getAttributes();
+        for (int cell = 0; cell < named.getLength(); cell = cell + 1) {
+            found.put(named.item(cell).getNodeName(), named.item(cell).getNodeValue());
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Same.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Same.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * The name a type and all its copies go by.
+ *
+ * <p>{@link Links} says that one type is a copy of another, and for now a
+ * copy is the same thing as what it copies: whatever one of them has or is
+ * asked for, the other one has or is asked for too. A chain of copies is
+ * therefore one type under several names, and the tables are easiest to read
+ * when the whole chain is called by one of them — the one at the end of the
+ * chain, which is the formation or the void the copies all come from, and
+ * which is a name a human recognises.</p>
+ *
+ * <p>This is the one place where the checker later gets smarter. When a copy
+ * begins to receive types of its own, chains stop collapsing and nothing else
+ * has to change, because every question about a type goes through the name
+ * handed out here first.</p>
+ *
+ * @since 0.68.0
+ */
+final class Same {
+
+    /**
+     * The links table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     * @param links The links table
+     */
+    Same(final XML links) {
+        this.table = links;
+    }
+
+    /**
+     * The name every type of the table goes by.
+     * @return The name, by type; a type the table says nothing about is
+     *  absent from the map, since it goes by its own name
+     */
+    Map<String, String> names() {
+        final Map<String, String> copies = new HashMap<>(0);
+        for (final XML link : this.table.nodes("/links/type")) {
+            copies.put(link.xpath("@id").get(0), link.xpath("@copy").get(0));
+        }
+        final Map<String, String> ends = new HashMap<>(copies.size());
+        for (final Map.Entry<String, String> link : copies.entrySet()) {
+            final Collection<String> walked = new HashSet<>(0);
+            String end = link.getValue();
+            while (copies.containsKey(end) && walked.add(end)) {
+                end = copies.get(end);
+            }
+            ends.put(link.getKey(), end);
+        }
+        return ends;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The rows of a table, read back from the document {@link Grouped} wrote.
+ *
+ * <p>A clue writes a table for a human to read, nested and short; the loop
+ * needs the same table flat and by the name of its owner, since it asks about
+ * tens of thousands of types and searching a document for every one of them
+ * costs more than the whole checking does. This turns the one into the other:
+ * a type row and the rows of its attributes end up together, under the name
+ * that the type and all its copies go by.</p>
+ *
+ * <p>Which of the two a row is can be seen from its cells, exactly as
+ * {@link Grouped} decided when it wrote them: a type row carries an
+ * {@code id}, a row about an attribute carries a {@code name}. Nothing else is
+ * known about the columns here, so a rule that starts writing a new one has it
+ * read back for free.</p>
+ *
+ * @since 0.68.0
+ */
+final class Ungrouped {
+
+    /**
+     * The table.
+     */
+    private final XML table;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param document The table, as a clue wrote it
+     * @param aliases The name every type goes by, from {@link Same}
+     */
+    Ungrouped(final XML document, final Map<String, String> aliases) {
+        this.table = document;
+        this.names = aliases;
+    }
+
+    /**
+     * The rows of the table, by the name their owner goes by.
+     * @return The rows, in the order the table keeps them, since the place of
+     *  a row is what says which void an argument fills
+     */
+    Map<String, Collection<Map<String, String>>> rows() {
+        final Map<String, Collection<Map<String, String>>> found = new LinkedHashMap<>(0);
+        for (final XML type : this.table.nodes("/*/type")) {
+            final Map<String, String> cells = new Row(type).cells();
+            final Collection<Map<String, String>> owned = found.computeIfAbsent(
+                this.names.getOrDefault(cells.get("id"), cells.get("id")),
+                key -> new ArrayList<>(1)
+            );
+            owned.add(cells);
+            for (final XML attr : type.nodes("attr")) {
+                owned.add(new Row(attr).cells());
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Worklist.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Worklist.java
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.yegor256.tojos.Tojos;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The checks, drained one by one.
+ *
+ * <p>{@link Checks} filed a promise for every argument put into a copy of
+ * something: this argument has to fit into that void. Deciding one is what the
+ * other three tables are for. The argument is a copy of an object
+ * {@link Provides} has written down, the void is asked for attributes
+ * {@link Needs} has written down, and {@link Links} says which of those types
+ * are the same thing. So a check is decided by asking the object for
+ * everything the void is asked for.</p>
+ *
+ * <p>"Yes, it has it" is rarely the end of it: whatever the attribute holds
+ * must in turn have everything that taking it is asked for, which is a smaller
+ * check of exactly the same shape. Those go back into the list, and the list is
+ * drained until nothing is left in it. On the program of the design note that
+ * takes the three steps the note describes: the {@code t} fills the void
+ * {@code x}, the {@code x} is asked for {@code next}, and the {@code next} it
+ * finds is asked for {@code foo}.</p>
+ *
+ * <p>A mistake is written down only when the checker is sure: the object that
+ * misses the attribute has been seen whole, and the attribute is still not
+ * there. An atom, an object nobody in the program describes, an argument whose
+ * void cannot be found — all of these leave a check undecided and nothing is
+ * said about them. It is better to miss a mistake than to complain about
+ * correct code.</p>
+ *
+ * <p>A check already started is dropped rather than started again. Nothing new
+ * is learned while the list is drained, since all four tables were written
+ * before it started, so a check nobody can decide now will not become
+ * decidable later: the list only ever grows by splitting a check into smaller
+ * ones, of which there are finitely many. Remembering the ones already started
+ * is what keeps an object that refers to itself from being walked forever.</p>
+ *
+ * @since 0.68.0
+ */
+final class Worklist {
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided given;
+
+    /**
+     * The rows of the needs table, by the name their owner goes by.
+     */
+    private final Map<String, Collection<Map<String, String>>> wanted;
+
+    /**
+     * The rows of the checks table, by the name their owner goes by.
+     */
+    private final Map<String, Collection<Map<String, String>>> pending;
+
+    /**
+     * Ctor.
+     * @param aliases The name every type goes by, from {@link Same}
+     * @param provided What the types certainly have
+     * @param needs The rows of the needs table, by the name of their owner
+     * @param checks The rows of the checks table, by the name of their owner
+     */
+    Worklist(
+        final Map<String, String> aliases,
+        final Provided provided,
+        final Map<String, Collection<Map<String, String>>> needs,
+        final Map<String, Collection<Map<String, String>>> checks
+    ) {
+        this.names = aliases;
+        this.given = provided;
+        this.wanted = needs;
+        this.pending = checks;
+    }
+
+    /**
+     * Drain the checks into the given table, a row per mistake.
+     * @param rows The table to write the mistakes into
+     */
+    void drain(final Tojos rows) {
+        final Deque<String> todo = new ArrayDeque<>(0);
+        for (final Map.Entry<String, Collection<Map<String, String>>> copy
+            : this.pending.entrySet()) {
+            for (final Map<String, String> argument : copy.getValue()) {
+                if (argument.containsKey("name")) {
+                    final String hole = this.hole(copy.getKey(), argument.get("name"));
+                    if (!hole.isEmpty()) {
+                        todo.add(
+                            String.join(
+                                " ", this.name(argument.getOrDefault("type", "")), hole
+                            )
+                        );
+                    }
+                }
+            }
+        }
+        final Collection<String> started = new HashSet<>(0);
+        while (!todo.isEmpty()) {
+            final String check = todo.poll();
+            if (started.add(check)) {
+                this.decide(check, todo, rows);
+            }
+        }
+    }
+
+    /**
+     * Decide one check: has the object everything the void is asked for?
+     * @param check The name of the object and the name of the void, together
+     * @param todo The list to put the smaller checks into
+     * @param rows The table to write a mistake into, if there is one
+     */
+    private void decide(final String check, final Collection<String> todo, final Tojos rows) {
+        final String has = check.substring(0, check.indexOf(' '));
+        final String want = check.substring(check.indexOf(' ') + 1);
+        for (final Map<String, String> need
+            : this.wanted.getOrDefault(want, Collections.emptyList())) {
+            if (need.containsKey("name")) {
+                final String owned = this.given.attribute(has, need.get("name"));
+                if (owned.isEmpty() && this.given.complete(has)) {
+                    rows.add(has);
+                    rows.add(String.join(" ", has, need.get("name")))
+                        .set("owner", has)
+                        .set("name", need.get("name"))
+                        .set("asked", need.getOrDefault("type", ""));
+                }
+                if (!owned.isEmpty()) {
+                    todo.add(
+                        String.join(" ", this.name(owned), need.getOrDefault("type", ""))
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * The void an argument bound under the given name lands in.
+     * @param copied The name of the object being copied
+     * @param name The name the argument is bound under
+     * @return The type of the void, or an empty string when it cannot be
+     *  found, which is the answer for anything the tables do not describe
+     */
+    private String hole(final String copied, final String name) {
+        final String found;
+        if (name.startsWith("α")) {
+            final List<String> holes = this.given.voids(copied);
+            final int place = Integer.parseInt(name.substring(1));
+            if (place < holes.size()) {
+                found = holes.get(place);
+            } else {
+                found = "";
+            }
+        } else {
+            found = this.given.attribute(copied, name);
+        }
+        return found;
+    }
+
+    /**
+     * The name the given type goes by.
+     * @param type The type
+     * @return The name, which is the type itself when it is a copy of nothing
+     */
+    private String name(final String type) {
+        return this.names.getOrDefault(type, type);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/package-info.java
+++ b/eo-inference/src/main/java/org/eolang/inference/package-info.java
@@ -36,10 +36,12 @@
  *
  * <p>Each rule is a {@link org.eolang.inference.Clue}, which reads the
  * XMIR of a whole program from one directory and writes what it has
- * understood into another. The Maven plugin prepares that XMIR and
- * follows every clue we know through
- * {@link org.eolang.inference.Clues}, which is the entry point. Only the
- * first rule is implemented so far.</p>
+ * understood into another. The Maven plugin prepares that XMIR and follows
+ * every clue we know through {@link org.eolang.inference.Clues}, wrapped in
+ * {@link org.eolang.inference.Concluded}, which drains the checks once the
+ * tables are written. Nothing is renamed and nothing fails the build; a
+ * copy is still the same object as what it copies, and what an atom returns
+ * is still unknown, so the checker is often quiet.</p>
  *
  * @since 0.67.0
  * @see <a href="https://www.eolang.org">Project site www.eolang.org</a>

--- a/eo-inference/src/test/java/org/eolang/inference/ProvidedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ProvidedTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Provided}.
+ *
+ * <p>What the checker understands about a program is checked by the packs of
+ * the Maven plugin, which read EO source. These are the three questions the
+ * loop asks of the provides table, which know nothing about EO, so they are
+ * asked here directly.</p>
+ *
+ * @since 0.68.0
+ */
+final class ProvidedTest {
+
+    @Test
+    void keepsVoidsInOrderTheyWereDeclared() {
+        MatcherAssert.assertThat(
+            "an argument fills a void by its place, so the voids must keep their order",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides><type id='Φ.jar'>",
+                            "<attr name='lid' void='true' type='Φ.jar.lid'/>",
+                            "<attr name='spout' void='true' type='Φ.jar.spout'/>",
+                            "</type></provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows()
+            ).voids("Φ.jar"),
+            Matchers.contains("Φ.jar.lid", "Φ.jar.spout")
+        );
+    }
+
+    @Test
+    void countsOnlyVoidsAmongAttributes() {
+        MatcherAssert.assertThat(
+            "an attribute that is already bound is no place for an argument to land in",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides><type id='Φ.jar'>",
+                            "<attr name='honey' type='Φ.jar.honey'/>",
+                            "<attr name='lid' void='true' type='Φ.jar.lid'/>",
+                            "</type></provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows()
+            ).voids("Φ.jar"),
+            Matchers.contains("Φ.jar.lid")
+        );
+    }
+
+    @Test
+    void doubtsTypeWhenOneOfItsNamesHidesSomething() {
+        MatcherAssert.assertThat(
+            "an argument put into a copy of an atom is as unknown as the atom is",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides>",
+                            "<type id='Φ.jar' complete='true'/>",
+                            "<type id='Φ.tin' complete='false'/>",
+                            "</provides>"
+                        )
+                    ),
+                    Collections.singletonMap("Φ.tin", "Φ.jar")
+                ).rows()
+            ).complete("Φ.jar"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void findsAttributeBesideTypeInItsPackage() {
+        MatcherAssert.assertThat(
+            "an attribute nobody binds falls through to the object of that name in the package",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides>",
+                            "<type id='Φ.jar' complete='true'/>",
+                            "<type id='Φ.jar.lid' complete='true'/>",
+                            "</provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows()
+            ).attribute("Φ.jar", "lid"),
+            Matchers.equalTo("Φ.jar.lid")
+        );
+    }
+
+    @Test
+    void saysNothingAboutAttributeTypeDoesNotHave() {
+        MatcherAssert.assertThat(
+            "a type that has no such attribute must answer with nothing at all",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        "<provides><type id='Φ.jar' complete='true'/></provides>"
+                    ),
+                    Collections.emptyMap()
+                ).rows()
+            ).attribute("Φ.jar", "lid"),
+            Matchers.emptyString()
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/SameTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SameTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Test case for {@link Same}.
+ *
+ * <p>What the checker understands about a program is checked by the packs of
+ * the Maven plugin, which read EO source. This is the collapsing of copies
+ * underneath, which knows nothing about EO and everything about a table of
+ * links, so it is asked here directly.</p>
+ *
+ * @since 0.68.0
+ */
+final class SameTest {
+
+    @Test
+    void callsCopyByTheNameOfWhatItCopies() {
+        MatcherAssert.assertThat(
+            "a copy must go by the name of the object it copies, but it didnt",
+            new Same(
+                new XMLDocument(
+                    "<links><type id='Φ.app.φ' copy='Φ.jar'/></links>"
+                )
+            ).names(),
+            Matchers.hasEntry("Φ.app.φ", "Φ.jar")
+        );
+    }
+
+    @Test
+    void followsChainOfCopiesToItsEnd() {
+        MatcherAssert.assertThat(
+            "a copy of a copy must go by the name at the end of the chain, but it didnt",
+            new Same(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<links>",
+                        "<type id='Φ.app.φ.α0' copy='Φ.app.lid'/>",
+                        "<type id='Φ.app.lid' copy='Φ.jar'/>",
+                        "</links>"
+                    )
+                )
+            ).names(),
+            Matchers.hasEntry("Φ.app.φ.α0", "Φ.jar")
+        );
+    }
+
+    @Test
+    void saysNothingAboutTypeThatCopiesNothing() {
+        MatcherAssert.assertThat(
+            "a type no link mentions must be left out, since it goes by its own name",
+            new Same(
+                new XMLDocument("<links><type id='Φ.app.φ' copy='Φ.jar'/></links>")
+            ).names(),
+            Matchers.not(Matchers.hasKey("Φ.jar"))
+        );
+    }
+
+    @Test
+    @Timeout(10L)
+    void walksOutOfCopiesThatCopyEachOther() {
+        MatcherAssert.assertThat(
+            "copies pointing at each other must not be walked forever, but they were",
+            new Same(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<links>",
+                        "<type id='Φ.honey' copy='Φ.comb'/>",
+                        "<type id='Φ.comb' copy='Φ.honey'/>",
+                        "</links>"
+                    )
+                )
+            ).names(),
+            Matchers.hasKey("Φ.honey")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/UngroupedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/UngroupedTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Ungrouped}.
+ *
+ * <p>What the checker understands about a program is checked by the packs of
+ * the Maven plugin, which read EO source. This is the reading of a table
+ * underneath, which knows nothing about EO and everything about the document
+ * {@link Grouped} writes, so it is asked here directly.</p>
+ *
+ * @since 0.68.0
+ */
+final class UngroupedTest {
+
+    @Test
+    void readsEveryCellOfRow() {
+        MatcherAssert.assertThat(
+            "a cell of a row must be read back whatever it is called, but one wasnt",
+            new Ungrouped(
+                new XMLDocument(
+                    "<provides><type id='Φ.jar'><attr name='lid' mood='shut'/></type></provides>"
+                ),
+                Collections.emptyMap()
+            ).rows().get("Φ.jar"),
+            Matchers.hasItem(Matchers.hasEntry("mood", "shut"))
+        );
+    }
+
+    @Test
+    void keepsTypeAndItsAttributesTogether() {
+        MatcherAssert.assertThat(
+            "the row of a type and the rows of its attributes must end up together",
+            new Ungrouped(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.jar' complete='true'>",
+                        "<attr name='lid'/><attr name='spout'/>",
+                        "</type></provides>"
+                    )
+                ),
+                Collections.emptyMap()
+            ).rows().get("Φ.jar"),
+            Matchers.hasSize(3)
+        );
+    }
+
+    @Test
+    void putsRowsUnderNameOwnerGoesBy() {
+        MatcherAssert.assertThat(
+            "the rows of a copy must be found under the name of what it copies, but they werent",
+            new Ungrouped(
+                new XMLDocument("<needs><type id='Φ.app.φ'><attr name='lid'/></type></needs>"),
+                Collections.singletonMap("Φ.app.φ", "Φ.jar")
+            ).rows(),
+            Matchers.hasKey("Φ.jar")
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.inference.Clues;
+import org.eolang.inference.Concluded;
 import org.eolang.parser.TrFull;
 
 /**
@@ -85,7 +86,7 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
-            new Clues().follow(this.prepared, this.tables);
+            new Concluded(new Clues()).follow(this.prepared, this.tables);
             Logger.info(
                 this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
                 ready, this.tables

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -39,10 +39,10 @@ import org.apache.maven.plugins.annotations.Parameter;
  * complete, so that parts of the program this goal cannot see — atoms,
  * delegation through {@code φ} — make it silent rather than wrong.</p>
  *
- * <p>Only the first of those rules is implemented so far, together with the
- * preparation the rest of them will need. The XMIR prepared for the rules
- * is saved in {@link #prepared} and the tables in
- * {@link #tables}, a document each.</p>
+ * <p>The XMIR prepared for the rules is saved in {@link #prepared} and the
+ * tables in {@link #tables}, a document each, the mistakes among them. Not
+ * one of them fails the build: the checker is a prototype, and what it
+ * understands is worth reading before it is worth obeying.</p>
  *
  * @since 0.67.0
  */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -169,7 +169,9 @@ final class InferringTest {
      */
     private Collection<String> unmatched(final Xtory pack, final Path temp) throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
-        final Collection<String> tables = Arrays.asList("provides", "needs", "links", "checks");
+        final Collection<String> tables = Arrays.asList(
+            "provides", "needs", "links", "checks", "problems"
+        );
         for (final Object key : pack.map().keySet()) {
             if (!"eo".equals(key) && !"xmir".equals(key) && !tables.contains(key)) {
                 failed.add(String.format("unknown key: %s", key));

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-from-package-is-not-missing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-from-package-is-not-missing.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `t` binds no `extra`, and yet `x.extra` is no mistake: an attribute nobody
+# binds falls through to the object of that name beside it in the package, and
+# a locator names such an object the same way it names an attribute. So the
+# loop looks in both places before it says anything, which is what keeps it
+# quiet about `Φ.number` answering to `eq` while binding eight attributes of
+# its own.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.extra > @
+  t.eo: |
+    [] > t
+      [] > next
+  extra.eo: |
+    +package t
+
+    [y] > extra
+      y > @
+provides:
+  - "/provides/type[@id='Φ.t.extra']"
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-nowhere-in-package-is-missing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-nowhere-in-package-is-missing.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The same program as `attribute-from-package-is-not-missing`, with the object
+# beside `t` taken away. Now there is nowhere left for `extra` to come from, so
+# the loop says what it could not say while the package answered for it.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.extra > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t']/attr[@name='extra']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-that-is-there-is-no-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-that-is-there-is-no-mistake.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The same program with the second step removed: `inc` asks its argument for
+# `next`, and the `t` it is given has one. Nothing is reported, which is the
+# answer the loop has to give most of the time.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.next > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-copies-is-one-object.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-copies-is-one-object.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The `t` reaches `inc` under a second name, and a copy of a copy is still the
+# same object for now, so the loop follows the chain to its end and finds the
+# same mistake it would have found without the detour.
+eo:
+  app.eo: |
+    [] > app
+      inc lid > @
+      t > lid
+  inc.eo: |
+    [x] > inc
+      x.next.foo > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t.next']/attr[@name='foo']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/check-without-facts-stays-quiet.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/check-without-facts-stays-quiet.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Nobody in this program says what `inc` is, so the check filed for the `t` put
+# into it cannot be decided: there is no formation to count the voids of, and
+# the argument never reaches a void. The check is dropped without a word, which
+# is what an unfinished program has to look like to the loop.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/incomplete-object-is-never-blamed.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/incomplete-object-is-never-blamed.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The attribute is missing, and the loop still says nothing, because the object
+# that misses it is an atom: its body is written in Java, which this prototype
+# cannot read, so `foo` may well be there. Better to miss a mistake than to
+# complain about correct code.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.next.foo > @
+  t.eo: |
+    [] > t
+      [] > next /Q.number
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -32,4 +32,5 @@ links:
 checks:
   - "/checks/type[@id='Φ.app.φ']/attr[@name='α0' and @type='Φ.app.φ.α0']"
 problems:
-  - "/problems/type[@id='Φ.app.t.next']/attr[@name='foo' and @asked='Φ.app.inc.φ']"
+  - "/problems/type[@id='Φ.app.t.next']/attr[@name='foo']"
+  - "/problems//attr[@asked='Φ.app.inc.φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -3,9 +3,9 @@
 ---
 # The program of the design note, which is the whole prototype in one place.
 # `t` does have `next`, but the object attached to `next` has nothing, so
-# `x.next.foo` asks for something that will never be there. Nobody reports it
-# yet: the tables only write down what is known, and comparing them is the job
-# of the checking loop.
+# `x.next.foo` asks for something that will never be there. The four tables
+# write down what is known and the loop reads them together, reaching the
+# mistake in the three steps the note describes.
 eo:
   app.eo: |
     [] > app
@@ -31,3 +31,5 @@ links:
   - "/links/type[@id='Φ.app.inc.φ.ρ.ρ' and @copy='Φ.app.inc.x']"
 checks:
   - "/checks/type[@id='Φ.app.φ']/attr[@name='α0' and @type='Φ.app.φ.α0']"
+problems:
+  - "/problems/type[@id='Φ.app.t.next']/attr[@name='foo' and @asked='Φ.app.inc.φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unreachable-attribute-is-a-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unreachable-attribute-is-a-mistake.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The mistake of the design note, found by the loop instead of being left in
+# the tables. `inc` is given a `t`, `inc` takes `next` from what it is given,
+# and then `foo` from that — while the `next` of a `t` has nothing at all and
+# is complete, so `foo` will never be there. Three files, three steps: the
+# check says the `t` fills the void `x`, the void is asked for `next`, and the
+# `next` it finds is asked for `foo`.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.next.foo > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t.next']/attr[@name='foo' and @asked='Φ.inc.φ']"


### PR DESCRIPTION
The four clues wrote down what they understood and decided nothing, so every
pending check stayed pending forever. Three javadocs promised otherwise —
`Clues`, `package-info` and `MjInference` all said the checks "are drained one
by one" — and `Checks` justified filing a check unresolved by leaving "the
arithmetic to the checking loop". This is that loop.

`Concluded` follows the clues and then reads their four tables together:

```xml
<problems>
  <type id="Φ.app.t.next">
    <attr name="foo" asked="Φ.app.inc.φ"/>
  </type>
</problems>
```

which says that the object at `Φ.app.t.next` is asked for `foo`, at
`Φ.app.inc.φ`, and will never have it. On the program of the design note that
takes the three steps the note describes: the `t` fills the void `x`, the `x`
is asked for `next`, and the `next` it finds is asked for `foo`. A check that
succeeds is rarely the end of it — whatever the attribute holds must in turn
have everything that taking it is asked for, which is a smaller check of the
same shape, so the list grows while it is drained.

The honesty rule is the point of the whole thing: a mistake is written down
only when the object that misses the attribute has been seen whole. An atom, an
object nobody in the program describes, an argument whose void cannot be found
— all of these leave a check undecided and nothing is said. Four of the seven
new packs are about exactly that silence, since it is what the checker will be
doing most of the time.

Three things I decided along the way and would rather have written down than
left implicit:

  * **No putting a check back.** The note has the loop park a check it cannot
    decide and try again later. Here it drops it, because all four tables are
    written before the loop starts, so nothing new is ever learned while it
    runs: a check nobody can decide now will not become decidable later. The
    list only grows by splitting, of which there are finitely many, so
    remembering the checks already started is about work and not about
    termination. When a copy starts receiving types of its own, facts will
    appear mid-loop and the parking comes back.

  * **The package is a second place to look.** `Φ.number` binds eight
    attributes and answers to forty; the rest are objects of their own in the
    same package, `Φ.number.eq` among them, and a locator names both kinds the
    same way — so an attribute that no row lists is looked for at
    `Φ.number.eq` before anything is said. The note names delegation through
    `φ` as the same sort of growth point; that one is not looked into yet.

  * **A chain of copies is one name.** `Same` collapses `Φ.app.φ.α0` →
    `Φ.app.lid` → `Φ.jar` into `Φ.jar`, so every question about a copy is
    answered by the formation it comes from. This is the single place the
    checker gets smarter later, and nothing else will have to change.

`Ungrouped` and `Row` are the inverse of `Grouped` and `Cells`: they read a
table back into flat rows under the name each owner goes by. Neither knows a
column by name, so a rule that starts writing a new one has it read back for
free.

---

On the runtime the loop drains **25,960** pending checks in about **5s** (the
`inference` step alone goes from 19.9s to 24.9s) beside 2,482 types, 10,090
needs and 21,068 links.

It reports 62 mistakes, and **every one of them is false**. That is worth
stating plainly rather than hiding, because they all have one cause and it is
not this loop: `complete="true"` is written for objects whose attributes arrive
through `φ` or through their package, which is #6565. Applying that ticket's
one-line rule locally — a formation that binds `φ` is not complete, as PR #6592
proposes — the same sweep reports **nothing at all**. So the loop is as honest
as the table it trusts, and it stays quiet on the whole runtime the moment
that table stops lying. I left `Provides` alone here rather than duplicating an
open PR.

Nothing fails the build. The verdicts land as a document beside the tables,
which is what a prototype's opinion is worth for now.

Closes: #6614
