### PR TITLE
Give clashing test names the object they test

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -19,4 +19,4 @@
 
   00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
 
-  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size
+  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size-when-converting-to-i16

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -19,4 +19,4 @@
 
   00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
 
-  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size
+  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size-when-converting-to-i32

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -26,9 +26,9 @@
   not. ++> cannot-match-the-bytes-of-the-same-number
     00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
 
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> rejects-bytes-of-wrong-size-when-converting-to-i64
     "recovered"
     01-01-01-01.as-i64
       "recovered" > [message]
 
-  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size
+  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size-when-converting-to-i64

--- a/eo-runtime/src/main/eo/bytes/as-i8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i8.eo
@@ -19,4 +19,4 @@
 
   2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
 
-  01-01.as-i8 --> stops-on-bytes-of-wrong-size
+  01-01.as-i8 --> stops-on-bytes-of-wrong-size-when-converting-to-i8

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -30,9 +30,10 @@
   is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
     FF-F8-00-00-00-00-00-00.as-number
 
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> rejects-bytes-of-wrong-size-when-converting-to-a-number
     "recovered"
     01-01-01-01.as-number
       "recovered" > [message]
 
-  01-01-01-01.as-number --> stops-on-bytes-of-wrong-size
+  as-number. --> stops-on-bytes-of-wrong-size-when-converting-to-a-number
+    01-01-01-01

--- a/eo-runtime/src/main/eo/bytes/as-u16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u16.eo
@@ -19,4 +19,4 @@
 
   00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
 
-  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size
+  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size-when-converting-to-u16

--- a/eo-runtime/src/main/eo/bytes/as-u32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u32.eo
@@ -19,4 +19,4 @@
 
   00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
 
-  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size
+  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size-when-converting-to-u32

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -21,9 +21,9 @@
     00-00-00-00-00-00-00-33.as-u64.as-bytes
     00-00-00-00-00-00-00-33
 
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> rejects-bytes-of-wrong-size-when-converting-to-u64
     "recovered"
     01-01-01-01.as-u64
       "recovered" > [message]
 
-  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size
+  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size-when-converting-to-u64

--- a/eo-runtime/src/main/eo/bytes/as-u8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u8.eo
@@ -19,4 +19,4 @@
 
   2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
 
-  01-01.as-u8 --> stops-on-bytes-of-wrong-size
+  01-01.as-u8 --> stops-on-bytes-of-wrong-size-when-converting-to-u8

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -76,11 +76,6 @@
     pinf.plus pinf
     pinf
 
-  lt. ++> can-approximate-a-square-root
-    abs.
-      9.sqrt.minus 3
-    1.0E-9
-
   pinf.gt 42.5 ++> can-be-greater-than-a-float-when-positive-infinity
 
   eq. ++> can-be-greater-than-a-smaller-integer
@@ -356,21 +351,11 @@
     pinf.times pinf
     pinf
 
-  eq. ++> can-raise-to-a-power
-    2.power 4
-    16
-
   eq. ++> can-raise-to-a-power-through-the-package
     number.power
       2
       5
     32
-
-  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative
-
-  eq. ++> can-take-the-modulo-of-two-numbers
-    7.mod 3
-    1
 
   eq. ++> cannot-be-greater-than-a-float-when-negative-infinity
     ninf.gt 42.5

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -47,7 +47,7 @@
         series magnitude
     base
 
-  lt. ++> can-behave-as-an-odd-function
+  lt. ++> can-behave-as-an-odd-function-when-taking-arc-sine
     abs
       times.
         plus.

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -23,7 +23,7 @@
         1000
     1
 
-  lt. ++> can-reduce-a-large-angle
+  lt. ++> can-reduce-a-large-angle-when-taking-cosine
     abs
       minus.
         times.

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -15,7 +15,7 @@
       pi
     180
 
-  lt. ++> can-convert-a-large-value-without-overflow
+  lt. ++> can-convert-a-large-value-to-degrees-without-overflow
     abs
       minus.
         degrees 1.0e306

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -395,7 +395,7 @@
         3
     1.0E-9
 
