### PR TITLE
#6598: reject an empty delimiter through a cant-split fallback

### DIFF
--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -1,4 +1,6 @@
 # Returns a `tuple` of `strings`: `text` separated by `delimiter`.
+# If `delimiter` is empty, the `cant-split` fallback is returned, or the
+# bottom object when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -7,51 +9,51 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text delimiter] > split
+[text delimiter cant-split] > split
   if. > @
-    eq.
-      size. >> len!
-        text >> bts!
-      0
-    * ""
-    [accum start current] >> rec-split
-      if. > @
-        len.eq current
-        appended
-        if.
-          or.
-            size.eq 0
-            gt.
-              current.plus size
-              len
-          rec-split
-            accum
-            start
-            as-number.
-              current.plus 1
+    delimiter.size.eq 0
+    cant-split
+      "The delimiter must not be empty"
+    if.
+      eq.
+        size. >> len!
+          text >> bts!
+        0
+      * ""
+      [accum start current] >> rec-split
+        if. > @
+          len.eq current
+          appended
           if.
-            delim.eq
-              bts.slice current size
-            rec-split
-              appended
-              as-number.
+            or.
+              size.eq 0
+              gt.
                 current.plus size
-              as-number.
-                current.plus size
+                len
             rec-split
               accum
               start
               as-number.
                 current.plus 1
-      accum.with > appended
-        string
-          bts.slice
-            start
-            current.minus start
-    |
-      *
-      0
-      0
+            if.
+              delim.eq
+                bts.slice current size
+              rec-split
+                appended
+                as-number.
+                  current.plus size
+                as-number.
+                  current.plus size
+              rec-split accum start (current.plus 1).as-number
+        accum.with > appended
+          string
+            bts.slice
+              start
+              current.minus start
+      |
+        *
+        0
+        0
   size. >> size!
     delimiter >> delim!
 
@@ -97,3 +99,14 @@
           " "
         1
     6
+
+  eq. ++> rejects-an-empty-delimiter
+    "recovered"
+    split
+      "abc"
+      ""
+      "recovered" > [message]
+
+  split --> stops-on-an-empty-delimiter
+    "abc"
+    ""

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -13,7 +13,7 @@
       size. >> len!
         text >> bts!
       0
-    *
+    * ""
     [accum start current] >> rec-split
       if. > @
         len.eq current
@@ -82,6 +82,12 @@
       "a"
       "b"
       "c"
+
+  eq. ++> can-split-an-empty-text-into-one-empty-string
+    split
+      ""
+      "-"
+    * ""
 
   eq. ++> can-split-into-strings
     length.


### PR DESCRIPTION
Closes #6598. Depends on #6597 (both touch the same file's base cases).

`string.split` accepted an empty `delimiter` and silently walked to the end of the text, returning the whole text as one part. The caller has no way to tell that apart from a text that simply has no delimiter in it. The sibling `nsplit` already rejects an invalid `limit` through its `cant-split` fallback (#6060); `split` had no fallback attribute at all.

Gave `split` the same `cant-split` fallback, returned when the delimiter is empty with a message saying so. Checked the one other caller in the runtime, `path.eo`'s `string.split driveless separator`: it leaves the fallback unbound, the same way `n.mod 2` and `7.mod 3` already leave `cant-mod` unbound elsewhere in the runtime, which is safe as long as the error branch is never reached (the path separator is never empty).

Added `rejects-an-empty-delimiter` and `stops-on-an-empty-delimiter`. Ran `EOsplitTest` and `EOpathTest`, both green.
