### PR TITLE
#6774: anchor PackageInfos.PACKAGE to segment-leading EO/EO_ only

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
@@ -22,9 +22,12 @@ import java.util.stream.Stream;
 final class PackageInfos {
 
     /**
-     * Pattern for replacing EO (object) or EO_ (package) prefixes in package.
+     * Pattern for stripping the leading EO (object) or EO_ (package) prefix
+     * off each dot-separated segment of a package, anchored to the start of
+     * the string or right after a dot so an EO occurring inside a segment's
+     * own name survives.
      */
-    private static final Pattern PACKAGE = Pattern.compile("EO_?");
+    private static final Pattern PACKAGE = Pattern.compile("(^|\\.)EO_?");
 
     /**
      * Pattern for replacing first default org.eolang package, with the dot
@@ -131,7 +134,7 @@ final class PackageInfos {
             String.format(
                 "@org.eolang.XmirPackage(\"%s\")",
                 PackageInfos.BASE.matcher(
-                    PackageInfos.PACKAGE.matcher(pkg).replaceAll("")
+                    PackageInfos.PACKAGE.matcher(pkg).replaceAll("$1")
                 ).replaceFirst("")
             ),
             String.format("package %s;", PackageInfos.escaped(pkg))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
@@ -101,6 +101,20 @@ final class PackageInfosTest {
         );
     }
 
+    @Test
+    void keepsEoInsideAnObjectsOwnName(@Mktmp final Path tmp) throws IOException {
+        Files.createDirectories(tmp.resolve("org").resolve("eolang").resolve("EO_xEOy"));
+        new PackageInfos(tmp, Collections.emptyList()).create();
+        MatcherAssert.assertThat(
+            "only the leading EO_ transpiler prefix should be stripped, not the EO inside xEOy",
+            Files.readString(
+                tmp.resolve("org").resolve("eolang").resolve("EO_xEOy")
+                    .resolve("package-info.java")
+            ),
+            Matchers.containsString("@org.eolang.XmirPackage(\"xEOy\")")
+        );
+    }
+
     @ParameterizedTest
     @CsvSource({
         "invalid-dir, invalid_dir",


### PR DESCRIPTION
PackageInfos.content(String pkg) strips the EO/EO_ transpiler prefix
out of the generated Java package's dotted name before writing it into
the @org.eolang.XmirPackage(...) annotation, using
Pattern.compile("EO_?").replaceAll(""). This pattern is unanchored, so
replaceAll removes every EO/EO_ occurrence anywhere in the string, not
only the transpiler prefix at the start of each dotted segment.

For a package whose generated Java name is org.eolang.EO_xEOy (an EO
object whose own name happens to contain the letters EO), the result
is org.eolang.xy, silently deleting the EO from inside the object's
own name too.

PhDefault.TO_FORMA already does the same kind of Java-package-to-EO-name
conversion correctly, anchored to (^|\.)EO_?. Applied the same anchor
here and preserved the matched dot in the replacement.

Fixes #6774
