### PR TITLE
#6706: accept a reversed-dispatch head on a compact-tuple line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -98,24 +98,13 @@ final class LnCompactTuple implements Line {
     }
 
     /**
-     * Push or replace the stack level per Step B/C/D of §5.2.
-     * @param stack The stack
-     * @param suffix The parsed suffix
-     * @return The pushed/replaced level
-     */
-    private Level transition(final Stack stack, final Suffix suffix) {
-        return new Transition(stack, this.span)
-            .apply(Kind.COMPACT_TUPLE, Openness.OPEN, suffix.named());
-    }
-
-    /**
      * Read the {@code N} count after {@code *}. Defaults to 0 when
      * absent.
      * @param tokens Token reader (cursor just past the {@code *})
      * @param span Source span, for a ParseError on overflow
      * @return The N value
      */
-    private static int readCount(final Tokens tokens, final Span span) {
+    static int readCount(final Tokens tokens, final Span span) {
         long count = 0;
         boolean any = false;
         final int start = tokens.cursor();
@@ -138,5 +127,16 @@ final class LnCompactTuple implements Line {
             count = 0;
         }
         return (int) count;
+    }
+
+    /**
+     * Push or replace the stack level per Step B/C/D of §5.2.
+     * @param stack The stack
+     * @param suffix The parsed suffix
+     * @return The pushed/replaced level
+     */
+    private Level transition(final Stack stack, final Suffix suffix) {
+        return new Transition(stack, this.span)
+            .apply(Kind.COMPACT_TUPLE, Openness.OPEN, suffix.named());
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -68,7 +68,13 @@ final class LnReversed implements Line {
             );
         }
         final boolean fragile = tokens.consumeDispatch();
-        final List<Value> args = tokens.readArgs();
+        final int star = this.compactStar(tokens);
+        final List<Value> args;
+        if (star >= 0) {
+            args = new java.util.ArrayList<>(0);
+        } else {
+            args = tokens.readArgs();
+        }
         if (!args.isEmpty()) {
             Bindings.checkReceiver(args.get(0), this.span);
             Bindings.checkAllOrNothing(
@@ -95,7 +101,11 @@ final class LnReversed implements Line {
             kind = Kind.REVERSED_WITH_HARGS;
             openness = Openness.HORIZONTAL_COMPLETED;
         }
-        this.transition(stack, suffix, kind, openness);
+        final Level level = this.transition(stack, suffix, kind, openness);
+        if (star >= 0) {
+            level.compact(star);
+            level.markStar();
+        }
         Bindings.observeChild(stack, outer, this.span);
         globals.clearBlanks();
         globals.markEmitted();
@@ -146,11 +156,46 @@ final class LnReversed implements Line {
      * @param suffix The parsed suffix
      * @param kind Initial outer kind
      * @param openness Initial openness
+     * @return The pushed-or-replaced level
      */
-    private void transition(
+    private Level transition(
         final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
     ) {
-        new Transition(stack, this.span).apply(kind, openness, suffix.named());
+        return new Transition(stack, this.span).apply(kind, openness, suffix.named());
+    }
+
+    /**
+     * Read a trailing compact-tuple marker {@code *N} on a bare (vertical)
+     * reversed dispatch (R-3.8.5 + R-3.9.1): the first deeper-indent child
+     * stays the receiver, the remaining {@code N-1} children before the
+     * synthesised tuple are ordinary method args, and the rest are
+     * collected into a {@code Φ.tuple} child. Per R-3.9.4, {@code N} must
+     * be at least one for the reversed form, since a receiver-less
+     * {@code joined. *0} has no legal reading.
+     * @param tokens Token reader positioned right after the dispatch dot
+     * @return N, or -1 when no compact-tuple marker follows
+     */
+    private int compactStar(final Tokens tokens) {
+        final int start = tokens.cursor();
+        final boolean space = !tokens.atEnd() && tokens.current() == ' ';
+        tokens.seek(start + 1);
+        final boolean marker = space && !tokens.atEnd() && tokens.current() == '*';
+        final int result;
+        if (marker) {
+            tokens.seek(start + 2);
+            final int count = LnCompactTuple.readCount(tokens, this.span);
+            if (count < 1) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent() + tokens.cursor(),
+                    "reversed-dispatch compact tuple requires N ≥ 1"
+                );
+            }
+            result = count;
+        } else {
+            tokens.seek(start);
+            result = -1;
+        }
+        return result;
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-compact-tuple.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='sixth' and @base='.joined']
+  - //o[@loc='Φ.app.sixth.ρ' and @base='Φ.string']
+  - //o[@base='Φ.tuple.empty']
+input: |
+  [] > app
+    joined. *1 > sixth
+      "receiver"
+      "x"
+      "y"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-compact-tuple-requires-n.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-compact-tuple-requires-n.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+line: 2
+message: |-
+  [2:12] error: 'reversed-dispatch compact tuple requires N ≥ 1'
+    joined. *0 > sixth
+              ^
+input: |
+  [] > app
+    joined. *0 > sixth
+      "receiver"


### PR DESCRIPTION
`Eo.applicative` routes any line with a trailing dot straight to `LnReversed` before checking for a compact-tuple marker, so `joined. *1 > sixth` fell into `LnReversed`'s ordinary argument parser, which read `*` as a horizontal receiver and left the `1` behind as trailing garbage.

Kept the routing to `LnReversed` unchanged and added compact-tuple handling inside it instead: right after the dispatch dot is consumed, a ` *N` marker is now read before falling back to `readArgs()`. When present, the line stays in the bare (vertical) reversed form (`Kind.BARE_REVERSED`, open for children), and the pushed level is marked with the same `compact()`/`markStar()` calls `LnCompactTuple` and `LnOnlyPhi` already use, so the existing close-time wrapping logic (`Eo.closeCompactTuple`/`beforeChild`) picks it up unchanged. The first `N` deeper-indent children stay direct (the first becomes the receiver via the same close-time check `LnReversed` already does), the rest are wrapped into a synthesised `Φ.tuple`.

`N` must be at least 1 for the reversed form (a receiver-less `joined. *0` has no legal reading), so `LnCompactTuple.readCount`'s default-0 result is rejected with a dedicated message when the marker is present but yields 0.

Added `reversed-compact-tuple.yaml` (positive case from the issue, verifying the receiver and the synthesised tuple both land where expected) and `reversed-compact-tuple-requires-n.yaml` (the `*0` rejection).

Ran the full `EoSyntaxTest` suite (1088 tests, 0 failures) and `qulice:check -Pqulice`, both green.

Closes #6706
