### PR TITLE
Look behind the decoratee for an attribute

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Concluded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Concluded.java
@@ -68,7 +68,8 @@ public final class Concluded implements Clue {
             new Worklist(
                 names,
                 new Provided(
-                    new Ungrouped(new XMLDocument(tables.resolve("provides.xml")), names).rows()
+                    new Ungrouped(new XMLDocument(tables.resolve("provides.xml")), names).rows(),
+                    names
                 ),
                 new Ungrouped(new XMLDocument(tables.resolve("needs.xml")), names).rows(),
                 new Ungrouped(new XMLDocument(tables.resolve("checks.xml")), names).rows()

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -7,6 +7,7 @@ package org.eolang.inference;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -18,19 +19,26 @@ import java.util.Map;
  * formation the argument is a copy of. Three questions are asked of it while
  * the checks are drained.</p>
  *
- * <p>Whether the whole of a type has been seen, which is what makes a missing
- * attribute a mistake rather than a gap. A type is whole when it says so and
- * nothing that goes by the same name says otherwise: an argument put into a
- * copy of an atom is as unknown as the atom.</p>
- *
  * <p>What the type of an attribute is, or nothing at all when the type has no
- * such attribute. An attribute is looked for in two places, because there are
- * two: the type itself, and its package, since an attribute nobody binds falls
+ * such attribute. An attribute is looked for in three places, because there are
+ * three. The type itself. Its package, since an attribute nobody binds falls
  * through to the object of that name beside it — {@code Φ.number} binds eight
  * attributes and answers to forty, the rest of them being objects of their own
- * in the same package, {@code Φ.number.eq} among them. A locator names both
- * kinds the same way, so the second place costs one lookup. Delegation through
- * {@code φ} is a third place, and is not looked into yet.</p>
+ * in the same package, {@code Φ.number.eq} among them, and a locator names both
+ * kinds the same way. And whatever stands behind its {@code φ}, which answers
+ * for every name the object does not bind itself.</p>
+ *
+ * <p>Whether the whole of a type has been seen, which is what makes a missing
+ * attribute a mistake rather than a gap. A type is whole when it says so and
+ * nothing that goes by the same name says otherwise, or when it delegates and
+ * the object it delegates to is whole. The chain is what carries the doubt:
+ * an argument put into a copy of an atom is as unknown as the atom, and so is
+ * anything that hands its answers to one. Since no formation in the runtime
+ * binds both {@code λ} and {@code φ}, following the decoratee cannot walk past
+ * a body written in Java.</p>
+ *
+ * <p>Both walks stop at a type they have already passed, so an object that
+ * delegates in a circle is walked once and answers nothing.</p>
  *
  * <p>And which of its attributes are void, in the order they were declared,
  * because an argument fills a void by its place among them.</p>
@@ -45,11 +53,21 @@ final class Provided {
     private final Map<String, Collection<Map<String, String>>> table;
 
     /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
      * Ctor.
      * @param rows The rows of the provides table, by the name of their owner
+     * @param aliases The name every type goes by, from {@link Same}
      */
-    Provided(final Map<String, Collection<Map<String, String>>> rows) {
+    Provided(
+        final Map<String, Collection<Map<String, String>>> rows,
+        final Map<String, String> aliases
+    ) {
         this.table = rows;
+        this.names = aliases;
     }
 
     /**
@@ -58,13 +76,7 @@ final class Provided {
      * @return TRUE when nothing about the type is hidden from the checker
      */
     boolean complete(final String type) {
-        final Collection<Boolean> flags = new ArrayList<>(1);
-        for (final Map<String, String> row : this.own(type)) {
-            if (row.containsKey("complete")) {
-                flags.add(Boolean.parseBoolean(row.get("complete")));
-            }
-        }
-        return !flags.isEmpty() && !flags.contains(false);
+        return this.whole(type, new HashSet<>(0));
     }
 
     /**
@@ -75,17 +87,7 @@ final class Provided {
      *  no attribute of that name
      */
     String attribute(final String type, final String name) {
-        String found = "";
-        for (final Map<String, String> row : this.own(type)) {
-            if (name.equals(row.getOrDefault("name", ""))) {
-                found = row.getOrDefault("type", "");
-            }
-        }
-        final String member = String.join(".", type, name);
-        if (found.isEmpty() && this.table.containsKey(member)) {
-            found = member;
-        }
-        return found;
+        return this.kept(type, name, new HashSet<>(0));
     }
 
     /**
@@ -99,6 +101,75 @@ final class Provided {
         for (final Map<String, String> row : this.own(type)) {
             if (row.containsKey("void")) {
                 found.add(row.getOrDefault("type", ""));
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Has the whole of this type been seen, following what it delegates to?
+     * @param type The name the type goes by
+     * @param walked The types passed already
+     * @return TRUE when nothing about the type is hidden from the checker
+     */
+    private boolean whole(final String type, final Collection<String> walked) {
+        final Collection<Boolean> flags = new ArrayList<>(1);
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("complete")) {
+                flags.add(Boolean.parseBoolean(row.get("complete")));
+            }
+        }
+        boolean found = !flags.isEmpty() && !flags.contains(false);
+        final String behind = this.behind(type);
+        if (!found && !behind.isEmpty() && walked.add(type)) {
+            found = this.whole(behind, walked);
+        }
+        return found;
+    }
+
+    /**
+     * The type of the attribute this type keeps, looking behind what it
+     * delegates to when it keeps none.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @param walked The types passed already
+     * @return The type of the attribute, or an empty string
+     */
+    private String kept(final String type, final String name, final Collection<String> walked) {
+        String found = this.bound(type, name);
+        final String member = String.join(".", type, name);
+        if (found.isEmpty() && this.table.containsKey(member)) {
+            found = member;
+        }
+        final String behind = this.behind(type);
+        if (found.isEmpty() && !behind.isEmpty() && walked.add(type)) {
+            found = this.kept(behind, name, walked);
+        }
+        return found;
+    }
+
+    /**
+     * The type this one hands its answers to.
+     * @param type The name the type goes by
+     * @return The name of the type behind its {@code φ}, or an empty string
+     *  when the type binds no {@code φ} and answers for itself
+     */
+    private String behind(final String type) {
+        final String decoratee = this.bound(type, "φ");
+        return this.names.getOrDefault(decoratee, decoratee);
+    }
+
+    /**
+     * The type of the attribute this type binds itself.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @return The type of the attribute, or an empty string
+     */
+    private String bound(final String type, final String name) {
+        String found = "";
+        for (final Map<String, String> row : this.own(type)) {
+            if (name.equals(row.getOrDefault("name", ""))) {
+                found = row.getOrDefault("type", "");
             }
         }
         return found;

--- a/eo-inference/src/test/java/org/eolang/inference/ProvidedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ProvidedTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test case for {@link Provided}.
@@ -38,7 +39,8 @@ final class ProvidedTest {
                         )
                     ),
                     Collections.emptyMap()
-                ).rows()
+                ).rows(),
+                Collections.emptyMap()
             ).voids("Φ.jar"),
             Matchers.contains("Φ.jar.lid", "Φ.jar.spout")
         );
