### PR TITLE
#6704: validate UTF-8 sequences in string.length

### DIFF
--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -1,7 +1,14 @@
 # Counts the characters in the `text`, and not its bytes. The UTF-8 sequence
 # is walked character by character, so a multi-byte character counts as one.
-# A sequence that does not end with a complete character terminates
-# the computation.
+# Every multi-byte sequence is validated against the UTF-8 rules of the
+# Unicode standard (Table 3-7): the leading byte fixes the character width and
+# each following byte must be a `10xxxxxx` continuation byte, while the second
+# byte is additionally range-checked so that overlong encodings (`C0`/`C1`
+# leads, `E0` with an `80`-`9F` second byte, `F0` with an `80`-`8F` second
+# byte), UTF-16 surrogates (`ED` with an `A0`-`BF` second byte) and code points
+# above U+10FFFF (`F4` with a `90`-`BF` second byte, and `F5`-`FF` leads) are
+# rejected. A sequence that is incomplete or malformed terminates the
+# computation, exactly like `slice` does for a truncated character.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -22,42 +29,112 @@
         accum
         if.
           eq.
-            byte.and 80-
+            lead.and 80-
             00-
-          inclen index 1 accum
+          reclen
+            index.plus 1
+            accum.plus 1
           if.
             eq.
-              byte.and E0-
+              lead.and E0-
               C0-
-            inclen index 2 accum
+            step
+              index
+              2
+              twovalid
+              accum
             if.
               eq.
-                byte.and F0-
+                lead.and F0-
                 E0-
-              inclen index 3 accum
+              step index 3 threevalid accum
               if.
                 eq.
-                  byte.and F8-
+                  lead.and F8-
                   F0-
-                inclen index 4 accum
+                step index 4 fourvalid accum
                 T
                   "Unknown byte format (%x), can't recognize character".printf
-                    * byte
-      text.as-bytes.slice index 1 > byte
+                    * lead
+      text.as-bytes.slice > b1
+        index.plus 1
+        1
+      eq. > b1808f
+        b1.and F0-
+        80-
+      eq. > b1809f
+        b1.and E0-
+        80-
+      or. > b190bf
+        eq.
+          b1.and F0-
+          90-
+        eq.
+          b1.and E0-
+          A0-
+      eq. > b1a0bf
+        b1.and E0-
+        A0-
+      eq. > b1cont
+        b1.and C0-
+        80-
+      text.as-bytes.slice > b2
+        index.plus 2
+        1
+      eq. > b2cont
+        b2.and C0-
+        80-
+      text.as-bytes.slice > b3
+        index.plus 3
+        1
+      eq. > b3cont
+        b3.and C0-
+        80-
+      b2cont.and > fourvalid
+        b3cont.and second4
+      text.as-bytes.slice index 1 > lead
+      eq. > leadc0c1
+        lead.and FE-
+        C0-
+      lead.eq E0- > leade0
+      lead.eq ED- > leaded
+      lead.eq F0- > leadf0
+      lead.eq F1- > leadf1
+      leadf1.or > leadf1f3
+        leadf2.or leadf3
+      lead.eq F2- > leadf2
+      lead.eq F3- > leadf3
+      lead.eq F4- > leadf4
+      leade0.if > second3
+        b1a0bf
+        leaded.if b1809f b1cont
+      leadf0.if > second4
+        b190bf
+        leadf4.if
+          b1808f
+          leadf1f3.if b1cont false
+      b2cont.and second3 > threevalid
+      leadc0c1.not.and b1cont > twovalid
     | 0 0
-  if. > [index csize len] >> inclen
+  if. > [idx csize valid accum] >> step
     gt.
-      index.plus csize
+      idx.plus csize
       size
     T
       "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
         *
           csize
-          index
+          idx
           text.as-bytes
-    reclen
-      index.plus csize
-      len.plus 1
+    valid.if
+      reclen
+        idx.plus csize
+        accum.plus 1
+      T
+        "Malformed UTF-8 sequence (%x) at %d index".printf
+          *
+            text.as-bytes.slice idx csize
+            idx
 
   eq. ++> can-count-a-text-of-spaces-only
     " ".length
@@ -84,6 +161,18 @@
       str.length.eq 12
       str.as-bytes.size.eq 16
     "Hello, друг!" > str
+
+  length. --> rejects-a-non-continuation-after-a-four-byte-lead
+    string F0-90-80-41
+
+  length. --> rejects-a-non-continuation-after-a-three-byte-lead
+    string E1-80-41
+
+  length. --> rejects-a-non-continuation-after-a-two-byte-lead
+    string C2-41
+
+  length. --> rejects-an-overlong-two-byte-encoding
+    string C0-80
 
   length. --> stops-on-an-incomplete-four-byte-character
     string F0-9F-98


### PR DESCRIPTION
Fixes #6704.

`string.length` used to determine a character width from the leading byte
alone and only checked that enough trailing bytes existed, so malformed data
was silently counted as text: `(string C2-41).length` returned `1`, and so
did `E1-80-41`, `F0-90-80-41` and the overlong `C0-80`.

Now every multi-byte sequence is validated against the UTF-8 rules of the
Unicode standard (Table 3-7): each following byte must be a `10xxxxxx`
continuation byte, and the second byte is range-checked per lead so that

- overlong encodings are rejected: `C0`/`C1` leads, `E0` with an `80`-`9F`
  second byte, `F0` with an `80`-`8F` second byte;
- UTF-16 surrogates are rejected: `ED` with an `A0`-`BF` second byte;
- code points above U+10FFFF are rejected: `F4` with a `90`-`BF` second byte,
  and `F5`-`FF` leads.

A malformed sequence now terminates the computation, exactly like the existing
truncated-character behaviour.

Verified against the runtime (each case dataized through the `string`/`length`
atoms): all the malformed classes above throw, while valid inputs still count,
including the boundary code points U+D7FF (last scalar before the surrogate
range) and U+10FFFF (the maximum). The existing character-counting examples
for 1/2/3/4-byte strings stay green.

The issue also notes that `string.slice` recognises widths with the same
leading-byte-only logic; that can reuse the same validation in a follow-up so
this change stays focused on `length`.
