### PR TITLE
fix(#6640): take heap blocks only through the releasing scope

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -14,10 +14,6 @@ import java.util.function.IntFunction;
 /**
  * Dynamic memory.
  * @since 0.19
- * @todo #6507:30min Move the negative-argument, size and resize tests in HeapsTest and
- *  both free probes in EOmallocEOofTest onto the scoped malloc, then make malloc with two
- *  arguments and free private, so that a block can only be taken through a scope that
- *  releases it, and drop failsOnClearingEmptyBlock, which nobody can reach any more.
  */
 final class Heaps {
 
@@ -43,31 +39,6 @@ final class Heaps {
     private Heaps() {
         this.blocks = new ConcurrentHashMap<>(0);
         this.lock = new ReentrantLock();
-    }
-
-    /**
-     * Allocate a block in memory.
-     * @param phi Object
-     * @param size How many bytes
-     * @return The identifier of pointer to the block in memory
-     */
-    int malloc(final Phi phi, final int size) {
-        final int identifier = phi.hashCode();
-        this.lock.lock();
-        try {
-            if (this.blocks.containsKey(identifier)) {
-                throw new ExFailure(
-                    String.format(
-                        "Can't allocate block in memory with identifier '%d' because it's already allocated",
-                        identifier
-                    )
-                );
-            }
-            this.blocks.put(identifier, new byte[size]);
-        } finally {
-            this.lock.unlock();
-        }
-        return identifier;
     }
 
     /**
@@ -251,10 +222,45 @@ final class Heaps {
     }
 
     /**
+     * Allocate a block in memory.
+     *
+     * <p>Private on purpose: a block handed out here has no owner responsible
+     * for releasing it. Take one through {@link #malloc(Phi, int, IntFunction)}
+     * instead, whose scope frees the block on every exit path.</p>
+     *
+     * @param phi Object
+     * @param size How many bytes
+     * @return The identifier of pointer to the block in memory
+     */
+    private int malloc(final Phi phi, final int size) {
+        final int identifier = phi.hashCode();
+        this.lock.lock();
+        try {
+            if (this.blocks.containsKey(identifier)) {
+                throw new ExFailure(
+                    String.format(
+                        "Can't allocate block in memory with identifier '%d' because it's already allocated",
+                        identifier
+                    )
+                );
+            }
+            this.blocks.put(identifier, new byte[size]);
+        } finally {
+            this.lock.unlock();
+        }
+        return identifier;
+    }
+
+    /**
      * Free it.
+     *
+     * <p>Private on purpose: the scope opened by
+     * {@link #malloc(Phi, int, IntFunction)} is the only thing that releases a
+     * block, so no caller can free one it does not own or free one twice.</p>
+     *
      * @param identifier Identifier of pointer
      */
-    void free(final int identifier) {
+    private void free(final int identifier) {
         this.lock.lock();
         try {
             if (!this.blocks.containsKey(identifier)) {

--- a/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
@@ -27,8 +27,8 @@ final class EOmallocEOofTest {
         ).take();
         Assertions.assertThrows(
             ExAbstract.class,
-            () -> Heaps.INSTANCE.free((int) dummy.id),
-            "Heaps should throw an exception on attempt to free already freed memory, but it didn't"
+            () -> Heaps.INSTANCE.size((int) dummy.id),
+            "Heaps should have released the block when the scope ended, but it was still allocated"
         );
     }
 
@@ -47,8 +47,8 @@ final class EOmallocEOofTest {
         );
         Assertions.assertThrows(
             ExAbstract.class,
-            () -> Heaps.INSTANCE.free((int) dummy.id),
-            "Heaps should throw an exception on attempting to free already freed memory after failure, but it didn't"
+            () -> Heaps.INSTANCE.size((int) dummy.id),
+            "Heaps should have released the block after the scope failed, but it was still allocated"
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -107,19 +107,22 @@ final class HeapsTest {
 
     @Test
     void keepsBlockIntactAfterWriteWithNegativeOffset() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 3);
-        Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.write(idx, -2, new byte[] {1, 2}),
-            "Heaps must reject a negative write offset before touching the block, but it didn't"
-        );
         MatcherAssert.assertThat(
             "Heaps must leave the block untouched after a rejected negative-offset write, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 3),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 3,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
+                    Assertions.assertThrows(
+                        ExFailure.class,
+                        () -> Heaps.INSTANCE.write(idx, -2, new byte[] {1, 2}),
+                        "Heaps must reject a negative write offset before touching the block, but it didn't"
+                    );
+                    return Heaps.INSTANCE.read(idx, 0, 3);
+                }
+            ),
             Matchers.equalTo(new byte[] {7, 8, 9})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -156,18 +159,21 @@ final class HeapsTest {
 
     @Test
     void failsCleanlyOnNegativeReadArguments() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10);
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.read(idx, -5, 3),
-            "Heaps must reject a negative offset with a clean ExFailure, not a raw JVM exception"
+        Heaps.INSTANCE.malloc(
+            new HeapsTest.PhFake(), 10,
+            idx -> {
+                Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, -5, 3),
+                    "Heaps must reject a negative offset with a clean ExFailure, not a raw JVM exception"
+                );
+                return Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, 2, -3),
+                    "Heaps must reject a negative length with a clean ExFailure, not a raw JVM exception"
+                );
+            }
         );
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.read(idx, 2, -3),
-            "Heaps must reject a negative length with a clean ExFailure, not a raw JVM exception"
-        );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -257,15 +263,6 @@ final class HeapsTest {
     }
 
     @Test
