### PR TITLE
#6656: write the merged XMIR only when its content differs

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
@@ -9,6 +9,7 @@ import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,14 +38,6 @@ import org.w3c.dom.Node;
  * arguments, stay as they were.</p>
  *
  * @since 0.68.0
- * @todo #6656:30min Write the merged XMIR only when it differs.
- *  The file is written on every build, so its timestamp always moves and
- *  {@link Transpiling} compiles the object again even when neither the object
- *  nor any member of it was touched. It is done this way because the opposite
- *  mistake is worse: a merged object left over from an earlier build would
- *  quietly compile yesterday's member. Comparing the text with what is
- *  already there, and writing only on a difference, would give the
- *  incremental build back without that risk.
  */
 final class Merging implements Step {
 
@@ -175,10 +168,10 @@ final class Merging implements Step {
             );
         }
         final Path target = new Place(pkg).make(this.dir, MjAssemble.XMIR);
-        new Saved(
-            new XMLDocument(formation.getOwnerDocument()).toString(),
-            target
-        ).value();
+        final String merged = new XMLDocument(formation.getOwnerDocument()).toString();
+        if (!Files.exists(target) || !new Diff(Files.readString(target), merged).same()) {
+            new Saved(merged, target).value();
+        }
         object.withXmir(target);
         for (final TjForeign member : members.values()) {
             member.withMerged(pkg);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MergingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MergingTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import org.cactoos.list.ListOf;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@link Merging}.
+ * @since 0.68.0
+ */
+final class MergingTest {
+
+    @Test
+    void writesTheMergedXmirOnlyWhenItsContentChanges(@TempDir final Path temp) throws Exception {
+        final Path pkg = temp.resolve("pkg.xmir");
+        Files.write(
+            pkg,
+            new EoSyntax("[] > foo").parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final Path member = temp.resolve("member.xmir");
+        Files.write(
+            member,
+            new EoSyntax("[] > bar").parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final Path merge = temp.resolve("4-merge");
+        final Path target = new Place("foo").make(merge, MjAssemble.XMIR);
+        this.merge(pkg, member, merge);
+        final FileTime before = Files.getLastModifiedTime(target);
+        Thread.sleep(1_100L);
+        this.merge(pkg, member, merge);
+        MatcherAssert.assertThat(
+            "Merged XMIR should not be rewritten when its content hasn't changed",
+            Files.getLastModifiedTime(target),
+            Matchers.equalTo(before)
+        );
+    }
+
+    /**
+     * Merge the "foo" package (with member "bar") from scratch into {@code merge}.
+     * @param pkg The package's own XMIR
+     * @param member The member's XMIR
+     * @param merge The directory for the merged XMIR
+     * @throws IOException If the merge fails
+     */
+    private void merge(
+        final Path pkg, final Path member, final Path merge
+    ) throws IOException {
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("foo").withXmir(pkg);
+        tojos.add("foo.bar").withXmir(member);
+        new Merging(tojos, merge, new ListOf<>("foo")).exec();
+    }
+}


### PR DESCRIPTION
Resolves the `@todo` puzzle from #6656: `Merging.spliced` wrote the merged XMIR unconditionally, so its timestamp moved on every build even when neither the package object nor any of its members had changed, forcing `Transpiling` to recompile it every time.

Now the merged text is compared against what's already on disk (the same `Diff` class `MjFormat` already uses for its own canonical-form comparison), and the file is written only when the target is missing or the content differs.

Added `MergingTest` (the class had no unit tests before): merges a package twice from the same unchanged inputs and asserts the merged file's mtime doesn't move on the second run. Verified it fails without the fix (mtime always moves) and passes with it.

Ran `MergingTest` and `qulice:check -Pqulice`, both green.

Closes #6747