@@ -60,7 +62,8 @@ final class ProvidedTest {
                         )
                     ),
                     Collections.emptyMap()
-                ).rows()
+                ).rows(),
+                Collections.emptyMap()
             ).voids("Φ.jar"),
             Matchers.contains("Φ.jar.lid")
         );
@@ -82,7 +85,8 @@ final class ProvidedTest {
                         )
                     ),
                     Collections.singletonMap("Φ.tin", "Φ.jar")
-                ).rows()
+                ).rows(),
+                Collections.emptyMap()
             ).complete("Φ.jar"),
             Matchers.is(false)
         );
@@ -104,9 +108,82 @@ final class ProvidedTest {
                         )
                     ),
                     Collections.emptyMap()
-                ).rows()
+                ).rows(),
+                Collections.emptyMap()
             ).attribute("Φ.jar", "lid"),
             Matchers.equalTo("Φ.jar.lid")
+        );
+    }
+
+    @Test
+    void findsAttributeBehindDelegation() {
+        MatcherAssert.assertThat(
+            "what stands behind the decoratee answers for a name the object does not bind",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides>",
+                            "<type id='Φ.jar' complete='false'>",
+                            "<attr name='φ' type='Φ.jar.φ'/></type>",
+                            "<type id='Φ.base' complete='true'>",
+                            "<attr name='lid' type='Φ.base.lid'/></type>",
+                            "</provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows(),
+                Collections.singletonMap("Φ.jar.φ", "Φ.base")
+            ).attribute("Φ.jar", "lid"),
+            Matchers.equalTo("Φ.base.lid")
+        );
+    }
+
+    @Test
+    void seesWholeOfTypeThroughItsDecoratee() {
+        MatcherAssert.assertThat(
+            "an object that hands its answers to one that was seen whole was seen whole too",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides>",
+                            "<type id='Φ.jar' complete='false'>",
+                            "<attr name='φ' type='Φ.jar.φ'/></type>",
+                            "<type id='Φ.base' complete='true'/>",
+                            "</provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows(),
+                Collections.singletonMap("Φ.jar.φ", "Φ.base")
+            ).complete("Φ.jar"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    @Timeout(10L)
+    void walksOutOfDelegationThatComesBack() {
+        MatcherAssert.assertThat(
+            "an object whose decoratee leads back to it must be walked once and left alone",
+            new Provided(
+                new Ungrouped(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<provides><type id='Φ.jar' complete='false'>",
+                            "<attr name='φ' type='Φ.jar.φ'/>",
+                            "</type></provides>"
+                        )
+                    ),
+                    Collections.emptyMap()
+                ).rows(),
+                Collections.singletonMap("Φ.jar.φ", "Φ.jar")
+            ).complete("Φ.jar"),
+            Matchers.is(false)
         );
     }
 
