### PR TITLE
#6823: preserve the IEEE negative-zero sign in mod's zero remainder

### DIFF
--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -28,33 +28,34 @@
     dividend.is-finite.not.if
       nan
       divisor.is-finite.not.if
-        divisor.is-nan.if
-          nan
-          x.plus 0
+        divisor.is-nan.if nan x
         if.
-          gte.
-            number x.as-bytes >> dividend
-            0
-          [] >> abs-mod
-            shrink > @
-              grow
-                abs divisor >> absy
-              abs dividend >> absx
-            if. > [chunk] > grow
-              chunk.gte absx
-              chunk
-              grow
-                chunk.plus chunk
-            if. > [chunk rest] > shrink
-              chunk.lt absy
-              rest
-              shrink
-                chunk.div 2
-                if.
-                  rest.gte chunk
-                  rest.minus chunk
-                  rest
-          abs-mod.neg
+          x.as-bytes.eq 80-00-00-00-00-00-00-00
+          x
+          if.
+            gte.
+              number x.as-bytes >> dividend
+              0
+            [] >> abs-mod
+              shrink > @
+                grow
+                  abs divisor >> absy
+                abs dividend >> absx
+              if. > [chunk] > grow
+                chunk.gte absx
+                chunk
+                grow
+                  chunk.plus chunk
+              if. > [chunk rest] > shrink
+                chunk.lt absy
+                rest
+                shrink
+                  chunk.div 2
+                  if.
+                    rest.gte chunk
+                    rest.minus chunk
+                    rest
+            abs-mod.neg
 
   eq. ++> can-recover-from-a-modulo-by-zero
     "recovered"
@@ -71,15 +72,20 @@
   is-nan. ++> can-return-nan-when-the-divisor-is-nan
     5.mod nan
 
-  eq. ++> can-return-positive-zero-for-negative-zero-dividend-and-negative-infinite-divisor
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-a-finite-divisor
+    as-bytes.
+      0.neg.mod 3
+    80-00-00-00-00-00-00-00
+
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-negative-infinite-divisor
     as-bytes.
       0.neg.mod ninf
-    0.as-bytes
+    80-00-00-00-00-00-00-00
 
-  eq. ++> can-return-positive-zero-for-negative-zero-dividend-and-positive-infinite-divisor
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-positive-infinite-divisor
     as-bytes.
       0.neg.mod pinf
-    0.as-bytes
+    80-00-00-00-00-00-00-00
 
   eq. ++> can-return-positive-zero-when-dividend-is-zero
     as-bytes.


### PR DESCRIPTION
number.mod loses the sign of a negative-zero dividend. Its result is
positive zero for both finite and infinite non-zero divisors:

| expression | actual bytes | expected bytes |
| --- | --- | --- |
| (-0).mod 3 | 00-00-00-00-00-00-00-00 | 80-00-00-00-00-00-00-00 |
| (-0).mod pinf | 00-00-00-00-00-00-00-00 | 80-00-00-00-00-00-00-00 |
| 0.mod 3 | 00-00-00-00-00-00-00-00 | 00-00-00-00-00-00-00-00 |

Two places drop the sign:
- The infinite-non-nan-divisor branch returned x.plus 0. IEEE -0.0 +
  0.0 is +0.0, a well-known IEEE-754 quirk, so this alone flips the
  sign.
- The finite-divisor branch picks its unsigned-magnitude result
  whenever gte.(dividend, 0), which -0 satisfies (IEEE -0 == 0), so the
  negation branch never runs for it.

Fix: return x directly (no arithmetic) for the infinite-non-nan-divisor
case, and check the exact -0 byte pattern before the magnitude
computation for the finite-divisor case, matching the idiom already
used in floor.eo/sqrt.eo/arc-sine.eo for the same class of bug.

Two existing tests were pinning the old positive-zero result
(can-return-positive-zero-for-negative-zero-dividend-and-*-infinite-divisor);
renamed and flipped them, plus added the missing finite-divisor case.

Fixes #6823
