### PR TITLE
Dispatch package members in their own tests

### DIFF
--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -25,7 +25,7 @@
     0
 
   eq. ++> can-convert-bytes-to-an-array
-    array 20-1F-EE-B5-FF
+    20-1F-EE-B5-FF.array
     *
       20-
       1F-
@@ -34,9 +34,9 @@
       FF-
 
   eq. ++> can-convert-a-single-byte-to-an-array
-    array 1F-
+    1F-.array
     * 1F-
 
   eq. ++> can-convert-zero-bytes-to-an-array
-    array --
+    --.array
     *

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -66,8 +66,6 @@
       eq.
         i3.read 2
         --
-    read. > i1
-      as-input 01-02-03-04-05-06-07-08-F5-F6
-      4
+    01-02-03-04-05-06-07-08-F5-F6.as-input.read 4 > i1
     i1.read 4 > i2
     i2.read 4 > i3

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -40,9 +40,7 @@
       seq * > [mem]
         write.
           write.
-            write.
-              to-output mem
-              01-02-03
+            mem.to-output.write 01-02-03
             04-05-06-07
           08-09-A0
         mem
@@ -60,8 +58,6 @@
     malloc.of
       2
       seq * > [mem]
-        write.
-          to-output mem
-          01-02-03
+        mem.to-output.write 01-02-03
         mem
     01-02-03

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -16,26 +16,15 @@
     value.neg
 
   eq. ++> can-normalize-the-sign-of-negative-zero
-    as-bytes.
-      abs -0
+    -0.abs.as-bytes
     00-00-00-00-00-00-00-00
 
-  eq. ++> can-take-the-absolute-value-of-a-negative-float
-    abs -17.9
-    17.9
+  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative-float
 
-  eq. ++> can-take-the-absolute-value-of-a-negative-integer
-    abs -3
-    3
+  -3.abs.eq 3 ++> can-take-the-absolute-value-of-a-negative-integer
 
-  eq. ++> can-take-the-absolute-value-of-a-positive-float
-    abs 13.5
-    13.5
+  13.5.abs.eq 13.5 ++> can-take-the-absolute-value-of-a-positive-float
 
-  eq. ++> can-take-the-absolute-value-of-a-positive-integer
-    abs 3
-    3
+  3.abs.eq 3 ++> can-take-the-absolute-value-of-a-positive-integer
 
-  eq. ++> can-take-the-absolute-value-of-zero
-    abs 0
-    0
+  0.abs.eq 0 ++> can-take-the-absolute-value-of-zero

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -15,47 +15,34 @@
     pi.div 2
     arc-sine num
 
-  eq. ++> can-take-an-arc-cosine-of-minus-one
-    arc-cosine -1
-    pi
+  -1.arc-cosine.eq pi ++> can-take-an-arc-cosine-of-minus-one
 
   lt. ++> can-take-an-arc-cosine-of-minus-zero-point-six
-    abs
+    abs.
       minus.
-        times.
-          arc-cosine -0.6
-          1000
+        -0.6.arc-cosine.times 1000
         2214.297
     1
 
-  eq. ++> can-take-an-arc-cosine-of-one
-    arc-cosine 1
-    0
+  1.arc-cosine.eq 0 ++> can-take-an-arc-cosine-of-one
 
   eq. ++> can-take-an-arc-cosine-of-zero
-    arc-cosine 0
+    0.arc-cosine
     pi.div 2
 
   lt. ++> can-take-an-arc-cosine-of-zero-point-six
-    abs
+    abs.
       minus.
-        times.
-          arc-cosine 0.6
-          1000
+        0.6.arc-cosine.times 1000
         927.295
     1
 
-  is-nan. ++> cannot-take-an-arc-cosine-above-one
-    arc-cosine 2
+  2.arc-cosine.is-nan ++> cannot-take-an-arc-cosine-above-one
 
-  is-nan. ++> cannot-take-an-arc-cosine-below-minus-one
-    arc-cosine -2
+  -2.arc-cosine.is-nan ++> cannot-take-an-arc-cosine-below-minus-one
 
-  is-nan. ++> cannot-take-an-arc-cosine-of-nan
-    arc-cosine nan
+  nan.arc-cosine.is-nan ++> cannot-take-an-arc-cosine-of-nan
 
-  is-nan. ++> cannot-take-an-arc-cosine-of-negative-infinity
-    arc-cosine ninf
+  ninf.arc-cosine.is-nan ++> cannot-take-an-arc-cosine-of-negative-infinity
 
-  is-nan. ++> cannot-take-an-arc-cosine-of-positive-infinity
-    arc-cosine pinf
+  pinf.arc-cosine.is-nan ++> cannot-take-an-arc-cosine-of-positive-infinity

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -48,31 +48,25 @@
     base
 
   lt. ++> can-behave-as-an-odd-function-when-taking-arc-sine
-    abs
+    abs.
       times.
-        plus.
-          arc-sine 0.6
-          arc-sine -0.6
+        0.6.arc-sine.plus -0.6.arc-sine
         1000
     1
 
   lt. ++> can-take-an-arc-sine-of-a-half
-    abs
+    abs.
       minus.
-        times.
-          arc-sine 0.5
-          1000
+        0.5.arc-sine.times 1000
         times.
           pi.div 6
           1000
     1
 
   lt. ++> can-take-an-arc-sine-of-minus-a-half
-    abs
+    abs.
       minus.
-        times.
-          arc-sine -0.5
-          1000
+        -0.5.arc-sine.times 1000
         times.
           neg.
             pi.div 6
@@ -80,11 +74,9 @@
     1
 
   lt. ++> can-take-an-arc-sine-of-minus-one
-    abs
+    abs.
       minus.
-        times.
-          arc-sine -1
-          1000
+        -1.arc-sine.times 1000
         times.
           neg.
             pi.div 2
@@ -92,40 +84,29 @@
     1
 
   lt. ++> can-take-an-arc-sine-of-one
-    abs
+    abs.
       minus.
-        times.
-          arc-sine 1
-          1000
+        1.arc-sine.times 1000
         times.
           pi.div 2
           1000
     1
 
-  eq. ++> can-take-an-arc-sine-of-zero
-    arc-sine 0
-    0
+  0.arc-sine.eq 0 ++> can-take-an-arc-sine-of-zero
 
   lt. ++> can-take-an-arc-sine-of-zero-point-six
-    abs
+    abs.
       minus.
-        times.
-          arc-sine 0.6
-          1000
+        0.6.arc-sine.times 1000
         643.5
     1
 
-  is-nan. ++> cannot-take-an-arc-sine-above-one
-    arc-sine 2
+  2.arc-sine.is-nan ++> cannot-take-an-arc-sine-above-one
 
-  is-nan. ++> cannot-take-an-arc-sine-below-minus-one
-    arc-sine -2
+  -2.arc-sine.is-nan ++> cannot-take-an-arc-sine-below-minus-one
 
-  is-nan. ++> cannot-take-an-arc-sine-of-nan
-    arc-sine nan
+  nan.arc-sine.is-nan ++> cannot-take-an-arc-sine-of-nan
 
-  is-nan. ++> cannot-take-an-arc-sine-of-negative-infinity
-    arc-sine ninf
+  ninf.arc-sine.is-nan ++> cannot-take-an-arc-sine-of-negative-infinity
 
-  is-nan. ++> cannot-take-an-arc-sine-of-positive-infinity
-    arc-sine pinf
+  pinf.arc-sine.is-nan ++> cannot-take-an-arc-sine-of-positive-infinity

--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -70,10 +70,7 @@
     -9.223372036854776e18.as-i64.as-bytes
     80-00-00-00-00-00-00-00
 
-  eq. ++> can-convert-the-origin-number
-    as-bytes.
-      as-i64 42
-    00-00-00-00-00-00-00-2A
+  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-convert-the-origin-number
 
   eq. ++> can-truncate-a-negative-toward-zero
     -3.7.as-i64.as-bytes

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -14,20 +14,20 @@
       pi.div 2
 
   lt. ++> can-behave-as-an-even-function
-    abs
+    abs.
       times.
         minus.
-          cosine
+          cosine.
             pi.div 3
-          cosine (pi.div 3).neg
+          cosine. (pi.div 3).neg
         1000
     1
 
   lt. ++> can-reduce-a-large-angle-when-taking-cosine
-    abs
+    abs.
       minus.
         times.
-          cosine
+          cosine.
             plus.
               pi.times 10
               pi.div 3
@@ -36,55 +36,46 @@
     1
 
   lt. ++> can-take-a-cosine-of-pi
-    abs
+    abs.
       minus.
-        times.
-          cosine pi
-          1000
+        pi.cosine.times 1000
         -1000
     1
 
   lt. ++> can-take-a-cosine-of-pi-halves
-    abs
+    abs.
       times.
-        cosine
+        cosine.
           pi.div 2
         1000
     1
 
   lt. ++> can-take-a-cosine-of-pi-thirds
-    abs
+    abs.
       minus.
         times.
-          cosine
+          cosine.
             pi.div 3
           1000
         500
     1
 
   lt. ++> can-take-a-cosine-of-seventeen-radians
-    abs
+    abs.
       minus.
-        times.
-          cosine 17
-          1000
+        17.cosine.times 1000
         -275
     1
 
   lt. ++> can-take-a-cosine-of-zero
-    abs
+    abs.
       minus.
-        times.
-          cosine 0
-          1000
+        0.cosine.times 1000
         1000
     1
 
-  is-nan. ++> cannot-take-a-cosine-of-nan
-    cosine nan
+  nan.cosine.is-nan ++> cannot-take-a-cosine-of-nan
 
-  is-nan. ++> cannot-take-a-cosine-of-negative-infinity
-    cosine ninf
+  ninf.cosine.is-nan ++> cannot-take-a-cosine-of-negative-infinity
 
-  is-nan. ++> cannot-take-a-cosine-of-positive-infinity
-    cosine pinf
+  pinf.cosine.is-nan ++> cannot-take-a-cosine-of-positive-infinity

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -16,45 +16,36 @@
     180
 
   lt. ++> can-convert-a-large-value-to-degrees-without-overflow
-    abs
-      minus.
-        degrees 1.0e306
-        5.729577951308232e307
+    abs.
+      1.0e306.degrees.minus 5.729577951308232e307
     1.0e294
 
   lt. ++> can-convert-minus-pi-to-degrees
-    abs
-      minus.
-        degrees pi.neg
-        -180
+    abs.
+      pi.neg.degrees.minus -180
     1.0E-4
 
   lt. ++> can-convert-pi-halves-to-degrees
-    abs
+    abs.
       minus.
-        degrees
+        degrees.
           pi.div 2
         90
     1.0E-4
 
   lt. ++> can-convert-pi-to-degrees
-    abs
-      minus.
-        degrees pi
-        180
+    abs.
+      pi.degrees.minus 180
     1.0E-4
 
   lt. ++> can-convert-two-pi-to-degrees
-    abs
+    abs.
       minus.
-        degrees
+        degrees.
           pi.times 2
         360
     1.0E-4
 
-  eq. ++> can-convert-zero-to-degrees
-    degrees 0
-    0
+  0.degrees.eq 0 ++> can-convert-zero-to-degrees
 
-  is-nan. ++> cannot-convert-nan-to-degrees
-    degrees nan
+  nan.degrees.is-nan ++> cannot-convert-nan-to-degrees

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -36,9 +36,7 @@
     false
 
   eq. ++> can-compare-two-numbers-through-the-package
-    eq
-      42
-      42
+    42.eq 42
     true
 
   42.eq 42.as-bytes ++> can-equal-an-integer-through-bytes

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -13,39 +13,33 @@
     num
 
   lt. ++> can-exponentiate-five
-    abs
+    abs.
       minus.
-        power e 5
-        exp 5
+        e.power 5
+        5.exp
     1.0E-7
 
   lt. ++> can-exponentiate-minus-one
-    abs
+    abs.
       minus.
         1.div e
-        exp -1
+        -1.exp
     1.0E-8
 
   lt. ++> can-exponentiate-minus-ten
-    abs
+    abs.
       minus.
-        power e -10
-        exp -10
+        e.power -10
+        -10.exp
     1.0E-12
 
-  eq. ++> can-exponentiate-negative-infinity
-    exp ninf
-    0
+  ninf.exp.eq 0 ++> can-exponentiate-negative-infinity
 
   lt. ++> can-exponentiate-one
-    abs
-      e.minus
-        exp 1
+    abs.
+      e.minus 1.exp
     1.0E-8
 
-  eq. ++> can-exponentiate-positive-infinity
-    exp pinf
-    pinf
+  pinf.exp.eq pinf ++> can-exponentiate-positive-infinity
 
-  is-nan. ++> cannot-exponentiate-nan
-    exp nan
+  nan.exp.is-nan ++> cannot-exponentiate-nan

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -66,7 +66,7 @@
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -88,7 +88,7 @@
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -110,7 +110,7 @@
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -132,7 +132,7 @@
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -154,7 +154,7 @@
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -100,62 +100,40 @@
         level.minus 1
   number num.as-bytes > n
 
-  lt. ++> can-stay-monotonic
-    ln 2
-    ln 3
+  2.ln.lt 3.ln ++> can-stay-monotonic
 
   lt. ++> can-take-a-logarithm-of-a-fraction
-    abs
-      minus.
-        ln 0.5
-        -0.6931471805599453
+    abs.
+      0.5.ln.minus -0.6931471805599453
     1.0E-11
 
   lt. ++> can-take-a-logarithm-of-a-very-large-number-without-overflowing-the-stack
-    abs
-      minus.
-        ln 1.0e300
-        690.7755278982137
+    abs.
+      1.0e300.ln.minus 690.7755278982137
     1.0E-9
 
   lt. ++> can-take-a-logarithm-of-a-very-small-fraction-without-overflowing-the-stack
