### PR TITLE
Merge package members into the object at compile time

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
@@ -12,10 +12,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.w3c.dom.Node;
 
 /**
@@ -87,7 +89,7 @@ final class Merging implements Step {
         } else {
             final Map<String, TjForeign> all = this.indexed();
             int done = 0;
-            for (final String pkg : this.packages) {
+            for (final String pkg : this.deepest()) {
                 done = done + this.spliced(pkg, all);
             }
             Logger.info(
@@ -95,6 +97,25 @@ final class Merging implements Step {
                 done, this.packages.size(), this.dir
             );
         }
+    }
+
+    /**
+     * The packages to merge, the deeper ones first.
+     *
+     * <p>A package can be a member of another one, as {@code Φ.number.i64} is
+     * a member of {@code Φ.number}, and then the order decides what
+     * {@code number} takes in: merged last, {@code i64} would arrive without
+     * the members it had just been given. Depth puts every package after the
+     * ones it holds, whatever order they were named in.</p>
+     *
+     * @return The names of the packages
+     */
+    private Collection<String> deepest() {
+        return this.packages.stream().sorted(
+            Comparator.comparingInt((String pkg) -> pkg.split("\\.").length)
+                .reversed()
+                .thenComparing(Comparator.naturalOrder())
+        ).collect(Collectors.toList());
     }
 
     /**
@@ -129,7 +150,9 @@ final class Merging implements Step {
         final Node formation = Merging.formation(object.xmir());
         final Collection<String> taken = Merging.names(formation);
         for (final Map.Entry<String, TjForeign> member : members.entrySet()) {
-            final Xnav top = Merging.top(member.getValue().xmir());
+            final Xnav top = Merging.top(
+                member.getValue().xmir()
+            );
             final String name = top.attribute("name").text().orElseThrow(
                 () -> new IllegalStateException(
                     String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import org.w3c.dom.Node;
+
+/**
+ * Put the members of a package inside the object that the package names.
+ *
+ * <p>The parsed XMIR of the object and of its members are all on disk by the
+ * time this runs, and the splice is a matter of moving one element: the
+ * top-level {@code <o>} of {@code number/lt.xmir} becomes a child of the
+ * top-level {@code <o>} of {@code number.xmir}. Nothing inside the moved tree
+ * is touched, because the parser leaves every name fully qualified and every
+ * {@code loc} already reads as the locator the node will carry once it is an
+ * attribute of {@code Φ.number}, so no reference can be captured by an
+ * attribute of the object it lands in.</p>
+ *
+ * <p>A member arrives after the attributes the object already had, so the
+ * places of the voids, and with them the meaning of applying the object to
+ * arguments, stay as they were.</p>
+ *
+ * @since 0.68.0
+ * @todo #6656:30min Write the merged XMIR only when it differs.
+ *  The file is written on every build, so its timestamp always moves and
+ *  {@link Transpiling} compiles the object again even when neither the object
+ *  nor any member of it was touched. It is done this way because the opposite
+ *  mistake is worse: a merged object left over from an earlier build would
+ *  quietly compile yesterday's member. Comparing the text with what is
+ *  already there, and writing only on a difference, would give the
+ *  incremental build back without that risk.
+ */
+final class Merging implements Step {
+
+    /**
+     * The directory for the merged XMIR.
+     */
+    static final String DIR = "4-merge";
+
+    /**
+     * The tojos of everything this build compiles.
+     */
+    private final TjsForeign tojos;
+
+    /**
+     * The directory to write the merged XMIR to.
+     */
+    private final Path dir;
+
+    /**
+     * The names of the packages to merge.
+     */
+    private final Collection<String> packages;
+
+    /**
+     * Ctor.
+     * @param foreign The tojos of everything this build compiles
+     * @param target The directory for the merged XMIR
+     * @param names The names of the packages to merge
+     */
+    Merging(final TjsForeign foreign, final Path target, final Collection<String> names) {
+        this.tojos = foreign;
+        this.dir = target;
+        this.packages = names;
+    }
+
+    @Override
+    public void exec() throws IOException {
+        if (this.packages.isEmpty()) {
+            Logger.info(
+                this, "No package is named for merging, every member stays an object of its own"
+            );
+        } else {
+            final Map<String, TjForeign> all = this.indexed();
+            int done = 0;
+            for (final String pkg : this.packages) {
+                done = done + this.spliced(pkg, all);
+            }
+            Logger.info(
+                this, "Put %d member(s) into %d package object(s), XMIR is in %[file]s",
+                done, this.packages.size(), this.dir
+            );
+        }
+    }
+
+    /**
+     * Every compiled object of this build, by its name.
+     * @return The tojos, by name
+     */
+    private Map<String, TjForeign> indexed() {
+        final Map<String, TjForeign> all = new HashMap<>(0);
+        for (final TjForeign tojo : this.tojos.withXmir()) {
+            all.put(tojo.identifier(), tojo);
+        }
+        return all;
+    }
+
+    /**
+     * Put every member of one package inside the object it names.
+     * @param pkg The name of the package
+     * @param all Every compiled object of this build, by its name
+     * @return How many members were put inside
+     * @throws IOException If the XMIR cannot be read or written
+     */
+    private int spliced(final String pkg, final Map<String, TjForeign> all) throws IOException {
+        final TjForeign object = Optional.ofNullable(all.get(pkg)).orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "The package '%s' is named for merging, while this build compiles no object '%s' for its members to go into",
+                    pkg, pkg
+                )
+            )
+        );
+        final Map<String, TjForeign> members = Merging.members(pkg, all);
+        final Node formation = Merging.formation(object.xmir());
+        final Collection<String> taken = Merging.names(formation);
+        for (final Map.Entry<String, TjForeign> member : members.entrySet()) {
+            final Xnav top = Merging.top(member.getValue().xmir());
+            final String name = top.attribute("name").text().orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "The member '%s' has no name, while only a named object can become an attribute of '%s'",
+                        member.getKey(), pkg
+                    )
+                )
+            );
+            if (taken.contains(name)) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The name '%s' of the member '%s' is already an attribute of '%s', while one object cannot hold two attributes under one name",
+                        name, member.getKey(), pkg
+                    )
+                );
+            }
+            taken.add(name);
+            formation.appendChild(
+                formation.getOwnerDocument().importNode(top.node(), true)
+            );
+        }
+        final Path target = new Place(pkg).make(this.dir, MjAssemble.XMIR);
+        new Saved(
+            new XMLDocument(formation.getOwnerDocument()).toString(),
+            target
+        ).value();
+        object.withXmir(target);
+        for (final TjForeign member : members.values()) {
+            member.withMerged(pkg);
+        }
+        Logger.debug(
+            this, "Put %d member(s) of '%s' into %[file]s",
+            members.size(), pkg, target
+        );
+        return members.size();
+    }
+
+    /**
+     * The members of a package, by their names, in the same order every time
+     * so that the merged XMIR comes out the same every time too.
+     * @param pkg The name of the package
+     * @param all Every compiled object of this build, by its name
+     * @return The members
+     */
+    private static Map<String, TjForeign> members(
+        final String pkg, final Map<String, TjForeign> all
+    ) {
+        final String prefix = String.format("%s.", pkg);
+        final Map<String, TjForeign> found = new TreeMap<>();
+        for (final Map.Entry<String, TjForeign> tojo : all.entrySet()) {
+            final String name = tojo.getKey();
+            if (name.startsWith(prefix) && name.indexOf('.', prefix.length()) < 0) {
+                found.put(name, tojo.getValue());
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The top-level object of an XMIR file, as a node that can be moved.
+     * @param xmir The path to the XMIR
+     * @return The node
+     * @throws IOException If the XMIR cannot be read
+     */
+    private static Node formation(final Path xmir) throws IOException {
+        return Merging.top(xmir).node();
+    }
+
+    /**
+     * The top-level object of an XMIR file.
+     * @param xmir The path to the XMIR
+     * @return The object
+     * @throws IOException If the XMIR cannot be read
+     */
+    private static Xnav top(final Path xmir) throws IOException {
+        return new Xnav(new XMLDocument(xmir).inner())
+            .element("object")
+            .element("o");
+    }
+
+    /**
+     * The names of the attributes an object already holds.
+     * @param formation The top-level object
+     * @return The names, in a collection that can be added to
+     */
+    private static Collection<String> names(final Node formation) {
+        final Collection<String> taken = new ArrayList<>(0);
+        new Xnav(formation).elements(Filter.withName("o")).forEach(
+            attr -> attr.attribute("name").text().ifPresent(taken::add)
+        );
+        return taken;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.cactoos.list.ListOf;
+
+/**
+ * Put every member of a package inside the object that the package names.
+ *
+ * <p>An object and the package of the same name are two things today, and it
+ * takes the runtime to join them: asked for an attribute it does not hold,
+ * {@code Φ.number} goes looking for {@code Φ.number.lt} on the classpath and
+ * binds itself into the first void of what it finds. This goal does that
+ * joining at compile time instead, where the parts are already on disk as
+ * XMIR, so that {@code lt} is simply an attribute of {@code number} and
+ * nothing has to be searched for at runtime.</p>
+ *
+ * <p>It runs after {@link MjLint}, so that every member is read and reported
+ * on as the file a human wrote, and before {@link MjTranspile}, which is the
+ * first goal that cares about the shape of the object it compiles. The
+ * merged XMIR goes to {@link Merging#DIR}.</p>
+ *
+ * <p>No package is merged unless it is named in {@code mergedPackages}, which
+ * is empty by default, so a build that says nothing keeps the runtime
+ * behaviour it has today.</p>
+ *
+ * @since 0.68.0
+ */
+@Mojo(
+    name = "merge",
+    defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+    threadSafe = true
+)
+public final class MjMerge extends MjSafe {
+
+    /**
+     * The packages whose members are put inside the object of the same name,
+     * as in {@code number}, one per element. A package that is not named here
+     * is left alone, and its members keep being compiled as objects of their
+     * own, found by the runtime.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "eo.mergedPackages")
+    @SuppressWarnings("PMD.ImmutableField")
+    private Collection<String> mergedPackages = new ListOf<>();
+
+    @Override
+    void exec() throws IOException {
+        new Timed(
+            new Merging(
+                this.scopedTojos(),
+                this.targetDir.toPath().resolve(Merging.DIR),
+                this.mergedPackages
+            )
+        ).exec();
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -147,7 +147,7 @@ public final class MjTranspile extends MjSafe {
     public void exec() throws IOException {
         new Timed(
             new Transpiling(
-                this.scopedTojos().withXmir(),
+                this.scopedTojos().unmerged(),
                 this.targetDir.toPath(),
                 this.generatedDir.toPath(),
                 this.cache.toPath(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -147,7 +147,7 @@ public final class MjTranspile extends MjSafe {
     public void exec() throws IOException {
         new Timed(
             new Transpiling(
-                this.scopedTojos().unmerged(),
+                this.scopedTojos().standalone(),
                 this.targetDir.toPath(),
                 this.generatedDir.toPath(),
                 this.cache.toPath(),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
@@ -228,6 +228,17 @@ final class TjForeign {
     }
 
     /**
+     * Say that this object now lives inside another one and is compiled as a
+     * part of it.
+     * @param object The name of the object it was put inside of
+     * @return The tojo itself
+     */
+    TjForeign withMerged(final String object) {
+        this.delegate.set(TjsForeign.Attribute.MERGED.getKey(), object);
+        return this;
+    }
+
+    /**
      * Set the xmir.
      * @param xmir The xmir
      * @return The tojo itself

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
@@ -122,6 +122,19 @@ final class TjsForeign implements Closeable {
     }
 
     /**
+     * Get the tojos that have an XMIR of their own to compile, which is every
+     * tojo with XMIR but the members that {@link MjMerge} has put inside the
+     * object of their package, since those are compiled as a part of it.
+     * @return The tojos
+     */
+    Collection<TjForeign> unmerged() {
+        return this.select(
+            row -> row.exists(Attribute.XMIR.getKey())
+                && !row.exists(Attribute.MERGED.getKey())
+        );
+    }
+
+    /**
      * Get the tojos that doesn't have dependency.
      * @return The tojos
      */
@@ -287,6 +300,13 @@ final class TjsForeign implements Closeable {
          * <p>For more info see {@link MjProbe}. </p>
          */
         PROBED("probed"),
+
+        /**
+         * The name of the object this one was put inside of by {@link MjMerge},
+         * which is the package it belongs to. A member that carries it is no
+         * longer compiled apart, since it is now an attribute of that object.
+         */
+        MERGED("merged"),
 
         /**
          * The scope of compilation, either {@code compile} or {@code test}.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
@@ -127,7 +127,7 @@ final class TjsForeign implements Closeable {
      * object of their package, since those are compiled as a part of it.
      * @return The tojos
      */
-    Collection<TjForeign> unmerged() {
+    Collection<TjForeign> standalone() {
         return this.select(
             row -> row.exists(Attribute.XMIR.getKey())
                 && !row.exists(Attribute.MERGED.getKey())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -509,6 +509,21 @@ final class FakeMaven {
     }
 
     /**
+     * Put the members of a package inside the object it names.
+     * @since 0.68.0
+     */
+    static final class Merge implements Iterable<Class<? extends AbstractMojo>> {
+
+        @Override
+        public Iterator<Class<? extends AbstractMojo>> iterator() {
+            return Arrays.<Class<? extends AbstractMojo>>asList(
+                MjParse.class,
+                MjMerge.class
+            ).iterator();
+        }
+    }
+
+    /**
      * Transpile full pipeline.
      * @since 0.29.0
      */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test cases for {@link MjMerge}.
+ * @since 0.68.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class MjMergeTest {
+
+    @Test
+    void putsAMemberIntoTheObjectOfItsPackage(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the member must arrive as an attribute of the object named by its package",
+            new XMLDocument(
+                MjMergeTest.merged(temp, "foo").targetPath().resolve("4-merge/foo.xmir")
+            ),
+            XhtmlMatchers.hasXPath("/object/o[@name='foo']/o[@name='bar']")
+        );
+    }
+
+    @Test
+    void keepsTheAttributesTheObjectAlreadyHad(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a member arrives after the voids, so the order of the arguments cannot shift",
+            new XMLDocument(
+                MjMergeTest.merged(temp, "foo").targetPath().resolve("4-merge/foo.xmir")
+            ),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='foo']/o[@name='n']/following-sibling::o[@name='bar']"
+            )
+        );
+    }
+
+    @Test
+    void pointsTheObjectAtTheMergedXmir(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the object must be transpiled from the merged XMIR and not from the parsed one",
+            MjMergeTest.merged(temp, "foo").foreignTojos().find("foo").xmir().toString(),
+            Matchers.endsWith(Paths.get("4-merge/foo.xmir").toString())
+        );
+    }
+
+    @Test
+    void takesTheMergedMemberAwayFromTranspiling(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a member that now lives inside its package object must not be transpiled apart",
+            MjMergeTest.merged(temp, "foo")
+                .execute(MjTranspile.class)
+                .result()
+                .keySet(),
+            Matchers.not(Matchers.hasItem(Matchers.containsString("EObar.java")))
+        );
+    }
+
+    @Test
+    void keepsTranspilingTheObjectTheMembersWentInto(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the object that now holds its members must still be compiled",
+            MjMergeTest.merged(temp, "foo")
+                .execute(MjTranspile.class)
+                .result()
+                .keySet(),
+            Matchers.hasItem(Matchers.containsString("EOfoo.java"))
+        );
+    }
+
+    @Test
+    void leavesEveryPackageAloneByDefault(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "no package is merged until one is named, so nothing may be written",
+            Files.exists(MjMergeTest.merged(temp).targetPath().resolve("4-merge")),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void refusesToMergeAMemberOverAnExistingAttribute(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a name held by both the object and its member must stop the build and name both",
+            MjMergeTest.root(
+                Assertions.assertThrows(
+                    IllegalStateException.class,
+                    () -> new FakeMaven(temp).withProgram(
+                        MjMergeTest.program("[n] > foo", "  42 > bar", "  n > @"),
+                        "foo",
+                        "foo.eo"
+                    ).withProgram(
+                        MjMergeTest.program("+package foo", "", "[] > bar", "  42 > @"),
+                        "foo.bar",
+                        "foo/bar.eo"
+                    ).with("mergedPackages", Collections.singletonList("foo"))
+                        .execute(new FakeMaven.Merge())
+                )
+            ),
+            Matchers.stringContainsInOrder("bar", "foo")
+        );
+    }
+
+    @Test
+    void refusesToMergeAPackageWithoutAnObject(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a package named for merging with no object of its own must not pass silently",
+            MjMergeTest.root(
+                Assertions.assertThrows(
+                    IllegalStateException.class,
+                    () -> new FakeMaven(temp).withProgram(
+                        MjMergeTest.program("+package foo", "", "[] > bar", "  42 > @"),
+                        "foo.bar",
+                        "foo/bar.eo"
+                    ).with("mergedPackages", Collections.singletonList("foo"))
+                        .execute(new FakeMaven.Merge())
+                )
+            ),
+            Matchers.containsString("foo")
+        );
+    }
+
+    /**
+     * A workspace holding the object {@code foo} with a void and the member
+     * {@code foo.bar}, taken through parsing and merging.
+     * @param temp The temporary directory
+     * @param packages The packages to merge
+     * @return The workspace, after the merge
+     * @throws Exception If the pipeline fails
+     */
+    private static FakeMaven merged(final Path temp, final String... packages) throws Exception {
+        return new FakeMaven(temp).withProgram(
+            MjMergeTest.program("[n] > foo", "  n > @"),
+            "foo",
+            "foo.eo"
+        ).withProgram(
+            MjMergeTest.program("+package foo", "", "[] > bar", "  42 > @"),
+            "foo.bar",
+            "foo/bar.eo"
+        ).with("mergedPackages", Arrays.asList(packages))
+            .execute(new FakeMaven.Merge());
+    }
+
+    /**
+     * The message of the deepest cause, which is where a mojo failure keeps
+     * what actually went wrong.
+     * @param thrown What the mojo threw
+     * @return The message
+     */
+    private static String root(final Throwable thrown) {
+        Throwable cause = thrown;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage();
+    }
+
+    /**
+     * The lines of an EO program as one text.
+     * @param lines The lines
+     * @return The program
+     */
+    private static String program(final String... lines) {
+        return String.join(System.lineSeparator(), lines);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
@@ -4,49 +4,62 @@
  */
 package org.eolang.maven;
 
-import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eolang.jucs.ClasspathSource;
+import org.eolang.xax.XtSticky;
+import org.eolang.xax.XtYaml;
+import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
- * Test cases for {@link MjMerge}.
+ * Test case for {@link MjMerge}.
+ *
+ * <p>What the merge does to a program is described by the packs in
+ * {@code merge-packs}: each one carries the files of a program, the packages to
+ * merge, and the XPaths the merged XMIR must satisfy, plus the text the
+ * generated Java must hold, so the behaviour is stated as the program a human
+ * would write rather than as XMIR by hand. What is left here are the mechanics
+ * no EO source can express: where the merged XMIR is pointed to from, what
+ * stops being compiled apart, and what the mojo refuses to do at all.</p>
+ *
  * @since 0.68.0
  */
 @ExtendWith(MktmpResolver.class)
 final class MjMergeTest {
 
-    @Test
-    void putsAMemberIntoTheObjectOfItsPackage(@Mktmp final Path temp) throws Exception {
-        MatcherAssert.assertThat(
-            "the member must arrive as an attribute of the object named by its package",
-            new XMLDocument(
-                MjMergeTest.merged(temp, "foo").targetPath().resolve("4-merge/foo.xmir")
-            ),
-            XhtmlMatchers.hasXPath("/object/o[@name='foo']/o[@name='bar']")
-        );
-    }
+    /**
+     * Temp directory, injected into every test instance, since a parameterized
+     * test cannot also take one as an argument.
+     */
+    @Mktmp
+    private Path dir;
 
-    @Test
-    void keepsTheAttributesTheObjectAlreadyHad(@Mktmp final Path temp) throws Exception {
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/merge-packs/", glob = "**.yaml")
+    void mergesTheProgramOfAPack(final String yaml) throws IOException {
+        final Xtory pack = new XtSticky(new XtYaml(yaml));
         MatcherAssert.assertThat(
-            "a member arrives after the voids, so the order of the arguments cannot shift",
-            new XMLDocument(
-                MjMergeTest.merged(temp, "foo").targetPath().resolve("4-merge/foo.xmir")
-            ),
-            XhtmlMatchers.hasXPath(
-                "/object/o[@name='foo']/o[@name='n']/following-sibling::o[@name='bar']"
-            )
+            "every XPath and every text of the pack must match what the merge wrote, but some didnt",
+            MjMergeTest.unmatched(pack, MjMergeTest.spliced(pack, this.dir)),
+            Matchers.empty()
         );
     }
 
@@ -72,22 +85,10 @@ final class MjMergeTest {
     }
 
     @Test
-    void keepsTranspilingTheObjectTheMembersWentInto(@Mktmp final Path temp) throws Exception {
-        MatcherAssert.assertThat(
-            "the object that now holds its members must still be compiled",
-            MjMergeTest.merged(temp, "foo")
-                .execute(MjTranspile.class)
-                .result()
-                .keySet(),
-            Matchers.hasItem(Matchers.containsString("EOfoo.java"))
-        );
-    }
-
-    @Test
     void leavesEveryPackageAloneByDefault(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "no package is merged until one is named, so nothing may be written",
-            Files.exists(MjMergeTest.merged(temp).targetPath().resolve("4-merge")),
+            Files.exists(MjMergeTest.merged(temp).targetPath().resolve(Merging.DIR)),
             Matchers.is(false)
         );
     }
@@ -135,14 +136,206 @@ final class MjMergeTest {
     }
 
     /**
+     * The program of a pack, parsed and merged, and transpiled as well when the
+     * pack asks anything of the generated Java.
+     * @param pack The pack
+     * @param temp The temporary directory
+     * @return The workspace, after the merge
+     * @throws IOException If the pipeline fails
+     */
+    private static FakeMaven spliced(final Xtory pack, final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        for (final Map.Entry<?, ?> source : MjMergeTest.sources(pack).entrySet()) {
+            final String name = source.getKey().toString();
+            maven.withProgram(source.getValue().toString(), MjMergeTest.identifier(name), name);
+        }
+        maven.with("mergedPackages", pack.map().get("merged"))
+            .execute(new FakeMaven.Merge());
+        if (!MjMergeTest.asked(pack, "java").isEmpty()) {
+            maven.execute(MjTranspile.class);
+        }
+        return maven;
+    }
+
+    /**
+     * Everything the pack asks for that is not there, each named by the
+     * document it was asked of, plus any key of the pack this runner does not
+     * know, since a key nobody reads would switch its assertions off in
+     * silence.
+     * @param pack The pack
+     * @param maven The workspace the merge has just written into
+     * @return What failed, empty when the pack is satisfied
+     * @throws IOException If a document cannot be read
+     */
+    private static Collection<String> unmatched(final Xtory pack, final FakeMaven maven)
+        throws IOException {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final Object key : pack.map().keySet()) {
+            if (!Arrays.asList("eo", "merged", "xmir", "java", "absent").contains(key)) {
+                failed.add(String.format("unknown key: %s", key));
+            }
+        }
+        failed.addAll(MjMergeTest.unmerged(pack, maven.targetPath().resolve(Merging.DIR)));
+        failed.addAll(MjMergeTest.untranspiled(pack, maven));
+        return failed;
+    }
+
+    /**
+     * The XPaths the pack asks of the merged XMIR that match nothing, together
+     * with the files it says must not be merged at all and were.
+     * @param pack The pack
+     * @param base The directory the merged XMIR was written to
+     * @return What failed
+     * @throws IOException If a document cannot be read
+     */
+    private static Collection<String> unmerged(final Xtory pack, final Path base)
+        throws IOException {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final Map.Entry<?, ?> entry : MjMergeTest.asked(pack, "xmir").entrySet()) {
+            final String name = entry.getKey().toString();
+            final Path file = base.resolve(name.replace(".eo", ".xmir"));
+            if (Files.exists(file)) {
+                failed.addAll(
+                    MjMergeTest.absent(new XMLDocument(file), name, (List<?>) entry.getValue())
+                );
+            } else {
+                failed.add(String.format("no merged XMIR for %s", name));
+            }
+        }
+        for (final Object name : MjMergeTest.listed(pack, "absent")) {
+            if (Files.exists(base.resolve(name.toString().replace(".eo", ".xmir")))) {
+                failed.add(String.format("%s was merged while it should not be", name));
+            }
+        }
+        return failed;
+    }
+
+    /**
+     * The texts the pack asks of the generated Java that are not in it, which is
+     * where a member that used to be an object of its own has to show up as an
+     * attribute of the class of its package.
+     * @param pack The pack
+     * @param maven The workspace the merge has just written into
+     * @return What failed
+     * @throws IOException If a file cannot be read
+     */
+    private static Collection<String> untranspiled(final Xtory pack, final FakeMaven maven)
+        throws IOException {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final Map.Entry<?, ?> entry : MjMergeTest.asked(pack, "java").entrySet()) {
+            final String name = entry.getKey().toString();
+            final Path file = MjMergeTest.generated(maven, name);
+            if (Files.exists(file)) {
+                failed.addAll(
+                    MjMergeTest.missing(Files.readString(file), name, (List<?>) entry.getValue())
+                );
+            } else {
+                failed.add(String.format("no Java generated for %s", name));
+            }
+        }
+        return failed;
+    }
+
+    /**
+     * The Java class a file of the program is transpiled into.
+     * @param maven The workspace
+     * @param name The name of the file
+     * @return The path to the class
+     * @throws IOException If the workspace cannot be read
+     */
+    private static Path generated(final FakeMaven maven, final String name) throws IOException {
+        return maven.generatedPath().resolve("org").resolve("eolang").resolve(
+            String.format("EO%s.java", name.replace(".eo", "").replace("/", "$EO"))
+        );
+    }
+
+    /**
+     * What the pack asks of one kind of document, by the name of the file.
+     * @param pack The pack
+     * @param key The key of the pack
+     * @return The demands, empty when the pack asks nothing
+     */
+    private static Map<?, ?> asked(final Xtory pack, final String key) {
+        return (Map<?, ?>) pack.map().getOrDefault(key, Collections.emptyMap());
+    }
+
+    /**
+     * What the pack lists under one of its keys.
+     * @param pack The pack
+     * @param key The key of the pack
+     * @return The list, empty when the pack lists nothing
+     */
+    private static List<?> listed(final Xtory pack, final String key) {
+        return (List<?>) pack.map().getOrDefault(key, Collections.emptyList());
+    }
+
+    /**
+     * The texts that are nowhere in the given one.
+     * @param java The text of the generated class
+     * @param about What the class is, for the message
+     * @param texts The texts
+     * @return The texts that failed
+     */
+    private static Collection<String> missing(
+        final String java, final String about, final List<?> texts
+    ) {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final Object text : texts) {
+            if (!java.contains(text.toString())) {
+                failed.add(String.format("%s: %s", about, text));
+            }
+        }
+        return failed;
+    }
+
+    /**
+     * The files of the program the pack describes.
+     * @param pack The pack
+     * @return The sources, by their names
+     */
+    private static Map<?, ?> sources(final Xtory pack) {
+        return (Map<?, ?>) pack.map().get("eo");
+    }
+
+    /**
+     * The name a file is known by in the tojos, which is what its path says
+     * with the separators read as dots, exactly as {@link MjRegister} reads it.
+     * @param name The name of the file
+     * @return The identifier
+     */
+    private static String identifier(final String name) {
+        return name.replace(".eo", "").replace('/', '.');
+    }
+
+    /**
+     * The XPaths that match nothing in the given document.
+     * @param document The document
+     * @param about What the document is, for the message
+     * @param xpaths The XPaths
+     * @return The XPaths that failed
+     */
+    private static Collection<String> absent(
+        final XML document, final String about, final List<?> xpaths
+    ) {
+        final Collection<String> failed = new ArrayList<>(0);
+        for (final Object xpath : xpaths) {
+            if (document.nodes(xpath.toString()).isEmpty()) {
+                failed.add(String.format("%s: %s", about, xpath));
+            }
+        }
+        return failed;
+    }
+
+    /**
      * A workspace holding the object {@code foo} with a void and the member
      * {@code foo.bar}, taken through parsing and merging.
      * @param temp The temporary directory
      * @param packages The packages to merge
      * @return The workspace, after the merge
-     * @throws Exception If the pipeline fails
+     * @throws IOException If the pipeline fails
      */