-  lt. ++> can-take-a-square-root-of-two
+  lt. ++> can-take-a-square-root-of-two-by-raising-to-a-power
     abs
       minus.
         power 2 0.5

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -29,7 +29,7 @@
         pi
     1.0E-4
 
-  lt. ++> can-convert-a-large-value-without-overflow
+  lt. ++> can-convert-a-large-value-to-radians-without-overflow
     abs
       minus.
         radians 1.0e308

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -44,7 +44,7 @@
             depth.plus 1
     | 1
 
-  lt. ++> can-behave-as-an-odd-function
+  lt. ++> can-behave-as-an-odd-function-when-taking-sine
     abs
       times.
         plus.
@@ -54,7 +54,7 @@
         1000
     1
 
-  lt. ++> can-reduce-a-large-angle
+  lt. ++> can-reduce-a-large-angle-when-taking-sine
     abs
       minus.
         times.

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -54,25 +54,9 @@
     "x".eq "x"
     true
 
-  contains. ++> can-contain-a-word-in-a-sentence
-    "hello, world, how are you?"
-    "how"
-
-  "eEo".is-alpha ++> can-detect-alphabetic-text
-
-  "2026".is-digit ++> can-detect-digits
-
-  ends-with. ++> can-end-with-a-suffix
-    "hello, world"
-    "world"
-
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> can-equal-a-string-through-bytes
 
   "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> can-equal-bytes
-
-  eq. ++> can-find-the-index-of-a-character
-    "hello".index-of "l"
-    2
 
   "Abc".eq "Abc" ++> can-hold-a-one-line-text-block
 
@@ -86,14 +70,6 @@
     "a\n b\n  c"
     "a\n b\n  c"
 
-  eq. ++> can-repeat-text
-    "ha".repeated 3
-    "hahaha"
-
-  starts-with. ++> can-start-with-a-prefix
-    "hello, world"
-    "hello"
-
   "\n".eq "\n" ++> can-support-a-line-break-escape-sequence
 
   "Ф".eq "Ф" ++> can-support-a-unicode-escape-sequence
@@ -105,14 +81,6 @@
   eq. ++> can-support-escape-sequences-in-a-text-block
     "Hello, друг!\n"
     "Hello, друг!\n"
-
-  eq. ++> can-take-a-character-at-an-index
-    "some".at 1
-    "o"
-
-  eq. ++> can-trim-surrounding-spaces
-    "  spaced  ".trimmed
-    "spaced"
 
   eq. ++> can-turn-into-bytes
     "€ друг".as-bytes

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -124,7 +124,7 @@
     string
       as-fixed -2.5 0
 
-  eq. ++> can-pad-with-trailing-zeros
+  eq. ++> can-pad-the-fraction-with-trailing-zeros
     "1.250000"
     string
       as-fixed 1.25 6

--- a/eo-runtime/src/main/eo/string/english.eo
+++ b/eo-runtime/src/main/eo/string/english.eo
@@ -67,7 +67,7 @@
           as-ascii byte > code
     as-ascii "a" >> mincode!
 
-  eq. ++> can-behave-like-the-wrapped-string
+  eq. ++> can-behave-like-the-wrapped-english-string
     5
     length.
       english "hello"
@@ -102,12 +102,12 @@
     upper.
       english "HELLO"
 
-  eq. ++> can-keep-non-ascii-letters-when-lower-casing
+  eq. ++> can-keep-non-ascii-letters-when-lower-casing-in-english
     "ÄÖÜ"
     lower.
       english "ÄÖÜ"
 
-  eq. ++> can-keep-non-ascii-letters-when-upper-casing
+  eq. ++> can-keep-non-ascii-letters-when-upper-casing-in-english
     "äöü"
     upper.
       english "äöü"

--- a/eo-runtime/src/main/eo/string/lower.eo
+++ b/eo-runtime/src/main/eo/string/lower.eo
@@ -17,7 +17,7 @@
   lower. > @
     english text
 