-    abs
-      minus.
-        ln 1.0E-300
-        -690.7755278982137
+    abs.
+      1.0E-300.ln.minus -690.7755278982137
     1.0E-9
 
-  eq. ++> can-take-a-logarithm-of-e
-    ln e
-    1
+  e.ln.eq 1 ++> can-take-a-logarithm-of-e
 
-  eq. ++> can-take-a-logarithm-of-one
-    ln 1
-    0
+  1.ln.eq 0 ++> can-take-a-logarithm-of-one
 
-  eq. ++> can-take-a-logarithm-of-positive-infinity
-    ln pinf
-    pinf
+  pinf.ln.eq pinf ++> can-take-a-logarithm-of-positive-infinity
 
   lt. ++> can-take-a-logarithm-of-twenty
-    abs
-      minus.
-        ln 20
-        2.995732273553991
+    abs.
+      20.ln.minus 2.995732273553991
     1.0E-11
 
-  eq. ++> can-take-a-logarithm-of-zero
-    ln 0
-    ninf
+  0.ln.eq ninf ++> can-take-a-logarithm-of-zero
 
-  is-nan. ++> cannot-take-a-logarithm-of-a-negative-float
-    ln -2.2
+  -2.2.ln.is-nan ++> cannot-take-a-logarithm-of-a-negative-float
 
-  is-nan. ++> cannot-take-a-logarithm-of-a-negative-integer
-    ln -42
+  -42.ln.is-nan ++> cannot-take-a-logarithm-of-a-negative-integer
 
-  is-nan. ++> cannot-take-a-logarithm-of-nan
-    ln nan
+  nan.ln.is-nan ++> cannot-take-a-logarithm-of-nan
 
-  is-nan. ++> cannot-take-a-logarithm-of-negative-infinity
-    ln ninf
+  ninf.ln.is-nan ++> cannot-take-a-logarithm-of-negative-infinity

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -57,19 +57,13 @@
           abs-mod.neg
 
   is-nan. ++> can-return-nan-when-the-dividend-is-infinite
-    mod
-      pinf
-      5
+    pinf.mod 5
 
   is-nan. ++> can-return-nan-when-the-dividend-is-nan
-    mod
-      nan
-      5
+    nan.mod 5
 
   is-nan. ++> can-return-nan-when-the-divisor-is-nan
-    mod
-      5
-      nan
+    5.mod nan
 
   eq. ++> can-return-positive-zero-for-negative-zero-dividend-and-negative-infinite-divisor
     as-bytes.
@@ -94,132 +88,91 @@
   ++> can-stay-compatible-with-division
     eq. > @
       plus.
-        mod dividend divisor
+        dividend.mod divisor
         divisor.times (dividend.div divisor).as-i64.as-number
       dividend
     -13 > dividend
     5 > divisor
 
   is-nan. ++> can-take-a-modulo-by-nan
-    mod
-      5
-      nan
+    5.mod nan
 
   eq. ++> can-take-a-modulo-by-one
-    mod
-      133
-      1
+    133.mod 1
     0
 
   eq. ++> can-take-a-modulo-of-a-dividend-below-the-divisor
-    mod
-      -1
-      5
+    -1.mod 5
     -1
 
   eq. ++> can-take-a-modulo-of-a-large-dividend-by-a-fractional-divisor
-    mod
-      1000000000000000
-      0.1
+    1000000000000000.mod 0.1
     0.04448884876874218
 
   eq. ++> can-take-a-modulo-of-a-negative-by-positive-infinity
-    mod
-      -5
-      pinf
+    -5.mod pinf
     -5
 
   eq. ++> can-take-a-modulo-of-a-negative-large-dividend-by-a-fractional-divisor
-    mod
-      -1000000000000000
-      0.1
+    -1000000000000000.mod 0.1
     -0.04448884876874218
 
   eq. ++> can-take-a-modulo-of-a-positive-by-negative-infinity
-    mod
-      5
-      ninf
+    5.mod ninf
     5
 
   eq. ++> can-take-a-modulo-of-a-positive-by-positive-infinity
-    mod
-      5
-      pinf
+    5.mod pinf
     5
 
   eq. ++> can-take-a-modulo-of-minus-one-by-seven
-    mod
-      -1
-      7
+    -1.mod 7
     -1
 
   eq. ++> can-take-a-modulo-of-minus-seven-by-three
-    mod
-      -7
-      3
+    -7.mod 3
     -1
 
   eq. ++> can-take-a-modulo-of-one-by-two
-    mod
-      1
-      2
+    1.mod 2
     1
 
   eq. ++> can-take-a-modulo-of-seven-by-three
-    mod
-      7
-      3
+    7.mod 3
     1
 
   eq. ++> can-take-a-modulo-of-sixteen-by-a-large-negative
-    mod
-      16
-      -200
+    16.mod -200
     16
 
   eq. ++> can-take-a-modulo-of-zero-by-a-negative
-    mod
-      0
-      -15
+    0.mod -15
     0
 
   eq. ++> can-take-a-modulo-of-zero-by-five
-    mod
-      0
-      5
+    0.mod 5
     0
 
   eq. ++> can-take-an-exact-modulo-of-a-large-dividend-by-thirteen
-    mod
-      10000000000000000
-      13
+    10000000000000000.mod 13
     3
 
   eq. ++> can-take-an-exact-modulo-of-a-large-dividend-by-three
-    mod
-      10000000000000000
-      3
+    10000000000000000.mod 3
     1
 
   eq. ++> can-take-an-exact-modulo-of-a-very-large-dividend-by-seven
-    mod
-      9200000000000000000
-      7
+    9200000000000000000.mod 7
     5
 
   eq. ++> can-take-an-exact-modulo-of-a-very-large-dividend-by-three
-    mod
-      9200000000000000000
-      3
+    9200000000000000000.mod 3
     2
 
   eq. ++> rejects-a-modulo-by-zero
     "recovered"
-    mod
-      5
+    5.mod
       0
       "recovered" > [message]
 
-  mod --> stops-on-a-modulo-by-zero
-    5
-    0
+  5.mod 0 --> stops-on-a-modulo-by-zero

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -122,302 +122,207 @@
     9
 
   eq. ++> can-be-reached-through-the-package
-    power
-      2
-      4
+    2.power 4
     16
 
   eq. ++> can-raise-a-float-to-zero
-    power
-      42.5
-      0
+    42.5.power 0
     1
 
   eq. ++> can-raise-a-negative-float-to-negative-infinity
-    power
-      -42.5
-      ninf
+    -42.5.power ninf
     0
 
   eq. ++> can-raise-a-negative-float-to-positive-infinity
-    power
-      -4.2
-      pinf
+    -4.2.power pinf
     pinf
 
   eq. ++> can-raise-a-negative-integer-to-negative-infinity
-    power
-      -42
-      ninf
+    -42.power ninf
     0
 
   eq. ++> can-raise-a-negative-integer-to-positive-infinity
-    power
-      -10
-      pinf
+    -10.power pinf
     pinf
 
   eq. ++> can-raise-a-positive-float-to-a-positive-integer
-    power
-      3.5
-      4
+    3.5.power 4
     150.0625
 
   eq. ++> can-raise-a-positive-float-to-negative-infinity
-    power
-      42.5
-      ninf
+    42.5.power ninf
     0
 
   eq. ++> can-raise-a-positive-float-to-positive-infinity
-    power
-      42.5
-      pinf
+    42.5.power pinf
     pinf
 
   eq. ++> can-raise-a-positive-integer-to-a-positive-integer
-    power
-      2
-      3
+    2.power 3
     8
 
   eq. ++> can-raise-a-positive-integer-to-negative-infinity
-    power
-      42
-      ninf
+    42.power ninf
     0
 
   eq. ++> can-raise-a-positive-integer-to-positive-infinity
-    power
-      42
-      pinf
+    42.power pinf
     pinf
 
   eq. ++> can-raise-a-zero-base
-    power
-      0
-      145
+    0.power 145
     0
 
   eq. ++> can-raise-an-integer-to-zero
-    power
-      42
-      0
+    42.power 0
     1
 
   eq. ++> can-raise-four-to-five
-    power
-      4
-      5
+    4.power 5
     1024
 
   eq. ++> can-raise-four-to-minus-three
-    power
-      4
-      -3
+    4.power -3
     0.015625
 
   eq. ++> can-raise-negative-infinity-to-a-positive-float
-    power
-      ninf
-      9.9
+    ninf.power 9.9
     pinf
 
   eq. ++> can-raise-negative-infinity-to-an-even-integer
-    power
-      ninf
-      10
+    ninf.power 10
     pinf
 
   eq. ++> can-raise-negative-infinity-to-an-odd-integer
-    power
-      ninf
-      9
+    ninf.power 9
     ninf
 
   eq. ++> can-raise-negative-infinity-to-negative-infinity
-    power
-      ninf
-      ninf
+    ninf.power ninf
     0
 
   eq. ++> can-raise-negative-zero-to-even-negative
-    power
-      -0
-      -4
+    -0.power -4
     pinf
 
   eq. ++> can-raise-negative-zero-to-even-positive
-    power
-      -0
-      4
+    -0.power 4
     0
 
   eq. ++> can-raise-negative-zero-to-odd-negative
-    power
-      -0
-      -3
+    -0.power -3
     ninf
 
   eq. ++> can-raise-negative-zero-to-odd-positive
-    power
-      -0
-      3
+    -0.power 3
     -0
 
   eq. ++> can-raise-positive-infinity-to-a-negative-float
-    power
-      pinf
-      -42.2
+    pinf.power -42.2
     0
 
   eq. ++> can-raise-positive-infinity-to-a-negative-integer
-    power
-      pinf
-      -42
+    pinf.power -42
     0
 
   eq. ++> can-raise-positive-infinity-to-a-positive-float
-    power
-      pinf
-      10.8
+    pinf.power 10.8
     pinf
 
   eq. ++> can-raise-positive-infinity-to-a-positive-integer
-    power
-      pinf
-      42
+    pinf.power 42
     pinf
 
   eq. ++> can-raise-positive-infinity-to-negative-infinity
-    power
-      pinf
-      ninf
+    pinf.power ninf
     0
 
   eq. ++> can-raise-positive-infinity-to-positive-infinity
-    power
-      pinf
-      pinf
+    pinf.power pinf
     pinf
 
   eq. ++> can-raise-three-to-two
-    power
-      3
-      2
+    3.power 2
     9
 
   eq. ++> can-raise-to-a-large-negative-exponent
-    power
-      984782
-      -12341
+    984782.power -12341
     0
 
   eq. ++> can-raise-to-a-zero-exponent
-    power
-      2
-      0
+    2.power 0
     1
 
   eq. ++> can-raise-two-to-four
-    power
-      2
-      4
+    2.power 4
     16
 
   eq. ++> can-raise-two-to-minus-one
-    power
-      2
-      -1
+    2.power -1
     0.5
 
   eq. ++> can-raise-two-to-minus-three
-    power
-      2
-      -3
+    2.power -3
     0.125
 
   eq. ++> can-raise-two-to-minus-two
-    power
-      2
-      -2
+    2.power -2
     0.25
 
   eq. ++> can-raise-zero-to-a-negative
-    power
-      0
-      -52
+    0.power -52
     pinf
 
   eq. ++> can-raise-zero-to-a-negative-odd-integer
-    power
-      0
-      -567
+    0.power -567
     pinf
 
   eq. ++> can-raise-zero-to-a-positive-float
-    power
-      0
-      4.2
+    0.power 4.2
     0
 
   eq. ++> can-raise-zero-to-a-positive-integer
-    power
-      0
-      4
+    0.power 4
     0
 
   eq. ++> can-raise-zero-to-negative-infinity
-    power
-      0
-      ninf
+    0.power ninf
     pinf
 
   eq. ++> can-raise-zero-to-positive-infinity
-    power
-      0
-      pinf
+    0.power pinf
     0
 
   lt. ++> can-take-a-cube-root-of-twenty-seven
-    abs
+    abs.
       minus.
-        power
-          27
+        27.power
           1.div 3
         3
     1.0E-9
 
   lt. ++> can-take-a-square-root-of-nine
-    abs
+    abs.
       minus.
-        power 9 0.5
+        9.power 0.5
         3
     1.0E-9
 
   lt. ++> can-take-a-square-root-of-two-by-raising-to-a-power
-    abs
+    abs.
       minus.
-        power 2 0.5
+        2.power 0.5
         1.4142135623730951
     1.0E-9
 
   is-nan. ++> cannot-raise-a-negative-to-a-fraction
-    power
-      -4
-      0.5
+    -4.power 0.5
 
   is-nan. ++> cannot-raise-anything-to-nan
-    power
-      52
-      nan
+    52.power nan
 
   is-nan. ++> cannot-raise-nan-to-anything
-    power
-      nan
-      42
+    nan.power 42
 
   is-nan. ++> cannot-raise-nan-to-nan
-    power
-      nan
-      nan
+    nan.power nan

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -16,43 +16,32 @@
     pi
 
   lt. ++> can-convert-a-full-turn-to-radians
-    abs
-      minus.
-        radians 360
+    abs.
+      360.radians.minus
         pi.times 2
     1.0E-4
 
   lt. ++> can-convert-a-half-turn-to-radians
-    abs
-      minus.
-        radians 180
-        pi
+    abs.
+      180.radians.minus pi
     1.0E-4
 
   lt. ++> can-convert-a-large-value-to-radians-without-overflow
-    abs
-      minus.
-        radians 1.0e308
-        1.7453292519943295e306
+    abs.
+      1.0e308.radians.minus 1.7453292519943295e306
     1.0e293
 
   lt. ++> can-convert-a-negative-half-turn-to-radians