-    private static FakeMaven merged(final Path temp, final String... packages) throws Exception {
+    private static FakeMaven merged(final Path temp, final String... packages)
+        throws IOException {
         return new FakeMaven(temp).withProgram(
             MjMergeTest.program("[n] > foo", "  n > @"),
             "foo",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/body-of-a-member-is-left-alone.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/body-of-a-member-is-left-alone.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Nothing inside a moved member is rewritten, and it does not have to be. The
+# parser leaves every name fully qualified, so a reference to another object
+# still reads the same after the move, and every `loc` already says where the
+# node will be once it is an attribute of `Φ.number`. That is what makes the
+# splice a matter of moving one element.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/gte.eo: |
+    +package number
+
+    [n x] > gte
+      or. > @
+        n.gt x
+        n.eq x
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='gte' and @loc='Φ.number.gte']"
+    - "//o[@name='gte']/o[@name='n' and @loc='Φ.number.gte.n']"
+    - "//o[@name='gte']/o[@name='φ' and @loc='Φ.number.gte.φ']"
+    - "//o[@name='gte']/o[@name='φ' and @base='.or']"
+    - "//o[@name='gte']//o[@base='ξ.n.gt']"
+    - "//o[@name='gte']//o[@base='ξ.n.eq']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/deeper-package-stays-out.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/deeper-package-stays-out.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A member belongs to the package right above it and to no other. `Φ.number.i64`
+# is a package of its own, so `plus` goes into `i64` and not into `number`,
+# where it would arrive under a name that says nothing about where it came
+# from and would clash with the `plus` of any other nested package.
+merged:
+  - number
+  - number.i64
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+  number/i64.eo: |
+    +package number
+
+    [as-bytes] > i64
+      as-bytes > @
+  number/i64/plus.eo: |
+    +package number.i64
+
+    [left right] > plus
+      left > @
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='lt']"
+    - "/object/o[@name='number']/o[@name='i64']"
+    - "/object/o[@name='number'][not(o[@name='plus'])]"
+    - "/object/o[@name='number']/o[@name='i64']/o[@name='plus']"
+  number/i64.eo:
+    - "/object/o[@name='i64']/o[@name='plus']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/member-becomes-a-java-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/member-becomes-a-java-attribute.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The point of the merge is what the transpiler then writes. `lt` and `neg` were
+# objects of their own, each compiled into a class of its own and found by the
+# runtime on the classpath; after the merge they are attributes of the class of
+# `number`, added by name in its constructor, so nothing has to be searched for
+# when the program runs.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+  number/neg.eo: |
+    +package number
+
+    [n] > neg
+      n.times -1 > @
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='lt']"
+    - "/object/o[@name='number']/o[@name='neg']"
+java:
+  number.eo:
+    - 'class EOnumber'
+    - 'this.add("lt"'
+    - 'this.add("neg"'
+    - 'this.add("as-bytes"'

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/member-becomes-an-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/member-becomes-an-attribute.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A member of a package is a file of its own, and after the merge it is an
+# attribute of the object the package names. Nothing else about it changes:
+# it keeps its name, its voids and its body.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='lt']"
+    - "/object/o[@name='number']/o[@name='lt']/o[@base='∅' and @name='n']"
+    - "/object/o[@name='number']/o[@name='lt']/o[@base='∅' and @name='x']"
+    - "/object/o[@name='number']/o[@name='lt']/o[@name='φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/members-arrive-after-the-voids.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/members-arrive-after-the-voids.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A member arrives after every attribute the object already had, so the voids
+# keep the places they were counted from. If a member landed before them,
+# applying `number` to an argument would bind it to the member instead of to
+# the first void, and every application in the program would mean something
+# else.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+  number/neg.eo: |
+    +package number
+
+    [n] > neg
+      n.times -1 > @
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[1][@base='∅' and @name='as-bytes']"
+    - "/object/o[@name='number']/o[@name='as-bytes']/following-sibling::o[@name='lt']"
+    - "/object/o[@name='number']/o[@name='as-bytes']/following-sibling::o[@name='neg']"
+    - "/object/o[@name='number']/o[last()][@name='neg']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/package-that-is-not-named-stays-apart.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/package-that-is-not-named-stays-apart.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Only a package that is named is merged. The members of every other package
+# stay objects of their own, found by the runtime as they are today, so a
+# migration can take one package at a time.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+  string.eo: |
+    [as-bytes] > string
+      as-bytes > @
+  string/upper.eo: |
+    +package string
+
+    [text] > upper
+      text > @
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='lt']"
+absent:
+  - string.eo

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -279,6 +279,7 @@
               <goal>format</goal>
               <goal>compile</goal>
               <goal>inference</goal>
