### PR TITLE
Name the parent a reference reaches for

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Scope.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Scope.java
@@ -58,6 +58,8 @@ final class Scope {
         final String found;
         if (base.startsWith("Φ.")) {
             found = this.rooted(base);
+        } else if ("ξ.ρ".equals(base)) {
+            found = this.around(this.around(reference));
         } else {
             found = this.outwards(reference, base.substring(base.indexOf('.') + 1));
         }
@@ -75,6 +77,32 @@ final class Scope {
             found = base;
         } else {
             found = "";
+        }
+        return found;
+    }
+
+    /**
+     * The nearest formation around the given locator.
+     *
+     * <p>Applied to a reference it answers with the object being formed
+     * around it, which is what {@code ξ} names; applied to that answer it
+     * gives what the object sits in, which is what {@code ξ.ρ} names. A
+     * top-level object sits in a package rather than in a formation, and
+     * nothing is answered about it.</p>
+     *
+     * @param locator The locator to walk out of
+     * @return The locator of the formation, or an empty string when no
+     *  formation is around it
+     */
+    private String around(final String locator) {
+        String walked = locator;
+        String found = "";
+        while (walked.contains(".")) {
+            walked = walked.substring(0, walked.lastIndexOf('.'));
+            if (this.formations.contains(walked)) {
+                found = walked;
+                break;
+            }
         }
         return found;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/ScopeTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ScopeTest.java
@@ -23,6 +23,33 @@ import org.junit.jupiter.api.Test;
 final class ScopeTest {
 
     @Test
+    void findsParentOfObjectTheReferenceStandsIn() {
+        MatcherAssert.assertThat(
+            "the parent of the object being formed must be named, but it wasnt",
+            new Scope(
+                Arrays.asList(
+                    "Φ.outer", "Φ.outer.held", "Φ.outer.inner",
+                    "Φ.outer.inner.φ", "Φ.outer.inner.φ.ρ"
+                ),
+                Arrays.asList("Φ.outer", "Φ.outer.held", "Φ.outer.inner")
+            ).target("Φ.outer.inner.φ.ρ", "ξ.ρ"),
+            Matchers.equalTo("Φ.outer")
+        );
+    }
+
+    @Test
+    void keepsQuietAboutParentOfTopLevelObject() {
+        MatcherAssert.assertThat(
+            "an object that sits in a package has no formation to name, but one was named",
+            new Scope(
+                Arrays.asList("Φ.app", "Φ.app.φ", "Φ.app.φ.ρ"),
+                Collections.singletonList("Φ.app")
+            ).target("Φ.app.φ.ρ", "ξ.ρ"),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
     void findsNameBoundFurtherOut() {
         MatcherAssert.assertThat(
             "a name bound by a formation above must be found by looking out, but it wasnt",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # A name bound in the object around this one is not a reference to it: the
-# parser turns it into a dispatch on the parent. So `held` is asked of
-# `ξ.ρ`, and that parent reference is the one thing the links clue cannot
-# resolve - no formation binds `ρ` as an attribute. It is the whole of what
-# stays unlinked in the runtime, and the checking loop, which knows what
-# object it is inside of, is where it belongs.
+# parser turns it into a dispatch on the parent. So `held` is asked of `ξ.ρ`,
+# and that parent is a thing the text names as plainly as any other reference —
+# `ξ` is the object being formed, so `ξ.ρ` is whatever `inner` sits in. Walking
+# out of the reference to the nearest formation reaches `inner`, and once more
+# reaches `outer`, which is where `held` is bound.
 eo:
   outer.eo: |
     [] > outer
@@ -19,4 +19,4 @@ xmir:
 needs:
   - "/needs/type[@id='Φ.outer.inner.φ.ρ']/attr[@name='held']"
 links:
-  - "/links[not(type)]"
+  - "/links/type[@id='Φ.outer.inner.φ.ρ' and @copy='Φ.outer']"


### PR DESCRIPTION
`Scope` resolved a `ξ.name` reference by walking out of it until it found a
formation that binds `name`. For `ξ.ρ` that asks whether some enclosing
formation has a locator `<formation>.ρ`, and nothing declares a `ρ` — it is what
an object sits in, not an attribute anybody writes — so the walk ran out of
segments and every parent reference in every program went unlinked.

`ξ` is the object being formed, so `ξ.ρ` is whatever that object sits in. The
same walk answers it, twice:

```java
} else if ("ξ.ρ".equals(base)) {
    found = this.around(this.around(reference));
```

The first `around` leaves the reference and lands on the object being formed;
the second leaves that and lands on what holds it. A top-level object sits in a
package rather than in a formation, so the second walk finds nothing and the
reference stays unlinked, which is the honest answer rather than a guess.

On a clean `eo-runtime` build:

```
ξ.ρ references                      : 405   (every one a dispatch receiver)
  linked before                     :   0
  linked now                        : 405
links rows                          : 21664 → 22069
dispatch receivers a link resolves  :  5742 → 6147
```

`Φ.bool.and.φ.ρ → Φ.bool` is the one from the ticket: the body of `and` is
`.if` taken from the parent, and `if` lives in `Φ.bool` beside it. `.ρ` chains
come out too — `Φ.bool.+can-take-a-parent-through-an-attribute.φ.φ.φ.φ.ρ.ρ.ρ.ρ`
reaches `…φ.φ` — because the rule does not care how deep the reference sits.

The pack that recorded the gap now records the link. It used to assert
`/links[not(type)]` with a comment saying the parent was the one thing the links
clue could not resolve and that it belonged to the checking loop; that was the
wrong home for it, since nothing about a parent needs a call site. 20 packs, 14
unit tests and 578 plugin tests are green.

Closes: #6653