-    abs
-      minus.
-        radians -180
-        pi.neg
+    abs.
+      -180.radians.minus pi.neg
     1.0E-4
 
   lt. ++> can-convert-a-quarter-turn-to-radians
-    abs
-      minus.
-        radians 90
+    abs.
+      90.radians.minus
         pi.div 2
     1.0E-4
 
-  eq. ++> can-convert-zero-to-radians
-    radians 0
-    0
+  0.radians.eq 0 ++> can-convert-zero-to-radians
 
-  is-nan. ++> cannot-convert-nan-to-radians
-    radians nan
+  nan.radians.is-nan ++> cannot-convert-nan-to-radians

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -61,8 +61,7 @@
   ++> can-reach-the-upper-half
     not. > @
       rand.lt 0.5
-    next. > rand
-      random 178609
+    178609.random.next > rand
 
   eq. ++> can-repeat-itself-with-the-same-seed
     next. (random 1654).next.next
@@ -83,10 +82,9 @@
         rand.next.next.lt 1
         not.
           rand.next.next.lt 0
-    next. > rand
-      random 123
+    123.random.next > rand
 
   ++> can-use-a-seed
     not. > @
       r.next.eq r.next.next
-    random 51 > r
+    51.random > r

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -45,20 +45,20 @@
     | 1
 
   lt. ++> can-behave-as-an-odd-function-when-taking-sine
-    abs
+    abs.
       times.
         plus.
-          sine
+          sine.
             pi.div 3
-          sine (pi.div 3).neg
+          sine. (pi.div 3).neg
         1000
     1
 
   lt. ++> can-reduce-a-large-angle-when-taking-sine
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             plus.
               pi.times 10
               pi.div 6
@@ -67,64 +67,56 @@
     1
 
   lt. ++> can-reduce-a-very-large-angle-with-cody-waite-precision
-    abs
+    abs.
       minus.
-        times.
-          sine 1000000000000000
-          1000
+        1000000000000000.sine.times 1000
         858
     1
 
   lt. ++> can-take-a-sine-of-minus-pi-halves
-    abs
+    abs.
       minus.
-        times.
-          sine (pi.div 2).neg
-          1000
+        times. (pi.div 2).neg.sine 1000
         -1000
     1
 
   lt. ++> can-take-a-sine-of-pi
-    abs
-      times.
-        sine pi
-        1000
+    abs.
+      pi.sine.times 1000
     1
 
   lt. ++> can-take-a-sine-of-pi-halves
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             pi.div 2
           1000
         1000
     1
 
   lt. ++> can-take-a-sine-of-pi-sixths
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             pi.div 6
           1000
         500
     1
 
   lt. ++> can-take-a-sine-of-seventeen-radians
-    abs
+    abs.
       minus.
-        times.
-          sine 17
-          1000
+        17.sine.times 1000
         -961
     1
 
   lt. ++> can-take-a-sine-of-three-pi-halves
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             div.
               pi.times 3
               2
@@ -133,22 +125,17 @@
     1
 
   lt. ++> can-take-a-sine-of-two-pi
-    abs
+    abs.
       times.
-        sine
+        sine.
           pi.times 2
         1000
     1
 
-  eq. ++> can-take-a-sine-of-zero
-    sine 0
-    0
+  0.sine.eq 0 ++> can-take-a-sine-of-zero
 
-  is-nan. ++> cannot-take-a-sine-of-nan
-    sine nan
+  nan.sine.is-nan ++> cannot-take-a-sine-of-nan
 
-  is-nan. ++> cannot-take-a-sine-of-negative-infinity
-    sine ninf
+  ninf.sine.is-nan ++> cannot-take-a-sine-of-negative-infinity
 
-  is-nan. ++> cannot-take-a-sine-of-positive-infinity
-    sine pinf
+  pinf.sine.is-nan ++> cannot-take-a-sine-of-positive-infinity

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -19,55 +19,38 @@
       0.5
 
   lt. ++> can-approximate-a-square-root-of-four
-    abs
-      2.minus
-        sqrt 4
+    abs.
+      2.minus 4.sqrt
     1.0E-11
 
   lt. ++> can-approximate-a-square-root-of-zero
-    abs
-      0.minus
-        sqrt 0
+    abs.
+      0.minus 0.sqrt
     1.0E-11
 
   lt. ++> can-take-a-square-root-of-a-half
-    abs
-      minus.
-        sqrt 0.25
-        0.5
+    abs.
+      0.25.sqrt.minus 0.5
     1.0E-9
 
   lt. ++> can-take-a-square-root-of-four
-    abs
-      minus.
-        sqrt 4
-        2
+    abs.
+      4.sqrt.minus 2
     1.0E-9
 
-  eq. ++> can-take-a-square-root-of-one
-    sqrt 1
-    1
+  1.sqrt.eq 1 ++> can-take-a-square-root-of-one
 
-  eq. ++> can-take-a-square-root-of-positive-infinity
-    sqrt pinf
-    pinf
+  pinf.sqrt.eq pinf ++> can-take-a-square-root-of-positive-infinity
 
   lt. ++> can-take-a-square-root-of-two
-    abs
-      minus.
-        sqrt 2
-        1.4142135623730951
+    abs.
+      2.sqrt.minus 1.4142135623730951
     1.0E-9
 
-  eq. ++> can-take-a-square-root-of-zero
-    sqrt 0
-    0
+  0.sqrt.eq 0 ++> can-take-a-square-root-of-zero
 
-  is-nan. ++> cannot-take-a-square-root-of-a-negative
-    sqrt -0.1
+  -0.1.sqrt.is-nan ++> cannot-take-a-square-root-of-a-negative
 
-  is-nan. ++> cannot-take-a-square-root-of-nan
-    sqrt nan
+  nan.sqrt.is-nan ++> cannot-take-a-square-root-of-nan
 
-  is-nan. ++> cannot-take-a-square-root-of-negative-infinity
-    sqrt ninf
+  ninf.sqrt.is-nan ++> cannot-take-a-square-root-of-negative-infinity

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -21,7 +21,7 @@
     r.end
 
   eq. ++> can-build-a-range-of-negatives
-    naturals
+    naturals.
       range -5 0
     *
       -5
@@ -31,15 +31,15 @@
       -1
 
   is-empty ++> can-build-an-empty-range-from-ten-to-ten
-    naturals
+    naturals.
       range 10 10
 
   is-empty ++> can-build-an-empty-range-when-descending
-    naturals
+    naturals.
       range 10 1
 
   eq. ++> can-build-naturals-from-one-to-ten
-    naturals
+    naturals.
       range 1 10
     *
       1

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -14,39 +14,22 @@
     as-i16.
       00-.concat char.as-bytes
 
-  eq. ++> can-read-the-code-of-a-lowercase-letter
-    97
-    as-ascii "a"
+  97.eq "a".as-ascii ++> can-read-the-code-of-a-lowercase-letter
 
-  eq. ++> can-read-the-code-of-a-punctuation-mark
-    33
-    as-ascii "!"
+  33.eq "!".as-ascii ++> can-read-the-code-of-a-punctuation-mark
 
   eq. ++> can-read-the-code-of-a-space
     32
-    as-ascii
-      " "
+    " ".as-ascii
 
-  eq. ++> can-read-the-code-of-an-uppercase-letter
-    65
-    as-ascii "A"
+  65.eq "A".as-ascii ++> can-read-the-code-of-an-uppercase-letter
 
-  eq. ++> can-read-the-code-of-the-last-lowercase-letter
-    122
-    as-ascii "z"
+  122.eq "z".as-ascii ++> can-read-the-code-of-the-last-lowercase-letter
 
-  eq. ++> can-read-the-code-of-the-last-printable-character
-    126
-    as-ascii "~"
+  126.eq "~".as-ascii ++> can-read-the-code-of-the-last-printable-character
 
-  eq. ++> can-read-the-code-of-the-last-uppercase-letter
-    90
-    as-ascii "Z"
+  90.eq "Z".as-ascii ++> can-read-the-code-of-the-last-uppercase-letter
 
-  eq. ++> can-read-the-code-of-the-nine-digit
-    57
-    as-ascii "9"
+  57.eq "9".as-ascii ++> can-read-the-code-of-the-nine-digit
 
-  eq. ++> can-read-the-code-of-the-zero-digit
-    48
-    as-ascii "0"
+  48.eq "0".as-ascii ++> can-read-the-code-of-the-zero-digit

--- a/eo-runtime/src/main/eo/string/as-char.eo
+++ b/eo-runtime/src/main/eo/string/as-char.eo
@@ -16,8 +16,7 @@
   eq. ++> can-round-trip-through-as-ascii
     "!"
     string
-      as-char
-        as-ascii "!"
+      as-char "!".as-ascii
 
   eq. ++> can-write-the-byte-of-a-lowercase-letter
     "z"

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -29,48 +29,37 @@
         at.
           scanf "%f" text
 
-  eq. ++> can-convert-float-text
-    3.14
-    as-number "3.14"
+  3.14.eq "3.14".as-number ++> can-convert-float-text
 
-  eq. ++> can-convert-negative-text
-    -42
-    as-number "-42"
+  -42.eq "-42".as-number ++> can-convert-negative-text
 
-  eq. ++> can-convert-text
-    5
-    as-number "5"
+  5.eq "5".as-number ++> can-convert-text
 
   42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch
 
   eq. ++> rejects-currency-prefixed-text
     42
-    as-number
-      "$100"
+    "$100".as-number
       42 > [message]
 
   eq. ++> rejects-non-numeric-text
     42
-    as-number
-      "Hello"
+    "Hello".as-number
       42 > [message]
 
   eq. ++> rejects-space-separated-numbers
     42
-    as-number
-      "1 2 3"
+    "1 2 3".as-number
       42 > [message]
 
   eq. ++> rejects-text-with-an-embedded-number
     42
-    as-number
-      "abc5"
+    "abc5".as-number
       42 > [message]
 
   eq. ++> rejects-text-with-multiple-dots
     42
-    as-number
-      "12.34.56"
+    "12.34.56".as-number
       42 > [message]
 
-  as-number "Hello" --> stops-on-converting-non-numeric-text
+  "Hello".as-number --> stops-on-converting-non-numeric-text

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -40,43 +40,32 @@
 
   eq. ++> can-return-a-character-at-a-negative-index
     "m"
-    at
-      "some"
-      -2
+    "some".at -2
 
   eq. ++> can-return-the-first-character
     "s"
-    at
-      "some"
-      0
+    "some".at 0
 
   eq. ++> can-return-the-third-character
     "m"
-    at
-      "some"
-      2
+    "some".at 2
 
   eq. ++> rejects-a-fractional-index-in-bounds
     "recovered"
-    at
-      "some"
+    "some".at
       1.5
       "recovered" > [message]
 
   eq. ++> rejects-a-negative-fractional-index-in-bounds
     "recovered"
-    at
-      "some"
+    "some".at
       -1.5
       "recovered" > [message]
 
   eq. ++> rejects-an-out-of-bounds-index
     "recovered"
-    at
-      "some"
+    "some".at
       10
       "recovered" > [message]
 
-  at --> stops-on-an-index-beyond-the-length
-    "some"
-    10
+  "some".at 10 --> stops-on-an-index-beyond-the-length

--- a/eo-runtime/src/main/eo/string/chained.eo
+++ b/eo-runtime/src/main/eo/string/chained.eo
@@ -20,14 +20,13 @@
 
   eq. ++> can-chain-with-other-strings
     "Hello, world!"
-    chained *1
-      "Hello"
-      ", "
-      "world"
-      "!"
+    "Hello".chained
+      *
+        ", "
+        "world"
+        "!"
 
   eq. ++> can-return-the-same-text-without-other-strings
     "Some"
-    chained
-      "Some"
+    "Some".chained
       *

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -15,29 +15,31 @@
     true
     x.and a > [a x]
 
-  contains-all ++> can-contain-all-of-no-substrings
+  contains-all. ++> can-contain-all-of-no-substrings
     "xyz"
     *
 
-  contains-all ++> can-contain-all-of-no-substrings-when-empty
+  contains-all. ++> can-contain-all-of-no-substrings-when-empty
     ""
     *
 
-  contains-all *1 ++> can-contain-all-substrings
+  contains-all. ++> can-contain-all-substrings
     "abcdefghijk"
-    "abc"
-    "ghi"
+    *
+      "abc"
+      "ghi"
 
-  contains-all *1 ++> can-contain-all-substrings-written-vertically
+  contains-all. ++> can-contain-all-substrings-written-vertically
     "Hello, world!"
-    "ell"
-    " "
-    ","
-    "d!"
+    *
+      "ell"
+      " "
+      ","
+      "d!"
 
   not. ++> cannot-contain-all-substrings
-    contains-all *1
-      "qwerty"
-      "qer"
-      "ty"
-      "abc"
+    "qwerty".contains-all
+      *
+        "qer"
+        "ty"
+        "abc"

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -15,31 +15,31 @@
     false
     x.or a > [a x]
 
-  contains-any *1 ++> can-contain-any-substring
+  contains-any. ++> can-contain-any-substring
     "Good morning"
-    "oo"
-    "goo"
+    *
+      "oo"
+      "goo"
 
-  contains-any *1 ++> can-contain-any-substring-written-vertically
+  contains-any. ++> can-contain-any-substring-written-vertically
     "foo bar buzz"
-    "bar"
-    " "
-    "o"
+    *
+      "bar"
+      " "
+      "o"
 
   not. ++> cannot-contain-any-of-no-substrings
-    contains-any
-      "text"
+    "text".contains-any
       *
 
   not. ++> cannot-contain-any-of-no-substrings-when-empty
-    contains-any
-      ""
+    "".contains-any
       *
 
   not. ++> cannot-contain-any-substring
