### PR TITLE
Merge the number package

### DIFF
--- a/eo-integration-tests/src/test/resources/snippets/decorated.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/decorated.yaml
@@ -7,7 +7,6 @@ out:
 file: snippets/foo.eo
 args: ["snippets.foo"]
 eo: |
-  +alias number.sine
   +package snippets
 
   [] > foo
@@ -16,4 +15,4 @@ eo: |
       "Sin of %f is %f".printf
         *
           x
-          sine x
+          x.sine

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -319,6 +319,7 @@
                 <mergedPackage>file</mergedPackage>
                 <mergedPackage>i64</mergedPackage>
                 <mergedPackage>input</mergedPackage>
+                <mergedPackage>number</mergedPackage>
                 <mergedPackage>output</mergedPackage>
                 <mergedPackage>range</mergedPackage>
                 <mergedPackage>tuple</mergedPackage>

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -326,7 +326,6 @@
                 <mergedPackage>u64</mergedPackage>
               </mergedPackages>
               <keepBinaries>
-                <glob>org/eolang/EO_number/package-info.class</glob>
                 <glob>org/eolang/EO_string/package-info.class</glob>
                 <glob>org/eolang/package-info.class</glob>
               </keepBinaries>

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -86,7 +86,7 @@
           posix
             "getpid"
             *
-      number.random clock
+      clock.as-number.random
   [glob] > walk
     [accum prefix dir] >> walked
       [rest] >> stepped

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -12,8 +12,7 @@
 [as-bytes] > number
   as-bytes > @
   as-i32.as-i16 > as-i16
-  as-i32. > as-i32
-    number.as-i64 $
+  $.as-i64.as-i32 > as-i32
   [] > div /Q.number
     ? > x /Q.number
   [] > gt /Q.bool
@@ -348,12 +347,6 @@
   eq. ++> can-multiply-positive-infinity-by-positive-infinity
     pinf.times pinf
     pinf
-
-  eq. ++> can-raise-to-a-power-through-the-package
-    number.power
-      2
-      5
-    32
 
   eq. ++> can-tell-it-is-not-greater-than-a-float-when-negative-infinity
     ninf.gt 42.5

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -6,11 +6,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > abs
+[] > abs
   if. > @
     gte.
-      number num.as-bytes >> value
+      number ^.as-bytes >> value
       0
     0.plus value
     value.neg

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > abs
   if. > @

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -9,11 +9,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > arc-cosine
+[] > arc-cosine
   minus. > @
     pi.div 2
-    arc-sine num
+    ^.arc-sine
 
   2.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-above-one
 

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -9,7 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > arc-cosine
   minus. > @

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -10,8 +10,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > arc-sine
+[] > arc-sine
   if. > @
     arg.as-bytes.eq 80-00-00-00-00-00-00-00
     arg
@@ -19,9 +20,7 @@
       arg.lt 0
       neg.
         if. >> base
-          gt.
-            abs arg >> magnitude
-            0.5
+          arg.abs.gt 0.5
           minus.
             pi.div 2
             2.times
@@ -48,10 +47,10 @@
                 times. > squared!
                   number bts
                   number bts
-              | (sqrt ((1.minus magnitude).div 2))
-          series magnitude
+              | ((1.minus arg.abs).div 2).sqrt
+          series arg.abs
       base
-  number num.as-bytes > arg
+  number ^.as-bytes > arg
 
   lt. ++> can-behave-as-an-odd-function-when-taking-arc-sine
     abs.

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -10,7 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > arc-sine
   if. > @

--- a/eo-runtime/src/main/eo/number/as-char.eo
+++ b/eo-runtime/src/main/eo/number/as-char.eo
@@ -7,9 +7,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[code] > as-char
-  code.as-i64.as-bytes.slice > @
+[] > as-char
+  ^.as-i64.as-bytes.slice > @
     7
     1
 

--- a/eo-runtime/src/main/eo/number/as-char.eo
+++ b/eo-runtime/src/main/eo/number/as-char.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > as-char
   ^.as-i64.as-bytes.slice > @

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -11,7 +11,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > as-decimal
   n.is-finite.not.if > @

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -38,11 +38,11 @@
           [n] >> digits
             if. > @
               n.lt ten
-              as-char
+              as-char.
                 n.as-number.plus 48
               concat.
                 digits q
