### PR TITLE
#6772: keep object-vs-package disambiguation on the isDirectory fallback

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyIndexed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyIndexed.java
@@ -85,7 +85,7 @@ final class OyIndexed implements Objectionary {
                             name,
                             ex
                         );
-                        return this.delegate.isDirectory(name);
+                        return !this.delegate.contains(name) && this.delegate.isDirectory(name);
                     }
                 )
             )

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyIndexedTest.java
@@ -81,7 +81,7 @@ final class OyIndexedTest {
             new OyIndexed(
                 new Objectionary.Fake(
                     name -> new InputOf("[] > qwerty"),
-                    name -> true,
+                    name -> false,
                     name -> true
                 ),
                 new ObjectsIndex(
@@ -91,6 +91,26 @@ final class OyIndexedTest {
                 )
             ).isDirectory("org.eolang.qwerty"),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void keepsDisambiguatingObjectFromPackageInDelegateFallback() throws IOException {
+        MatcherAssert.assertThat(
+            "OyIndexed with a broken index must not call a name a directory when the delegate also has it as a program",
+            new OyIndexed(
+                new Objectionary.Fake(
+                    name -> new InputOf("[] > tuple"),
+                    name -> true,
+                    name -> true
+                ),
+                new ObjectsIndex(
+                    () -> {
+                        throw new IllegalStateException("Fake exception");
+                    }
+                )
+            ).isDirectory("org.eolang.tuple"),
+            Matchers.is(false)
         );
     }
 


### PR DESCRIPTION
OyIndexed.isDirectory computes `!this.index.contains(name) && this.delegate.isDirectory(name)`
on the normal path, using the `!index.contains` half to disambiguate a name
that is both a program and a package (e.g. `org.eolang.tuple`, which is
both `objects/tuple.eo` and the directory `objects/tuple/`).

When the index lookup itself fails (ScalarWithFallback's Fallback.From
branch, triggered by any exception reading the index: a network hiccup,
a 5xx, offline CI), the fallback drops that disambiguation and just
returns `this.delegate.isDirectory(name)`. OyRemote.isDirectory only
checks whether the GitHub tree URL for the name returns 2xx, which says
nothing about whether the same name is also a real object. Confirmed
live: both `objects/tuple` (tree) and `objects/tuple.eo` (raw) return
200, so `tuple` genuinely is both. Pulling.exec skips pulling any object
for which isDirectory returns true, with no separate contains check, so
on the fallback path an object like `tuple` would never get pulled.

Fix: also check `!this.delegate.contains(name)` on the fallback path,
matching what the normal path already does with the index.

Fixes #6772
