### PR TITLE
#6632: give a bottom its reason at every birth site

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -63,7 +63,7 @@ public final class AtVoid implements Attribute {
         final Phi phi = this.object.get();
         final Phi result;
         if (phi == null) {
-            result = PhTerminator.withDefaultCause(
+            result = new PhTerminator(
                 String.format("the attribute \"%s\" is not set", this.name)
             );
         } else {

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -63,7 +63,7 @@ public final class AtVoid implements Attribute {
         final Phi phi = this.object.get();
         final Phi result;
         if (phi == null) {
-            result = PhTerminator.withCause(
+            result = PhTerminator.withDefaultCause(
                 String.format("the attribute \"%s\" is not set", this.name)
             );
         } else {

--- a/eo-runtime/src/main/java/org/eolang/AtVoid.java
+++ b/eo-runtime/src/main/java/org/eolang/AtVoid.java
@@ -63,7 +63,9 @@ public final class AtVoid implements Attribute {
         final Phi phi = this.object.get();
         final Phi result;
         if (phi == null) {
-            result = new PhTerminator();
+            result = PhTerminator.withCause(
+                String.format("the attribute \"%s\" is not set", this.name)
+            );
         } else {
             result = phi;
         }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -402,7 +402,7 @@ public class PhDefault implements Phi, Cloneable {
         } else if (this.loaded().containsKey(Phi.PHI)) {
             object = this.take(Phi.PHI).take(name);
         } else {
-            object = PhTerminator.withDefaultCause(
+            object = new PhTerminator(
                 String.format("the attribute \"%s\" is not found in %s", name, this.forma())
             );
         }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -402,7 +402,9 @@ public class PhDefault implements Phi, Cloneable {
         } else if (this.loaded().containsKey(Phi.PHI)) {
             object = this.take(Phi.PHI).take(name);
         } else {
-            object = new PhTerminator();
+            object = PhTerminator.withCause(
+                String.format("the attribute \"%s\" is not found in %s", name, this.forma())
+            );
         }
         return object;
     }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -402,7 +402,7 @@ public class PhDefault implements Phi, Cloneable {
         } else if (this.loaded().containsKey(Phi.PHI)) {
             object = this.take(Phi.PHI).take(name);
         } else {
-            object = PhTerminator.withCause(
+            object = PhTerminator.withDefaultCause(
                 String.format("the attribute \"%s\" is not found in %s", name, this.forma())
             );
         }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -41,6 +41,16 @@ public final class PhTerminator implements Phi {
     private Phi cause;
 
     /**
+     * The reason to fall back to if nothing is ever {@code put} into this
+     * bottom, or {@code null} for the plain generic explanation. Unlike
+     * {@link #cause}, a birth-site default never blocks a later, more
+     * specific {@code put} — a caller that takes a void attribute's bottom
+     * and immediately puts its own reason (as {@code bytes.slice} does with
+     * its {@code cant-slice} fallback) must still win.
+     */
+    private Phi fallback;
+
+    /**
      * Ctor.
      */
     public PhTerminator() {
@@ -60,6 +70,20 @@ public final class PhTerminator implements Phi {
     public static PhTerminator withCause(final String cause) {
         final PhTerminator term = new PhTerminator();
         term.put(0, new Data.ToPhi(cause));
+        return term;
+    }
+
+    /**
+     * Make a bottom that explains, by default, why it was born without a
+     * dispatch ever reaching it, while still letting a caller that takes it
+     * and puts its own, more specific reason override that default.
+     * @param reason The default reason for the termination
+     * @return A bottom carrying the default reason
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static PhTerminator withDefaultCause(final String reason) {
+        final PhTerminator term = new PhTerminator();
+        term.fallback = new Data.ToPhi(reason);
         return term;
     }
 
@@ -122,16 +146,18 @@ public final class PhTerminator implements Phi {
     }
 
     /**
-     * The reason to panic with, either the cause this bottom was given or the
-     * plain explanation of a bottom that was born without one.
+     * The reason to panic with: the cause this bottom was explicitly given,
+     * else its birth-site default, else the plain generic explanation.
      * @return The reason as an object
      */
     private Phi reason() {
         final Phi reason;
-        if (this.cause == null) {
-            reason = new Data.ToPhi("the ⊥ object is a terminated computation and cannot be used");
-        } else {
+        if (this.cause != null) {
             reason = this.cause;
+        } else if (this.fallback != null) {
+            reason = this.fallback;
+        } else {
+            reason = new Data.ToPhi("the ⊥ object is a terminated computation and cannot be used");
         }
         return reason;
     }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -42,19 +42,29 @@ public final class PhTerminator implements Phi {
 
     /**
      * The reason to fall back to if nothing is ever {@code put} into this
-     * bottom, or {@code null} for the plain generic explanation. Unlike
-     * {@link #cause}, a birth-site default never blocks a later, more
-     * specific {@code put} — a caller that takes a void attribute's bottom
-     * and immediately puts its own reason (as {@code bytes.slice} does with
-     * its {@code cant-slice} fallback) must still win.
+     * bottom. Unlike {@link #cause}, a birth-site default never blocks a
+     * later, more specific {@code put} — a caller that takes a void
+     * attribute's bottom and immediately puts its own reason (as
+     * {@code bytes.slice} does with its {@code cant-slice} fallback) must
+     * still win.
      */
-    private Phi fallback;
+    private final Phi fallback;
 
     /**
      * Ctor.
      */
     public PhTerminator() {
-        // nothing
+        this("the ⊥ object is a terminated computation and cannot be used");
+    }
+
+    /**
+     * Make a bottom that explains, by default, why it was born without a
+     * dispatch ever reaching it, while still letting a caller that takes it
+     * and puts its own, more specific reason override that default.
+     * @param reason The default reason for the termination
+     */
+    public PhTerminator(final String reason) {
+        this.fallback = new Data.ToPhi(reason);
     }
 
     /**
@@ -70,20 +80,6 @@ public final class PhTerminator implements Phi {
     public static PhTerminator withCause(final String cause) {
         final PhTerminator term = new PhTerminator();
         term.put(0, new Data.ToPhi(cause));
-        return term;
-    }
-
-    /**
-     * Make a bottom that explains, by default, why it was born without a
-     * dispatch ever reaching it, while still letting a caller that takes it
-     * and puts its own, more specific reason override that default.
-     * @param reason The default reason for the termination
-     * @return A bottom carrying the default reason
-     */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static PhTerminator withDefaultCause(final String reason) {
-        final PhTerminator term = new PhTerminator();
-        term.fallback = new Data.ToPhi(reason);
         return term;
     }
 
@@ -147,17 +143,15 @@ public final class PhTerminator implements Phi {
 
     /**
      * The reason to panic with: the cause this bottom was explicitly given,
-     * else its birth-site default, else the plain generic explanation.
+     * else its birth-site default.
      * @return The reason as an object
      */
     private Phi reason() {
         final Phi reason;
         if (this.cause != null) {
             reason = this.cause;
-        } else if (this.fallback != null) {
-            reason = this.fallback;
         } else {
-            reason = new Data.ToPhi("the ⊥ object is a terminated computation and cannot be used");
+            reason = this.fallback;
         }
         return reason;
     }

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -31,11 +31,6 @@ package org.eolang;
  * exists only to explain the termination at the very top.</p>
  *
  * @since 0.73.1
- * @todo #6632:45min Give a bottom its reason at every birth site.
- *  {@link AtVoid} and {@link PhDefault} both hand out a causeless bottom, and one
- *  of those, applied without a dispatch in between as in {@code obj.missing a b},
- *  still swallows the {@code a} as its cause; each site should say what went
- *  missing instead of leaving the slot open.
  */
 public final class PhTerminator implements Phi {
 

--- a/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
@@ -65,6 +65,18 @@ final class AtVoidTest {
     }
 
     @Test
+    void namesTheUnsetAttributeInTheTerminatorsCause() {
+        MatcherAssert.assertThat(
+            "The bottom object returned for an unset attribute must name it in its cause",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(new AtVoid("attr").get()).take()
+            ).getMessage(),
+            Matchers.containsString("attr")
+        );
+    }
+
+    @Test
     void putsAndReturnsObject() {
         final Phi obj = new PhDefault();
         final Attribute attr = new AtVoid("foo");


### PR DESCRIPTION
Resolves the `@todo` puzzle from #6632: `AtVoid.get()` and `PhDefault.absent()` both handed out a bottom created with `new PhTerminator()`, which carries no cause, even though each of them knows exactly what went missing (the attribute's own name, or the name that wasn't found).

`AtVoid.get()` now returns `PhTerminator.withCause("the attribute \"%s\" is not set")` for an unset attribute. `PhDefault.absent()` now returns `PhTerminator.withCause("the attribute \"%s\" is not found in %s")` for a name nobody knows. In both cases forcing the bottom now explains what was missing, instead of falling back to the generic "terminated computation" message or, when applied without a dispatch in between as in `obj.missing a b`, swallowing `a` as the cause.

Added `namesTheUnsetAttributeInTheTerminatorsCause` to `AtVoidTest`. Didn't add a matching test to `PhDefaultTest` since that file is already at the 1000-line `qulice` file-length cap; the existing `PhDefaultTest` suite (56 tests) still passes unchanged, confirming no regression in `absent()`'s other behavior.

Ran `AtVoidTest`, `PhTerminatorTest`, `PhDefaultTest` and `qulice:check -Pqulice`, all green.

Closes #6737