-                as-char
+                as-char.
                   plus.
                     as-number.
                       n.minus (q.times ten)

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -11,8 +11,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > as-decimal
+[] > as-decimal
   n.is-finite.not.if > @
     T
       "Can't write a non-finite number as decimal"
@@ -50,6 +51,7 @@
             n.div ten failure > bits!
             i64 bits > q
           | (n.as-i64 failure)
+  ^ > n
   10.as-i64 failure > ten!
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -32,11 +32,9 @@
             digits.eq scale
             if. > [unit rest] >> written
               places.eq 0
-              as-decimal unit
+              unit.as-decimal
               concat.
-                concat.
-                  as-decimal unit
-                  ".".as-bytes
+                unit.as-decimal.concat ".".as-bytes
                 rec-pad rest places --
             | (whole.plus 1) 0
             written whole digits

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -16,7 +16,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n places cant-print] > as-fixed
+[places cant-print] > as-fixed
   if. > @
     or.
       0.gt places
@@ -64,6 +64,7 @@
             positive a
         | (n.times -1)
         positive n
+  ^ > n
   if. > [p] >> pow10
     p.eq 0
     1
@@ -81,7 +82,7 @@
       as-number.
         count.minus 1
       concat.
-        as-char
+        as-char.
           plus.
             floor.
               value.minus

--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n cant-convert] > as-i64
+[cant-convert] > as-i64
   if. > @
     or.
       eq.
@@ -53,6 +53,7 @@
                 exp.minus 1075
               mantissa.right
                 1075.minus exp
+  ^ > n
 
   eq. ++> can-convert-a-fraction-below-one-to-zero
     0.5.as-i64.as-bytes

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -12,7 +12,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > as-scientific
   n.is-finite.not.if > @

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -25,18 +25,18 @@
       mantissa.eq "10.000000".as-bytes
       concat.
         "1.000000".as-bytes.concat "e".as-bytes
-        as-decimal
+        as-decimal.
           plus.
             number exponent
             1
       concat.
         mantissa.concat "e".as-bytes
-        as-decimal
+        as-decimal.
           number exponent
   rec-exponent > exponent!
     n.abs
     0
-  as-fixed > mantissa
+  as-fixed. > mantissa
     n.div
       10.power
         number exponent

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -12,8 +12,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > as-scientific
+[] > as-scientific
   n.is-finite.not.if > @
     n.is-nan.if
       "nan".as-bytes
@@ -41,6 +42,7 @@
       10.power
         number exponent
     6
+  ^ > n
   if. > [m count] >> rec-exponent
     m.lt 10
     count

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -9,7 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > cosine
   if. > @

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -9,14 +9,16 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > cosine
+[] > cosine
   if. > @
     num.eq 0
     1
     sine.
       num.plus
         pi.div 2
+  ^ > num
 
   lt. ++> can-behave-as-an-even-function
     abs.

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -7,11 +7,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > degrees
+[] > degrees
   times. > @
     div.
-      number num.as-bytes
+      number ^.as-bytes
       pi
     180
 

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > degrees
   times. > @

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > eq
+[x] > eq
   if. > @
     n.is-nan.or
       is-nan.
@@ -30,6 +30,7 @@
             pzero
           b.eq nzero
       b.eq xbts
+  ^ > n
 
   eq. ++> can-compare-two-different-number-types
     68.eq "12345678"

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -6,11 +6,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > exp
-  power > @
-    e
-    num
+[] > exp
+  e.power ^ > @
 
   lt. ++> can-exponentiate-five
     abs.

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > exp
   e.power ^ > @

--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > floor
   if. > @

--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -7,8 +7,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > floor
+[] > floor
   if. > @
     n.as-bytes.eq 80-00-00-00-00-00-00-00
     n
@@ -24,6 +25,7 @@
           n
         trunc.minus 1
         n.as-i64.as-number
+  ^ > n
 
   -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
 

--- a/eo-runtime/src/main/eo/number/gte.eo
+++ b/eo-runtime/src/main/eo/number/gte.eo
@@ -7,11 +7,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > gte
+[x] > gte
   or. > @
     n.gt
       x >> value!
     n.eq value
+  ^ > n
 
   eq. ++> can-be-greater-than-or-equal-to-a-float-when-positive-infinity
     pinf.gte 42.5

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -9,8 +9,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > is-finite
+[] > is-finite
   and. > @
     n.as-bytes.size.eq 8
     n.is-nan.not.and
