### PR TITLE
Say that an object is a datum

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,8 @@ public final class Depth {
         final Pairs pairs = new Pairs(new XMLDocument(this.tables.resolve("links.xml")));
         final Rung rung = new Rung(
             new Ungrouped(given, Collections.emptyMap()).rows(),
-            given.xpath("//attr[@void='true']/@type"),
+            new HashSet<>(given.xpath("//attr[@void='true']/@type")),
+            new HashSet<>(pairs.data()),
             new Ends(pairs.all()).names()
         );
         final Map<String, Integer> filled = pairs.binds();
@@ -66,7 +68,7 @@ public final class Depth {
             "a name rooted at a void",
             "a formation, voids still free",
             "a formation, nothing left free",
-            "a formation seen whole"
+            "nothing left to find out"
         );
         final Map<String, Integer> counts = new LinkedHashMap<>(names.size());
         for (final String name : names) {

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -45,8 +45,10 @@ import java.util.Map;
  *
  * <p>Which is why a row carries what an object is as an element of its own
  * rather than as a cell, and what {@link Types} makes of it. Being a copy is
- * one of the things an object turns out to be, and the others — a datum, a
- * termination, a choice between several objects — arrive beside it.</p>
+ * one of the things an object turns out to be, and the second one arrives
+ * here as well: a datum. It is a copy of nothing — the bytes of a literal are
+ * the ground the program stands on — so it is the one row this clue writes
+ * without a reference to look at.</p>
  *
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
@@ -76,10 +78,14 @@ final class Links implements Clue {
                 found.put(from, target);
             }
         }
+        final Collection<String> ground = new ArrayList<>(0);
+        for (final XML datum : world.data()) {
+            ground.add(datum.xpath("@loc").get(0));
+        }
         Files.createDirectories(tables);
         Files.write(
             tables.resolve("links.xml"),
-            new Types(found).asXml().toString().getBytes(StandardCharsets.UTF_8)
+            new Types(found, ground).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -5,6 +5,7 @@
 package org.eolang.inference;
 
 import com.jcabi.xml.XML;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -49,6 +50,19 @@ final class Pairs {
             found.put(link.xpath("@id").get(0), link.xpath("ref/@loc").get(0));
         }
         return found;
+    }
+
+    /**
+     * Every object of the table that is a datum.
+     *
+     * <p>A pass that reads the table and writes it again must put these back
+     * where it found them: a row saying an object is a datum is not a pair and
+     * would fall out of a document rebuilt from pairs alone.</p>
+     *
+     * @return The locators
+     */
+    Collection<String> data() {
+        return this.table.xpath("/links/type[data]/@id");
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -68,19 +68,21 @@ public final class Resolved implements Clue {
         final Collection<XML> dispatches = world.dispatches();
         final Map<String, List<String>> args = new Given(world.applications()).arguments();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Pairs written = new Pairs(new XMLDocument(links));
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, dispatches, args, voids)
         ).from(
             new Settled(
                 new Dispatched(given, dispatches, args, Collections.emptyList())
-            ).from(new Pairs(new XMLDocument(links)).all())
+            ).from(written.all())
         );
         final Map<String, String> names = new Ends(pairs).names();
         Files.write(
             links,
             new Types(
                 pairs,
-                new Bound(args, names, new Provided(given, names, voids)).all()
+                new Bound(args, names, new Provided(given, names, voids)).all(),
+                written.data()
             ).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Rung.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rung.java
@@ -21,9 +21,13 @@ import java.util.Map;
  * <p>The rungs run: nothing at all; a name rooted at a void, true of every
  * caller and concrete for none; a formation with voids still free, so it is
  * known which object this is but not what it holds; a formation with nothing
- * left free; and a formation every attribute of which was seen. A formation
- * needs no rung of its own: it is a copy of itself that has filled none of its
- * own voids, and lands where that puts it.</p>
+ * left free; and, at the top, an object with nothing left to find out about
+ * it. A formation needs no rung of its own: it is a copy of itself that has
+ * filled none of its own voids, and lands where that puts it.</p>
+ *
+ * <p>A datum goes straight to the top. The bytes of a literal are the ground
+ * the program stands on, and asking what more there is to know about
+ * {@code 01-} is asking nothing.</p>
  *
  * @since 0.69.0
  */
@@ -40,6 +44,11 @@ final class Rung {
     private final Collection<String> hollows;
 
     /**
+     * The objects that are data.
+     */
+    private final Collection<String> ground;
+
+    /**
      * Every chain of copies, walked to its end, from {@link Ends}.
      */
     private final Map<String, String> ends;
@@ -49,15 +58,18 @@ final class Rung {
      * @param rows The rows of the provides table, by the locator of their
      *  owner, from {@link Ungrouped}
      * @param voids The locator of every void
+     * @param data The objects that are data
      * @param names Every chain of copies, walked to its end
      */
     Rung(
         final Map<String, Collection<Map<String, String>>> rows,
         final Collection<String> voids,
+        final Collection<String> data,
         final Map<String, String> names
     ) {
         this.table = rows;
         this.hollows = voids;
+        this.ground = data;
         this.ends = names;
     }
 
@@ -65,12 +77,14 @@ final class Rung {
      * The rung this object stands on.
      * @param locator The locator of the object
      * @param filled How many voids this object has filled itself
-     * @return The rung, from nothing at all up to a formation seen whole
+     * @return The rung, from nothing at all up to nothing left to find out
      */
     int reached(final String locator, final int filled) {
         final String end = this.ends.getOrDefault(locator, locator);
         final int found;
-        if (this.table.containsKey(end)) {
+        if (this.ground.contains(end)) {
+            found = 4;
+        } else if (this.table.containsKey(end)) {
             found = this.depth(end, this.voids(end) - filled);
         } else if (this.rooted(end)) {
             found = 1;

--- a/eo-inference/src/main/java/org/eolang/inference/Types.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Types.java
@@ -6,6 +6,7 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.xembly.Directives;
@@ -15,9 +16,9 @@ import org.xembly.Xembler;
  * What every object of a program turns out to be, as a document.
  *
  * <p>A row is keyed by the locator of an object and holds a type. There are
- * two forms of type so far — an object being a copy of another one, and the
- * voids of that copy it has filled — and both are written as elements rather
- * than as cells of the row:</p>
+ * three forms of type so far — an object being a copy of another one, the
+ * voids of that copy it has filled, and a datum — and every one of them is
+ * written as an element rather than as a cell of the row:</p>
  *
  * <pre> &lt;type id="Φ.app.held"&gt;
  *   &lt;ref loc="Φ.inc"&gt;
@@ -25,6 +26,9 @@ import org.xembly.Xembler;
  *       &lt;ref loc="Φ.app.held.α0"/&gt;
  *     &lt;/bind&gt;
  *   &lt;/ref&gt;
+ * &lt;/type&gt;
+ * &lt;type id="Φ.app.held.α0.α0"&gt;
+ *   &lt;data/&gt;
  * &lt;/type&gt;</pre>
  *
  * <p>A cell would have been shorter and is what this table used to write. It
@@ -52,11 +56,17 @@ final class Types {
     private final Map<String, Map<String, String>> filled;
 
     /**
+     * The objects that are data.
+     */
+    private final Collection<String> ground;
+
+    /**
      * Ctor.
      * @param pairs The pairs, each object against the one it is a copy of
+     * @param data The objects that are data
      */
-    Types(final Map<String, String> pairs) {
-        this(pairs, Collections.emptyMap());
+    Types(final Map<String, String> pairs, final Collection<String> data) {
+        this(pairs, Collections.emptyMap(), data);
     }
 
     /**
@@ -64,10 +74,16 @@ final class Types {
      * @param pairs The pairs, each object against the one it is a copy of
      * @param binds What every application put into the voids of what it
      *  copies, from {@link Bound}
+     * @param data The objects that are data
      */
-    Types(final Map<String, String> pairs, final Map<String, Map<String, String>> binds) {
+    Types(
+        final Map<String, String> pairs,
+        final Map<String, Map<String, String>> binds,
+        final Collection<String> data
+    ) {
         this.copies = pairs;
         this.filled = binds;
+        this.ground = data;
     }
 
     /**
@@ -84,6 +100,9 @@ final class Types {
                 .append(this.binds(pair.getKey()))
                 .up()
                 .up();
+        }
+        for (final String datum : this.ground) {
+            dirs.add("type").attr("id", datum).add("data").up().up();
         }
         return new XMLDocument(new Xembler(dirs).domQuietly());
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -59,6 +59,21 @@ final class Xmirs {
     }
 
     /**
+     * Every datum of the program.
+     *
+     * <p>A datum has no {@code @base}, like a formation, and carries its
+     * bytes as text, unlike one. It is the ground the whole program stands
+     * on and the one kind of object that is not a copy of anything: there is
+     * nothing to know about {@code 01-} beyond that it is what it is.</p>
+     *
+     * @return The data, file by file, in the order they appear in the code
+     * @throws IOException If a file cannot be read
+     */
+    Collection<XML> data() throws IOException {
+        return this.matching("//o[@loc and not(@base) and text()[normalize-space()]]");
+    }
+
+    /**
      * The object every file of the program is about.
      *
      * <p>A file carries one object at the top and the package it declares

--- a/eo-inference/src/test/java/org/eolang/inference/DepthTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DepthTest.java
@@ -40,6 +40,25 @@ final class DepthTest {
     }
 
     @Test
+    void leavesNothingUnknownInAProgramOfBytes(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.cup' name='cup'><o loc='Φ.cup.lid' name='lid'>",
+                "<o loc='Φ.cup.lid.α0' as='α0'>01-</o></o></o></object>"
+            )
+        );
+        new Resolved(new Clues()).follow(temp.resolve("xmirs"), temp.resolve("tables"));
+        MatcherAssert.assertThat(
+            "the bytes of a program must be understood as they stand, but they werent",
+            new Depth(temp.resolve("xmirs"), temp.resolve("tables"))
+                .ladder().rungs().get("nothing at all"),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
     void putsNamesTakenFromAVoidOnTheirOwnRung(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("inc.xmir"),

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/datum-is-the-ground-of-a-literal.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/datum-is-the-ground-of-a-literal.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A literal is not one object but three: a number, made of bytes, made of the
+# bytes themselves. The last of them is a datum, and a datum is a copy of
+# nothing at all, since the bytes are the ground everything else stands on.
+eo:
+  app.eo: |
+    [] > app
+      42 > answer
+links:
+  - "/links/type[@id='Φ.app.answer.α0.α0']/data"
+  - "/links/type[@id='Φ.app.answer.α0.α0'][not(ref)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/datum-stays-through-dispatch-resolution.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/datum-stays-through-dispatch-resolution.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Working out what a dispatch is means reading the table and writing it again,
+# and a row saying an object is a datum is not a pair: it has to be put back
+# where it was found, or it falls out of the document the second time round.
+eo:
+  app.eo: |
+    [] > app
+      inc t > held
+      held.next > @
+      42 > answer
+  inc.eo: |
+    [x] > inc
+      x > @
+  t.eo: |
+    [] > t
+      [] > next
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.t.next']"
+  - "/links/type[@id='Φ.app.answer.α0.α0']/data"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-is-not-a-datum.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/formation-is-not-a-datum.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A formation has no base either, and carries no bytes, so nothing in a program
+# without a literal in it is a datum.
+eo:
+  cup.eo: |
+    [] > cup
+  lid.eo: |
+    [] > lid
+links:
+  - "/links[not(type/data)]"


### PR DESCRIPTION
The bytes of a literal were the largest thing the tables said nothing about — 7,178 of the 7,760 objects the ladder put on the bottom rung. A literal is three objects, and only the last of them is the ground:

```xml
<o base="Φ.number" loc="Φ.app.answer">
  <o base="Φ.bytes" loc="Φ.app.answer.α0">
    <o loc="Φ.app.answer.α0.α0">40-45-00-00-00-00-00-00</o>
```

That leaf has no base, so no rule ever looked at it, and there was no form of type to write it down with anyway. Now there is a third one, beside a reference and the binds inside it:

```xml
<type id="Φ.app.answer.α0.α0">
  <data/>
</type>
```

A datum is deliberately not written as a copy of `Φ.bytes`. `Φ.bytes` is a formation with a void, and saying "a copy of it" would put a free void on an object that has none, and drop it a rung for a reason that is not true.

Three things move together. `Links` writes the rows, since a datum has no base to resolve and this is the one row that clue writes without a reference to look at. `Pairs` reads them back, because resolving dispatches means reading the table and writing it again, and a row that is not a pair falls out of a document rebuilt from pairs alone — the third pack is there to keep that from regressing quietly. And `Rung` sends a datum to the top: asking what more there is to know about `01-` is asking nothing. The top rung is renamed from "a formation seen whole" to "nothing left to find out", which is what it now holds.

On `eo-runtime`, 171 files:

```
                        before    after
described                82.0%    98.6%
depth                    48.8%    65.5%
nothing at all            7760      582
nothing left to find out  1688     8866
```

All 31,876 existing rows are unchanged in target and order, `provides.xml` and `needs.xml` are byte-identical, and two runs of the goal produce the same file.

What is left on the bottom rung is 582 objects — 1.4%: 433 dispatches whose receiver nothing describes, 66 terminations, 58 names in scope resolving to nothing, and the 25 `λ` markers of atoms, which carry the forma they come back with in an attribute nobody reads yet.

The ticket said 7,203. That count included those 25 `λ`, which have no base and no bytes; the rows are 7,178.
