### PR TITLE
fix(printer): #6669 atomise attribute nodes at function boundaries

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -26,10 +26,26 @@
   `ξ.ρ.a🌵4-2`, everything up to the cactus prefix is stripped, so the
   resolved name is the trailing `a🌵4-2`. This mirrors the `$name`
   computation in the inlining template below.
+
+  Every call site hands over the `@base` attribute node itself, and it is turned
+  into a string here rather than declared as `xs:string` and left to the function
+  conversion rules (#6669). Saxon may bind a parameter to a closure over the
+  argument expression instead of over its converted value, and the node then
+  arrives in the body, where an expression compiled on the strength of a
+  statically atomic parameter (the `substring-before` below, or the
+  `ValueComparison` against `$name` in `eo:references`) casts it straight to an
+  atomic value and kills the whole sheet with `DOMNodeWrapper cannot be cast to
+  AtomicValue`. The `[2]` of #6638 is what made that reachable: it moved such a
+  predicate into a lazy subscript, which is exactly the context where the
+  deferred conversion is lost. Nothing is read differently for it: `string()` of
+  an attribute node is the value the conversion rules would have produced, and a
+  node carrying no `@base` at all now resolves to the empty string, which no
+  reference to an auto-name can equal, rather than raising a type error.
   -->
   <xsl:function name="eo:resolved-name" as="xs:string">
-    <xsl:param name="base" as="xs:string"/>
-    <xsl:sequence select="substring-after($base, substring-before($base, $auto))"/>
+    <xsl:param name="base" as="item()?"/>
+    <xsl:variable name="text" as="xs:string" select="string($base)"/>
+    <xsl:sequence select="substring-after($text, substring-before($text, $auto))"/>
   </xsl:function>
   <!--
   The based `&gt;&gt; name` handle that `$target` ultimately denotes, chasing a
@@ -310,9 +326,20 @@
   never moved its value anywhere: dropping it deletes the declaration from the
   printed source, so a private helper formation or const cache that nothing
   reads yet would silently vanish (#5914).
+
+  The handle name is atomised once here, for the reason spelled out on
+  `eo:resolved-name` above (#6669). Each of the nine questions below declares its
+  `$name` as `xs:string`, and this template is the only place that answered them
+  with the `@name` attribute node rather than its string value — every other
+  caller passes the `$name` variable of the inlining template, itself the string
+  returned by `eo:resolved-name`. Handing over the node is what let a
+  `DOMNodeWrapper` reach the `ValueComparison` inside `eo:references` and crash
+  the whole sheet. The match pattern requires `@name`, so the string is always
+  the name the nine were asked about before.
   -->
   <xsl:template match="o[starts-with(@name, $auto) and not(eo:void(.))]" priority="1">
-    <xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or eo:vertical-const(.) or eo:unreferenced(., @name) or (eo:multi-referenced(., @name) and eo:rebuilt(.)) or eo:piped(., @name) or eo:arg-applied(., @name) or eo:nested-applied(., @name) or eo:reapplied(., @name)">
+    <xsl:variable name="name" as="xs:string" select="string(@name)"/>
+    <xsl:if test="eo:recursive(., $name) or eo:dispatched(., $name) or eo:vertical-const(.) or eo:unreferenced(., $name) or (eo:multi-referenced(., $name) and eo:rebuilt(.)) or eo:piped(., $name) or eo:arg-applied(., $name) or eo:nested-applied(., $name) or eo:reapplied(., $name)">
       <xsl:copy>
         <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -61,10 +61,21 @@
   A reference resolves to its own auto-name: given a base such as
   "ξ.ρ.a🌵4-2", everything up to the cactus prefix is stripped, so the
   resolved name is the trailing "a🌵4-2". Mirrors "inline-cactoos".
+
+  The "@base" attribute node is turned into a string here rather than declared as
+  "xs:string" and left to the function conversion rules, for the reason spelled
+  out on the twin function in "inline-cactoos" (#6669): a node that reaches an
+  atomically typed parameter through a lazily bound argument is cast straight to
+  an atomic value by whatever the body compiled around it, and the sheet dies
+  with "DOMNodeWrapper cannot be cast to AtomicValue". Every "@name" handed to
+  the functions below is atomised at its call site for the same reason, spelled
+  "@name/string()" rather than "string(@name)" so that a missing handle stays the
+  empty sequence those parameters are declared to accept.
   -->
   <xsl:function name="eo:resolved-name" as="xs:string">
-    <xsl:param name="base" as="xs:string"/>
-    <xsl:sequence select="substring-after($base, substring-before($base, $auto))"/>
+    <xsl:param name="base" as="item()?"/>
+    <xsl:variable name="text" as="xs:string" select="string($base)"/>
+    <xsl:sequence select="substring-after($text, substring-before($text, $auto))"/>
   </xsl:function>
   <!--
   Whether the auto-named abstract "$target" transitively references its
@@ -220,9 +231,9 @@
   -->
   <xsl:function name="eo:relocated" as="xs:boolean">
     <xsl:param name="ref" as="element()"/>
-    <xsl:sequence select="exists($ref/following-sibling::o[@local and eo:recursive(., @name) and @name = eo:resolved-name($ref/@base)])"/>
+    <xsl:sequence select="exists($ref/following-sibling::o[@local and eo:recursive(., @name/string()) and @name = eo:resolved-name($ref/@base)])"/>
   </xsl:function>
-  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name) or @pipe)]" use="@name"/>
+  <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name/string()) or @pipe)]" use="@name"/>
   <!--
   References: rewrite each cactus segment that names a handled void, a
   recursive formation, or a pipe-application handle (`| args &gt;&gt; name`,
@@ -251,7 +262,7 @@
   "inline-cactoos" to pipe against, the pipe handle to read as a `|` line whose
   "&gt;&gt; name" comes from "@local" rather than a promoted "@name".
   -->
-  <xsl:template match="o[@local and (@base=$eo:empty or eo:recursive(., @name))]/@name">
+  <xsl:template match="o[@local and (@base=$eo:empty or eo:recursive(., @name/string()))]/@name">
     <xsl:attribute name="name" select="../@local"/>
   </xsl:template>
   <!--
@@ -277,7 +288,7 @@
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(@pipe) and not(eo:recursive(., @name)) and not(eo:applied-receiver(., @name)) and not(eo:multi-referenced(., @name)) and not(eo:unreferenced(., @name)) and not(eo:nested-referenced(., @name)) and not(eo:reapplied(., @name)) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(@pipe) and not(eo:recursive(., @name/string())) and not(eo:applied-receiver(., @name/string())) and not(eo:multi-referenced(., @name/string())) and not(eo:unreferenced(., @name/string())) and not(eo:nested-referenced(., @name/string())) and not(eo:reapplied(., @name/string())) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the
@@ -292,7 +303,7 @@
   that already carries "@pipe" (an already-piped handle round-tripping) is
   left as is.
   -->
-  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and preceding-sibling::o[1][@local and eo:recursive(., @name)] and eo:resolved-name(@base) = preceding-sibling::o[1]/@name]">
+  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and preceding-sibling::o[1][@local and eo:recursive(., @name/string())] and eo:resolved-name(@base) = preceding-sibling::o[1]/@name]">
     <xsl:copy>
       <xsl:if test="not(@pipe)">
         <xsl:attribute name="pipe"/>