-    contains-any *1
-      "xyzw"
-      "yx"
-      "zyx"
-      "wx"
-      "abc"
+    "xyzw".contains-any
+      *
+        "yx"
+        "zyx"
+        "wx"
+        "abc"

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -33,11 +33,10 @@
     number length
     size
 
-  contains ++> can-contain-a-substring
+  contains. ++> can-contain-a-substring
     "Hello, world!"
     "o, wo"
 
   not. ++> cannot-contain-an-absent-substring
-    contains
-      "Hello, world!"
+    "Hello, world!".contains
       "Hey"

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -22,11 +22,10 @@
         size
       substring >> part!
 
-  ends-with ++> can-end-with-a-substring
+  ends-with. ++> can-end-with-a-substring
     "Hello world!"
     "world!"
 
   not. ++> cannot-end-with-an-absent-substring
-    ends-with
-      "Hello world!"
+    "Hello world!".ends-with
       "Hello"

--- a/eo-runtime/src/main/eo/string/english.eo
+++ b/eo-runtime/src/main/eo/string/english.eo
@@ -67,47 +67,24 @@
           as-ascii byte > code
     as-ascii "a" >> mincode!
 
-  eq. ++> can-behave-like-the-wrapped-english-string
-    5
-    length.
-      english "hello"
+  5.eq "hello".english.length ++> can-behave-like-the-wrapped-english-string
 
-  eq. ++> can-convert-already-lower-cased-text
-    "hello"
-    lower.
-      english "HeLlO"
+  "hello".eq "HeLlO".english.lower ++> can-convert-already-lower-cased-text
 
-  eq. ++> can-convert-already-upper-cased-text
-    "HELLO"
-    upper.
-      english "HeLlO"
+  "HELLO".eq "HeLlO".english.upper ++> can-convert-already-upper-cased-text
 
-  eq. ++> can-convert-text-to-lower-case
-    "hello"
-    lower.
-      english "HELLO"
+  "hello".eq "HELLO".english.lower ++> can-convert-text-to-lower-case
 
-  eq. ++> can-convert-text-to-upper-case
-    "HELLO"
-    upper.
-      english "hello"
+  "HELLO".eq "hello".english.upper ++> can-convert-text-to-upper-case
 
-  eq. ++> can-keep-already-lower-cased-text
-    "hello"
-    lower.
-      english "hello"
+  "hello".eq "hello".english.lower ++> can-keep-already-lower-cased-text
 
-  eq. ++> can-keep-already-upper-cased-text
-    "HELLO"
-    upper.
-      english "HELLO"
+  "HELLO".eq "HELLO".english.upper ++> can-keep-already-upper-cased-text
 
   eq. ++> can-keep-non-ascii-letters-when-lower-casing-in-english
     "ÄÖÜ"
-    lower.
-      english "ÄÖÜ"
+    "ÄÖÜ".english.lower
 
   eq. ++> can-keep-non-ascii-letters-when-upper-casing-in-english
     "äöü"
-    upper.
-      english "äöü"
+    "äöü".english.upper

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -45,36 +45,28 @@
 
   eq. ++> can-find-a-present-substring-in-utf-text
     3
-    index-of
-      "привет, друг!"
+    "привет, друг!".index-of
       "в"
 
   eq. ++> can-return-the-index-of-a-substring
     6
-    index-of
-      "Hello \n world"
+    "Hello \n world".index-of
       "\n"
 
   eq. ++> can-return-the-index-of-a-substring-at-the-end
     6
-    index-of
-      "Hello world"
+    "Hello world".index-of
       "world"
 
   eq. ++> cannot-find-a-longer-substring
     -1
-    index-of
-      "Hello"
-      "Somebody"
+    "Hello".index-of "Somebody"
 
   eq. ++> cannot-find-an-absent-substring-in-utf-text
     -1
-    index-of
-      "привет, друг!"
+    "привет, друг!".index-of
       "x"
 
   eq. ++> cannot-find-an-absent-substring-of-the-same-length
     -1
-    index-of
-      "Hello"
-      "world"
+    "Hello".index-of "world"

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -13,13 +13,10 @@
     regex "/^[a-zA-Z]+$/"
     text
 
-  is-alpha "eEo" ++> can-be-alphabetic-when-simple-text
+  "eEo".is-alpha ++> can-be-alphabetic-when-simple-text
 
-  not. ++> cannot-be-alphabetic-when-empty
-    is-alpha ""
+  "".is-alpha.not ++> cannot-be-alphabetic-when-empty
 
-  not. ++> cannot-be-alphabetic-with-a-number
-    is-alpha "ab3d"
+  "ab3d".is-alpha.not ++> cannot-be-alphabetic-with-a-number
 
-  not. ++> cannot-be-alphabetic-with-dashes
-    is-alpha "-w-"
+  "-w-".is-alpha.not ++> cannot-be-alphabetic-with-dashes

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -13,12 +13,10 @@
     regex "/^[A-Za-z0-9]+$/"
     text
 
-  is-alphanumeric "eEo" ++> can-be-alphanumeric-when-simple-text
+  "eEo".is-alphanumeric ++> can-be-alphanumeric-when-simple-text
 
-  is-alphanumeric "ab3d" ++> can-be-alphanumeric-with-a-number
+  "ab3d".is-alphanumeric ++> can-be-alphanumeric-with-a-number
 
-  not. ++> cannot-be-alphanumeric-when-empty
-    is-alphanumeric ""
+  "".is-alphanumeric.not ++> cannot-be-alphanumeric-when-empty
 
-  not. ++> cannot-be-alphanumeric-with-dashes
-    is-alphanumeric "-w-"
+  "-w-".is-alphanumeric.not ++> cannot-be-alphanumeric-with-dashes

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -12,12 +12,10 @@
     regex "/^[\\x00-\\x7F]+$/"
     text
 
-  is-ascii "123" ++> can-be-ascii-when-digits
+  "123".is-ascii ++> can-be-ascii-when-digits
 
-  is-ascii "H311oW" ++> can-be-ascii-when-plain-text
+  "H311oW".is-ascii ++> can-be-ascii-when-plain-text
 
-  not. ++> cannot-be-ascii-when-empty
-    is-ascii ""
+  "".is-ascii.not ++> cannot-be-ascii-when-empty
 
-  not. ++> cannot-be-ascii-with-an-emoji
-    is-ascii "🌵"
+  "🌵".is-ascii.not ++> cannot-be-ascii-with-an-emoji

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -13,25 +13,19 @@
     regex "/^[0-9]+$/"
     text
 
-  is-digit "2026" ++> can-be-digits-when-a-number
+  "2026".is-digit ++> can-be-digits-when-a-number
 
-  is-digit "7" ++> can-be-digits-when-a-single-digit
+  "7".is-digit ++> can-be-digits-when-a-single-digit
 
-  is-digit ++> can-be-digits-when-a-very-long-number
+  is-digit. ++> can-be-digits-when-a-very-long-number
     "123456789012345678901234567890123456789012345678901234567890"
 
-  not. ++> cannot-be-digits-when-empty
-    is-digit ""
+  "".is-digit.not ++> cannot-be-digits-when-empty
 
-  not. ++> cannot-be-digits-with-a-letter
-    is-digit "1a2"
+  "1a2".is-digit.not ++> cannot-be-digits-with-a-letter
 
-  not. ++> cannot-be-digits-with-a-space
-    is-digit
-      "12 34"
+  "12 34".is-digit.not ++> cannot-be-digits-with-a-space
 
-  not. ++> cannot-be-digits-with-a-special-character
-    is-digit "1🌵2"
+  "1🌵2".is-digit.not ++> cannot-be-digits-with-a-special-character
 
-  not. ++> cannot-be-digits-with-a-trailing-newline
-    is-digit "123\n"
+  "123\n".is-digit.not ++> cannot-be-digits-with-a-trailing-newline

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -26,21 +26,19 @@
 
   eq. ++> can-join-many-strings
     "hello-world-dear-friend"
-    joined *1
-      "-"
-      "hello"
-      "world"
-      "dear"
-      "friend"
+    "-".joined
+      *
+        "hello"
+        "world"
+        "dear"
+        "friend"
 
   eq. ++> can-join-no-strings
     ""
-    joined
-      "-"
+    "-".joined
       *
 
   eq. ++> can-join-one-string
     "some"
-    joined *1
-      "-"
-      "some"
+    "-".joined
+      * "some"

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -45,30 +45,24 @@
 
   eq. ++> can-find-the-last-index-of-a-substring
     5
-    last-index-of
-      "Hey, Hey, Hey"
+    "Hey, Hey, Hey".last-index-of
       "Hey,"
 
   eq. ++> can-find-the-last-index-of-a-substring-in-utf-text
     3
-    last-index-of
-      "привет, друг!"
+    "привет, друг!".last-index-of
       "в"
 
   eq. ++> can-find-the-last-index-of-the-whole-string
     0
-    last-index-of
-      "Hello"
-      "Hello"
+    "Hello".last-index-of "Hello"
 
   eq. ++> cannot-find-the-last-index-of-an-absent-substring
     -1
-    last-index-of
-      "Hello, world"
+    "Hello, world".last-index-of
       "somebody"
 
   eq. ++> cannot-find-the-last-index-of-an-absent-substring-in-utf-text
     -1
-    last-index-of
-      "привет, друг!"
+    "привет, друг!".last-index-of
       "x"

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -70,8 +70,7 @@
     "The 😀 smile" > str
 
   eq. ++> can-count-the-characters-of-the-origin-text
-    length
-      "Hello, world!"
+    "Hello, world!".length
     13
 
   ++> can-count-three-byte-characters
@@ -86,5 +85,5 @@
       str.as-bytes.size.eq 16
     "Hello, друг!" > str
 
-  length --> stops-on-an-incomplete-four-byte-character
+  length. --> stops-on-an-incomplete-four-byte-character
     string F0-9F-98

--- a/eo-runtime/src/main/eo/string/lower.eo
+++ b/eo-runtime/src/main/eo/string/lower.eo
@@ -23,6 +23,4 @@
     "good evening"
     "Good evening".lower
 
-  eq. ++> can-lower-case-text-through-the-package
-    "hello"
-    lower "HELLO"
+  "hello".eq "HELLO".lower ++> can-lower-case-text-through-the-package

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -75,8 +75,7 @@
   delimiter.size >> size!
 
   eq. ++> can-split-into-empty-strings
-    nsplit
-      "-a-b-c"
+    "-a-b-c".nsplit
       "-"
       3
     *
@@ -85,8 +84,7 @@
       "b-c"
 
   eq. ++> can-split-multi-byte-characters
-    nsplit
-      "аХбХв"
+    "аХбХв".nsplit
       "Х"
       3
     *
@@ -95,8 +93,7 @@
       "в"
 
   eq. ++> can-split-on-a-multi-character-delimiter
-    nsplit
-      "a::b::c::d"
+    "a::b::c::d".nsplit
       "::"
       2
     *
@@ -104,8 +101,7 @@
       "b::c::d"
 
   eq. ++> can-split-on-dashes-with-a-limit-of-two
-    nsplit
-      "a-b-c-d"
+    "a-b-c-d".nsplit
       "-"
       2
     *
@@ -113,8 +109,7 @@
       "b-c-d"
 
   eq. ++> can-split-with-a-high-limit
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       10
     *
@@ -123,15 +118,13 @@
       "c"
 
   eq. ++> can-split-with-a-limit-of-one
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       1
     * "a-b-c"
 
   eq. ++> can-split-with-a-limit-of-two
-    nsplit
-      "Cookie: a=1; b=2"
+    "Cookie: a=1; b=2".nsplit
       " "
       2
     *
@@ -140,34 +133,31 @@
 
   eq. ++> rejects-a-fractional-limit
     "recovered"
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       1.5
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-limit-when-splitting
     "recovered"
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       pinf
       "recovered" > [message]
 
   eq. ++> rejects-an-invalid-limit
     "fallback"
-    nsplit
-      "text"
+    "text".nsplit
       "-"
       0
       "fallback" > [message]
 
-  nsplit --> stops-on-a-limit-of-zero
+  nsplit. --> stops-on-a-limit-of-zero
     "text"
     "-"
     0
 
-  nsplit --> stops-on-a-negative-limit-when-splitting
+  nsplit. --> stops-on-a-negative-limit-when-splitting
     "text"
     "-"
     -1

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -41,87 +41,76 @@
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-left
     "  Ж"
-    padded-left
-      "Ж"
+    "Ж".padded-left
       3
       " "
 
   eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-left
     "Can't pad text to -1.000000 characters with x"
-    padded-left
-      "y"
+    "y".padded-left
       -1
       "x"
       message > [message]
 
   eq. ++> can-pad-a-number-with-leading-spaces
     "   42"
-    padded-left
-      "42"
+    "42".padded-left
       5
       " "
 
   eq. ++> can-pad-with-leading-zeros
     "0042"
-    padded-left
-      "42"
+    "42".padded-left
       4
       "0"
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-left
     "hello"
-    padded-left
-      "hello"
+    "hello".padded-left
       3
       " "
 
   eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-left
     "hey"
-    padded-left
-      "hey"
+    "hey".padded-left
       3
       " "
 
   eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-left
     "x"
-    padded-left
-      "x"
+    "x".padded-left
       0
       " "
 
   eq. ++> rejects-a-multi-character-fill-when-padding-left
     "recovered"
-    padded-left
-      "y"
+    "y".padded-left
       5
       "ab"
       "recovered" > [message]
 
   eq. ++> rejects-a-negative-width-when-padding-left
     "recovered"
-    padded-left
-      "y"
+    "y".padded-left
       -1
       "x"
       "recovered" > [message]
 
   eq. ++> rejects-a-non-integer-width-when-padding-left
     "recovered"
-    padded-left
-      "y"
+    "y".padded-left
       2.5
       "x"
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-width-when-padding-left
     "recovered"
