### PR TITLE
#6695: preserve the sign of negative zero in number.floor

### DIFF
--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -10,17 +10,20 @@
 
 [n] > floor
   if. > @
-    n.is-finite.not.or
-      or.
-        n.gte 4503599627370496
-        n.lte -4503599627370496
+    n.as-bytes.eq 80-00-00-00-00-00-00-00
     n
     if.
-      gt.
-        n.as-i64.as-number >> trunc
-        n
-      trunc.minus 1
-      n.as-i64.as-number
+      n.is-finite.not.or
+        or.
+          n.gte 4503599627370496
+          n.lte -4503599627370496
+      n
+      if.
+        gt.
+          n.as-i64.as-number >> trunc
+          n
+        trunc.minus 1
+        n.as-i64.as-number
 
   -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
 
@@ -37,6 +40,10 @@
   42.floor.eq 42 ++> can-floor-an-integer
 
   ninf.floor.eq ninf ++> can-floor-negative-infinity
+
+  eq. ++> can-floor-negative-zero-preserving-sign
+    0.neg.floor.as-bytes
+    80-00-00-00-00-00-00-00
 
   pinf.floor.eq pinf ++> can-floor-positive-infinity
 


### PR DESCRIPTION
`number.floor` converts a negative zero to a positive zero, because the finite fast path delegates to `n.as-i64.as-number`, and integer conversion has no signed-zero representation.

Added a fast path before the existing magnitude check: when `n`'s bytes are exactly the negative-zero bit pattern, return `n` unchanged.

Added `can-floor-negative-zero-preserving-sign`, comparing `as-bytes` since numeric equality can't distinguish the two zeros.

Ran `EOfloorTest` (11 tests, 0 failures) and `qulice:check -Pqulice`, both green.
