### PR TITLE
Stop dataization on an interrupted thread

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
+++ b/eo-runtime/src/main/java/org/eolang/ExInterrupted.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * Error that stops a computation running on an interrupted thread.
+ *
+ * <p>Dataization is a long chain of attribute lookups, where nothing ever
+ * blocks. A thread that has to be stopped from the outside — a test that
+ * outlived its deadline, a program that must shut down — therefore never
+ * notices the interrupt and keeps computing forever, holding a CPU core
+ * until the JVM dies. {@link PhDefault#take(String)} throws this error on
+ * the very next lookup instead.</p>
+ *
+ * <p>The interrupt flag stays up when this error is thrown, so every next
+ * lookup fails the same way and no {@code try} can resurrect the
+ * computation.</p>
+ *
+ * @since 0.74.0
+ */
+public final class ExInterrupted extends ExAbstract {
+
+    /**
+     * Serialization identifier.
+     */
+    private static final long serialVersionUID = 597749420437007616L;
+
+    /**
+     * Ctor.
+     * @param cause Exception cause
+     */
+    public ExInterrupted(final String cause) {
+        super(cause);
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -217,6 +217,14 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public Phi take(final String name) {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new ExInterrupted(
+                String.format(
+                    "Can't take \"%s\" from %s, because the thread was interrupted",
+                    name, this.forma()
+                )
+            );
+        }
         PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
         try {
             final Phi resolved;

--- a/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExInterruptedTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ExInterrupted}.
+ * @since 0.74.0
+ */
+final class ExInterruptedTest {
+
+    @Test
+    void stopsTakingInInterruptedThread() throws InterruptedException {
+        final PhDefault phi = new PhDefault();
+        phi.add("stopsTakingInInterruptedThread", new AtComposite(phi, rho -> new Data.ToPhi(42L)));
+        final AtomicReference<Throwable> thrown = new AtomicReference<>();
+        final Thread thread = new Thread(
+            () -> {
+                while (true) {
+                    phi.take("stopsTakingInInterruptedThread");
+                }
+            }
+        );
+        thread.setDaemon(true);
+        thread.setUncaughtExceptionHandler((ignore, error) -> thrown.set(error));
+        thread.start();
+        thread.interrupt();
+        thread.join(Duration.ofSeconds(10L).toMillis());
+        MatcherAssert.assertThat(
+            "Interrupted thread must abandon its computation, but it kept taking attributes",
+            thrown.get(),
+            Matchers.instanceOf(ExInterrupted.class)
+        );
+    }
+}


### PR DESCRIPTION
A test that outlives `eo.deadline` gets skipped, but its work does not stop: JUnit interrupts the thread and never joins it, and nothing in dataization ever looked at the interrupt flag. `PhDefault.take()` now checks it and throws the new `ExInterrupted` on the very next attribute lookup. The flag is read, not cleared, so every later lookup fails the same way and an EO-level `try` cannot bring the computation back to life.

Without this, every skipped test left a non-daemon `junit-timeout-thread` spinning for the rest of the fork. They pile up, starve the runner, and then tests that need a few hundred milliseconds start overrunning their wall-clock deadline too and leak threads of their own — which is how the `runtime` job ends up skipping whole classes at once and getting cancelled at the 30-minute limit. With a 1s deadline, eight endless dataizations used to leave eight live threads behind; now they leave none. `ExInterruptedTest` reproduces it: without the guard the interrupted thread is still taking attributes when the test gives up on it.

One thing to keep in mind: the deadline is still measured in wall clock under parallel execution, so `eo.deadline=1` will keep skipping tests that are merely slow rather than stuck. That value probably wants raising, but it is a separate decision.

Closes #6670