### PR TITLE
#6606: defer AtomSafe's Atom cast into the guarded lambda call

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtomSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtomSafe.java
@@ -21,23 +21,23 @@ package org.eolang;
 public final class AtomSafe implements Atom {
 
     /**
-     * Original atom.
+     * Original object, expected to also be an atom.
      */
-    private final Atom origin;
+    private final Phi origin;
 
     /**
      * Ctor.
      * @param atom Phi as atom
      */
     public AtomSafe(final Phi atom) {
-        this.origin = (Atom) atom;
+        this.origin = atom;
     }
 
     // @checkstyle IllegalCatchCheck (12 lines)
     @Override
     public Phi lambda() {
         try {
-            return this.origin.lambda();
+            return ((Atom) this.origin).lambda();
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             throw AtomSafe.failure(ex);

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -110,6 +110,19 @@ final class PhSafeTest {
     }
 
     @Test
+    void catchesNonAtomOriginOnLambda() {
+        MatcherAssert.assertThat(
+            "wraps a non-atom origin's cast failure into ExFailure instead of letting it escape",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PhSafe(new PhDefault()).lambda(),
+                "was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.containsString(".λ")
+        );
+    }
+
+    @Test
     void showsFileNameAndLineNumber() {
         MatcherAssert.assertThat(
             "shows file name, line number and the original cause",


### PR DESCRIPTION
Closes #6606.

`AtomSafe`'s constructor cast its argument to `Atom` right away: `this.origin = (Atom) atom;`. `PhSafe.lambda()` calls it as `this.through(new AtomSafe(this.origin)::lambda, ".λ")`, and the receiver of a bound method reference is evaluated when the reference is created, not when the functional method runs. So `new AtomSafe(this.origin)` runs before `through` is entered, and a `Phi` that isn't an `Atom` throws `ClassCastException` right there, before the try/catch in `through` (the only thing that turns a failure into an `ExFailure`) ever sees it.

Moved the cast from the constructor into `lambda()` itself, inside the same try block that already catches everything else. The cast failure now happens where `through`'s try/catch can see it, same as any other failure from the wrapped atom.

Added `catchesNonAtomOriginOnLambda` to `PhSafeTest`, asserting `new PhSafe(new PhDefault()).lambda()` throws `ExFailure` (with the `.λ` location) instead of a raw `ClassCastException`.
