### PR TITLE
Write down what an atom comes back with

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -22,8 +22,9 @@ import java.util.Map;
  * through to the object of that name beside it — {@code Φ.number} binds eight
  * attributes and answers to forty, the rest of them being objects of their own
  * in the same package, {@code Φ.number.eq} among them, and a locator names both
- * kinds the same way. And whatever stands behind its {@code φ}, which answers
- * for every name the object does not bind itself.</p>
+ * kinds the same way. And whatever the type hands its answers to, which is
+ * what stands behind its {@code φ}, or, for an atom, the type it says it comes
+ * back with.</p>
  *
  * <p>The walk stops at a type it has already passed, so an object that
  * delegates in a circle is walked once and answers nothing. A void answers
@@ -91,13 +92,39 @@ final class Provided {
 
     /**
      * The type this one hands its answers to.
+     *
+     * <p>A formation hands them to what stands behind its {@code φ}. An atom
+     * has no {@code φ} to stand behind, since its body is written in Java, but
+     * it says what it comes back with, and a copy of it answers for every name
+     * that type answers for.</p>
+     *
      * @param type The name the type goes by
-     * @return The name of the type behind its {@code φ}, or an empty string
-     *  when the type binds no {@code φ} and answers for itself
+     * @return The name of the type behind its {@code φ} or of the one it comes
+     *  back with, or an empty string when the type answers for itself
      */
     private String behind(final String type) {
-        final String decoratee = this.bound(type, "φ");
-        return this.names.getOrDefault(decoratee, decoratee);
+        String next = this.bound(type, "φ");
+        if (next.isEmpty()) {
+            next = this.cell(type, "returns");
+        }
+        return this.names.getOrDefault(next, next);
+    }
+
+    /**
+     * What the row about the type itself says under the given name.
+     * @param type The name the type goes by
+     * @param cell The name of the cell
+     * @return What the cell says, or an empty string when the table has no
+     *  such cell about this type
+     */
+    private String cell(final String type, final String cell) {
+        String found = "";
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("id")) {
+                found = row.getOrDefault(cell, "");
+            }
+        }
+        return found;
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -46,14 +46,19 @@ import java.util.Collection;
  * it delegates to answers for every name it does not bind itself, and
  * that object is the business of the links table, not of this one.</p>
  *
- * <p>Three kinds of objects are deliberately absent from this table.
+ * <p>Two kinds of objects are deliberately absent from this table.
  * Applications and references (anything with a {@code @base}) provide
  * nothing on their own — what they have is what the object they copy
- * has, which is the business of the links table. A void attribute
- * provides nothing either, until something is put into it. And the
- * results of atoms are not here at all yet: what an atom returns is
- * written in Java, so its rows will have to be given to this table from
- * outside one day, and until they are, the checker simply knows less.</p>
+ * has, which is the business of the links table. And a void attribute
+ * provides nothing either, until something is put into it.</p>
+ *
+ * <p>What an atom comes back with is written down, though its body is not.
+ * {@code [] > div /Q.number} says that a {@code div} is a {@code Φ.number}
+ * once it has run, and the parser carries that annotation into the XMIR, so
+ * the row keeps it and whoever reads the table can ask a {@code number} what
+ * the atom itself cannot answer. An annotation that names no object is
+ * skipped: {@code [] > recovered /A} comes back with whatever the caller put
+ * in, and that is a variable, which nothing here understands yet.</p>
  *
  * <p>Not every attribute is written inside the formation it belongs to:
  * {@code minus} in the package {@code number} is {@code Φ.number.minus} and
@@ -80,6 +85,10 @@ final class Provides implements Clue {
                 final String owner = formation.xpath("@loc").get(0);
                 final boolean whole = formation.nodes("o[@name='λ' or @name='φ']").isEmpty();
                 rows.add(owner).set("complete", Boolean.toString(whole));
+                for (final String back
+                    : formation.xpath("o[@name='λ']/@atom[starts-with(., 'Φ.')]")) {
+                    rows.add(owner).set("returns", back);
+                }
                 for (final XML attr : formation.nodes("o[@name and not(@name='λ')]")) {
                     final String name = attr.xpath("@name").get(0);
                     final Tojo row = rows.add(String.join(" ", owner, name))

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-says-what-it-comes-back-with.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-says-what-it-comes-back-with.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What `half` does is written in Java, which this module cannot read, but what
+# it comes back with is written right here, as `/Q.number`. That is a fact
+# about the type like any other, so the table keeps it.
+eo:
+  half.eo: |
+    [] > half /Q.number
+      ? > x
+provides:
+  - "/provides/type[@id='Φ.half' and @returns='Φ.number']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `A` names no object. It stands for whatever the caller puts in, and which
+# object that is cannot be read off the text of `keep` alone. So nothing is
+# written down and `keep.plus` waits for the day variables are understood.
+eo:
+  app.eo: |
+    [] > app
+      keep.plus > @
+  keep.eo: |
+    [] > keep /A
+      ? > value
+provides:
+  - "/provides/type[@id='Φ.keep'][not(@returns)]"
+links:
+  - "/links[not(type[@id='Φ.app.φ'])]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-what-an-atom-returns-is-answered.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-what-an-atom-returns-is-answered.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `half` binds nothing but a void and a body written in Java, so `plus` is not
+# among its attributes and never will be. It is among the attributes of what a
+# `half` comes back with, though, and the text says what that is. So the object
+# `half.plus` makes is a copy of the `plus` of a `number`.
+eo:
+  app.eo: |
+    [] > app
+      half.plus > @
+  half.eo: |
+    [] > half /Q.number
+      ? > x
+  number.eo: |
+    [] > number
+      [] > plus
+links:
+  - "/links/type[@id='Φ.app.φ' and @copy='Φ.number.plus']"


### PR DESCRIPTION
An atom keeps its body in Java, which this module cannot read, and the tables treated what it comes back with as equally unreadable — the class javadoc of `Provides` said so outright, that "the results of atoms are not here at all yet". That has not been true for a while. `[] > div /Q.number` says a `div` is a `Φ.number` once it has run, and the parser carries the annotation into the XMIR:

```xml
<o loc="Φ.number.div" name="div">
  <o base="∅" loc="Φ.number.div.x" name="x" type="Φ.number"/>
  <o atom="Φ.number" loc="Φ.number.div.λ" name="λ"/>
</o>
```

The rule walked `o[@name and not(@name='λ')]` and stepped straight over the one child that carries it. So `Φ.number.div` was a type with a void and nothing else, `.plus` asked of what a `div` came back with found nothing, and every chain through an atom stopped there.

Now the row about a type keeps what it returns, and `Provided` asks that type when the atom binds no attribute of the name asked. It is the same move it already makes behind a `φ`, so it belongs in the same place: a formation hands its answers to what stands behind its `φ`, an atom to what it says it comes back with, and the cycle guard covers both.

An annotation that names no object is skipped. `[] > recovered /A` comes back with whatever the caller put in, and a variable is nobody's locator; one of the 25 atoms in `eo-runtime` is polymorphic like that, and it stays unanswered until variables mean something here.

Measured on a clean `eo-runtime` build: dispatches that have a type 4,380 → 4,930 of 10,355; links rows 26,153 → 26,703; dispatch receivers whose type is known 8,129 → 8,290; delegation chains that end at a locator nothing describes 1,790 → 1,672 of 2,444. The `complete` flag does not move — an atom is still not complete, since its body is still unread. Three packs describe the behaviour: what the table keeps, what a dispatch on an atom's result turns out to be, and the silence about a variable.

Closes #6738
