### PR TITLE
Name each fractional-index refusal after the member that makes it

### DIFF
--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -63,7 +63,7 @@
         5
       0
 
-  back. --> stops-on-a-fractional-index
+  back. --> stops-on-a-fractional-index-when-taking-the-back
     *
       "a"
       "b"

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -97,7 +97,7 @@
       2
       3
 
-  front. --> stops-on-a-fractional-index
+  front. --> stops-on-a-fractional-index-when-taking-the-front
     *
       "a"
       "b"

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -53,7 +53,7 @@
       "smthg"
       27
 
-  withouti. --> stops-on-a-fractional-index
+  withouti. --> stops-on-a-fractional-index-when-dropping-an-item
     *
       "a"
       "b"


### PR DESCRIPTION
Three members of the `tuple` package each called their refusal by the same name:

```
tuple/front.eo:100     front.    --> stops-on-a-fractional-index
tuple/back.eo:66       back.     --> stops-on-a-fractional-index
tuple/withouti.eo:56   withouti. --> stops-on-a-fractional-index
```

Merging the package puts all three inside one object, and one object cannot hold three attributes under one name — `MjMerge` refuses outright since #6755, so this is what stands between `tuple` and #6657. Each name now says which member did the refusing, which is what a failure report wants regardless of the merge: three methods called `_stops_on_a_fractional_index` in one report say nothing about which object rejected what.

Most of this ticket had already been done. I rescanned every package and this was the only name left over: the 26 duplicates the issue counted are down to one, and the sixteen redundant smoke tests it wanted dropped from `number.eo`, `string.eo` and `tuple.eo` are gone — `"eEo".is-alpha` and `7.mod 3` are no longer there to find. The three `*-through-the-package` tests stay, since they assert the explicit form that #6657 removes along with the form itself.

Nothing enforces the rule for a package nobody has merged yet, so a duplicate can still arrive in one. That closes on its own as #6657 turns the packages on one at a time, and until then the check lives in `MjMerge`.
