### PR TITLE
#6710: re-qualify Probing sibling names to match the probed object's prefix

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -144,12 +144,18 @@ final class Probing implements Step {
         final Set<String> completed
     ) throws IOException {
         final int split = object.lastIndexOf('.');
-        if (split > 0) {
-            final String pkg = object.substring(0, split);
-            if (completed.add(pkg)) {
-                for (final String sibling : this.objectionary.children(pkg)) {
-                    this.tojos.add(sibling).withDiscoveredAt(src);
+        final String pkg = object.substring(0, Math.max(split, 0));
+        if (split > 0 && completed.add(pkg)) {
+            final String root = "org.eolang.";
+            final boolean rooted = object.startsWith(root);
+            for (final String sibling : this.objectionary.children(pkg)) {
+                final String qualified;
+                if (rooted && !sibling.startsWith(root)) {
+                    qualified = root.concat(sibling);
+                } else {
+                    qualified = sibling;
                 }
+                this.tojos.add(qualified).withDiscoveredAt(src);
             }
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -75,6 +75,40 @@ final class ProbingTest {
     }
 
     @Test
+    void avoidsDuplicateTojoForAnOrgEolangPrefixedReference(
+        @TempDir final Path temp
+    ) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > test",
+                    "  Q.org.eolang.number.gte > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(
+                    () -> new SetOf<>("number", "number.gte", "number.sqrt", "number.abs")
+                )
+            ),
+            true
+        ).exec();
+        MatcherAssert.assertThat(
+            "Probe should not also track the sibling under its short, unqualified name",
+            tojos.contains("number.gte"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void skipsWhenOffline(@TempDir final Path temp) throws IOException {
         final Path xmir = temp.resolve("test.xmir");
         Files.write(


### PR DESCRIPTION
`ObjectsIndex.children()` returns short (index-form) names, e.g. `number.gte`, even when queried with an `org.eolang.`-prefixed package. `Probing.complete` registered those short names as-is (`this.tojos.add(sibling)`), so a probed reference like `Q.org.eolang.number.gte` ended up tracked under two different tojo identifiers: `org.eolang.number.gte` (the probed object itself) and `number.gte` (the same object, discovered again as its own package's sibling).

Re-qualified the sibling names in `Probing.complete`: when the probed object carries the `org.eolang.` prefix, siblings that don't already carry it get it prepended before registration, so the object is tracked under one identifier consistently.

Added `avoidsDuplicateTojoForAnOrgEolangPrefixedReference`, reproducing the case from the issue (`Q.org.eolang.number.gte` against an index containing `number`, `number.gte`, `number.sqrt`, `number.abs`) and asserting the short form is not also registered.

Closes #6710
