### PR TITLE
#6600: fail loudly when the write syscall returns -1

### DIFF
--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -55,6 +55,12 @@
 # ```
 #
 # Sequential reuse maintains the console state across operations.
+#
+# @todo #6600:30min Keep writing the remaining bytes on a partial write. Right
+#  now `write` panics only when the `write` syscall returns -1; a successful
+#  write of fewer bytes than `buffer.size` is accepted as if the whole buffer
+#  went out, same as `stderr.write`. Both should retry with the unwritten
+#  tail until the buffer is fully flushed or a syscall fails.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -92,14 +98,21 @@
           write.
             [] >> output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard output"
+                    output-block
+                  code
+                  output-block
+                code. > code
                   win32 *1
                     "_write"
                     win32.stdout
                     buffer
                     buffer.size
-                output-block
             buffer
     [] >>
       [size] > read
@@ -128,14 +141,21 @@
           write.
             [] >> output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard output"
+                    output-block
+                  code
+                  output-block
+                code. > code
                   posix *1
                     "write"
                     posix.stdout
                     buffer
                     buffer.size
-                output-block
             buffer
 
   console.write ++> can-write-to-the-console

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -29,28 +29,42 @@
               output-block.write buffer
             [] > output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard error"
+                    output-block
+                  code
+                  output-block
+                code. > code
                   win32 *1
                     "_write"
                     win32.stderr
                     buffer
                     buffer.size
-                output-block
         [] >>
           [buffer] > write
             @. > @
               output-block.write buffer
             [] > output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard error"
+                    output-block
+                  code
+                  output-block
+                code. > code
                   posix *1
                     "write"
                     posix.stderr
                     buffer
                     buffer.size
-                output-block
       text
     true
 


### PR DESCRIPTION
Every write path in `console.write` and `stderr.write` (win32 and posix) dataized the `write` syscall's return code and threw it away. `write` returns -1 on failure, so writing to a closed pipe, a full disk, or a stream interrupted by a signal was reported as success while the output was silently lost.

Fixed by checking the code the same way the read side already does: -1 now panics with a clear message instead of continuing as if the write succeeded.

Partial writes (code smaller than buffer.size) are a separate piece of work, left as a `@todo` puzzle in `console.eo` referencing this issue, since retrying the unwritten tail needs its own design and tests.

Ran the existing `EOconsoleTest`, `EOstdoutTest`, `EOstderrTest` and `qulice:check -Pqulice` locally, all green.

Closes #6600
