### PR TITLE
Move misplaced package members to the package of their receiver

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-hex.eo
+++ b/eo-runtime/src/main/eo/bytes/as-hex.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package string
++package bytes
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -11,9 +11,9 @@
 [b] > as-hex
   if. > [h] >> hex-digit
     h.lt 10
-    as-char
+    as-char.
       h.plus 48
-    as-char
+    as-char.
       h.plus 55
   [index acc] >> rec-hex
     if. > @
@@ -28,7 +28,7 @@
           concat.
             acc.concat "-".as-bytes
             pair
-    as-ascii > bval
+    string.as-ascii > bval
       b.slice index 1
     concat. > pair
       hex-digit
@@ -46,25 +46,20 @@
 
   eq. ++> can-write-a-single-byte
     "41"
-    string
-      as-hex "A".as-bytes
+    string "A".as-bytes.as-hex
 
   eq. ++> can-join-bytes-with-hyphens
     "4A-65-66-66"
-    string
-      as-hex "Jeff".as-bytes
+    string "Jeff".as-bytes.as-hex
 
   eq. ++> can-write-letter-nibbles
     "00-00-00-00-00-00-00-FF"
-    string
-      as-hex 255.as-i64.as-bytes
+    string 255.as-i64.as-bytes.as-hex
 
   eq. ++> can-write-the-bytes-of-a-number
     "40-45-00-00-00-00-00-00"
-    string
-      as-hex 42.as-bytes
+    string 42.as-bytes.as-hex
 
   eq. ++> can-write-empty-bytes
     ""
-    string
-      as-hex --
+    string --.as-hex

--- a/eo-runtime/src/main/eo/number/as-char.eo
+++ b/eo-runtime/src/main/eo/number/as-char.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package string
++package number
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -15,35 +15,28 @@
 
   eq. ++> can-round-trip-through-as-ascii
     "!"
-    string
-      as-char "!".as-ascii
+    string "!".as-ascii.as-char
 
   eq. ++> can-write-the-byte-of-a-lowercase-letter
     "z"
-    string
-      as-char 122
+    string 122.as-char
 
   eq. ++> can-write-the-byte-of-a-space
     " "
-    string
-      as-char 32
+    string 32.as-char
 
   eq. ++> can-write-the-byte-of-an-uppercase-letter
     "A"
-    string
-      as-char 65
+    string 65.as-char
 
   eq. ++> can-write-the-byte-of-the-last-printable-character
     "~"
-    string
-      as-char 126
+    string 126.as-char
 
   eq. ++> can-write-the-byte-of-the-last-uppercase-letter
     "Z"
-    string
-      as-char 90
+    string 90.as-char
 
   eq. ++> can-write-the-byte-of-the-zero-digit
     "0"
-    string
-      as-char 48
+    string 48.as-char

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -7,7 +7,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package string
++package number
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -51,75 +51,62 @@
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"
-    string
-      as-decimal -0.9
+    string -0.9.as-decimal
 
   eq. ++> can-drop-the-sign-of-a-negative-truncating-to-zero
     "0"
-    string
-      as-decimal -0.5
+    string -0.5.as-decimal
 
   eq. ++> can-truncate-a-negative-fraction
     "-7"
-    string
-      as-decimal -7.89
+    string -7.89.as-decimal
 
   eq. ++> can-truncate-a-positive-fraction
     "42"
-    string
-      as-decimal 42.987
+    string 42.987.as-decimal
 
   eq. ++> can-write-a-large-negative-magnitude
     "-9007199254740992"
-    string
-      as-decimal -9007199254740992
+    string -9007199254740992.as-decimal
 
   eq. ++> can-write-a-magnitude-above-two-to-the-53rd
     "9007199254740992"
-    string
-      as-decimal 9007199254740992
+    string 9007199254740992.as-decimal
 
   eq. ++> can-write-a-multi-digit-number
     "31415"
-    string
-      as-decimal 31415
+    string 31415.as-decimal
 
   eq. ++> can-write-a-negative-number
     "-42"
-    string
-      as-decimal -42
+    string -42.as-decimal
 
   eq. ++> can-write-a-number-with-an-inner-zero
     "105"
-    string
-      as-decimal 105
+    string 105.as-decimal
 
   eq. ++> can-write-a-single-digit
     "7"
-    string
-      as-decimal 7
+    string 7.as-decimal
 
   eq. ++> can-write-the-largest-exactly-representable-magnitude
     "9007199254740991"
-    string
-      as-decimal 9007199254740991
+    string 9007199254740991.as-decimal
 
   eq. ++> can-write-the-largest-magnitude-below-two-to-the-63rd
     "9223372036854774784"
