### PR TITLE
Drop the dead index cell from the provides table

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -73,25 +73,19 @@ final class Provides implements Clue {
     @Override
     public void follow(final Path xmirs, final Path tables) throws IOException {
         try (Tojos rows = new TjDeferred(new MnMemory())) {
-            int seen = 0;
             for (final XML formation : new Xmirs(xmirs).formations()) {
                 final String owner = formation.xpath("@loc").get(0);
                 final boolean whole = formation.nodes("o[@name='λ' or @name='φ']").isEmpty();
-                rows.add(owner)
-                    .set("index", Integer.toString(seen))
-                    .set("complete", Boolean.toString(whole));
-                seen = seen + 1;
+                rows.add(owner).set("complete", Boolean.toString(whole));
                 for (final XML attr : formation.nodes("o[@name and not(@name='λ')]")) {
                     final String name = attr.xpath("@name").get(0);
                     final Tojo row = rows.add(String.join(" ", owner, name))
                         .set("owner", owner)
-                        .set("index", Integer.toString(seen))
                         .set("name", name)
                         .set("type", attr.xpath("@loc").get(0));
                     if (attr.xpath("@base").contains("∅")) {
                         row.set("void", "true");
                     }
-                    seen = seen + 1;
                 }
             }
             Files.createDirectories(tables);


### PR DESCRIPTION
`Provides` was writing a cell nobody reads:

```java
rows.add(owner)
    .set("index", Integer.toString(seen))
    .set("complete", Boolean.toString(whole));
```

It was needed while `Grouped` sorted rows by it. #6551 deleted it from all four
clues along with both sorts, because `TjDeferred` hands the rows back in the
order they arrived and a row's place is meaningful on its own. #6592 branched
before that and restored the cell here, so master carried it in `provides.xml`
and in none of its three siblings — 8,793 of them in a document meant to be
read by a human.

Nothing else moves: no pack asserts the cell, `Grouped` has no comparator left,
and `Provided`, which is how the checking loop reads this table, keeps the rows
in the order they came.

Closes: #6644
