### PR TITLE
fix(#6605): reject writes past chunk bounds

### DIFF
--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -30,11 +30,19 @@
 
 [id] > chunk
   get > @
-  write > [source target length] > copy
-    target
-    read
-      source
-      length
+  [source target length] > copy
+    seq * > @
+      read source length >> data!
+      if.
+        gt.
+          target.plus length
+          size
+        write.
+          resized
+            target.plus length
+          target
+          data
+        write target data
   read > get
     0
     size
@@ -45,9 +53,17 @@
     T
       "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
         * object.size size
-    seq *
-      write 0 object
-      get
+    if.
+      size.eq 0
+      seq *
+        write.
+          resized object.size
+          0
+          object
+        get
+      seq *
+        write 0 object
+        get
   [] > read /Q.bytes
     ? > offset /Q.number
     ? > length /Q.number

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -28,7 +28,16 @@
       [offset] >> output-block
         true > @
         seq * > [buffer] > write
-          allocated.write offset buffer
+          if.
+            gt.
+              offset.plus buffer.size
+              allocated.size
+            write.
+              allocated.resized
+                offset.plus buffer.size
+              offset
+              buffer
+            allocated.write offset buffer
           output-block
             offset.plus buffer.size
       | 0

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -312,12 +312,6 @@
                 m.read 0 12
                 "Hello, Jeff!"
 
-  malloc.of ++> can-write-beyond-an-offset-and-resize
-    1
-    seq * > [m]
-      m.write 1 true
-      m.size.eq 2
-
   ++> can-write-into-a-block-made-by-of
     mem.eq 10 > @
     malloc.of > mem
@@ -380,3 +374,9 @@
     m.read > [m]
       0
       100
+
+  malloc.of --> stops-on-writing-beyond-an-offset
+    1
+    m.write > [m]
+      1
+      true

--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -236,11 +236,19 @@ final class Heaps {
                     )
                 );
             }
-            if (this.blocks.get(identifier).length < end) {
-                this.resize(identifier, (int) end);
-            }
             final byte[] source = this.blocks.get(identifier);
             final int length = source.length;
+            if (length < end) {
+                throw new ExFailure(
+                    String.format(
+                        "Can't write '%d' bytes with offset '%d' to the block with identifier '%d', because only '%d' were allocated",
+                        data.length,
+                        offset,
+                        identifier,
+                        length
+                    )
+                );
+            }
             final byte[] result = new byte[length];
             System.arraycopy(source, 0, result, 0, length);
             System.arraycopy(data, 0, result, offset, data.length);

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -201,32 +201,30 @@ final class HeapsTest {
     }
 
     @Test
-    void resizesOnWriteMoreThanAllocated() {
+    void rejectsWritePastAllocatedBlock() {
+        final byte[] original = {7, 8, 9};
         MatcherAssert.assertThat(
-            "Heaps should resize block when writing more bytes than allocated, but it didn't",
+            "Heaps must leave the allocated block unchanged after rejecting an out-of-bounds write",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 2,
-                idx -> {
-                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
-                    return Heaps.INSTANCE.read(idx, 0, 5);
-                }
+                new HeapsTest.PhFake(), original.length,
+                idx -> HeapsTest.rejectedWrite(idx, original)
             ),
-            Matchers.equalTo(new byte[] {1, 2, 3, 4, 5})
+            Matchers.equalTo(original)
         );
     }
 
     @Test
-    void resizesOnWriteMoreThanAllocatedWithOffset() {
-        MatcherAssert.assertThat(
-            "Heaps should resize block when writing past allocated boundary using offset, but it didn't",
-            Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 3,
+    void rejectsWritePastZeroSizedBlock() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 0,
                 idx -> {
-                    Heaps.INSTANCE.write(idx, 1, new byte[] {1, 2, 3});
-                    return Heaps.INSTANCE.read(idx, 1, 3);
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1});
+                    return idx;
                 }
             ),
-            Matchers.equalTo(new byte[] {1, 2, 3})
+            "Heaps must not implicitly grow a zero-sized block"
         );
     }
 
@@ -342,6 +340,35 @@ final class HeapsTest {
             Matchers.equalTo(3)
         );
         Heaps.INSTANCE.free(idx);
+    }
+
+    /**
+     * Reject an out-of-bounds write and return the unchanged block.
+     * @param identifier Block identifier
+     * @param original Original bytes
+     * @return Bytes left in the block
+     */
+    private static byte[] rejectedWrite(final int identifier, final byte[] original) {
+        Heaps.INSTANCE.write(identifier, 0, original);
+        MatcherAssert.assertThat(
+            "The failure must describe the rejected write and allocated block",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> Heaps.INSTANCE.write(identifier, 100, new byte[] {1})
+            ).getMessage(),
+            Matchers.equalTo(
+                String.format(
+                    "Can't write '1' bytes with offset '100' to the block with identifier '%d', because only '3' were allocated",
+                    identifier
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "A rejected write must not change the allocated size",
+            Heaps.INSTANCE.size(identifier),
+            Matchers.equalTo(original.length)
+        );
+        return Heaps.INSTANCE.read(identifier, 0, original.length);
     }
 
     /**


### PR DESCRIPTION
## Summary

- reject `Heaps.write` ranges that extend past the allocated block instead of resizing implicitly
- preserve the intended growth behavior of empty `put`, `copy`, and `to-output` through explicit `resized` calls
- verify the rejected write leaves both the allocation size and the original bytes unchanged

## Validation

- `mvn -ntp -PskipITs --errors --batch-mode -Deo.coverageTracking=false -Deo.deadline=2 clean install -pl :eo-runtime` (2059 tests, 0 failures, 0 errors, 351 skipped)
- `mvn -ntp -PskipTests -Pqulice --errors --batch-mode verify -pl :eo-runtime`

Fixes #6605