-    void failsOnClearingEmptyBlock() {
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.free(new HeapsTest.PhFake().hashCode()),
-            "Heaps should throw an exception on attempting to free a non-existent block, but it didn't"
-        );
-    }
-
-    @Test
     void throwsOnGettingSizeOfEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
@@ -276,24 +273,23 @@ final class HeapsTest {
 
     @Test
     void returnsValidSize() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         MatcherAssert.assertThat(
             "Heaps should return valid size of allocated block, but it didn't",
-            Heaps.INSTANCE.size(idx),
+            Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5, Heaps.INSTANCE::size),
             Matchers.equalTo(5)
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void throwsOnChangingSizeToNegative() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.resize(idx, -1),
-            "Heaps should throw an exception on trying to changing size to negative, but it didn't"
+        Heaps.INSTANCE.malloc(
+            new HeapsTest.PhFake(), 5,
+            idx -> Assertions.assertThrows(
+                ExFailure.class,
+                () -> Heaps.INSTANCE.resize(idx, -1),
+                "Heaps should throw an exception on trying to changing size to negative, but it didn't"
+            )
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -307,41 +303,50 @@ final class HeapsTest {
 
     @Test
     void increasesSizeSuccessfully() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 7);
         MatcherAssert.assertThat(
             "Heaps should successfully increase size of allocated block, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 7),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 7);
+                    return Heaps.INSTANCE.read(idx, 0, 7);
+                }
+            ),
             Matchers.equalTo(new byte[] {1, 2, 3, 4, 5, 0, 0})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void decreasesSizeSuccessfully() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should successfully decrease size of allocated block, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 3),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 3);
+                    return Heaps.INSTANCE.read(idx, 0, 3);
+                }
+            ),
             Matchers.equalTo(new byte[] {1, 2, 3})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void returnsValidSizeAfterDecreasing() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should return valid size after decreasing, but it didn't",
-            Heaps.INSTANCE.size(idx),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 3);
+                    return Heaps.INSTANCE.size(idx);
+                }
+            ),
             Matchers.equalTo(3)
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     /**


### PR DESCRIPTION
@yegor256 — this resolves the `6507-93ee2a46` puzzle in `Heaps`.

Closes #6640

## What the puzzle asked for

Four steps, and they only work together: `free` cannot become private until nothing outside the class calls it, so the test moves and the visibility change have to land in one commit.

- the negative-argument, size and resize tests in `HeapsTest` moved onto the scoped `malloc`;
- both free probes in `EOmallocEOofTest` moved off `free`;
- two-argument `malloc` and `free` are private;
- `failsOnClearingEmptyBlock` is gone.

## What changed

**`Heaps`.** The two-argument `malloc` handed out a block with nobody responsible for releasing it, and `free` let any caller release a block it did not own — so `malloc(phi, size, scope)` was a convention rather than a rule. Both are private now, which makes the scope the only way in and out. Nothing in `src/main` was affected: `EOmalloc$EOof` already goes through the scoped form, and it was the only production caller.

**`HeapsTest`.** Seven cases took a block raw and freed it by hand; they now run inside the scope. Two of them got shorter — `returnsValidSize` is a one-liner against `Heaps.INSTANCE::size` — and the ones that assert on an exception mid-scope keep the assertion inside the lambda so the block is still allocated when it runs. `failsOnClearingEmptyBlock` is deleted rather than adapted, because "freeing an unallocated block fails" is no longer a reachable state.

**`EOmallocEOofTest`.** Both probes asked "is it freed?" by calling `free` a second time and expecting a throw. They now ask `size` instead, which throws the same `ExFailure` for an unallocated block, so the assertion type is unchanged and the probe no longer needs a private method.

## On the size of this one

185 hits, over the 40–100 the guidelines ask for, and I could not find an honest way to split it.

Roughly 56 of those are mechanical: qulice orders methods by visibility, so leaving `malloc` where it was reported `MethodsOrderCheck` against every package-private method below it. Moving the private pair to the end of the class fixes that but counts as a delete plus an add of the same body. The remaining change is the seven test conversions, which cannot be separated from the visibility change without leaving the tree uncompilable in between. Happy to reshape it if you would rather have it another way.

## Verification

```
$ mvn -pl eo-runtime test -Dtest=HeapsTest,EOmallocEOofTest
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0 -- in org.eolang.HeapsTest
Tests run:  4, Failures: 0, Errors: 0, Skipped: 0 -- in org.eolang.EOmallocEOofTest
BUILD SUCCESS
```

That run compiles the whole module, main and test, which is also what rules out a missed caller of the now-private methods.

`mvn -Pqulice` caught the ordering problem above; after the move it reports no violations on the changed file.

## What I could not run here, and why

I am on Windows, and `mvn clean install -Pqulice` does not complete on this machine for two reasons that predate this branch. I checked both by stashing the change and re-running on unmodified `master`, which fails identically:

- `eo-parser` fetches `blns.txt` from `raw.githubusercontent.com` through `maven-antrun-plugin`, which times out here (`github.com` and `api.github.com` are fine, that host is not). Worked around with `-Dmaven.antrun.skip=true`.
- `eo-runtime`'s `project-validate` step then fails with `Missing: EOwin32$EOφ.class` / `Missing: EOposix$EOφ.class` — "Not all .java files were compiled to .class files". Same failure with an empty working tree, so it is not from this change, but it does mean I have not run the full `-Pqulice` lifecycle end to end.

Separately, `format` reports `2 of 170 EO source(s) are not formatted canonically` on a clean checkout. I left those alone — no `.eo` file is touched here — and used `-Deo.autoFix` locally to get past it.