-    string
-      as-decimal 9223372036854774784
+    string 9223372036854774784.as-decimal
 
   eq. ++> can-write-zero
     "0"
-    string
-      as-decimal 0
+    string 0.as-decimal
 
-  as-decimal 1.0e30 --> stops-on-a-magnitude-far-past-the-long-range
+  1.0e30.as-decimal --> stops-on-a-magnitude-far-past-the-long-range
 
-  as-decimal 9.223372036854776e18 --> stops-on-a-magnitude-of-two-to-the-63rd
+  9.223372036854776e18.as-decimal --> stops-on-a-magnitude-of-two-to-the-63rd
 
-  as-decimal nan --> stops-on-nan
+  nan.as-decimal --> stops-on-nan
 
-  as-decimal ninf --> stops-on-negative-infinity
+  ninf.as-decimal --> stops-on-negative-infinity
 
-  as-decimal pinf --> stops-on-positive-infinity
+  pinf.as-decimal --> stops-on-positive-infinity

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -11,7 +11,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package string
++package number
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -88,101 +88,95 @@
   eq. ++> can-carry-rounding-into-the-integer-part
     "1.000000"
     string
-      as-fixed 0.9999999 6
+      0.9999999.as-fixed 6
 
   eq. ++> can-carry-rounding-into-the-integer-part-with-zero-places
     "1"
     string
-      as-fixed 0.9999999 0
+      0.9999999.as-fixed 0
 
   eq. ++> can-drop-the-sign-of-a-negative-rounding-to-zero
     "0.00"
     string
-      as-fixed -1.0E-4 2
+      -1.0E-4.as-fixed 2
 
   eq. ++> can-drop-the-sign-of-a-tiny-negative-rounding-to-zero
     "0.00"
     string
-      as-fixed -0.001 2
+      -0.001.as-fixed 2
 
   eq. ++> can-format-the-error-message-of-negative-places
     "Can't write a fixed-point decimal with -2.000000 fraction places"
-    as-fixed
-      3.14159
+    3.14159.as-fixed
       -2
       message > [message]
 
   eq. ++> can-honour-custom-places
     "3.14"
     string
-      as-fixed 3.14159 2
+      3.14159.as-fixed 2
 
   eq. ++> can-omit-the-decimal-point-with-zero-places
     "3"
     string
-      as-fixed 2.5 0
+      2.5.as-fixed 0
 
   eq. ++> can-omit-the-decimal-point-with-zero-places-when-negative
     "-3"
     string
-      as-fixed -2.5 0
+      -2.5.as-fixed 0
 
   eq. ++> can-pad-the-fraction-with-trailing-zeros
     "1.250000"
     string
-      as-fixed 1.25 6
+      1.25.as-fixed 6
 
   eq. ++> can-recover-from-infinite-places
     "recovered"
-    as-fixed
-      1.25
+    1.25.as-fixed
       pinf
       "recovered" > [message]
 
   eq. ++> can-recover-from-negative-places
     "recovered"
-    as-fixed
-      3.14159
+    3.14159.as-fixed
       -2
       "recovered" > [message]
 
   eq. ++> can-recover-from-non-integer-places
     "recovered"
-    as-fixed
-      3.14159
+    3.14159.as-fixed
       2.5
       "recovered" > [message]
 
   eq. ++> can-round-to-the-last-place
     "0.123457"
     string
-      as-fixed 0.123456789 6
+      0.123456789.as-fixed 6
 
   eq. ++> can-scale-a-magnitude-above-two-to-the-53rd
     "100000000000000000.000000"
     string
-      as-fixed 100000000000000000 6
+      100000000000000000.as-fixed 6
 
   eq. ++> can-scale-a-negative-magnitude-above-two-to-the-53rd
     "-100000000000000000.000000"
     string
-      as-fixed -100000000000000000 6
+      -100000000000000000.as-fixed 6
 
   eq. ++> can-write-a-negative-value
     "-2.500000"
     string
-      as-fixed -2.5 6
+      -2.5.as-fixed 6
 
   eq. ++> can-write-a-single-place
     "2.5"
     string
-      as-fixed 2.5 1
+      2.5.as-fixed 1
 
   eq. ++> can-write-zero-with-places
     "0.000000"
     string
-      as-fixed 0 6
+      0.as-fixed 6
 
-  as-fixed --> stops-on-negative-places
-    3.14159
-    -2
+  3.14159.as-fixed -2 --> stops-on-negative-places

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -8,7 +8,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package string
++package number
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -44,25 +44,20 @@
 
   eq. ++> can-name-a-magnitude-past-the-long-range
     "1.000000e19"
