### PR TITLE
#6734: normalize the mantissa when rounding carries it to ten

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -12,6 +12,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 
 [n] > as-scientific
   n.is-finite.not.if > @
@@ -21,19 +22,25 @@
         n.lt 0
         "-infinity".as-bytes
         "infinity".as-bytes
-    concat.
+    if.
+      mantissa.eq "10.000000".as-bytes
       concat.
-        as-fixed
-          n.div
-            10.power
-              number exponent
-          6
-        "e".as-bytes
-      as-decimal
-        number exponent
+        "1.000000".as-bytes.concat "e".as-bytes
+        as-decimal
+          number bumped
+      concat.
+        mantissa.concat "e".as-bytes
+        as-decimal
+          number exponent
+  wrapped.plus 1 > bumped
   rec-exponent > exponent!
     n.abs
     0
+  as-fixed > mantissa
+    n.div
+      10.power
+        number exponent
+    6
   if. > [m count] >> rec-exponent
     m.lt 10
     count
@@ -41,6 +48,15 @@
       m.div 10
       as-number.
         count.plus 1
+  number exponent > wrapped
+
+  eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
+    "1.000000e1"
+    string 9.9999996.as-scientific
+
+  eq. ++> can-carry-a-rounded-mantissa-past-the-long-range
+    "1.000000e20"
+    string 9.9999996e19.as-scientific
 
   eq. ++> can-name-a-magnitude-past-the-long-range
     "1.000000e19"

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -12,7 +12,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [n] > as-scientific
   n.is-finite.not.if > @
@@ -27,12 +26,13 @@
       concat.
         "1.000000".as-bytes.concat "e".as-bytes
         as-decimal
-          number bumped
+          plus.
+            number exponent
+            1
       concat.
         mantissa.concat "e".as-bytes
         as-decimal
           number exponent
-  wrapped.plus 1 > bumped
   rec-exponent > exponent!
     n.abs
     0
@@ -48,7 +48,6 @@
       m.div 10
       as-number.
         count.plus 1
-  number exponent > wrapped
 
   eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
     "1.000000e1"


### PR DESCRIPTION
`as-scientific` computed its power-of-ten exponent from `n`'s unrounded magnitude, then independently rounded the mantissa to six places with `as-fixed`. When the true mantissa was within `0.0000005` of `10`, `as-fixed` correctly carried it into the integer part, but the already-computed exponent was never adjusted, so the result showed an unnormalized two-digit mantissa like `10.000000e0` instead of `1.000000e1`.

Added a check comparing the fixed-point mantissa against `"10.000000"`. When it carries, the mantissa is reset to `1.000000` and the exponent used for the printed power is bumped by one; otherwise the original mantissa and exponent are used unchanged.

Added `can-carry-a-rounded-mantissa-into-the-next-power-of-ten` (`9.9999996`) and `can-carry-a-rounded-mantissa-past-the-long-range` (`9.9999996e19`, the magnitude range this object exists for).

Ran `EOas_scientificTest` and `qulice:check -Pqulice`, both green.

Closes #6734
