### PR TITLE
fix(#6649): reject lossy format recovery

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -195,9 +195,10 @@ public final class MjFormat extends MjSafe {
      * {@code <errors>} (see {@link Parsing}), but the parser also recovers
      * from many purely cosmetic layout violations (e.g. extra blank lines,
      * exactly what this goal exists to fix) the same way, tagged with the
-     * same {@code severity="error"} and no other distinguishing marker.
-     * Rejecting every {@code <errors>} entry, as suggested by the issue this
-     * fixes, would therefore also reject this goal's own core use case.
+     * same {@code severity="error"}; only lossy recovery also carries
+     * {@code lost="true"}. Rejecting every {@code <errors>} entry, as
+     * suggested by the issue this fixes, would therefore also reject this
+     * goal's own core use case.
      *
      * <p>What actually matters is whether the recovered tree still covers
      * the whole source: a genuine syntax error (e.g. an unterminated paren
@@ -207,7 +208,8 @@ public final class MjFormat extends MjSafe {
      * that some {@code <o>} element references a line at or past the
      * source's last non-blank line; if none does, part of the source was
      * never parsed at all, and this goal would otherwise print back (or, in
-     * {@code -Deo.autoFix} mode, save) a truncated version of it.</p>
+     * {@code -Deo.autoFix} mode, save) a truncated version of it, while
+     * {@code lost} catches discarded fragments within complete coverage.</p>
      *
      * <p>Line coverage is necessary but not sufficient: the parser recovers
      * from some <em>structural</em> errors not by dropping the remaining
@@ -230,7 +232,9 @@ public final class MjFormat extends MjSafe {
             .filter(MjFormat::severe)
             .count();
         if (errors > 0L
-            && (MjFormat.truncated(xmir, structure) || MjFormat.placeholder(xmir))) {
+            && (MjFormat.truncated(xmir, structure)
+                || MjFormat.placeholder(xmir)
+                || !xmir.nodes("/object/errors/error[@lost='true']").isEmpty())) {
             throw new IllegalStateException(
                 String.format(
                     "%s does not fully parse (%d error(s) found) and part of it was lost, won't format it",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -158,6 +158,34 @@ final class MjFormatTest {
         );
     }
 
+    @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    void rejectsLossyRecoveryWithoutOverwriting(@Mktmp final Path temp) throws Exception {
+        final String source = MjFormatTest.lossy();
+        for (final boolean fixing : new boolean[]{false, true}) {
+            final Path home = temp.resolve(Boolean.toString(fixing));
+            final IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new FakeMaven(home)
+                    .with("autoFix", fixing)
+                    .withProgram(source)
+                    .execute(MjFormat.class)
+            );
+            final StringWriter writer = new StringWriter();
+            exception.printStackTrace(new PrintWriter(writer));
+            MatcherAssert.assertThat(
+                "a source recovered by dropping a binding must fail the format check",
+                writer.toString(),
+                Matchers.containsString("does not fully parse")
+            );
+        }
+        MatcherAssert.assertThat(
+            "the source must remain byte-for-byte intact after the rejected auto-fix",
+            new TextOf(temp.resolve("true/foo/x/main.eo")).asString(),
+            Matchers.equalTo(source)
+        );
+    }
+
     /**
      * Reformat a program into its canonical EO layout.
      * @param program The EO program
@@ -206,6 +234,25 @@ final class MjFormatTest {
             "    true",
             "    1",
             "    2",
+            ""
+        );
+    }
+
+    /**
+     * A source the parser recovers by dropping a binding in the middle.
+     * @return The EO text
+     */
+    private static String lossy() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[x] > foo",
+            "  seq * > @",
+            "    last",
+            "    last.plus 1",
+            "  x! > last",
+            "  42 > tail",
             ""
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -225,6 +225,32 @@ final class Emit {
     }
 
     /**
+     * Append an error for a line the parser discarded during recovery.
+     * @param line Line where the error occurred
+     * @param pos Column where the error occurred
+     * @param message Canonical message text
+     */
+    void lost(final int line, final int pos, final String message) {
+        this.append(
+            new Directives()
+                .push()
+                .xpath("/object")
+                .strict(1)
+                .addIf("errors")
+                .strict(1)
+                .add("error")
+                .attr("line", line)
+                .attr("pos", pos)
+                .attr("check", "parser")
+                .attr("severity", "error")
+                .attr("lost", true)
+                .set(this.formatted(line, pos, message))
+                .up().up()
+                .pop()
+        );
+    }
+
+    /**
      * Open an {@code <o>} element at the current cursor — §9.0.2 /
      * §9.4.2.
      *

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -313,10 +313,10 @@ final class Eo implements Iterable<Directive> {
         if (globals.inTextBlock()) {
             Eo.continueTextBlock(span, stack, globals, emit);
         } else if (span.tab()) {
-            emit.error(span.line(), 0, "tab character in leading whitespace");
+            emit.lost(span.line(), 0, "tab character in leading whitespace");
             failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {
-            emit.error(span.line(), 0, "unexpected odd indent");
+            emit.lost(span.line(), 0, "unexpected odd indent");
             failed = true;
         } else if (Eo.opensTextBlock(span)) {
             globals.openTextBlock(span.line(), span.indent());
@@ -349,7 +349,7 @@ final class Eo implements Iterable<Directive> {
             } catch (final ParseError err) {
                 emit.rollback(tstartsen);
                 stack.restore(frame);
-                emit.error(err.line(), err.pos(), err.getMessage());
+                emit.lost(err.line(), err.pos(), err.getMessage());
                 globals.closeTextBlock();
             }
         } else {
@@ -416,7 +416,7 @@ final class Eo implements Iterable<Directive> {
         } catch (final ParseError err) {
             emit.rollback(tstartsen);
             stack.restore(frame);
-            emit.error(err.line(), err.pos(), err.getMessage());
+            emit.lost(err.line(), err.pos(), err.getMessage());
             failed = true;
         }
         return failed;

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -268,6 +268,11 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="lost" type="xs:boolean">
+          <xs:annotation>
+            <xs:appinfo>Whether parser recovery discarded source</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="severity" use="required">
           <xs:annotation>
             <xs:appinfo>The severity of the error</xs:appinfo>

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [n] > is-nan
-  if. > @
+  if?. > @
     and.
       bts.size.gt 7
       not.


### PR DESCRIPTION
Closes #6649.

This change:
- tags parser errors when recovery discards source;
- refuses to format or auto-fix XMIR carrying that loss marker;
- covers both check and auto-fix modes, including byte-for-byte preservation of the original source.

Verification:
- `mvn -pl eo-maven-plugin clean test -Dtest=MjFormatTest -DskipITs -ntp` (9 passed)
- parser suite (1,728 passed)
- plugin suite (593 passed, 5 skipped)
- `mvn clean -q -pl eo-parser,eo-maven-plugin -am verify -Pqulice -DskipTests`

The patch is 100 hits, within the project contribution limit.

@yegor256 please take a look.