### PR TITLE
Name the number that does not fit into the long range

### DIFF
--- a/eo-runtime/src/main/eo/string/as-scientific.eo
+++ b/eo-runtime/src/main/eo/string/as-scientific.eo
@@ -15,8 +15,7 @@
 
 [n] > as-scientific
   n.is-finite.not.if > @
-    if.
-      n.is-nan
+    n.is-nan.if
       "nan".as-bytes
       if.
         n.lt 0
@@ -26,10 +25,12 @@
       concat.
         as-fixed
           n.div
-            10.power (number exponent)
+            10.power
+              number exponent
           6
         "e".as-bytes
-      as-decimal (number exponent)
+      as-decimal
+        number exponent
   rec-exponent > exponent!
     n.abs
     0

--- a/eo-runtime/src/main/eo/string/as-scientific.eo
+++ b/eo-runtime/src/main/eo/string/as-scientific.eo
@@ -1,0 +1,67 @@
+# Writes the number `n` in scientific notation, as a mantissa with six fraction
+# digits, the letter `e`, and the power of ten that scales the mantissa back to
+# `n`, so that `1.0e19` becomes `1.000000e19`. A magnitude past the range of a
+# signed 64-bit integer is named this way, since `as-decimal` writes only what
+# it spells out digit by digit, and a non-finite number becomes `nan`,
+# `infinity` or `-infinity`, having no digits at all. The power is never
+# negative, so a magnitude below one keeps it at zero, as `0.500000e0` for `0.5`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > as-scientific
+  n.is-finite.not.if > @
+    if.
+      n.is-nan
+      "nan".as-bytes
+      if.
+        n.lt 0
+        "-infinity".as-bytes
+        "infinity".as-bytes
+    concat.
+      concat.
+        as-fixed
+          n.div
+            10.power (number exponent)
+          6
+        "e".as-bytes
+      as-decimal (number exponent)
+  rec-exponent > exponent!
+    n.abs
+    0
+  if. > [m count] >> rec-exponent
+    m.lt 10
+    count
+    rec-exponent
+      m.div 10
+      as-number.
+        count.plus 1
+
+  eq. ++> can-name-a-magnitude-past-the-long-range
+    "1.000000e19"
+    string
+      as-scientific 1.0e19
+
+  eq. ++> can-name-a-negative-magnitude
+    "-9.223372e18"
+    string
+      as-scientific -9.223372036854776e18
+
+  eq. ++> can-name-nan
+    "nan"
+    string
+      as-scientific nan
+
+  eq. ++> can-name-negative-infinity
+    "-infinity"
+    string
+      as-scientific ninf
+
+  eq. ++> can-name-positive-infinity
+    "infinity"
+    string
+      as-scientific pinf

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -202,8 +202,7 @@
               "The number %s doesn't fit into the long range of the '%%d' conversion".printf
                 *
                   string
-                    as-scientific
-                      number numeric
+                    as-scientific (number numeric)
             number numeric
         if.
           66-.eq conv

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -38,12 +38,9 @@
 # characters that share that encoding, because an object knows its own bytes
 # here and not its type.
 #
-# @todo #6359:60min Name the number that does not fit into the long range. The
-#  `%d` guard below used to render its own reason through `%f`, but `as-fixed`
-#  refuses any magnitude of 2^53 or larger, and every number that guard rejects is
-#  past that threshold, so the reason destroyed itself and the caller saw a chain
-#  of some forty `Error in "..."` links instead. The reason now carries no number
-#  at all; give it one back once `%f` can print a magnitude that big.
+# The `%d` guard names the number it rejects through `as-scientific` and not
+# through `%f`, because every magnitude it rejects is past the range `as-fixed`
+# writes, and a reason rendered with `%f` destroyed itself instead of arriving.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -202,7 +199,11 @@
                   number limit
                   -1
             T
-              "The number doesn't fit into the long range of the '%d' conversion"
+              "The number %s doesn't fit into the long range of the '%%d' conversion".printf
+                *
+                  string
+                    as-scientific
+                      number numeric
             number numeric
         if.
           66-.eq conv

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -129,6 +129,24 @@ final class PhTerminatorTest {
     }
 
     @Test
+    void namesTheNumberOutOfTheLongRange() {
+        MatcherAssert.assertThat(
+            "the number out of the long range is not named in the reason",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        Phi.Φ.take("string.printf").copy(),
+                        new Bind("format", new Data.ToPhi("%d")),
+                        new Bind("args", new Data.ToPhi(new Phi[]{new Data.ToPhi(1.0e19)}))
+                    )
+                ).take()
+            ).toString(),
+            Matchers.containsString("1.000000e19")
+        );
+    }
+
+    @Test
     void toleratesPutAtOtherPositions() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(1, new Data.ToPhi("nope")),


### PR DESCRIPTION
`printf "%d"` rejects any magnitude past the range of a signed 64-bit integer, but until now its reason carried no number at all: the guard could not name the value it was refusing, because every value it refuses is past what `as-decimal` and `as-fixed` can write, so a reason rendered through `%f` destroyed itself and the caller saw a chain of `Error in "..."` links instead of the message.

The new `string.as-scientific` writes any number as a six-digit mantissa, the letter `e` and the power of ten that scales it back, so `1.0e19` reads as `1.000000e19`. It divides the magnitude down to a mantissa below ten and renders that mantissa with `as-fixed`, which stays well inside the range `as-fixed` handles exactly, and it writes a non-finite number as `nan`, `infinity` or `-infinity`, since those carry no digits. The `%d` guard names its number through that object now, and the reason arrives whole.

The power of ten is never negative, so a magnitude below one keeps it at zero and `0.5` reads as `0.500000e0`. Nothing on this path ever hands it such a magnitude, and the docblock says as much; a caller that needs proper normalisation there deserves its own ticket.

Closes #6631
