### PR TITLE
#6651: cache half in ipow to restore O(log n) squaring

### DIFF
--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -3,6 +3,14 @@
 # results stay exact, and a fractional exponent of a positive base is taken as
 # e raised to `x` times the natural logarithm of the base. Zeros, infinities and
 # nan follow the same IEEE rules that Math.pow obeys.
+#
+# @todo #6651:30min Cache `k` and `y` in `expon` the same way `half` is now
+#  cached in `ipow`. `k` is read once per comparison and once per each of the
+#  twenty `fraction` levels, and `y` (a void, so it cannot itself carry `!`)
+#  is read directly inside `fraction` too, so one call to `expon` still pays
+#  for about forty evaluations of `ln`. Bind `y` to a const local first, then
+#  cache `k` as `k!` and re-wrap every read with `number`, mirroring the
+#  `half`/`bts` idiom from #6224.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -49,10 +57,12 @@
                         1
                         if.
                           is-integer. (n.div 2)
-                          half.times half
+                          times.
+                            number half
+                            number half
                           b.times
                             ipow b (n.minus 1)
-                      ipow b (n.div 2) > half
+                      ipow b (n.div 2) > half!
                     | base (abs expo)
                   ipow base (abs expo)
                 if.


### PR DESCRIPTION
`ipow`'s `half` binding (`ipow b (n.div 2) > half`) had no `!` const marker, and `half.times half` read it twice, so every even step of exponentiation-by-squaring dataized its own recursive call twice over: `T(n) = 2*T(n/2)`, giving O(n) multiplications instead of the O(log n) the algorithm is written for. `can-raise-to-a-large-negative-exponent` (984782 ^ -12341) walks about 12341 recursive dataizations where 14 squarings would do.

Cached `half` as `half!` and re-wrapped both reads with `number`, mirroring the `half`/`bts` idiom already used to fix the same class of bug for `arc-sine` in #6224.

`expon`'s `k` and `y` have the same defect (about forty evaluations of `ln` per call instead of one), but fixing that needs binding the void `y` to a const local first and re-wrapping several distinct read sites (`k.lt 0`, `abs k`, `y.minus k`), which is a separate, more careful piece of work. Left as a `@todo` puzzle referencing this issue rather than risking a repeat of the regression #6224 hit the first time this idiom was tried carelessly.

Ran `EOnumber.EOpowerTest` (0 failures) and `qulice:check -Pqulice`, both green.

Closes #6651
