### PR TITLE
#6697: reject fractional shifts in tuple.shifted

### DIFF
--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -8,13 +8,16 @@
 +spdx SPDX-License-Identifier: MIT
 
 [list shift] > shifted
-  slice > @
-    list
-    if.
-      shift.lt 0
-      0
-      shift
-    list.length
+  shift.is-integer.if > @
+    slice
+      list
+      if.
+        shift.lt 0
+        0
+        shift
+      list.length
+    T
+      "Given shift must be an integer"
 
   eq. ++> can-ignore-a-negative-shift
     shifted
@@ -78,3 +81,15 @@
         5
       6
     *
+
+  shifted --> stops-on-a-negative-fractional-shift
+    *
+      "a"
+      "b"
+    -0.5
+
+  shifted --> stops-on-a-positive-fractional-shift
+    *
+      "a"
+      "b"
+    0.5


### PR DESCRIPTION
`tuple.shifted` only checks `shift.lt 0`, so a negative fraction is silently treated as a zero shift, while a positive fraction is forwarded to `tuple.slice`, which rejects it with its own message naming "slice start and end", not "shift". Both signs need the same rule, and the public `shifted` operation should not leak an unrelated implementation's error text.

Added an `is-integer` guard at the entry point, rejecting a fractional shift with `T "Given shift must be an integer"` before either branch is reached.

Added regression tests for both `-0.5` and `0.5`, matching the `-->` error-test convention.

Ran `EOshiftedTest` (7 tests, 0 failures) and `qulice:check -Pqulice`, both green.