@@ -328,7 +339,7 @@
   A reference already carrying "@pipe" is left as is. A handle with no such
   preceding reference (the #5837 reference-below shape) just copies through.
   -->
-  <xsl:template match="o[@local and eo:recursive(., @name)]">
+  <xsl:template match="o[@local and eo:recursive(., @name/string())]">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -27,9 +27,20 @@
   <!--
   Render a base as an EO head: drop implicit ξ./Φ. roots, render a
   leading dot as reversed dispatch, map ξ/ρ/φ/Φ and every segment.
+
+  The parameter takes the "@base" attribute node as it stands and atomises it
+  here, rather than declaring "xs:string" and leaving that to the function
+  conversion rules (#6669): Saxon may bind a parameter to a closure over the
+  argument expression instead of over its converted value, and the node then
+  reaches the "$base = $eo:xi" comparison below, which was compiled as a
+  "ValueComparison" on the strength of a statically atomic parameter and casts
+  straight to an atomic value. That is how the same shape killed
+  "inline-cactoos" in #6669. "eo:root-name" is hardened the same way, being the
+  other function this sheet asks about a raw "@base".
   -->
   <xsl:function name="eo:surface" as="xs:string">
-    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="raw" as="item()?"/>
+    <xsl:variable name="base" as="xs:string" select="string($raw)"/>
     <xsl:sequence select="if (starts-with($base, '.')) then concat(eo:translate-path(substring($base, 2)), '.') else if (starts-with($base, concat($eo:program, '.'))) then eo:translate-path(substring-after($base, concat($eo:program, '.'))) else if (starts-with($base, concat($eo:xi, '.'))) then eo:translate-path(substring-after($base, concat($eo:xi, '.'))) else if ($base = $eo:xi) then '$' else if ($base = $eo:program) then 'Q' else eo:translate-path($base)"/>
   </xsl:function>
   <!--
@@ -44,9 +55,14 @@
     <xsl:variable name="last" select="tokenize($surface, '\.')[last()]"/>
     <xsl:sequence select="if ($fragile and contains($surface, '.')) then concat(substring($surface, 1, string-length($surface) - string-length($last) - 1), '?.', $last) else $surface"/>
   </xsl:function>
-  <!-- First name segment of a program-rooted base (Φ.foo.bar -> foo). -->
+  <!--
+  First name segment of a program-rooted base (Φ.foo.bar -> foo). The raw
+  "@base" node is atomised here for the reason spelled out on "eo:surface"
+  above (#6669).
+  -->
   <xsl:function name="eo:root-name" as="xs:string">
-    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="raw" as="item()?"/>
+    <xsl:variable name="base" as="xs:string" select="string($raw)"/>
     <xsl:variable name="rest" select="substring-after($base, concat($eo:program, '.'))"/>
     <xsl:sequence select="if (contains($rest, '.')) then substring-before($rest, '.') else $rest"/>
   </xsl:function>


### PR DESCRIPTION
Closes #6669

## Root cause

The stack trace names the caller: the drop template at `inline-cactoos.xsl:314`, which asked nine functions about `@name`:

```xml
<xsl:if test="eo:recursive(., @name) or eo:dispatched(., @name) or ... or eo:reapplied(., @name)">
```

Every one of them declares its `$name` as `xs:string`, so the atomisation was left to the function conversion rules. Saxon may bind a parameter to a closure over the argument expression rather than over its converted value, and the node itself then arrives inside the function. There the comparison in `eo:references`

```xml
eo:resolved-name(@base) = $name
```

has already been compiled to a `ValueComparison`, on the strength of both operands being statically `xs:string` — so it casts straight to `AtomicValue` and the sheet dies with `DOMNodeWrapper cannot be cast to AtomicValue`.

The other operand cannot be the node: `eo:resolved-name` builds its result with `substring-after`, so it is a string by construction. `$name` is the only candidate, and that template is the only place a node reaches it — every other call site passes the `$name` variable of the inlining template, which is itself `eo:resolved-name(@base)`.

This also settles the "moved the crash" reading in the issue. `count()` materialised the sequence inside the function's own evaluation; `[2]` reaches it through a lazy subscript, which is exactly the context where the deferred conversion is lost. #6638 did not introduce the type mismatch — it changed the evaluation strategy enough to expose it.

## The change

The reported crash is fixed by atomising once, in that template, before any of the nine is asked:

```xml
<xsl:variable name="name" as="xs:string" select="string(@name)"/>
```

The match pattern is `o[starts-with(@name, $auto) and not(eo:void(.))]`, so `@name` is always present and the parameters are required `xs:string`: nothing about what the nine are asked changes.

That alone would leave the class in place, one optimiser roll from the next crash, so the remaining boundaries of the same shape in the print train are closed too. I scanned every `xsl:function` in `eo-*/src/main/resources` for call sites handing a bare attribute node to a parameter declared as an atomic type; these were the print-train hits:

| sheet | boundary | closed by |
|---|---|---|
| `inline-cactoos` | `@name` → nine functions, 1 site | `string(@name)` in the template |
| `inline-cactoos` | `@base` → `eo:resolved-name`, 10 sites | `item()?` param, atomised in the body |
| `restore-local-names` | `@base` → `eo:resolved-name`, 8 sites | same |
| `restore-local-names` | `@name` → six functions, 11 sites | `@name/string()` at each site |
| `to-eo-tree` | `@base` → `eo:surface`, `eo:root-name` | `item()?` param, atomised in the body |

Two idioms, picked by where the caller sits:

- Where many callers pass the raw `@base` into one small function, the atomisation moves inside it (`as="item()?"` plus `string()` in the body). One edit closes ten call sites, and it cannot be optimised away — Saxon elides `fn:string` when its argument is statically a single string, so wrapping the operands of the comparison instead, as the issue suggests as an alternative, would not reliably survive compilation. The declared cardinality is unchanged for any node that has a base; a node without one now resolves to `''` instead of raising a type error, and `''` is a name no reference to an auto-name can equal.
- Where the caller is a match pattern, no variable can be hoisted, so the call site atomises: `@name/string()` rather than `string(@name)`, because those parameters are `xs:string?` and a missing handle has to stay the empty sequence rather than become `''`.

`eo:surface` is worth calling out: its body compares `$base = $eo:xi` and `$base = $eo:program`, so it is the same `ValueComparison` shape as the one that crashed, reached from `eo:surface(@base)` in the head template. It has not failed yet; there is no reason it could not.

## Verification

The failure is optimiser-dependent and does not reproduce on demand — that is the shape of the bug, and why there is no runtime regression test here. What is testable is that the change is inert on everything that does run, and both checks below are stronger than a unit test would be, because the printer's output is compared against the canonical form master produces:

| check | result |
|---|---|
| `mvn -pl eo-printer -am install` (JDK 21, Linux) | `Tests run: 348, Failures: 0, Errors: 0` — 304 of them `XmirTest` print packs |
| `mvn -pl eo-runtime process-sources` — the goal that failed in CI | `All 170 EO source(s) are formatted canonically` |

`eo:format` parses each source, prints it back through this train and compares against what is on disk, so a single green run means the printed text is byte-identical to master's for all 170 real sources — including the `restore-local-names` patterns and the `to-eo-tree` heads this diff touches.

## What I deliberately left alone

The same scan found 14 boundaries of this shape outside the print train, all reached from templates rather than lazy predicates: `eo:class-name`, `eo:attr-name` and `eo:escape-plus` in `to-java.xsl` (12 sites) and `eo:homed` in `add-default-package.xsl` (2). They are one-token fixes of the same kind, but they sit in the transpile and parse trains, and closing them means re-verifying generated Java rather than printed EO. Happy to open that as a separate issue or PR if you want it.

## Relation to #6672

@yangjj-iso's #6672 reaches the same diagnosis and the same two-line fix for the crash site; this PR agrees with it there and additionally closes the other 31 boundaries of the class, including the `restore-local-names` ones that PR sets aside. Whichever you take, the `inline-cactoos` template is the part that unblocks master.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpRBPd5CNMDZfamFNgtC8D)_