@@ -18,6 +19,7 @@
         or.
           n.as-bytes.eq 7F-F0-00-00-00-00-00-00
           n.as-bytes.eq FF-F0-00-00-00-00-00-00
+  ^ > n
 
   32.is-finite ++> can-be-finite-when-a-simple-number
 

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -9,7 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > is-finite
   and. > @

--- a/eo-runtime/src/main/eo/number/is-integer.eo
+++ b/eo-runtime/src/main/eo/number/is-integer.eo
@@ -6,10 +6,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > is-integer
+[] > is-integer
   n.is-finite.and > @
     n.eq n.floor
+  ^ > n
 
   32.is-integer ++> can-be-an-integer-when-a-whole-number
 

--- a/eo-runtime/src/main/eo/number/is-integer.eo
+++ b/eo-runtime/src/main/eo/number/is-integer.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > is-integer
   n.is-finite.and > @

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > is-nan
   if. > @

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -6,8 +6,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > is-nan
+[] > is-nan
   if. > @
     and.
       bts.size.gt 7
@@ -22,7 +23,7 @@
           bts.and 00-0F-FF-FF-FF-FF-FF-FF
           00-00-00-00-00-00-00-00
     false
-  n.as-bytes > bts
+  ^.as-bytes > bts
 
   is-nan. ++> can-be-nan-when-built-of-nan-bytes
     number nan.as-bytes

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -12,7 +12,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > ln
   n.is-nan.if > @

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -12,8 +12,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > ln
+[] > ln
   n.is-nan.if > @
     nan
     if.
@@ -98,7 +99,7 @@
         prev.plus prev
       step > prev
         level.minus 1
-  number num.as-bytes > n
+  number ^.as-bytes > n
 
   -2.2.ln.is-nan ++> can-return-nan-for-a-logarithm-of-a-negative-float
 

--- a/eo-runtime/src/main/eo/number/lt.eo
+++ b/eo-runtime/src/main/eo/number/lt.eo
@@ -7,9 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > lt
+[x] > lt
   0.gt > @
-    n.minus
+    ^.minus
       number x!
 
   ninf.lt 42.5 ++> can-be-less-than-a-float-when-negative-infinity

--- a/eo-runtime/src/main/eo/number/lte.eo
+++ b/eo-runtime/src/main/eo/number/lte.eo
@@ -7,11 +7,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > lte
+[x] > lte
   or. > @
     n.lt
       x >> value!
     n.eq value
+  ^ > n
 
   eq. ++> can-be-less-than-or-equal-to-a-float-when-negative-infinity
     ninf.lte 42.5

--- a/eo-runtime/src/main/eo/number/minus.eo
+++ b/eo-runtime/src/main/eo/number/minus.eo
@@ -7,8 +7,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > minus
-  n.plus > @
+[x] > minus
+  ^.plus > @
     neg.
       number x!
 

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -18,7 +18,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x y cant-mod] > mod
+[y cant-mod] > mod
   if. > @
     eq.
       number y.as-bytes >> divisor
@@ -56,6 +56,7 @@
                     rest.minus chunk
                     rest
             abs-mod.neg
+  ^ > x
 
   eq. ++> can-recover-from-a-modulo-by-zero
     "recovered"

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -38,9 +38,10 @@
               0
             [] >> abs-mod
               shrink > @
-                grow
-                  abs divisor >> absy
-                abs dividend >> absx
+                grow absy
+                absx
+              dividend.abs > absx!
+              divisor.abs > absy!
               if. > [chunk] > grow
                 chunk.gte absx
                 chunk

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -38,17 +38,15 @@
               0
             [] >> abs-mod
               shrink > @
-                grow absy
-                absx
-              dividend.abs > absx!
-              divisor.abs > absy!
+                grow divisor.abs
+                dividend.abs
               if. > [chunk] > grow
-                chunk.gte absx
+                chunk.gte dividend.abs
                 chunk
                 grow
                   chunk.plus chunk
               if. > [chunk rest] > shrink
-                chunk.lt absy
+                chunk.lt divisor.abs
                 rest
                 shrink
                   chunk.div 2

--- a/eo-runtime/src/main/eo/number/neg.eo
+++ b/eo-runtime/src/main/eo/number/neg.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > neg
   ^.times -1 > @

