### PR TITLE
#6707: reject arguments applied to the bottom term T

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -61,6 +61,12 @@ final class LnApplication implements Line {
         final Value head = tokens.readValue();
         final List<MethodChain> chain = tokens.readChain();
         final List<Value> args = tokens.readArgs();
+        if (head.kind() == Value.Kind.TERM && !args.isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "the bottom term `T` is self-contained and cannot take arguments"
+            );
+        }
         Bindings.checkAllOrNothing(args, this.span);
         final String outer = LnApplication.readOuterBinding(tokens);
         final Suffix suffix = new Suffix(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/term-cannot-take-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/term-cannot-take-arguments.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+line: 1
+message: |-
+  [1:0] error: 'the bottom term `T` is self-contained and cannot take arguments'
+  T 42 > result
+  ^
+input: |
+  T 42 > result


### PR DESCRIPTION
`Tokens.readValue()` classifies `T` as `Value.Kind.TERM`, and the no-chain restriction is already enforced (`T.foo` is rejected), but `LnApplication` unconditionally calls `readArgs()` for every head kind, including `TERM`, and emits the arguments as children of the bottom object. `T 42 > result` parsed with no errors into `<o base="⊥"><o base="Φ.number" as="α0">...</o></o>`, an XMIR shape with no meaning in the grammar.

Added a check right after `head`/`args` are read: a `TERM` head with a non-empty `args` list is a parse error, matching the existing chain restriction.

Added `term-cannot-take-arguments.yaml` under `eo-typos`, following the harness's existing convention.

Ran the full `EoSyntaxTest` suite (1087 tests, 0 failures) and `qulice:check -Pqulice`, both green.

Closes #6707
