### PR TITLE
#6775: give string.as-ascii its own cant-read fallback

### DIFF
--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -1,6 +1,9 @@
 # Reads the single character `char` as its ASCII numeric value (0-255).
 # The byte of `char` is left-padded with a zero byte into a 16-bit word,
-# read as an integer and then expressed as a number.
+# read as an integer and then expressed as a number. If `char` is not
+# exactly one byte wide (an empty string, or a multi-byte UTF-8
+# character), the `cant-read` fallback is returned, or the bottom
+# object when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,10 +12,15 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[char] > as-ascii
-  as-number. > @
-    as-i16.
-      00-.concat char.as-bytes
+[char cant-read] > as-ascii
+  if. > @
+    char.as-bytes.size.eq 1
+    as-number.
+      as-i16.
+        00-.concat char.as-bytes
+    cant-read
+      "Can't read %x as an ASCII code, it is not a single byte".printf
+        * char.as-bytes
 
   97.eq "a".as-ascii ++> can-read-the-code-of-a-lowercase-letter
 
@@ -33,3 +41,15 @@
   57.eq "9".as-ascii ++> can-read-the-code-of-the-nine-digit
 
   48.eq "0".as-ascii ++> can-read-the-code-of-the-zero-digit
+
+  eq. ++> can-recover-from-a-multi-byte-character
+    "recovered"
+    "Ж".as-ascii "recovered" > [message]
+
+  eq. ++> can-recover-from-an-empty-string
+    "recovered"
+    "".as-ascii "recovered" > [message]
+
+  "Ж".as-ascii --> stops-on-a-multi-byte-character
+
+  "".as-ascii --> stops-on-an-empty-string


### PR DESCRIPTION
string.as-ascii reads a character's ASCII code via
as-number.as-i16.(00-.concat char.as-bytes), with no fallback of its
own. For any input that isn't exactly one byte after the zero-padding
(an empty string, or a multi-byte UTF-8 character), the call falls
through to the underlying bytes.as-i16 atom failure:

  Error in "Φ.string.as-ascii.φ.Δ" at string.as-ascii:13:2; Can't
  convert non 2 length bytes to i16, bytes are 00

This message names i16 and raw byte lengths, meaningless to a caller
who only knows they passed a string to as-ascii.

as-i16 already has a cant-convert fallback parameter for exactly this
case, but as-ascii never binds it. Every sibling bytes/as-* object
exposes and documents a cant-convert fallback, and every string object
with an input precondition (at, truncated, repeated, padded-*) takes
its own cant-* fallback parameter. as-ascii was the only one in this
family that did neither.

Fix: as-ascii now takes its own cant-read fallback, checks
char.as-bytes.size up front, and returns the fallback (or the bottom
object when unbound) with a message naming the character it was given.

Fixes #6775
