### PR TITLE
Merge the tuple package

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -308,6 +308,7 @@
                 <mergedPackage>input</mergedPackage>
                 <mergedPackage>output</mergedPackage>
                 <mergedPackage>range</mergedPackage>
+                <mergedPackage>tuple</mergedPackage>
                 <mergedPackage>u64</mergedPackage>
               </mergedPackages>
               <keepBinaries>

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -9,9 +9,7 @@
 # hash code is derived from those bytes rather than from the key itself,
 # so that keys with side effects are never evaluated more than once.
 
-+alias tuple.filtered
 +alias bytes.hash
-+alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -40,8 +38,7 @@
                   tup.head.value > value
             bytes.hash >> hash!
               tup.head.key.as-bytes >> kbts!
-            filtered > others
-              prev
+            prev.filtered > others
               not. > [ent] >>
                 and.
                   ent.hash.eq hash
@@ -80,18 +77,15 @@
             * hash
     exists. > [key] > has
       found key
-    mapped > keys
-      entries
+    entries.mapped > keys
       entry.key > [entry]
     entries.length > size
-    mapped > values
-      entries
+    entries.mapped > values
       entry.value > [entry]
     [key value] > with
       map.ctor > @
         with.
-          filtered
-            entries
+          entries.filtered
             not. > [entry] >>
               and.
                 hash.eq entry.hash
@@ -105,8 +99,7 @@
         key.as-bytes >> kbts!
     [key] > without
       map.ctor > @
-        filtered
-          entries
+        entries.filtered
           not. > [entry] >>
             and.
               hash.eq entry.hash

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -107,7 +107,7 @@
                 is-absolute.if separator --
               string.joined >> body!
                 separator
-                tuple.reduced
+                reduced.
                   string.split driveless separator
                   *
                   if. > [accum segment] >>

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -96,7 +96,7 @@
       10
 
   ++> can-build-an-empty-range-from-wrong-items
-    tuple.is-empty rng > @
+    rng.is-empty > @
     range > rng
       []
         y 10 > @

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -2,7 +2,6 @@
 # It is a method of `range`, so it reads `start` and `end` from the range it
 # is taken from.
 
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package range
@@ -33,11 +32,11 @@
       -2
       -1
 
-  is-empty ++> can-build-an-empty-range-from-ten-to-ten
+  is-empty. ++> can-build-an-empty-range-from-ten-to-ten
     naturals.
       range 10 10
 
-  is-empty ++> can-build-an-empty-range-when-descending
+  is-empty. ++> can-build-an-empty-range-when-descending
     naturals.
       range 10 1
 

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -19,8 +19,7 @@
       mp.without item
   | > @
     map
-      tuple.mapped
-        lst
+      lst.mapped
         map.entry item true > [item]
 
   has. ++> can-append-a-new-item

--- a/eo-runtime/src/main/eo/string/chained.eo
+++ b/eo-runtime/src/main/eo/string/chained.eo
@@ -13,8 +13,7 @@
     0.eq others.length
     text
     string
-      tuple.reduced
-        others
+      others.reduced
         text.as-bytes
         accum.concat str.as-bytes > [accum str]
 

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -8,9 +8,8 @@
 +spdx SPDX-License-Identifier: MIT
 
 [text substrings] > contains-all
-  tuple.reduced > @
-    tuple.mapped
-      substrings
+  reduced. > @
+    substrings.mapped
       contains text x > [x] >>
     true
     x.and a > [a x]

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -8,9 +8,8 @@
 +spdx SPDX-License-Identifier: MIT
 
 [text substrings] > contains-any
-  tuple.reduced > @
-    tuple.mapped
-      substrings
+  reduced. > @
+    substrings.mapped
       contains text! x > [x] >>
     false
     x.or a > [a x]

--- a/eo-runtime/src/main/eo/string/english.eo
+++ b/eo-runtime/src/main/eo/string/english.eo
@@ -10,7 +10,6 @@
 # Each conversion hoists its lower letter bound into a `mincode` constant, so
 # the bound is computed once rather than for every byte walked.
 
-+alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
@@ -22,8 +21,7 @@
   s > @
   [] > lower
     string > @
-      reduced
-        s.as-bytes.array
+      s.as-bytes.array.reduced
         --
         [accum byte] >>
           accum.concat > @
@@ -45,8 +43,7 @@
     as-ascii "A" >> mincode!
   [] > upper
     string > @
-      reduced
-        s.as-bytes.array
+      s.as-bytes.array.reduced
         --
         [accum byte] >>
           accum.concat > @

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -154,13 +154,6 @@
         2
       3
 
-  tuple.contains ++> can-check-containment-through-the-package
-    *
-      1
-      2
-      3
-    2
-
   eq. ++> can-concat-with-another-tuple
     concat.
       * 0 1

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -14,8 +14,7 @@
       0.gt
         list.length.minus index! >> start!
       list
-      reducedi
-        list
+      list.reducedi
         *
         if. > [accum item idx] >>
           idx.gte start

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index] > back
+[index] > back
   index.is-integer.if > @
     if.
       0.gt
