### PR TITLE
#6765: anchor each segment of the locator pattern in XMIR.xsd

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -116,7 +116,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="Φ(\.(ρ|φ|α[0-9]+|[a-z]\S*))*"/>
+      <xs:pattern value="Φ(\.(ρ|φ|λ|α[0-9]+|[a-z+-][^\s.]*))*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="o" mixed="true">

--- a/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -114,6 +116,31 @@ final class StrictXmirTest {
             )::inner,
             "validation should pass as normal"
         );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'Φ.chunk.read.λ', true",
+        "'Φ.set.+can-append-a-new-item.φ.ρ.ρ.α0', true",
+        "'Φ.foo.bar', true",
+        "'Φ', true",
+        "'Φ.a.WRONG', false",
+        "'Φ.a.λEXTRA', false"
+    })
+    void validatesLocatorAttribute(final String loc, final boolean valid) {
+        final XML xml = new StrictXmir(StrictXmirTest.xmirWithLocator(loc));
+        if (valid) {
+            Assertions.assertDoesNotThrow(
+                xml::inner,
+                String.format("locator '%s' should have been accepted, but wasn't", loc)
+            );
+        } else {
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                xml::inner,
+                String.format("locator '%s' should have been rejected, but wasn't", loc)
+            );
+        }
     }
 
     @Test
@@ -234,6 +261,30 @@ final class StrictXmirTest {
                         schema
                     )
                     .add("o")
+                    .up()
+            ).xmlQuietly()
+        );
+    }
+
+    /**
+     * Make an XMIR, validated against the local (current-version) schema,
+     * with a single top-level object carrying the given {@code loc}.
+     * @param loc The locator to put into the {@code loc} attribute
+     * @return XMIR
+     */
+    private static XML xmirWithLocator(final String loc) {
+        return new XMLDocument(
+            new Xembler(
+                new Directives()
+                    .append(new DrProgram())
+                    .xpath("/object")
+                    .attr("author", "noname").attr(
+                        "noNamespaceSchemaLocation xsi http://www.w3.org/2001/XMLSchema-instance",
+                        String.format(
+                            "https://www.eolang.org/xsd/XMIR-%s.xsd", StrictXmirTest.version()
+                        )
+                    )
+                    .add("o").attr("loc", loc)
                     .up()
             ).xmlQuietly()
         );


### PR DESCRIPTION
The `locator` simple type in `XMIR.xsd` uses the pattern:

```
Φ(\.(ρ|φ|α[0-9]+|[a-z]\S*))*
```

`\S*` is unanchored, so `[a-z]\S*` matches any non-whitespace run including
dots. That means a locator segment can swallow the rest of the path (or
even multiple dot-separated segments) instead of being validated one
segment at a time, so a malformed locator like `Φ.a.WRONG` still passes
because `\S*` just eats through the extra dot.

This diverges from how the file already handles the same problem for
`fqn`, `signature` and `type-anno` (each uses `[^\s.]*` to stop a segment
at the next dot). It also doesn't allow two segment shapes real XMIR
actually produces: the `λ` atom-marker segment (e.g. `Φ.chunk.read.λ`)
and `+`-prefixed test-attribute segments (e.g.
`Φ.set.+can-append-a-new-item.φ.ρ.ρ.α0`), both confirmed by grepping
generated `.xmir` files.

Fix: anchor each segment like the sibling types do, add `λ` as an
explicit alternative, and widen the leading character class to
`[a-z+-]` (matching `attribute-name`'s own idiom):

```
Φ(\.(ρ|φ|λ|α[0-9]+|[a-z+-][^\s.]*))*
```

Verified against every `@loc` produced by a clean `eo-runtime` build,
and added a parameterized test (`StrictXmirTest.validatesLocatorAttribute`)
covering both the previously-accepted-in-error cases and the newly
allowed real-world shapes.

Fixes #6765
