### PR TITLE
#6702: reject a non-digit port suffix in uri

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -246,12 +246,12 @@
       uri "http://user:pass@host:80/some/path"
     "user:pass"
 
-  eq. ++> cannot-treat-a-letter-suffixed-port-as-numeric
+  eq. ++> can-treat-a-letter-suffixed-port-as-invalid
     port.
       uri "http://host:12x/"
     ""
 
-  eq. ++> cannot-treat-a-non-digit-port-as-numeric
+  eq. ++> can-treat-a-non-digit-port-as-invalid
     port.
       uri "http://host:abc/"
     ""

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -68,7 +68,25 @@
     ""
   if. > host
     not. >> has-port
-      port-colon-idx.eq -1
+      eq.
+        if. >> port-colon-idx
+          string.starts-with host-port "[" >>
+          if.
+            eq.
+              string.index-of >> rel-colon
+                host-port.slice
+                  bracket-start
+                  host-port.length.minus
+                    number bracket-start
+                ":"
+              -1
+            -1
+            rel-colon.plus
+              plus. >> bracket-start
+                string.index-of host-port "]" >>
+                1
+          string.index-of host-port ":"
+        -1
     slice.
       has-userinfo.if >> host-port
         authority.slice
@@ -91,29 +109,17 @@
       ""
     hier-part
   has-port.if > port
-    host-port.slice
-      plus.
-        if. >> port-colon-idx
-          string.starts-with host-port "[" >>
-          if.
-            eq.
-              string.index-of >> rel-colon
-                host-port.slice
-                  bracket-start
-                  host-port.length.minus
-                    number bracket-start
-                ":"
-              -1
-            -1
-            rel-colon.plus
-              plus. >> bracket-start
-                string.index-of host-port "]" >>
-                1
-          string.index-of host-port ":"
-        1
-      host-port.length.minus
-        number
-          port-colon-idx.plus 1
+    if.
+      raw-port.is-digit.or
+        eq.
+          host-port.slice >> raw-port
+            port-colon-idx.plus 1
+            host-port.length.minus
+              number
+                port-colon-idx.plus 1
+          ""
+      raw-port
+      ""
     ""
   if. > query
     not. >> has-query
@@ -180,6 +186,11 @@
       uri "http://host/some/path?x=1#top"
     "x=1"
 
+  eq. ++> can-parse-an-empty-port
+    port.
+      uri "http://host:/"
+    ""
+
   eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
     host.
       uri "file:///etc/passwd"
@@ -234,3 +245,13 @@
     userinfo.
       uri "http://user:pass@host:80/some/path"
     "user:pass"
+
+  eq. ++> cannot-treat-a-letter-suffixed-port-as-numeric
+    port.
+      uri "http://host:12x/"
+    ""
+
+  eq. ++> cannot-treat-a-non-digit-port-as-numeric
+    port.
+      uri "http://host:abc/"
+    ""


### PR DESCRIPTION
`uri` exposes everything after the authority's port colon as `port`, without checking that the suffix is actually digits (RFC 3986 defines `port = *DIGIT`). `http://host:abc/` exposed `"abc"` and `http://host:12x/` exposed `"12x"`.

Added a validity check on the sliced port suffix: it must be either empty or all ASCII digits (`string.is-digit`). When invalid, `port` returns `""` instead of the malformed text, the same way it already does when no port colon is present at all. `host` and `path` are unaffected since they only depend on the colon's position, not its content.

Added `can-parse-an-empty-port`, `cannot-treat-a-letter-suffixed-port-as-numeric`, `cannot-treat-a-non-digit-port-as-numeric`.

Closes #6702
