### PR TITLE
fix(#6762): report unpacked dependency count

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -109,17 +109,22 @@ final class Resolving implements Step {
     @Override
     public void exec() {
         final Collection<Dep> deps = this.deps();
+        final int unpacked;
         if (deps.isEmpty()) {
-            Logger.info(this, "No new dependencies unpacked");
+            unpacked = 0;
         } else {
-            new Threaded<>(
+            unpacked = new Threaded<>(
                 deps,
                 dep -> this.resolved(dep, this.target)
             ).total();
+        }
+        if (unpacked == 0) {
+            Logger.info(this, "No new dependencies unpacked");
+        } else {
             Logger.info(
                 this,
                 "New %d dependenc(ies) unpacked to %[file]s: %s",
-                deps.size(), this.target,
+                unpacked, this.target,
                 new Joined(", ", new Mapped<>(Dep::toString, deps))
             );
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -37,9 +37,12 @@ final class MjResolveTest {
     void reportsNoNewDependenciesWhenAllAreCached(@Mktmp final Path temp)
         throws IOException {
         final FakeMaven maven = new FakeMaven(temp).withProgram(
-            "+package foo.x",
-            "+rt jvm org.eolang:eo-runtime:0.7.0",
-            "[] > main /bytes"
+            String.join(
+                System.lineSeparator(),
+                "+package foo.x",
+                "+rt jvm org.eolang:eo-runtime:0.7.0",
+                "[] > main /bytes"
+            )
         );
         maven.execute(new FakeMaven.Resolve());
         final List<String> messages = new ArrayList<>(0);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -9,7 +9,14 @@ import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.hamcrest.MatcherAssert;
@@ -25,6 +32,49 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(MktmpResolver.class)
 final class MjResolveTest {
+
+    @Test
+    void reportsNoNewDependenciesWhenAllAreCached(@Mktmp final Path temp)
+        throws IOException {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            "+package foo.x",
+            "+rt jvm org.eolang:eo-runtime:0.7.0",
+            "[] > main /bytes"
+        );
+        maven.execute(new FakeMaven.Resolve());
+        final List<String> messages = new ArrayList<>(0);
+        final Appender appender = new AppenderSkeleton() {
+            @Override
+            protected void append(final LoggingEvent event) {
+                messages.add(String.valueOf(event.getRenderedMessage()));
+            }
+
+            @Override
+            public void close() {
+                // Nothing to release.
+            }
+
+            @Override
+            public boolean requiresLayout() {
+                return false;
+            }
+        };
+        final Logger logger = Logger.getLogger(Resolving.class);
+        final Level level = logger.getLevel();
+        logger.setLevel(Level.INFO);
+        logger.addAppender(appender);
+        try {
+            maven.execute(new FakeMaven.Resolve());
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(level);
+        }
+        MatcherAssert.assertThat(
+            "A cached dependency must not be reported as newly unpacked",
+            messages,
+            Matchers.hasItem("No new dependencies unpacked")
+        );
+    }
 
     @Test
     void resolvesWithSingleDependency(@Mktmp final Path temp) throws IOException {


### PR DESCRIPTION
## Summary

- use the value returned by `Threaded.total()` when reporting unpacked dependencies
- report that there are no new dependencies when every resolved artifact is already cached
- cover the repeated-resolve case with a regression test

## Validation

- `mvn -pl eo-maven-plugin -DskipITs -Deo.coverageTracking=false -Dtest=MjResolveTest test` (13 tests passed)
- `mvn -pl eo-maven-plugin -DskipITs -Deo.coverageTracking=false test` (615 tests passed)
- `mvn -pl eo-maven-plugin -Pqulice -DskipTests -DskipITs -Deo.coverageTracking=false clean verify`

Closes #6762

## AI assistance

OpenAI Codex assisted with implementation and test execution. The resulting diff and validation output were reviewed before submission.