-    padded-left
-      "y"
+    "y".padded-left
       pinf
       "x"
       "recovered" > [message]
 
-  padded-left --> stops-on-a-negative-width-when-padding-left
+  padded-left. --> stops-on-a-negative-width-when-padding-left
     "y"
     -1
     "x"

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -40,87 +40,76 @@
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-right
     "Ж  "
-    padded-right
-      "Ж"
+    "Ж".padded-right
       3
       " "
 
   eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-right
     "Can't pad text to -1.000000 characters with x"
-    padded-right
-      "y"
+    "y".padded-right
       -1
       "x"
       message > [message]
 
   eq. ++> can-pad-a-text-with-trailing-spaces
     "x         "
-    padded-right
-      "x"
+    "x".padded-right
       10
       " "
 
   eq. ++> can-pad-with-trailing-zeros-when-padding-right
     "4200"
-    padded-right
-      "42"
+    "42".padded-right
       4
       "0"
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-right
     "hello"
-    padded-right
-      "hello"
+    "hello".padded-right
       3
       " "
 
   eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-right
     "hey"
-    padded-right
-      "hey"
+    "hey".padded-right
       3
       " "
 
   eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-right
     "x"
-    padded-right
-      "x"
+    "x".padded-right
       0
       " "
 
   eq. ++> rejects-a-multi-character-fill-when-padding-right
     "recovered"
-    padded-right
-      "y"
+    "y".padded-right
       5
       "ab"
       "recovered" > [message]
 
   eq. ++> rejects-a-negative-width-when-padding-right
     "recovered"
-    padded-right
-      "y"
+    "y".padded-right
       -1
       "x"
       "recovered" > [message]
 
   eq. ++> rejects-a-non-integer-width-when-padding-right
     "recovered"
-    padded-right
-      "y"
+    "y".padded-right
       2.5
       "x"
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-width-when-padding-right
     "recovered"
-    padded-right
-      "y"
+    "y".padded-right
       pinf
       "x"
       "recovered" > [message]
 
-  padded-right --> stops-on-a-negative-width-when-padding-right
+  padded-right. --> stops-on-a-negative-width-when-padding-right
     "y"
     -1
     "x"

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -52,68 +52,50 @@
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-with-zeros
     "00Ж"
-    padded-zeros
-      "Ж"
-      3
+    "Ж".padded-zeros 3
 
   eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-with-zeros
     "Can't pad text to -4.000000 characters with zeros"
-    padded-zeros
-      "7"
+    "7".padded-zeros
       -4
       message > [message]
 
   eq. ++> can-keep-a-minus-sign-in-front-of-the-zeros
     "-0042"
-    padded-zeros
-      "-42"
-      5
+    "-42".padded-zeros 5
 
   eq. ++> can-pad-a-positive-number-with-leading-zeros
     "00042"
-    padded-zeros
-      "42"
-      5
+    "42".padded-zeros 5
 
   eq. ++> can-pad-an-empty-text
     "000"
-    padded-zeros
-      ""
-      3
+    "".padded-zeros 3
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-with-zeros
     "12345"
-    padded-zeros
-      "12345"
-      3
+    "12345".padded-zeros 3
 
   eq. ++> can-return-a-negative-text-of-the-exact-width-unchanged
     "-42"
-    padded-zeros
-      "-42"
-      3
+    "-42".padded-zeros 3
 
   eq. ++> rejects-a-negative-width-when-padding-with-zeros
     "recovered"
-    padded-zeros
-      "7"
+    "7".padded-zeros
       -4
       "recovered" > [message]
 
   eq. ++> rejects-a-non-integer-width-when-padding-with-zeros
     "recovered"
-    padded-zeros
-      "7"
+    "7".padded-zeros
       3.5
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-width-when-padding-with-zeros
     "recovered"
-    padded-zeros
-      "7"
+    "7".padded-zeros
       pinf
       "recovered" > [message]
 
-  padded-zeros --> stops-on-a-negative-width-when-padding-with-zeros
-    "7"
-    -4
+  "7".padded-zeros -4 --> stops-on-a-negative-width-when-padding-with-zeros

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -377,264 +377,236 @@
 
   eq. ++> can-answer-the-size-of-the-formatted-text
     size.
-      printf *1
-        "Hello, %s"
-        "Jeff"
+      "Hello, %s".printf
+        * "Jeff"
     11
 
   eq. ++> can-apply-a-precision-to-a-string
     "Jef"
-    printf *1
-      "%.3s"
-      "Jeffrey"
+    "%.3s".printf
+      * "Jeffrey"
 
   eq. ++> can-apply-a-precision-to-bytes
     "40-"
-    printf *1
-      "%.3x"
-      42.as-bytes
+    "%.3x".printf
+      * 42.as-bytes
 
   eq. ++> can-apply-a-width-to-bytes
     "  40-45-00-00-00-00-00-00"
-    printf *1
-      "%25x"
-      42.as-bytes
+    "%25x".printf
+      * 42.as-bytes
 
   eq. ++> can-format-a-computed-string
     "abcd"
-    printf *1
-      "%s"
-      "ab".concat "cd"
+    "%s".printf
+      *
+        "ab".concat "cd"
 
   eq. ++> can-format-a-decimal-above-two-to-the-53rd
     "9007199254740992"
-    printf *1
-      "%d"
-      9007199254740992
+    "%d".printf
+      * 9007199254740992
 
   eq. ++> can-format-a-float-above-two-to-the-53rd
     "9007199254740992.000000"
-    printf *1
-      "%f"
-      9007199254740992
+    "%f".printf
+      * 9007199254740992
 
   eq. ++> can-format-a-float-with-six-fraction-digits
     "1.250000"
-    printf *1
-      "%f"
-      1.25
+    "%f".printf
+      * 1.25
 
   eq. ++> can-format-a-large-negative-decimal
     "-9007199254740992"
-    printf *1
-      "%d"
-      -9007199254740992
+    "%d".printf
+      * -9007199254740992
 
   eq. ++> can-format-a-numbered-substitution
     "Hello, Jeff! Bye, Jeff!"
-    printf *1
-      "Hello, %s! Bye, %1$s!"
-      "Jeff"
+    "Hello, %s! Bye, %1$s!".printf
+      * "Jeff"
 
   eq. ++> can-format-a-numbered-substitution-with-many-arguments
     "This is the first; This is the first as well; The second; and the 3"
-    printf *1
-      "This is the %s; This is the %1$s as well; The %s; and the %d"
-      "first"
-      "second"
-      3
+    "This is the %s; This is the %1$s as well; The %s; and the %d".printf
+      *
+        "first"
+        "second"
+        3
 
   eq. ++> can-format-a-precision-of-two-decimals
     "3.14"
-    printf *1
-      "%.2f"
-      3.1415
+    "%.2f".printf
+      * 3.1415
 
   eq. ++> can-format-a-width-with-leading-spaces
     "   42"
-    printf *1
-      "%5d"
-      42
+    "%5d".printf
+      * 42
 
   eq. ++> can-format-a-zero-float-with-six-fraction-digits
     "0.000000"
-    printf *1
-      "%f"
-      0
+    "%f".printf
+      * 0
 
   eq. ++> can-format-left-justified-with-trailing-spaces
     "x         "
-    printf *1
-      "%-10s"
-      "x"
+    "%-10s".printf
+      * "x"
 
   eq. ++> can-format-objects-of-every-type
     "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
-    printf *1
-      "string %s, bytes %x, float %f, int %d, bool %b"
-      "Jeff"
-      "Jeff".as-bytes
-      42.3
-      14
-      false
+    "string %s, bytes %x, float %f, int %d, bool %b".printf
+      *
+        "Jeff"
+        "Jeff".as-bytes
+        42.3
+        14
+        false
 
   eq. ++> can-format-ordered-numbered-substitutions
     "first second second is after first"
-    printf *1
-      "%s %s %2$s is after %1$s"
-      "first"
-      "second"
+    "%s %s %2$s is after %1$s".printf
+      * "first" "second"
 
   eq. ++> can-ignore-extra-arguments
     "Hey"
-    printf *1
-      "%s"
-      "Hey"
-      "Jeff"
+    "%s".printf
+      * "Hey" "Jeff"
 
   eq. ++> can-left-align-bytes
     "40-45-00-00-00-00-00-00  "
-    printf *1
-      "%-25x"
-      42.as-bytes
+    "%-25x".printf
+      * 42.as-bytes
 
   eq. ++> can-preserve-an-escaped-bytes-format
     "%x"
-    printf
-      "%%x"
+    "%%x".printf
       *
 
   eq. ++> can-print-a-complex-string
     "Привет 3.140000 Jeff X!"
-    printf *1
-      "Привет %f %s %s!"
-      3.14
-      "Jeff"
-      "X"
+    "Привет %f %s %s!".printf
+      *
+        3.14
+        "Jeff"
+        "X"
 
   eq. ++> can-print-a-percent-sign
     "%Jeff"
-    printf *1
-      "%%%s"
-      "Jeff"
+    "%%%s".printf
+      * "Jeff"
 
   eq. ++> can-print-a-simple-string
     "Hello, Jeffrey!"
-    printf *1
-      "Hello, %s!"
-      "Jeffrey"
+    "Hello, %s!".printf
+      * "Jeffrey"
 
   eq. ++> can-print-an-i64-as-a-number
     "42"
-    printf *1
-      "%d"
-      42.as-i64.as-number
+    "%d".printf
+      * 42.as-i64.as-number
 
   eq. ++> can-print-bytes
     "40-45-00-00-00-00-00-00"
-    printf *1
-      "%x"
-      42.as-bytes
+    "%x".printf
+      * 42.as-bytes
 
   eq. ++> can-round-a-float-carrying-into-the-integer-part
     "1.000000"
-    printf *1
-      "%f"
-      0.9999999
+    "%f".printf
+      * 0.9999999
 
   eq. ++> can-truncate-a-negative-float-toward-zero
     "-7"
-    printf *1
-      "%d"
-      -7.89
+    "%d".printf
+      * -7.89
 
   eq. ++> can-truncate-a-positive-float-toward-zero
     "42"
-    printf *1
-      "%d"
-      42.321
+    "%d".printf
+      * 42.321
 
   eq. ++> can-truncate-rather-than-round-a-float
     "9"
-    printf *1
-      "%d"
-      9.99
+    "%d".printf
+      * 9.99
 
   not. ++> cannot-print-an-i64
     eq.
-      printf *1
-        "%d"
-        42.as-i64
+      "%d".printf
+        * 42.as-i64
       "42"
 
-  printf *1 --> stops-on-a-bool-as-a-string
+  printf. --> stops-on-a-bool-as-a-string
     "%s"
-    true
+    * true
 
-  printf *1 --> stops-on-a-comma-flag-with-s
+  printf. --> stops-on-a-comma-flag-with-s
     "%,s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-comma-flag-with-x
+  printf. --> stops-on-a-comma-flag-with-x
     "%,x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-hash-flag-with-s
+  printf. --> stops-on-a-hash-flag-with-s
     "%#s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-hash-flag-with-x
+  printf. --> stops-on-a-hash-flag-with-x
     "%#x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-non-utf8-byte-argument-as-a-string
+  printf. --> stops-on-a-non-utf8-byte-argument-as-a-string
     "%s"
-    3.14
+    * 3.14
 
-  printf *1 --> stops-on-a-number-as-a-string
+  printf. --> stops-on-a-number-as-a-string
     "%s"
-    42
+    * 42
 
-  printf *1 --> stops-on-a-paren-flag-with-s
+  printf. --> stops-on-a-paren-flag-with-s
     "%(s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-precision-with-d
+  printf. --> stops-on-a-precision-with-d
     "%.2d"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-zero-flag-with-x
+  printf. --> stops-on-a-zero-flag-with-x
     "%0x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-zero-positional-index
+  printf. --> stops-on-a-zero-positional-index
     "%0$s"
-    "first"
+    * "first"
 
-  printf *1 --> stops-on-an-i64-as-a-string
+  printf. --> stops-on-an-i64-as-a-string
     "%s"
-    42.as-i64
+    * 42.as-i64
 
-  printf *1 --> stops-on-an-oversized-positional-index
+  printf. --> stops-on-an-oversized-positional-index
     "%99999999999999999999$s"
-    "Jeff"
+    * "Jeff"
 
-  printf --> stops-on-an-unsupported-format
+  printf. --> stops-on-an-unsupported-format
     "%o"
     *
 
-  printf *1 --> stops-on-arguments-that-do-not-match
+  printf. --> stops-on-arguments-that-do-not-match
     "%s%s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-formatting-a-huge-number-as-a-decimal
+  printf. --> stops-on-formatting-a-huge-number-as-a-decimal
     "%d"
-    1.0e30
+    * 1.0e30
 
-  printf *1 --> stops-on-formatting-nan-as-a-decimal
+  printf. --> stops-on-formatting-nan-as-a-decimal
     "%d"
-    nan
+    * nan
 
-  printf *1 --> stops-on-the-negative-long-boundary-as-a-decimal
+  printf. --> stops-on-the-negative-long-boundary-as-a-decimal
     "%d"
-    -9.223372036854776e18
+    * -9.223372036854776e18

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -114,12 +114,7 @@
 
   eq. ++> can-advance-after-a-zero-width-match
     1
-    from.
-      next.
-        next.
-          match.
-            regex "/a*/"
-            "xa"
+    from. ("/a*/".regex.match "xa").next.next
 
   ++> can-count-supplementary-characters-as-one-position
     and. > @
@@ -130,10 +125,7 @@
         1.eq second.from
         2.eq second.to
     next. > first
-      match.
-        compiled.
-          regex "/./"
-        "😀x"
+      "/./".regex.compiled.match "😀x"
     first.next > second
 
   ++> can-expose-groups-on-each-matched-block
