### PR TITLE
#6761: honor rewriteBinaries in Placing.isNotAlreadyPlaced

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -183,9 +183,10 @@ final class Placing implements Step {
         }
 
         /**
-         * Check if the file has not been placed yet.
+         * Check if the file has not been placed yet, or {@link #rwte} forces
+         * it to be placed again regardless.
          * @param file The file to check
-         * @return True if the file is not already placed
+         * @return True if the file is not already placed, or rewriting is on
          */
         private boolean isNotAlreadyPlaced(final Path file) {
             final Path target = Placing.this.classes.resolve(
@@ -193,7 +194,8 @@ final class Placing implements Step {
             );
             final Optional<TjPlaced> tojo = Placing.this.placed.find(target);
             final boolean res;
-            if (tojo.isPresent()
+            if (!this.rwte
+                && tojo.isPresent()
                 && Files.exists(target)
                 && !tojo.get().unplaced()
             ) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
@@ -54,7 +54,7 @@ final class MjPlaceTest {
         ).toFile().lastModified();
         MatcherAssert.assertThat(
             "PlaceMojo must skip already placed binaries, but it doesn't",
-            new FakeMaven(temp).withPlacedBinary(
+            new FakeMaven(temp).with("rewriteBinaries", false).withPlacedBinary(
                 temp.resolve(this.targetClasses()).resolve(binary)
                 )
             .execute(MjPlace.class)
@@ -184,8 +184,26 @@ final class MjPlaceTest {
     }
 
     @Test
-    void doesNotPlacesAgainIfWasNotUnplaced(@Mktmp final Path temp) throws Exception {
+    void rewritesAgainIfNotUnplacedButRewriteBinariesIsOn(@Mktmp final Path temp)
+        throws Exception {
         final FakeMaven maven = new FakeMaven(temp);
+        final String binary = "some.class";
+        final String updated = "new content";
+        MjPlaceTest.saveBinary(temp, "some old content", binary);
+        maven.execute(MjPlace.class).result();
+        MjPlaceTest.saveBinary(temp, updated, binary);
+        maven.execute(MjPlace.class).result();
+        MatcherAssert.assertThat(
+            "The binary file must be replaced with new content because rewriteBinaries is on by default, but it was not",
+            new TextOf(MjPlaceTest.pathToPlacedBinary(temp, binary)).asString(),
+            Matchers.equalTo(updated)
+        );
+    }
+
+    @Test
+    void doesNotPlaceAgainIfNotUnplacedAndRewriteBinariesIsOff(@Mktmp final Path temp)
+        throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).with("rewriteBinaries", false);
         final String binary = "some.class";
         final String old = "some old content";
         MjPlaceTest.saveBinary(temp, old, binary);
@@ -193,7 +211,7 @@ final class MjPlaceTest {
         MjPlaceTest.saveBinary(temp, "new content", binary);
         maven.execute(MjPlace.class).result();
         MatcherAssert.assertThat(
-            "The binary file must not be replaced with new content, but it was not",
+            "The binary file must not be replaced with new content because rewriteBinaries is off, but it was",
             new TextOf(MjPlaceTest.pathToPlacedBinary(temp, binary)).asString(),
             Matchers.equalTo(old)
         );


### PR DESCRIPTION
Placing.PlacedDependency.isNotAlreadyPlaced decides whether to skip a
binary using only whether a tojo for the target already exists, the
target file exists, and the tojo is not marked unplaced. It never read
rwte, the rewriteBinaries flag passed into the constructor. rewrite
was only consulted later, inside placeBinary, on files that already
passed this filter.

So for a binary that is already placed and still exists,
-Deo.rewriteBinaries=true and -Deo.rewriteBinaries=false behaved
identically: the file was skipped either way, and the option (default
true, documented as "Rewrite binaries in output directory or not")
had no effect on the case it is named for. A dependency version change
would leave stale binaries in target/classes until a mvn clean.

Fix: isNotAlreadyPlaced now returns true unconditionally when rewrite
is on, matching the option's stated purpose.

Two existing tests were pinning the old (buggy) behavior under the
default rewriteBinaries=true:
- doesNotPlacesAgainIfWasNotUnplaced ran with the default true but
  asserted the file was NOT replaced. Renamed and flipped to expect a
  replace, plus a new explicit off-case test.
- skipsAlreadyPlacedBinaries relied on the same default to assert a
  skip; now explicitly sets rewriteBinaries=false, matching what it's
  actually testing.

Fixes #6761