+              <goal>merge</goal>
               <goal>transpile</goal>
               <goal>atoms-table</goal>
               <goal>unplace</goal>


### PR DESCRIPTION
An object and the package of its name are two separate things today, and it takes the runtime to join them: asked for an attribute it does not hold, `Φ.number` goes looking for `Φ.number.lt` on the classpath and binds itself into the first void of whatever it finds. `MjMerge` does that joining at compile time, after `lint` so every member is still reported on as the file a human wrote, and before `transpile`, the first goal that cares about the shape of what it compiles:

```java
formation.appendChild(
    formation.getOwnerDocument().importNode(top.node(), true)
);
```

That one move is the whole splice. Nothing inside the member is rewritten, because the parser leaves every name fully qualified and every `loc` already reads as the locator the node will carry once it is an attribute of `Φ.number`, so nothing in the body can be captured by an attribute of the object it lands in. Appending rather than prepending keeps the places of the voids, and with them the meaning of applying the object to arguments.

The merged XMIR goes to `4-merge/`, the object's tojo is pointed at it, and each member is marked `merged` with the name of the object it went into, which takes it out of `standalone()` and so out of transpiling. The mark is read only there, deliberately: `withXmir()` stays as it was, since `eo-foreign.csv` outlives a build and a mark left in it would otherwise stop `MjLint` from ever looking at that member again.

