### PR TITLE
#6773: filter MjPrint's walk to .xmir files only

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -102,7 +103,7 @@ public final class MjPrint extends MjSafe {
     @Override
     void exec() throws IOException {
         final int total = new Threaded<>(
-            new Walk(this.printSourcesDir.toPath()),
+            new Walk(this.printSourcesDir.toPath()).includes(Set.of("**.xmir")),
             this::print
         ).total();
         if (total == 0) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -103,6 +103,37 @@ final class MjPrintTest {
         );
     }
 
+    @Test
+    void skipsNonXmirFilesInPrintSourcesDir(@Mktmp final Path temp) throws Exception {
+        final Path source = temp.resolve("xmir/main.xmir");
+        Files.createDirectories(source.getParent());
+        new Saved(
+            new EoSyntax(
+                new InputOf(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package foo",
+                        "",
+                        "[] > main"
+                    )
+                )
+            ).parsed().toString(),
+            source
+        ).value();
+        new Saved(new InputOf("not xml at all"), temp.resolve("xmir/README.md")).value();
+        final Path output = temp.resolve("eo");
+        new FakeMaven(temp)
+            .with("printSourcesDir", temp.resolve("xmir").toFile())
+            .with("printOutputDir", output.toFile())
+            .execute(new FakeMaven.Print())
+            .result();
+        MatcherAssert.assertThat(
+            "the .xmir file should have been printed despite a non-XMIR file sitting next to it",
+            Files.exists(output.resolve("main.eo")),
+            Matchers.is(true)
+        );
+    }
+
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/print-packs", glob = "**.yaml")
     void printsXmirToEo(final String pack) throws Exception {


### PR DESCRIPTION
MjPrint.exec walks every regular file under printSourcesDir with
new Walk(this.printSourcesDir.toPath()), with no includes filter, then
parses each one as XML. Walk's unfiltered constructor returns every
regular file in the tree, not only .xmir files.

Verified: with a printSourcesDir containing a single non-XML file
(e.g. README.md), mvn eo:print fails with "Content is not allowed in
prolog." instead of skipping it.

Other steps that walk the same kind of directory filter first:
Inferring.sources() filters to .xmir before processing, and
MjRegister/Placing constrain their walk with Walk.includes(...).
MjPrint was the odd one out.

Fix: filter the walk to **.xmir before printing.

Fixes #6773