-  "äöü".eq "äöü".lower ++> can-keep-non-ascii-letters
+  "äöü".eq "äöü".lower ++> can-keep-non-ascii-letters-when-lower-casing
 
   eq. ++> can-lower-case-text
     "good evening"

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -146,7 +146,7 @@
       1.5
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-limit
+  eq. ++> rejects-an-infinite-limit-when-splitting
     "recovered"
     nsplit
       "a-b-c"
@@ -167,7 +167,7 @@
     "-"
     0
 
-  nsplit --> stops-on-a-negative-limit
+  nsplit --> stops-on-a-negative-limit-when-splitting
     "text"
     "-"
     -1

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -39,14 +39,14 @@
           text.as-bytes
       text
 
-  eq. ++> can-count-characters-and-not-bytes
+  eq. ++> can-count-characters-and-not-bytes-when-padding-left
     "  Ж"
     padded-left
       "Ж"
       3
       " "
 
-  eq. ++> can-format-the-error-message-of-a-negative-width
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-left
     "Can't pad text to -1.000000 characters with x"
     padded-left
       "y"
@@ -68,28 +68,28 @@
       4
       "0"
 
-  eq. ++> can-return-a-longer-text-unchanged
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-left
     "hello"
     padded-left
       "hello"
       3
       " "
 
-  eq. ++> can-return-a-text-of-the-exact-width-unchanged
+  eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-left
     "hey"
     padded-left
       "hey"
       3
       " "
 
-  eq. ++> can-return-a-text-unchanged-at-zero-width
+  eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-left
     "x"
     padded-left
       "x"
       0
       " "
 
-  eq. ++> rejects-a-multi-character-fill
+  eq. ++> rejects-a-multi-character-fill-when-padding-left
     "recovered"
     padded-left
       "y"
@@ -97,7 +97,7 @@
       "ab"
       "recovered" > [message]
 
-  eq. ++> rejects-a-negative-width
+  eq. ++> rejects-a-negative-width-when-padding-left
     "recovered"
     padded-left
       "y"
@@ -105,7 +105,7 @@
       "x"
       "recovered" > [message]
 
-  eq. ++> rejects-a-non-integer-width
+  eq. ++> rejects-a-non-integer-width-when-padding-left
     "recovered"
     padded-left
       "y"
@@ -113,7 +113,7 @@
       "x"
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-width
+  eq. ++> rejects-an-infinite-width-when-padding-left
     "recovered"
     padded-left
       "y"
@@ -121,7 +121,7 @@
       "x"
       "recovered" > [message]
 
-  padded-left --> stops-on-a-negative-width
+  padded-left --> stops-on-a-negative-width-when-padding-left
     "y"
     -1
     "x"

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -38,14 +38,14 @@
               cant-pad
       text
 
-  eq. ++> can-count-characters-and-not-bytes
+  eq. ++> can-count-characters-and-not-bytes-when-padding-right
     "Ж  "
     padded-right
       "Ж"
       3
       " "
 
-  eq. ++> can-format-the-error-message-of-a-negative-width
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-right
     "Can't pad text to -1.000000 characters with x"
     padded-right
       "y"
@@ -60,35 +60,35 @@
       10
       " "
 
-  eq. ++> can-pad-with-trailing-zeros
+  eq. ++> can-pad-with-trailing-zeros-when-padding-right
     "4200"
     padded-right
       "42"
       4
       "0"
 
-  eq. ++> can-return-a-longer-text-unchanged
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-right
     "hello"
     padded-right
       "hello"
       3
       " "
 
-  eq. ++> can-return-a-text-of-the-exact-width-unchanged
+  eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-right
     "hey"
     padded-right
       "hey"
       3
       " "
 
-  eq. ++> can-return-a-text-unchanged-at-zero-width
+  eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-right
     "x"
     padded-right
       "x"
       0
       " "
 
-  eq. ++> rejects-a-multi-character-fill
+  eq. ++> rejects-a-multi-character-fill-when-padding-right
     "recovered"
     padded-right
       "y"
@@ -96,7 +96,7 @@
       "ab"
       "recovered" > [message]
 
