### PR TITLE
#6709: write the object attribute into wpa.xmir so cached WPA defects keep their program name

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -64,6 +64,13 @@ final class Linting implements Step {
     static final String CACHE = "linted";
 
     /**
+     * The XMIR {@code object} element/attribute name, used both for
+     * navigating a source XMIR and for round-tripping a WPA defect's
+     * program name through {@code wpa.xmir}.
+     */
+    private static final String OBJECT = "object";
+
+    /**
      * Scoped foreign tojos.
      */
     private final TjsForeign tojos;
@@ -537,7 +544,7 @@ final class Linting implements Step {
      */
     private static Collection<Defect> existing(final Xnav xnav) {
         return xnav
-            .element("object")
+            .element(Linting.OBJECT)
             .elements(Filter.withName("errors"))
             .findFirst().map(
                 errors -> errors
@@ -609,7 +616,7 @@ final class Linting implements Step {
         dirs.add("error")
             .attr("check", defect.rule())
             .attr("severity", defect.severity().mnemo())
-            .attr("object", defect.object())
+            .attr(Linting.OBJECT, defect.object())
             .set(defect.text());
         if (defect.line() > 0) {
             dirs.attr("line", defect.line());
@@ -654,7 +661,7 @@ final class Linting implements Step {
                 org.eolang.wpa.Severity.parsed(
                     node.attribute("severity").text().orElseThrow()
                 ),
-                node.attribute("object").text().orElse(""),
+                node.attribute(Linting.OBJECT).text().orElse(""),
                 Integer.parseInt(node.attribute("line").text().orElse("0")),
                 node.text().orElse("")
             )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -609,6 +609,7 @@ final class Linting implements Step {
         dirs.add("error")
             .attr("check", defect.rule())
             .attr("severity", defect.severity().mnemo())
+            .attr("object", defect.object())
             .set(defect.text());
         if (defect.line() > 0) {
             dirs.attr("line", defect.line());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -208,6 +208,28 @@ final class MjLintTest {
     }
 
     @Test
+    void namesTheProgramInAWholeProgramAnalysisDefectFromCache(@Mktmp final Path temp)
+        throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("lintAsPackage", true)
+            .withProgram(MjLintTest.problematic());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> maven.execute(new FakeMaven.Lint()),
+            "First (uncached) run must report the WPA error"
+        );
+        MatcherAssert.assertThat(
+            "A WPA defect read back from the cache must still name its program, but it didn't",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> maven.execute(new FakeMaven.Lint()),
+                "Second (cached) run must report the WPA error too"
+            ).getCause().getCause().getMessage(),
+            Matchers.containsString("foo.x.main")
+        );
+    }
+
+    @Test
     void savesForWholeProgramAnalysisResultsToCache(@Mktmp final Path temp) throws IOException {
         final Path cache = temp.resolve("wpa-cache");
         final FakeMaven maven = new FakeMaven(temp)


### PR DESCRIPTION
`Linting.embedded` wrote `check`, `severity`, `line` and the defect text into `wpa.xmir`, but never wrote an `object` attribute. `Linting.read` reads a WPA defect back with `node.attribute("object").text().orElse("")`, so `defect.object()` is always empty for any run that hits the cache, which is every run once `lintAsPackage` (default `true`) and caching (also default `true`) are both on.

Added `.attr("object", defect.object())` to the WPA `embedded` overload, so the program name round-trips through the cache the same way it already does for the per-file lint path.

Added `namesTheProgramInAWholeProgramAnalysisDefectFromCache`: runs the same problematic program twice, verifying the second (cached) run's exception still names `foo.x.main`, not just the bare rule text. Verified this catches the bug: reverted the fix locally and the new test failed with the program name missing from the message, confirming it before restoring the fix.

Ran the full `MjLintTest` suite (27 tests, 0 failures) and `qulice:check -Pqulice`, both green.

Closes #6709
