### PR TITLE
#6608: escape control characters in PhApplication string literals

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -120,17 +120,7 @@ public final class PhApplication extends PhOnce {
         }
         final String result;
         if (text.isPresent()) {
-            result = String.format(
-                "\"%s\"",
-                text.get()
-                    .replace("\\", "\\\\")
-                    .replace("\"", "\\\"")
-                    .replace("\b", "\\b")
-                    .replace("\f", "\\f")
-                    .replace(String.valueOf('\n'), "\\n")
-                    .replace(String.valueOf('\r'), "\\r")
-                    .replace("\t", "\\t")
-            );
+            result = new Quoted(bytes).get();
         } else {
             result = null;
         }

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -133,6 +133,21 @@ final class PhApplicationTest {
     }
 
     @Test
+    void escapesControlCharactersOutsideTheSevenHandwritten() {
+        MatcherAssert.assertThat(
+            "String φ-term must escape control characters like ESC and DEL, but it didn't",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "string"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"), 0,
+                    new PhDefault(new byte[] {0x1B, 0x7F})
+                )
+            ).φTerm(),
+            Matchers.equalTo("\"\\u001b\\u007f\"")
+        );
+    }
+
+    @Test
     void rendersInvalidUtfAsBytes() {
         MatcherAssert.assertThat(
             "Invalid UTF-8 must not be rendered as a misleading string literal",


### PR DESCRIPTION
`PhApplication.string()` escaped only the seven hand-written characters (backslash, quote, \b, \f, \n, \r, \t). Every other control character (0x00-0x07, vertical tab, 0x0E-0x1F including ESC, and DEL) went into the φ-term raw, unlike `PhDefault.φTerm()`, which already routes through `Quoted`/`Escaped`.

Replaced the hand-written replace chain with `new Quoted(bytes).get()`, the same escaper `PhDefault` uses. The strict UTF-8 decode stays in place so malformed input still falls back to the generic rendering.

Added a test for a control character outside the original seven (ESC, DEL).

Closes #6608
