### PR TITLE
#6779: keep the once-wrapper alive after normalized()

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -123,10 +123,14 @@ public class PhOnce implements Phi {
 
     @Override
     public Phi normalized() {
-        return new PhOnce(
-            () -> this.object.get().normalized(),
-            this.term
-        );
+        final Phi result = this.object.get().normalized();
+        final Phi normalized;
+        if (result instanceof PhTerminator) {
+            normalized = result;
+        } else {
+            normalized = new PhOnce(() -> result, this.term);
+        }
+        return normalized;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -123,7 +123,10 @@ public class PhOnce implements Phi {
 
     @Override
     public Phi normalized() {
-        return this.object.get().normalized();
+        return new PhOnce(
+            () -> this.object.get().normalized(),
+            this.term
+        );
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -24,6 +24,15 @@ final class PhOnceTest {
     }
 
     @Test
+    void keepsOnceWrapperAfterNormalized() {
+        MatcherAssert.assertThat(
+            "normalized() must remain wrapped in PhOnce, so the once-caching guarantee survives, but it didn't",
+            new PhOnce(() -> new PhDefault()).normalized(),
+            Matchers.instanceOf(PhOnce.class)
+        );
+    }
+
+    @Test
     void doesNotEvaluateWrappedObjectForTerm() {
         MatcherAssert.assertThat(
             "PhOnce with explicit term must render it without evaluating the wrapped object, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -33,6 +33,15 @@ final class PhOnceTest {
     }
 
     @Test
+    void letsANormalizedBottomPropagateBare() {
+        MatcherAssert.assertThat(
+            "normalized() must not re-wrap a bottom, so callers can still detect it with instanceof, but it did",
+            new PhOnce(PhTerminator::new).normalized(),
+            Matchers.instanceOf(PhTerminator.class)
+        );
+    }
+
+    @Test
     void doesNotEvaluateWrappedObjectForTerm() {
         MatcherAssert.assertThat(
             "PhOnce with explicit term must render it without evaluating the wrapped object, but it didnt",


### PR DESCRIPTION
PhOnce.normalized() returned `this.object.get().normalized()` directly,
handing back the raw wrapped object instead of a new PhOnce. Its own
copy() a few lines above does this correctly, returning
`new PhOnce(() -> this.object.get().copy(), this.term)`.

PhOnce exists to fetch and cache its wrapped object exactly once,
thread-safely. Because normalized() unwrapped instead of re-wrapping,
any object obtained by normalizing a PhOnce lost that once-caching
guarantee for itself and whatever is built on top of it. This is the
same defect already found and fixed in the sibling class PhLogged
(#6368), whose normalized() was changed to
`return new PhLogged(this.origin.normalized());`, but the same fix
was never applied to PhOnce.

Fix: mirror copy()'s pattern in normalized().

Fixes #6779
