### PR TITLE
fix(#6628): enforce atom body rules in transitions

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -147,7 +147,7 @@ final class LnApplication implements Line {
     private void transition(
         final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
     ) {
-        new Transition(stack, this.span).apply(kind, openness, suffix.named());
+        new Transition(stack, this.span).apply(kind, openness, suffix);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -105,7 +105,7 @@ final class LnCompactTuple implements Line {
      */
     private Level transition(final Stack stack, final Suffix suffix) {
         return new Transition(stack, this.span)
-            .apply(Kind.COMPACT_TUPLE, Openness.OPEN, suffix.named());
+            .apply(Kind.COMPACT_TUPLE, Openness.OPEN, suffix);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -147,54 +147,11 @@ final class LnFormation implements Line {
      * @param suffix The parsed suffix (sets named/atom flags)
      */
     private void transition(final Stack stack, final Suffix suffix) {
-        final Level level;
-        if (stack.empty() || stack.top().indent() < this.span.indent()) {
-            this.checkChildAllowed(stack, suffix);
-            level = stack.push(
-                this.span.indent(), this.span.line(),
-                Kind.BARE_FORMATION, Openness.OPEN
-            );
-        } else {
-            level = stack.replace(
-                this.span.line(), Kind.BARE_FORMATION, Openness.OPEN
-            );
-        }
-        if (suffix.present()) {
-            level.name(suffix.label());
-        }
+        final Level level = new Transition(stack, this.span).apply(
+            Kind.BARE_FORMATION, Openness.OPEN, suffix
+        );
         if (suffix.atom()) {
             level.mark();
-        }
-    }
-
-    /**
-     * Validate that a deeper-indent formation is legal under its
-     * pending parent — indent step is exactly one, parent is open, and
-     * (per R-3.10.13) the parent is not an atom unless this child is
-     * itself a test attribute.
-     * @param stack The stack
-     * @param suffix The parsed suffix
-     */
-    private void checkChildAllowed(final Stack stack, final Suffix suffix) {
-        if (!stack.empty()
-            && this.span.indent() != stack.top().indent() + 2) {
-            throw new ParseError(
-                this.span.line(), 0,
-                "indent increased by more than one level"
-            );
-        }
-        if (!stack.empty()
-            && stack.top().openness() != Openness.OPEN) {
-            throw new ParseError(
-                this.span.line(), 0,
-                "unexpected deeper-indent line — previous expression is closed for children"
-            );
-        }
-        if (!stack.empty() && stack.top().atom() && !suffix.test()) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
-            );
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -284,7 +284,7 @@ final class LnOnlyPhi implements Line {
             openness = Openness.HORIZONTAL_COMPLETED;
         }
         return new Transition(stack, this.span).apply(
-            Kind.ONLY_PHI_FORMATION, openness, suffix.named()
+            Kind.ONLY_PHI_FORMATION, openness, suffix
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -83,7 +83,7 @@ final class LnPipe implements Line {
             openness = Openness.VERTICAL_COMPLETED;
         }
         new Transition(stack, this.span).apply(
-            Kind.PIPE_APPLICATION, openness, suffix.named()
+            Kind.PIPE_APPLICATION, openness, suffix
         );
         globals.clearBlanks();
         globals.markEmitted();

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -150,7 +150,7 @@ final class LnReversed implements Line {
     private void transition(
         final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
     ) {
-        new Transition(stack, this.span).apply(kind, openness, suffix.named());
+        new Transition(stack, this.span).apply(kind, openness, suffix);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -97,7 +97,7 @@ final class LnTextBlock implements Line {
      */
     private void transition(final Stack stack, final Suffix suffix) {
         new Transition(stack, this.span).apply(
-            Kind.TEXT_BLOCK, Openness.VERTICAL_COMPLETED, suffix.named()
+            Kind.TEXT_BLOCK, Openness.VERTICAL_COMPLETED, suffix
         );
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -81,7 +81,7 @@ final class LnVoid implements Line {
         }
         Comments.seal(globals, emit, this.span);
         final Level level = new Transition(stack, this.span).apply(
-            Kind.VOID, Openness.VERTICAL_COMPLETED, suffix.named()
+            Kind.VOID, Openness.VERTICAL_COMPLETED, suffix
         );
         if (slash >= 0 && !level.patom()) {
             throw new ParseError(

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.parser;
 
+import java.util.Optional;
+
 /**
  * The stack transition triggered when a {@link Line} adopts the
  * parser cursor — §5.2 (Step B/C/D) of the spec.
@@ -44,14 +46,13 @@ final class Transition {
     /**
      * Push a fresh level (when stepping deeper) or replace the level
      * on top (when staying at the same indent), and mark it named if
-     * {@code named} is true.
+     * the suffix is present.
      * @param kind Outer kind for the level
      * @param openness Openness for the level
-     * @param label The suffix's source name, or {@code null} when the
-     *  line carries no name suffix
+     * @param suffix Parsed suffix, or {@code null} when absent
      * @return The pushed-or-replaced level
      */
-    Level apply(final Kind kind, final Openness openness, final String label) {
+    Level apply(final Kind kind, final Openness openness, final Suffix suffix) {
         final Level level;
         if (this.stack.empty() || this.stack.top().indent() < this.span.indent()) {
             if (!this.stack.empty() && this.span.indent() != this.stack.top().indent() + 2) {
@@ -66,13 +67,30 @@ final class Transition {
                     "unexpected deeper-indent line — previous expression is closed for children"
                 );
             }
+            if (!this.stack.empty() && this.forbidden(kind, suffix)) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
+                );
+            }
             level = this.stack.push(this.span.indent(), this.span.line(), kind, openness);
         } else {
             level = this.stack.replace(this.span.line(), kind, openness);
         }
-        if (label != null) {
-            level.name(label);
+        if (Optional.ofNullable(suffix).filter(Suffix::present).isPresent()) {
+            level.name(suffix.label());
         }
         return level;
+    }
+
+    /**
+     * Whether this child is forbidden in an atom body.
+     * @param kind Outer kind for the child
+     * @param suffix Parsed suffix, or {@code null} when absent
+     * @return True if the atom cannot contain this child
+     */
+    private boolean forbidden(final Kind kind, final Suffix suffix) {
+        return this.stack.top().atom() && kind != Kind.VOID
+            && (suffix == null || !suffix.test());
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
@@ -85,7 +85,7 @@ final class TransitionTest {
         MatcherAssert.assertThat(
             "applying with a non-null label must record the level as carrying a name suffix",
             new Transition(new Stack(), new Span("kappa", 1))
-                .apply(Kind.HEAD, Openness.OPEN, "mu")
+                .apply(Kind.HEAD, Openness.OPEN, new Suffix(" > mu", new Span("kappa > mu", 1), 5))
                 .named(),
             Matchers.is(true)
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -5,8 +5,8 @@
 line: 2
 message: |-
   [2:2] error: 'Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body'
-    [] > inner
+    42 > inner
     ^
 input: |
   [] > test /bytes
-    [] > inner
+    42 > inner


### PR DESCRIPTION
## Summary

- move atom-child validation into the shared `Transition.apply` path
- reject non-test application, reversed, compact-tuple, pipe, text-block, and only-phi children while preserving atom void parameters
- keep `+>` and `->` test attributes valid and cover the application-child regression

## Validation

- `mvn -pl eo-parser -Pqulice verify` (1,729 tests, 0 failures, 6 skipped; Qulice passed)
- `mvn -pl eo-parser -DskipITs '-Dtest=TransitionTest,EoSyntaxTest#checksTypoPacks' test` (104 tests, 0 failures)

Closes #6628

@yegor256
