### PR TITLE
#6700: reject fractional indexes in tuple.withouti

### DIFF
--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -8,13 +8,16 @@
 +spdx SPDX-License-Identifier: MIT
 
 [list i] > withouti
-  reducedi > @
-    list
-    *
-    if. > [accum item index] >>
-      i.eq index
-      accum
-      accum.with item
+  i.is-integer.if > @
+    reducedi
+      list
+      *
+      if. > [accum item index] >>
+        i.eq index
+        accum
+        accum.with item
+    T
+      "Given index must be an integer"
 
   eq. ++> can-drop-an-item-by-index
     withouti
@@ -51,3 +54,9 @@
     *
       "smthg"
       27
+
+  withouti --> stops-on-a-fractional-index
+    *
+      "a"
+      "b"
+    0.5


### PR DESCRIPTION
`tuple.withouti` compares the supplied `i` directly against each integral element position produced by `reducedi`. A fractional `i` can never equal an integer index, so `withouti` silently returns the tuple unchanged instead of rejecting the request, unlike `tuple.slice` which already validates its start/end as integers.

Added the same `is-integer` guard `slice.eo` uses, rejecting a fractional index with `T "Given index must be an integer"`.

Added `stops-on-a-fractional-index`, matching the `-->` error-test convention already used in `slice.eo`.

Ran `EOwithoutiTest` (4 tests, 0 failures) and `qulice:check -Pqulice`, both green.
