### PR TITLE
Sanitize object and attribute names before emitting Java

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -41,7 +41,7 @@
   <xsl:function name="eo:identifier" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
     <xsl:variable name="escaped">
-      <xsl:analyze-string select="$n" regex="[^\p{{L}}\p{{Nd}}_$]">
+      <xsl:analyze-string select="$n" regex="[^\p{{L}}\d_$]">
         <xsl:matching-substring>
           <xsl:value-of select="eo:escape-char(.)"/>
         </xsl:matching-substring>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -31,10 +31,36 @@
       <xsl:value-of select="$TAB"/>
     </xsl:for-each>
   </xsl:function>
+  <!-- Unicode escape of a character Java forbids in an identifier -->
+  <xsl:function name="eo:escape-char" as="xs:string">
+    <xsl:param name="c" as="xs:string"/>
+    <xsl:variable name="code" select="string-to-codepoints($c)[1]"/>
+    <xsl:value-of select="concat('$u', string-join(for $w in (4096, 256, 16, 1) return substring('0123456789ABCDEF', ($code idiv $w) mod 16 + 1, 1), ''))"/>
+  </xsl:function>
+  <!-- Turn a name into a Java identifier, escaping every character Java forbids there -->
+  <xsl:function name="eo:identifier" as="xs:string">
+    <xsl:param name="n" as="xs:string"/>
+    <xsl:variable name="escaped">
+      <xsl:analyze-string select="$n" regex="[^\p{{L}}\p{{Nd}}_$]">
+        <xsl:matching-substring>
+          <xsl:value-of select="eo:escape-char(.)"/>
+        </xsl:matching-substring>
+        <xsl:non-matching-substring>
+          <xsl:value-of select="."/>
+        </xsl:non-matching-substring>
+      </xsl:analyze-string>
+    </xsl:variable>
+    <xsl:value-of select="$escaped"/>
+  </xsl:function>
+  <!-- Turn a name into the body of a Java string literal, escaping the backslash and the quote -->
+  <xsl:function name="eo:literal" as="xs:string">
+    <xsl:param name="n" as="xs:string"/>
+    <xsl:value-of select="replace(replace($n, '\\', '\\\\'), '&quot;', '\\&quot;')"/>
+  </xsl:function>
   <!-- Get clean escaped object name -->
   <xsl:function name="eo:clean" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
-    <xsl:value-of select="concat('EO', replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), '@', $eo:phi), $eo:alpha, '_'), '\$', '\$EO'))"/>
+    <xsl:value-of select="concat('EO', eo:identifier(replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), '@', $eo:phi), $eo:alpha, '_'), '\$', '\$EO')))"/>
   </xsl:function>
   <!-- Get object name with suffix -->
   <xsl:function name="eo:suffix" as="xs:string">
@@ -78,7 +104,7 @@
   <!-- Get clean escaped package segment, prefixed to never clash with an object class -->
   <xsl:function name="eo:clean-package" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
-    <xsl:value-of select="concat('EO_', replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), '@', $eo:phi), $eo:alpha, '_'), '\$', '\$EO'))"/>
+    <xsl:value-of select="concat('EO_', eo:identifier(replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), '@', $eo:phi), $eo:alpha, '_'), '\$', '\$EO')))"/>
   </xsl:function>
   <!-- Get Java package name for the EO package, one clean-package per segment -->
   <xsl:function name="eo:package-name" as="xs:string">
@@ -120,7 +146,7 @@
           <xsl:otherwise>
             <xsl:variable name="quoted">
               <xsl:text>"</xsl:text>
-              <xsl:value-of select="$name"/>
+              <xsl:value-of select="eo:literal($name)"/>
               <xsl:text>"</xsl:text>
             </xsl:variable>
             <xsl:value-of select="$quoted"/>
@@ -135,7 +161,7 @@
   <!-- Convert location to class name -->
   <xsl:function name="eo:loc-to-class">
     <xsl:param name="loc"/>
-    <xsl:value-of select="concat('EO', replace(translate(string-join(tokenize($loc, '\.'), ''), '-', '_'), $eo:cactoos, $eo:alpha))"/>
+    <xsl:value-of select="concat('EO', eo:identifier(replace(translate(string-join(tokenize($loc, '\.'), ''), '-', '_'), $eo:cactoos, $eo:alpha)))"/>
   </xsl:function>
   <!-- Get RHO variable depends on context -->
   <xsl:function name="eo:rho">
