### PR TITLE
Seal a bottom with its reason when it propagates through a dispatch

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -129,7 +129,6 @@ public final class PhTerminator implements Phi {
     /**
      * The reason to panic with, either the cause this bottom was given or the
      * plain explanation of a bottom that was born without one.
-     *
      * @return The reason as an object
      */
     private Phi reason() {

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -14,31 +14,28 @@ package org.eolang;
  * nothing intercepts, so forcing bottom terminates the program for good.</p>
  *
  * <p>The remaining operations are tolerant on purpose: {@link #copy()}
- * yields the same bottom and {@link #take(String)} yields bottom again, so it
- * propagates through copying and dispatch and surfaces the failure at
- * the outer dataization, not at the point it was produced.</p>
+ * yields the same bottom and {@link #take(String)} yields another one carrying
+ * the same reason, so it propagates through copying and dispatch and surfaces
+ * the failure at the outer dataization, not at the point it was produced.</p>
  *
  * <p>A bottom may carry a <em>cause</em>: it has a single slot, addressable only
- * at position 0 (as in {@code T "why it failed"}). A {@code put} at any other
- * position is ignored rather than rejected, because a propagated bottom answers
- * every take with itself and then receives the arguments of whatever dispatch
- * follows it: a two-argument one, such as {@code .if a b}, would otherwise abort
- * on its second argument and destroy the cause it was carrying. A {@code put} by
+ * at position 0 (as in {@code T "why it failed"}). Only a bottom without a cause
+ * listens to that slot, and a dispatch hands one to the bottom it yields, so the
+ * arguments that follow a propagated bottom, as in {@code (T).if a b}, are
+ * dropped instead of being read as the reason it terminated. A {@code put} by
  * name other than ρ aborts — bottom has no named attributes. The ρ-binding the
  * runtime attempts on every take (via {@link AtWithRho}) is silently ignored,
  * since a bottom has no ρ; this keeps its cause from being masked by a
- * ρ-rejection while it propagates. The first object put at position 0 is
- * remembered and used as the panic message when the bottom is finally forced.
- * The cause is write-once and never handed back by {@link #take(String)}, so
- * EO code can neither read it nor catch it — it exists only to explain the
- * termination at the very top.</p>
+ * ρ-rejection while it propagates. The cause is write-once and never handed back
+ * by {@link #take(String)}, so EO code can neither read it nor catch it — it
+ * exists only to explain the termination at the very top.</p>
  *
  * @since 0.73.1
- * @todo #6359:45min Keep a causeless bottom from adopting a dispatch argument.
- *  Position 0 is both the cause slot of {@code T "why"} and the first argument
- *  of whatever dispatch follows a propagated bottom, so {@code (T).if 1 2} takes
- *  the {@code 1} as its cause and panics with those bytes read as text, instead
- *  of saying that the computation was terminated.
+ * @todo #6632:45min Give a bottom its reason at every birth site.
+ *  {@link AtVoid} and {@link PhDefault} both hand out a causeless bottom, and one
+ *  of those, applied without a dispatch in between as in {@code obj.missing a b},
+ *  still swallows the {@code a} as its cause; each site should say what went
+ *  missing instead of leaving the slot open.
  */
 public final class PhTerminator implements Phi {
 
@@ -83,7 +80,9 @@ public final class PhTerminator implements Phi {
 
     @Override
     public Phi take(final String name) {
-        return this;
+        final PhTerminator term = new PhTerminator();
+        term.put(0, this.reason());
+        return term;
     }
 
     @Override
@@ -114,13 +113,7 @@ public final class PhTerminator implements Phi {
 
     @Override
     public byte[] delta() {
-        final String reason;
-        if (this.cause == null) {
-            reason = "the ⊥ object is a terminated computation and cannot be used";
-        } else {
-            reason = new Dataized(this.cause).asString();
-        }
-        throw new ExFailure("%s", reason);
+        throw new ExFailure("%s", new Dataized(this.reason()).asString());
     }
 
     @Override
@@ -131,5 +124,21 @@ public final class PhTerminator implements Phi {
     @Override
     public String φTerm() {
         return "⊥";
+    }
+
+    /**
+     * The reason to panic with, either the cause this bottom was given or the
+     * plain explanation of a bottom that was born without one.
+     *
+     * @return The reason as an object
+     */
+    private Phi reason() {
+        final Phi reason;
+        if (this.cause == null) {
+            reason = new Data.ToPhi("the ⊥ object is a terminated computation and cannot be used");
+        } else {
+            reason = this.cause;
+        }
+        return reason;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -129,6 +129,41 @@ final class PhTerminatorTest {
     }
 
     @Test
+    void keepsDispatchArgumentsOutOfTheCause() {
+        MatcherAssert.assertThat(
+            "a bottom reached by a dispatch names the argument it was handed, not the termination",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        new PhDispatch(new PhTerminator(), "if"),
+                        new Bind(0, new Data.ToPhi("первый")),
+                        new Bind(1, new Data.ToPhi("второй"))
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("terminated computation")
+        );
+    }
+
+    @Test
+    void carriesTheCauseThroughDispatch() {
+        MatcherAssert.assertThat(
+            "the reason a bottom was born with is lost once it travels through a dispatch",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        new PhDispatch(PhTerminator.withCause("cannot open Ω"), "eq"),
+                        new Bind(0, new Data.ToPhi("другое"))
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.equalTo("cannot open Ω")
+        );
+    }
+
+    @Test
     void toleratesPutAtOtherPositions() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(1, new Data.ToPhi("nope")),


### PR DESCRIPTION
A bottom that reached a dispatch used to answer with itself, so the arguments of whatever call followed it landed in its cause slot. `(T).if 1 2` took the `1` as the reason it terminated and then panicked with those bytes read as text, which said nothing about the computation having been terminated at all.

Now a dispatch hands the bottom it yields a reason at birth: the cause the original was carrying, or the plain explanation when it had none. Since the slot is write-once, the arguments that follow are dropped instead of being mistaken for a reason, and a cause given to `T "why"` now survives the dispatches it travels through rather than only surviving them by accident.

The same swallowing still happens at the two other places a causeless bottom is born, `AtVoid.get` for an unbound void and `PhDefault.absent` for a missing attribute, when one of them is applied with no dispatch in between, as in `obj.missing a b`. Closing that needs each site to name what went missing, which changes messages more widely, so it is left as a puzzle.

Closes #6632
