### PR TITLE
#6428: take the caching decision out of MjSafe

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Caching.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Caching.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.File;
+
+/**
+ * The caching decision configured by the user.
+ *
+ * <p>This is the only place that turns {@code eo.cache} and
+ * {@code eo.cacheEnabled} into a {@link GlobalCache} for one step, so
+ * {@link MjSafe} itself no longer has to name {@link GlobalCache},
+ * {@link GcShared} and {@link GlobalCache.GcFresh} directly.</p>
+ *
+ * @since 0.74
+ */
+final class Caching {
+
+    /**
+     * The machine-wide cache directory, as configured by the user.
+     */
+    private final File dir;
+
+    /**
+     * Whether caching is enabled at all.
+     */
+    private final boolean enabled;
+
+    /**
+     * The version that tells one compiler output from another.
+     */
+    private final String version;
+
+    /**
+     * Ctor.
+     * @param home The machine-wide cache directory, as configured by the user
+     * @param able Whether caching is enabled at all
+     * @param ver The version that tells one compiler output from another
+     */
+    Caching(final File home, final boolean able, final String ver) {
+        this.dir = home;
+        this.enabled = able;
+        this.version = ver;
+    }
+
+    /**
+     * The cache of one step.
+     * @param sub Directory of that step inside the machine-wide cache
+     * @return The cache of that step
+     */
+    GlobalCache forStep(final String sub) {
+        final GlobalCache store;
+        if (this.enabled) {
+            store = new GcShared(this.dir.toPath().resolve(sub), this.version);
+        } else {
+            store = new GlobalCache.GcFresh();
+        }
+        return store;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -26,9 +26,6 @@ import org.slf4j.impl.StaticLoggerBinder;
 /**
  * Abstract Mojo for all others.
  * @since 0.1
- * @todo #6428:60min Take the caching decision out of this class. It names 30 types
- *  now, the maximum, so the next one moved to {@link GlobalCache} brings the fan-out
- *  suppression back. A cache of its own for {@link #caching(String)} would drop two.
  */
 @SuppressWarnings("PMD.TooManyFields")
 abstract class MjSafe extends AbstractMojo {
@@ -566,15 +563,7 @@ abstract class MjSafe extends AbstractMojo {
      * @return The cache of that step
      */
     GlobalCache caching(final String sub) {
-        final GlobalCache store;
-        if (this.cacheEnabled) {
-            store = new GcShared(
-                this.cache.toPath().resolve(sub), this.plugin.getVersion()
-            );
-        } else {
-            store = new GlobalCache.GcFresh();
-        }
-        return store;
+        return new Caching(this.cache, this.cacheEnabled, this.plugin.getVersion()).forStep(sub);
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CachingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CachingTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for {@link Caching}.
+ * @since 0.74
+ */
+@ExtendWith(MktmpResolver.class)
+final class CachingTest {
+
+    @Test
+    void servesTheSecondRunFromTheCacheWhenEnabled(@Mktmp final Path temp) throws IOException {
+        final Path source = temp.resolve("source.eo");
+        Files.writeString(source, "[] > main", StandardCharsets.UTF_8);
+        final Path target = temp.resolve("target.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final GlobalCache cache = new Caching(temp.resolve("cache").toFile(), true, "1.2.3")
+            .forStep("step");
+        for (int idx = 0; idx < 2; ++idx) {
+            cache.footprint(
+                Path.of("target.xmir"),
+                () -> "0123456789",
+                src -> String.format("compiled %d", counter.incrementAndGet())
+            ).apply(source, target);
+        }
+        MatcherAssert.assertThat(
+            "the second run must be written from the cache, not compiled again",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("compiled 1")
+        );
+    }
+
+    @Test
+    void compilesAgainOnEveryRunWhenDisabled(@Mktmp final Path temp) throws IOException {
+        final Path source = temp.resolve("source.eo");
+        Files.writeString(source, "[] > main", StandardCharsets.UTF_8);
+        final Path target = temp.resolve("target.xmir");
+        final AtomicInteger counter = new AtomicInteger(0);
+        final GlobalCache cache = new Caching(temp.resolve("cache").toFile(), false, "1.2.3")
+            .forStep("step");
+        for (int idx = 0; idx < 2; ++idx) {
+            cache.footprint(
+                Path.of("target.xmir"),
+                () -> "0123456789",
+                src -> String.format("compiled %d", counter.incrementAndGet())
+            ).apply(source, target);
+        }
+        MatcherAssert.assertThat(
+            "nothing must be remembered between two runs when caching is disabled",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("compiled 2")
+        );
+    }
+}


### PR DESCRIPTION
Resolves the `@todo` puzzle from #6428: `MjSafe.caching(String)` built the `GlobalCache` for a step directly, naming `GlobalCache`, `GcShared` and `GlobalCache.GcFresh`, which pushed the class toward PMD's fan-out limit.

Extracted the decision into a new `Caching` class: it holds the cache directory, the `eo.cacheEnabled` flag and the plugin version, and turns them into a `GlobalCache` for a given step through `forStep(String)`. `MjSafe.caching(String)` now just delegates to it, so `MjSafe` itself no longer names any of the three `GlobalCache`-related types.

Added `CachingTest`, mirroring the existing `GlobalCacheTest`/`GcSharedTest` pattern: one case for caching enabled (second run served from the cache), one for disabled (recompiled every run).

Ran `CachingTest`, `MjSafeTest` and `qulice:check -Pqulice`, both green.

Closes #6641
