### PR TITLE
#6825: require eight-byte width in number.is-finite

### DIFF
--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -1,4 +1,7 @@
-# TRUE when `n` is neither infinite nor not-a-number.
+# TRUE when `n` is a valid eight-byte IEEE-754 value that is neither infinite
+# nor not-a-number. A byte sequence of any other width can never represent a
+# number, so it is not finite: `is-nan` returns FALSE for such widths, which
+# would otherwise let them fall through as finite.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,17 +11,27 @@
 +spdx SPDX-License-Identifier: MIT
 
 [n] > is-finite
-  n.is-nan.not.and > @
-    not.
-      or.
-        n.as-bytes.eq 7F-F0-00-00-00-00-00-00
-        n.as-bytes.eq FF-F0-00-00-00-00-00-00
+  and. > @
+    n.as-bytes.size.eq 8
+    n.is-nan.not.and
+      not.
+        or.
+          n.as-bytes.eq 7F-F0-00-00-00-00-00-00
+          n.as-bytes.eq FF-F0-00-00-00-00-00-00
 
   32.is-finite ++> can-be-finite-when-a-simple-number
+
+  not. ++> can-tell-it-is-not-finite-when-a-single-byte
+    is-finite.
+      number FF-
 
   not. ++> can-tell-it-is-not-finite-when-built-of-infinite-bytes
     is-finite.
       number pinf.as-bytes
+
+  not. ++> can-tell-it-is-not-finite-when-fewer-than-eight-bytes
+    is-finite.
+      number 00-00
 
   nan.is-finite.not ++> can-tell-it-is-not-finite-when-nan
 


### PR DESCRIPTION
Fixes #6825.

`number.is-finite` only excluded `nan` and the two infinity encodings. Because
`number.is-nan` returns `false` for any byte sequence whose length is not eight,
malformed widths fell through and were reported as finite: `(number FF-).is-finite`
and `(number 00-00).is-finite` both returned `true`, even though those values
throw the moment they are dataized as numbers.

The predicate now requires `n.as-bytes.size` to equal eight before the NaN and
infinity checks, so only a genuine eight-byte IEEE-754 value can be finite.

Verified by the added examples, which run in CI: a one-byte `FF-` and a
two-byte `00-00` are now reported as not finite, while the existing finite,
NaN and infinity examples stay green.
