### PR TITLE
fix(#6669): atomize the auto-name before the fold checks

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -310,9 +310,21 @@
   never moved its value anywhere: dropping it deletes the declaration from the
   printed source, so a private helper formation or const cache that nothing
   reads yet would silently vanish (#5914).
+
+  The name is atomized once here, before any of those functions is asked
+  (#6669). Each declares its `$name` as `xs:string`, so handing over the
+  `@name` node left the conversion to the function conversion rules, and Saxon
+  is free to bind the parameter to a closure over the argument expression
+  rather than over its converted value. The node then arrives inside the
+  function, where `eo:resolved-name(@base) = $name` has already been compiled
+  to a `ValueComparison` on the strength of the declared types — it casts
+  straight to `AtomicValue` and the sheet dies with "DOMNodeWrapper cannot be
+  cast to AtomicValue". A string leaves the conversion with nothing to lose,
+  as at the `eo:signature` call in "to-eo-tree".
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:arg-applied(., @name) or eo:nested-applied(., @name) or eo:reapplied(., @name)">
+    <xsl:variable name="name" as="xs:string" select="string(@name)"/>
+    <xsl:if test="eo:recursive(., $name) or eo:dispatched(., $name) or eo:vertical-const(.) or eo:unreferenced(., $name) or (eo:multi-referenced(., $name) and eo:rebuilt(.)) or eo:piped(., $name) or eo:arg-applied(., $name) or eo:nested-applied(., $name) or eo:reapplied(., $name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>


### PR DESCRIPTION
Closes #6669

`runtime` is red on master because of this, so nothing merges until it is green — including my own #6668, which is how I came to it.

## Root cause

The stack trace on the issue names the caller: the template rule at `inline-cactoos.xsl:314`. That template hands `@name` — an attribute node — to nine functions in a row:

```xml
<xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or ... or eo:reapplied(., @name)">
```

Every one of them declares its `$name` as `xs:string`, so the atomization was left to the function conversion rules. Saxon is free to bind a parameter to a closure over the argument expression rather than over its converted value, and then the node itself arrives inside the function. There the comparison

```xml
eo:resolved-name(@base) = $name
```

has already been compiled to a `ValueComparison`, on the strength of both operands being statically `xs:string` — so it casts straight to `AtomicValue`, and the sheet dies with `DOMNodeWrapper cannot be cast to AtomicValue`.

The other operand cannot be the node: `eo:resolved-name` builds its result with `substring-after`, so it is a string by construction. `$name` is the only candidate, and that template is the only place a node can reach it — every other call site passes the `$name` of the inlining template at line 100, which is itself `eo:resolved-name(@base)`.

This also accounts for the "moved the crash" reading in the issue. `count()` materialised the sequence inside the function's own evaluation; `[2]` reaches it through a lazy subscript, which is exactly the context where the deferred conversion is lost. #6638 did not introduce the type mismatch — it changed the evaluation strategy enough to expose it.

## The change

Atomize once, in the template, before any of the nine is asked:

```xml
<xsl:variable name="name" as="xs:string" select="string(@name)"/>
```

Two lines. It leaves the conversion nothing to lose and covers all nine functions at once, rather than rewriting the comparison inside each of them — the same move as the `eo:signature` call in `to-eo-tree`, and as the `@local` wrap in `restore-local-names` for #6650.

`string()` is exact here rather than merely close: the match pattern is `o[starts-with(@name, $auto) and not(eo:void(.))]`, so `@name` is always present, and the parameters are required `xs:string`. Nothing about what the nine functions are asked changes.

## Verification

The failure is optimiser-dependent and does not reproduce on demand — that is the shape of the bug, and it is why I have no regression test to offer. Master is red on `runtime (23)` while the same sources print canonically on the other runners.

So what I can show is that the change is inert on everything that does run:

| | master | with this change |
|---|---|---|
| `mvn -pl eo-printer test` | 346 passed | 346 passed |
| `mvn -pl eo-runtime process-sources` | all 170 sources canonical | all 170 sources canonical |
| transpiled | 170 XMIRs, 179 Java files | 170 XMIRs, 179 Java files |

Both columns are this branch's base, `d421d8d`; the left one was produced by stashing the change and reinstalling `eo-printer`, so the comparison is like for like.

## What I deliberately left alone

`restore-local-names.xsl` has the same shape — `eo:recursive(., @name)` and five others, called from match patterns — and it took the same `[2]` change in 28e7534. I did not touch it here: its parameters are `xs:string?` rather than `xs:string`, so `string(@name)` would turn an absent `@name` from an empty sequence into `''` and change what those functions answer. The faithful form there is `@name/string()`, which deserves its own change and its own reasoning rather than riding along with this one. Glad to open it if you want it.
