### PR TITLE
#6594 #6595: remove unescapeBody and its exclusive appendOctal helper

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -234,38 +234,6 @@ final class Emissions {
     }
 
     /**
-     * Decode escape sequences from a raw string body (without
-     * surrounding quotes). Supports {@code \n}, {@code \t}, {@code \r},
-     * {@code \b}, {@code \f}, {@code \"}, {@code \'}, {@code \\},
-     * {@code \\uXXXX} unicode, and {@code \NNN} octal escapes.
-     * @param inner Source body (no quotes)
-     * @return Decoded text
-     */
-    static String unescapeBody(final String inner) {
-        final StringBuilder out = new StringBuilder(inner.length());
-        int idx = 0;
-        while (idx < inner.length()) {
-            final char glyph = inner.charAt(idx);
-            if (glyph != '\\' || idx + 1 >= inner.length()) {
-                out.append(glyph);
-                idx = idx + 1;
-                continue;
-            }
-            final char next = inner.charAt(idx + 1);
-            if (next == 'u') {
-                idx = Emissions.appendUnicode(out, inner, idx + 1);
-            } else if (next >= '0' && next <= '7') {
-                idx = Emissions.appendOctal(out, inner, idx + 1);
-            } else {
-                out.append(Emissions.singleCharEscape(glyph, next));
-                idx = idx + 2;
-            }
-        }
-        Emissions.rejectLoneSurrogates(out);
-        return out.toString();
-    }
-
-    /**
      * Decode a string body to its raw byte representation.
      * @param inner Source body without surrounding quotes
      * @return Decoded bytes
@@ -615,38 +583,6 @@ final class Emissions {
         final byte[] bytes = text.toString().getBytes(StandardCharsets.UTF_8);
         out.write(bytes, 0, bytes.length);
         text.setLength(0);
-    }
-
-    /**
-     * Decode an octal escape {@code \NNN} (1 to 3 octal digits)
-     * starting at the first digit position and append the resulting
-     * codepoint to {@code out}.
-     * @param out Output buffer
-     * @param body String body
-     * @param start Index of the first octal digit
-     * @return Index past the consumed digits
-     */
-    private static int appendOctal(
-        final StringBuilder out, final String body, final int start
-    ) {
-        int cursor = start;
-        int value = 0;
-        while (cursor < body.length()
-            && cursor < start + 3
-            && body.charAt(cursor) >= '0' && body.charAt(cursor) <= '7') {
-            value = value * 8 + body.charAt(cursor) - '0';
-            cursor = cursor + 1;
-        }
-        if (value > Emissions.MAX_OCTAL_BYTE) {
-            throw new NumberFormatException(
-                String.format(
-                    "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
-                    body.substring(start, cursor), value
-                )
-            );
-        }
-        out.append((char) value);
-        return cursor;
     }
 
     /**


### PR DESCRIPTION
`Emissions.unescapeBody` has no callers anywhere in the repository (`grep -rn "unescapeBody\b"` outside its own definition returns zero hits) — #6594. Its only caller of `appendOctal` was itself, so once `unescapeBody` is gone `appendOctal` becomes unreachable too — #6595. Both are removed together since they were only reachable through each other; leaving one without the other would still be dead code.

`appendUnicode`, `singleCharEscape`, `rejectLoneSurrogates` and `MAX_OCTAL_BYTE` all stay, they're still used by the live `unescapeBytes` sibling method.

Ran the full `eo-parser` test suite (1085 tests) and `qulice:check -Pqulice`, both green.

Closes #6594, #6595
