### PR TITLE
#6813: validate UTF-8 sequences in string.slice

### DIFF
--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -4,7 +4,15 @@
 # take. A fractional, `nan` or infinite `start` or `len` terminates the
 # computation immediately. Both of them walk the UTF-8 sequence character by
 # character, so a multi-byte character counts as one. An index outside the
-# bounds of the `text` terminates the computation.
+# bounds of the `text` terminates the computation. Every multi-byte sequence is
+# validated against the UTF-8 rules of the Unicode standard (Table 3-7), the
+# same way `length` does: each following byte must be a `10xxxxxx` continuation
+# byte, and the second byte is range-checked so that overlong encodings
+# (`C0`/`C1` leads, `E0` with an `80`-`9F` second byte, `F0` with an `80`-`8F`
+# second byte), UTF-16 surrogates (`ED` with an `A0`-`BF` second byte) and code
+# points above U+10FFFF (`F4` with a `90`-`BF` second byte, and `F5`-`FF` leads)
+# are rejected. A malformed sequence terminates the computation, exactly like a
+# truncated character does.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -53,34 +61,98 @@
             eq.
               byte.and p1
               r1
-            increase
-              index
-              1
-              accum
+            recidx
+              increase index 1 true
+              accum.plus 1
               result
               cause
             if.
               eq.
                 byte.and p2
                 r2
-              increase
-                index
-                2
-                accum
+              recidx
+                increase index 2 twovalid
+                accum.plus 1
                 result
                 cause
               if.
                 eq.
                   byte.and p3
                   r3
-                increase index 3 accum result cause
+                recidx
+                  increase index 3 threevalid
+                  accum.plus 1
+                  result
+                  cause
                 if.
                   eq. (byte.and p4) r4
-                  increase index 4 accum result cause
+                  recidx
+                    increase index 4 fourvalid
+                    accum.plus 1
+                    result
+                    cause
                   T
                     "Unknown byte format (%x), can't recognize character".printf
                       * byte
+      text.as-bytes.slice > b1
+        index.plus 1
+        1
+      eq. > b1808f
+        b1.and F0-
+        80-
+      eq. > b1809f
+        b1.and E0-
+        80-
+      or. > b190bf
+        eq.
+          b1.and F0-
+          90-
+        eq.
+          b1.and E0-
+          A0-
+      eq. > b1a0bf
+        b1.and E0-
+        A0-
+      eq. > b1cont
+        b1.and C0-
+        80-
+      text.as-bytes.slice > b2
+        index.plus 2
+        1
+      eq. > b2cont
+        b2.and C0-
+        80-
+      text.as-bytes.slice > b3
+        index.plus 3
+        1
+      eq. > b3cont
+        b3.and C0-
+        80-
       text.as-bytes.slice index 1 > byte
+      b2cont.and > fourvalid
+        b3cont.and second4
+      eq. > leadc0c1
+        byte.and FE-
+        C0-
+      byte.eq E0- > leade0
+      byte.eq ED- > leaded
+      byte.eq F0- > leadf0
+      byte.eq F1- > leadf1
+      leadf1.or > leadf1f3
+        leadf2.or leadf3
+      byte.eq F2- > leadf2
+      byte.eq F3- > leadf3
+      byte.eq F4- > leadf4
+      leade0.if > second3
+        b1a0bf
+        leaded.if b1809f b1cont
+      leadf0.if > second4
+        b190bf
+        leadf4.if
+          b1808f
+          leadf1f3.if b1cont false
+      b2cont.and second3 > threevalid
+      leadc0c1.not.and b1cont > twovalid
     |
       number bstart
       0
@@ -89,7 +161,7 @@
         *
           nstart.plus nlen
     bstart
-  if. > [index csize accum result cause] > increase
+  if. > [index csize valid] > increase
     gt.
       index.plus csize
       size
@@ -99,11 +171,13 @@
           csize
           index
           text.as-bytes
-    recidx
+    valid.if
       index.plus csize
-      accum.plus 1
-      result
-      cause
+      T
+        "Malformed UTF-8 sequence (%x) at %d index".printf
+          *
+            text.as-bytes.slice index csize
+            index
   number len! > nlen
   number start! > nstart
   80- > p1
@@ -193,6 +267,21 @@
       1
       2
     "ри"
+
+  slice. --> rejects-a-non-continuation-after-a-three-byte-lead
+    string E1-80-41
+    0
+    1
+
+  slice. --> rejects-a-utf-16-surrogate-encoding
+    string ED-A0-80
+    0
+    1
+
+  slice. --> rejects-an-overlong-two-byte-encoding
+    string C0-80
+    0
+    1
 
   slice. --> stops-on-a-fractional-length
     "some"


### PR DESCRIPTION
Fixes #6813.

`string.slice` decided a character width from its leading byte and only checked
that enough trailing bytes remained, so it accepted malformed data that
`string.length` already rejects: `(string C0-80).slice 0 1` returned `C0-80`,
and so did `(string E1-80-41).slice 0 1` and `(string ED-A0-80).slice 0 1`.

The walker now validates every multi-byte sequence with the same UTF-8 rules
as `string.length` (Unicode Table 3-7): each following byte must be a `10xxxxxx`
continuation byte, and the second byte is range-checked per lead so that

- overlong encodings are rejected: `C0`/`C1` leads, `E0` with an `80`-`9F`
  second byte, `F0` with an `80`-`8F` second byte;
- UTF-16 surrogates are rejected: `ED` with an `A0`-`BF` second byte;
- code points above U+10FFFF are rejected: `F4` with a `90`-`BF` second byte,
  and `F5`-`FF` leads.

A malformed sequence now terminates the computation, exactly like the existing
truncated-character behaviour. The validity check runs after the existing
length check, so a genuinely truncated character still reports the "not enough
bytes" error rather than a malformed one.

Verified against the runtime (each case dataized through the `string`/`slice`
atoms): the three malformed inputs from the issue throw, while valid inputs
still slice correctly, including two-byte and four-byte characters. All the
existing character-slicing examples stay green.