@@ -157,61 +149,43 @@
           second.group 2
           "2"
     next. > first
-      match.
-        compiled.
-          regex "/([a-z]+)([1-9]{1})/"
-        "!hello1!world2"
+      "/([a-z]+)([1-9]{1})/".regex.compiled.match "!hello1!world2"
     first.next > second
 
   matches. ++> can-ignore-comments-in-a-pattern
-    compiled.
-      regex
-        "/(\\d) #ignore this comment/x"
+    "/(\\d) #ignore this comment/x".regex.compiled
     "4"
 
-  matches. ++> can-match-a-text-against-a-pattern
-    compiled.
-      regex "/[a-z]+/"
-    "hello"
+  "/[a-z]+/".regex.compiled.matches "hello" ++> can-match-a-text-against-a-pattern
 
   matches. ++> can-match-a-text-containing-supplementary-characters
-    compiled.
-      regex "/😀x/"
+    "/😀x/".regex.compiled
     "😀x"
 
-  matches. ++> can-match-an-entire-pattern
-    compiled.
-      regex "/[0-9]/\\d+/"
-    "2/75"
+  "/[0-9]/\\d+/".regex.compiled.matches "2/75" ++> can-match-an-entire-pattern
 
   matches. ++> can-match-with-the-case-insensitive-option
-    compiled.
-      regex "/(string)/i"
+    "/(string)/i".regex.compiled
     "StRiNg"
 
   matches. ++> can-match-with-the-case-insensitive-option-and-capitals
-    compiled.
-      regex "/(word)/i"
+    "/(word)/i".regex.compiled
     "WORD"
 
   matches. ++> can-match-with-the-dotall-option
-    compiled.
-      regex "/(.*)/s"
+    "/(.*)/s".regex.compiled
     "too \\n many \\n line \\n Feed\\n"
 
   matches. ++> can-match-with-the-multiline-option
-    compiled.
-      regex "/(^([0-9]+).*)/m"
+    "/(^([0-9]+).*)/m".regex.compiled
     "1 bottle of water on the wall. \\n1 bottle of water."
 
   matches. ++> can-match-with-the-unicode-case-option
-    compiled.
-      regex "/(yildirim)/ui"
+    "/(yildirim)/ui".regex.compiled
     "Yıldırım"
 
   matches. ++> can-match-with-the-unix-lines-option
-    compiled.
-      regex "/(.+)/d"
+    "/(.+)/d".regex.compiled
     "A\\r\\nB\\rC\\nD"
 
   ++> can-report-the-border-indexes-of-a-match
@@ -221,16 +195,12 @@
         1.eq n.from
         6.eq n.to
     next. > n
-      match.
-        regex "/[a-z]+/"
-        "!hello!"
+      "/[a-z]+/".regex.match "!hello!"
 
   eq. ++> can-return-the-matched-string-sequence
     text.
       next.
-        match.
-          regex "/[a-z]+/"
-          "!hello!"
+        "/[a-z]+/".regex.match "!hello!"
     "hello"
 
   ++> can-return-the-second-matched-block
@@ -245,130 +215,87 @@
       second.to.eq 12
     next. > second
       next.
-        match.
-          regex "/[a-z]+/"
-          "!hello!world!"
+        "/[a-z]+/".regex.match "!hello!world!"
 
   not. ++> cannot-match-a-text-against-a-wrong-pattern
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "123"
+    "/[a-z]+/".regex.compiled.matches "123"
 
   not. ++> cannot-match-an-anchored-pattern-with-a-trailing-newline
-    matches.
-      compiled.
-        regex "/^[0-9]+$/"
-      "123\n"
+    "/^[0-9]+$/".regex.compiled.matches "123\n"
 
   not. ++> cannot-match-with-unmatched-leading-characters
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "1abc"
+    "/[a-z]+/".regex.compiled.matches "1abc"
 
   eq. ++> rejects-a-pattern-with-a-missing-slash
     "no-slash"
-    compile.
-      regex "(.)+"
+    "(.)+".regex.compile
       "no-slash" > [message]
 
   eq. ++> rejects-invalid-regex-syntax
     "recovered"
-    compile.
-      regex "/[a-z/"
+    "/[a-z/".regex.compile
       "recovered" > [message]
 
   not. ++> stops-on-a-terminal-zero-width-match
-    exists.
-      next.
-        next.
-          match.
-            regex "/$/"
-            "x"
+    exists. ("/$/".regex.match "x").next.next
 
   next. --> rejects-serialized-bytes-of-the-wrong-type
     match.
       pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
       "hello"
 
-  compiled. --> stops-on-a-missing-closing-slash
-    regex "/pattern"
+  "/pattern".regex.compiled --> stops-on-a-missing-closing-slash
 
-  compiled. --> stops-on-a-missing-first-slash
-    regex "(.)+"
+  "(.)+".regex.compiled --> stops-on-a-missing-first-slash
 
-  compile. --> stops-on-compiling-an-invalid-pattern
-    regex "/[a-z/"
+  "/[a-z/".regex.compile --> stops-on-compiling-an-invalid-pattern
 
   group. --> stops-on-taking-a-group-of-a-terminal-zero-width-match
     next.
       next.
-        match.
-          regex "/$/"
-          "x"
+        "/$/".regex.match "x"
     1
 
   group. --> stops-on-taking-a-group-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
     1
 
   to. --> stops-on-taking-the-end-position-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   count. --> stops-on-taking-the-group-count-of-a-terminal-zero-width-match
     next.
       next.
-        match.
-          regex "/$/"
-          "x"
+        "/$/".regex.match "x"
 
   count. --> stops-on-taking-the-group-count-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   groups. --> stops-on-taking-the-groups-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   next. --> stops-on-taking-the-next-of-a-terminal-zero-width-match
     next.
       next.
-        match.
-          regex "/$/"
-          "x"
+        "/$/".regex.match "x"
 
   next. --> stops-on-taking-the-next-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   from. --> stops-on-taking-the-start-position-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   text. --> stops-on-taking-the-text-of-a-terminal-zero-width-match
     next.
       next.
-        match.
-          regex "/$/"
-          "x"
+        "/$/".regex.match "x"
 
   text. --> stops-on-taking-the-text-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -36,56 +36,44 @@
 
   eq. ++> can-format-the-error-message-of-a-negative-count
     "Can't repeat text -1.000000 times"
-    repeated
-      "x"
+    "x".repeated
       -1
       message > [message]
 
   eq. ++> can-repeat-a-text-five-times
     "heyheyheyheyhey"
-    repeated
-      "hey"
-      5
+    "hey".repeated 5
 
   eq. ++> can-repeat-a-text-six-times
     "zxzxzxzxzxzx"
-    repeated
-      "zx"
-      6
+    "zx".repeated 6
 
   eq. ++> can-repeat-a-text-twenty-thousand-times
     20000
     size.
       as-bytes.
-        repeated "x" 20000
+        "x".repeated 20000
 
   eq. ++> can-repeat-a-text-zero-times
     ""
-    repeated
-      "some"
-      0
+    "some".repeated 0
 
   eq. ++> rejects-a-negative-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       -1
       "recovered" > [message]
 
   eq. ++> rejects-a-non-integer-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       2.5
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       pinf
       "recovered" > [message]
 
-  repeated --> stops-on-a-negative-count
-    ""
-    -1
+  "".repeated -1 --> stops-on-a-negative-count

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -36,43 +36,37 @@
           target.match reinit
 
   eq. ++> can-replace-a-nullable-pattern-like-java
-    replaced
-      "abc"
-      regex "/x*/"
+    "abc".replaced
+      "/x*/".regex
       "-"
     "-a-b-c-"
 
   eq. ++> can-replace-a-windows-separator-with-a-slash
-    replaced
-      "C:\\Windows\\Users\\AppLocal\\shrek"
-      regex "/[\\\\:]+/"
+    "C:\\Windows\\Users\\AppLocal\\shrek".replaced
+      "/[\\\\:]+/".regex
       "/"
     "C/Windows/Users/AppLocal/shrek"
 
   eq. ++> can-replace-digits-with-a-string
-    replaced
-      "Hell0, w0rld"
-      regex "/[0-9]+/"
+    "Hell0, w0rld".replaced
+      "/[0-9]+/".regex
       "o"
     "Hello, world"
 
   eq. ++> can-replace-slashes-with-a-windows-separator
-    replaced
-      "C:\\Windows/foo\\bar/hello.txt"
-      regex "/\\//"
+    "C:\\Windows/foo\\bar/hello.txt".replaced
+      "/\\//".regex
       "\\"
     "C:\\Windows\\foo\\bar\\hello.txt"
 
   eq. ++> can-sanitize-a-windows-path
-    replaced
-      "foo\\bar<:>?*\"|baz\\asdf"
-      regex "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/"
+    "foo\\bar<:>?*\"|baz\\asdf".replaced
+      "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/".regex
       ""
     "foo\\barbaz\\asdf"
 
   eq. ++> cannot-replace-when-the-pattern-is-absent
-    replaced
-      "Hello, world"
-      regex "/[0-9]+/"
+    "Hello, world".replaced
+      "/[0-9]+/".regex
       "12345"
     "Hello, world"

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -262,8 +262,7 @@
     false
 
   eq. ++> can-scan-a-complex-format
-    scanf
-      "Im%d %s old and this is! Let's calculate %f + %f= %f"
+    "Im%d %s old and this is! Let's calculate %f + %f= %f".scanf
       "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
     *
       18
@@ -275,62 +274,58 @@
   eq. ++> can-scan-a-complex-float
     1991.01
     head.
-      scanf
-        "this will be=%f"
+      "this will be=%f".scanf
         "this will be=1991.01"
 
   eq. ++> can-scan-a-complex-integer
     734987259
     head.
-      scanf "!%d!" "!734987259!"
+      "!%d!".scanf "!734987259!"
 
   eq. ++> can-scan-a-complex-string
     "test"
     head.
-      scanf "some%sstring" "someteststring"
+      "some%sstring".scanf "someteststring"
 
   eq. ++> can-scan-a-float
     0.24
     head.
-      scanf "%f" "0.24"
+      "%f".scanf "0.24"
 
   eq. ++> can-scan-an-integer
     33
     head.
-      scanf "%d" "33"
+      "%d".scanf "33"
 
   eq. ++> can-scan-a-negative-integer
     -42
     head.
-      scanf "%d" "-42"
+      "%d".scanf "-42"
 
   eq. ++> can-scan-a-positive-signed-integer
     42
     head.
-      scanf "%d" "+42"
+      "%d".scanf "+42"
 
   eq. ++> can-scan-a-zero-padded-integer
     42
     head.
-      scanf "%d" "00000000000000000042"
+      "%d".scanf "00000000000000000042"
 
   eq. ++> can-scan-a-zero-padded-negative-integer
     -42
     head.
-      scanf "%d" "-00000000000000000042"
+      "%d".scanf "-00000000000000000042"
 
   eq. ++> can-scan-many-zeroes-as-zero
     0
     head.
-      scanf "%d" "00000000000000000000"
+      "%d".scanf "00000000000000000000"
 
   eq. ++> can-scan-what-printf-wrote
-    scanf
-      "%s is about %d?"
-      printf *1
-        "%s is about %d?"
-        "This"
-        8
+    "%s is about %d?".scanf
+      "%s is about %d?".printf
+        * "This" 8
     *
       "This"
       8
@@ -338,11 +333,10 @@
   eq. ++> can-scan-a-string
     "hello"
     head.
-      scanf "%s" "hello"
+      "%s".scanf "hello"
 
   eq. ++> can-scan-a-string-an-integer-and-a-float
-    scanf
-      "%s %d %f"
+    "%s %d %f".scanf
       "hello 33 0.24"
     *
       "hello"
@@ -352,52 +346,44 @@
   eq. ++> can-scan-a-string-followed-by-a-literal
     "hello"
     head.
-      scanf "%s!" "hello!"
+      "%s!".scanf "hello!"
 
   eq. ++> can-scan-while-ignoring-trailing-text
     42
     head.
-      scanf
-        "id=%d"
+      "id=%d".scanf
         "id=42 suffix"
 
   eq. ++> cannot-scan-past-unmatched-leading-text
     length.
-      scanf
-        "id=%d"
+      "id=%d".scanf
         "prefix id=42"
     0
 
-  scanf --> stops-on-a-dangling-percent
-    "hello%"
-    "hello"
+  "hello%".scanf "hello" --> stops-on-a-dangling-percent
 
-  scanf --> stops-on-an-oversized-integer
-    "%d"
-    "99999999999999999999"
+  "%d".scanf "99999999999999999999" --> stops-on-an-oversized-integer
 
   gt. ++> can-scan-a-nineteen-digit-value-at-long-max
     head.
-      scanf "%d" "9223372036854775807"
+      "%d".scanf "9223372036854775807"
     9000000000000000000
 
   lt. ++> can-scan-a-nineteen-digit-value-at-long-min
     head.
-      scanf "%d" "-9223372036854775808"
+      "%d".scanf "-9223372036854775808"
     -9000000000000000000
 
-  scanf --> stops-on-a-nineteen-digit-value-above-long-max
+  scanf. --> stops-on-a-nineteen-digit-value-above-long-max
     "%d"
     "9223372036854775808"
 
-  scanf --> stops-on-a-nineteen-digit-value-below-long-min
+  scanf. --> stops-on-a-nineteen-digit-value-below-long-min
     "%d"
     "-9223372036854775809"
 
-  scanf --> stops-on-a-zero-padded-integer-above-long-max
+  scanf. --> stops-on-a-zero-padded-integer-above-long-max
     "%d"
     "00009223372036854775808"
 
-  scanf --> stops-on-a-wrong-format
-    "%l"
-    "error"
+  "%l".scanf "error" --> stops-on-a-wrong-format

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -172,8 +172,7 @@
     ""
 
   eq. ++> can-slice-the-origin-string
