### PR TITLE
Shorten three MjSafe options so PMD needs no suppression

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
@@ -99,12 +99,12 @@ final class MjTranspileIT {
                     .set("trackTransformationSteps", "true")
                     .set("cacheEnabled", "false");
                 f.exec("process-sources");
-                MatcherAssert.assertThat(
-                    "the plugin must still understand the old name of the tracking option",
-                    temp.resolve("target/eo/5-pre-transpile").toFile().exists(),
-                    Matchers.is(true)
-                );
             }
+        );
+        MatcherAssert.assertThat(
+            "the plugin must still understand the old name of the tracking option",
+            temp.resolve("target/eo/5-pre-transpile").toFile().exists(),
+            Matchers.is(true)
         );
     }
 

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
@@ -74,6 +74,28 @@ final class MjTranspileIT {
         );
     }
 
+    @Test
+    void acceptsOldNameOfTrackingOption(@Mktmp final Path temp) throws Exception {
+        new Farea(temp).together(
+            f -> {
+                f.clean();
+                f.files().file("src/main/eo/foo.eo").write(
+                    MjTranspileIT.simpleApp().getBytes(StandardCharsets.UTF_8)
+                );
+                new AppendedPlugin(f).value()
+                    .goals("register", "parse", "transpile")
+                    .configuration()
+                    .set("trackTransformationSteps", "true");
+                f.exec("process-sources");
+                MatcherAssert.assertThat(
+                    "the plugin must still understand the old name of the tracking option",
+                    temp.resolve("target/eo/5-pre-transpile").toFile().exists(),
+                    Matchers.is(true)
+                );
+            }
+        );
+    }
+
     private static void transpile(
         final Farea farea, final String path, final String source
     ) throws java.io.IOException {

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjTranspileIT.java
@@ -74,6 +74,17 @@ final class MjTranspileIT {
         );
     }
 
