### PR TITLE
#6701: reject an invalid scheme prefix as schemeless in uri

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -137,7 +137,16 @@
     ""
   if. > scheme
     eq.
-      string.index-of text ":" >> scheme-colon
+      if. >> scheme-colon
+        or.
+          eq.
+            string.index-of text ":" >> raw-colon
+            -1
+          not.
+            "/[A-Za-z][A-Za-z0-9+.-]*/".regex.compiled.matches
+              text.slice 0 raw-colon
+        -1
+        raw-colon
       -1
     ""
     text.slice
@@ -190,6 +199,11 @@
     port.
       uri "http://host:/"
     ""
+
+  eq. ++> can-parse-a-scheme-with-a-plus-and-a-dot
+    scheme.
+      uri "a+b.c:part"
+    "a+b.c"
 
   eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
     host.
@@ -254,4 +268,14 @@
   eq. ++> can-treat-a-non-digit-port-as-invalid
     port.
       uri "http://host:abc/"
+    ""
+
+  eq. ++> cannot-treat-a-digit-led-prefix-as-a-scheme
+    scheme.
+      uri "1http://host/path"
+    ""
+
+  eq. ++> cannot-treat-a-plus-led-prefix-as-a-scheme
+    scheme.
+      uri "+foo:bar"
     ""

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -195,15 +195,15 @@
       uri "http://host/some/path?x=1#top"
     "x=1"
 
-  eq. ++> can-parse-an-empty-port
-    port.
-      uri "http://host:/"
-    ""
-
   eq. ++> can-parse-a-scheme-with-a-plus-and-a-dot
     scheme.
       uri "a+b.c:part"
     "a+b.c"
+
+  eq. ++> can-parse-an-empty-port
+    port.
+      uri "http://host:/"
+    ""
 
   eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
     host.
@@ -260,6 +260,11 @@
       uri "http://user:pass@host:80/some/path"
     "user:pass"
 
+  eq. ++> can-treat-a-digit-led-prefix-as-schemeless
+    scheme.
+      uri "1http://host/path"
+    ""
+
   eq. ++> can-treat-a-letter-suffixed-port-as-invalid
     port.
       uri "http://host:12x/"
@@ -268,11 +273,6 @@
   eq. ++> can-treat-a-non-digit-port-as-invalid
     port.
       uri "http://host:abc/"
-    ""
-
-  eq. ++> can-treat-a-digit-led-prefix-as-schemeless
-    scheme.
-      uri "1http://host/path"
     ""
 
   eq. ++> can-treat-a-plus-led-prefix-as-schemeless

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -270,12 +270,12 @@
       uri "http://host:abc/"
     ""
 
-  eq. ++> cannot-treat-a-digit-led-prefix-as-a-scheme
+  eq. ++> can-treat-a-digit-led-prefix-as-schemeless
     scheme.
       uri "1http://host/path"
     ""
 
-  eq. ++> cannot-treat-a-plus-led-prefix-as-a-scheme
+  eq. ++> can-treat-a-plus-led-prefix-as-schemeless
     scheme.
       uri "+foo:bar"
     ""


### PR DESCRIPTION
`uri` treats any prefix before the first colon as the scheme, without checking it against the RFC 3986 grammar (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`). `1http://host/path` exposed `"1http"` as a scheme and `+foo:bar` exposed `"+foo"`.

Added a validity check on the candidate substring before the colon: it must start with an ASCII letter and contain only letters, digits, `+`, `-`, `.` after that, checked with a regex (`string.regex`). When the check fails, the object now treats the colon as if it were absent (same as a text with no colon at all), so the whole `uri.scheme` becomes `""` and the malformed prefix falls into `path` instead, consistent with the existing schemeless-URI behavior. A valid scheme like `a+b.c` still parses correctly.

Added `can-parse-a-scheme-with-a-plus-and-a-dot`, `cannot-treat-a-digit-led-prefix-as-a-scheme`, `cannot-treat-a-plus-led-prefix-as-a-scheme`.

Closes #6701