@@ -23,6 +23,7 @@
           accum
     T
       "Given index must be an integer"
+  ^ > list
 
   eq. ++> can-take-a-back-slice
     back.

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list passed] > concat
+[passed] > concat
   reducedi > @
     passed
-    list
+    ^
     accum.with item > [accum item index]
 
   ++> can-concat-two-lists

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -8,8 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [passed] > concat
-  reducedi > @
-    passed
+  passed.reducedi > @
     ^
     accum.with item > [accum item index]
 

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list element] > contains
+[element] > contains
   not. > @
     -1.eq
-      index-of list element
+      index-of ^ element
 
   contains. ++> can-contain-a-number
     *

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -10,7 +10,7 @@
 [element] > contains
   not. > @
     -1.eq
-      index-of ^ element
+      ^.index-of element
 
   contains. ++> can-contain-a-number
     *

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -10,8 +10,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [func] > each
-  eachi > @
-    ^
+  ^.eachi > @
     func item > [item index] >>
 
   ++> can-iterate-over-a-list

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -9,9 +9,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > each
+[func] > each
   eachi > @
-    list
+    ^
     func item > [item index] >>
 
   ++> can-iterate-over-a-list

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -11,9 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > eachi
+[func] > eachi
   reducedi > @
-    list
+    ^
     true
     seq * > [acc item index] >>
       acc

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -12,8 +12,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [func] > eachi
-  reducedi > @
-    ^
+  ^.reducedi > @
     true
     seq * > [acc item index] >>
       acc

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -12,8 +12,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [func] > filtered
-  filteredi > @
-    ^
+  ^.filteredi > @
     func item > [item index] >>
 
   eq. ++> can-filter-a-list

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -11,9 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > filtered
+[func] > filtered
   filteredi > @
-    list
+    ^
     func item > [item index] >>
 
   eq. ++> can-filter-a-list

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -12,7 +12,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > filteredi
+[func] > filteredi
   [tup] >> recfilter
     if. > @
       tup.length.eq 0
@@ -22,7 +22,7 @@
         next.with tup.head
         next
     recfilter tup.tail > next
-  | list > @
+  | ^ > @
 
   eq. ++> can-filter-by-a-less-than-condition
     filteredi.

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -15,10 +15,7 @@
       if.
         0.gt
           index >> idx!
-        back
-          list
-          neg.
-            number idx
+        list.back (number idx).neg
         if.
           gte.
             number idx

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index] > front
+[index] > front
   index.is-integer.if > @
     if.
       idx.eq 0
@@ -31,6 +31,7 @@
           | list
     T
       "Given index must be an integer"
+  ^ > list
 
   eq. ++> can-take-a-front-slice
     front.

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list wanted] > index-of
+[wanted] > index-of
   number > @
     [tup] >> recidx
       if. > @
@@ -21,7 +21,7 @@
             tup.length.minus 1
             -1
           recidx tup.tail >> next!
-    | list
+    | ^
 
   eq. ++> can-find-no-index-of-an-absent-item
     -1

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -6,9 +6,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[list] > is-empty
-  0.eq list.length > @
+[] > is-empty
+  0.eq ^.length > @
 
   tuple.empty.is-empty ++> can-be-empty-when-built-empty
 

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list wanted] > last-index-of
+[wanted] > last-index-of
   if. > [t] >> rec
     t.length.eq 0
     -1
@@ -16,7 +16,7 @@
       t.head.eq wanted
       t.length.minus 1
       rec t.tail
-  | list > @
+  | ^ > @
 
   eq. ++> can-find-the-last-index-of-an-item
     1

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -10,8 +10,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [func] > mapped
-  mappedi > @
-    ^
+  ^.mappedi > @
     func item > [item idx] >>
 
   eq. ++> can-map-a-list

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -9,9 +9,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > mapped
+[func] > mapped
   mappedi > @
-    list
+    ^
     func item > [item idx] >>
 
   eq. ++> can-map-a-list

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -10,9 +10,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > mappedi
+[func] > mappedi
   reducedi > @
-    list
+    ^
     *
     accum.with > [accum item idx] >>
       func item idx

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -11,8 +11,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [func] > mappedi
-  reducedi > @
-    ^
+  ^.reducedi > @
     *
     accum.with > [accum item idx] >>
       func item idx

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -10,12 +10,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [cant-max] > maximum
-  if. > @
-    is-empty sequence
+  sequence.is-empty.if > @
     cant-max
       "cannot get the maximum number from an empty sequence"
-    reduced
-      sequence
+    sequence.reduced
       ninf
       if. > [max item]
         item.as-number.gt max

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-max] > maximum
+[cant-max] > maximum
   if. > @
     is-empty sequence
     cant-max
@@ -21,6 +21,7 @@
         item.as-number.gt max
         item
         max
+  ^ > sequence
 
   eq. ++> can-recover-from-an-empty-list-when-taking-the-maximum
     "recovered"

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-min] > minimum
+[cant-min] > minimum
   if. > @
     is-empty sequence
     cant-min
