### PR TITLE
Account for the attributes a package hands to its owner

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Members.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Members.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.yegor256.tojos.Tojos;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * What the packages of a program hand to the objects they are named after.
+ *
+ * <p>A package is a prefix of a locator, so {@code minus} in the package
+ * {@code number} is {@code Φ.number.minus} and belongs to {@code Φ.number}
+ * without ever appearing among the children of that formation. Reading the
+ * object at the top of every file is what finds those attributes, and it is
+ * the only way to find them: nothing inside the formation mentions them.</p>
+ *
+ * <p>A row is written only when the program forms something under the
+ * prefix. A package nobody declares as an object is a prefix and nothing
+ * else, and giving it rows would put a type into the table that the program
+ * does not have.</p>
+ *
+ * @since 0.68.0
+ */
+final class Members {
+
+    /**
+     * The formations of the program, the only objects a package can add to.
+     */
+    private final Collection<XML> made;
+
+    /**
+     * The object every file of the program is about.
+     */
+    private final Collection<XML> roots;
+
+    /**
+     * Ctor.
+     * @param formations The formations of the program
+     * @param tops The object every file is about
+     */
+    Members(final Collection<XML> formations, final Collection<XML> tops) {
+        this.made = formations;
+        this.roots = tops;
+    }
+
+    /**
+     * Write these attributes into the given table.
+     * @param rows The table to fill
+     */
+    void fill(final Tojos rows) {
+        final Collection<String> owners = new HashSet<>(0);
+        for (final XML formation : this.made) {
+            owners.add(formation.xpath("@loc").get(0));
+        }
+        for (final XML root : this.roots) {
+            final String type = root.xpath("@loc").get(0);
+            final String owner = type.substring(0, type.lastIndexOf('.'));
+            if (owners.contains(owner)) {
+                final String name = root.xpath("@name").get(0);
+                rows.add(String.join(" ", owner, name))
+                    .set("owner", owner)
+                    .set("name", name)
+                    .set("type", type);
+            }
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * What every object certainly has.
@@ -54,14 +56,15 @@ import java.nio.file.Path;
  * written in Java, so its rows will have to be given to this table from
  * outside one day, and until they are, the checker simply knows less.</p>
  *
+ * <p>Not every attribute is written inside the formation it belongs to. A
+ * package is a prefix of a locator, so {@code minus} in the package
+ * {@code number} is {@code Φ.number.minus} and belongs to {@code Φ.number}
+ * without ever appearing among its children. Those rows come from the
+ * top-level object of every file, and only when the program forms
+ * something under that prefix: a package nobody declares as an object is a
+ * prefix and nothing else.</p>
+ *
  * @since 0.67.0
- * @todo #6565:35min Account for attributes reached through the package.
- *  An attribute of {@code Φ.number} like {@code minus} lives in the same
- *  package as a top-level object {@code Φ.number.minus}, so it never
- *  shows up among the children of the formation and this table calls the
- *  object complete while listing a strict subset of what it has. Either
- *  write those package members down as attributes of their owner, or
- *  leave the owner incomplete until they are.
  * @todo #6565:35min Write down the {@code ρ} every object has. An outer
  *  name lowers to a dispatch of {@code ρ}, so the needs table asks for
  *  it, while no row here ever lists it and the owner is called complete
@@ -72,8 +75,10 @@ final class Provides implements Clue {
 
     @Override
     public void follow(final Path xmirs, final Path tables) throws IOException {
+        final Xmirs world = new Xmirs(xmirs);
+        final Collection<XML> made = world.formations();
         try (Tojos rows = new TjDeferred(new MnMemory())) {
-            for (final XML formation : new Xmirs(xmirs).formations()) {
+            for (final XML formation : made) {
                 final String owner = formation.xpath("@loc").get(0);
                 final boolean whole = formation.nodes("o[@name='λ' or @name='φ']").isEmpty();
                 rows.add(owner).set("complete", Boolean.toString(whole));
@@ -88,11 +93,41 @@ final class Provides implements Clue {
                     }
                 }
             }
+            this.adopt(made, world.roots(), rows);
             Files.createDirectories(tables);
             Files.write(
                 tables.resolve("provides.xml"),
                 new Grouped(rows, "provides").asXml().toString().getBytes(StandardCharsets.UTF_8)
             );
+        }
+    }
+
+    /**
+     * Write down what a package hands to the object it is named after,
+     * after every attribute the formations write out themselves, since the
+     * order of attributes is what binds the arguments of an application and
+     * a file of a package binds none of them.
+     * @param made The formations of the program
+     * @param roots The object every file is about
+     * @param rows The table to fill
+     */
+    private void adopt(
+        final Collection<XML> made, final Collection<XML> roots, final Tojos rows
+    ) {
+        final Collection<String> owners = new HashSet<>(0);
+        for (final XML formation : made) {
+            owners.add(formation.xpath("@loc").get(0));
+        }
+        for (final XML root : roots) {
+            final String type = root.xpath("@loc").get(0);
+            final String owner = type.substring(0, type.lastIndexOf('.'));
+            if (owners.contains(owner)) {
+                final String name = root.xpath("@name").get(0);
+                rows.add(String.join(" ", owner, name))
+                    .set("owner", owner)
+                    .set("name", name)
+                    .set("type", type);
+            }
         }
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashSet;
 
 /**
  * What every object certainly has.
@@ -56,13 +55,12 @@ import java.util.HashSet;
  * written in Java, so its rows will have to be given to this table from
  * outside one day, and until they are, the checker simply knows less.</p>
  *
- * <p>Not every attribute is written inside the formation it belongs to. A
- * package is a prefix of a locator, so {@code minus} in the package
- * {@code number} is {@code Φ.number.minus} and belongs to {@code Φ.number}
- * without ever appearing among its children. Those rows come from the
- * top-level object of every file, and only when the program forms
- * something under that prefix: a package nobody declares as an object is a
- * prefix and nothing else.</p>
+ * <p>Not every attribute is written inside the formation it belongs to:
+ * {@code minus} in the package {@code number} is {@code Φ.number.minus} and
+ * belongs to {@code Φ.number} without ever appearing among its children.
+ * {@link Members} finds those and they go into this table too, last, since
+ * the order of attributes is what binds the arguments of an application and
+ * a file of a package binds none of them.</p>
  *
  * @since 0.67.0
  * @todo #6565:35min Write down the {@code ρ} every object has. An outer
@@ -93,41 +91,12 @@ final class Provides implements Clue {
                     }
                 }
             }
-            this.adopt(made, world.roots(), rows);
+            new Members(made, world.roots()).fill(rows);
             Files.createDirectories(tables);
             Files.write(
                 tables.resolve("provides.xml"),
                 new Grouped(rows, "provides").asXml().toString().getBytes(StandardCharsets.UTF_8)
             );
-        }
-    }
-
-    /**
-     * Write down what a package hands to the object it is named after,
-     * after every attribute the formations write out themselves, since the
-     * order of attributes is what binds the arguments of an application and
-     * a file of a package binds none of them.
-     * @param made The formations of the program
-     * @param roots The object every file is about
-     * @param rows The table to fill
-     */
-    private void adopt(
-        final Collection<XML> made, final Collection<XML> roots, final Tojos rows
-    ) {
-        final Collection<String> owners = new HashSet<>(0);
-        for (final XML formation : made) {
-            owners.add(formation.xpath("@loc").get(0));
-        }
-        for (final XML root : roots) {
-            final String type = root.xpath("@loc").get(0);
-            final String owner = type.substring(0, type.lastIndexOf('.'));
-            if (owners.contains(owner)) {
-                final String name = root.xpath("@name").get(0);
-                rows.add(String.join(" ", owner, name))
-                    .set("owner", owner)
-                    .set("name", name)
-                    .set("type", type);
-            }
         }
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -59,6 +59,22 @@ final class Xmirs {
     }
 
     /**
+     * The object every file of the program is about.
+     *
+     * <p>A file carries one object at the top and the package it declares
+     * goes into the locator of that object, so {@code minus} in the package
+     * {@code number} is {@code Φ.number.minus}. That is how an attribute
+     * comes to live in a file of its own.</p>
+     *
+     * @return The named top-level objects, one per file, in the order the
+     *  files come in
+     * @throws IOException If a file cannot be read
+     */
+    Collection<XML> roots() throws IOException {
+        return this.matching("/object/o[@name]");
+    }
+
+    /**
      * Every dispatch of the program.
      *
      * <p>A dispatch is an object whose base begins with a dot: it takes an

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
@@ -14,6 +14,7 @@ eo:
 
     [] > minus
 provides:
-  - "/provides/type[@id='Φ.number']/attr[@name='minus' and @type='Φ.number.minus']"
+  - "/provides/type[@id='Φ.number']/attr[@name='minus']"
+  - "/provides//attr[@name='minus' and @type='Φ.number.minus']"
   - "/provides/type[@id='Φ.number' and @complete='true' and count(attr)=2]"
   - "/provides/type[@id='Φ.number.minus' and @complete='true']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An attribute may live in a file of its own. Here `minus` sits in the package
+# `number`, so it is `Φ.number.minus` and never shows up among the children of
+# the formation `number`. Its row is written all the same, or the table would
+# call `Φ.number` complete while listing a strict subset of what it has.
+eo:
+  number.eo: |
+    [] > number
+      [] > plus
+  minus.eo: |
+    +package number
+
+    [] > minus
+provides:
+  - "/provides/type[@id='Φ.number']/attr[@name='minus' and @type='Φ.number.minus']"
+  - "/provides/type[@id='Φ.number' and @complete='true' and count(attr)=2]"
+  - "/provides/type[@id='Φ.number.minus' and @complete='true']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-with-no-object-of-its-own.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-with-no-object-of-its-own.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A package is a prefix of a locator and nothing more. When the program forms
+# nothing under that prefix, there is no object for the file to be an attribute
+# of, and the table says nothing rather than inventing an owner.
+eo:
+  minus.eo: |
+    +package number
+
+    [] > minus
+provides:
+  - "/provides/type[@id='Φ.number.minus']"
+  - "/provides[not(//attr)]"


### PR DESCRIPTION
The provides table listed only what a formation writes inside its own body, so an attribute that lives in a file of its own was missing from it. A package is a prefix of a locator: `minus` in the package `number` is `Φ.number.minus` and belongs to `Φ.number`, yet it never shows up among the children of that formation. The table called `Φ.number` complete while listing a strict subset of what it has, which is exactly the kind of half-truth a later check would read as a missing attribute.

Now `Provides` also reads the top-level object of every file and writes it down as an attribute of the object formed under its prefix. `Xmirs` grew `roots()` for that, since the named object at the top of a file is the only place a package shows itself. The row is written only when the program actually forms something under the prefix — a package nobody declares as an object stays a prefix and nothing else, and inventing an owner for it would put a type into the table that the program does not have.

These rows come after every attribute a formation writes out itself. The order of attributes is what binds the arguments of an application, and a file of a package binds none of them, so appending keeps the voids where they were.

Two packs cover both sides: one where the owner exists and picks up the extra attribute, one where the package names nothing and the table stays quiet.

The second puzzle in that docblock, about the `ρ` every object has, is untouched and still open.

Closes #6635
