### PR TITLE
#6612: assert the folder hash against Sha directly

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Cache.java
@@ -114,25 +114,11 @@ final class Cache {
      * @return Base64-encoded SHA-256 hash of the file or directory contents
      */
     private String sha(final Path any) {
-        final String result;
-        if (Files.isDirectory(any)) {
-            result = this.dirSha(any);
-        } else if (Files.isRegularFile(any)) {
-            result = new Sha(any).toString();
-        } else {
+        if (!Files.isDirectory(any) && !Files.isRegularFile(any)) {
             throw new IllegalArgumentException(
                 String.format("Path '%s' is neither a regular file nor a directory", any)
             );
         }
-        return result;
-    }
-
-    /**
-     * Calculate SHA-256 hash of a directory by hashing all regular files inside it.
-     * @param dir Directory path
-     * @return Base64-encoded SHA-256 hash of the directory contents
-     */
-    private String dirSha(final Path dir) {
-        return new Sha(dir, this.filter).toString();
+        return new Sha(any, this.filter).toString();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -73,9 +73,15 @@ final class Sha {
      */
     private String hash() throws IOException, NoSuchAlgorithmException {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final Predicate<Path> active;
+        if (Files.isDirectory(this.path)) {
+            active = this.filter;
+        } else {
+            active = any -> true;
+        }
         try (Stream<Path> walk = Files.walk(this.path)) {
             walk.filter(Files::isRegularFile)
-                .filter(this.filter)
+                .filter(active)
                 .sorted(Comparator.comparing(this::relative))
                 .forEach(file -> this.feed(digest, file));
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CacheTest.java
@@ -222,16 +222,13 @@ final class CacheTest {
             temp.resolve("out.txt"),
             source.getFileName()
         );
-        final MessageDigest instance = MessageDigest.getInstance("SHA-256");
-        CacheTest.frame(instance, "file1.txt", first);
-        CacheTest.frame(instance, "file2.txt", second);
         MatcherAssert.assertThat(
             "SHA-256 hash file has incorrect content for folder with several files",
             Files.readString(
                 cache.resolve("folder.sha256"),
                 StandardCharsets.UTF_8
             ),
-            Matchers.equalTo(Base64.getEncoder().encodeToString(instance.digest()))
+            Matchers.equalTo(new Sha(source).toString())
         );
     }
 
@@ -350,23 +347,6 @@ final class CacheTest {
             MessageDigest.getInstance("SHA-256")
                 .digest(content.getBytes(StandardCharsets.UTF_8))
         );
-    }
-
-    /**
-     * Feed a digest with a single file's contents, framed by its relative
-     * path and its byte length, the same way {@link Sha} frames a file
-     * inside a directory.
-     * @param digest Digest to feed
-     * @param relative Relative path of the file
-     * @param content File content
-     */
-    private static void frame(
-        final MessageDigest digest, final String relative, final String content
-    ) {
-        final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        digest.update(String.format("%s\0", relative).getBytes(StandardCharsets.UTF_8));
-        digest.update(bytes);
-        digest.update(String.format("\0%d\0", bytes.length).getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -99,6 +99,27 @@ final class ShaTest {
     }
 
     @Test
+    void ignoresTheFilterForALoneFile(@Mktmp final Path temp)
+        throws IOException, NoSuchAlgorithmException {
+        final long seed = System.nanoTime();
+        final String text = String.format("%s-λόγος", Long.toHexString(seed));
+        final Path file = temp.resolve("rejected.txt");
+        new Saved(text, file).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "a lone file must hash its own bytes even if the filter rejects it, seed=%d", seed
+            ),
+            new Sha(file, path -> false).toString(),
+            Matchers.equalTo(
+                Base64.getEncoder().encodeToString(
+                    MessageDigest.getInstance("SHA-256")
+                        .digest(text.getBytes(StandardCharsets.UTF_8))
+                )
+            )
+        );
+    }
+
+    @Test
     void hashesEqualDirsEqually(@Mktmp final Path temp) throws IOException {
         final long seed = System.nanoTime();
         final String text = String.format("%s-שלום", Long.toHexString(seed));


### PR DESCRIPTION
Closes #6612. Depends on #6611 (touches the same test method just simplified there).

`CacheTest.frame` re-implemented the way `Sha` frames a file inside a directory, relative path, then NUL, then bytes, then `\0length\0`, so the folder-hash test could predict the digest it asserts. That duplication makes the test blind to a regression in `Sha`'s own framing: change it there and `frame` has to change to match, and the test passes again having verified nothing.

Replaced the hand-built digest with `new Sha(source).toString()`, asserting what `Cache` actually promises: the marker file holds the `Sha` of the source. Removed `frame` along with the `MessageDigest` plumbing it needed.

Ran `CacheTest` and `ShaTest` locally, both green. `qulice:check -Pqulice` on `eo-maven-plugin` is clean.