@@ -120,7 +197,8 @@ final class ProvidedTest {
                         "<provides><type id='Φ.jar' complete='true'/></provides>"
                     ),
                     Collections.emptyMap()
-                ).rows()
+                ).rows(),
+                Collections.emptyMap()
             ).attribute("Φ.jar", "lid"),
             Matchers.emptyString()
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-behind-delegation-is-not-missing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-behind-delegation-is-not-missing.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The same four files as `mistake-behind-delegation-is-reported`, asking for
+# `next` instead of `foo`. `t` binds no `next` either, and yet there is nothing
+# to report, because the object behind its `φ` does.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.next > @
+  t.eo: |
+    [] > t
+      base > @
+  base.eo: |
+    [] > base
+      [] > next
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An object whose `φ` leads back to itself is a circle, and a circle is walked
+# once. Nothing is known about `t` at the end of it, so nothing is said.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.foo > @
+  t.eo: |
+    [] > t
+      t > @
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-to-an-atom-stays-quiet.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-to-an-atom-stays-quiet.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Following `φ` buys nothing when it ends at an atom: the body is written in
+# Java, this prototype cannot read it, and so neither `t` nor what it delegates
+# to has been seen whole. The chain carries the doubt along with the answers.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.foo > @
+  t.eo: |
+    [] > t
+      base > @
+  base.eo: |
+    [] > base /Q.number
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-behind-delegation-is-reported.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-behind-delegation-is-reported.yaml
@@ -5,6 +5,14 @@
 # whole and has no `foo` anywhere in it. So `foo` will never be there, and the
 # loop says so: what stands behind `φ` is the third place an attribute can come
 # from, after the object itself and its package.
