### PR TITLE
#6766: report canonical error for horizontal formation as argument

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -900,6 +900,12 @@ final class Tokens {
      * @return Parsed value
      */
     private Value readGlyph(final char first) {
+        if (first == '[') {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + this.cursor,
+                "horizontal formation not allowed as argument"
+            );
+        }
         final Value value;
         if (first == '*') {
             value = this.reserved(Value.Kind.STAR, "*");
@@ -909,11 +915,6 @@ final class Tokens {
             value = this.reserved(Value.Kind.SELF, "%");
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
-        } else if (first == '[') {
-            throw new ParseError(
-                this.span.line(), this.span.indent() + this.cursor,
-                "horizontal formation not allowed as argument"
-            );
         } else {
             throw new ParseError(
                 this.span.line(), this.span.indent() + this.cursor,

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -909,6 +909,11 @@ final class Tokens {
             value = this.reserved(Value.Kind.SELF, "%");
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
+        } else if (first == '[') {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + this.cursor,
+                "horizontal formation not allowed as argument"
+            );
         } else {
             throw new ParseError(
                 this.span.line(), this.span.indent() + this.cursor,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/horizontal-formation-as-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/horizontal-formation-as-arg.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:15] error: 'expected value'
+  [2:15] error: 'horizontal formation not allowed as argument'
     malloc.for 4 [m]>>
                  ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/name-after-scoped-happlication.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/name-after-scoped-happlication.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:15] error: 'expected value'
+  [3:15] error: 'horizontal formation not allowed as argument'
       malloc 100 [m]>> > @
                  ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/nested-paren-with-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/nested-paren-with-formation.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:3] error: 'expected value'
+  [2:3] error: 'horizontal formation not allowed as argument'
     ([] (^ > x)).plus.minus > s
      ^
 input: |


### PR DESCRIPTION
PARSER_SPEC.md R-9.9.1 lists one canonical text for a horizontal formation
appearing where it's not allowed: `horizontal formation not allowed as
argument`. The parser instead threw the generic `expected value`
(`Tokens.readGlyph`, the fallback branch for any character it doesn't
otherwise handle, which is what `[` hits).

Three existing `eo-typos` fixtures were already pinning this exact
generic message for inputs shaped this way (`malloc.for 4 [m]>>`,
`malloc 100 [m]>> > @`, `([] (^ > x)).plus.minus > s`), so the bug was
already covered by tests, just asserting the wrong text.

Fix: `readGlyph` now recognizes `[` specifically and throws the
canonical message. Updated the three fixtures to expect it.

Fixes #6766
