### PR TITLE
#6776: use %f for string.at's fractional out-of-bounds message

### DIFF
--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -31,12 +31,18 @@
               number index
             number index
     fallback
-      "Given index %d is out of text bounds".printf
+      "Given index %f is out of text bounds".printf
         * i
     slice
       text
       index
       1
+
+  eq. ++> can-format-the-error-message-of-a-fractional-index-in-bounds
+    "Given index 1.500000 is out of text bounds"
+    "some".at
+      1.5
+      message > [message]
 
   eq. ++> can-recover-from-a-fractional-index-in-bounds
     "recovered"


### PR DESCRIPTION
string.at's out-of-bounds error message formats the rejected index
with %d, which routes through as-decimal and truncates the fraction.
"some".at 1.5 (text "some" has 4 characters, so index 1 alone is in
bounds) returns "Given index 1 is out of text bounds" through a
message-capturing fallback: self-contradictory, since index 1 is not
out of bounds, and the message never mentions the real rejection
reason was the fractional part.

at rejects a fractional index via the same or. branch that rejects an
out-of-range index, so both failure modes share one message that only
had room for an integer-shaped complaint.

Every sibling object in this file's family that rejects a non-integer
numeric argument already uses %f for exactly this reason: truncated.eo,
repeated.eo, padded-left.eo, padded-right.eo, padded-zeros.eo. at.eo
was the outlier still using %d.

Fix: use %f, so the message reads "Given index 1.500000 is out of text
bounds". Added a test pinning the exact message text, matching
truncated.eo's own precedent.

Fixes #6776
