### PR TITLE
Read the inference tables back for mistakes

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Clues.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Clues.java
@@ -33,11 +33,11 @@ import java.util.Collection;
  *
  * <p>No clue decides anything, which is why they can be read one after
  * another in any order, and why nothing here says whether a program is
- * wrong. Judging used to live beside these rules and was taken out again
- * in #6661: it reported nothing, because a verdict needs the object that
- * misses an attribute to have been seen whole, and almost none of them have
- * been. It comes back when every object can be given a type, rather than
- * only those a call site happens to reach.</p>
+ * wrong. Judging it is {@link Concluded}, which reads the tables back once
+ * they are written and puts what it is sure of into a table of its own. A
+ * rule that decided while it read would have to be handed answers no rule
+ * has found yet, and there would be nowhere to put a second reading of the
+ * same rows.</p>
  *
  * @since 0.67.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Concluded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Concluded.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.tojos.MnMemory;
+import com.yegor256.tojos.TjDeferred;
+import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * The tables, read together for mistakes.
+ *
+ * <p>A clue writes down what it understands and decides nothing, which is what
+ * keeps the rules simple and apart from one another. This is the other half:
+ * the tables they wrote are read back and what is certainly wrong lands in a
+ * table of its own beside them. Nothing but the documents passes between the
+ * two halves, so a rule can change how it fills a table, or a table can gain a
+ * column, without this being touched.</p>
+ *
+ * <p>The mistakes are written the way every other table is written, a type
+ * with the names it is asked for and will never have:</p>
+ *
+ * <pre> &lt;problems&gt;
+ *   &lt;type id="Φ.t"&gt;
+ *     &lt;attr name="extra" asked="Φ.app.φ"/&gt;
+ *   &lt;/type&gt;
+ * &lt;/problems&gt;</pre>
+ *
+ * <p>which says that {@code extra} is taken from a {@code Φ.t}, at
+ * {@code Φ.app.φ}, and that a {@code Φ.t} will never have it. The document is
+ * written even when it is empty, because "nothing was found" is an answer and
+ * a missing file is not. Nothing fails the build: this is a prototype, and its
+ * verdicts are worth reading before they are worth obeying.</p>
+ *
+ * <p>This was written once before and taken out again in #6661, when it
+ * reported nothing at all: a verdict needs the object that misses an attribute
+ * to have been seen whole, and hardly any object had been. It needed a
+ * worklist then — a queue of promises filed by every application, each split
+ * into smaller ones — to push a type into the body it was passed to. The
+ * tables now answer without being pushed, so what is left of it is
+ * {@link Missing}, one pass over the rows.</p>
+ *
+ * @since 0.69.0
+ */
+public final class Concluded implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the tables are read
+     */
+    public Concluded(final Clue clues) {
+        this.origin = clues;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final XML given = new XMLDocument(tables.resolve("provides.xml"));
+        final Map<String, String> names = new Ends(
+            new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()
+        ).names();
+        try (Tojos rows = new TjDeferred(new MnMemory())) {
+            new Missing(
+                new Provided(given, names),
+                new Ungrouped(new XMLDocument(tables.resolve("needs.xml")), names).rows()
+            ).fill(rows);
+            Files.write(
+                tables.resolve("problems.xml"),
+                new Grouped(rows, "problems").asXml().toString().getBytes(StandardCharsets.UTF_8)
+            );
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Missing.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Missing.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.yegor256.tojos.Tojos;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * What a program asks for and will never find.
+ *
+ * <p>{@link Needs} has a row for every dispatch, saying which object is asked
+ * for which name; {@link Links}, closed by {@link Resolved}, says what that
+ * object is; and {@link Provides} says what it holds. So a mistake is those
+ * three read together, and nothing else is needed to find one: the object
+ * {@code .foo} is taken from has been seen whole, and there is no {@code foo}
+ * in it.</p>
+ *
+ * <p>Both halves of that sentence are guards. "Seen whole" leaves an atom, an
+ * object nobody in the program describes, and anything a caller decides out of
+ * the verdict — a name taken from a void is a question, not a claim, and the
+ * table has no row for one, so it is never whole. "There is no such name"
+ * means there is none in the type, none in its package, and none behind what
+ * it delegates to, which {@link Provided} walks before answering. It is better
+ * to miss a mistake than to complain about correct code.</p>
+ *
+ * <p>What that leaves out is the mistake that is one for a single caller. In
+ * the program of the design note, {@code inc} takes {@code foo} from whatever
+ * it is given, and it is given a {@code t} whose {@code next} has no
+ * {@code foo}; the dispatch itself is written against a void and is right for
+ * some other argument, so nothing is said about it. Only where a receiver is
+ * concrete where it stands is anything said at all, which is why the verdicts
+ * hold for every caller of the code they are about.</p>
+ *
+ * @since 0.69.0
+ */
+final class Missing {
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided given;
+
+    /**
+     * The rows of the needs table, by the name their owner goes by.
+     */
+    private final Map<String, Collection<Map<String, String>>> wanted;
+
+    /**
+     * Ctor.
+     * @param provided What the types certainly have
+     * @param needs The rows of the needs table, by the name of their owner
+     */
+    Missing(
+        final Provided provided,
+        final Map<String, Collection<Map<String, String>>> needs
+    ) {
+        this.given = provided;
+        this.wanted = needs;
+    }
+
+    /**
+     * Write every mistake into the given table.
+     * @param rows The table to fill
+     */
+    void fill(final Tojos rows) {
+        for (final Map.Entry<String, Collection<Map<String, String>>> asked
+            : this.wanted.entrySet()) {
+            if (this.given.complete(asked.getKey())) {
+                for (final Map<String, String> need : asked.getValue()) {
+                    this.judge(asked.getKey(), need, rows);
+                }
+            }
+        }
+    }
+
+    /**
+     * Write this one question down, when the type will never answer it.
+     *
+     * <p>A row is kept under the locator of the dispatch, since the same name
+     * may be taken from the same object in several places and every one of
+     * them is a mistake of its own, worth pointing at.</p>
+     *
+     * @param type The name the type goes by
+     * @param need The row of the needs table about the question
+     * @param rows The table to fill
+     */
+    private void judge(
+        final String type, final Map<String, String> need, final Tojos rows
+    ) {
+        final String name = need.getOrDefault("name", "");
+        if (!name.isEmpty() && this.given.attribute(type, name).isEmpty()) {
+            final String where = need.getOrDefault("type", "");
+            rows.add(type);
+            rows.add(where).set("owner", type).set("name", name).set("asked", where);
+        }
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -14,8 +15,9 @@ import java.util.Map;
  *
  * <p>This is the table {@link Provides} wrote, read by the name a type and
  * its copies go by, so that a question about a copy is answered by the
- * formation it is a copy of. One question is asked of it: what the type of an
- * attribute is, or nothing at all when the type has no such attribute.</p>
+ * formation it is a copy of. Two questions are asked of it: what the type of
+ * an attribute is, or nothing at all when the type has no such attribute, and
+ * whether the whole of a type has been seen.</p>
  *
  * <p>An attribute is looked for in three places, because there are three. The
  * type itself. Its package, since an attribute nobody binds falls
@@ -46,15 +48,28 @@ final class Provided {
     private final Map<String, String> names;
 
     /**
-     * The locator of every void, from {@link Hollows}.
+     * The locator of every void the table knows.
      */
     private final Collection<String> hollows;
 
     /**
      * Ctor.
+     * @param provides The provides table, as {@link Provides} wrote it
+     * @param aliases The name every type goes by, from {@link Ends}
+     */
+    Provided(final XML provides, final Map<String, String> aliases) {
+        this(
+            new Ungrouped(provides, aliases).rows(),
+            aliases,
+            provides.xpath("//attr[@void='true']/@type")
+        );
+    }
+
+    /**
+     * Ctor.
      * @param rows The rows of the provides table, by the name of their owner
-     * @param aliases The name every type goes by, from {@link Same}
-     * @param voids The locator of every void, from {@link Hollows}
+     * @param aliases The name every type goes by, from {@link Ends}
+     * @param voids The locator of every void the table knows
      */
     Provided(
         final Map<String, Collection<Map<String, String>>> rows,
@@ -75,6 +90,29 @@ final class Provided {
      */
     String attribute(final String type, final String name) {
         return this.kept(type, name, new HashSet<>(0));
+    }
+
+    /**
+     * Has the whole of this type been seen?
+     *
+     * <p>A type nothing in the table is about has not, which is what keeps a
+     * name taken from a void out of every verdict: nobody but a caller can say
+     * what such a name is, and no caller is being read here.</p>
+     *
+     * @param type The name the type goes by
+     * @return TRUE when nothing about the type is hidden
+     */
+    boolean complete(final String type) {
+        boolean whole = false;
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("complete")) {
+                whole = Boolean.parseBoolean(row.get("complete"));
+                if (!whole) {
+                    break;
+                }
+            }
+        }
+        return whole;
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/package-info.java
+++ b/eo-inference/src/main/java/org/eolang/inference/package-info.java
@@ -26,19 +26,22 @@
  * a copy of another. A dispatch ({@code .next}) says that the object it
  * is taken from must have that attribute.</p>
  *
- * <p>Nothing here decides whether the program is wrong. Reading the tables
- * together, draining the checks an application files and reporting what is
- * certainly missing was written and taken out again in #6661, because it
- * reported nothing: a verdict needs the object that misses an attribute to
- * have been seen whole, and on a runtime build 48 objects out of 2,505
- * have. The tables have to describe the program before anything can judge
- * it, and that is what this module is for until then.</p>
+ * <p>Then the tables are read together and one kind of mistake is looked
+ * for: a name taken from an object that will never have it. A verdict is
+ * given only about an object the whole of which has been seen, so that the
+ * parts of a program this module cannot see — atoms, delegation through
+ * {@code φ}, a void nobody has filled — make it quiet rather than wrong.
+ * The mistake of the program above is not among them: {@code foo} is taken
+ * from a void and is a mistake for this caller only, while what is reported
+ * holds for every caller of the code it is about.</p>
  *
  * <p>Each rule is a {@link org.eolang.inference.Clue}, which reads the
  * XMIR of a whole program from one directory and writes what it has
  * understood into another. The Maven plugin prepares that XMIR and follows
- * every clue we know through {@link org.eolang.inference.Clues}. Nothing is
- * renamed and nothing fails the build.</p>
+ * every clue we know through {@link org.eolang.inference.Clues}, wrapped in
+ * {@link org.eolang.inference.Resolved}, which works out what the dispatches
+ * are, and in {@link org.eolang.inference.Concluded}, which reads the tables
+ * for mistakes. Nothing is renamed and nothing fails the build.</p>
  *
  * @since 0.67.0
  * @see <a href="https://www.eolang.org">Project site www.eolang.org</a>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.inference.Clues;
+import org.eolang.inference.Concluded;
 import org.eolang.inference.Resolved;
 import org.eolang.parser.TrFull;
 
@@ -45,6 +46,9 @@ import org.eolang.parser.TrFull;
  * locators are set again, because the objects that the splitting has just
  * created have none. That is what the prepared files hold, and they are worth
  * keeping: every row of every table points into them.</p>
+ *
+ * <p>The tables are then read back for mistakes, and what is found goes into
+ * one more of them. Nothing fails the build over it.</p>
  *
  * @since 0.67.0
  */
@@ -86,10 +90,11 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
-            new Resolved(new Clues()).follow(this.prepared, this.tables);
+            new Concluded(new Resolved(new Clues())).follow(this.prepared, this.tables);
             Logger.info(
-                this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
-                ready, this.tables
+                this,
+                "Inferred the types of %d XMIR(s) and found %d mistake(s), tables are in %[file]s",
+                ready, this.mistakes(), this.tables
             );
         } else {
             Logger.info(
@@ -97,6 +102,17 @@ final class Inferring implements Step {
                 this.input
             );
         }
+    }
+
+    /**
+     * How many names the program takes from objects that will never have them.
+     * @return The number of mistakes the tables were read for
+     * @throws IOException If the table cannot be read
+     */
+    private int mistakes() throws IOException {
+        return new XMLDocument(this.tables.resolve("problems.xml"))
+            .nodes("/problems/type/attr")
+            .size();
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -32,11 +32,11 @@ import org.apache.maven.plugins.annotations.Parameter;
  * that one type is a copy of another. A dispatch ({@code .next}) says that
  * the object it is taken from must have that attribute.</p>
  *
- * <p>Nothing here says whether the program is wrong. Judging it was written
- * and taken out again in #6661, because a verdict needs the object that
- * misses an attribute to have been seen whole, and almost none of them have
- * been; the tables have to describe the program before anything can read
- * them for mistakes.</p>
+ * <p>The tables are then read together for one kind of mistake: a name taken
+ * from an object that will never have it. Nothing is said about an object the
+ * whole of which has not been seen — an atom, one that delegates, a void
+ * nobody has filled — so that what this goal cannot see makes it quiet rather
+ * than wrong.</p>
  *
  * <p>The XMIR prepared for the rules is saved in {@link #prepared} and the
  * tables in {@link #tables}, a document each. Not one of them fails the

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -170,7 +170,7 @@ final class InferringTest {
     private Collection<String> unmatched(final Xtory pack, final Path temp) throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
         final Collection<String> tables = Arrays.asList(
-            "provides", "needs", "links"
+            "provides", "needs", "links", "problems"
         );
         for (final Object key : pack.map().keySet()) {
             if (!"eo".equals(key) && !"xmir".equals(key) && !tables.contains(key)) {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-from-package-is-not-missing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-from-package-is-not-missing.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `t` binds no `extra`, and yet `t.extra` is no mistake: an attribute nobody
+# binds falls through to the object of that name beside it in the package, and
+# a locator names such an object the same way it names an attribute. Both
+# places are looked in before anything is said, which is what keeps this quiet
+# about `Φ.number` answering to forty names while binding eight.
+eo:
+  app.eo: |
+    [] > app
+      t.extra > @
+  t.eo: |
+    [] > t
+      [] > next
+  extra.eo: |
+    +package t
+
+    [y] > extra
+      y > @
+provides:
+  - "/provides/type[@id='Φ.t.extra']"
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-nowhere-in-the-object-is-a-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-nowhere-in-the-object-is-a-mistake.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `extra` is taken from a `t`, the whole of a `t` has been seen, and there is
+# no `extra` in it. That is the one thing the tables are read for, and the row
+# says where it was asked as well as what was asked of, since the mistake is
+# in the asking and the object is innocent.
+eo:
+  app.eo: |
+    [] > app
+      t.extra > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.t']/attr[@name='extra' and @asked='Φ.app.φ']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-of-a-void-is-never-a-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-of-a-void-is-never-a-mistake.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `x.next` is the `next` of whatever fills `x`, which is a question and not a
+# claim: only a caller can say what such a name holds, and no caller is being
+# read. So a name rooted at a void is never whole, and nothing taken from one
+# is ever a mistake — which is what keeps this quiet about a runtime whose
+# core objects are voids.
+eo:
+  inc.eo: |
+    [x] > inc
+      x.next.foo > @
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-that-is-there-is-no-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/attribute-that-is-there-is-no-mistake.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The same program with the name spelled the way `t` spells it. Nothing is
+# reported, which is the answer this has to give about almost every dispatch
+# of almost every program.
+eo:
+  app.eo: |
+    [] > app
+      t.next > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/incomplete-object-is-never-blamed.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/incomplete-object-is-never-blamed.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The attribute is missing and nothing is said, because the object that misses
+# it is an atom: its body is written in Java, which this module cannot read,
+# so `foo` may well be there. Better to miss a mistake than to complain about
+# correct code.
+eo:
+  app.eo: |
+    [] > app
+      t.next.foo > @
+  t.eo: |
+    [] > t
+      [] > next /Q.number
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-of-a-copy-is-blamed-on-what-it-copies.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/mistake-of-a-copy-is-blamed-on-what-it-copies.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `held` is a `box`, so asking it for `extra` is asking a `box`, and the row
+# is written about the formation rather than about the copy. Nobody would be
+# helped by being told that `Φ.app.held` has no `extra`, since that object is
+# nowhere in the code and the mistake is in `box` for as long as it stands.
+eo:
+  app.eo: |
+    [] > app
+      box t > held
+      held.extra > @
+  box.eo: |
+    [x] > box
+      [] > kept
+        x > @
+  t.eo: |
+    [] > t
+      [] > next
+problems:
+  - "/problems/type[@id='Φ.box']/attr[@name='extra']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -6,9 +6,11 @@
 # `x.next.foo` asks for something that will never be there. Every fact needed
 # to know that is in the rows below — that the `next` of a `t` is complete and
 # empty, that `foo` is asked of what `next` gives, that the `x` it is asked of
-# is the `t` — and no row says it. Reading them together is what was parked in
-# #6661. The links now name the two computed objects as well: `x.next` is the
-# `next` of whatever fills `x`, and `x.next.foo` the `foo` of that.
+# is the `t` — and still nothing is reported. The dispatch is written against a
+# void and is right for any argument that has a `foo`, so it is a mistake for
+# this caller only, and pushing the `t` into the `x` is what would decide it.
+# The links name the two computed objects meanwhile: `x.next` is the `next` of
+# whatever fills `x`, and `x.next.foo` the `foo` of that.
 eo:
   app.eo: |
     [] > app
@@ -35,3 +37,5 @@ links:
   - "/links/type[@id='Φ.app.inc.φ.ρ.ρ' and @copy='Φ.app.inc.x']"
   - "/links/type[@id='Φ.app.inc.φ.ρ' and @copy='Φ.app.inc.x.next']"
   - "/links/type[@id='Φ.app.inc.φ' and @copy='Φ.app.inc.x.next.foo']"
+problems:
+  - "/problems[not(type)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/parent-is-never-a-mistake.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/parent-is-never-a-mistake.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name from two scopes out is lowered into a dispatch of `ρ` and then of the
+# name, so `Φ.app.outer` is asked for the object it sits in. Every object has
+# one and no formation binds it, which made this the only thing the tables
+# ever complained about until #6636 wrote it down.
+eo:
+  app.eo: |
+    [] > app
+      [] > label
+      [] > outer
+        [] > inner
+          label > @
+problems:
+  - "/problems[not(type)]"


### PR DESCRIPTION
Three tables were written and nobody read them. `Concluded` follows the clues and then reads what they wrote, keeping in `problems.xml` every name a program takes from an object that will never have it.

The rule is one pass over the rows. `Needs` has a row for every dispatch and its receiver, `Links` closed by `Resolved` says what that receiver is, `Provides` says what it holds, so a mistake is those three read together:

```java
if (this.given.complete(asked.getKey())) {
    for (final Map<String, String> need : asked.getValue()) {
        this.judge(asked.getKey(), need, rows);
    }
}
```

Both halves of it are guards. "Seen whole" leaves out an atom, an object nobody describes, and every name rooted at a void — the table has no row for a void, so it is never whole, which is what keeps this quiet about a runtime whose core objects are voids. "There is no such name" means none in the type, none in its package, and none behind what it delegates to, which `Provided` walks before answering.

Measured on a clean `eo-runtime` build: **zero** mistakes reported, and `links.xml`, `needs.xml` and `provides.xml` come out byte-identical to the run before this change, so the only thing that moved is the new document. Seeding misspelled dispatch names into sites the rule can judge — 1,010 of them, of 10,404 dispatches — it catches **eight of eight**:

```
zzz02 asked of Φ.malloc  at Φ.malloc.+can-copy-data-from-start-to-end.φ
zzz06 asked of Φ.tuple   at Φ.tuple.+can-build-an-empty-tuple-with-an-indented-keyword.array.ρ.ρ
```

The worklist does not come back with it. `Checks` filed a promise for every argument put into a copy and `Worklist` drained the queue, splitting each promise into smaller ones, which was the only way to push a type into a body at the time. What that bought is the mistake that is one for a single caller, and that is exactly what this does not report: in the program of the design note, `x.next.foo` is written against a void and is right for any argument that has a `foo`. `note-example.yaml` now says so and asserts the silence. Everything reported holds for every caller of the code it is about.

Eight packs describe the behaviour, among them the one that would have been ten false positives a day ago:

```yaml
eo:
  app.eo: |
    [] > app
      [] > label
      [] > outer
        [] > inner
          label > @
problems:
  - "/problems[not(type)]"
```

Nothing fails the build. The goal logs how many mistakes it found and leaves it at that: this is a prototype, and its verdicts are worth reading before they are worth obeying.

Closes #6757
