### PR TITLE
#6711: log the actual count of pulled programs and deleted binaries

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Pulling.java
@@ -150,7 +150,7 @@ final class Pulling implements Step {
             Logger.info(
                 this,
                 "%d program(s) were pulled: %s",
-                sources.size(),
+                names.size(),
                 names
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
@@ -84,7 +84,7 @@ final class Unplacing implements Step {
             } else if (total == available.size()) {
                 Logger.info(
                     this, "All %d binari(es) deleted, which were found in %[file]s",
-                    binaries.size(), this.classes
+                    available.size(), this.classes
                 );
             } else {
                 Logger.info(


### PR DESCRIPTION
Two log lines reported the wrong count.

`Pulling` logged `sources.size()` as "N program(s) were pulled", but `sources` includes directories that get skipped rather than pulled; `names` is the collection that actually holds what was pulled and is what's printed right after. Switched the count to `names.size()`.

`Unplacing`'s "All N binari(es) deleted" branch is only reached when `total == available.size()`, but logged `binaries.size()` (the pre-`keepBinaries`-exclusion count) instead of `available.size()` (what was actually compared and deleted). Switched that one line; the other two branches already log `binaries.size()` intentionally, as the "out of N found" denominator.

Neither is a functional bug, both operations still process the correct items. Existing `UnplacingTest`/`CompilingTest` pass unchanged; didn't add a dedicated log-capture test since neither file has that infrastructure and this is a one-line count fix, not a behavior change.
