### PR TITLE
Let a links row hold a type, not a copy

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -5,9 +5,6 @@
 package org.eolang.inference;
 
 import com.jcabi.xml.XML;
-import com.yegor256.tojos.MnMemory;
-import com.yegor256.tojos.TjDeferred;
-import com.yegor256.tojos.Tojos;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,6 +12,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Which types are copies of which.
@@ -44,6 +43,11 @@ import java.util.HashSet;
  * where the checker later gets smarter, when a copy starts receiving types
  * of its own, and then nothing else has to change.</p>
  *
+ * <p>Which is why a row carries what an object is as an element of its own
+ * rather than as a cell, and what {@link Types} makes of it. Being a copy is
+ * one of the things an object turns out to be, and the others — a datum, a
+ * termination, a choice between several objects — arrive beside it.</p>
+ *
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
  * make it decide wrongly. On the runtime this happens to 730 references out
@@ -64,19 +68,18 @@ final class Links implements Clue {
             made.add(formation.xpath("@loc").get(0));
         }
         final Scope scope = new Scope(new HashSet<>(world.locators()), new HashSet<>(made));
-        try (Tojos rows = new TjDeferred(new MnMemory())) {
-            for (final XML reference : world.references()) {
-                final String from = reference.xpath("@loc").get(0);
-                final String target = scope.target(from, reference.xpath("@base").get(0));
-                if (!target.isEmpty()) {
-                    rows.add(from).set("copy", target);
-                }
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final XML reference : world.references()) {
+            final String from = reference.xpath("@loc").get(0);
+            final String target = scope.target(from, reference.xpath("@base").get(0));
+            if (!target.isEmpty()) {
+                found.put(from, target);
             }
-            Files.createDirectories(tables);
-            Files.write(
-                tables.resolve("links.xml"),
-                new Grouped(rows, "links").asXml().toString().getBytes(StandardCharsets.UTF_8)
-            );
         }
+        Files.createDirectories(tables);
+        Files.write(
+            tables.resolve("links.xml"),
+            new Types(found).asXml().toString().getBytes(StandardCharsets.UTF_8)
+        );
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -36,12 +36,17 @@ final class Pairs {
 
     /**
      * Every pair of the table.
+     *
+     * <p>A row whose type is not an object of the program is passed over: it
+     * says something true, and nothing that a chain of copies can be walked
+     * through.</p>
+     *
      * @return The pairs, each name against the one it is a copy of
      */
     Map<String, String> all() {
         final Map<String, String> found = new LinkedHashMap<>(0);
-        for (final XML link : this.table.nodes("/links/type")) {
-            found.put(link.xpath("@id").get(0), link.xpath("@copy").get(0));
+        for (final XML link : this.table.nodes("/links/type[ref]")) {
+            found.put(link.xpath("@id").get(0), link.xpath("ref/@loc").get(0));
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -6,9 +6,6 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import com.yegor256.tojos.MnMemory;
-import com.yegor256.tojos.TjDeferred;
-import com.yegor256.tojos.Tojos;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -65,21 +62,19 @@ public final class Resolved implements Clue {
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
         final Collection<XML> dispatches = world.dispatches();
         final Map<String, List<String>> args = new Given(world.applications()).arguments();
-        final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, given.xpath("//attr[@void='true']/@type"))
-        ).from(
-            new Settled(
-                new Dispatched(given, dispatches, args, Collections.emptyList())
-            ).from(new Pairs(new XMLDocument(links)).all())
+        Files.write(
+            links,
+            new Types(
+                new Settled(
+                    new Dispatched(
+                        given, dispatches, args, given.xpath("//attr[@void='true']/@type")
+                    )
+                ).from(
+                    new Settled(
+                        new Dispatched(given, dispatches, args, Collections.emptyList())
+                    ).from(new Pairs(new XMLDocument(links)).all())
+                )
+            ).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
-        try (Tojos rows = new TjDeferred(new MnMemory())) {
-            for (final Map.Entry<String, String> pair : pairs.entrySet()) {
-                rows.add(pair.getKey()).set("copy", pair.getValue());
-            }
-            Files.write(
-                links,
-                new Grouped(rows, "links").asXml().toString().getBytes(StandardCharsets.UTF_8)
-            );
-        }
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Types.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Types.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.util.Map;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * What every object of a program turns out to be, as a document.
+ *
+ * <p>A row is keyed by the locator of an object and holds a type. There is
+ * one form of type so far, an object being a copy of another one, and it is
+ * written as an element rather than as a cell of the row:</p>
+ *
+ * <pre> &lt;type id="Φ.app.φ"&gt;
+ *   &lt;ref loc="Φ.app.inc"/&gt;
+ * &lt;/type&gt;</pre>
+ *
+ * <p>A cell would have been shorter and is what this table used to write. It
+ * cannot survive the other forms, though: an object is sometimes a datum,
+ * sometimes a termination, sometimes a choice between several objects, and a
+ * choice is not one answer. Since every one of those wants an element of its
+ * own, the one form there is today gets an element too, and the four that
+ * follow are added beside it rather than by rewriting this.</p>
+ *
+ * <p>The rows come out in the order they were worked out, so that two builds
+ * of the same program can be compared as text.</p>
+ *
+ * @since 0.69.0
+ */
+final class Types {
+
+    /**
+     * The pairs, each object against the one it is a copy of.
+     */
+    private final Map<String, String> copies;
+
+    /**
+     * Ctor.
+     * @param pairs The pairs, each object against the one it is a copy of
+     */
+    Types(final Map<String, String> pairs) {
+        this.copies = pairs;
+    }
+
+    /**
+     * This table as an XML document.
+     * @return The document
+     */
+    XML asXml() {
+        final Directives dirs = new Directives().add("links");
+        for (final Map.Entry<String, String> pair : this.copies.entrySet()) {
+            dirs.add("type")
+                .attr("id", pair.getKey())
+                .add("ref")
+                .attr("loc", pair.getValue())
+                .up()
+                .up();
+        }
+        return new XMLDocument(new Xembler(dirs).domQuietly());
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-dispatches-is-answered-in-order.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-of-dispatches-is-answered-in-order.yaml
@@ -14,5 +14,5 @@ eo:
       [] > held
         [] > deep
 links:
-  - "/links/type[@id='Φ.app.φ.ρ' and @copy='Φ.outer.held']"
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.outer.held.deep']"
+  - "/links/type[@id='Φ.app.φ.ρ']/ref[@loc='Φ.outer.held']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.outer.held.deep']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-through-a-void-keeps-going.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-through-a-void-keeps-going.yaml
@@ -9,5 +9,5 @@ eo:
     [x] > inc
       x.next.foo > @
 links:
-  - "/links/type[@id='Φ.inc.φ.ρ' and @copy='Φ.inc.x.next']"
-  - "/links/type[@id='Φ.inc.φ' and @copy='Φ.inc.x.next.foo']"
+  - "/links/type[@id='Φ.inc.φ.ρ']/ref[@loc='Φ.inc.x.next']"
+  - "/links/type[@id='Φ.inc.φ']/ref[@loc='Φ.inc.x.next.foo']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-finds-a-member-of-the-package.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-finds-a-member-of-the-package.yaml
@@ -13,4 +13,4 @@ eo:
     [] > bool
       [] > if
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.bool.if']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.bool.if']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-is-the-attribute-it-takes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-is-the-attribute-it-takes.yaml
@@ -13,4 +13,4 @@ eo:
     [] > outer
       [] > held
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.outer.held']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.outer.held']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-looks-behind-delegation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-looks-behind-delegation.yaml
@@ -15,4 +15,4 @@ eo:
     [] > base
       [] > next
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.base.next']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.base.next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-a-void-is-the-attribute-of-the-void.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-a-void-is-the-attribute-of-the-void.yaml
@@ -10,4 +10,4 @@ eo:
     [x] > inc
       x.next > @
 links:
-  - "/links/type[@id='Φ.inc.φ' and @copy='Φ.inc.x.next']"
+  - "/links/type[@id='Φ.inc.φ']/ref[@loc='Φ.inc.x.next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-what-an-atom-returns-is-answered.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-on-what-an-atom-returns-is-answered.yaml
@@ -16,4 +16,4 @@ eo:
     [] > number
       [] > plus
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.number.plus']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.number.plus']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-reaches-into-another-file.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-reaches-into-another-file.yaml
@@ -14,6 +14,6 @@ eo:
 needs:
   - "/needs/type[@id='Φ.sum.φ.ρ']/attr[@name='plus']"
 links:
-  - "/links/type[@id='Φ.sum.φ.ρ' and @copy='Φ.number']"
+  - "/links/type[@id='Φ.sum.φ.ρ']/ref[@loc='Φ.number']"
 provides:
   - "/provides/type[@id='Φ.number']/attr[@name='plus']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/filling-a-void-answers-what-it-holds.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/filling-a-void-answers-what-it-holds.yaml
@@ -16,4 +16,4 @@ eo:
     [] > t
       [] > next
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.t.next']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.t.next']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -30,8 +30,8 @@ needs:
   - "/needs//attr[@name='next' and @type='Φ.app.inc.φ.ρ']"
   - "/needs/type[@id='Φ.app.inc.φ.ρ']/attr[@name='foo' and @type='Φ.app.inc.φ']"
 links:
-  - "/links/type[@id='Φ.app.φ' and @copy='Φ.app.inc']"
-  - "/links/type[@id='Φ.app.φ.α0' and @copy='Φ.app.t']"
-  - "/links/type[@id='Φ.app.inc.φ.ρ.ρ' and @copy='Φ.app.inc.x']"
-  - "/links/type[@id='Φ.app.inc.φ.ρ' and @copy='Φ.app.inc.x.next']"
-  - "/links/type[@id='Φ.app.inc.φ' and @copy='Φ.app.inc.x.next.foo']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.app.inc']"
+  - "/links/type[@id='Φ.app.φ.α0']/ref[@loc='Φ.app.t']"
+  - "/links/type[@id='Φ.app.inc.φ.ρ.ρ']/ref[@loc='Φ.app.inc.x']"
+  - "/links/type[@id='Φ.app.inc.φ.ρ']/ref[@loc='Φ.app.inc.x.next']"
+  - "/links/type[@id='Φ.app.inc.φ']/ref[@loc='Φ.app.inc.x.next.foo']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/outer-name-arrives-as-parent-dispatch.yaml
@@ -19,4 +19,4 @@ xmir:
 needs:
   - "/needs/type[@id='Φ.outer.inner.φ.ρ']/attr[@name='held']"
 links:
-  - "/links/type[@id='Φ.outer.inner.φ.ρ' and @copy='Φ.outer']"
+  - "/links/type[@id='Φ.outer.inner.φ.ρ']/ref[@loc='Φ.outer']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-reaches-into-another-file.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-reaches-into-another-file.yaml
@@ -12,4 +12,4 @@ eo:
     [] > number
       [] > plus
 links:
-  - "/links/type[@id='Φ.two.φ' and @copy='Φ.number']"
+  - "/links/type[@id='Φ.two.φ']/ref[@loc='Φ.number']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-to-root-object.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/reference-to-root-object.yaml
@@ -9,4 +9,4 @@ eo:
       number > @
     [] > number
 links:
-  - "/links/type[@id='Φ.tworef.φ' and @copy='Φ.number']"
+  - "/links/type[@id='Φ.tworef.φ']/ref[@loc='Φ.number']"


### PR DESCRIPTION
A links row said what an object copies in a cell:

```java
rows.add(from).set("copy", target);
```

One cell holds one answer, and four of the things an object turns out to be are not one answer. On a clean `eo-runtime` build, 1,614 objects are Δ literals, 65 are `⊥`, and 295 are a choice between two or more objects; none of the three can be written into an attribute, and a choice between objects that themselves carry filled voids cannot be written into any number of attributes.

So the row carries an element:

```xml
<type id="Φ.app.φ">
  <ref loc="Φ.app.inc"/>
</type>
```

which says exactly what `copy="Φ.app.inc"` said. `Types` writes the document, `Pairs` reads it back, and `Links` and `Resolved` stop keeping rows in a table of cells for it.

Nothing moves. On the same parse of `eo-runtime`, before and after: `provides.xml` and `needs.xml` are byte-identical, and the links table has the same 31,876 rows carrying the same targets in the same order. Thirteen packs say `ref` where they said `copy`.

The forms this makes room for arrive one at a time, each with the packs that describe it: what fills a void at an application (#6787), Δ, `⊥`, a choice, and a name only a caller can fill.

Closes #6786