+#
+# The four tables below are the whole basis of that verdict, and none of them
+# holds it alone. The provides rows say `t` binds only `φ` and was not seen
+# whole on its own, while `base` was and has nothing but `next`. The links row
+# says what that `φ` of `t` is, which is what turns "not seen whole" into "seen
+# whole through `base`". The needs row says somebody asks `foo` of whatever
+# fills the void `x`, and the checks row says a `t` is what fills it. Read
+# together they leave one answer, and the loop writes it down.
 eo:
   app.eo: |
     [] > app
@@ -18,5 +26,17 @@ eo:
   base.eo: |
     [] > base
       [] > next
+provides:
+  - "/provides/type[@id='Φ.t' and @complete='false']/attr[@name='φ' and @type='Φ.t.φ']"
+  - "/provides/type[@id='Φ.base' and @complete='true']/attr[@name='next']"
+  - "/provides/type[@id='Φ.base'][not(attr[@name='foo'])]"
+  - "/provides/type[@id='Φ.inc']/attr[@name='x' and @void='true']"
+links:
+  - "/links/type[@id='Φ.t.φ' and @copy='Φ.base']"
+  - "/links/type[@id='Φ.app.φ.α0' and @copy='Φ.t']"
+needs:
+  - "/needs/type[@id='Φ.inc.φ.ρ']/attr[@name='foo' and @type='Φ.inc.φ']"
+checks:
+  - "/checks/type[@id='Φ.app.φ']/attr[@name='α0' and @type='Φ.app.φ.α0']"
 problems:
   - "/problems/type[@id='Φ.t']/attr[@name='foo']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-behind-delegation-is-reported.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-behind-delegation-is-reported.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `t` binds nothing itself and hands everything to `base`, which has been seen
+# whole and has no `foo` anywhere in it. So `foo` will never be there, and the
+# loop says so: what stands behind `φ` is the third place an attribute can come
+# from, after the object itself and its package.
+eo:
+  app.eo: |
+    [] > app
+      inc t > @
+  inc.eo: |
+    [x] > inc
+      x.foo > @
+  t.eo: |
+    [] > t
+      base > @
+  base.eo: |
+    [] > base
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t']/attr[@name='foo']"


### PR DESCRIPTION
`Provided` looked for an attribute in two places, the type itself and its
package, and its javadoc ended by naming the missing third: "Delegation through
`φ` is a third place, and is not looked into yet." Now it is. When a type binds
neither the attribute nor a package member of that name, the type behind its
`φ` is resolved through `Same` and asked the same question. Completeness walks
the same path — an object that hands its answers to one that was seen whole was
seen whole too — and both walks stop at a type they have already passed, so an
object that delegates in a circle is walked once and answers nothing.

Four packs describe it, and they come in a pair that pins the behaviour from
both sides: the same four files ask `x.foo` and `x.next` of a `t` that binds
neither and delegates to a `base` that binds only `next`. The first is
reported, the second is not. The other two are about the doubt travelling along
the chain: a `t` that delegates to an atom stays unjudged, and a `t` whose `φ`
leads back to itself is walked once.

---

Now the part worth reading, because it is not what I expected. On the runtime
this changes the sweep by **nothing at all** — `problems.xml` was empty before
and is empty after — and the reason is a good one:

```
types in provides       : 2505
complete=true           : 48
delegators (bind φ)     : 2432
  decoratee has a row   : 295
  decoratee is complete : 1     (Φ.tuple.with)
```

Following `φ` makes exactly one more object judgeable. Not because the walk is
wrong — the packs show it working — but because a decoratee is almost never a
named object. It is a computed one: `x.next.foo > @` binds `φ` to a dispatch,
and no table says what a dispatch turns out to be, so the chain ends at a
locator nothing describes. Of 2,432 objects that delegate, only 295 hand over
to something the tables have a row for.

So this is one of the three places to look, tested and in place, and the
measurement it made possible says where the next one is: nothing writes down
the type of a computed object, while the loop works that out every time it
resolves an attribute and then throws the answer away. That is #6647, and it is
also where a check that cannot be decided has to start being parked again,
since facts will begin to appear while the list is being drained.

Closes: #6643
