### PR TITLE
Say what every dispatch turns out to be

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * What every dispatch of a program turns out to be.
+ *
+ * <p>A dispatch takes a name from an object, so when that object's type is
+ * known and it has such an attribute, the dispatch <em>is</em> that attribute:
+ * a copy of it, which is what a pair in {@link Links} means. The body of
+ * {@code and} is {@code .if} taken from {@code Φ.bool}, {@code if} is a member
+ * of that package, so the body is a copy of {@code Φ.bool.if}. Where the
+ * attribute is looked for is {@link Provided}'s business — the object itself,
+ * its package, or behind its {@code φ}.</p>
+ *
+ * <p>Nothing is guessed. A receiver whose type nothing describes is left
+ * alone, and so is a receiver that is a void: {@code x.next} inside an object
+ * that takes {@code x} is one object in the text and a different one for every
+ * caller, and the pair that would settle it belongs to the call site rather
+ * than here. A dispatch already spoken for is left alone too, since a pass is
+ * only ever asked for what the last one could not answer.</p>
+ *
+ * @since 0.68.0
+ */
+final class Dispatched {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * Every dispatch of the program.
+     */
+    private final Collection<XML> all;
+
+    /**
+     * Ctor.
+     * @param provides The provides table
+     * @param dispatches Every dispatch of the program
+     */
+    Dispatched(final XML provides, final Collection<XML> dispatches) {
+        this.given = provides;
+        this.all = dispatches;
+    }
+
+    /**
+     * The pairs that follow from what is known, beyond what is known already.
+     * @param pairs The pairs, each name against the one it is a copy of
+     * @return The dispatches answered this time, each against the attribute it
+     *  turns out to be, empty when nothing further can be answered
+     */
+    Map<String, String> answers(final Map<String, String> pairs) {
+        final Map<String, String> names = new Ends(pairs).names();
+        final Provided owned = new Provided(new Ungrouped(this.given, names).rows(), names);
+        final Map<String, String> found = new HashMap<>(0);
+        for (final XML dispatch : this.all) {
+            final String made = dispatch.xpath("@loc").get(0);
+            if (!pairs.containsKey(made)) {
+                final String bearer = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+                final String kept = owned.attribute(
+                    names.getOrDefault(bearer, bearer),
+                    dispatch.xpath("@base").get(0).substring(1)
+                );
+                if (!kept.isEmpty()) {
+                    found.put(made, kept);
+                }
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Ends.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ends.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Every chain of copies, walked to its end.
+ *
+ * <p>A copy of a copy is a copy of the same thing, and the pairs come in one
+ * at a time: {@code a} is a copy of {@code b}, {@code b} of {@code c}. Asking
+ * the table about {@code a} has to arrive at {@code c}, so each pair is
+ * followed as far as it goes and the end is written down against every name on
+ * the way. A chain that comes back on itself is walked once and stops where it
+ * started, since an object that is a copy of itself is nothing new.</p>
+ *
+ * @since 0.68.0
+ */
+final class Ends {
+
+    /**
+     * The pairs, each name against the one it is a copy of.
+     */
+    private final Map<String, String> copies;
+
+    /**
+     * Ctor.
+     * @param pairs The pairs, each name against the one it is a copy of
+     */
+    Ends(final Map<String, String> pairs) {
+        this.copies = pairs;
+    }
+
+    /**
+     * The name every type goes by.
+     * @return The names, each type against the end of its chain of copies
+     */
+    Map<String, String> names() {
+        final Map<String, String> ends = new HashMap<>(this.copies.size());
+        for (final Map.Entry<String, String> link : this.copies.entrySet()) {
+            final Collection<String> walked = new HashSet<>(0);
+            String end = link.getValue();
+            while (this.copies.containsKey(end) && walked.add(end)) {
+                end = this.copies.get(end);
+            }
+            ends.put(link.getKey(), end);
+        }
+        return ends;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What the links table says, pair by pair.
+ *
+ * <p>{@link Links} writes one row per name that is a copy of another, and
+ * reading them back is how a later pass adds to them without losing what is
+ * there. The order they were written in is kept, so a document read and written
+ * again keeps the rules' rows where they were and carries the worked-out ones
+ * after them.</p>
+ *
+ * @since 0.68.0
+ */
+final class Pairs {
+
+    /**
+     * The links table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     * @param links The links table
+     */
+    Pairs(final XML links) {
+        this.table = links;
+    }
+
+    /**
+     * Every pair of the table.
+     * @return The pairs, each name against the one it is a copy of
+     */
+    Map<String, String> all() {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final XML link : this.table.nodes("/links/type")) {
+            found.put(link.xpath("@id").get(0), link.xpath("@copy").get(0));
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * What the types of a program certainly have.
+ *
+ * <p>This is the table {@link Provides} wrote, read by the name a type and
+ * its copies go by, so that a question about a copy is answered by the
+ * formation it is a copy of. One question is asked of it: what the type of an
+ * attribute is, or nothing at all when the type has no such attribute.</p>
+ *
+ * <p>An attribute is looked for in three places, because there are three. The
+ * type itself. Its package, since an attribute nobody binds falls
+ * through to the object of that name beside it — {@code Φ.number} binds eight
+ * attributes and answers to forty, the rest of them being objects of their own
+ * in the same package, {@code Φ.number.eq} among them, and a locator names both
+ * kinds the same way. And whatever stands behind its {@code φ}, which answers
+ * for every name the object does not bind itself.</p>
+ *
+ * <p>The walk stops at a type it has already passed, so an object that
+ * delegates in a circle is walked once and answers nothing. A void answers
+ * nothing either: the table has no row for one, since what a void holds is
+ * decided by whoever fills it.</p>
+ *
+ * @since 0.68.0
+ */
+final class Provided {
+
+    /**
+     * The rows of the provides table, by the name their owner goes by.
+     */
+    private final Map<String, Collection<Map<String, String>>> table;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param rows The rows of the provides table, by the name of their owner
+     * @param aliases The name every type goes by, from {@link Same}
+     */
+    Provided(
+        final Map<String, Collection<Map<String, String>>> rows,
+        final Map<String, String> aliases
+    ) {
+        this.table = rows;
+        this.names = aliases;
+    }
+
+    /**
+     * The type of the attribute this type keeps under the given name.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @return The type of the attribute, or an empty string when this type has
+     *  no attribute of that name
+     */
+    String attribute(final String type, final String name) {
+        return this.kept(type, name, new HashSet<>(0));
+    }
+
+    /**
+     * The type of the attribute this type keeps, looking behind what it
+     * delegates to when it keeps none.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @param walked The types passed already
+     * @return The type of the attribute, or an empty string
+     */
+    private String kept(final String type, final String name, final Collection<String> walked) {
+        String found = this.bound(type, name);
+        final String member = String.join(".", type, name);
+        if (found.isEmpty() && this.table.containsKey(member)) {
+            found = member;
+        }
+        final String behind = this.behind(type);
+        if (found.isEmpty() && !behind.isEmpty() && walked.add(type)) {
+            found = this.kept(behind, name, walked);
+        }
+        return found;
+    }
+
+    /**
+     * The type this one hands its answers to.
+     * @param type The name the type goes by
+     * @return The name of the type behind its {@code φ}, or an empty string
+     *  when the type binds no {@code φ} and answers for itself
+     */
+    private String behind(final String type) {
+        final String decoratee = this.bound(type, "φ");
+        return this.names.getOrDefault(decoratee, decoratee);
+    }
+
+    /**
+     * The type of the attribute this type binds itself.
+     * @param type The name the type goes by
+     * @param name The name of the attribute
+     * @return The type of the attribute, or an empty string
+     */
+    private String bound(final String type, final String name) {
+        String found = "";
+        for (final Map<String, String> row : this.own(type)) {
+            if (name.equals(row.getOrDefault("name", ""))) {
+                found = row.getOrDefault("type", "");
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The rows about the type of the given name.
+     * @param type The name the type goes by
+     * @return The rows, empty when the table says nothing about it
+     */
+    private Collection<Map<String, String>> own(final String type) {
+        return this.table.getOrDefault(type, Collections.emptyList());
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.tojos.MnMemory;
+import com.yegor256.tojos.TjDeferred;
+import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * The links, closed under what a dispatch turns out to be.
+ *
+ * <p>A rule writes down what it reads in the text and nothing else, which
+ * leaves a gap no rule can fill: an object the program computes. A dispatch
+ * {@code .if} is made while the program runs, and the tables know only that
+ * somebody asked {@code if} of something, never what came back. So a chain of
+ * them stops at the first one, and an object that hands its answers to a
+ * dispatch hands them to a locator nothing describes.</p>
+ *
+ * <p>The fact is there to be had, and no call site is needed for it, which is
+ * what {@link Dispatched} works out. Answering {@code a.b.c} needs {@code a.b}
+ * answered first, and one pass cannot put them in that order, so passes run
+ * until one of them adds nothing. Pairs are only ever added, of which there
+ * are finitely many, so it settles.</p>
+ *
+ * <p>What comes out belongs in the document the rules already keep for pairs,
+ * rather than beside it: two documents saying "is a copy of" in different
+ * words would only invite the two to disagree. So this reads the tables and
+ * writes {@code links.xml} back, with the pairs it worked out added to the
+ * ones the rules found.</p>
+ *
+ * @since 0.68.0
+ */
+public final class Resolved implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the links are closed
+     */
+    public Resolved(final Clue clues) {
+        this.origin = clues;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final Path links = tables.resolve("links.xml");
+        final Map<String, String> pairs = new Pairs(new XMLDocument(links)).all();
+        final Dispatched made = new Dispatched(
+            new XMLDocument(tables.resolve("provides.xml")),
+            new Xmirs(xmirs).dispatches()
+        );
+        Map<String, String> answers = made.answers(pairs);
+        while (!answers.isEmpty()) {
+            pairs.putAll(answers);
+            answers = made.answers(pairs);
+        }
+        try (Tojos rows = new TjDeferred(new MnMemory())) {
+            for (final Map.Entry<String, String> pair : pairs.entrySet()) {
+                rows.add(pair.getKey()).set("copy", pair.getValue());
+            }
+            Files.write(
+                links,
+                new Grouped(rows, "links").asXml().toString().getBytes(StandardCharsets.UTF_8)
+            );
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Row.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Row.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.w3c.dom.NamedNodeMap;
+
+/**
+ * One row of a table, as its document keeps it.
+ *
+ * <p>A row is a few named cells and nothing else, which is what
+ * {@link Cells} turns into a document and what this turns back. No column is
+ * known here by name, so a rule that starts writing a new one has it read
+ * back without anything being changed.</p>
+ *
+ * @since 0.68.0
+ */
+final class Row {
+
+    /**
+     * The element of the document the row was written as.
+     */
+    private final XML element;
+
+    /**
+     * Ctor.
+     * @param row The element of the document the row was written as
+     */
+    Row(final XML row) {
+        this.element = row;
+    }
+
+    /**
+     * The cells of the row.
+     * @return The cells, by their names, in the order the document keeps them
+     */
+    Map<String, String> cells() {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        final NamedNodeMap named = this.element.inner().getAttributes();
+        for (int cell = 0; cell < named.getLength(); cell = cell + 1) {
+            found.put(named.item(cell).getNodeName(), named.item(cell).getNodeValue());
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The rows of a table, read back from the document {@link Grouped} wrote.
+ *
+ * <p>A clue writes a table for a human to read, nested and short; the loop
+ * needs the same table flat and by the name of its owner, since it asks about
+ * tens of thousands of types and searching a document for every one of them
+ * costs more than the whole checking does. This turns the one into the other:
+ * a type row and the rows of its attributes end up together, under the name
+ * that the type and all its copies go by.</p>
+ *
+ * <p>Which of the two a row is can be seen from its cells, exactly as
+ * {@link Grouped} decided when it wrote them: a type row carries an
+ * {@code id}, a row about an attribute carries a {@code name}. Nothing else is
+ * known about the columns here, so a rule that starts writing a new one has it
+ * read back for free.</p>
+ *
+ * @since 0.68.0
+ */
+final class Ungrouped {
+
+    /**
+     * The table.
+     */
+    private final XML table;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param document The table, as a clue wrote it
+     * @param aliases The name every type goes by, from {@link Same}
+     */
+    Ungrouped(final XML document, final Map<String, String> aliases) {
+        this.table = document;
+        this.names = aliases;
+    }
+
+    /**
+     * The rows of the table, by the name their owner goes by.
+     * @return The rows, in the order the table keeps them, since the place of
+     *  a row is what says which void an argument fills
+     */
+    Map<String, Collection<Map<String, String>>> rows() {
+        final Map<String, Collection<Map<String, String>>> found = new LinkedHashMap<>(0);
+        for (final XML type : this.table.nodes("/*/type")) {
+            final Map<String, String> cells = new Row(type).cells();
+            final Collection<Map<String, String>> owned = found.computeIfAbsent(
+                this.names.getOrDefault(cells.get("id"), cells.get("id")),
+                key -> new ArrayList<>(1)
+            );
+            owned.add(cells);
+            for (final XML attr : type.nodes("attr")) {
+                owned.add(new Row(attr).cells());
+            }
+        }
+        return found;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.inference.Clues;
+import org.eolang.inference.Resolved;
 import org.eolang.parser.TrFull;
 
 /**
@@ -85,7 +86,7 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
-            new Clues().follow(this.prepared, this.tables);
+            new Resolved(new Clues()).follow(this.prepared, this.tables);
             Logger.info(
                 this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
                 ready, this.tables

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-dispatches-is-answered-in-order.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-dispatches-is-answered-in-order.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `outer.held.deep` cannot be answered in one go: what `.deep` is taken from is
+# itself computed, and only once `outer.held` has a name does asking `deep` of
+# it mean anything. So the passes run until one adds nothing, and both objects
+# come out named.
+eo:
+  app.eo: |
+    [] > app
+      outer.held.deep > @
+  outer.eo: |
+    [] > outer
+      [] > held
+        [] > deep
+links:
+  - "/links/type[@id='Φ.app.φ.ρ' and @copy='Φ.outer.held']"
+  - "/links/type[@id='Φ.app.φ' and @copy='Φ.outer.held.deep']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `one` hands its answers to `two` and `two` hands them back, so looking for a
+# name behind the delegation walks in a circle. It is walked once and answers
+# nothing, which leaves the dispatch unnamed rather than the pass unfinished.
+eo:
+  app.eo: |
+    [] > app
+      one.nowhere > @
+  one.eo: |
+    [] > one
+      two > @
+  two.eo: |
+    [] > two
+      one > @
+links:
+  - "/links[not(type[@id='Φ.app.φ'])]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-finds-a-member-of-the-package.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-finds-a-member-of-the-package.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `bool` binds no `if` of its own, and `if` is an object of its own beside it in
+# the same package, which is where an unbound name falls through to. A dispatch
+# that lands there is a copy of that member, exactly as one that lands on an own
+# attribute is.
+eo:
+  app.eo: |
+    [] > app
+      bool.if > @
+  bool.eo: |
+    [] > bool
+      [] > if
+links:
+  - "/links/type[@id='Φ.app.φ' and @copy='Φ.bool.if']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-is-the-attribute-it-takes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-is-the-attribute-it-takes.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `held` is taken from `outer`, and `outer` binds it, so the object that taking
+# it makes is a copy of what is bound there. Nobody wrote that object down —
+# the program computes it — and no rule could have said what it is, since it
+# takes reading the provides table to find out.
+eo:
+  app.eo: |
+    [] > app
+      outer.held > @
+  outer.eo: |
+    [] > outer
+      [] > held
+links:
+  - "/links/type[@id='Φ.app.φ' and @copy='Φ.outer.held']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-looks-behind-delegation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-looks-behind-delegation.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `t` binds nothing but `φ` and hands every name it is asked for to `base`. So
+# `t.next` is the `next` of a `base`, and the object the dispatch makes is a
+# copy of that, found by following what stands behind the delegation.
+eo:
+  app.eo: |
+    [] > app
+      t.next > @
+  t.eo: |
+    [] > t
+      base > @
+  base.eo: |
+    [] > base
+      [] > next
+links:
+  - "/links/type[@id='Φ.app.φ' and @copy='Φ.base.next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-a-void-stays-unanswered.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-a-void-stays-unanswered.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `x.next` is one object in the text of `inc` and a different one for every
+# caller, since what `x` holds is decided by whoever fills it. The text alone
+# cannot name it, so nothing is written down about it and the pair that would
+# settle it waits for the context a call site gives.
+eo:
+  inc.eo: |
+    [x] > inc
+      x.next > @
+links:
+  - "/links[not(type[@id='Φ.inc.φ'])]"


### PR DESCRIPTION
Three rules write down what a program says about itself, and none of them says what a *computed* object is. A dispatch `.if` is made while the program runs, so the tables knew only that somebody asked `if` of something, never what came back. A chain of dispatches stopped at the first one, and an object that hands its answers to a dispatch handed them to a locator nothing described.

The fact is there to be had and no call site is needed for it. When a dispatch takes a name from an object whose type is known, and that type has such an attribute, the dispatch **is** that attribute — a copy of it, which is what a pair in `links.xml` means. `Dispatched` works out those pairs, `Resolved` asks it again until a pass adds nothing, since answering `a.b.c` needs `a.b` answered first:

```java
Map<String, String> answers = made.answers(pairs);
while (!answers.isEmpty()) {
    pairs.putAll(answers);
    answers = made.answers(pairs);
}
```

Pairs are only ever added, of which there are finitely many, so it settles. What comes out goes into `links.xml` beside the rules' own rows, rather than into a second document that would only invite the two to disagree.

Where a name is looked for is `Provided`'s business: the type's own attributes, then its package, since a name nobody binds falls through to the object beside it (#5486), then whatever stands behind its `φ`, walked once so an object that delegates in a circle answers nothing. Nothing is guessed. A receiver whose type nothing describes is left alone, and so is one that is a void: `x.next` is a different object for every caller, and the pair that settles it belongs to the call site.

Measured on a clean `eo-runtime` build, this branch with the phase off and then on: links rows 21,953 → 26,347; dispatch receivers whose type is known 6,128 → 8,098 out of 10,114; dispatches that have a type of their own 0 → 4,394; delegation chains that end at a locator nothing describes 2,118 → 1,760 out of 2,410. The `complete` flag does not move, that being `Provides`' business.

Six packs describe the behaviour, one each for the attribute a dispatch takes, a chain answered in order, a void left alone, a member of the package, a look behind delegation, and a circle walked once. What is left is the contextual half: a fresh type per copy, so that a dispatch on a void is answered where the void is filled.

Closes #6684