+    /**
+     * The plugin must keep understanding the old name of the tracking option.
+     *
+     * <p>Caching is off on purpose: a cache hit returns the Java without
+     * running the XSL train, and it is the train that leaves the tracked
+     * XMIRs behind. The machine-wide cache is shared with the other tests
+     * of this class, which transpile the very same source.</p>
+     *
+     * @param temp Temporary directory
+     * @throws Exception If fails
+     */
     @Test
     void acceptsOldNameOfTrackingOption(@Mktmp final Path temp) throws Exception {
         new Farea(temp).together(
@@ -85,7 +96,8 @@ final class MjTranspileIT {
                 new AppendedPlugin(f).value()
                     .goals("register", "parse", "transpile")
                     .configuration()
-                    .set("trackTransformationSteps", "true");
+                    .set("trackTransformationSteps", "true")
+                    .set("cacheEnabled", "false");
                 f.exec("process-sources");
                 MatcherAssert.assertThat(
                     "the plugin must still understand the old name of the tracking option",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -48,7 +48,7 @@ public final class MjCompile extends MjSafe {
                         this.plugin.getVersion(),
                         this.skipSourceLints,
                         this.skipProgramLints,
-                        this.skipExperimentalLints,
+                        this.skipExperimental,
                         this.failOnWarning,
                         this.lintAsPackage,
                         this.skipLinting
@@ -64,7 +64,7 @@ public final class MjCompile extends MjSafe {
                         this.resolveJna,
                         this.ignoreRuntime,
                         this.runtime(),
-                        this.ignoreVersionConflicts
+                        this.ignoreConflicts
                     )
                 ),
                 new Timed(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -48,7 +48,7 @@ public final class MjLint extends MjSafe {
             this.plugin.getVersion(),
             this.skipSourceLints,
             this.skipProgramLints,
-            this.skipExperimentalLints,
+            this.skipExperimental,
             this.failOnWarning,
             this.lintAsPackage,
             this.skipLinting

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -65,7 +65,7 @@ public final class MjResolve extends MjSafe {
             this.resolveJna,
             this.ignoreRuntime,
             this.runtime(),
-            this.ignoreVersionConflicts
+            this.ignoreConflicts
         ).exec();
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -170,12 +170,16 @@ abstract class MjSafe extends AbstractMojo {
     /**
      * Track optimization steps into intermediate XMIR files?
      * @since 0.24.0
-     * @checkstyle MemberNameCheck (7 lines)
-     * @checkstyle VisibilityModifierCheck (5 lines)
+     * @checkstyle MemberNameCheck (10 lines)
+     * @checkstyle VisibilityModifierCheck (9 lines)
      */
-    @SuppressWarnings("PMD.LongVariable")
-    @Parameter(property = "eo.trackTransformationSteps", required = true, defaultValue = "false")
-    protected boolean trackTransformationSteps;
+    @Parameter(
+        alias = "trackTransformationSteps",
+        property = "eo.trackTransformationSteps",
+        required = true,
+        defaultValue = "false"
+    )
+    protected boolean trackSteps;
 
     /**
      * If set to TRUE, the exception on exit will be printed in details
@@ -232,11 +236,15 @@ abstract class MjSafe extends AbstractMojo {
      * If set to TRUE, experimental lints are skipped during the linting.
      * @since 0.57.0
      * @checkstyle VisibilityModifierCheck (10 lines)
-     * @checkstyle MemberNameCheck (7 lines)
+     * @checkstyle MemberNameCheck (9 lines)
      */
-    @Parameter(property = "eo.skipExperimentalLints", required = true, defaultValue = "false")
-    @SuppressWarnings("PMD.LongVariable")
-    protected boolean skipExperimentalLints;
+    @Parameter(
+        alias = "skipExperimentalLints",
+        property = "eo.skipExperimentalLints",
+        required = true,
+        defaultValue = "false"
+    )
+    protected boolean skipExperimental;
 
     /**
      * Pull again even if the .eo file is already present?
@@ -260,11 +268,15 @@ abstract class MjSafe extends AbstractMojo {
      * Fail resolution process on conflicting dependencies.
      * @since 0.1.0
      * @checkstyle MemberNameCheck (10 lines)
-     * @checkstyle VisibilityModifierCheck (7 lines)
+     * @checkstyle VisibilityModifierCheck (9 lines)
      */
-    @Parameter(property = "eo.ignoreVersionConflicts", required = true, defaultValue = "false")
-    @SuppressWarnings("PMD.LongVariable")
-    protected boolean ignoreVersionConflicts;
+    @Parameter(
+        alias = "ignoreVersionConflicts",
+        property = "eo.ignoreVersionConflicts",
+        required = true,
+        defaultValue = "false"
+    )
+    protected boolean ignoreConflicts;
 
     /**
      * Shall we discover JAR artifacts for .EO sources?

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -155,7 +155,7 @@ public final class MjTranspile extends MjSafe {
                 this.plugin.getVersion(),
                 this.transpileTests,
                 this.xslMeasures.toPath(),
-                new Tracking(this.trackTransformationSteps, this.trackLocations),
+                new Tracking(this.trackSteps, this.trackLocations),
                 this.coverageTracking,
                 this.base(),
                 this.roots()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -172,7 +172,7 @@ final class FakeMaven {
             this.params.putIfAbsent("skipZeroVersions", true);
             this.params.putIfAbsent("cacheEnabled", true);
             this.params.putIfAbsent("discoverSelf", false);
-            this.params.putIfAbsent("ignoreVersionConflicts", false);
+            this.params.putIfAbsent("ignoreConflicts", false);
             this.params.putIfAbsent("central", new FakeMaven.DummyCentral());
             this.params.putIfAbsent("resolveInCentral", false);
             this.params.putIfAbsent(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -253,7 +253,7 @@ final class MjResolveTest {
                     "[] > main-1 /bytes"
                 )
             );
-        maven.with("ignoreVersionConflicts", true)
+        maven.with("ignoreConflicts", true)
             .execute(new FakeMaven.Resolve());
         MatcherAssert.assertThat(
             "The class file must exist, but it doesn't",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -74,7 +74,7 @@ final class MjTranspileTest {
                     "",
                     "[] > x"
                 )
-                ).with("trackTransformationSteps", true)
+                ).with("trackSteps", true)
                 .execute(MjParse.class)
                 .execute(MjTranspile.class),
             "We should be able to transpile a simple EO program without exceptions when tracking transformation steps"
@@ -86,7 +86,7 @@ final class MjTranspileTest {
         MatcherAssert.assertThat(
             "the first tracked step of a program holding two objects did not leave its XMIR in the pre-transpile directory",
             new FakeMaven(temp).withProgram(MjTranspileTest.pair())
-                .with("trackTransformationSteps", true)
+                .with("trackSteps", true)
                 .execute(MjParse.class)
                 .execute(MjTranspile.class)
                 .result(),
@@ -102,7 +102,7 @@ final class MjTranspileTest {
         MatcherAssert.assertThat(
             "the second object of a tracked program did not reach the generated Java",
             new FakeMaven(temp).withProgram(MjTranspileTest.pair())
-                .with("trackTransformationSteps", true)
+                .with("trackSteps", true)
                 .execute(MjParse.class)
                 .execute(MjTranspile.class)
                 .result(),


### PR DESCRIPTION
Three `@Parameter` fields in `MjSafe` carried `@SuppressWarnings("PMD.LongVariable")` only because their names doubled as the names users write in the plugin's XML. That is no longer a reason to keep them long: `trackTransformationSteps`, `skipExperimentalLints` and `ignoreVersionConflicts` are now `trackSteps`, `skipExperimental` and `ignoreConflicts`, and all three suppressions are gone.

Nothing changes for anyone configuring the plugin. Each field keeps its `eo.*` user property untouched, so `-Deo.trackTransformationSteps=true` and friends work exactly as before, and each one gains an `alias` with its old name, so an existing `<configuration><ignoreVersionConflicts>` element still binds. Maven resolves aliases before it injects, both at plugin level and inside an `<execution>`.

`MjTranspileIT.acceptsOldNameOfTrackingOption` is the guard for that: it runs a real Maven build that configures the plugin with the old `trackTransformationSteps` element and then checks that `target/eo/5-pre-transpile` was written, which only happens when the value actually reached `trackSteps`.

Two of the five suppressions listed in #6459 are still there and I left them alone. `PMD.TooManyFields` on the class cannot go until the options are grouped into objects, which the issue itself says is the real work; `PMD.ImmutableField` on `objectionary` is held in place by `FakeMaven` setting that field reflectively, and every way I tried to make it `final` either broke the fake or traded the PMD suppression for a Checkstyle one. Both are worth their own change, so the issue should stay open.

Related to #6459.