-    slice
-      "Hello, world!"
+    "Hello, world!".slice
       7
       5
     "world"
@@ -190,17 +189,17 @@
       2
     "ри"
 
-  slice --> stops-on-a-start-below-zero
+  slice. --> stops-on-a-start-below-zero
     "some string"
     -1
     1
 
-  slice --> stops-on-an-end-below-the-start
+  slice. --> stops-on-an-end-below-the-start
     "some string"
     2
     -1
 
-  slice --> stops-on-an-end-beyond-the-length
+  slice. --> stops-on-an-end-beyond-the-length
     "some string"
     7
     5

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -58,9 +58,7 @@
     delimiter >> delim!
 
   eq. ++> can-split-a-text-into-empty-strings
-    split
-      "-a-b-"
-      "-"
+    "-a-b-".split "-"
     *
       ""
       "a"
@@ -68,45 +66,35 @@
       ""
 
   eq. ++> can-split-a-text-on-a-dash
-    split
-      "a-b-c"
-      "-"
+    "a-b-c".split "-"
     *
       "a"
       "b"
       "c"
 
   eq. ++> can-split-a-text-on-a-multi-character-delimiter
-    split
-      "a::b::c"
-      "::"
+    "a::b::c".split "::"
     *
       "a"
       "b"
       "c"
 
   eq. ++> can-split-an-empty-text-into-one-empty-string
-    split
-      ""
-      "-"
+    "".split "-"
     * ""
 
   eq. ++> can-split-into-strings
     length.
       at.
-        split
-          "hello world!"
+        "hello world!".split
           " "
         1
     6
 
   eq. ++> rejects-an-empty-delimiter
     "recovered"
-    split
-      "abc"
+    "abc".split
       ""
       "recovered" > [message]
 
-  split --> stops-on-an-empty-delimiter
-    "abc"
-    ""
+  "abc".split "" --> stops-on-an-empty-delimiter

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -20,11 +20,10 @@
         size
       substring >> part!
 
-  starts-with ++> can-start-with-a-substring
+  starts-with. ++> can-start-with-a-substring
     "Hello, world"
     "Hello"
 
   not. ++> cannot-start-with-an-absent-substring
-    starts-with
-      "Hello, world"
+    "Hello, world".starts-with
       "world"

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -43,42 +43,28 @@
             c.eq 0C-
             c.eq 0D-
 
-  eq. ++> can-trim-a-leading-carriage-return
-    trimmed-left "\rvalue"
-    "value"
+  "\rvalue".trimmed-left.eq "value" ++> can-trim-a-leading-carriage-return
 
-  eq. ++> can-trim-a-leading-form-feed
-    trimmed-left "\fvalue"
-    "value"
+  "\fvalue".trimmed-left.eq "value" ++> can-trim-a-leading-form-feed
 
-  eq. ++> can-trim-a-leading-line-feed
-    trimmed-left "\nvalue"
-    "value"
+  "\nvalue".trimmed-left.eq "value" ++> can-trim-a-leading-line-feed
 
-  eq. ++> can-trim-a-leading-tab
-    trimmed-left "\tvalue"
-    "value"
+  "\tvalue".trimmed-left.eq "value" ++> can-trim-a-leading-tab
 
   eq. ++> can-trim-a-text-of-leading-spaces-only
-    trimmed-left
-      "     "
+    "     ".trimmed-left
     ""
 
-  eq. ++> can-trim-an-empty-text-from-the-left
-    trimmed-left ""
-    ""
+  "".trimmed-left.eq "" ++> can-trim-an-empty-text-from-the-left
 
   eq. ++> can-trim-many-leading-spaces
-    trimmed-left
-      "     some"
+    "     some".trimmed-left
     "some"
 
   eq. ++> can-trim-mixed-leading-whitespace
-    trimmed-left
-      " \t\n\f\rvalue"
+    " \t\n\f\rvalue".trimmed-left
     "value"
 
   eq. ++> can-trim-one-leading-space-from-the-left
-    trimmed-left
-      " s"
+    " s".trimmed-left
     "s"

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -42,41 +42,27 @@
             c.eq 0D-
 
   eq. ++> can-trim-a-text-of-trailing-spaces-only
-    trimmed-right
-      "     "
+    "     ".trimmed-right
     ""
 
-  eq. ++> can-trim-a-trailing-carriage-return
-    trimmed-right "value\r"
-    "value"
+  "value\r".trimmed-right.eq "value" ++> can-trim-a-trailing-carriage-return
 
-  eq. ++> can-trim-a-trailing-form-feed
-    trimmed-right "value\f"
-    "value"
+  "value\f".trimmed-right.eq "value" ++> can-trim-a-trailing-form-feed
 
-  eq. ++> can-trim-a-trailing-line-feed
-    trimmed-right "value\n"
-    "value"
+  "value\n".trimmed-right.eq "value" ++> can-trim-a-trailing-line-feed
 
-  eq. ++> can-trim-a-trailing-tab
-    trimmed-right "value\t"
-    "value"
+  "value\t".trimmed-right.eq "value" ++> can-trim-a-trailing-tab
 
-  eq. ++> can-trim-an-empty-text-from-the-right
-    trimmed-right ""
-    ""
+  "".trimmed-right.eq "" ++> can-trim-an-empty-text-from-the-right
 
   eq. ++> can-trim-many-trailing-spaces
-    trimmed-right
-      "some     "
+    "some     ".trimmed-right
     "some"
 
   eq. ++> can-trim-mixed-trailing-whitespace
-    trimmed-right
-      "value \t\n\f\r"
+    "value \t\n\f\r".trimmed-right
     "value"
 
   eq. ++> can-trim-one-trailing-space-from-the-right
-    trimmed-right
-      "s "
+    "s ".trimmed-right
     "s"

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -19,45 +19,34 @@
     trimmed-left
       trimmed-right text
 
-  eq. ++> can-preserve-inner-content
-    trimmed "no-whitespace"
-    "no-whitespace"
+  "no-whitespace".trimmed.eq "no-whitespace" ++> can-preserve-inner-content
 
   eq. ++> can-preserve-inner-whitespace
-    trimmed
-      "\t hello world \n"
+    "\t hello world \n".trimmed
     "hello world"
 
   eq. ++> can-trim-a-text-of-spaces-only
-    trimmed
-      "        "
+    "        ".trimmed
     ""
 
-  eq. ++> can-trim-an-empty-text
-    trimmed ""
-    ""
+  "".trimmed.eq "" ++> can-trim-an-empty-text
 
   eq. ++> can-trim-many-surrounding-spaces
-    trimmed
-      "    some     "
+    "    some     ".trimmed
     "some"
 
   eq. ++> can-trim-mixed-whitespace-on-both-sides
-    trimmed
-      " \t\n\f\rvalue \t\n\f\r"
+    " \t\n\f\rvalue \t\n\f\r".trimmed
     "value"
 
   eq. ++> can-trim-one-leading-space
-    trimmed
-      " some"
+    " some".trimmed
     "some"
 
   eq. ++> can-trim-one-space-on-both-sides
-    trimmed
-      " some "
+    " some ".trimmed
     "some"
 
   eq. ++> can-trim-one-trailing-space
-    trimmed
-      "some "
+    "some ".trimmed
     "some"

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -32,62 +32,46 @@
 
   eq. ++> can-count-characters-and-not-bytes-when-truncating
     "Жу"
-    truncated
-      "Жук"
-      2
+    "Жук".truncated 2
 
   eq. ++> can-format-the-error-message-of-a-negative-limit
     "Can't truncate text to -3.000000 characters"
-    truncated
-      "Jeff"
+    "Jeff".truncated
       -3
       message > [message]
 
   eq. ++> can-return-a-shorter-text-unchanged
     "hi"
-    truncated
-      "hi"
-      9
+    "hi".truncated 9
 
   eq. ++> can-return-a-text-of-the-exact-limit-unchanged
     "hey"
-    truncated
-      "hey"
-      3
+    "hey".truncated 3
 
   eq. ++> can-truncate-to-an-empty-text
     ""
-    truncated
-      "Jeffrey"
-      0
+    "Jeffrey".truncated 0
 
   eq. ++> can-truncate-to-fewer-characters
     "Jef"
-    truncated
-      "Jeffrey"
-      3
+    "Jeffrey".truncated 3
 
   eq. ++> rejects-a-negative-limit
     "recovered"
-    truncated
-      "Jeff"
+    "Jeff".truncated
       -3
       "recovered" > [message]
 
   eq. ++> rejects-a-non-integer-limit
     "recovered"
-    truncated
-      "Jeff"
+    "Jeff".truncated
       1.75
       "recovered" > [message]
 
   eq. ++> rejects-an-infinite-limit-when-truncating
     "recovered"
-    truncated
-      "Jeff"
+    "Jeff".truncated
       pinf
       "recovered" > [message]
 
-  truncated --> stops-on-a-negative-limit-when-truncating
-    "Jeff"
-    -3
+  "Jeff".truncated -3 --> stops-on-a-negative-limit-when-truncating

--- a/eo-runtime/src/main/eo/string/turkish.eo
+++ b/eo-runtime/src/main/eo/string/turkish.eo
@@ -38,36 +38,20 @@
         regex "/ı/"
         "I"
 
-  eq. ++> can-behave-like-the-wrapped-turkish-string
-    8
-    length.
-      turkish "İSTANBUL"
+  8.eq "İSTANBUL".turkish.length ++> can-behave-like-the-wrapped-turkish-string
 
-  eq. ++> can-lower-case-dotted-and-dotless-i
-    "ıistanbul"
-    lower.
-      turkish "IİSTANBUL"
+  "ıistanbul".eq "IİSTANBUL".turkish.lower ++> can-lower-case-dotted-and-dotless-i
 
   eq. ++> can-lower-case-every-occurrence-of-a-mapped-character
     "ıııı"
-    lower.
-      turkish "IIII"
+    "IIII".turkish.lower
 
   eq. ++> can-round-trip-a-lower-cased-word
     "ıstanbul"
-    lower.
-      turkish
-        upper.
-          turkish "ıstanbul"
+    "ıstanbul".turkish.upper.turkish.lower
 
   eq. ++> can-round-trip-an-upper-cased-word
     "İSTANBUL"
-    upper.
-      turkish
-        lower.
-          turkish "İSTANBUL"
+    "İSTANBUL".turkish.lower.turkish.upper
 
-  eq. ++> can-upper-case-dotted-and-dotless-i
-    "İSTANBUL"
-    upper.
-      turkish "istanbul"
+  "İSTANBUL".eq "istanbul".turkish.upper ++> can-upper-case-dotted-and-dotless-i

--- a/eo-runtime/src/main/eo/string/upper.eo
+++ b/eo-runtime/src/main/eo/string/upper.eo
@@ -21,6 +21,4 @@
 
   "HELLO".eq "hello".upper ++> can-upper-case-text
 
-  eq. ++> can-upper-case-text-through-the-package
-    "HELLO"
-    upper "hello"
+  "HELLO".eq "hello".upper ++> can-upper-case-text-through-the-package

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -22,7 +22,7 @@
         accum
 
   eq. ++> can-take-a-back-slice
-    back
+    back.
       *
         1
         2
@@ -35,7 +35,7 @@
       5
 
   eq. ++> can-take-a-back-slice-with-a-large-index
-    back
+    back.
       *
         1
         2
@@ -50,8 +50,8 @@
       4
       5
 
-  is-empty ++> can-take-a-back-slice-with-a-zero-index
-    back
+  is-empty. ++> can-take-a-back-slice-with-a-zero-index
+    back.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -22,18 +22,16 @@
           1
           2
           3
-    withouti > list3
-      concat *1
+    withouti. > list3
+      concat.
         * 0 1
-        2
-        3
+        * 2 3
       0
 
   eq. ++> can-concat-with-a-tuple
-    concat *1
+    concat.
       * 0 1
-      2
-      4
+      * 2 4
     *
       0
       1

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -12,7 +12,7 @@
     -1.eq
       index-of list element
 
-  contains ++> can-contain-a-number
+  contains. ++> can-contain-a-number
     *
       "qwerty"
       "asdfgh"
@@ -20,7 +20,7 @@
       "qwerty"
     3
 
-  contains ++> can-contain-a-string
+  contains. ++> can-contain-a-string
     *
       "qwerty"
       "asdfgh"
@@ -29,7 +29,7 @@
     "qwerty"
 
   not. ++> cannot-contain-an-absent-item
-    contains
+    contains.
       *
         "Привет"
         "asdfgh"

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -19,14 +19,14 @@
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 1 2 3
             m.put > [i] >>
               m.as-number.plus i
       6
 
   eq. ++> can-return-the-result-of-the-last-call
-    each
+    each.
       *
         1
         2
@@ -39,7 +39,7 @@
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 10 20 30
             m.put > [i] >>
               m.as-number.plus i
@@ -50,12 +50,11 @@
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 7
             m.put > [i] >>
               m.as-number.plus i
       7
 
-  each ++> can-walk-an-empty-list
-    *
+  tuple.empty.each ++> can-walk-an-empty-list
     false > [x]

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -24,7 +24,7 @@
       malloc.for
         0
         [m]
-          eachi > @
+          eachi. > @
             * 1 2 3
             m.put > [item index] >>
               plus.

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -17,7 +17,7 @@
     func item > [item index] >>
 
   eq. ++> can-filter-a-list
-    filtered
+    filtered.
       *
         3
         1
@@ -31,7 +31,7 @@
       5
 
   eq. ++> can-filter-bools
-    filtered
+    filtered.
       *
         true
         false

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -25,7 +25,7 @@
   | list > @
 
   eq. ++> can-filter-by-a-less-than-condition
