### PR TITLE
#6599: reject a fractional slice start or end

### DIFF
--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -10,38 +10,42 @@
 
 [list start end] > slice
   if. > @
-    gte.
-      number
-        if. >> s!
-          start.gte 0
+    start.is-integer.and end.is-integer
+    if.
+      gte.
+        number
+          if. >> s!
+            start.gte 0
+            if.
+              start.gte list.length
+              list.length
+              start
+            if.
+              list.length.neg.lte start
+              start.plus list.length
+              0
+        if. >> e!
+          end.gte 0
           if.
-            start.gte list.length
+            end.gte list.length
             list.length
-            start
+            end
           if.
-            list.length.neg.lte start
-            start.plus list.length
+            list.length.neg.lte end
+            end.plus list.length
             0
-      if. >> e!
-        end.gte 0
-        if.
-          end.gte list.length
-          list.length
-          end
-        if.
-          list.length.neg.lte end
-          end.plus list.length
-          0
-    *
-    reducedi
-      list
       *
-      if. > [accum item index] >>
-        and.
-          index.gte s
-          index.lt e
-        accum.with item
-        accum
+      reducedi
+        list
+        *
+        if. > [accum item index] >>
+          and.
+            index.gte s
+            index.lt e
+          accum.with item
+          accum
+    T
+      "Given slice start and end must both be integers"
 
   eq. ++> can-slice-a-list
     slice
@@ -197,3 +201,19 @@
     *
       "bar"
       "buzz"
+
+  slice --> stops-on-a-fractional-end
+    *
+      1
+      2
+      3
+    0
+    2.5
+
+  slice --> stops-on-a-fractional-start
+    *
+      1
+      2
+      3
+    0.5
+    2


### PR DESCRIPTION
Closes #6599.

`tuple.slice` clamped `start` and `end` to the list bounds but never checked they were integers, so a fractional index like `0.5` sat silently between two positions. Same defect already fixed for `tuple.at` in #6057 and `string.at` in #5981.

Added a `start.is-integer.and end.is-integer` guard before the existing clamp-and-reduce logic, falling back to a bottom object (`T`) when either isn't an integer, matching the no-fallback-parameter shape `slice` already has.

Added `stops-on-a-fractional-start` and `stops-on-a-fractional-end` tests using the `slice --> stops-on-...` convention already used elsewhere in the runtime for a bottom-object rejection.