@@ -279,14 +305,14 @@
     <xsl:apply-templates select="xmir"/>
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:text>@XmirObject(name = "</xsl:text>
-    <xsl:value-of select="@name"/>
+    <xsl:value-of select="eo:literal(@name)"/>
     <xsl:text>", oname = "</xsl:text>
     <xsl:choose>
       <xsl:when test="@original-name">
-        <xsl:value-of select="@original-name"/>
+        <xsl:value-of select="eo:literal(@original-name)"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="@name"/>
+        <xsl:value-of select="eo:literal(@name)"/>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:text>")</xsl:text>
@@ -408,7 +434,7 @@
         <xsl:text>)</xsl:text>
       </xsl:if>
       <xsl:text>.add("</xsl:text>
-      <xsl:value-of select="$name"/>
+      <xsl:value-of select="eo:literal($name)"/>
       <xsl:text>", </xsl:text>
       <xsl:apply-templates select="void|bound|atom|abstract">
         <xsl:with-param name="indent" select="$indent"/>
@@ -423,7 +449,7 @@
   <xsl:template match="void">
     <xsl:param name="name"/>
     <xsl:text>new AtVoid("</xsl:text>
-    <xsl:value-of select="$name"/>
+    <xsl:value-of select="eo:literal($name)"/>
     <xsl:text>")</xsl:text>
   </xsl:template>
   <!--
@@ -503,7 +529,7 @@
     <xsl:value-of select="concat(' = new ', $phiDefaultClass, '(')"/>
     <xsl:if test="@loc and not(contains(@loc, '🌵'))">
       <xsl:text>"</xsl:text>
-      <xsl:value-of select="@loc"/>
+      <xsl:value-of select="eo:literal(@loc)"/>
       <xsl:text>"</xsl:text>
     </xsl:if>
     <xsl:text>);</xsl:text>
@@ -658,17 +684,17 @@
       <xsl:text> = new PhSafe(</xsl:text>
       <xsl:value-of select="$name"/>
       <xsl:text>, "</xsl:text>
-      <xsl:value-of select="$object-name"/>
+      <xsl:value-of select="eo:literal($object-name)"/>
       <xsl:text>", </xsl:text>
       <xsl:value-of select="@line"/>
       <xsl:text>, </xsl:text>
       <xsl:value-of select="@pos"/>
       <xsl:text>, </xsl:text>
       <xsl:text>"</xsl:text>
-      <xsl:value-of select="@loc"/>
+      <xsl:value-of select="eo:literal(@loc)"/>
       <xsl:text>"</xsl:text>
       <xsl:text>, "</xsl:text>
-      <xsl:value-of select="eo:escape-plus(@original-name)"/>
+      <xsl:value-of select="eo:literal(eo:escape-plus(@original-name))"/>
       <xsl:text>");</xsl:text>
     </xsl:if>
     <xsl:if test="$coverage='true' and @line and @pos and not(contains(@loc, '+'))">
@@ -677,7 +703,7 @@
       <xsl:text> = new PhCoverage(</xsl:text>
       <xsl:value-of select="$name"/>
       <xsl:text>, "</xsl:text>
-      <xsl:value-of select="@loc"/>
+      <xsl:value-of select="eo:literal(@loc)"/>
       <xsl:text>:</xsl:text>
       <xsl:value-of select="@line"/>
       <xsl:text>:</xsl:text>
@@ -754,14 +780,14 @@
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:text>@XmirObject(name = "</xsl:text>
-    <xsl:value-of select="@name"/>
+    <xsl:value-of select="eo:literal(@name)"/>
     <xsl:text>", oname = "</xsl:text>
     <xsl:choose>
       <xsl:when test="@original-name">
-        <xsl:value-of select="@original-name"/>
+        <xsl:value-of select="eo:literal(@original-name)"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="@name"/>
+        <xsl:value-of select="eo:literal(@name)"/>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:text>")</xsl:text>
@@ -846,7 +872,7 @@
         <xsl:text>)</xsl:text>
       </xsl:if>
       <xsl:text>.add("</xsl:text>
-      <xsl:value-of select="eo:escape-plus($name)"/>
+      <xsl:value-of select="eo:literal(eo:escape-plus($name))"/>
       <xsl:text>", </xsl:text>
       <xsl:apply-templates select="void|bound|atom|abstract">
         <xsl:with-param name="indent" select="$indent"/>
@@ -868,7 +894,7 @@
         <xsl:text>@Test</xsl:text>
         <xsl:value-of select="eo:eol(1)"/>
         <xsl:text>void </xsl:text>
-        <xsl:value-of select="replace(eo:escape-plus(@name), '-', '_')"/>
+        <xsl:value-of select="eo:identifier(replace(eo:escape-plus(@name), '-', '_'))"/>
         <xsl:text>() throws java.lang.Exception {</xsl:text>
         <xsl:value-of select="eo:eol(2)"/>
         <xsl:choose>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/punctuated-names-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/punctuated-names-to-java.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java[contains(text(), 'public final class EOa$u002Ab extends PhDefault')]
+  - //java[contains(text(), '.add("a\"b", new AtOnce')]
+  - //java[contains(text(), '.add("a\\b", new AtOnce')]
+  - //java[contains(text(), '"Φ.a*b.a\"b", "a*b.a\"b"')]
+input: |
+  [] > a*b
+    1 > a"b
+    2 > a\b


### PR DESCRIPTION
The parser accepts a much wider `NAME` alphabet than `to-java.xsl` knows how to emit. Only `_ - @ α $` were sanitized, so the remaining punctuation went straight into Java identifiers and string literals. `[] > a*b` produced `public final class EOa*b`, which does not compile. `1 > a"b` produced `this.add("a"b", ...)`, which does not compile either. Worst of the three, `1 > a\b` produced `this.add("a\b", ...)`, which compiles fine but binds the attribute under `a` + backspace instead of `a\b` — a silent corruption.

There are two distinct sinks and this adds one function for each. `eo:identifier` hex-escapes every character Java forbids in an identifier as `$uXXXX`, and now wraps `eo:clean`, `eo:clean-package`, `eo:loc-to-class` and the generated test method name. The escape stays injective: `$` in a name already becomes `$EO`, and `EO` is not a pair of hex digits, so no two EO names can collapse onto one Java name. `eo:literal` escapes the backslash and the quote, and now wraps every place a name reaches a Java string literal — the attribute name in `add` and `take`, `AtVoid`, the `@XmirObject` annotation on both the class and its test class, and the locator, object name and original name passed to `PhSafe`, `PhCoverage` and `PhDefault`.

I checked the fix by running the same XSL chain the transpiler runs and compiling the result: `a*b` now becomes `EOa$u002Ab`, the quote case becomes `add("a\"b", ...)`, and the backslash case becomes `add("a\\b", ...)`, which is the attribute name the source actually asked for.

The generated Javadoc still carries the raw XMIR dump with unescaped names in it. That is harmless today because `/` is not a legal `NAME` character, so a name can never close the comment, but it is worth a look if the parser's alphabet ever widens.

Closes #6712