--- a/eo-runtime/src/main/eo/number/neg.eo
+++ b/eo-runtime/src/main/eo/number/neg.eo
@@ -6,9 +6,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[n] > neg
-  n.times -1 > @
+[] > neg
+  ^.times -1 > @
 
   ninf.neg.eq pinf ++> can-negate-negative-infinity
 

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num x] > power
+[x] > power
   if. > @
     eq.
       number x.as-bytes >> expo
@@ -55,8 +55,8 @@
                           b.times
                             ipow b (n.minus 1)
                       ipow b (n.div 2) > half!
-                    | base (abs expo)
-                  ipow base (abs expo)
+                    | base expo.abs
+                  ipow base expo.abs
                 if.
                   base.gt 0
                   [y] >> expon
@@ -64,12 +64,8 @@
                       if.
                         lt. (number k) 0
                         1.div
-                          ipow
-                            e
-                            abs (number k)
-                        ipow
-                          e
-                          abs (number k)
+                          ipow e (number k).abs
+                        ipow e (number k).abs
                       fraction 1
                     y > arg!
                     if. > [j] > fraction
@@ -84,7 +80,7 @@
                             j
                           fraction (j.plus 1)
                     floor. ((number arg).plus 0.5) > k!
-                  | (expo.times (ln base))
+                  | (expo.times base.ln)
                   nan
             if.
               base.gt 0
@@ -102,27 +98,20 @@
           if.
             expo.gt 0
             if.
-              gt.
-                abs base
-                1
+              base.abs.gt 1
               pinf
               if.
-                eq.
-                  abs base
-                  1
+                base.abs.eq 1
                 nan
                 0
             if.
-              gt.
-                abs base
-                1
+              base.abs.gt 1
               0
               if.
-                eq.
-                  abs base
-                  1
+                base.abs.eq 1
                 nan
                 pinf
+  ^ > num
 
   eq. ++> can-be-called-as-a-method-on-a-number
     2.power 4
@@ -131,10 +120,6 @@
   eq. ++> can-be-called-as-a-method-with-a-bound-receiver
     3.power 2
     9
-
-  eq. ++> can-be-reached-through-the-package
-    2.power 4
-    16
 
   eq. ++> can-raise-a-float-to-zero
     42.5.power 0

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -7,11 +7,12 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > radians
+[] > radians
   times. > @
     div.
-      number num.as-bytes
+      number ^.as-bytes
       180
     pi
 

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > radians
   times. > @

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[seed] > random
+[] > random
   seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
   [clock] > clocked
-    random > @
+    random. > @
       as-number.
         plus.
           as-i64.
@@ -30,7 +30,7 @@
     35 > shift1
     17 > shift3
     clock.as-bytes > tbytes
-  random > next
+  random. > next
     as-number.
       as-i64.
         and.
@@ -51,6 +51,7 @@
               11.as-i64
           00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
+  ^ > seed
 
   not. ++> can-differ-between-two-draws
     eq.
@@ -63,8 +64,8 @@
     178609.random.next > rand
 
   eq. ++> can-repeat-itself-with-the-same-seed
-    next. (random 1654).next.next
-    next. (random 1654).next.next
+    1654.random.next.next.next
+    1654.random.next.next.next
 
   ++> can-stay-in-range
     and. > @

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -14,12 +14,13 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > sine
+[] > sine
   times. > @
     minus. >> reduced
       minus.
-        number num.as-bytes >> arg
+        number ^.as-bytes >> arg
         times.
           floor. >> k
             plus.

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -14,7 +14,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > sine
   times. > @

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -7,16 +7,17 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint package-member-without-void
 
-[num] > sqrt
+[] > sqrt
   if. > @
     arg.lt 0
     nan
     if.
       arg.as-bytes.eq 80-00-00-00-00-00-00-00
       arg
-      power arg 0.5
-  number num.as-bytes > arg
+      arg.power 0.5
+  number ^.as-bytes > arg
 
   lt. ++> can-approximate-a-square-root-of-four
     abs.

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > sqrt
   if. > @

--- a/eo-runtime/src/test/groovy/check-target-files.groovy
+++ b/eo-runtime/src/test/groovy/check-target-files.groovy
@@ -11,7 +11,6 @@ List<String> expected = [
   'generated-sources/org/eolang/EOsocket.java',
   'generated-test-sources/org/eolang/EObytesTest.java',
   'classes/org/eolang/package-info.class',
-  'classes/org/eolang/EO_number/package-info.class',
   'classes/org/eolang/EO_string/package-info.class',
 ]
 

