### PR TITLE
Revert the logarithmic while, master is red

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -9,11 +9,10 @@
 # @todo #5751:30min Stop descending into a symbolic link to a directory. The
 #  `walk` below asks stat, which follows the link, so a link to its own ancestor
 #  recurses forever, while the `Files.walk` it replaced only listed such a link.
-# @todo #6550:60min Walk a directory in constant stack space. The `stepped`
-#  below still costs one frame per entry, even though `while` now nests only as
-#  deep as the logarithm of its cycles: the walk carries a tuple as its
-#  accumulator and `malloc` holds bytes only, so a cycle has nowhere to keep it.
-#  Joining the matched paths into one string and splitting it at the end fits.
+# @todo #6484:60min Walk a directory in constant stack space. The `stepped`
+#  below still costs one frame per entry, because every loop EO has grows the
+#  stack: `while` nests a frame per cycle and `tuple.reducedi` one per element,
+#  so a directory of a few thousand entries still overflows.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -21,9 +21,6 @@
 # Only the first three strings are dataized for side effects while the last one
 # is returned as the result value assigned to the `last` object.
 # The `while` loop example produces identical behavior.
-# The cycles are made in blocks that double in size, and a block is a balanced
-# tree of cycles, so a million of them nest about forty deep instead of a
-# million deep. The index of the last cycle is the only thing the loop keeps.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -36,37 +33,18 @@
   if. > @
     as-bool.
       condition 0
-    body
-      as-number.
-        malloc.for
-          -1
-          [stop] >>
-            seq * > @
-              seq * > [from count] >> doubled
-                stepped from count
-                if.
-                  0.gt stop.as-number
-                  doubled
-                    from.plus count
-                    count.times 2
-                  true
-              | 0 1
-              stop.as-number
-            [from count] >> stepped
-              if. > @
-                0.gt stop.as-number
-                if.
-                  count.eq 1
-                  if.
-                    as-bool.
-                      condition (from.plus 1)
-                    body from
-                    stop.put from
-                  seq *
-                    stepped from half
-                    stepped (from.plus half) half
-                true
-              count.div 2 > half!
+    [index] >> loop
+      if. > @
+        as-bool.
+          condition
+            index.plus 1
+        seq *
+          current
+          loop
+            index.plus 1
+        current
+      body index > current
+    | 0
     false
 
   ++> can-dataize-only-the-first-cycle
@@ -176,16 +154,6 @@
                 true > [i]
               acc
     array.length > max
-
-  ++> can-loop-five-thousand-times
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            i.lt 5000 > [i]
-            m.put i > [i] >>
-      4999
 
   ++> can-loop-on-a-bool-expression-kept-in-malloc
     eq. > @


### PR DESCRIPTION
This puts `while` back to the recursive version it had before #6596, and restores the `@todo` in `directory.eo` that came with it. Nothing else changes.

The `ec2` job on master is red because of #6596 — 7 failures and 3 errors in `EOwhileTest` and `EO_number.EOintegralTest`, see run 31583359814. Two things are wrong in that rewrite. `count.div 2 > half!` leaves `half` as bytes, since a const compiles down to `as-bytes`, so the next level of `stepped` divides bytes and dies on a raw IEEE-754 blob. And the loop only turns as a side effect of dataizing the argument of the final `body` application, so a body that ignores its argument never drives it at all — which is exactly the set of tests that fail, and why `integral` only passed for a single partition.

Two things worth knowing before #6550 gets another attempt. The `can-loop-five-thousand-times` test it added has never actually been green: our `Deadline` extension turns a JUnit timeout into a `TestAbortedException`, so a test slower than the deadline is reported as skipped rather than failed. And #6596 was merged with its own `runtime (23)` check red, which nothing else caught, because `mvn.yml` passes `-Deo.transpileTests=false` and so never runs EO unit tests at all. Locally on this branch `EOwhileTest` is 10/10 and `EOintegralTest` 11/11; I got 534 tests into a full run with no failures before my 8G heap gave out, so I am leaving the rest to CI, which has far more room.
