### PR TITLE
#6447: skip createDirectories when atomsOutput has no parent

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
@@ -125,7 +125,10 @@ public final class MjAtomsTable extends MjSafe {
      */
     private void write(final Map<String, String> table) throws IOException {
         final Path target = this.atomsOutput.toPath();
-        Files.createDirectories(target.getParent());
+        final Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
         final StringBuilder out = new StringBuilder();
         for (final Map.Entry<String, String> entry : table.entrySet()) {
             out.append(entry.getKey())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
@@ -55,6 +55,24 @@ final class MjAtomsTableTest {
     }
 
     @Test
+    void writesTableWhenOutputHasNoParentDirectory(@Mktmp final Path temp) throws Exception {
+        final Path output = Path.of("mjatomstable-6447-test.csv");
+        try {
+            new FakeMaven(temp)
+                .with("atomsInputDir", temp.resolve("nothing").toFile())
+                .with("atomsOutput", output.toFile())
+                .execute(MjAtomsTable.class);
+            MatcherAssert.assertThat(
+                "A parentless atomsOutput must not throw and must produce the file",
+                Files.exists(output),
+                Matchers.is(true)
+            );
+        } finally {
+            Files.deleteIfExists(output);
+        }
+    }
+
+    @Test
     void writesEmptyTableWhenNoXmirSources(@Mktmp final Path temp) throws Exception {
         new FakeMaven(temp)
             .with("atomsInputDir", temp.resolve("nothing").toFile())


### PR DESCRIPTION
`MjAtomsTable.write()` called `Files.createDirectories(target.getParent())` unconditionally. For a parentless relative path like `atoms.csv`, `getParent()` is null, so `createDirectories` throws a `NullPointerException` before the table is written.

Skip the directory creation when there is no parent to create.

Added a test that configures `atomsOutput` as a bare filename and verifies the file is written instead of throwing.

Closes #6447
