### PR TITLE
#6760: restrict removeStale to directories eo itself wrote into

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -133,6 +133,15 @@ final class JavaFiles {
 
     /**
      * Delete generated Java files absent from the current XMIR collection.
+     *
+     * <p>Only considers files inside a directory this run's own {@link
+     * #fresh} output actually landed in, never the whole {@link #generated}
+     * tree: {@code generated-sources} is the standard Maven convention
+     * directory, and other generators (antlr4, protobuf, jaxb2, the
+     * annotation-processor output of maven-compiler-plugin) can write their
+     * own {@code .java} files there too, outside any directory eo itself
+     * touched this run.</p>
+     *
      * @throws IOException If fails to inspect or remove a generated file
      */
     void removeStale() throws IOException {
@@ -150,9 +159,9 @@ final class JavaFiles {
                     .filter(path -> path.toString().endsWith(JavaFiles.JAVA)).collect(
                         Collectors.toList()
                     )) {
-                    if (!expected.contains(file) && (!"package-info.java".equals(
-                        file.getFileName().toString()
-                    ) || !dirs.contains(file.getParent()))) {
+                    if (dirs.contains(file.getParent())
+                        && !expected.contains(file)
+                        && !"package-info.java".equals(file.getFileName().toString())) {
                         Files.delete(file);
                         Logger.debug(this, "Deleted stale generated Java file %[file]s", file);
                     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -79,6 +79,27 @@ final class JavaFilesTest {
     }
 
     @Test
+    void keepsAJavaFileWrittenByAnotherToolInAnUntouchedDirectory(@Mktmp final Path temp)
+        throws IOException {
+        final Path generated = temp.resolve("generated");
+        final Path foreign = generated.resolve("com/example/Foreign.java");
+        new Saved("class Foreign {}", foreign).value();
+        final Path xmir = temp.resolve("main.xmir");
+        new Saved(
+            "<object><class java-name='org.eolang.EOfirst'><java>class EOfirst {}</java></class></object>",
+            xmir
+        ).value();
+        final JavaFiles files = new JavaFiles(generated, temp.resolve("cache"), false);
+        files.total(true, xmir, "", false);
+        files.removeStale();
+        MatcherAssert.assertThat(
+            "a .java file written by another tool outside eo's own output directories must survive, but it didn't",
+            foreign.toFile().exists(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
     void writesExactlyOneFileForAtom(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "only a test class of an atom must be written",


### PR DESCRIPTION
JavaFiles.removeStale() walks the whole generatedDir tree and deletes
every .java file this transpile run did not itself write, except a
package-info.java carve-out.

generatedDir defaults to target/generated-sources, the standard Maven
convention directory. Other code generators write there too by
default: antlr4, protobuf, jaxb2, openapi-generator, and
maven-compiler-plugin's own annotation-processor output
(target/generated-sources/annotations). Most of those bind to the
generate-sources phase, which runs before process-sources where eo's
transpile goal lives. So in a single mvn compile on a project that
uses eo-maven-plugin alongside any of those tools: the other tool
writes its .java files first, transpile runs, and removeStale()
deletes all of them because they are not in eo's own fresh set. mvn
compile then fails on missing classes.

Fix: removeStale() now only deletes a .java file whose parent
directory is one eo itself wrote a fresh file into during this run,
computed the same way the existing package-info.java carve-out already
scoped itself to eo's own directories.

Fixes #6760
