### PR TITLE
#6696: preserve the sign of negative zero in number.sqrt

### DIFF
--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -10,13 +10,13 @@
 
 [num] > sqrt
   if. > @
-    lt.
-      number num.as-bytes
-      0
+    arg.lt 0
     nan
-    power
-      num
-      0.5
+    if.
+      arg.as-bytes.eq 80-00-00-00-00-00-00-00
+      arg
+      power arg 0.5
+  number num.as-bytes > arg
 
   lt. ++> can-approximate-a-square-root-of-four
     abs
@@ -43,6 +43,10 @@
         sqrt 4
         2
     1.0E-9
+
+  eq. ++> can-take-a-square-root-of-negative-zero-preserving-sign
+    0.neg.sqrt.as-bytes
+    80-00-00-00-00-00-00-00
 
   eq. ++> can-take-a-square-root-of-one
     sqrt 1


### PR DESCRIPTION
`number.sqrt` is `power num 0.5`. `power`'s zero-base branch only restores a negative sign for an odd integer exponent, so `0.5` (not an integer) takes the positive-zero path and the sign of a negative-zero input is lost.

Fixed in `sqrt.eo` directly rather than in `power.eo`, to keep this change isolated: added a fast path that returns the argument unchanged when it's exactly the negative-zero bit pattern, before delegating to `power`.

Added `can-take-a-square-root-of-negative-zero-preserving-sign`, comparing `as-bytes` since numeric equality can't distinguish the two zeros.

Ran `EOsqrtTest` (12 tests, 0 failures) and `qulice:check -Pqulice`, both green.
