### PR TITLE
Record what a computed object turns out to be

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Agreed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Agreed.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The answers that came out one way.
+ *
+ * <p>The loop asks what a computed object turns out to be, and asks it once
+ * for every copy of the formation the dispatch stands in. One answer is a
+ * fact. Two are a locator that is not one object, and the honest thing to do
+ * with it is nothing at all — it goes by its own name, the tables say nothing
+ * about it, and every check about it stays undecided.</p>
+ *
+ * @since 0.68.0
+ */
+final class Agreed {
+
+    /**
+     * Every answer given, by the locator it was given about.
+     */
+    private final Map<String, Collection<String>> answers;
+
+    /**
+     * Ctor.
+     * @param given Every answer given, by the locator it was given about
+     */
+    Agreed(final Map<String, Collection<String>> given) {
+        this.answers = given;
+    }
+
+    /**
+     * The name every computed object goes by.
+     * @return The locators that came out one way, against that one answer
+     */
+    Map<String, String> names() {
+        final Map<String, String> found = new HashMap<>(this.answers.size());
+        for (final Map.Entry<String, Collection<String>> answer : this.answers.entrySet()) {
+            if (answer.getValue().size() == 1) {
+                found.put(answer.getKey(), answer.getValue().iterator().next());
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Concluded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Concluded.java
@@ -41,6 +41,18 @@ import java.util.Map;
  * prototype, and its verdicts are worth reading before they are worth
  * obeying.</p>
  *
+ * <p>The loop leaves a second table behind it, of the same shape as the links
+ * one, saying what the objects nobody wrote down turned out to be:</p>
+ *
+ * <pre> &lt;copies&gt;
+ *   &lt;type id="Φ.use.φ.α0" copy="Φ.t.next"/&gt;
+ * &lt;/copies&gt;</pre>
+ *
+ * <p>A rule cannot write that row: it takes a check to find out that the
+ * {@code x.next} in one file is the {@code next} of a {@code t} in another.
+ * It is kept apart from the links the rules wrote for the same reason the
+ * rules are kept apart from each other — one document, one author.</p>
+ *
  * @since 0.68.0
  */
 public final class Concluded implements Clue {
@@ -61,21 +73,26 @@ public final class Concluded implements Clue {
     @Override
     public void follow(final Path xmirs, final Path tables) throws IOException {
         this.origin.follow(xmirs, tables);
-        final Map<String, String> names = new Same(
-            new XMLDocument(tables.resolve("links.xml"))
-        ).names();
-        try (Tojos rows = new TjDeferred(new MnMemory())) {
-            new Worklist(
-                names,
-                new Provided(
-                    new Ungrouped(new XMLDocument(tables.resolve("provides.xml")), names).rows()
-                ),
-                new Ungrouped(new XMLDocument(tables.resolve("needs.xml")), names).rows(),
-                new Ungrouped(new XMLDocument(tables.resolve("checks.xml")), names).rows()
-            ).drain(rows);
+        try (
+            Tojos rows = new TjDeferred(new MnMemory());
+            Tojos found = new TjDeferred(new MnMemory())
+        ) {
+            for (final Map.Entry<String, String> copy
+                : new Settled(
+                    new XMLDocument(tables.resolve("provides.xml")),
+                    new XMLDocument(tables.resolve("needs.xml")),
+                    new XMLDocument(tables.resolve("checks.xml")),
+                    new Same(new XMLDocument(tables.resolve("links.xml"))).names()
+                ).drain(rows).entrySet()) {
+                found.add(copy.getKey()).set("copy", copy.getValue());
+            }
             Files.write(
                 tables.resolve("problems.xml"),
                 new Grouped(rows, "problems").asXml().toString().getBytes(StandardCharsets.UTF_8)
+            );
+            Files.write(
+                tables.resolve("copies.xml"),
+                new Grouped(found, "copies").asXml().toString().getBytes(StandardCharsets.UTF_8)
             );
         }
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Ends.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ends.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Every chain of copies, walked to its end.
+ *
+ * <p>A copy of a copy is a copy of the same thing, and the pairs come in one
+ * at a time: {@code a} is a copy of {@code b}, {@code b} of {@code c}. Asking
+ * the table about {@code a} has to arrive at {@code c}, so each pair is
+ * followed as far as it goes and the end is written down against every name on
+ * the way. A chain that comes back on itself is walked once and stops where it
+ * started, since an object that is a copy of itself is nothing new.</p>
+ *
+ * @since 0.68.0
+ */
+final class Ends {
+
+    /**
+     * The pairs, each name against the one it is a copy of.
+     */
+    private final Map<String, String> copies;
+
+    /**
+     * Ctor.
+     * @param pairs The pairs, each name against the one it is a copy of
+     */
+    Ends(final Map<String, String> pairs) {
+        this.copies = pairs;
+    }
+
+    /**
+     * The name every type goes by.
+     * @return The names, each type against the end of its chain of copies
+     */
+    Map<String, String> names() {
+        final Map<String, String> ends = new HashMap<>(this.copies.size());
+        for (final Map.Entry<String, String> link : this.copies.entrySet()) {
+            final Collection<String> walked = new HashSet<>(0);
+            String end = link.getValue();
+            while (this.copies.containsKey(end) && walked.add(end)) {
+                end = this.copies.get(end);
+            }
+            ends.put(link.getKey(), end);
+        }
+        return ends;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Same.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Same.java
@@ -5,9 +5,7 @@
 package org.eolang.inference;
 
 import com.jcabi.xml.XML;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -53,15 +51,6 @@ final class Same {
         for (final XML link : this.table.nodes("/links/type")) {
             copies.put(link.xpath("@id").get(0), link.xpath("@copy").get(0));
         }
-        final Map<String, String> ends = new HashMap<>(copies.size());
-        for (final Map.Entry<String, String> link : copies.entrySet()) {
-            final Collection<String> walked = new HashSet<>(0);
-            String end = link.getValue();
-            while (copies.containsKey(end) && walked.add(end)) {
-                end = copies.get(end);
-            }
-            ends.put(link.getKey(), end);
-        }
-        return ends;
+        return new Ends(copies).names();
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Settled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Settled.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.yegor256.tojos.MnMemory;
+import com.yegor256.tojos.TjDeferred;
+import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * The checks, drained until the loop stops learning.
+ *
+ * <p>{@link Worklist} works out what a computed object is a copy of every time
+ * it resolves an attribute, and one draining is not enough to use that: the
+ * check that needed the fact may have been decided before the check that found
+ * it. So the list is drained again, with what the last draining learned added
+ * to the names, and again, until a draining brings nothing new. Each one starts
+ * from the tables as they were written, so a fact never rests on a fact that a
+ * later draining takes back.</p>
+ *
+ * <p>A locator that came out two ways is not learned at all. The dispatch
+ * {@code x.next} is one object in the program text, and a formation copied
+ * twice asks it of two different things — the answers disagree, and neither is
+ * the truth about that locator. Staying silent about it is the same honesty
+ * that keeps an incomplete object from being blamed; the day a copy receives
+ * types of its own, the two answers will belong to two locators and the
+ * disagreement will disappear on its own.</p>
+ *
+ * <p>Only the last draining says what is missing. An earlier one judges with
+ * less than everything known, and a mistake found there may be no mistake at
+ * all once the last fact arrives, so its verdicts are thrown away and the
+ * final pass, which knows everything the loop can know, writes the table.</p>
+ *
+ * @since 0.68.0
+ */
+final class Settled {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * The needs table.
+     */
+    private final XML wanted;
+
+    /**
+     * The checks table.
+     */
+    private final XML pending;
+
+    /**
+     * The name every type goes by, from {@link Same}.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param provides The provides table
+     * @param needs The needs table
+     * @param checks The checks table
+     * @param aliases The name every type goes by, from {@link Same}
+     */
+    Settled(
+        final XML provides,
+        final XML needs,
+        final XML checks,
+        final Map<String, String> aliases
+    ) {
+        this.given = provides;
+        this.wanted = needs;
+        this.pending = checks;
+        this.names = aliases;
+    }
+
+    /**
+     * Drain the checks into the given table, a row per mistake, and hand back
+     * what the loop worked out about the objects nobody wrote down.
+     * @param rows The table to write the mistakes into
+     * @return What every computed object is a copy of, by its locator
+     * @throws IOException If the rows of a draining cannot be let go of
+     */
+    Map<String, String> drain(final Tojos rows) throws IOException {
+        final Map<String, Collection<String>> answers = new HashMap<>(0);
+        boolean fresh = true;
+        while (fresh) {
+            fresh = false;
+            try (Tojos ignored = new TjDeferred(new MnMemory())) {
+                for (final Map.Entry<String, Collection<String>> found
+                    : this.drained(answers, ignored).entrySet()) {
+                    fresh = answers.computeIfAbsent(
+                        found.getKey(), made -> new HashSet<>(1)
+                    ).addAll(found.getValue()) || fresh;
+                }
+            }
+        }
+        this.drained(answers, rows);
+        return new Agreed(answers).names();
+    }
+
+    /**
+     * Drain the checks once, knowing what has been learned so far.
+     * @param answers What every computed object has come out as, so far
+     * @param rows The table to write the mistakes into
+     * @return What this draining worked out
+     */
+    private Map<String, Collection<String>> drained(
+        final Map<String, Collection<String>> answers, final Tojos rows
+    ) {
+        final Map<String, String> known = new HashMap<>(this.names);
+        known.putAll(new Agreed(answers).names());
+        final Map<String, String> ends = new Ends(known).names();
+        return new Worklist(
+            ends,
+            new Provided(new Ungrouped(this.given, ends).rows()),
+            new Ungrouped(this.wanted, ends).rows(),
+            new Ungrouped(this.pending, ends).rows()
+        ).drain(rows);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Worklist.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Worklist.java
@@ -9,6 +9,7 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -39,12 +40,22 @@ import java.util.Map;
  * said about them. It is better to miss a mistake than to complain about
  * correct code.</p>
  *
- * <p>A check already started is dropped rather than started again. Nothing new
- * is learned while the list is drained, since all four tables were written
- * before it started, so a check nobody can decide now will not become
- * decidable later: the list only ever grows by splitting a check into smaller
- * ones, of which there are finitely many. Remembering the ones already started
- * is what keeps an object that refers to itself from being walked forever.</p>
+ * <p>A check already started is dropped rather than started again. Within one
+ * draining nothing new arrives, since the tables were all written before it
+ * began and the list only ever grows by splitting a check into smaller ones,
+ * of which there are finitely many. Remembering the ones already started is
+ * what keeps an object that refers to itself from being walked forever.</p>
+ *
+ * <p>Deciding a check works something out that no table holds. When {@code t}
+ * is asked for {@code next} and answers with the {@code next} of a {@code t},
+ * the dispatch that asked — an object the program computes and nobody names —
+ * has just turned out to be that very attribute. The tables say nothing about
+ * such an object, so every question about it is answered by an empty row until
+ * this is written down. It is handed back rather than used here, because the
+ * same locator can come out two ways: the dispatch stands in a formation, and
+ * a formation copied twice asks its question of two different objects. Only
+ * whoever sees every answer can tell a fact from a coincidence, which is
+ * {@link Settled}.</p>
  *
  * @since 0.68.0
  */
@@ -90,10 +101,16 @@ final class Worklist {
     }
 
     /**
-     * Drain the checks into the given table, a row per mistake.
+     * Drain the checks into the given table, a row per mistake, and hand back
+     * what was worked out on the way about the objects nobody wrote down.
      * @param rows The table to write the mistakes into
+     * @return What every computed object turned out to be, by its locator;
+     *  more than one answer against a locator means the object is not one
+     *  thing, since the dispatch that made it stands in a formation that was
+     *  copied more than once
      */
-    void drain(final Tojos rows) {
+    Map<String, Collection<String>> drain(final Tojos rows) {
+        final Map<String, Collection<String>> learned = new HashMap<>(0);
         final Deque<String> todo = new ArrayDeque<>(0);
         for (final Map.Entry<String, Collection<Map<String, String>>> copy
             : this.pending.entrySet()) {
@@ -103,7 +120,9 @@ final class Worklist {
                     if (!hole.isEmpty()) {
                         todo.add(
                             String.join(
-                                " ", this.name(argument.getOrDefault("type", "")), hole
+                                " ",
+                                this.name(argument.getOrDefault("type", "")),
+                                this.name(hole)
                             )
                         );
                     }
@@ -114,9 +133,10 @@ final class Worklist {
         while (!todo.isEmpty()) {
             final String check = todo.poll();
             if (started.add(check)) {
-                this.decide(check, todo, rows);
+                this.decide(check, todo, rows, learned);
             }
         }
+        return learned;
     }
 
     /**
@@ -124,8 +144,14 @@ final class Worklist {
      * @param check The name of the object and the name of the void, together
      * @param todo The list to put the smaller checks into
      * @param rows The table to write a mistake into, if there is one
+     * @param learned What every computed object turns out to be
      */
-    private void decide(final String check, final Collection<String> todo, final Tojos rows) {
+    private void decide(
+        final String check,
+        final Collection<String> todo,
+        final Tojos rows,
+        final Map<String, Collection<String>> learned
+    ) {
         final String has = check.substring(0, check.indexOf(' '));
         final String want = check.substring(check.indexOf(' ') + 1);
         for (final Map<String, String> need
@@ -140,8 +166,13 @@ final class Worklist {
                         .set("asked", need.getOrDefault("type", ""));
                 }
                 if (!owned.isEmpty()) {
+                    learned.computeIfAbsent(
+                        need.getOrDefault("type", ""), made -> new HashSet<>(1)
+                    ).add(this.name(owned));
                     todo.add(
-                        String.join(" ", this.name(owned), need.getOrDefault("type", ""))
+                        String.join(
+                            " ", this.name(owned), this.name(need.getOrDefault("type", ""))
+                        )
                     );
                 }
             }

--- a/eo-inference/src/test/java/org/eolang/inference/AgreedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AgreedTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Agreed}.
+ *
+ * <p>The loop asks what a computed object turns out to be once for every copy
+ * of the formation it stands in, and this is what decides whether the answers
+ * add up to a fact. It knows nothing about EO and everything about counting,
+ * so it is asked here directly.</p>
+ *
+ * @since 0.68.0
+ */
+final class AgreedTest {
+
+    @Test
+    void believesAnswerNothingContradicts() {
+        MatcherAssert.assertThat(
+            "an object asked about once must go by the answer that came back, but it didnt",
+            new Agreed(
+                Collections.singletonMap(
+                    "Φ.use.φ", Collections.singletonList("Φ.t.next")
+                )
+            ).names(),
+            Matchers.hasEntry("Φ.use.φ", "Φ.t.next")
+        );
+    }
+
+    @Test
+    void leavesOutLocatorThatCameOutTwoWays() {
+        MatcherAssert.assertThat(
+            "a locator two copies answer differently about must be left out, but it wasnt",
+            new Agreed(
+                Collections.singletonMap(
+                    "Φ.use.φ", Arrays.asList("Φ.t.next", "Φ.u.next")
+                )
+            ).names(),
+            Matchers.not(Matchers.hasKey("Φ.use.φ"))
+        );
+    }
+
+    @Test
+    void keepsTheOthersWhenOneIsMuddled() {
+        final Map<String, Collection<String>> answers = new HashMap<>(2);
+        answers.put("Φ.use.φ", Arrays.asList("Φ.t.next", "Φ.u.next"));
+        answers.put("Φ.ask.φ", Collections.singletonList("Φ.t.lid"));
+        MatcherAssert.assertThat(
+            "a locator that came out one way must survive its muddled neighbour, but it didnt",
+            new Agreed(answers).names(),
+            Matchers.hasEntry("Φ.ask.φ", "Φ.t.lid")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Test case for {@link Ends}.
+ *
+ * <p>The pairs arrive one at a time, from the links a rule wrote and from what
+ * the loop worked out later, and this is the walking that turns them into one
+ * name per type. It knows nothing about EO and everything about chains, so it
+ * is asked here directly.</p>
+ *
+ * @since 0.68.0
+ */
+final class EndsTest {
+
+    @Test
+    void followsChainToItsEnd() {
+        final Map<String, String> pairs = new HashMap<>(2);
+        pairs.put("Φ.app.φ.α0", "Φ.app.lid");
+        pairs.put("Φ.app.lid", "Φ.jar");
+        MatcherAssert.assertThat(
+            "a copy of a copy must go by the name at the end of the chain, but it didnt",
+            new Ends(pairs).names(),
+            Matchers.hasEntry("Φ.app.φ.α0", "Φ.jar")
+        );
+    }
+
+    @Test
+    void leavesLonePairAlone() {
+        MatcherAssert.assertThat(
+            "a pair that leads nowhere further must stay as it is, but it didnt",
+            new Ends(Collections.singletonMap("Φ.app.φ", "Φ.jar")).names(),
+            Matchers.hasEntry("Φ.app.φ", "Φ.jar")
+        );
+    }
+
+    @Test
+    @Timeout(10L)
+    void walksCircleOnlyOnce() {
+        final Map<String, String> pairs = new HashMap<>(2);
+        pairs.put("Φ.app.one", "Φ.app.two");
+        pairs.put("Φ.app.two", "Φ.app.one");
+        MatcherAssert.assertThat(
+            "a chain that comes back on itself must be walked once, but it wasnt",
+            new Ends(pairs).names(),
+            Matchers.hasKey("Φ.app.one")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -170,7 +170,7 @@ final class InferringTest {
     private Collection<String> unmatched(final Xtory pack, final Path temp) throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
         final Collection<String> tables = Arrays.asList(
-            "provides", "needs", "links", "checks", "problems"
+            "provides", "needs", "links", "checks", "problems", "copies"
         );
         for (final Object key : pack.map().keySet()) {
             if (!"eo".equals(key) && !"xmir".equals(key) && !tables.contains(key)) {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/computed-object-goes-by-what-it-turns-out-to-be.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/computed-object-goes-by-what-it-turns-out-to-be.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Nobody writes down what `x.next` is: it is made while the program runs, out
+# of whatever `x` happens to be. The loop is where it comes out — a `t` fills
+# the void `x`, and the `next` of a `t` is an object with a name — and what it
+# comes out as is written down beside the links the rules wrote, in a table of
+# its own, because no rule could have written it.
+eo:
+  app.eo: |
+    [] > app
+      use t > @
+  use.eo: |
+    [x] > use
+      x.next > @
+  t.eo: |
+    [] > t
+      [] > next
+copies:
+  - "/copies/type[@id='Φ.use.φ' and @copy='Φ.t.next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/computed-object-of-two-copies-stays-unknown.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/computed-object-of-two-copies-stays-unknown.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# One `x.next` stands in the text of `use`, and `use` is copied twice, with a
+# `t` and with a `u`. The loop finds it is the `next` of a `t`, and finds it is
+# the `next` of a `u`, and both answers are true of their own copy while
+# neither is true of the locator. So nothing is written down about it, and
+# every question about it goes on being unanswered.
+eo:
+  app.eo: |
+    [] > app
+      use t > first
+      use u > second
+  use.eo: |
+    [x] > use
+      x.next > @
+  t.eo: |
+    [] > t
+      [] > next
+  u.eo: |
+    [] > u
+      [] > next
+copies:
+  - "/copies[not(type[@id='Φ.use.φ'])]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-in-a-computed-object-is-reported.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-in-a-computed-object-is-reported.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What `use` hands to `ask` is not an object anybody wrote down: it is
+# `x.next`, worked out while the program runs. No table says what it turns out
+# to be, and the loop is the only one who ever finds out — a `t` fills the void
+# `x`, and a `t` has `next`. Once that is written down, the object `ask` is
+# given goes by the name of the `next` of a `t`, which is complete and has
+# nothing, so asking it for `foo` is the mistake.
+eo:
+  app.eo: |
+    [] > app
+      use t > @
+  use.eo: |
+    [x] > use
+      ask x.next > @
+  ask.eo: |
+    [y] > ask
+      y.foo > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t.next']/attr[@name='foo' and @asked='Φ.ask.φ']"


### PR DESCRIPTION
`Worklist.decide` worked out what a computed object turns out to be every time
it resolved an attribute, spent the answer on one check, and dropped it. It
hands it back now:

```java
if (!owned.isEmpty()) {
    learned.computeIfAbsent(
        need.getOrDefault("type", ""), made -> new HashSet<>(1)
    ).add(this.name(owned));
```

One draining cannot use what that draining finds — the check that needed the
fact may have been decided before the check that found it — so `Settled` drains
the list again with the new names added, and again, until a draining brings
nothing new. Only the last one writes verdicts: an earlier draining judges with
less than everything known, and a mistake found there may be no mistake by the
end. The javadoc's old promise that "nothing new is learned while the list is
drained" is now true only within a single draining, and says so.

A locator that came out two ways is not learned at all. The `x.next` in `use`
is one object in the program text, and `use` copied twice asks it of two
different things; both answers are true of their own copy and neither is true
of the locator. `Agreed` is where that is decided — the same honesty that keeps
an incomplete object from being blamed. The day a copy receives types of its
own, the two answers will belong to two locators and this disappears.

What the loop finds goes into a table of its own, shaped like the links a rule
wrote, because no rule could have written it:

```xml
<copies>
  <type id="Φ.use.φ.α0" copy="Φ.t.next"/>
</copies>
```

Three packs describe it: a mistake reachable only through a computed object
(which fails on master), the fact being written down, and the two-copy
disagreement — that last one I checked by disabling the rule and watching it
fail on its own while the other thirty-six stayed green.

---

Now the measurement, which is more interesting than the change.

On `eo-runtime` this writes 126 rows into `copies.xml` and reports nothing. With
#6648's φ-following applied on top locally, 1,389 rows — eleven times as many —
and still nothing, because the number of objects the checker may judge moves
from 48 to 49 out of 2,505.

Following the delegation chains says why:

```
objects that delegate                     : 2432
  chain ends at a locator no table describes : 2410
  chain ends at an object with no φ          :   22   (1 of them complete)
```

Chasing one of those endings found something small and fixable. `Φ.bool.and`
delegates to `Φ.bool.and.φ`, which is the dispatch `.if` on a receiver whose
base is `ξ.ρ` — the parent — and `Scope` never resolves `ξ.ρ`, because it looks
for a locator `<formation>.ρ` that nothing declares. Of the 412 `ξ.ρ`
references in `eo-runtime`, none are linked and all 412 are a dispatch
receiver, so the loop cannot say what taking `if` from one gives, and the body
of `and` has no type for this change to record. That is #6653, and it is the
next one to fix.

Closes: #6647
