### PR TITLE
#6777: guard NESTING bookkeeping in take() behind the FINE check

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -225,7 +225,10 @@ public class PhDefault implements Phi, Cloneable {
                 )
             );
         }
-        PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
+        final boolean logging = PhDefault.LOGGER.isLoggable(Level.FINE);
+        if (logging) {
+            PhDefault.NESTING.set(PhDefault.NESTING.get() + 1);
+        }
         try {
             final Phi resolved;
             if (this.loaded().containsKey(name)) {
@@ -237,7 +240,7 @@ public class PhDefault implements Phi, Cloneable {
             } else {
                 resolved = this.absent(name);
             }
-            if (PhDefault.LOGGER.isLoggable(Level.FINE)) {
+            if (logging) {
                 PhDefault.LOGGER.log(
                     Level.FINE,
                     String.format(
@@ -251,11 +254,8 @@ public class PhDefault implements Phi, Cloneable {
             }
             return resolved;
         } finally {
-            final int current = PhDefault.NESTING.get();
-            if (current > 0) {
-                PhDefault.NESTING.set(current - 1);
-            } else {
-                PhDefault.NESTING.set(0);
+            if (logging) {
+                PhDefault.NESTING.set(Math.max(0, PhDefault.NESTING.get() - 1));
             }
         }
     }


### PR DESCRIPTION
PhDefault.take(String) increments and decrements a ThreadLocal<Integer>
counter (NESTING) on every call, unconditionally. NESTING is read in
exactly one other place, padding(), which is only called inside
if (LOGGER.isLoggable(Level.FINE)) - i.e. only when FINE logging is
actually enabled, which it never is during a normal build or test run.

take() is the single most frequently called method in the runtime:
every object dispatch goes through it. So every dispatch paid two
ThreadLocal lookups, two ThreadLocal writes, and Integer (un)boxing,
purely to maintain a counter that almost never gets read.

Fix: guard the NESTING increment/decrement with the same
isLoggable(Level.FINE) check already used to guard the log call, so
the bookkeeping only runs when it can actually be observed. Behavior
is identical whenever FINE is on; the ThreadLocal overhead disappears
from the hot path in the common case.

Fixes #6777