@@ -21,6 +21,7 @@
         min.gt item.as-number
         item
         min
+  ^ > sequence
 
   eq. ++> can-recover-from-an-empty-list-when-taking-the-minimum
     "recovered"

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -10,12 +10,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [cant-min] > minimum
-  if. > @
-    is-empty sequence
+  sequence.is-empty.if > @
     cant-min
       "cannot get the minimum number from an empty sequence"
-    reduced
-      sequence
+    sequence.reduced
       pinf
       if. > [min item]
         min.gt item.as-number

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -10,9 +10,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start func] > reduced
+[start func] > reduced
   reducedi > @
-    list
+    ^
     start
     func > [accum item index] >>
       accum

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -11,8 +11,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [start func] > reduced
-  reducedi > @
-    ^
+  ^.reducedi > @
     start
     func > [accum item index] >>
       accum

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start func] > reducedi
+[start func] > reducedi
   if. > @
     is-empty list
     start
@@ -25,6 +25,7 @@
         tup.head
         tup.tail.length
     | list
+  ^ > list
 
   eq. ++> can-reduce-a-list-with-indexes
     6

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -11,8 +11,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [start func] > reducedi
-  if. > @
-    is-empty list
+  list.is-empty.if > @
     start
     if. > [tup] >> rec-reducedi
       tup.length.eq 1

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list shift] > shifted
+[shift] > shifted
   shift.is-integer.if > @
     slice
       list
@@ -18,6 +18,7 @@
       list.length
     T
       "Given shift must be an integer"
+  ^ > list
 
   eq. ++> can-ignore-a-negative-shift
     shifted.

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -9,8 +9,7 @@
 
 [shift] > shifted
   shift.is-integer.if > @
-    slice
-      list
+    list.slice
       if.
         shift.lt 0
         0

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start end] > slice
+[start end] > slice
   if. > @
     start.is-integer.and end.is-integer
     if.
@@ -46,6 +46,7 @@
           accum
     T
       "Given slice start and end must both be integers"
+  ^ > list
 
   eq. ++> can-slice-a-list
     slice.

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -35,8 +35,7 @@
             end.plus list.length
             0
       *
-      reducedi
-        list
+      list.reducedi
         *
         if. > [accum item index] >>
           and.

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -8,12 +8,11 @@
 +spdx SPDX-License-Identifier: MIT
 
 [index item] > withi
-  concat > @
+  concat. > @
     with.
-      front list bounded
+      list.front bounded
       item
-    back
-      list
+    list.back
       list.length.minus bounded
   if. > bounded
     0.gt index

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index item] > withi
+[index item] > withi
   concat > @
     with.
       front list bounded
@@ -22,6 +22,7 @@
       index.gt list.length
       list.length
       index
+  ^ > list
 
   eq. ++> can-clamp-a-negative-index-to-the-front-without-duplicating
     withi.

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -7,9 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list element] > without
+[element] > without
   reduced > @
-    list
+    ^
     *
     if. > [accum item] >>
       element.eq item

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -8,8 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [element] > without
-  reduced > @
-    ^
+  ^.reduced > @
     *
     if. > [accum item] >>
       element.eq item

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list i] > withouti
+[i] > withouti
   i.is-integer.if > @
     reducedi
-      list
+      ^
       *
       if. > [accum item index] >>
         i.eq index

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -9,8 +9,7 @@
 
 [i] > withouti
   i.is-integer.if > @
-    reducedi
-      ^
+    ^.reducedi
       *
       if. > [accum item index] >>
         i.eq index


### PR DESCRIPTION
Twenty-two members, the same shape the last three pull requests established:

```
-[list func] > mapped
+[func] > mapped
   mappedi > @
-    list
+    ^
     func item > [item idx] >>
```

Every one of the twenty-two read its receiver exactly once, so none of them keeps a `^ > list` binding at all — `redundant-object/S` asks for the rho where it is used, and there it reads better anyway. `maximum` and `minimum` are the two that read theirs twice and keep the named binding.

The explicit `tuple.member list args` form was in eight places and all of them now dispatch: `tuple.mapped` in `set.eo`, `tuple.reduced` in `path.eo`, `tuple.is-empty` in `range.eo`, and the `+alias tuple.reduced` / `tuple.mapped` / `tuple.filtered` / `tuple.is-empty` that let `map.eo`, `string/chained.eo`, `string/contains-all.eo`, `string/contains-any.eo`, `string/english.eo` and `range/naturals.eo` write the bare name. The aliases are gone with them.

`tuple.eo` also loses `can-check-containment-through-the-package`, which asserted the form this removes. #6654 said it should go rather than be rewritten when its package moved, and this is that moment.

Locally the pipeline puts 39 members into 9 package objects and `EOtupleTest` comes out with 119 tests. This is the last package that #6781 does not block: `bytes` waits for it, and `number` and `string` are the same kind of object, allocated per operation rather than once in a while.
