### PR TITLE
#6694: preserve the sign of negative zero in number.arc-sine

### DIFF
--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -13,39 +13,41 @@
 
 [num] > arc-sine
   if. > @
-    lt.
-      number num.as-bytes >> arg
-      0
-    neg.
-      if. >> base
-        gt.
-          abs arg >> magnitude
-          0.5
-        minus.
-          pi.div 2
-          2.times
-            [point] >> series
-              point.times > @
-                poly 1
-              if. > [depth] > poly
-                depth.gt 30
-                1
-                1.plus
-                  times.
-                    div.
-                      times.
+    arg.as-bytes.eq 80-00-00-00-00-00-00-00
+    arg
+    if.
+      arg.lt 0
+      neg.
+        if. >> base
+          gt.
+            abs arg >> magnitude
+            0.5
+          minus.
+            pi.div 2
+            2.times
+              [point] >> series
+                point.times > @
+                  poly 1
+                if. > [depth] > poly
+                  depth.gt 30
+                  1
+                  1.plus
+                    times.
+                      div.
                         times.
-                          minus. (depth.times 2) 1
-                          minus. (depth.times 2) 1
-                        squared
-                      times.
-                        depth.times 2
-                        plus. (depth.times 2) 1
-                    poly (depth.plus 1)
-              point.times point > squared
-            | (sqrt ((1.minus magnitude).div 2))
-        series magnitude
-    base
+                          times.
+                            minus. (depth.times 2) 1
+                            minus. (depth.times 2) 1
+                          squared
+                        times.
+                          depth.times 2
+                          plus. (depth.times 2) 1
+                      poly (depth.plus 1)
+                point.times point > squared
+              | (sqrt ((1.minus magnitude).div 2))
+          series magnitude
+      base
+  number num.as-bytes > arg
 
   lt. ++> can-behave-as-an-odd-function-when-taking-arc-sine
     abs
@@ -90,6 +92,10 @@
             pi.div 2
           1000
     1
+
+  eq. ++> can-take-an-arc-sine-of-negative-zero-preserving-sign
+    0.neg.arc-sine.as-bytes
+    80-00-00-00-00-00-00-00
 
   lt. ++> can-take-an-arc-sine-of-one
     abs


### PR DESCRIPTION
`number.arc-sine` branches only on `arg < 0`. IEEE `-0.0 < 0.0` is false, so a negative-zero input falls into the non-negative branch, which computes the series from `abs(arg)` and never restores the sign. The result loses the negative-zero bit pattern and breaks the round trip with `number.sine`.

Added a fast path before the existing sign check: when `arg`'s bytes are exactly the negative-zero pattern, return `arg` unchanged. Moved the `arg` binding out to a sibling of the outer `if.` so both branches can reference it.

Added `can-take-an-arc-sine-of-negative-zero-preserving-sign`, comparing `as-bytes` since numeric equality can't distinguish the two zeros.

Ran `EOarc_sineTest` (13 tests, 0 failures) and `qulice:check -Pqulice`, both green.
