### PR TITLE
#6677: guard EoSyntax.parsed() against a null transform

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -10,6 +10,7 @@ import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
@@ -97,7 +98,7 @@ public final class EoSyntax implements Syntax {
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return this.transform.apply(
+        return Objects.requireNonNull(this.transform, "transform").apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -76,6 +76,15 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void rejectsANullTransform() {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new EoSyntax(new InputOf(""), (UnaryOperator<XML>) null).parsed(),
+            "EoSyntax must reject a null transform, but it didn't"
+        );
+    }
+
+    @Test
     void parsesSimpleCodeWithDebugMode() {
         final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(EoSyntax.class);
         final Level previous = logger.getLevel();


### PR DESCRIPTION
SonarCloud's `new_reliability_rating` gate is red on master (rated C where A is required), because of a BLOCKER-severity NPE-risk finding at `EoSyntax.java:100`: `this.transform.apply(...)` in `parsed()`, flagged since `EoSyntax(Input, UnaryOperator<XML>)` is a public constructor that accepts `transform` without a null check. It's the newest of the several open SonarCloud BUG findings on master (created 2026-07-13, the rest are from Feb-Aug 2025), so it's the one most likely inside the new-code window that's failing the gate.

Guarded the call site instead of the constructor: qulice's `ConstructorsCodeFreeCheck` forbids method calls in a constructor body, so the null check couldn't live there. Folded the guard and the use into one expression (`Objects.requireNonNull(this.transform, "transform").apply(...)`), so there's no separate statement whose order with the guard could drift.

Added `rejectsANullTransform`, asserting `.parsed()` throws `NullPointerException` for a null transform instead of an unguarded NPE.

Ran the full `EoSyntaxTest` suite (1086 tests, 0 failures) and `qulice:check -Pqulice`, both green. I don't have access to the project's SonarCloud settings to confirm this specific finding is what's inside the new-code window, so this may need a second look at the gate after merge; the other open findings (BytesRaw, ChText, OnDetailed, Dependencies) are all from well before the likely window and probably aren't the cause.
