### PR TITLE
#6699: reject fractional counts in tuple.back

### DIFF
--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -9,17 +9,20 @@
 +spdx SPDX-License-Identifier: MIT
 
 [list index] > back
-  if. > @
-    0.gt
-      list.length.minus index! >> start!
-    list
-    reducedi
+  index.is-integer.if > @
+    if.
+      0.gt
+        list.length.minus index! >> start!
       list
-      *
-      if. > [accum item idx] >>
-        idx.gte start
-        accum.with item
-        accum
+      reducedi
+        list
+        *
+        if. > [accum item idx] >>
+          idx.gte start
+          accum.with item
+          accum
+    T
+      "Given index must be an integer"
 
   eq. ++> can-take-a-back-slice
     back
@@ -59,3 +62,9 @@
         4
         5
       0
+
+  back --> stops-on-a-fractional-index
+    *
+      "a"
+      "b"
+    0.5


### PR DESCRIPTION
`tuple.back` computes `start = list.length - index` and includes an item when its integer position is `>= start`, with no `index.is-integer` check. A fractional count becomes an accidental threshold value instead of being rejected, so the result depends on which integer positions happen to land on either side of the fraction rather than on a defined rule.

Added an `is-integer` guard at the entry point, matching `tuple.slice`/`tuple.withouti`/`tuple.front`, rejecting a fractional count with `T "Given index must be an integer"`.

Added `stops-on-a-fractional-index`, matching the `-->` error-test convention.

Ran `EObackTest` (4 tests, 0 failures) and `qulice:check -Pqulice`, both green.
