### PR TITLE
Split the value before scaling so large magnitudes keep their digits

### DIFF
--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -5,12 +5,9 @@
 # or infinite), the `cant-print` fallback is returned, or the bottom object
 # when unbound.
 #
-# @todo #6572:30min Scale a large value without losing its last digits. The
-#  `positive` object below multiplies the value by a power of ten in double
-#  arithmetic, so a product above 2^53 is rounded and the integer part handed
-#  to `as-decimal` can be off by one, which makes `printf`'s `%f` misprint a
-#  magnitude past 2^53 that `%d` now prints exactly; split the value into its
-#  integer and fraction parts over `i64` before scaling.
+# The value is split into its integer and fraction parts before scaling, so
+# only the fraction is multiplied by a power of ten and every magnitude that
+# `as-decimal` writes exactly is written exactly here too.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -43,23 +40,29 @@
       | (n.times -1)
       [a] >> positive
         if. > @
+          digits.eq scale
+          written
+            whole.plus 1
+            0
+          written whole digits
+        if. > [unit rest] >> written
           places.eq 0
-          as-decimal ip
+          as-decimal unit
           concat.
             concat.
-              as-decimal ip
+              as-decimal unit
               ".".as-bytes
             rec-pad
-              m.minus
-                ip.times scale
+              rest
               places
               --
-        floor. > ip
-          m.div scale
-        floor. > m
+        floor. > digits
           plus.
-            a.times scale
+            times.
+              a.minus whole
+              scale
             0.5
+        a.floor > whole
         pow10 places > scale
       | n
   if. > [p] >> pow10
@@ -91,6 +94,11 @@
     "1.000000"
     string
       as-fixed 0.9999999 6
+
+  eq. ++> can-carry-rounding-into-the-integer-part-with-zero-places
+    "1"
+    string
+      as-fixed 0.9999999 0
 
   eq. ++> can-drop-the-sign-of-a-negative-rounding-to-zero
     "0.00"
@@ -133,6 +141,16 @@
     "0.123457"
     string
       as-fixed 0.123456789 6
+
+  eq. ++> can-scale-a-magnitude-above-two-to-the-53rd
+    "100000000000000000.000000"
+    string
+      as-fixed 1.0e17 6
+
+  eq. ++> can-scale-a-negative-magnitude-above-two-to-the-53rd
+    "-100000000000000000.000000"
+    string
+      as-fixed -1.0e17 6
 
   eq. ++> can-write-a-negative-value
     "-2.500000"

--- a/eo-runtime/src/main/eo/string/as-fixed.eo
+++ b/eo-runtime/src/main/eo/string/as-fixed.eo
@@ -41,29 +41,24 @@
       [a] >> positive
         if. > @
           digits.eq scale
-          written
-            whole.plus 1
-            0
-          written whole digits
-        if. > [unit rest] >> written
-          places.eq 0
-          as-decimal unit
-          concat.
+          if. > [unit rest] >> written
+            places.eq 0
+            as-decimal unit
             concat.
-              as-decimal unit
-              ".".as-bytes
-            rec-pad
-              rest
-              places
-              --
+              concat.
+                as-decimal unit
+                ".".as-bytes
+              rec-pad rest places --
+          | (whole.plus 1) 0
+          written whole digits
         floor. > digits
           plus.
             times.
               a.minus whole
               scale
             0.5
-        a.floor > whole
         pow10 places > scale
+        a.floor > whole
       | n
   if. > [p] >> pow10
     p.eq 0
@@ -145,12 +140,12 @@
   eq. ++> can-scale-a-magnitude-above-two-to-the-53rd
     "100000000000000000.000000"
     string
-      as-fixed 1.0e17 6
+      as-fixed 100000000000000000 6
 
   eq. ++> can-scale-a-negative-magnitude-above-two-to-the-53rd
     "-100000000000000000.000000"
     string
-      as-fixed -1.0e17 6
+      as-fixed -100000000000000000 6
 
   eq. ++> can-write-a-negative-value
     "-2.500000"


### PR DESCRIPTION
`as-fixed` used to multiply the whole value by `10^places` and then divide the product back down to recover the integer part. Past 2^53 that product no longer lands on an exact double, so the integer part handed to `as-decimal` came out short: `1.0e17` with six places printed `99999999999999984.000000`, while `as-decimal` writes the same magnitude exactly because it peels its digits off an `i64`. `printf`'s `%f` inherited the same misprint, so `%f` and `%d` disagreed on the same number.

Now the value is split into its integer and fraction parts first, and only the fraction — always below one — is scaled. The integer part travels to `as-decimal` untouched, so every magnitude `as-decimal` writes exactly is written exactly here too. Rounding that spills over one, like `0.9999999` at six places, is carried into the integer part explicitly instead of falling out of the division.

Four tests cover it: the two magnitudes past 2^53, positive and negative, both of which fail on the old code, plus the carry into the integer part at zero places, which the rewrite reaches through a new path.

Closes #6634
