### PR TITLE
fix(transpile): #6674 buffer the generated Java before handing it to the DOM

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -219,18 +219,42 @@
     <xsl:text>import org.eolang.*;</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
   </xsl:template>
-  <!-- Class. Entry point -->
+  <!--
+  Class. Entry point.
+
+  The Java of a class is assembled from thousands of small "xsl:text" and
+  "xsl:value-of" pieces by the templates below, and it must reach "<java>" as
+  one text node. Each piece is handed to the result tree as it is produced,
+  and that tree is a DOM, where merging a piece into the text node already
+  there copies everything accumulated so far - so writing the pieces straight
+  into "<java>" was quadratic in the size of the generated Java. The biggest
+  class of "eo-runtime" ends up at ~485k characters, and paying for all of it
+  again on every piece made this one pass four fifths of the whole transpile
+  train (#6674).
+
+  Collecting the pieces in a variable first costs nothing, because a temporary
+  tree is Saxon's own, where appending text grows a buffer instead of copying
+  one, and the single "xsl:value-of" then hands the DOM the finished string in
+  one piece. Both bodies are pure text, so a variable holds exactly what the
+  element would have held.
+  -->
   <xsl:template match="class">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
       <tests>
-        <xsl:call-template name="commonclass"/>
-        <xsl:apply-templates select="." mode="testing"/>
+        <xsl:variable name="code">
+          <xsl:call-template name="commonclass"/>
+          <xsl:apply-templates select="." mode="testing"/>
+        </xsl:variable>
+        <xsl:value-of select="$code"/>
       </tests>
       <xsl:if test="not(@skip-java)">
         <java>
-          <xsl:call-template name="commonclass"/>
-          <xsl:apply-templates select="." mode="body"/>
+          <xsl:variable name="code">
+            <xsl:call-template name="commonclass"/>
+            <xsl:apply-templates select="." mode="body"/>
+          </xsl:variable>
+          <xsl:value-of select="$code"/>
         </java>
       </xsl:if>
     </xsl:copy>


### PR DESCRIPTION
Closes #6674. Follow-up to #6666 — same mechanism, and after that fix `to-java.xsl` was **82% of the transpile train**.

## Where the time went

Per stylesheet, all 170 sources of `eo-runtime/src/main/eo`, best of two warm runs, Saxon-HE 13.0, single-threaded:

```
    725 ms  parse/set-locators.xsl              1205 ms  transpile/classes.xsl
    508 ms  transpile/set-original-names.xsl     649 ms  transpile/tests.xsl
    728 ms  transpile/anonymous-to-nested.xsl    675 ms  transpile/package.xsl
    683 ms  transpile/attrs.xsl                  585 ms  transpile/data.xsl
  25408 ms  transpile/to-java.xsl   <-- 82%
  31168 ms  TRAIN TOTAL
```

Saxon's `TimingTraceListener` on `string/printf.eo` put **8,328ms of the 8,881ms total in the net time of `xsl:template match="class"`** — the template that only opens `<tests>` and `<java>` and delegates. Net, so not the 26 templates it calls: that is the cost of handing text to the result tree.

## Why

The result tree is a DOM (`XSLDocument.transform` passes Saxon a `DOMSource` and a `DOMResult`). The templates produce the Java as thousands of small `xsl:text`/`xsl:value-of` pieces, each handed over as it is produced, and Saxon merges adjacent text into one DOM text node. Merging into a Xerces `Text` node is `setNodeValue(this.data + data)` — a full copy of everything accumulated.

So the pass was **quadratic in the size of the generated Java**. `<java>` for `string/printf.eo` is one text node of **484,853 characters**, and every piece paid for a copy of all the text before it. Retargeting the identical transform isolates it — same stylesheet, same input, warm:

| result | before | after |
|---|---|---|
| `DOMResult` (what the build uses) | 3460 ms | 159 ms |
| `StreamResult` | 91 ms | 144 ms |

The gap closing is the point: the quadratic term is gone, not just smaller.

## The change

Nine lines. Each body goes into a variable, then reaches the element through one `xsl:value-of`:

```xml
<java>
  <xsl:variable name="code">
    <xsl:call-template name="commonclass"/>
    <xsl:apply-templates select="." mode="body"/>
  </xsl:variable>
  <xsl:value-of select="$code"/>
</java>
```

A temporary tree is Saxon's own, where appending text grows a buffer rather than copying one. Both bodies are pure text, so the variable holds exactly what the element held before — **none of the 26 templates changed**.

| | `to-java.xsl` | whole train |
|---|---|---|
| before | 25.4s | 31.2s |
| after | **2.1s** | **7.9s** |

## What I ruled out first

`eo:eol()` and `eo:tabs()` are each called 4,257 times on one source and build a temporary tree per call, since neither declares `as="xs:string"` — the obvious suspect. Rewriting `$TAB`, `eo:eol` and `eo:tabs` as pure string functions moved the total by nothing measurable (24.5s → 26.1s, i.e. noise), and the trace agrees: 61ms and 27ms gross. That variant is **not** in this PR; it would be churn for no gain.

## Correctness

- Output **byte-identical** for all 170 `eo-runtime` sources — the generated Java itself.
- `MjTranspileTest` (52 transpile packs) and `FingerprintTest`: 57 tests green. That suite also drops from 34.5s to 14.0s.
- `xcop` clean on the changed file.
- `to-java.xsl` is fingerprinted into the transpile cache key via `Transpilation.XSLS`, so existing caches invalidate on their own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GevVXivd1KDNnCHqKW9rua)_