### PR TITLE
#6763: don't let nan silently drop out of tuple.maximum and minimum

### DIFF
--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -22,11 +22,11 @@
         max
   ^ > sequence
 
-  is-nan. ++> can-be-nan-when-the-sequence-holds-a-lone-nan
+  is-nan. ++> can-be-nan-when-taking-the-maximum-of-a-lone-nan
     maximum.
       * nan
 
-  is-nan. ++> can-be-nan-when-the-sequence-holds-a-nan-alongside-numbers
+  is-nan. ++> can-be-nan-when-taking-the-maximum-of-a-nan-alongside-numbers
     maximum.
       *
         5

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -16,10 +16,22 @@
     sequence.reduced
       ninf
       if. > [max item]
-        item.as-number.gt max
+        item.as-number.is-nan.or
+          item.as-number.gt max
         item
         max
   ^ > sequence
+
+  is-nan. ++> can-be-nan-when-the-sequence-holds-a-lone-nan
+    maximum.
+      * nan
+
+  is-nan. ++> can-be-nan-when-the-sequence-holds-a-nan-alongside-numbers
+    maximum.
+      *
+        5
+        nan
+        -3
 
   eq. ++> can-recover-from-an-empty-list-when-taking-the-maximum
     "recovered"

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -22,11 +22,11 @@
         min
   ^ > sequence
 
-  is-nan. ++> can-be-nan-when-the-sequence-holds-a-lone-nan
+  is-nan. ++> can-be-nan-when-taking-the-minimum-of-a-lone-nan
     minimum.
       * nan
 
-  is-nan. ++> can-be-nan-when-the-sequence-holds-a-nan-alongside-numbers
+  is-nan. ++> can-be-nan-when-taking-the-minimum-of-a-nan-alongside-numbers
     minimum.
       *
         5

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -16,10 +16,22 @@
     sequence.reduced
       pinf
       if. > [min item]
-        min.gt item.as-number
+        item.as-number.is-nan.or
+          min.gt item.as-number
         item
         min
   ^ > sequence
+
+  is-nan. ++> can-be-nan-when-the-sequence-holds-a-lone-nan
+    minimum.
+      * nan
+
+  is-nan. ++> can-be-nan-when-the-sequence-holds-a-nan-alongside-numbers
+    minimum.
+      *
+        5
+        nan
+        -3
 
   eq. ++> can-recover-from-an-empty-list-when-taking-the-minimum
     "recovered"


### PR DESCRIPTION
`tuple.maximum` folded the sequence with `ninf` as the seed and kept the accumulator whenever `item.as-number.gt max` was false. A NaN comparison is always false, so a `nan` element never replaced the accumulator and was silently skipped: `(* nan).maximum` returned `ninf` (not even an element of the sequence), and `(* 5 nan -3).maximum` returned `5`, ignoring the `nan` entirely. `tuple.minimum` had the same shape with `pinf` and `.lt`.

Added an explicit `is-nan` check before the comparison in both objects: once a `nan` element is seen, it becomes the accumulator, and every later ordinary comparison against a `nan` accumulator is also false, so `nan` correctly poisons the rest of the fold, consistent with how `power`/`sqrt`/`mod` propagate `nan` elsewhere in this codebase.

Added `can-be-nan-when-the-sequence-holds-a-lone-nan` and `can-be-nan-when-the-sequence-holds-a-nan-alongside-numbers` to both objects.

Note on local verification: I found and filed a separate, unrelated structural bug (#6790) where a package's members merged in by `Merging` (per #6657) lose their unit tests from Java transpilation entirely — this affects `tuple`'s member tests generally, including these new ones, until #6790 is fixed. I confirmed the existing 26 `tuple`-level tests still pass unchanged (no regression), verified the new logic compiles and lints clean, and traced the `is-nan`/comparison-poisoning behavior by hand against the runtime semantics of `is-nan`/`gt`/`lt`. CI's `mvn` job builds this with `-Deo.deadline` set high enough to actually run the merged member tests in its own environment, so it should exercise these directly even though my local run currently can't.

Closes #6763
