### PR TITLE
Lift the tests of a package member to the top of the object

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
@@ -19,15 +19,16 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Put the members of a package inside the object that the package names.
  *
  * <p>The parsed XMIR of the object and of its members are all on disk by the
- * time this runs, and the splice is a matter of moving one element: the
+ * time this runs, and the splice is a matter of moving elements: the
  * top-level {@code <o>} of {@code number/lt.xmir} becomes a child of the
- * top-level {@code <o>} of {@code number.xmir}. Nothing inside the moved tree
- * is touched, because the parser leaves every name fully qualified and every
+ * top-level {@code <o>} of {@code number.xmir}. No name inside the moved tree
+ * is rewritten, because the parser leaves every name fully qualified and every
  * {@code loc} already reads as the locator the node will carry once it is an
  * attribute of {@code Φ.number}, so no reference can be captured by an
  * attribute of the object it lands in.</p>
@@ -35,6 +36,14 @@ import org.w3c.dom.Node;
  * <p>A member arrives after the attributes the object already had, so the
  * places of the voids, and with them the meaning of applying the object to
  * arguments, stay as they were.</p>
+ *
+ * <p>The tests a member declares do not travel with it. A test is legal only
+ * as a direct child of the top-level object of a file, which is what the
+ * parser demands and what the transpiler reads when it writes the test class,
+ * so each one is lifted out of the member and appended to the object beside
+ * the tests the object declares itself. The member is merged before the
+ * package that holds it, so a test written three files deep arrives at the top
+ * one level at a time and nothing has to look for it.</p>
  *
  * @since 0.68.0
  * @todo #6656:30min Write the merged XMIR only when it differs.
