### PR TITLE
#6821: return the exact unit value for cosine of zero

### DIFF
--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -1,5 +1,7 @@
 # Cosine of `num` radians as `org.eolang.number`, taken from the sine of the
-# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2).
+# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2). The
+# finite approximation of `pi` used in that shift misses the exact extremum
+# at zero, so zero is special-cased to return the exact unit value.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,9 +11,12 @@
 +spdx SPDX-License-Identifier: MIT
 
 [num] > cosine
-  sine > @
-    num.plus
-      pi.div 2
+  if. > @
+    num.eq 0
+    1
+    sine.
+      num.plus
+        pi.div 2
 
   lt. ++> can-behave-as-an-even-function
     abs.
@@ -79,3 +84,5 @@
         0.cosine.times 1000
         1000
     1
+
+  1.eq 0.cosine ++> can-take-an-exact-cosine-of-zero


### PR DESCRIPTION
number.cosine does not return the exact unit value at zero. It
produces the adjacent lower IEEE-754 value, so an EO equality check
fails:

| expression | actual | expected |
| --- | --- | --- |
| 0.cosine.eq 1 | false | true |
| 0.cosine.as-bytes | 3F-EF-FF-FF-FF-FF-FF-FF | 3F-F0-00-00-00-00-00-00 |

The result is 0.9999999999999999, one ULP below one.

cosine is implemented as sine(num + pi/2). The finite approximation of
pi makes the shifted input miss the exact extremum, and the Taylor
calculation returns the neighbouring representable value instead of
exactly 1.

Fix: return 1 for a zero argument before applying the phase shift.
Added an exact 0.cosine.eq 1 regression alongside the existing
tolerance-based accuracy tests.

Fixes #6821