Two refusals, both loud: a package named for merging that this build has no object for, and a member whose name the object already holds — one formation cannot carry two attributes under one name.

Enabling a package is not part of this. `mergedPackages` is empty, `merge` is bound in `eo-runtime` as a no-op, and master keeps today's behaviour. That is not caution for its own sake: I merged the real `bytes` package as a smoke test and 17 members spliced, transpiled and compiled, but 36 of 44 `EObytesTest` cases then failed with `Φ.bytes.as-bytes.φ` reaching ⊥ — the receiver used to arrive through that first void, and once the attribute really exists nothing puts it there. That is exactly what #6657 replaces with `^`, so each package gets switched on by the pull request that migrates it.

What the merge does to a program is stated as packs of EO files rather than as XMIR by hand, so each one reads as the program a human would write, and one of them goes on through `transpile` to check that a member really does come out as an attribute of the class of its package:

```yaml
java:
  number.eo:
    - 'class EOnumber'
    - 'this.add("lt"'
```

A pack found a bug worth having: with `number` and `number.i64` both named, `number` was merged first and took in an `i64` that had not yet been given its own members. Packages are merged deepest first now. The mechanics no EO source can express — where the object is pointed, what stops being compiled apart, and both refusals — stay as Java tests. `mvn compile` on `eo-runtime` is clean with the goal bound and empty.

