### PR TITLE
Write down what every object sits in

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Nesting.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Nesting.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+
+/**
+ * What a locator is written inside.
+ *
+ * <p>A locator is the path to where an object is written, so walking it back
+ * one name at a time and stopping at the first formation is how the object
+ * something is written inside is found, and nobody has to be asked. Applied to
+ * a reference it answers with the object being formed around it, which is what
+ * {@code ξ} names; applied to that answer it gives what the object sits in,
+ * which is what {@code ξ.ρ} names.</p>
+ *
+ * <p>A top-level object is written inside a package rather than a formation,
+ * and nothing is answered about it here.</p>
+ *
+ * @since 0.69.0
+ */
+final class Nesting {
+
+    /**
+     * The locators of the formations, the only objects anything sits in.
+     */
+    private final Collection<String> formations;
+
+    /**
+     * Ctor.
+     * @param made The locators of the formations of the program
+     */
+    Nesting(final Collection<String> made) {
+        this.formations = made;
+    }
+
+    /**
+     * The formation this locator is written inside.
+     * @param locator The locator to walk out of
+     * @return The locator of the formation, or an empty string when no
+     *  formation is around it
+     */
+    String around(final String locator) {
+        String walked = locator;
+        String found = "";
+        while (walked.contains(".")) {
+            walked = walked.substring(0, walked.lastIndexOf('.'));
+            if (this.formations.contains(walked)) {
+                found = walked;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Parents.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Parents.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.yegor256.tojos.Tojos;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * What every object of a program sits in.
+ *
+ * <p>An object answers to {@code ρ} for the one it is written inside, and an
+ * outer name is lowered into a dispatch of exactly that, so the needs table
+ * asks about {@code ρ} all the time. No row ever mentioned it, which left
+ * every such question unanswered while the owner was called complete all the
+ * same — the one way this table could say "there is no such attribute" about
+ * an attribute every object has.</p>
+ *
+ * <p>Nobody has to be asked for the answer. A locator is the path to where an
+ * object is written, so the nearest formation the path runs through is what
+ * the object sits in. The object a file is about runs through none, and sits
+ * in the root: {@code Φ} describes nothing and is not meant to, since "it sits
+ * in the root" and "it sits in nothing" are different answers and only the
+ * first is true.</p>
+ *
+ * @since 0.69.0
+ */
+final class Parents {
+
+    /**
+     * The formations of the program.
+     */
+    private final Collection<XML> made;
+
+    /**
+     * Ctor.
+     * @param formations The formations of the program
+     */
+    Parents(final Collection<XML> formations) {
+        this.made = formations;
+    }
+
+    /**
+     * Write these attributes into the given table.
+     * @param rows The table to fill
+     */
+    void fill(final Tojos rows) {
+        final Collection<String> owners = new HashSet<>(0);
+        for (final XML formation : this.made) {
+            owners.add(formation.xpath("@loc").get(0));
+        }
+        final Nesting nesting = new Nesting(owners);
+        for (final XML formation : this.made) {
+            final String owner = formation.xpath("@loc").get(0);
+            final String sits = nesting.around(owner);
+            final String root;
+            if (sits.isEmpty()) {
+                root = "Φ";
+            } else {
+                root = sits;
+            }
+            rows.add(String.join(" ", owner, "ρ"))
+                .set("owner", owner)
+                .set("name", "ρ")
+                .set("type", root);
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -60,19 +60,16 @@ import java.util.Collection;
  * skipped: {@code [] > recovered /A} comes back with whatever the caller put
  * in, and that is a variable, which nothing here understands yet.</p>
  *
- * <p>Not every attribute is written inside the formation it belongs to:
+ * <p>Not every attribute is written inside the formation it belongs to.
+ * {@code ρ}, the object something sits in, is written nowhere and every
+ * object has one, which {@link Parents} reads off the locator. And
  * {@code minus} in the package {@code number} is {@code Φ.number.minus} and
- * belongs to {@code Φ.number} without ever appearing among its children.
- * {@link Members} finds those and they go into this table too, last, since
- * the order of attributes is what binds the arguments of an application and
- * a file of a package binds none of them.</p>
+ * belongs to {@code Φ.number} without ever appearing among its children,
+ * which {@link Members} finds. Both go into this table after the attributes
+ * a formation binds itself, since the order of those is what binds the
+ * arguments of an application and neither of these two is one of them.</p>
  *
  * @since 0.67.0
- * @todo #6565:35min Write down the {@code ρ} every object has. An outer
- *  name lowers to a dispatch of {@code ρ}, so the needs table asks for
- *  it, while no row here ever lists it and the owner is called complete
- *  all the same. Give every type a {@code ρ} attribute, or say in this
- *  table that {@code ρ} is not a name the checker judges.
  */
 final class Provides implements Clue {
 
@@ -100,6 +97,7 @@ final class Provides implements Clue {
                     }
                 }
             }
+            new Parents(made).fill(rows);
             new Members(made, world.roots()).fill(rows);
             Files.createDirectories(tables);
             Files.write(

--- a/eo-inference/src/main/java/org/eolang/inference/Scope.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Scope.java
@@ -59,7 +59,8 @@ final class Scope {
         if (base.startsWith("Φ.")) {
             found = this.rooted(base);
         } else if ("ξ.ρ".equals(base)) {
-            found = this.around(this.around(reference));
+            final Nesting nesting = new Nesting(this.formations);
+            found = nesting.around(nesting.around(reference));
         } else {
             found = this.outwards(reference, base.substring(base.indexOf('.') + 1));
         }
@@ -77,32 +78,6 @@ final class Scope {
             found = base;
         } else {
             found = "";
-        }
-        return found;
-    }
-
-    /**
-     * The nearest formation around the given locator.
-     *
-     * <p>Applied to a reference it answers with the object being formed
-     * around it, which is what {@code ξ} names; applied to that answer it
-     * gives what the object sits in, which is what {@code ξ.ρ} names. A
-     * top-level object sits in a package rather than in a formation, and
-     * nothing is answered about it.</p>
-     *
-     * @param locator The locator to walk out of
-     * @return The locator of the formation, or an empty string when no
-     *  formation is around it
-     */
-    private String around(final String locator) {
-        String walked = locator;
-        String found = "";
-        while (walked.contains(".")) {
-            walked = walked.substring(0, walked.lastIndexOf('.'));
-            if (this.formations.contains(walked)) {
-                found = walked;
-                break;
-            }
         }
         return found;
     }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-lists-attributes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-lists-attributes.yaml
@@ -9,6 +9,6 @@ eo:
       [] > steam
       [] > whistle
 provides:
-  - "/provides/type[@id='Φ.kettle' and count(attr)=2]"
+  - "/provides/type[@id='Φ.kettle' and count(attr[@name!='ρ'])=2]"
   - "/provides/type[@id='Φ.kettle']/attr[@name='steam']"
   - "/provides//attr[@name='steam' and @type='Φ.kettle.steam']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -22,7 +22,8 @@ xmir:
     - "//o[@base='.foo']/o[@base='.next']/o[@base='ξ.x']"
 provides:
   - "/provides/type[@id='Φ.app.t']/attr[@name='next' and @type='Φ.app.t.next']"
-  - "/provides/type[@id='Φ.app.t.next' and @complete='true' and not(attr[@name!='ρ'])]"
+  - "/provides/type[@id='Φ.app.t.next' and @complete='true']"
+  - "/provides/type[@id='Φ.app.t.next'][not(attr[@name!='ρ'])]"
   - "/provides/type[@id='Φ.app.inc']/attr[@name='x' and @void='true']"
 needs:
   - "/needs/type[@id='Φ.app.inc.φ.ρ.ρ']/attr[@name='next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -22,7 +22,7 @@ xmir:
     - "//o[@base='.foo']/o[@base='.next']/o[@base='ξ.x']"
 provides:
   - "/provides/type[@id='Φ.app.t']/attr[@name='next' and @type='Φ.app.t.next']"
-  - "/provides/type[@id='Φ.app.t.next' and @complete='true' and not(attr)]"
+  - "/provides/type[@id='Φ.app.t.next' and @complete='true' and not(attr[@name!='ρ'])]"
   - "/provides/type[@id='Φ.app.inc']/attr[@name='x' and @void='true']"
 needs:
   - "/needs/type[@id='Φ.app.inc.φ.ρ.ρ']/attr[@name='next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/object-says-what-it-sits-in.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/object-says-what-it-sits-in.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Every object sits in another one and answers to `ρ` for it. The text says
+# which, since the locator of an object is the path to where it is written, so
+# the row is there to be had without asking anybody.
+eo:
+  outer.eo: |
+    [] > outer
+      [] > inner
+provides:
+  - "/provides/type[@id='Φ.outer.inner']/attr[@name='ρ' and @type='Φ.outer']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
@@ -16,5 +16,6 @@ eo:
 provides:
   - "/provides/type[@id='Φ.number']/attr[@name='minus']"
   - "/provides//attr[@name='minus' and @type='Φ.number.minus']"
-  - "/provides/type[@id='Φ.number' and @complete='true' and count(attr[@name!='ρ'])=2]"
+  - "/provides/type[@id='Φ.number' and @complete='true']"
+  - "/provides/type[@id='Φ.number'][count(attr[@name!='ρ'])=2]"
   - "/provides/type[@id='Φ.number.minus' and @complete='true']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-member-is-attribute.yaml
@@ -16,5 +16,5 @@ eo:
 provides:
   - "/provides/type[@id='Φ.number']/attr[@name='minus']"
   - "/provides//attr[@name='minus' and @type='Φ.number.minus']"
-  - "/provides/type[@id='Φ.number' and @complete='true' and count(attr)=2]"
+  - "/provides/type[@id='Φ.number' and @complete='true' and count(attr[@name!='ρ'])=2]"
   - "/provides/type[@id='Φ.number.minus' and @complete='true']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-with-no-object-of-its-own.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/package-with-no-object-of-its-own.yaml
@@ -11,4 +11,4 @@ eo:
     [] > minus
 provides:
   - "/provides/type[@id='Φ.number.minus']"
-  - "/provides[not(//attr)]"
+  - "/provides[not(//attr[@name!='ρ'])]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/top-level-object-sits-in-the-root.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/top-level-object-sits-in-the-root.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The object a file is about sits in nothing that is written down: its `ρ` is
+# the root, which no table describes. The row says so rather than saying
+# nothing, because "the parent is Φ" and "there is no parent" are different
+# answers and only one of them is true.
+eo:
+  outer.eo: |
+    [] > outer
+      [] > inner
+provides:
+  - "/provides/type[@id='Φ.outer']/attr[@name='ρ' and @type='Φ']"


### PR DESCRIPTION
Every object answers to `ρ` for the one it is written inside, and an outer name is lowered into a dispatch of exactly that, so the needs table asks about `ρ` all the time. Nothing ever wrote it down. That left the provides table saying something certainly wrong: that an object seen whole has no attribute of that name.

It is not hypothetical. Applying the parked verdict rule — report when the receiver's type is complete and has no such attribute — to a clean `eo-runtime` gave ten reports, and every one of the ten was this:

```
map.xmir:80     ρ asked of Φ.map.ctor.found.not-found
socket.xmir:160 ρ asked of Φ.socket.a🌵55-4
regex.xmir:104  ρ asked of Φ.string.regex.pattern
```

Nobody has to be asked for the answer. A locator is the path to where an object is written, so the nearest formation the path runs through is what the object sits in; `Parents` reads it off and writes one row per formation. The object a file is about runs through no formation and sits in the root, which is written as `Φ` and described by nothing — "it sits in the root" and "it sits in nothing" are different answers and only the first is true.

The walk itself is now `Nesting`. `Scope` was already doing it privately to resolve `ξ.ρ`, so the two agree by construction rather than by coincidence.

With this in, the rule reports **nothing** on a clean runtime, and still catches every typo I seed into it — eight of eight this time, misspelled dispatch names at judgeable sites, each reported as `zzzNN asked of Φ.malloc` and friends. The tables gain 2,518 rows, one per formation: links rows 31,826 → 31,845, dispatches with a type 10,049 → 10,068 of 10,404, delegation chains ending nowhere 1,421 → 1,413, and dispatches whose receiver is whole enough to judge 1,004 → 1,028.

Two packs describe the behaviour, and the four packs that counted attributes now say what they always meant, since `ρ` is not a name a formation binds. The puzzle text is gone from `Provides`.

Closes #6636
