### PR TITLE
#6824: reject non-integer bounds in range.naturals

### DIFF
--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -1,6 +1,10 @@
 # Range of natural numbers from `start` to `end` (soft border) with step = 1.
 # It is a method of `range`, so it reads `start` and `end` from the range it
-# is taken from.
+# is taken from. Both bounds must be integers, otherwise the computation
+# terminates: a fractional or non-finite seed would otherwise stay fractional
+# or non-finite through the whole generated sequence, contradicting the range
+# of natural numbers. `is-integer` already excludes `nan` and the infinities,
+# so it doubles as the finiteness check.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -12,14 +16,19 @@
 +unlint redundant-object
 
 [] > naturals
-  range > @
-    [] >>
-      build r.start > @
-      [num] > build
-        num > @
-        build > next
-          1.plus @
-    r.end
+  if. > @
+    r.start.is-integer.and r.end.is-integer
+    range
+      [] >>
+        build r.start > @
+        [num] > build
+          num > @
+          build > next
+            1.plus @
+      r.end
+    T
+      "Range bounds must be integers, but were %f and %f".printf
+        * r.start r.end
   ^ > r
 
   eq. ++> can-build-a-range-of-negatives
@@ -53,3 +62,13 @@
       7
       8
       9
+
+  naturals. --> rejects-a-fractional-lower-bound
+    range
+      0.5
+      2
+
+  naturals. --> rejects-a-fractional-upper-bound
+    range
+      1
+      3.5


### PR DESCRIPTION
Fixes #6824.

`range.naturals` fed its inherited `start` straight into a builder whose `next`
adds one, without validating the bounds. A fractional seed therefore stayed
fractional through the whole sequence: `(range 0.5 2).naturals` produced
`* 0.5 1.5`, which is not a range of natural numbers.

Both bounds are now checked with `is-integer` before the range is built, and a
non-integer bound terminates the computation. `is-integer` already returns
false for `nan` and both infinities, so the same check also rejects non-finite
bounds without a separate `is-finite` guard.

Verified by reasoning against `number.is-integer` (its own tests confirm
`32.is-integer`, `32.5.is-integer.not`, `nan.is-integer.not`,
`pinf.is-integer.not`, `ninf.is-integer.not`). The existing integer-bound
examples (`range -5 0`, `range 1 10`, the empty and descending ranges) stay
green, and new negative examples cover a fractional lower and upper bound.
