### PR TITLE
Say what every application puts into a void

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What every application puts into the voids of what it copies.
+ *
+ * <p>An application is the one place in a program where a void stops being a
+ * question: {@code inc t} says that the {@code x} of that {@code inc} holds a
+ * {@code t}. The place of an argument says which void it lands in, counted
+ * through the voids in the order the formation declares them, which is the
+ * order {@link Ungrouped} keeps.</p>
+ *
+ * <p>What fills the void is written down as the argument itself and not as
+ * what the argument turns out to be. The two differ exactly when the argument
+ * is an application of its own: {@code inc (dec u)} fills the {@code x} of the
+ * {@code inc} with an object that has filled the {@code x} of a {@code dec},
+ * and naming {@code Φ.dec} here would throw that half away. The argument has a
+ * row of its own, which says both.</p>
+ *
+ * @since 0.69.0
+ */
+final class Bound {
+
+    /**
+     * The arguments of every application, from {@link Given}.
+     */
+    private final Map<String, List<String>> args;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * Ctor.
+     * @param arguments The arguments of every application, from {@link Given}
+     * @param aliases The name every type goes by, from {@link Ends}
+     * @param provided What the types certainly have
+     */
+    Bound(
+        final Map<String, List<String>> arguments,
+        final Map<String, String> aliases,
+        final Provided provided
+    ) {
+        this.args = arguments;
+        this.names = aliases;
+        this.owned = provided;
+    }
+
+    /**
+     * What every application fills, by the locator of the application.
+     * @return The objects the voids hold, by the locator of the void, in the
+     *  order the voids were declared, without the applications that fill
+     *  nothing we can name
+     */
+    Map<String, Map<String, String>> all() {
+        final Map<String, Map<String, String>> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, List<String>> application : this.args.entrySet()) {
+            final Map<String, String> filled = this.filled(
+                this.names.getOrDefault(application.getKey(), application.getKey()),
+                application.getValue()
+            );
+            if (!filled.isEmpty()) {
+                found.put(application.getKey(), filled);
+            }
+        }
+        return found;
+    }
+
+    /**
+     * What these arguments fill in a copy of this type.
+     * @param copied The name the copied type goes by
+     * @param given The locators of the arguments, in the order the places run
+     * @return The objects the voids hold, by the locator of the void, empty
+     *  when nothing describes the copied type or it declares fewer voids
+     */
+    private Map<String, String> filled(final String copied, final List<String> given) {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (int place = 0; place < given.size(); place += 1) {
+            final String hollow = this.owned.slot(copied, place);
+            if (!hollow.isEmpty()) {
+                found.put(hollow, given.get(place));
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -80,9 +80,7 @@ final class Dispatched {
      */
     Map<String, String> answers(final Map<String, String> pairs) {
         final Map<String, String> names = new Ends(pairs).names();
-        final Provided owned = new Provided(
-            new Ungrouped(this.given, names).rows(), names, this.hollows
-        );
+        final Provided owned = new Provided(this.given, names, this.hollows);
         final Filled filled = new Filled(this.args, pairs, owned);
         final Map<String, String> found = new HashMap<>(0);
         for (final XML dispatch : this.all) {

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -49,6 +50,20 @@ final class Provided {
      * The locator of every void, from {@link Hollows}.
      */
     private final Collection<String> hollows;
+
+    /**
+     * Ctor.
+     * @param provides The provides table, as {@link Provides} wrote it
+     * @param aliases The name every type goes by, from {@link Same}
+     * @param voids The locator of every void, from {@link Hollows}
+     */
+    Provided(
+        final XML provides,
+        final Map<String, String> aliases,
+        final Collection<String> voids
+    ) {
+        this(new Ungrouped(provides, aliases).rows(), aliases, voids);
+    }
 
     /**
      * Ctor.

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -37,6 +37,11 @@ import java.util.Map;
  * writes {@code links.xml} back, with the pairs it worked out added to the
  * ones the rules found.</p>
  *
+ * <p>What every application fills is written here as well, and not by a rule
+ * of its own, for want of anywhere earlier to write it: naming the void an
+ * argument lands in means knowing which formation is being copied, and that is
+ * what the pairs have just settled.</p>
+ *
  * @since 0.68.0
  */
 public final class Resolved implements Clue {
@@ -62,18 +67,20 @@ public final class Resolved implements Clue {
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
         final Collection<XML> dispatches = world.dispatches();
         final Map<String, List<String>> args = new Given(world.applications()).arguments();
+        final List<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Map<String, String> pairs = new Settled(
+            new Dispatched(given, dispatches, args, voids)
+        ).from(
+            new Settled(
+                new Dispatched(given, dispatches, args, Collections.emptyList())
+            ).from(new Pairs(new XMLDocument(links)).all())
+        );
+        final Map<String, String> names = new Ends(pairs).names();
         Files.write(
             links,
             new Types(
-                new Settled(
-                    new Dispatched(
-                        given, dispatches, args, given.xpath("//attr[@void='true']/@type")
-                    )
-                ).from(
-                    new Settled(
-                        new Dispatched(given, dispatches, args, Collections.emptyList())
-                    ).from(new Pairs(new XMLDocument(links)).all())
-                )
+                pairs,
+                new Bound(args, names, new Provided(given, names, voids)).all()
             ).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Types.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Types.java
@@ -6,6 +6,7 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
 import java.util.Map;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -13,20 +14,25 @@ import org.xembly.Xembler;
 /**
  * What every object of a program turns out to be, as a document.
  *
- * <p>A row is keyed by the locator of an object and holds a type. There is
- * one form of type so far, an object being a copy of another one, and it is
- * written as an element rather than as a cell of the row:</p>
+ * <p>A row is keyed by the locator of an object and holds a type. There are
+ * two forms of type so far — an object being a copy of another one, and the
+ * voids of that copy it has filled — and both are written as elements rather
+ * than as cells of the row:</p>
  *
- * <pre> &lt;type id="Φ.app.φ"&gt;
- *   &lt;ref loc="Φ.app.inc"/&gt;
+ * <pre> &lt;type id="Φ.app.held"&gt;
+ *   &lt;ref loc="Φ.inc"&gt;
+ *     &lt;bind void="Φ.inc.x"&gt;
+ *       &lt;ref loc="Φ.app.held.α0"/&gt;
+ *     &lt;/bind&gt;
+ *   &lt;/ref&gt;
  * &lt;/type&gt;</pre>
  *
  * <p>A cell would have been shorter and is what this table used to write. It
  * cannot survive the other forms, though: an object is sometimes a datum,
  * sometimes a termination, sometimes a choice between several objects, and a
  * choice is not one answer. Since every one of those wants an element of its
- * own, the one form there is today gets an element too, and the four that
- * follow are added beside it rather than by rewriting this.</p>
+ * own, the one form there was got an element too, and the ones that follow are
+ * added beside it rather than by rewriting this.</p>
  *
  * <p>The rows come out in the order they were worked out, so that two builds
  * of the same program can be compared as text.</p>
@@ -41,11 +47,27 @@ final class Types {
     private final Map<String, String> copies;
 
     /**
+     * What every application put into the voids of what it copies.
+     */
+    private final Map<String, Map<String, String>> filled;
+
+    /**
      * Ctor.
      * @param pairs The pairs, each object against the one it is a copy of
      */
     Types(final Map<String, String> pairs) {
+        this(pairs, Collections.emptyMap());
+    }
+
+    /**
+     * Ctor.
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @param binds What every application put into the voids of what it
+     *  copies, from {@link Bound}
+     */
+    Types(final Map<String, String> pairs, final Map<String, Map<String, String>> binds) {
         this.copies = pairs;
+        this.filled = binds;
     }
 
     /**
@@ -59,9 +81,30 @@ final class Types {
                 .attr("id", pair.getKey())
                 .add("ref")
                 .attr("loc", pair.getValue())
+                .append(this.binds(pair.getKey()))
                 .up()
                 .up();
         }
         return new XMLDocument(new Xembler(dirs).domQuietly());
+    }
+
+    /**
+     * The voids this object has filled.
+     * @param id The locator of the object
+     * @return The directives that put them inside its type, empty when it
+     *  fills none
+     */
+    private Directives binds(final String id) {
+        final Directives dirs = new Directives();
+        for (final Map.Entry<String, String> bind
+            : this.filled.getOrDefault(id, Collections.emptyMap()).entrySet()) {
+            dirs.add("bind")
+                .attr("void", bind.getKey())
+                .add("ref")
+                .attr("loc", bind.getValue())
+                .up()
+                .up();
+        }
+        return dirs;
     }
 }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/application-says-what-fills-a-void.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/application-says-what-fills-a-void.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An application is the one place where a void stops being a question: this one
+# says that the `x` of that `inc` holds a `t`, and the row of the application
+# says so too, naming the void and what went into it.
+eo:
+  app.eo: |
+    [] > app
+      inc t > held
+  inc.eo: |
+    [x] > inc
+      x > @
+  t.eo: |
+    [] > t
+links:
+  - "/links/type[@id='Φ.app.held']/ref[@loc='Φ.inc']/bind"
+  - "//type[@id='Φ.app.held']//bind[@void='Φ.inc.x']"
+  - "//bind[@void='Φ.inc.x']/ref[@loc='Φ.app.held.α0']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/argument-fills-the-void-of-its-place.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/argument-fills-the-void-of-its-place.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An argument goes into a void by its place, counted through the voids in the
+# order the formation declares them. So the first argument fills `left` and the
+# second fills `right`, and nothing but the order says which is which.
+eo:
+  app.eo: |
+    [] > app
+      pair 1 2 > both
+  pair.eo: |
+    [left right] > pair
+      left > @
+links:
+  - "//bind[@void='Φ.pair.left']/ref[@loc='Φ.app.both.α0']"
+  - "//bind[@void='Φ.pair.right']/ref[@loc='Φ.app.both.α1']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/argument-keeps-the-voids-it-filled.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/argument-keeps-the-voids-it-filled.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What fills a void is written down as the argument itself, not as what the
+# argument turns out to be, since an argument is sometimes an application of its
+# own: the `x` of the `inc` holds a `dec` whose `y` is filled, and both halves
+# survive because the argument has a row of its own.
+eo:
+  app.eo: |
+    [] > app
+      inc (dec 1) > got
+  inc.eo: |
+    [x] > inc
+      x > @
+  dec.eo: |
+    [y] > dec
+      y > @
+links:
+  - "//type[@id='Φ.app.got']//bind[@void='Φ.inc.x']"
+  - "//bind[@void='Φ.inc.x']/ref[@loc='Φ.app.got.α0']"
+  - "//bind[@void='Φ.dec.y']/ref[@loc='Φ.app.got.α0.α0']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-nobody-fills-stays-free.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-nobody-fills-stays-free.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A partial application fills the voids its arguments reach and leaves the rest
+# alone, so `right` is not mentioned at all. How many voids a copy has left is
+# read off what its row does not say.
+eo:
+  app.eo: |
+    [] > app
+      pair 1 > half
+  pair.eo: |
+    [left right] > pair
+      left > @
+links:
+  - "//type[@id='Φ.app.half']/ref[@loc='Φ.pair']/bind[@void='Φ.pair.left']"
+  - "//type[@id='Φ.app.half']/ref[not(bind[@void='Φ.pair.right'])]"


### PR DESCRIPTION
An application is the one place in a program where a void stops being a question, and until now the tables threw that away. `inc t` says the `x` of that `inc` holds a `t`; `Filled` worked it out to answer one dispatch and dropped it. Now the row for the application says it:

```xml
<type id="Φ.app.held">
  <ref loc="Φ.inc">
    <bind void="Φ.inc.x"><ref loc="Φ.app.held.α0"/></bind>
  </ref>
</type>
```

An argument lands in a void by its place, counted through the voids in the order the formation declares them, which is the order `Ungrouped` already keeps. What fills the void is named as the argument itself and not as what the argument turns out to be — the two differ exactly when the argument is an application of its own, and writing `Φ.dec` for `inc (dec u)` would throw away that the `x` of that `dec` holds a `u`. The argument has a row of its own, which says both.

`Bound` works these out, `Types` renders them, and `Resolved` calls it once the pairs have settled, since naming the void an argument lands in means knowing which formation is being copied. `Provided` gains a ctor taking the provides document, which `Dispatched` uses too. Four packs describe the behaviour: the fact itself, the place-to-void order, the nested argument, and a partial application leaving the rest of the voids free.

On a clean `eo-runtime` build: 22,195 binds over 18,483 rows, `provides.xml` and `needs.xml` byte-identical, and all 31,876 existing links rows unchanged in target and order. No coverage number moves, and none should — `Filled` already substituted along receiver chains in memory. What changes is that the fact stops being private to one pass: it is what a reader outside the module needs to compose a context, and what a void's witnessed join will be gathered from.
