### PR TITLE
Merge the five single-member packages and read receivers through the rho

### DIFF
--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -4,13 +4,24 @@
  */
 package integration;
 
+import com.jcabi.xml.XMLDocument;
 import com.yegor256.farea.Farea;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.Proc;
 
 /**
  * Execution of EO source.
+ *
+ * <p>The sandbox compiles the {@code .eo} sources of the eo-runtime from
+ * scratch, so it must merge the same packages the runtime's own build merges.
+ * A member that reaches its receiver through {@code ^} has no rho until the
+ * merge gives it one, and unmerged it is applied to the receiver through the
+ * first void it does not have any more, which shifts every argument by one.
+ * The list is read from the pom that declares it, so that a package named for
+ * merging there needs no second mention here.</p>
+ *
  * @since 0.56.3
  */
 final class EoSourceRun implements Proc<Object> {
@@ -30,23 +41,26 @@ final class EoSourceRun implements Proc<Object> {
 
     @Override
     public void exec(final Object args) throws IOException {
+        final Path runtime = Paths.get(
+            System.getProperty("basedir", System.getProperty("user.dir"))
+        ).getParent().resolve("eo-runtime");
         new RuntimeSources(
-            Paths.get(System.getProperty("basedir", System.getProperty("user.dir")))
-                .getParent()
-                .resolve("eo-runtime")
-                .resolve("src")
-                .resolve("main")
-                .resolve("eo")
+            runtime.resolve("src").resolve("main").resolve("eo")
         ).exec(this.farea);
         new EoMavenPlugin(this.farea)
             .appended()
             .execution("compile")
             .phase("generate-sources")
-            .goals("register", "compile", "transpile")
+            .goals("register", "compile", "merge", "transpile")
             .configuration()
             .set("failOnWarning", "false")
             .set("offline", "true")
-            .set("skipLinting", "true");
+            .set("skipLinting", "true")
+            .set(
+                "mergedPackages",
+                new XMLDocument(runtime.resolve("pom.xml"))
+                    .xpath("//*[local-name()='mergedPackage']/text()")
+            );
         this.farea.build()
             .plugins()
             .append("org.codehaus.mojo", "exec-maven-plugin", "3.1.1")

--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -9,6 +9,7 @@ import com.yegor256.farea.Farea;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import org.cactoos.Proc;
 
 /**
@@ -44,6 +45,9 @@ final class EoSourceRun implements Proc<Object> {
         final Path runtime = Paths.get(
             System.getProperty("basedir", System.getProperty("user.dir"))
         ).getParent().resolve("eo-runtime");
+        final List<String> merged = new XMLDocument(
+            runtime.resolve("pom.xml")
+        ).xpath("//*[local-name()='mergedPackage']/text()");
         new RuntimeSources(
             runtime.resolve("src").resolve("main").resolve("eo")
         ).exec(this.farea);
@@ -56,11 +60,7 @@ final class EoSourceRun implements Proc<Object> {
             .set("failOnWarning", "false")
             .set("offline", "true")
             .set("skipLinting", "true")
-            .set(
-                "mergedPackages",
-                new XMLDocument(runtime.resolve("pom.xml"))
-                    .xpath("//*[local-name()='mergedPackage']/text()")
-            );
+            .set("mergedPackages", merged);
         this.farea.build()
             .plugins()
             .append("org.codehaus.mojo", "exec-maven-plugin", "3.1.1")

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -294,6 +294,19 @@
               <skipProgramLints>
                 <lint>inconsistent-args</lint>
               </skipProgramLints>
+              <!--
+              A package is named here once its members reach their receiver
+              through '^' instead of through a first void, since the two only
+              work together: with the void still there the merged member never
+              gets a receiver, and with '^' but no merge it has no rho to read.
+              -->
+              <mergedPackages>
+                <mergedPackage>chunk</mergedPackage>
+                <mergedPackage>i64</mergedPackage>
+                <mergedPackage>output</mergedPackage>
+                <mergedPackage>range</mergedPackage>
+                <mergedPackage>u64</mergedPackage>
+              </mergedPackages>
               <keepBinaries>
                 <glob>org/eolang/EO_number/package-info.class</glob>
                 <glob>org/eolang/EO_string/package-info.class</glob>

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -1,8 +1,5 @@
-# Makes an output from a `chunk` of memory. Here `allocated` is a `chunk`.
-#
-# Because this object lives in the `chunk` package, it is available on any
-# chunk as `chunk.to-output` (package extension), so there is no need to
-# reference it explicitly:
+# Makes an output from a `chunk` of memory. It is a method of `chunk`, and
+# `allocated` is the chunk it is taken off:
 #
 # ```
 # malloc.of > result
@@ -21,8 +18,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[allocated] > to-output
+[] > to-output
+  ^ > allocated
   [buffer] > write
     write. > @
       [offset] >> output-block

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x cant-divide] > div
+[x cant-divide] > div
   if. > @
     x.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -61,6 +61,7 @@
                 index
               00-00-00-00-00-00-00-01
           quot
+  ^ > n
   as-bytes. >> subtrahend
     plus.
       i64

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -1,6 +1,6 @@
-# Dead output is an output that writes to nowhere. Here `origin` is the
-# output this one is taken off, as in `o.dead`. It is ignored, because a
-# dead output writes to nowhere anyway.
+# Dead output is an output that writes to nowhere. It is a method of
+# `output`, as in `o.dead`, and reads nothing from the output it is taken
+# off, because it writes to nowhere anyway.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,8 +8,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[origin] > dead
+[] > dead
   [buffer] > write
     [] >> output-block
       true > @

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -1,5 +1,6 @@
 # Range of natural numbers from `start` to `end` (soft border) with step = 1.
-# The `r` is an instance of `range`, which provides `start` and `end`.
+# It is a method of `range`, so it reads `start` and `end` from the range it
+# is taken from.
 
 +alias tuple.is-empty
 +architect yegor256@gmail.com
@@ -8,9 +9,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 +unlint redundant-object
 
-[r] > naturals
+[] > naturals
   range > @
     [] >>
       build r.start > @
@@ -19,6 +21,7 @@
         build > next
           1.plus @
     r.end
+  ^ > r
 
   eq. ++> can-build-a-range-of-negatives
     naturals.

--- a/eo-runtime/src/main/eo/u64/div.eo
+++ b/eo-runtime/src/main/eo/u64/div.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x cant-divide] > div
+[x cant-divide] > div
   if. > @
     d.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -43,6 +43,7 @@
           u64 q0
           u64 00-00-00-00-00-00-00-01
         u64 q0
+  ^ > n
 
   eq. ++> can-divide-a-small-value-by-a-larger-divisor
     00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64

--- a/eo-runtime/src/test/groovy/check-folders-numbering.groovy
+++ b/eo-runtime/src/test/groovy/check-folders-numbering.groovy
@@ -12,6 +12,7 @@ List<String> allowed = [
     '1-parse',
     '2-pull',
     '3-lint',
+    '4-merge',
     '4-resolve',
     '5-pre-transpile',
     '5-transpile',


### PR DESCRIPTION
The five packages that hold one member each — `chunk`, `i64`, `output`, `range`, `u64` — and the shape every later package will follow:

```
-[r] > naturals
+[] > naturals
   range > @
     ...
     r.end
+  ^ > r
```

The body is not touched. A member is parsed alone, long before `4-merge` joins it to the object its package names, so the parser cannot see `range` and no bare `start` can reach it: `build-fqns` walks the enclosing formations of the file, finds nothing, and emits `Φ.start`. Binding the rho to the name the void used to have puts the declaration back where the walk can find it, and every reference below resolves to exactly what it resolved to before — `ξ.r.end` and `ξ.ρ.r.start`, byte for byte the same parse as the void produced.

Writing the hops by hand instead works too, and is worse. Both spellings were tried:

| written | resolves to | result |
| --- | --- | --- |
| `start` | `Φ.start` | a global that does not exist |
| `^.start` | `ξ.ρ.start` | `naturals.start`, which falls back into naturals' own φ and spins |
| `^.^.start` | `ξ.ρ.ρ.start` | correct, and one miscount away from the line above |

The middle row is the reason this matters. It does not fail — it hangs, and `eo.deadline` turns the timeout into a skip, so the suite reports `Tests run: 8, Failures: 0, Skipped: 4` and reads as green. One `^` per member and no counting leaves nothing to miscount.

`output/dead` keeps nothing at all, since its `origin` was never read; `i64/div` and `u64/div` keep `x` and `cant-divide` and give up only `n`.

The merged packages are faster, which is what one would hope for from resolving at compile time what `PhDefault.absent` used to probe the classpath for on every dispatch. Same tests, same deadline, before and after:

```
i64 family   58 tests   60.8s -> 41.3s
u64 family   25 tests   22.8s -> 20.1s
```

Three things that only the first real merge could expose, fixed here for every package that follows. The `4-merge` directory was missing from `check-folders-numbering.groovy`, which fails on any directory it does not know, and never fired before because an empty `mergedPackages` writes nothing. And `package-member-without-void/S` reports a member with no voids as unreachable, which is the rule this epic removes; it is silenced per file, only in the files that have no voids left, so it goes on watching the seven packages that have not moved. Retiring it belongs to #6659, where I have said so.

And `ReadmeSnippetsIT` compiles the runtime's `.eo` sources from scratch in a Farea sandbox of its own, where nothing said which packages to merge. A member reading its receiver through `^` has no rho there, and the old runtime dispatch binds the receiver into the first void it no longer has, so `2.as-i64.div 0.as-i64` shifted every argument one place along and set `cant-divide` twice. The sandbox now runs the `merge` goal and reads the list out of `eo-runtime/pom.xml`, so the next package to move needs no second mention there.