### PR TITLE
Halt the walk at a symbolic link, with a test

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -6,10 +6,6 @@
 #  like [a-z] or [!a] reaches the regex engine neither translated nor escaped,
 #  so a negation matches nothing it should and a lone bracket refuses to
 #  compile, while a star inside a class keeps its glob meaning by mistake.
-# @todo #6483:30min Test that `walk` below halts at a symbolic link. EO cannot
-#  make one, because `posix` has no `symlink` syscall yet, so the halting is
-#  covered only through `lstat` in `StatSyscallTest`, while the walk that leans
-#  on it has no test of its own.
 # @todo #6483:30min Stop descending into a symbolic link on Windows. The `walk`
 #  below asks `lstat`, which reports the link itself, so on POSIX a link to its
 #  own ancestor is listed instead of followed, while `_stat64` on Windows knows
@@ -374,6 +370,25 @@
           ","
           d.resolved "sub"
           d.resolved "sub/b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-past-a-symbolic-link-to-its-own-parent
+    os.is-windows.or > @
+      seq *
+        touched.
+          as-file.
+            d.resolved "щи.txt"
+        code.
+          posix *1
+            "symlink"
+            d
+            d.resolved "ссылка"
+        eq.
+          length.
+            d.as-dir.walk "**"
+          2
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -377,9 +377,7 @@
   ++> can-walk-past-a-symbolic-link-to-its-own-parent
     os.is-windows.or > @
       seq *
-        touched.
-          as-file.
-            d.resolved "щи.txt"
+        touched. (d.resolved "щи.txt").as-file
         code.
           posix *1
             "symlink"

--- a/eo-runtime/src/main/java/org/eolang/posix/CStdLib.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CStdLib.java
@@ -186,6 +186,14 @@ public interface CStdLib extends Library {
     int rename(String from, String target);
 
     /**
+     * Create a symbolic link pointing at a file or a directory.
+     * @param target Path the link leads to
+     * @param path Path of the link itself
+     * @return Zero on success, -1 on error
+     */
+    int symlink(String target, String path);
+
+    /**
      * Get environment variable.
      * @param name Name of the variable
      * @return Name of the environment variable

--- a/eo-runtime/src/main/java/org/eolang/posix/NamedSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/NamedSyscall.java
@@ -43,6 +43,7 @@ public final class NamedSyscall implements Syscall {
         NamedSyscall.ALL.put("rmdir", RmdirSyscall::new);
         NamedSyscall.ALL.put("mkdir", MkdirSyscall::new);
         NamedSyscall.ALL.put("rename", RenameSyscall::new);
+        NamedSyscall.ALL.put("symlink", SymlinkSyscall::new);
         NamedSyscall.ALL.put("read", ReadSyscall::new);
         NamedSyscall.ALL.put("write", WriteSyscall::new);
         NamedSyscall.ALL.put("getenv", GetenvSyscall::new);

--- a/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.eolang.Syscall;
+
+/**
+ * Symlink syscall.
+ *
+ * <p>It creates a symbolic link at the second path, leading to the file or
+ * the directory at the first one.</p>
+ *
+ * @since 0.74.0
+ */
+public final class SymlinkSyscall implements Syscall {
+
+    /**
+     * Posix object.
+     */
+    private final Phi posix;
+
+    /**
+     * Ctor.
+     * @param posix Posix object
+     */
+    public SymlinkSyscall(final Phi posix) {
+        this.posix = posix;
+    }
+
+    @Override
+    public Phi make(final Phi... params) {
+        final Phi result = this.posix.take("return").copy();
+        final int code = CStdLib.INSTANCE.symlink(
+            new Dataized(params[0]).asString(),
+            new Dataized(params[1]).asString()
+        );
+        result.put(0, new Data.ToPhi(code));
+        result.put(1, new Errno(code).get());
+        return result;
+    }
+}


### PR DESCRIPTION
`walk` already refuses to descend into a symbolic link: it asks `lstat` through `file.is-symlink` and lists such an entry instead of following it. Nothing exercised that in EO, though. The only coverage was `StatSyscallTest`, which checks `lstat` alone and says nothing about the walk that leans on it.

The test could not be written because EO had no way to make a symbolic link. So `posix` gets a `symlink` syscall, alongside `rename` and the rest, and the new test in `directory.eo` builds a link inside a directory that points back at that same directory. Before the guard existed, walking `**` over such a directory recursed until the stack gave up; now it yields the two entries and stops.

The test is skipped on Windows, where `_stat64` knows nothing about links. That gap is the remaining `@todo` in the same docblock.

Closes #6719
