### PR TITLE
#6597: split empty text into one empty string

### DIFF
--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -13,7 +13,7 @@
       size. >> len!
         text >> bts!
       0
-    *
+    * ""
     [accum start current] >> rec-split
       if. > @
         len.eq current
@@ -82,6 +82,12 @@
       "a"
       "b"
       "c"
+
+  eq. ++> can-split-an-empty-text-into-one-empty-string
+    split
+      ""
+      "-"
+    * ""
 
   eq. ++> can-split-into-strings
     length.


### PR DESCRIPTION
Closes #6597.

`string.split` short-circuited on a zero-length text and returned an empty tuple, zero parts. That contradicts how the object treats empty parts everywhere else: `can-split-a-text-into-empty-strings` keeps both the leading and trailing empty part of `"-a-b-"`, so an empty text should be one empty part, not zero parts, the same way it works in Ruby, Python and JS.

Changed the empty-text branch from `*` to `* ""`.

Added `can-split-an-empty-text-into-one-empty-string`.