@@ -150,29 +159,24 @@ final class Merging implements Step {
         final Node formation = Merging.formation(object.xmir());
         final Collection<String> taken = Merging.names(formation);
         for (final Map.Entry<String, TjForeign> member : members.entrySet()) {
-            final Xnav top = Merging.top(
-                member.getValue().xmir()
+            final Node top = formation.getOwnerDocument().importNode(
+                Merging.top(member.getValue().xmir()).node(), true
             );
-            final String name = top.attribute("name").text().orElseThrow(
-                () -> new IllegalStateException(
+            final String name = Merging.named(top);
+            if (name.isEmpty()) {
+                throw new IllegalStateException(
                     String.format(
                         "The member '%s' has no name, while only a named object can become an attribute of '%s'",
                         member.getKey(), pkg
                     )
-                )
-            );
-            if (taken.contains(name)) {
-                throw new IllegalStateException(
-                    String.format(
-                        "The name '%s' of the member '%s' is already an attribute of '%s', while one object cannot hold two attributes under one name",
-                        name, member.getKey(), pkg
-                    )
                 );
             }
-            taken.add(name);
-            formation.appendChild(
-                formation.getOwnerDocument().importNode(top.node(), true)
-            );
+            Merging.claimed(taken, name, member.getKey(), pkg);
+            formation.appendChild(top);
+            for (final Node test : Merging.tests(top)) {
+                Merging.claimed(taken, Merging.named(test), member.getKey(), pkg);
+                formation.appendChild(top.removeChild(test));
+            }
         }
         final Path target = new Place(pkg).make(this.dir, MjAssemble.XMIR);
         new Saved(
@@ -188,6 +192,64 @@ final class Merging implements Step {
             members.size(), pkg, target
         );
         return members.size();
+    }
+
+    /**
+     * Take a name for one object, refusing a name that is taken already.
+     * @param taken The names the object holds, added to
+     * @param name The name to take
+     * @param member The member the name comes from, for the message
+     * @param pkg The name of the package, for the message
+     */
+    private static void claimed(
+        final Collection<String> taken, final String name, final String member, final String pkg
+    ) {
+        if (taken.contains(name)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The name '%s' arriving from the member '%s' is already an attribute of '%s', while one object cannot hold two attributes under one name",
+                    name, member, pkg
+                )
+            );
+        }
+        taken.add(name);
+    }
+
+    /**
+     * The tests one object declares.
+     *
+     * <p>A test is an attribute whose name the parser prefixed with a plus or a
+     * minus, which is what it does to the name of every {@code ++>} and
+     * {@code -->} it reads and to nothing else. They are collected before any
+     * of them moves, since the children of a node are a live list.</p>
+     *
+     * @param object The object
+     * @return The tests
+     */
+    private static Collection<Node> tests(final Node object) {
+        final Collection<Node> found = new ArrayList<>(0);
+        final NodeList kids = object.getChildNodes();
+        for (int idx = 0; idx < kids.getLength(); ++idx) {
+            final Node kid = kids.item(idx);
+            final String name = Merging.named(kid);
+            if (name.startsWith("+") || name.startsWith("-")) {
+                found.add(kid);
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The name an object carries, empty when it carries none, which is what
+     * the indentation between two objects comes back as too.
+     * @param object The object
+     * @return The name
+     */
+    private static String named(final Node object) {
+        return Optional.ofNullable(object.getAttributes())
+            .map(attrs -> attrs.getNamedItem("name"))
+            .map(Node::getNodeValue)
+            .orElse("");
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
@@ -35,8 +35,9 @@ import org.junit.jupiter.params.ParameterizedTest;
  * <p>What the merge does to a program is described by the packs in
  * {@code merge-packs}: each one carries the files of a program, the packages to
  * merge, and the XPaths the merged XMIR must satisfy, plus the text the
- * generated Java must hold, so the behaviour is stated as the program a human
- * would write rather than as XMIR by hand. What is left here are the mechanics
+ * generated Java must hold, both of the object and of its tests, so the
+ * behaviour is stated as the program a human would write rather than as XMIR
+ * by hand. What is left here are the mechanics
  * no EO source can express: where the merged XMIR is pointed to from, what
  * stops being compiled apart, and what the mojo refuses to do at all.</p>
  *
@@ -117,6 +118,37 @@ final class MjMergeTest {
     }
 
     @Test
+    void refusesToLiftOneNameOutOfTwoMembers(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "two members declaring one name for their tests must stop the build and name it",
+            MjMergeTest.root(
+                Assertions.assertThrows(
+                    IllegalStateException.class,
+                    () -> new FakeMaven(temp).withProgram(
+                        MjMergeTest.program("[n] > foo", "  n > @"),
+                        "foo",
+                        "foo.eo"
+                    ).withProgram(
+                        MjMergeTest.program(
+                            "+package foo", "", "[] > bar", "  42 > @", "  1.eq 1 ++> can-be-one"
+                        ),
+                        "foo.bar",
+                        "foo/bar.eo"
+                    ).withProgram(
+                        MjMergeTest.program(
+                            "+package foo", "", "[] > baz", "  42 > @", "  1.eq 1 ++> can-be-one"
+                        ),
+                        "foo.baz",
+                        "foo/baz.eo"
+                    ).with("mergedPackages", Collections.singletonList("foo"))
+                        .execute(new FakeMaven.Merge())
+                )
+            ),
+            Matchers.stringContainsInOrder("can-be-one", "foo.baz", "foo")
+        );
+    }
+
+    @Test
     void refusesToMergeAPackageWithoutAnObject(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "a package named for merging with no object of its own must not pass silently",
@@ -151,7 +183,8 @@ final class MjMergeTest {
         }
         maven.with("mergedPackages", pack.map().get("merged"))
             .execute(new FakeMaven.Merge());
-        if (!MjMergeTest.asked(pack, "java").isEmpty()) {
+        if (!MjMergeTest.asked(pack, "java").isEmpty()
+            || !MjMergeTest.asked(pack, "tests").isEmpty()) {
             maven.execute(MjTranspile.class);
         }
         return maven;
@@ -171,7 +204,7 @@ final class MjMergeTest {
         throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
         for (final Object key : pack.map().keySet()) {
-            if (!Arrays.asList("eo", "merged", "xmir", "java", "absent").contains(key)) {
+            if (!Arrays.asList("eo", "merged", "xmir", "java", "tests", "absent").contains(key)) {
                 failed.add(String.format("unknown key: %s", key));
             }
         }
@@ -222,30 +255,48 @@ final class MjMergeTest {
     private static Collection<String> untranspiled(final Xtory pack, final FakeMaven maven)
         throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
-        for (final Map.Entry<?, ?> entry : MjMergeTest.asked(pack, "java").entrySet()) {
-            final String name = entry.getKey().toString();
-            final Path file = MjMergeTest.generated(maven, name);
-            if (Files.exists(file)) {
-                failed.addAll(
-                    MjMergeTest.missing(Files.readString(file), name, (List<?>) entry.getValue())
-                );
-            } else {
-                failed.add(String.format("no Java generated for %s", name));
+        for (final String kind : Arrays.asList("java", "tests")) {
+            for (final Map.Entry<?, ?> entry : MjMergeTest.asked(pack, kind).entrySet()) {
+                final String name = entry.getKey().toString();
+                final Path file = MjMergeTest.generated(maven, name, kind);
+                if (Files.exists(file)) {
+                    failed.addAll(
+                        MjMergeTest.missing(
+                            Files.readString(file), name, (List<?>) entry.getValue()
+                        )
+                    );
+                } else {
+                    failed.add(String.format("nothing generated for %s under %s", name, kind));
+                }
             }
         }
         return failed;
     }
 
     /**
-     * The Java class a file of the program is transpiled into.
+     * The class a file of the program is transpiled into, either the object
+     * itself or the tests it declares, which land in a source root of their own.
      * @param maven The workspace
      * @param name The name of the file
+     * @param kind Either the object or its tests
      * @return The path to the class
      * @throws IOException If the workspace cannot be read
      */
-    private static Path generated(final FakeMaven maven, final String name) throws IOException {
-        return maven.generatedPath().resolve("org").resolve("eolang").resolve(
-            String.format("EO%s.java", name.replace(".eo", "").replace("/", "$EO"))
+    private static Path generated(final FakeMaven maven, final String name, final String kind)
+        throws IOException {
+        final Path base;
+        final String suffix;
+        if ("tests".equals(kind)) {
+            base = maven.generatedPath().getParent().resolve("generated-test-sources");
+            suffix = "Test";
+        } else {
+            base = maven.generatedPath();
+            suffix = "";
+        }
+        return base.resolve("org").resolve("eolang").resolve(
+            String.format(
+                "EO%s%s.java", name.replace(".eo", "").replace("/", "$EO"), suffix
+            )
         );
     }
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/tests-of-a-member-keep-running.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/tests-of-a-member-keep-running.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A member declares its tests in its own file, where they are attributes of the
+# member. A test is legal only as a direct child of the top-level object, so the
+# merge lifts them out of the member and leaves them beside the tests the object
+# declares itself, which is the one place the transpiler reads them from. The
+# member no longer has a class of its own, and its tests run from the test class
+# of the object its package names.
+merged:
+  - number
+eo:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+
+      1.eq 1 ++> can-be-what-a-number-is
+  number/lt.eo: |
+    +package number
+
+    [n x] > lt
+      n.gt x > @
+
+      lt 2 1 ++> can-tell-two-is-above-one
+      lt 1 2 --> stops-on-one-below-two
+xmir:
+  number.eo:
+    - "/object/o[@name='number']/o[@name='lt']"
+    - "/object/o[@name='number']/o[@name='+can-tell-two-is-above-one']"
+    - "/object/o[@name='number']/o[@name='-stops-on-one-below-two']"
+    - "/object/o[@name='number']/o[@name='lt'][not(o[@name='+can-tell-two-is-above-one'])]"
+tests:
+  number.eo:
+    - 'class EOnumberTest'
+    - 'void can_be_what_a_number_is()'
+    - 'void can_tell_two_is_above_one()'
+    - 'void _stops_on_one_below_two()'
+    - 'this.add("can-tell-two-is-above-one"'
+    - 'new Dataized(this.take("can-tell-two-is-above-one")).asBool()'
+    - 'Assertions.assertThrows(Exception.class'


### PR DESCRIPTION
A test is legal only as a direct child of the top-level object of a file. The parser says so outright — `test attribute legal only as direct child of top-level object` — and the transpiler agrees by construction, since it assembles the test class from the direct attributes of the class and nothing below them. Until #6656 the two could not disagree, because a package member was the top-level object of its own file. `MjMerge` makes the member an attribute of the object its package names, and a test spliced in along with it lands one level too deep, where nothing looks for it:

```java
formation.appendChild(top);
for (final Node test : Merging.tests(top)) {
    Merging.claimed(taken, Merging.named(test), member.getKey(), pkg);
    formation.appendChild(top.removeChild(test));
}
```

So the member goes in, and its tests come back out and sit beside the tests the object declares itself. Merged XMIR stays a shape the parser would have accepted, and the transpiler keeps knowing nothing about packages — which is right, since the merge is the only component that knows members exist.

Package members in `eo-runtime/src/main/eo` declare 944 test attributes, and each package's share was set to disappear the moment that package was named in `mergedPackages`, with nothing failing to say so. The `bytes` smoke test in #6743 reported 44 cases in `EObytesTest`, and 44 is what `bytes.eo` declares by itself — all seventeen members' tests were already gone and I read the number as normal.

Lifting them also puts the collision where it belongs. Two members claiming one test name now meet the same refusal a member claiming a taken attribute name meets, naming the test and the member it came from, instead of reaching javac as two methods of one generated class. That makes the last duplicate in #6654 — `stops-on-a-fractional-index`, in three members of `tuple` — a hard blocker for merging `tuple` rather than something a human has to remember to scan for.

Nothing needs to walk deeper than one level. Packages merge deepest first, so `number.i64.plus` gives its tests to `i64` before `i64` gives its own to `number`, and a test written three files down arrives at the top one level at a time. A lifted test keeps the `loc` it was parsed with, `Φ.number.i64.plus.+can-…`, which is what names it in `PhDefault` labels and failure messages — worth keeping, since that is the only thing left in the merged XMIR that says which member the test came from.
