### PR TITLE
#6610: apply Sha's filter only when hashing a directory

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -73,9 +73,15 @@ final class Sha {
      */
     private String hash() throws IOException, NoSuchAlgorithmException {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final Predicate<Path> active;
+        if (Files.isDirectory(this.path)) {
+            active = this.filter;
+        } else {
+            active = any -> true;
+        }
         try (Stream<Path> walk = Files.walk(this.path)) {
             walk.filter(Files::isRegularFile)
-                .filter(this.filter)
+                .filter(active)
                 .sorted(Comparator.comparing(this::relative))
                 .forEach(file -> this.feed(digest, file));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -99,6 +99,27 @@ final class ShaTest {
     }
 
     @Test
+    void ignoresTheFilterForALoneFile(@Mktmp final Path temp)
+        throws IOException, NoSuchAlgorithmException {
+        final long seed = System.nanoTime();
+        final String text = String.format("%s-λόγος", Long.toHexString(seed));
+        final Path file = temp.resolve("rejected.txt");
+        new Saved(text, file).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "a lone file must hash its own bytes even if the filter rejects it, seed=%d", seed
+            ),
+            new Sha(file, path -> false).toString(),
+            Matchers.equalTo(
+                Base64.getEncoder().encodeToString(
+                    MessageDigest.getInstance("SHA-256")
+                        .digest(text.getBytes(StandardCharsets.UTF_8))
+                )
+            )
+        );
+    }
+
+    @Test
     void hashesEqualDirsEqually(@Mktmp final Path temp) throws IOException {
         final long seed = System.nanoTime();
         final String text = String.format("%s-שלום", Long.toHexString(seed));


### PR DESCRIPTION
Closes #6610.

`Sha.hash()` applied its filter unconditionally, even for a lone file, contradicting the field's own Javadoc ("applied only when hashing a directory"). A lone file the filter rejects hashed to the digest of no input at all instead of its own bytes.

Guarded the filter with `Files.isDirectory(this.path)`, so a lone file always hashes its own bytes regardless of what filter was passed in, matching the documented contract.

Added `ignoresTheFilterForALoneFile` to `ShaTest`, constructing `Sha` with a filter that rejects everything and checking the hash still matches the file's raw bytes.