-  eq. ++> rejects-a-negative-width
+  eq. ++> rejects-a-negative-width-when-padding-right
     "recovered"
     padded-right
       "y"
@@ -104,7 +104,7 @@
       "x"
       "recovered" > [message]
 
-  eq. ++> rejects-a-non-integer-width
+  eq. ++> rejects-a-non-integer-width-when-padding-right
     "recovered"
     padded-right
       "y"
@@ -112,7 +112,7 @@
       "x"
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-width
+  eq. ++> rejects-an-infinite-width-when-padding-right
     "recovered"
     padded-right
       "y"
@@ -120,7 +120,7 @@
       "x"
       "recovered" > [message]
 
-  padded-right --> stops-on-a-negative-width
+  padded-right --> stops-on-a-negative-width-when-padding-right
     "y"
     -1
     "x"

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -50,13 +50,13 @@
         "0"
         cant-pad
 
-  eq. ++> can-count-characters-and-not-bytes
+  eq. ++> can-count-characters-and-not-bytes-when-padding-with-zeros
     "00Ж"
     padded-zeros
       "Ж"
       3
 
-  eq. ++> can-format-the-error-message-of-a-negative-width
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-with-zeros
     "Can't pad text to -4.000000 characters with zeros"
     padded-zeros
       "7"
@@ -81,7 +81,7 @@
       ""
       3
 
-  eq. ++> can-return-a-longer-text-unchanged
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-with-zeros
     "12345"
     padded-zeros
       "12345"
@@ -93,27 +93,27 @@
       "-42"
       3
 
-  eq. ++> rejects-a-negative-width
+  eq. ++> rejects-a-negative-width-when-padding-with-zeros
     "recovered"
     padded-zeros
       "7"
       -4
       "recovered" > [message]
 
-  eq. ++> rejects-a-non-integer-width
+  eq. ++> rejects-a-non-integer-width-when-padding-with-zeros
     "recovered"
     padded-zeros
       "7"
       3.5
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-width
+  eq. ++> rejects-an-infinite-width-when-padding-with-zeros
     "recovered"
     padded-zeros
       "7"
       pinf
       "recovered" > [message]
 
-  padded-zeros --> stops-on-a-negative-width
+  padded-zeros --> stops-on-a-negative-width-when-padding-with-zeros
     "7"
     -4

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -64,7 +64,7 @@
       "     "
     ""
 
-  eq. ++> can-trim-an-empty-text
+  eq. ++> can-trim-an-empty-text-from-the-left
     trimmed-left ""
     ""
 
@@ -78,7 +78,7 @@
       " \t\n\f\rvalue"
     "value"
 
-  eq. ++> can-trim-one-leading-space
+  eq. ++> can-trim-one-leading-space-from-the-left
     trimmed-left
       " s"
     "s"

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -62,7 +62,7 @@
     trimmed-right "value\t"
     "value"
 
-  eq. ++> can-trim-an-empty-text
+  eq. ++> can-trim-an-empty-text-from-the-right
     trimmed-right ""
     ""
 
@@ -76,7 +76,7 @@
       "value \t\n\f\r"
     "value"
 
-  eq. ++> can-trim-one-trailing-space
+  eq. ++> can-trim-one-trailing-space-from-the-right
     trimmed-right
       "s "
     "s"

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -30,7 +30,7 @@
         limit
       text
 
-  eq. ++> can-count-characters-and-not-bytes
+  eq. ++> can-count-characters-and-not-bytes-when-truncating
     "Жу"
     truncated
       "Жук"
@@ -81,13 +81,13 @@
       1.75
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-limit
+  eq. ++> rejects-an-infinite-limit-when-truncating
     "recovered"
     truncated
       "Jeff"
       pinf
       "recovered" > [message]
 
-  truncated --> stops-on-a-negative-limit
+  truncated --> stops-on-a-negative-limit-when-truncating
     "Jeff"
     -3

--- a/eo-runtime/src/main/eo/string/turkish.eo
+++ b/eo-runtime/src/main/eo/string/turkish.eo
@@ -38,7 +38,7 @@
         regex "/ı/"
         "I"
 
