### PR TITLE
fix(transpile): #6664 serialize XMIR into one string in classes.xsl

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/classes.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/classes.xsl
@@ -3,47 +3,47 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" exclude-result-prefixes="eo" id="classes" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="eo xs" id="classes" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:template name="serialize">
-    <xsl:param name="node"/>
-    <xsl:param name="indent"/>
-    <xsl:variable name="name" select="name($node)"/>
-    <xsl:value-of select="$indent"/>
-    <xsl:text>&lt;</xsl:text>
-    <xsl:value-of select="$name"/>
-    <xsl:for-each select="$node/@*">
-      <xsl:text> </xsl:text>
-      <xsl:value-of select="name()"/>
-      <xsl:text>="</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>"</xsl:text>
-    </xsl:for-each>
-    <xsl:variable name="content" select="normalize-space(string(text()[1]))"/>
-    <xsl:if test="$content = '' and not($node/element())">
-      <xsl:text>/</xsl:text>
-    </xsl:if>
-    <xsl:text>&gt;</xsl:text>
-    <xsl:value-of select="$content"/>
-    <xsl:if test="$node/element()">
-      <xsl:for-each select="$node/element()">
-        <xsl:value-of select="'&#10;'"/>
-        <xsl:call-template name="serialize">
-          <xsl:with-param name="node" select="."/>
-          <xsl:with-param name="indent" select="concat($indent, '  ')"/>
-        </xsl:call-template>
-      </xsl:for-each>
-      <xsl:value-of select="'&#10;'"/>
-      <xsl:value-of select="$indent"/>
-    </xsl:if>
-    <xsl:if test="$content != '' or $node/element()">
-      <xsl:text>&lt;/</xsl:text>
-      <xsl:value-of select="$name"/>
-      <xsl:text>&gt;</xsl:text>
-    </xsl:if>
-  </xsl:template>
-  <xsl:template match="object/o[not(eo:atom(.)) or (eo:atom(.) and count(./o[eo:test-attr(.)])&gt;0)]" priority="1">
+  <!--
+  The XMIR of an object, indented, as the text that "to-java" turns into the
+  Javadoc of the generated class. It is one function returning one string,
+  rather than a template writing many small pieces of text, because the result
+  tree we write into is a DOM: every "xsl:text" or "xsl:value-of" a template
+  executes becomes a separate DOM text node, and a template that spelled a
+  start tag out piece by piece - indent, "&lt;", name, then five pieces per
+  attribute - left tens of thousands of them behind for a single object. Both
+  building that many nodes and later reading them back (the DOM has to merge
+  adjacent text nodes to answer "text()") cost far more than the string
+  concatenation itself, so serializing the biggest objects of "eo-runtime"
+  took seconds each and this pass alone was two fifths of the whole transpile
+  train (#6664).
+
+  Nesting the recursive call inside the enclosing "concat" means the string of
+  a subtree is copied once per level of depth above it, which for the depth of
+  a real XMIR is far cheaper than the per-node bookkeeping it replaces:
+  returning a sequence of pieces and joining them at the end, instead, is
+  three times slower here.
+  -->
+  <xsl:function name="eo:serialize" as="xs:string">
+    <xsl:param name="node" as="element()"/>
+    <xsl:param name="indent" as="xs:string"/>
+    <xsl:variable name="name" as="xs:string" select="name($node)"/>
+    <xsl:variable name="kids" as="element()*" select="$node/*"/>
+    <xsl:variable name="content" as="xs:string" select="normalize-space(string($node/text()[1]))"/>
+    <!-- An object with neither data nor children is written as a single self-closing tag. -->
+    <xsl:variable name="void" as="xs:boolean" select="$content = '' and empty($kids)"/>
+    <xsl:variable name="deeper" as="xs:string" select="concat($indent, '  ')"/>
+    <xsl:sequence select="concat($indent, '&lt;', $name, string-join(for $a in $node/@* return concat(' ', name($a), '=&quot;', $a, '&quot;'), ''), if ($void) then '/&gt;' else '&gt;', $content, string-join(for $k in $kids return concat('&#10;', eo:serialize($k, $deeper)), ''), if (empty($kids)) then '' else concat('&#10;', $indent), if ($void) then '' else concat('&lt;/', $name, '&gt;'))"/>
+  </xsl:function>
+  <!--
+  An atom is a class only when it holds tests, since it is the tests that need
+  a Java class of their own - "to-java" writes no ".java" for it, only its
+  tests. Spelled as "not atom, or has a test attribute", because when it is
+  not an atom the second half of the question does not need asking.
+  -->
+  <xsl:template match="object/o[not(eo:atom(.)) or exists(o[eo:test-attr(.)])]" priority="1">
     <xsl:apply-templates select="." mode="class"/>
   </xsl:template>
   <xsl:template match="object/o[@base and @name]" priority="2">
@@ -67,10 +67,7 @@
         </xsl:otherwise>
       </xsl:choose>
       <xmir>
-        <xsl:call-template name="serialize">
-          <xsl:with-param name="node" select="."/>
-          <xsl:with-param name="indent" select="''"/>
-        </xsl:call-template>
+        <xsl:value-of select="eo:serialize(., '')"/>
       </xmir>
     </class>
   </xsl:template>


### PR DESCRIPTION
Closes #6664.

`classes.xsl` writes the XMIR of each top-level object into `<xmir>`, as the text `to-java.xsl` turns into the Javadoc of the generated class. The `serialize` template spelled that text out piece by piece — one instruction per indent, per angle bracket, per name and five per attribute. `jcabi-xml` runs every stylesheet DOM to DOM (`DOMSource` → `DOMResult`), so **each piece became a separate DOM text node**: a single `<xmir>` for `string/printf.eo` (~1.6k elements, ~8.3k attributes) held roughly 50k of them. Building them, and then reading them back through a DOM that has to merge adjacent text nodes to answer `text()`, cost far more than the concatenation itself — hence `XSL 'classes' took 4s (over 500ms)` from xsline's `StFast` on a single XMIR.

It is now an `xsl:function` returning one `xs:string`, written with one `xsl:value-of`, so `<xmir>` holds exactly one text node.

## Numbers

Saxon-HE 13.0, all 170 sources of `eo-runtime/src/main/eo` parsed with `EoSyntax` and put through `set-locators.xsl` + `set-original-names.xsl` first, best of two warm runs, single-threaded:

| | `classes.xsl` alone | whole transpile train (9 XSLs) | worst file, train (`string/printf.eo`) |
|---|---|---|---|
| before | 21.5s | 56.9s | 8.0s |
| after | 1.0s | 34.4s | 4.0s |

**21x for the pass, 1.7x for the train.** The train gains more than the pass saves, because the eight downstream stylesheets no longer walk those adjacent text nodes either. For reference, replacing the serializer with an empty `<xmir/>` altogether takes the pass to 0.14s, so what is left is close to the floor.

## Why nested `concat` and not a joined sequence

Two other shapes were measured on the 21 largest sources (baseline 15.2s there):

| shape | time |
|---|---|
| function returning `xs:string*`, one `string-join` at the end | 2.1s |
| same, but each attribute as its own sequence item | 4.8s |
| function returning `xs:string`, recursive call inside `concat` (this PR) | 0.53s |

Nesting the recursive call copies a subtree's string once per level of depth above it, which at the depth of a real XMIR is far cheaper than Saxon's per-item bookkeeping. The rejected shapes are noted in the comment on the function so the next reader does not re-try them.

## Correctness

- Output is **byte-identical** for all 170 `eo-runtime` sources — both of this pass alone, and of the full nine-stylesheet train, i.e. of the generated Java.
- `MjTranspileTest` (52 transpile packs) and `FingerprintTest`: 57 tests, all green.
- `xcop` clean on the changed file.
- The pass is fingerprinted into the transpile cache key via `Transpilation.XSLS`, so existing caches invalidate on their own.

## Also in this diff

The class-matching pattern loses a redundant `eo:atom` call and a `count(...) > 0`:

```diff
-match="object/o[not(eo:atom(.)) or (eo:atom(.) and count(./o[eo:test-attr(.)])&gt;0)]"
+match="object/o[not(eo:atom(.)) or exists(o[eo:test-attr(.)])]"
```

`not(A) or (A and B)` is `not(A) or B`. Not measurable next to the serializer, but it is the same question asked once instead of twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GevVXivd1KDNnCHqKW9rua)_