### PR TITLE
#6797: don't lower an aliased tuple.empty reference to a star

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/tuples-to-stars.xsl
@@ -37,8 +37,17 @@
   An empty tuple is stored as the bare "Φ.tuple.empty" base. Render it as
   the "*" star shorthand with no elements, mirroring how non-empty tuples
   are lowered to stars above.
+
+  The same base is what "resolve-aliases.xsl" puts on an ordinary
+  reference whenever the program declares "+alias tuple.empty", so a node
+  carrying it is not necessarily a "*" in the source — it may just be a
+  name the author wrote that happens to resolve to this base. Lowering it
+  to a star anyway would print the wrong shorthand and leave the alias
+  meta dangling with nothing left referring to it. Skip a node whose base
+  is the target of such an alias, leaving it for "restore-aliases.xsl" to
+  print back under its declared short name instead.
   -->
-  <xsl:template match="o[@base = 'Φ.tuple.empty']">
+  <xsl:template match="o[@base = 'Φ.tuple.empty' and not(/object/metas/meta[head = 'alias' and part[last()] = 'Φ.tuple.empty'])]">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
       <xsl:attribute name="star"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-of-tuple-empty-restored.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/alias-of-tuple-empty-restored.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# "tuples-to-stars" matched every base of "Φ.tuple.empty" and lowered it to
+# the "*" star shorthand, on the assumption that only the star could have
+# produced that base. "resolve-aliases" puts the very same base on a bare
+# reference whenever the program declares "+alias tuple.empty", so an
+# ordinary reference read back as "*" instead of the name the author wrote,
+# and the alias meta was left dead (#6797).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +alias tuple.empty
+  +package foo
+
+  [] > app
+    empty > a
+    empty > b
+
+printed: |
+  +alias tuple.empty
+  +package foo
+
+  [] > app
+    empty > a
+    empty > b


### PR DESCRIPTION
tuples-to-stars.xsl matches every o[@base = 'Φ.tuple.empty'] and marks
it as a star, on the assumption that only the * shorthand can carry
that base. It cannot: resolve-aliases.xsl puts the very same base on a
bare reference whenever the program declares +alias tuple.empty, so an
ordinary reference to that object is printed as * rather than the name
the author wrote.

+alias tuple.empty
+package foo

[] > app
  empty > a
  empty > b

Printing this program's XMIR through Xmir.FOR_EO gives * > a and
* > b, and +alias tuple.empty stays in the preamble with nothing left
referring to it. restore-aliases.xsl does put the short name back
(it runs after tuples-to-stars in the same train), but to-eo-tree.xsl
tests @star before it ever looks at @base, so the restored name never
reaches the output. The alias survives too, since both references
still counted as references while the alias pass ran, so
format -Deo.autoFix turns a clean source into one that unused-alias
rejects.

Fix: skip a node whose base is the target of an +alias the program
declares, leaving it for restore-aliases.xsl to print back under its
declared short name. Added a print-pack regression covering the exact
program from this report.

Fixes #6797