-  eq. ++> can-behave-like-the-wrapped-string
+  eq. ++> can-behave-like-the-wrapped-turkish-string
     8
     length.
       turkish "İSTANBUL"

--- a/eo-runtime/src/main/eo/string/upper.eo
+++ b/eo-runtime/src/main/eo/string/upper.eo
@@ -17,7 +17,7 @@
   upper. > @
     english text
 
-  "ÄÖÜ".eq "ÄÖÜ".upper ++> can-keep-non-ascii-letters
+  "ÄÖÜ".eq "ÄÖÜ".upper ++> can-keep-non-ascii-letters-when-upper-casing
 
   "HELLO".eq "hello".upper ++> can-upper-case-text
 

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -171,13 +171,6 @@
       2
       3
 
-  contains. ++> can-contain-an-element
-    *
-      1
-      2
-      3
-    2
-
   ++> can-create-an-empty-tuple-with-a-number
     eq. > @
       a.at 0
@@ -203,15 +196,6 @@
       1
       2
       3
-
-  eq. ++> can-find-the-index-of-an-element
-    index-of.
-      *
-        10
-        20
-        30
-      20
-    1
 
   ++> can-get-the-length-of-an-empty-tuple
     a.length.eq 0 > @
@@ -271,14 +255,6 @@
       2
       3
       4
-
-  not. ++> cannot-contain-an-absent-element
-    contains.
-      *
-        1
-        2
-        3
-      5
 
   not. ++> cannot-equal-a-different-tuple
     eq.

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -48,11 +48,11 @@
       25
     25
 
-  eq. ++> rejects-an-empty-list
+  eq. ++> rejects-an-empty-list-when-taking-the-maximum
     "recovered"
     maximum
       *
       "recovered" > [msg]
 
-  maximum --> stops-on-an-empty-list
+  maximum --> stops-on-an-empty-list-when-taking-the-maximum
     *

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -48,11 +48,11 @@
       -2
     -2
 
-  eq. ++> rejects-an-empty-list
+  eq. ++> rejects-an-empty-list-when-taking-the-minimum
     "recovered"
     minimum
       *
       "recovered" > [msg]
 
-  minimum --> stops-on-an-empty-list
+  minimum --> stops-on-an-empty-list-when-taking-the-minimum
     *


### PR DESCRIPTION
Twenty-six test names were shared by more than one member of the same package, across sixty-seven test attributes. That is legal today, since each member compiles to its own object and its own JUnit class, but it stops being legal the moment a package is merged into the object it belongs to (#6616), where two attributes cannot answer to one name. The three padding members were the worst of it, repeating almost their whole validation suite:

```
string/padded-left.eo    rejects-a-negative-width  ->  padded-left "y" -1 "x"
string/padded-right.eo   rejects-a-negative-width  ->  padded-right "y" -1 "x"
string/padded-zeros.eo   rejects-a-negative-width  ->  padded-zeros "y" -1
```

None of the twenty-six were redundant, so none are deleted: each asserts the same contract against a different object and now says which one, as in `rejects-a-negative-width-when-padding-left` or `stops-on-bytes-of-wrong-size-when-converting-to-i8`. The `bytes` package alone repeated that second name in nine members, one per conversion.

What was genuinely duplicated sits in the main objects, which smoke-tested behaviour their members already cover in full. `string.eo` asserted `"eEo".is-alpha`, character for character what `string/is-alpha.eo` asserts in `can-be-alphabetic-when-simple-text`; `number.eo` asserted `7.mod 3` is `1`, which is `number/mod.eo`'s `can-take-a-modulo-of-seven-by-three`; and `number.eo` reached for `sqrt`, `power` and `abs` while each of those members carries between six and fifty-two tests of its own. Sixteen such tests are dropped and left where they belong.

Left alone on purpose: the three tests named `*-through-the-package`, which assert the explicit `number.power 2 5` form. They go with the form itself, in #6657.

One renamed `-->` line outgrew the canonical width and `eo:format` rewrapped it to the vertical shape, which is the only change here that is not a name.
