### PR TITLE
#6600: retry write with the unwritten tail on a partial write

### DIFF
--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -55,12 +55,6 @@
 # ```
 #
 # Sequential reuse maintains the console state across operations.
-#
-# @todo #6600:30min Keep writing the remaining bytes on a partial write. Right
-#  now `write` panics only when the `write` syscall returns -1; a successful
-#  write of fewer bytes than `buffer.size` is accepted as if the whole buffer
-#  went out, same as `stderr.write`. Both should retry with the unwritten
-#  tail until the buffer is fully flushed or a syscall fails.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -106,13 +100,18 @@
                       "Failed to write to standard output"
                     output-block
                   code
-                  output-block
+                  remainder
                 code. > code
                   win32 *1
                     "_write"
                     win32.stdout
                     buffer
                     buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  output-block
             buffer
     [] >>
       [size] > read
@@ -149,14 +148,27 @@
                       "Failed to write to standard output"
                     output-block
                   code
-                  output-block
+                  remainder
                 code. > code
                   posix *1
                     "write"
                     posix.stdout
                     buffer
                     buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  output-block
             buffer
+
+  ++> can-chain-writes-across-output-blocks
+    seq * > @
+      o1
+      o1.write
+        "part two.\n"
+    console.write > o1
+      "part one, "
 
   console.write ++> can-write-to-the-console
     "Hello, console-test!\n"

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -37,13 +37,18 @@
                       "Failed to write to standard error"
                     output-block
                   code
-                  output-block
+                  remainder
                 code. > code
                   win32 *1
                     "_write"
                     win32.stderr
                     buffer
                     buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  output-block
         [] >>
           [buffer] > write
             @. > @
@@ -58,13 +63,18 @@
                       "Failed to write to standard error"
                     output-block
                   code
-                  output-block
+                  remainder
                 code. > code
                   posix *1
                     "write"
                     posix.stderr
                     buffer
                     buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  output-block
       text
     true
 


### PR DESCRIPTION
Resolves the `@todo` puzzle from #6600: `console.write` and `stderr.write` only checked the `write` syscall's return code for `-1` (failure). A successful write of fewer bytes than the buffer's size (a partial write) was treated as if the whole buffer went out, silently dropping the unwritten tail.

Both `write` implementations (POSIX and Windows, in `console.eo` and `stderr.eo`) now compare the syscall's byte count against the buffer size. On a short write, they retry through the same output block with the remaining unwritten slice (`buffer.slice`), until the whole buffer is flushed or a syscall fails.

Added `can-chain-writes-across-output-blocks` in `console.eo`, chaining two writes through the returned output blocks. A genuine short write can't be forced deterministically from EO (the underlying syscall is a native atom), so this covers the retry path structurally without breaking the normal one; `can-write-to-the-console` and `can-print-to-stderr` already cover the full-write path through the same code.

Ran `EOconsoleTest`/`EOstderrTest` and `qulice:check -Pqulice`, both green.

Closes #6735