-    filteredi
+    filteredi.
       *
         3
         1
@@ -38,7 +38,7 @@
       2
 
   eq. ++> can-filter-by-string-length
-    filteredi
+    filteredi.
       *
         "Hello"
         "Name"
@@ -47,13 +47,12 @@
       v.length.gt 4 > [v i]
     * "Hello"
 
-  is-empty ++> can-filter-an-empty-list
-    filteredi
-      *
+  is-empty. ++> can-filter-an-empty-list
+    tuple.empty.filteredi
       v.lt 3 > [v i]
 
   eq. ++> can-filter-by-index
-    filteredi
+    filteredi.
       *
         3
         1
@@ -64,7 +63,7 @@
       4
 
   eq. ++> can-filter-bools-with-indexes
-    filteredi
+    filteredi.
       *
         true
         false

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -30,7 +30,7 @@
         | list
 
   eq. ++> can-take-a-front-slice
-    front
+    front.
       *
         1
         2
@@ -41,7 +41,7 @@
     * 1
 
   eq. ++> can-take-a-front-slice-of-a-complex-list
-    front
+    front.
       *
         "foo"
         2.2
@@ -53,7 +53,7 @@
       2.2
 
   eq. ++> can-take-a-front-slice-of-a-complex-list-with-a-negative-index
-    front
+    front.
       *
         "foo"
         2.2
@@ -66,7 +66,7 @@
       "bar"
 
   eq. ++> can-take-a-front-slice-with-a-negative-index
-    front
+    front.
       *
         1
         2
@@ -74,8 +74,8 @@
       -1
     * 3
 
-  is-empty ++> can-take-a-front-slice-with-a-zero-index
-    front
+  is-empty. ++> can-take-a-front-slice-with-a-zero-index
+    front.
       *
         1
         2
@@ -83,7 +83,7 @@
       0
 
   eq. ++> can-take-a-front-slice-with-the-length-as-index
-    front
+    front.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -25,7 +25,7 @@
 
   eq. ++> can-find-the-index-of-a-non-symmetric-match
     1
-    index-of
+    index-of.
       *
         10
         20
@@ -36,7 +36,7 @@
 
   eq. ++> can-find-the-index-of-a-string
     1
-    index-of
+    index-of.
       *
         "asdfgh"
         "qwerty"
@@ -45,7 +45,7 @@
 
   eq. ++> can-return-the-first-index-of-an-element
     0
-    index-of
+    index-of.
       *
         -1
         2
@@ -54,7 +54,7 @@
 
   eq. ++> can-return-the-index-of-an-element
     1
-    index-of
+    index-of.
       *
         1
         2
@@ -63,7 +63,7 @@
 
   eq. ++> cannot-find-the-index-of-an-absent-item
     -1
-    index-of
+    index-of.
       *
         "qwerty"
         2

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -10,23 +10,19 @@
 [list] > is-empty
   0.eq list.length > @
 
-  is-empty ++> can-be-empty-when-built-empty
-    *
+  tuple.empty.is-empty ++> can-be-empty-when-built-empty
 
   ++> cannot-be-empty-with-one-anonymous-object
-    not. > @
-      is-empty xs
+    xs.is-empty.not > @
     * > xs
       [f]
 
   not. ++> cannot-be-empty-with-one-item
-    is-empty *
-      1
-      2
+    is-empty.
+      * 1 2
 
   ++> cannot-be-empty-with-three-objects
-    not. > @
-      is-empty xs
+    xs.is-empty.not > @
     * > xs
       [x]
       [y]

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -20,7 +20,7 @@
 
   eq. ++> can-find-the-last-index-of-an-item
     1
-    last-index-of
+    last-index-of.
       *
         "qwerty"
         2
@@ -29,7 +29,7 @@
 
   eq. ++> can-find-the-last-index-of-a-repeated-item
     2
-    last-index-of
+    last-index-of.
       *
         24
         42
@@ -38,7 +38,7 @@
 
   eq. ++> cannot-find-the-last-index-of-an-absent-item
     -1
-    last-index-of
+    last-index-of.
       *
         1
         2
@@ -47,13 +47,11 @@
 
   eq. ++> cannot-find-the-last-index-in-an-empty-list
     -1
-    last-index-of
-      *
-      "abc"
+    tuple.empty.last-index-of "abc"
 
   eq. ++> can-find-the-last-index-of-a-unicode-item
     3
-    last-index-of
+    last-index-of.
       *
         "Hi"
         "Привет"
@@ -64,7 +62,7 @@
 
   eq. ++> can-find-the-last-index-of-a-non-symmetric-match
     4
-    last-index-of
+    last-index-of.
       *
         10
         20

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -15,7 +15,7 @@
     func item > [item idx] >>
 
   eq. ++> can-map-a-list
-    mapped
+    mapped.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -18,7 +18,7 @@
       func item idx
 
   eq. ++> can-map-a-list-with-indexes
-    mappedi
+    mappedi.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -23,36 +23,37 @@
         max
 
   eq. ++> can-take-a-maximum-of-one-item
-    maximum
+    maximum.
       * 42
     42
 
   eq. ++> can-take-a-maximum-that-is-first
-    maximum *
-      25
-      12
-      -2
+    maximum.
+      *
+        25
+        12
+        -2
     25
 
   eq. ++> can-take-a-maximum-that-is-in-the-middle
-    maximum *
-      12
-      25
-      -2
+    maximum.
+      *
+        12
+        25
+        -2
     25
 
   eq. ++> can-take-a-maximum-that-is-last
-    maximum *
-      12
-      -2
-      25
+    maximum.
+      *
+        12
+        -2
+        25
     25
 
   eq. ++> rejects-an-empty-list-when-taking-the-maximum
     "recovered"
-    maximum
-      *
+    tuple.empty.maximum
       "recovered" > [msg]
 
-  maximum --> stops-on-an-empty-list-when-taking-the-maximum
-    *
+  tuple.empty.maximum --> stops-on-an-empty-list-when-taking-the-maximum

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -23,36 +23,37 @@
         min
 
   eq. ++> can-take-a-minimum-of-one-item
-    minimum
+    minimum.
       * 42
     42
 
   eq. ++> can-take-a-minimum-that-is-first
-    minimum *
-      -2
-      25
-      12
+    minimum.
+      *
+        -2
+        25
+        12
     -2
 
   eq. ++> can-take-a-minimum-that-is-in-the-middle
-    minimum *
-      12
-      -2
-      25
+    minimum.
+      *
+        12
+        -2
+        25
     -2
 
   eq. ++> can-take-a-minimum-that-is-last
-    minimum *
-      12
-      25
-      -2
+    minimum.
+      *
+        12
+        25
+        -2
     -2
 
   eq. ++> rejects-an-empty-list-when-taking-the-minimum
     "recovered"
-    minimum
-      *
+    tuple.empty.minimum
       "recovered" > [msg]
 
-  minimum --> stops-on-an-empty-list-when-taking-the-minimum
-    *
+  tuple.empty.minimum --> stops-on-an-empty-list-when-taking-the-minimum

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -19,7 +19,7 @@
       item
 
   eq. ++> can-reduce-a-list
-    reduced
+    reduced.
       *
         1
         2
@@ -30,7 +30,7 @@
     -24
 
   eq. ++> can-reduce-a-list-into-a-string
-    reduced
+    reduced.
       * 0 1
       ""
       acc.concat > [acc item]

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -28,7 +28,7 @@
 
   ++> can-reduce-a-list-with-indexes
     6.eq > @
-      reducedi
+      reducedi.
         * 1 1
         0
         x.plus > [a x i] >>
@@ -38,7 +38,7 @@
               i
 
   eq. ++> can-reduce-a-long-integer-list-with-indexes
-    reducedi
+    reducedi.
       *
         0
         0
@@ -90,7 +90,7 @@
     1
 
   not. ++> can-reduce-bools-with-indexes
-    reducedi
+    reducedi.
       *
         true
         true
@@ -100,7 +100,7 @@
 
   ++> can-reduce-with-nested-functions
     eq. > @
-      reducedi
+      reducedi.
         * 10 500
         0
         [acc x i]

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -17,7 +17,7 @@
     list.length
 
   eq. ++> can-ignore-a-negative-shift
-    shifted
+    shifted.
       *
         "привет"
         -42
@@ -31,7 +31,7 @@
       "ξ"
 
   eq. ++> can-ignore-a-shift-below-the-negative-length
-    shifted
+    shifted.
       *
         82.42
         ""
@@ -43,7 +43,7 @@
       "日本"
 
   eq. ++> can-ignore-a-zero-shift
-    shifted
+    shifted.
       *
         "a"
         -0.5
@@ -55,7 +55,7 @@
       "Ω"
 
   eq. ++> can-shift-by-less-than-the-length
-    shifted
+    shifted.
       *
         8
         2
@@ -69,7 +69,7 @@
       5
 
   eq. ++> can-shift-by-more-than-the-length
-    shifted
+    shifted.
       *
         8
         2

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -48,7 +48,7 @@
       "Given slice start and end must both be integers"
 
   eq. ++> can-slice-a-list
-    slice
+    slice.
       *
         1
         2
@@ -64,7 +64,7 @@
       5
 
   eq. ++> can-slice-with-a-negative-end
-    slice
+    slice.
       *
         "a"
         2
@@ -82,7 +82,7 @@
       82.42
 
   eq. ++> can-slice-with-a-negative-start
-    slice
+    slice.
       *
         8
         76
@@ -99,7 +99,7 @@
       8
 
   eq. ++> can-slice-with-a-negative-start-and-end
-    slice
+    slice.
       *
         8
         23
@@ -114,7 +114,7 @@
       0
 
   eq. ++> can-slice-with-a-negative-start-not-below-the-end
-    slice
+    slice.
       *
         "f"
         1
@@ -127,7 +127,7 @@
     *
 
   eq. ++> can-slice-with-a-start-below-the-negative-length
-    slice
+    slice.
       *
         9
         99
@@ -141,7 +141,7 @@
       999
 
   eq. ++> can-slice-with-a-start-not-below-a-negative-end
-    slice
+    slice.
       *
         8
         -2
@@ -154,7 +154,7 @@
     *
 
   eq. ++> can-slice-with-a-start-not-below-the-end-when-both-negative
-    slice
+    slice.
       *
         3
         92
@@ -168,7 +168,7 @@
     *
 
   eq. ++> can-slice-with-a-start-not-below-the-end-when-both-positive
-    slice
+    slice.
       *
         3
         "-5"
@@ -179,7 +179,7 @@
     *
 
   eq. ++> can-slice-with-an-end-below-the-negative-length
-    slice
+    slice.
       *
         "A"
         "b"
@@ -191,7 +191,7 @@
     *
 
   eq. ++> can-slice-with-an-end-beyond-the-length
-    slice
+    slice.
       *
         "foo"
         "bar"
@@ -202,7 +202,7 @@
       "bar"
       "buzz"
 
-  slice --> stops-on-a-fractional-end
+  slice. --> stops-on-a-fractional-end
     *
       1
       2
@@ -210,7 +210,7 @@
     0
     2.5
 
-  slice --> stops-on-a-fractional-start
+  slice. --> stops-on-a-fractional-start
     *
       1
       2

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -24,7 +24,7 @@
       index
 
   eq. ++> can-clamp-a-negative-index-to-the-front-without-duplicating
-    withi
+    withi.
       *
         1
         2
@@ -38,7 +38,7 @@
       3
 
   eq. ++> can-clamp-an-index-beyond-the-end-without-duplicating
-    withi
+    withi.
       *
         1
         2
@@ -52,7 +52,7 @@
       9
 
   eq. ++> can-insert-at-a-zero-index
-    withi
+    withi.
       *
         1
         2
@@ -70,7 +70,7 @@
       5
 
   eq. ++> can-insert-at-an-index
-    withi
+    withi.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -17,7 +17,7 @@
       accum.with item
 
   eq. ++> can-drop-an-item
-    without
+    without.
       *
         1
         2

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -17,7 +17,7 @@
       accum.with item
 
   eq. ++> can-drop-an-item-by-index
-    withouti
+    withouti.
       *
         1
         2
@@ -34,12 +34,10 @@
         "text"
         "f"
       * "text" "f"
-    withouti > [a] > foo
-      a
-      0
+    a.withouti 0 > [a] > foo
 
   eq. ++> can-drop-an-item-by-index-in-a-nested-list
-    withouti
+    withouti.
       *
         "smthg"
         27


### PR DESCRIPTION
Tests living inside a package member often applied that member standalone, by name, and passed the receiver as the first argument:

```
truncated --> stops-on-a-negative-limit-when-truncating
  "Jeff"
  -3
```

That only works while the member is a separate object sitting next to `string`. After `MjMerge` folds members into the same-named object, the bare name has nothing left to resolve, so every such site now goes through dispatch instead:

```
"Jeff".truncated -3 --> stops-on-a-negative-limit-when-truncating
```

577 sites across 79 files, own-member and cross-member alike (`tuple/back.eo` calling `is-empty`, for one). Six members keep the standalone form on purpose — `bytes.hash`, `number.integral`, `string.as-char`, `string.as-decimal`, `string.as-fixed`, `string.as-hex` — because their first void is not an instance of the enclosing package object, so there is no receiver to dispatch on.

Compact tuples needed spelling out. `printf "%.3s" *1 "Jeffrey"` cannot become `printf. *1 …`: PARSER_SPEC R-3.9.1 lists a bare reversed head as legal there, but the parser rejects it, so those 56 heads carry an explicit `*` instead. Worth filing separately.

Test count is unchanged, 1596 markers before and after; every hunk sits below its file's first marker, so no production code moved. The 1204 `inconsistent-args` warnings from a standalone `eo:lint` are the same 1204 master already emits — the build's own `compile` execution skips that rule.

Closes #6682.