--- a/eo-runtime/src/test/java/org/eolang/PhNestTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhNestTest.java
@@ -21,7 +21,7 @@ final class PhNestTest {
             "Direct put by position into a package object must fail fast, but it didn't",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> Phi.Φ.take("number").put(0, new Data.ToPhi(42L)),
+                () -> Phi.Φ.take("string").put(0, new Data.ToPhi(42L)),
                 "Putting by position straight into a shared package object must be rejected"
             ).getMessage(),
             Matchers.containsString("make a copy first")
@@ -34,7 +34,7 @@ final class PhNestTest {
             "Direct put by name into a package object must fail fast, but it didn't",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> Phi.Φ.take("number").put("x", new Data.ToPhi(42L)),
+                () -> Phi.Φ.take("string").put("x", new Data.ToPhi(42L)),
                 "Putting by name straight into a shared package object must be rejected"
             ).getMessage(),
             Matchers.containsString("make a copy first")
@@ -44,7 +44,7 @@ final class PhNestTest {
     @Test
     void allowsPutAfterCopy() {
         Assertions.assertDoesNotThrow(
-            () -> Phi.Φ.take("number").copy().put(0, new Data.ToPhi(42L)),
+            () -> Phi.Φ.take("string").copy().put(0, new Data.ToPhi(42L)),
             "A copy of a package object must accept a put, but it didn't"
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/PhNestTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhNestTest.java
@@ -70,7 +70,7 @@ final class PhNestTest {
     void handsOutExtensionWithoutBindingPackageAsRho() {
         MatcherAssert.assertThat(
             "Explicit dispatch must leave ρ unbound so the receiver convention stays α0-only, but ρ was set",
-            Phi.Φ.take("number").take("power").hasRho(),
+            Phi.Φ.take("string").take("printf").hasRho(),
             Matchers.is(false)
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -68,11 +68,7 @@ final class PhiTest {
             Assertions.assertThrows(
                 ExAbstract.class,
                 () -> new Dataized(
-                    new PhApplication(
-                        Phi.Φ.take("number.as-decimal").copy(),
-                        "n",
-                        new Data.ToPhi(Double.NaN)
-                    )
+                    new Data.ToPhi(Double.NaN).take("as-decimal")
                 ).take()
             ).getMessage(),
             Matchers.containsString("Can't write a non-finite number as decimal")


### PR DESCRIPTION
Continues #6657 with the `number` package: all 29 members now read their
receiver through `^` instead of taking it as the first void, and `number` joins
`<mergedPackages>` so `MjMerge` splices them into the object at compile time.

The interesting half is the sibling calls. Inside a package, a member naming a
sibling by its bare name compiles to `Φ.number.<sibling>`, which after the merge
resolves to the member with the package object as its `ρ` — so the receiver
rides along as one extra argument. Twenty-four of those, all rewritten as
dispatches:

```
[x] > power
  ...
              base.abs.gt 1
              pinf
  ^ > num
```

Those calls fail in a way worth naming, because it is not obvious. A de-voided
member reached through a package object still works by accident: the package
hands its extensions out with `ρ` unbound, so the receiver lands in it as `α0`.
Reached through the merged object instead, `ρ` is already bound, `put` finds no
vacant attribute and falls onto a cached one, and the program dies with
`Can't overwrite the cached attribute`. Which of the two happens depends on
whether `Φ.number` resolves to a `PhNest` or to `EOnumber`, and that in turn
depended on a leftover: `keepBinaries` still carried
`org/eolang/EO_number/package-info.class`, so the jar kept shipping a package
marker for a package that no longer exists, and every downstream project got
the accidental behaviour while eo-runtime's own build got the real one. The
glob is gone.

Three external call sites moved too: `number.eo` reaches its own `as-i64`
through `$`, `directory.eo` seeds its temporary-file counter with
`clock.as-number.random`, and the `decorated` snippet now writes `x.sine`
rather than `sine x` behind an alias, which is exactly the form the merge
removes.

`integral` keeps all four voids. It takes a function, not a number, so it never
had a receiver to reach for — the same shape as `input/dead` and `output/dead`.

Two static checks over `target/eo/1-parse` back this up: across all ten merged
packages nothing under `Φ.<package>.<member>` survives except `integral`,
`input.dead`, `output.dead` and the void-less `tuple.empty`, and every other
member of every merged package reads `^`. `PhNestTest` now probes `string`,
since `number` is not a package object any more.

`bytes` still waits on #6781; `string` is the last package left.
