### PR TITLE
Say how much of a program was understood

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * How much of a program the tables turned out to say.
+ *
+ * <p>This reads the tables back and puts every object of the program on the
+ * ladder {@link Rung} describes. It is a measurement of ourselves rather than a
+ * fact about the program, so it writes nothing: what comes out is meant for the
+ * log of the goal, where two builds of the same sources can be compared by
+ * anybody, and not for a document beside the tables.</p>
+ *
+ * @since 0.69.0
+ */
+public final class Depth {
+
+    /**
+     * The directory with the prepared XMIR files of the program.
+     */
+    private final Path world;
+
+    /**
+     * The directory with the tables.
+     */
+    private final Path tables;
+
+    /**
+     * Ctor.
+     * @param xmirs The directory with the prepared XMIR files
+     * @param rows The directory with the tables
+     */
+    public Depth(final Path xmirs, final Path rows) {
+        this.world = xmirs;
+        this.tables = rows;
+    }
+
+    /**
+     * How much of the program was understood.
+     * @return The objects of the program, counted by the rung they stand on
+     * @throws IOException If a table or a file cannot be read
+     */
+    public Ladder ladder() throws IOException {
+        final XML given = new XMLDocument(this.tables.resolve("provides.xml"));
+        final Pairs pairs = new Pairs(new XMLDocument(this.tables.resolve("links.xml")));
+        final Rung rung = new Rung(
+            new Ungrouped(given, Collections.emptyMap()).rows(),
+            given.xpath("//attr[@void='true']/@type"),
+            new Ends(pairs.all()).names()
+        );
+        final Map<String, Integer> filled = pairs.binds();
+        final List<String> names = Arrays.asList(
+            "nothing at all",
+            "a name rooted at a void",
+            "a formation, voids still free",
+            "a formation, nothing left free",
+            "a formation seen whole"
+        );
+        final Map<String, Integer> counts = new LinkedHashMap<>(names.size());
+        for (final String name : names) {
+            counts.put(name, 0);
+        }
+        for (final String locator : new Xmirs(this.world).locators()) {
+            final String name = names.get(rung.reached(locator, filled.getOrDefault(locator, 0)));
+            counts.put(name, counts.get(name) + 1);
+        }
+        return new Ladder(counts);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * How much of a program was understood.
+ *
+ * <p>The objects of the program counted by the rung they stand on, from the
+ * shallowest up, and the two numbers that summarise them. A number without the
+ * rungs beside it would be a number to game: writing an empty row for every
+ * object would take {@link Ladder#described()} to a hundred and leave
+ * {@link Ladder#percent()} where it was.</p>
+ *
+ * @since 0.69.0
+ */
+public final class Ladder {
+
+    /**
+     * How many objects stand on each rung.
+     */
+    private final Map<String, Integer> counts;
+
+    /**
+     * Ctor.
+     * @param rungs How many objects stand on each rung, from the shallowest up
+     */
+    public Ladder(final Map<String, Integer> rungs) {
+        this.counts = rungs;
+    }
+
+    /**
+     * How many objects stand on each rung.
+     * @return The rungs, from the shallowest up
+     */
+    public Map<String, Integer> rungs() {
+        return Collections.unmodifiableMap(this.counts);
+    }
+
+    /**
+     * How many objects the program has.
+     * @return The objects
+     */
+    public int total() {
+        return this.counts.values().stream().mapToInt(Integer::intValue).sum();
+    }
+
+    /**
+     * How many of them we know anything at all about.
+     * @return The share, out of a hundred
+     */
+    public double described() {
+        return this.share(this.total() - this.counts.values().iterator().next());
+    }
+
+    /**
+     * How deeply the program is understood.
+     *
+     * <p>The mean rung, against the highest one there is, so that a program
+     * every object of which was seen whole comes out at a hundred.</p>
+     *
+     * @return The depth, out of a hundred
+     */
+    public double percent() {
+        int climbed = 0;
+        int rung = 0;
+        for (final Integer count : this.counts.values()) {
+            climbed = climbed + rung * count;
+            rung = rung + 1;
+        }
+        return this.share(climbed) / (rung - 1);
+    }
+
+    /**
+     * This many objects, out of a hundred.
+     * @param some How many
+     * @return The share, or nothing at all when the program has no objects
+     */
+    private double share(final int some) {
+        final double found;
+        if (this.total() == 0) {
+            found = 0.0d;
+        } else {
+            found = 100.0d * some / this.total();
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -50,4 +50,17 @@ final class Pairs {
         }
         return found;
     }
+
+    /**
+     * How many voids every object of the table has filled.
+     * @return The counts, by the locator of the object, without the ones that
+     *  filled none
+     */
+    Map<String, Integer> binds() {
+        final Map<String, Integer> found = new LinkedHashMap<>(0);
+        for (final XML link : this.table.nodes("/links/type[ref/bind]")) {
+            found.put(link.xpath("@id").get(0), link.nodes("ref/bind").size());
+        }
+        return found;
+    }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Rung.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rung.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * How deeply an object of a program is understood.
+ *
+ * <p>Knowing something about an object is not one thing, and counting the
+ * objects we wrote a row about says almost nothing on its own. That
+ * {@code Φ.inc.x.next} is the {@code next} of whatever fills {@code x} is a
+ * fact, and a shallower one than that an object is a {@code Φ.number}, which
+ * is itself shallower than a copy with no void left free. So the objects go on
+ * a ladder and the rungs are counted apart.</p>
+ *
+ * <p>The rungs run: nothing at all; a name rooted at a void, true of every
+ * caller and concrete for none; a formation with voids still free, so it is
+ * known which object this is but not what it holds; a formation with nothing
+ * left free; and a formation every attribute of which was seen. A formation
+ * needs no rung of its own: it is a copy of itself that has filled none of its
+ * own voids, and lands where that puts it.</p>
+ *
+ * @since 0.69.0
+ */
+final class Rung {
+
+    /**
+     * The rows of the provides table, by the locator of their owner.
+     */
+    private final Map<String, Collection<Map<String, String>>> table;
+
+    /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
+
+    /**
+     * Every chain of copies, walked to its end, from {@link Ends}.
+     */
+    private final Map<String, String> ends;
+
+    /**
+     * Ctor.
+     * @param rows The rows of the provides table, by the locator of their
+     *  owner, from {@link Ungrouped}
+     * @param voids The locator of every void
+     * @param names Every chain of copies, walked to its end
+     */
+    Rung(
+        final Map<String, Collection<Map<String, String>>> rows,
+        final Collection<String> voids,
+        final Map<String, String> names
+    ) {
+        this.table = rows;
+        this.hollows = voids;
+        this.ends = names;
+    }
+
+    /**
+     * The rung this object stands on.
+     * @param locator The locator of the object
+     * @param filled How many voids this object has filled itself
+     * @return The rung, from nothing at all up to a formation seen whole
+     */
+    int reached(final String locator, final int filled) {
+        final String end = this.ends.getOrDefault(locator, locator);
+        final int found;
+        if (this.table.containsKey(end)) {
+            found = this.depth(end, this.voids(end) - filled);
+        } else if (this.rooted(end)) {
+            found = 1;
+        } else {
+            found = 0;
+        }
+        return found;
+    }
+
+    /**
+     * How deeply a copy of this type is understood.
+     * @param type The locator of the type
+     * @param free How many of its voids nobody has filled here
+     * @return The rung
+     */
+    private int depth(final String type, final int free) {
+        final int found;
+        if (free > 0) {
+            found = 2;
+        } else if (this.whole(type)) {
+            found = 4;
+        } else {
+            found = 3;
+        }
+        return found;
+    }
+
+    /**
+     * How many voids this type declares.
+     * @param type The locator of the type
+     * @return The voids
+     */
+    private int voids(final String type) {
+        int found = 0;
+        for (final Map<String, String> row : this.own(type)) {
+            if ("true".equals(row.get("void"))) {
+                found = found + 1;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether every attribute of this type was seen.
+     * @param type The locator of the type
+     * @return True when nothing about it is left to find out
+     */
+    private boolean whole(final String type) {
+        boolean found = false;
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("id")) {
+                found = "true".equals(row.get("complete"));
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether this locator is a name taken from a void.
+     * @param locator The locator
+     * @return True when nothing but a caller can say what it is
+     */
+    private boolean rooted(final String locator) {
+        boolean found = false;
+        String walked = locator;
+        while (!walked.isEmpty()) {
+            if (this.hollows.contains(walked)) {
+                found = true;
+                break;
+            }
+            if (!walked.contains(".")) {
+                break;
+            }
+            walked = walked.substring(0, walked.lastIndexOf('.'));
+        }
+        return found;
+    }
+
+    /**
+     * The rows about the type of the given locator.
+     * @param type The locator of the type
+     * @return The rows, empty when the table says nothing about it
+     */
+    private Collection<Map<String, String>> own(final String type) {
+        return this.table.getOrDefault(type, Collections.emptyList());
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/DepthTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DepthTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Depth}.
+ * @since 0.69.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class DepthTest {
+
+    @Test
+    void understandsWhollyAProgramThatHidesNothing(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.cup' name='cup'>",
+                "<o loc='Φ.cup.lid' name='lid'/></o></object>"
+            )
+        );
+        new Resolved(new Clues()).follow(temp.resolve("xmirs"), temp.resolve("tables"));
+        MatcherAssert.assertThat(
+            "a program hiding nothing must come out at a hundred, but it didnt",
+            new Depth(temp.resolve("xmirs"), temp.resolve("tables")).ladder().percent(),
+            Matchers.closeTo(100.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void putsNamesTakenFromAVoidOnTheirOwnRung(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("inc.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.inc' name='inc'>",
+                "<o base='∅' loc='Φ.inc.x' name='x'/>",
+                "<o base='ξ.x' loc='Φ.inc.φ' name='φ'/></o></object>"
+            )
+        );
+        new Resolved(new Clues()).follow(temp.resolve("xmirs"), temp.resolve("tables"));
+        MatcherAssert.assertThat(
+            "the void and what it answers for must stand apart, but they didnt",
+            new Depth(temp.resolve("xmirs"), temp.resolve("tables"))
+                .ladder().rungs().get("a name rooted at a void"),
+            Matchers.equalTo(2)
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Ladder}.
+ * @since 0.69.0
+ */
+final class LadderTest {
+
+    @Test
+    void takesTheMeanRungAgainstTheHighestOne() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 7);
+        rungs.put("something", 0);
+        rungs.put("everything", 7);
+        MatcherAssert.assertThat(
+            "a program half of which is on the top rung must be half understood, but it wasnt",
+            new Ladder(rungs).percent(),
+            Matchers.closeTo(50.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void leavesOutOnlyTheObjectsOnTheBottomRung() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 3);
+        rungs.put("something", 1);
+        MatcherAssert.assertThat(
+            "one object in four is known, so a quarter must be described, but it wasnt",
+            new Ladder(rungs).described(),
+            Matchers.closeTo(25.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void countsAnEmptyProgramWithoutFalling() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 0);
+        rungs.put("something", 0);
+        MatcherAssert.assertThat(
+            "a program with no objects cannot be understood to any depth, but it was",
+            new Ladder(rungs).percent(),
+            Matchers.closeTo(0.0d, 0.001d)
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -14,9 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.inference.Clues;
+import org.eolang.inference.Depth;
+import org.eolang.inference.Ladder;
 import org.eolang.inference.Resolved;
 import org.eolang.parser.TrFull;
 
@@ -91,11 +94,35 @@ final class Inferring implements Step {
                 this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
                 ready, this.tables
             );
+            this.measured();
         } else {
             Logger.info(
                 this, "The directory %[file]s is absent, nothing to infer from it",
                 this.input
             );
+        }
+    }
+
+    /**
+     * Say how much of the program the tables turned out to say.
+     *
+     * <p>The summary is one line, because a build that says nothing about how
+     * well it understood the sources leaves every reader to open the tables and
+     * guess. The rungs it is the mean of go to the debug log, since a number
+     * nobody can take apart is a number that gets gamed: writing an empty row
+     * for every object would take the share described to a hundred and move the
+     * depth not at all.</p>
+     *
+     * @throws IOException If a table cannot be read
+     */
+    private void measured() throws IOException {
+        final Ladder ladder = new Depth(this.prepared, this.tables).ladder();
+        Logger.info(
+            this, "%d objects, %.1f%% of them described, depth %.1f%%",
+            ladder.total(), ladder.described(), ladder.percent()
+        );
+        for (final Map.Entry<String, Integer> rung : ladder.rungs().entrySet()) {
+            Logger.debug(this, "  %6d  %s", rung.getValue(), rung.getKey());
         }
     }
 


### PR DESCRIPTION
The `inference` goal now ends by saying how much of the program it made sense of. On `eo-runtime`:

```
[INFO] Inferred the types of 171 XMIR(s), tables are in target/eo/6-inference
[INFO] 43083 objects, 82.0% of them described, depth 48.8%
[DEBUG]     7760  nothing at all
[DEBUG]     8070  a name rooted at a void
[DEBUG]     7358  a formation, voids still free
[DEBUG]    18207  a formation, nothing left free
[DEBUG]     1688  a formation seen whole
```

Depth is the mean rung against the highest one, so a program every object of which was seen whole comes out at a hundred. The ladder is what keeps that number honest and it is printed beside it: writing an empty row for every object would take "described" to a hundred and move the depth not at all.

`Rung` decides where an object stands, `Depth` puts the world on the ladder, `Ladder` is what comes out. Rungs 2 and 3 are only tellable apart since #6799 — knowing that a copy has nothing left free is exactly what the `bind` elements say. A formation gets no special case: it is a copy of itself that has filled none of its own voids, and lands where that puts it.

```java
final String end = this.ends.getOrDefault(locator, locator);
if (this.table.containsKey(end)) {
    found = this.depth(end, this.voids(end) - filled);
} else if (this.rooted(end)) {
    found = 1;
} else {
    found = 0;
}
```

Nothing is written to a document. `problems.xml` and `coverage.xml` were both proposed before and both dropped, and a measurement of ourselves is not a fact about the program, so it belongs in the log rather than in a table beside the facts that are.

One number in the ticket moved: it said depth 49.3%, from a script that gave a formation with free voids the same rung as a saturated copy. This treats the two alike, which is the rule with no special case in it, and costs half a point. The first thing the ladder shows is worth acting on next: 7,203 of the 7,760 objects on rung 0 are Δ literals.