-    string
-      as-scientific 1.0e19
+    string 1.0e19.as-scientific
 
   eq. ++> can-name-a-negative-magnitude
     "-9.223372e18"
-    string
-      as-scientific -9.223372036854776e18
+    string -9.223372036854776e18.as-scientific
 
   eq. ++> can-name-nan
     "nan"
-    string
-      as-scientific nan
+    string nan.as-scientific
 
   eq. ++> can-name-negative-infinity
     "-infinity"
-    string
-      as-scientific ninf
+    string ninf.as-scientific
 
   eq. ++> can-name-positive-infinity
     "infinity"
-    string
-      as-scientific pinf
+    string pinf.as-scientific

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -187,7 +187,7 @@
               string datum
       if.
         64-.eq conv
-        as-decimal
+        as-decimal.
           if.
             or.
               gte.
@@ -201,12 +201,11 @@
             T
               "The number %s doesn't fit into the long range of the '%%d' conversion".printf
                 *
-                  string
-                    as-scientific (number numeric)
+                  string (number numeric).as-scientific
             number numeric
         if.
           66-.eq conv
-          as-fixed
+          as-fixed.
             number numeric
             precise.as-bool.if
               number precision
@@ -214,9 +213,7 @@
             failure
           if.
             78-.eq conv
-            capped
-              as-hex
-                bytes datum
+            capped (bytes datum).as-hex
             if.
               62-.eq conv
               capped

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -63,7 +63,7 @@
         5
       0
 
-  back --> stops-on-a-fractional-index
+  back. --> stops-on-a-fractional-index
     *
       "a"
       "b"

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -97,7 +97,7 @@
       2
       3
 
-  front --> stops-on-a-fractional-index
+  front. --> stops-on-a-fractional-index
     *
       "a"
       "b"

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -82,13 +82,13 @@
       6
     *
 
-  shifted --> stops-on-a-negative-fractional-shift
+  shifted. --> stops-on-a-negative-fractional-shift
     *
       "a"
       "b"
     -0.5
 
-  shifted --> stops-on-a-positive-fractional-shift
+  shifted. --> stops-on-a-positive-fractional-shift
     *
       "a"
       "b"

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -53,7 +53,7 @@
       "smthg"
       27
 
-  withouti --> stops-on-a-fractional-index
+  withouti. --> stops-on-a-fractional-index
     *
       "a"
       "b"

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -69,7 +69,7 @@ final class PhiTest {
                 ExAbstract.class,
                 () -> new Dataized(
                     new PhApplication(
-                        Phi.Φ.take("string.as-decimal").copy(),
+                        Phi.Φ.take("number.as-decimal").copy(),
                         "n",
                         new Data.ToPhi(Double.NaN)
                     )


### PR DESCRIPTION
Five members sat in `string` while their receiver is a number or bytes. `as-hex` renders bytes, `as-char`, `as-decimal`, `as-fixed` and `as-scientific` all read a number, so `01-02.as-hex` and `65.as-char` could never resolve — the package rule probes `Φ.bytes.as-hex`, finds nothing, and only the explicit `string.as-hex 01-02` worked. They move to `bytes/` and `number/`, which makes the dispatched form reachable and puts the right object behind `^` when #6657 replaces the first void.

A moved file loses its old siblings, so every bare name in it has to be re-read. `as-hex` called two:

```
    as-char.
      h.plus 48
    string.as-ascii > bval
      b.slice index 1
```

`as-char` is now a dispatch on the number it is handed, and `as-ascii` stays in `string`, where it belongs, so `as-hex` names it explicitly — a byte handed to a string member, which #6657 will have to resolve one way or another. `printf` lost three siblings the same way and dispatches on its receivers instead, and `as-scientific` had to move together with `as-fixed` and `as-decimal`, since it calls both.

The 59 tests in the moved files stop being standalone applications and dispatch, which is what #6682 could not do for them while they were misfiled. Four `--> stops-on-a-fractional-*` tests that arrived in `tuple` with #6699 after #6682 merged are converted here too, so the standalone form does not creep back.

`bytes/hash.eo` was in the issue's list and is dropped from it. Its void is *named* `input`, but that means "any object with `as-bytes`" and not the `input` role: the file hashes `true`, `42`, `"hello"` and an abstract object, and `map.eo` already hands it bytes. Moving it to `input/` would put an input stream behind `^` and break all of that. It is already in the right package.

`mvn compile` is clean — 171 sources canonical, lint with no complaints, 180 Java files transpiled and 315 compiled.

Closes #6655.
