### PR TITLE
#6698: reject fractional indexes in tuple.front

### DIFF
--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -8,26 +8,29 @@
 +spdx SPDX-License-Identifier: MIT
 
 [list index] > front
-  if. > @
-    idx.eq 0
-    *
+  index.is-integer.if > @
     if.
-      0.gt
-        index >> idx!
-      back
-        list
-        neg.
-          number idx
+      idx.eq 0
+      *
       if.
-        gte.
-          number idx
-          list.length
-        list
-        if. > [tup] >> rechead
-          tup.length.eq idx
-          tup
-          rechead tup.tail
-        | list
+        0.gt
+          index >> idx!
+        back
+          list
+          neg.
+            number idx
+        if.
+          gte.
+            number idx
+            list.length
+          list
+          if. > [tup] >> rechead
+            tup.length.eq idx
+            tup
+            rechead tup.tail
+          | list
+    T
+      "Given index must be an integer"
 
   eq. ++> can-take-a-front-slice
     front
@@ -93,3 +96,9 @@
       1
       2
       3
+
+  front --> stops-on-a-fractional-index
+    *
+      "a"
+      "b"
+    0.5


### PR DESCRIPTION
`tuple.front` never checks that `index` is an integer. A negative fractional index gets silently converted by the recursive traversal, and a positive fractional index recurses past the end of the tuple, surfacing an internal `Can't get tail from the empty tuple` failure instead of a clear one about the argument itself.

Added an `is-integer` guard at the entry point, matching the pattern already used in `tuple.slice` and `tuple.withouti`, rejecting a fractional index with `T "Given index must be an integer"`.

Added `stops-on-a-fractional-index`, matching the `-->` error-test convention.

Ran `EOfrontTest` (7 tests, 0 failures) and `qulice:check -Pqulice`, both green.
