### PR TITLE
#6611: collapse Cache.dirSha into Cache.sha

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -114,25 +114,11 @@ final class Cache {
      * @return Base64-encoded SHA-256 hash of the file or directory contents
      */
     private String sha(final Path any) {
-        final String result;
-        if (Files.isDirectory(any)) {
-            result = this.dirSha(any);
-        } else if (Files.isRegularFile(any)) {
-            result = new Sha(any).toString();
-        } else {
+        if (!Files.isDirectory(any) && !Files.isRegularFile(any)) {
             throw new IllegalArgumentException(
                 String.format("Path '%s' is neither a regular file nor a directory", any)
             );
         }
-        return result;
-    }
-
-    /**
-     * Calculate SHA-256 hash of a directory by hashing all regular files inside it.
-     * @param dir Directory path
-     * @return Base64-encoded SHA-256 hash of the directory contents
-     */
-    private String dirSha(final Path dir) {
-        return new Sha(dir, this.filter).toString();
+        return new Sha(any, this.filter).toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -73,9 +73,15 @@ final class Sha {
      */
     private String hash() throws IOException, NoSuchAlgorithmException {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final Predicate<Path> active;
+        if (Files.isDirectory(this.path)) {
+            active = this.filter;
+        } else {
+            active = any -> true;
+        }
         try (Stream<Path> walk = Files.walk(this.path)) {
             walk.filter(Files::isRegularFile)
-                .filter(this.filter)
+                .filter(active)
                 .sorted(Comparator.comparing(this::relative))
                 .forEach(file -> this.feed(digest, file));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -99,6 +99,27 @@ final class ShaTest {
     }
 
     @Test
+    void ignoresTheFilterForALoneFile(@Mktmp final Path temp)
+        throws IOException, NoSuchAlgorithmException {
+        final long seed = System.nanoTime();
+        final String text = String.format("%s-λόγος", Long.toHexString(seed));
+        final Path file = temp.resolve("rejected.txt");
+        new Saved(text, file).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "a lone file must hash its own bytes even if the filter rejects it, seed=%d", seed
+            ),
+            new Sha(file, path -> false).toString(),
+            Matchers.equalTo(
+                Base64.getEncoder().encodeToString(
+                    MessageDigest.getInstance("SHA-256")
+                        .digest(text.getBytes(StandardCharsets.UTF_8))
+                )
+            )
+        );
+    }
+
+    @Test
     void hashesEqualDirsEqually(@Mktmp final Path temp) throws IOException {
         final long seed = System.nanoTime();
         final String text = String.format("%s-שלום", Long.toHexString(seed));


### PR DESCRIPTION
Closes #6611. Depends on #6610 (Sha now guards the filter to directories only, so passing it through unconditionally is safe for both branches).

`Cache.dirSha` was a one-line delegator, `return new Sha(dir, this.filter).toString();`, with Javadoc still describing the loop it used to run before #6602. Its only caller, `Cache.sha`, built the same kind of object with different arguments on its two branches for no reason a reader could recover from the code.

Collapsed both branches into one `new Sha(any, this.filter).toString()` call and removed `dirSha` along with its stale Javadoc. The `IllegalArgumentException` guard for a path that's neither a file nor a directory stays.

Ran `CacheTest`, `ShaTest`, and the cache-consumer tests (`ConcurrentCacheTest`, `GlobalCacheTest`, `ChCachedTest`, `OyCachedTest`, `Fp*CacheTest`) locally, all green. `qulice:check -Pqulice` on `eo-maven-plugin` is clean.
