### PR TITLE
Add the I glyph for the identity object

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -169,6 +169,7 @@ The parser recognises the following lexical tokens:
 | `ROOT` | `Q` |
 | `XI` | `$` |
 | `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A self-contained single-character token; carries no arguments and no chain. |
+| `IDENTITY` | `I` — the identity object (§3.16), the one-character spelling of `x > [x]`. A value: it may carry arguments (`I 5`) and a `.method` chain, like any other head. |
 | `SELF` | `%` — self-reference (§3.15). Sugar for the auto-name of the enclosing anonymous (`>>`-named) formation; substituted at compile time. A value: it may carry arguments (`% 5`) and a `.method` chain, like any other head. |
 | `VOID` | `?` — the vertical-void marker (§3.4). A `? > name` body line declares a void attribute, equivalent to listing `name` in `[…]`. |
 | `QDOT` | `?.` — the fragile-dispatch operator (§3.5). Accepted in every position the plain `.` dispatch is, recorded as `@fragile` in XMIR. A `?` immediately followed by `.` is `QDOT`; a `?` followed by space (`? > name`) is `VOID`. |
@@ -215,6 +216,7 @@ Each non-blank, non-comment line is classified into exactly one shape, determine
 | `*` | — | star tuple as application head (§3.6) |
 | `(` | — | application starting with group (§3.6) |
 | `%` | — | self-reference as application head (§3.15) |
+| `I` | — | identity object as application head (§3.16) |
 
 The classifier emits a **line-shape record**:
 
@@ -615,7 +617,7 @@ A line whose first non-space character is `|` is a *pipe-application line*. It a
 
 R-3.14.1. The `|` is followed by a single space, then either a horizontal argument list (§3.6) or nothing, then an optional name suffix (§3.10). Its tail is parsed exactly as an application's argument list plus suffix — the pipe supplies the arguments; the *head* is the implicit predecessor.
 
-R-3.14.2. **Predecessor requirement.** The stack top at the pipe's indent must be a **formation** (`bare-formation` or `inline-phi-formation`) or another **pipe-application**, and it must be **named** (an explicit `> name` or an auto-generated `>>`). A pipe with no predecessor (top-level / empty stack), a deeper-indent ("descending") pipe, or a pipe whose predecessor is an unnamed formation, a plain value, an application, or any `.method` dispatch is an error. The named requirement is what lets the pipe refer to the predecessor by name (R-3.14.7); an unnamed formation cannot be a pipe target — give it a `>>`.
+R-3.14.2. **Predecessor requirement.** The stack top at the pipe's indent must be a **formation** (`bare-formation`, `inline-phi-formation` or `identity-object`) or another **pipe-application**, and it must be **named** (an explicit `> name` or an auto-generated `>>`). A pipe with no predecessor (top-level / empty stack), a deeper-indent ("descending") pipe, or a pipe whose predecessor is an unnamed formation, a plain value, an application, or any `.method` dispatch is an error. The named requirement is what lets the pipe refer to the predecessor by name (R-3.14.7); an unnamed formation cannot be a pipe target — give it a `>>`.
 
 R-3.14.3. **Two forms**, distinguished by whether horizontal args are present on the line:
   - **Horizontal form** — `| arg1 arg2 … [> name]` (≥1 arg): the args are the application arguments. The line takes no deeper-indent children (`vertical-completed`), but may still be wrapped by a same-indent `.method` (§3.5) or extended by a following pipe (chained application, R-3.14.5).
@@ -703,6 +705,22 @@ io.stdout > @                         ← prints the 5th Fibonacci number
 ```
 
 Outer kind: that of the underlying application (§3.6), since `%` is just a head value.
+
+### 3.16 Identity object — `I`
+
+An `I` token is *the one-character spelling of the identity object* `x > [x]` — the formation that binds a single void and decorates it, so that dataizing it dataizes whatever was applied to it. It is the object counterpart of the [identity function](https://mathworld.wolfram.com/IdentityFunction.html), and it reads best where a callback is asked for but nothing is to be done with the value:
+
+```
+"hello".at 1.5 I                      ← the error branch hands the message back
+```
+
+R-3.16.1. `I` is a value: it is recognised wherever a value is expected — as a line head, as a horizontal argument, as a vertical one, and inside a paren group — and takes horizontal arguments (`I 5`) and a `.method` chain with the ordinary application shape (§3.6).
+
+R-3.16.2. **The void.** The void `I` binds is always named `x`, since nothing but the φ ever reads it. A same-named attribute of an enclosing formation does not capture that φ: the void is the nearest declaration of `x`, so scope resolution binds to it.
+
+R-3.16.3. **Emission / XMIR.** The parser emits a base-less `<o>` with two children in this order — the void `<o name='x' base='∅'/>` and the decoratee `<o name='φ' base='x'/>` — which is exactly what the spelled-out `x > [x]` emits.
+
+R-3.16.4. **Outer kind.** A bare `I` line is an `identity-object` (Appendix A): a pipe may apply arguments to it (R-3.14.2), because `I` names a formation, while its own deeper-indent children stay arguments, not bindings, as under any other head. An `I` carrying a chain or horizontal args takes the outer kind of the underlying application (§3.6).
 
 ---
 
@@ -865,7 +883,7 @@ R-5.2.3. **MethodDispatch line dispatch.** If the line's kind is `MethodDispatch
 
 R-5.2.4. **Non-MethodDispatch same-indent line.** If the line's kind is **not** MethodDispatch: the top entry is a *completed previous sibling*. Run close-time checks (§5.3) on it, then **replace** it with a new entry built from the new line. The new entry's `parent_kind` is read from the stack entry below.
 
-R-5.2.4a. **PipeApplication same-indent line.** A `PipeApplication` line (§3.14) is a Non-MethodDispatch line and so replaces the top per R-5.2.4, but first the top must satisfy R-3.14.2: its kind must be `bare-formation`, `inline-phi-formation`, or `pipe-application`, and it must be named. Otherwise error `a pipe must follow a named formation or another pipe` (§9.9). In particular a top whose kind is `vmethod` / `vmethod-with-hargs` (a `.method` was taken off the predecessor) fails this check — R-3.14.4.
+R-5.2.4a. **PipeApplication same-indent line.** A `PipeApplication` line (§3.14) is a Non-MethodDispatch line and so replaces the top per R-5.2.4, but first the top must satisfy R-3.14.2: its kind must be `bare-formation`, `inline-phi-formation`, `identity-object`, or `pipe-application`, and it must be named. Otherwise error `a pipe must follow a named formation or another pipe` (§9.9). In particular a top whose kind is `vmethod` / `vmethod-with-hargs` (a `.method` was taken off the predecessor) fails this check — R-3.14.4.
 
 **Step C — Deeper line.** If the top entry now has indent < `N`:
 
@@ -1237,6 +1255,7 @@ R-9.2.3. **File-local handles (R-3.10.12).** A `>> name` suffix emits the object
 | `$` (XI) | `ξ` | `@base='ξ'` for self reference |
 | `%` (SELF) | — | base-less `<o self=''>` marker; `resolve-self` (§9) later sets `@base` to the enclosing anonymous formation's auto-name (§3.15) |
 | `T` (TERM) | `⊥` | `@base='⊥'` for the bottom term |
+| `I` (IDENTITY) | — | base-less `<o>` with a single void `<o name='x' base='∅'/>` and the decoratee `<o name='φ' base='x'/>` — the identity object (§3.16) |
 | atom signature head `Q` | `Φ` | `@atom='Φ....'` |
 | generic type variable `A`–`F` | (verbatim) | `@atom`, `@type`, `@args` member — never `Φ`-promoted or alias-expanded (§3.10.11) |
 
@@ -1411,6 +1430,7 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 | `vmethod` | multi-line | yes while in progress (only if last `.method` has 0 hargs) | yes (more `.method`s extend the chain; same-indent `.method` after block closes wraps it) | chain of `.method` continuations |
 | `vmethod-with-hargs` | multi-line | **no** | **no** | a `.method` continuation line that itself carries ≥1 horizontal args — closes the chain immediately |
 | `pipe-application` | 1 line (+ body if 0 hargs) | yes if 0 hargs (vertical form's args) | yes (after) | `\| [args] [> name]`; applies args to the same-indent named formation/pipe above (§3.14) |
+| `identity-object` | 1 line | yes (its vertical args) | yes (after) | a bare `I` (§3.16); a formation a pipe may apply args to, whose own children are arguments |
 | `text-block` | multi-line | n/a | yes (after closing `"""`) | `"""…"""` |
 
 **Horizontally-completed kinds (the single source of truth)** — these never receive deeper children and cannot be wrapped by same-indent `.method`:
@@ -1438,6 +1458,7 @@ Reproduced from §3.1 for convenience:
 | identifier | otherwise | application or just-an-identifier (§3.6) |
 | literal | — | application (§3.6) |
 | `*` | — | star tuple (§3.6) |
+| `I` | — | identity object (§3.16) |
 | `(` | — | group application (§3.6) |
 
 ## Appendix C — Worked examples

--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -126,7 +126,8 @@ final class Bindings {
      * @return True if the parent tracks binding consistency
      */
     private static boolean tracksBindings(final Kind kind) {
-        return kind == Kind.HEAD || kind == Kind.HMETHOD || kind == Kind.VAPPLICATION;
+        return kind == Kind.HEAD || kind == Kind.HMETHOD
+            || kind == Kind.VAPPLICATION || kind == Kind.IDENTITY_OBJECT;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -30,6 +30,11 @@ final class Emissions {
     private static final int MAX_OCTAL_BYTE = 0xFF;
 
     /**
+     * The void the identity object {@code I} binds and decorates.
+     */
+    private static final String IDENTITY = "x";
+
+    /**
      * Kinds of head value that a {@code .method} chain may follow.
      */
     private static final Set<Value.Kind> CHAINABLE = Set.of(
@@ -264,11 +269,35 @@ final class Emissions {
             emit.self();
         } else if (value.kind() == Value.Kind.TERM) {
             emit.object(name, "⊥", line, value.pos());
+        } else if (value.kind() == Value.Kind.IDENTITY) {
+            Emissions.identity(emit, name, value, line);
         } else if (value.kind() == Value.Kind.GROUP) {
             Emissions.group(emit, name, value, line);
         } else {
             emit.object(name, value.raw(), line, value.pos());
         }
+    }
+
+    /**
+     * Open the {@code <o>} for the identity object {@code I} (§3.16) —
+     * an anonymous formation that binds one void and decorates it, the
+     * one-glyph spelling of {@code x > [x]}. The void is always named
+     * {@link Emissions#IDENTITY}, since the glyph carries no name of
+     * its own and the body it decorates is that very void. The element
+     * stays open, so horizontal arguments land on the identity exactly
+     * as they land on a parenthesised {@code (x > [x])}.
+     * @param emit Emitter
+     * @param name Name attribute (or {@code null})
+     * @param value The identity value
+     * @param line Source line
+     */
+    private static void identity(
+        final Emit emit, final String name, final Value value, final int line
+    ) {
+        emit.object(name, null, line, value.pos());
+        emit.voidParam(Emissions.IDENTITY, line, value.pos());
+        emit.object("φ", Emissions.IDENTITY, line, value.pos());
+        emit.close();
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -36,9 +36,9 @@ final class Eo implements Iterable<Directive> {
 
     /**
      * Head characters of §3.1 that open a root-headed line without
-     * opening a literal — the group, star, root, and self tokens.
+     * opening a literal — group, star, root, identity, and self tokens.
      */
-    private static final String ROOT_TOKENS = "*(QT@^$%";
+    private static final String ROOT_TOKENS = "*(QTI@^$%";
 
     /**
      * Initial capacity of the source line buffer, {@link java.util.ArrayList}'s own default.

--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -114,7 +114,17 @@ enum Kind {
      * Vertical void attribute {@code ? > name} (R-3.4.7). A closed leaf
      * that must precede every non-void child of its formation.
      */
-    VOID;
+    VOID,
+
+    /**
+     * The identity object {@code I} standing alone as a line head
+     * (§3.16) — a formation that binds nothing but its own void, so a
+     * pipe may apply arguments to it (R-3.14.2). It is not a
+     * {@link #formation()}: its deeper-indent children are arguments
+     * applied to the identity, not bindings, exactly as under
+     * {@link #HEAD}.
+     */
+    IDENTITY_OBJECT;
 
     /**
      * Whether this kind is in the horizontally-completed set.
@@ -149,11 +159,11 @@ enum Kind {
 
     /**
      * Whether a pipe application (§3.14) may attach to a predecessor of
-     * this kind — a formation or another pipe. Read by {@link LnPipe} to
-     * enforce R-3.14.2 / R-5.2.4a.
+     * this kind — a formation, an identity object, or another pipe.
+     * Read by {@link LnPipe} to enforce R-3.14.2 / R-5.2.4a.
      * @return True iff this kind may be a pipe's predecessor
      */
     boolean pipeable() {
-        return this.formation() || this == PIPE_APPLICATION;
+        return this.formation() || this == PIPE_APPLICATION || this == IDENTITY_OBJECT;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -80,7 +80,7 @@ final class LnApplication implements Line {
             );
         }
         Comments.seal(globals, emit, this.span);
-        final Kind kind = LnApplication.classify(chain, args);
+        final Kind kind = LnApplication.classify(head, chain, args);
         final Openness openness;
         if (kind == Kind.HAPPLICATION) {
             openness = Openness.HORIZONTAL_COMPLETED;
@@ -118,21 +118,42 @@ final class LnApplication implements Line {
     }
 
     /**
-     * Decide the outer kind based on chain and argument presence.
+     * Decide the outer kind based on head, chain and argument presence.
+     * @param head The line head
      * @param chain Method-dispatch chain (may be empty)
      * @param args Horizontal arguments (may be empty)
      * @return Outer kind
      */
-    private static Kind classify(final List<MethodChain> chain, final List<Value> args) {
+    private static Kind classify(
+        final Value head, final List<MethodChain> chain, final List<Value> args
+    ) {
         final Kind kind;
         if (args.isEmpty()) {
             if (chain.isEmpty()) {
-                kind = Kind.HEAD;
+                kind = LnApplication.bare(head);
             } else {
                 kind = Kind.HMETHOD;
             }
         } else {
             kind = Kind.HAPPLICATION;
+        }
+        return kind;
+    }
+
+    /**
+     * Decide the outer kind of a head that carries neither arguments nor
+     * a chain. An {@code I} head is an identity object, a formation a
+     * pipe may apply arguments to (R-3.16.4); every other head is a
+     * plain {@link Kind#HEAD}.
+     * @param head The line head
+     * @return Outer kind
+     */
+    private static Kind bare(final Value head) {
+        final Kind kind;
+        if (head.kind() == Value.Kind.IDENTITY) {
+            kind = Kind.IDENTITY_OBJECT;
+        } else {
+            kind = Kind.HEAD;
         }
         return kind;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -894,8 +894,7 @@ final class Tokens {
 
     /**
      * Read a value that no delimiter, digit, or root token introduces —
-     * one of the reserved glyphs {@code *}, {@code T}, {@code %}, or a
-     * NAME — rejecting a head that starts no value at all.
+     * a reserved glyph ({@code *}, {@code T}, {@code I}, {@code %}) or a NAME.
      * @param first The character at the cursor
      * @return Parsed value
      */
@@ -911,6 +910,8 @@ final class Tokens {
             value = this.reserved(Value.Kind.STAR, "*");
         } else if (first == 'T') {
             value = this.reserved(Value.Kind.TERM, "T");
+        } else if (first == 'I') {
+            value = this.reserved(Value.Kind.IDENTITY, "I");
         } else if (first == '%') {
             value = this.reserved(Value.Kind.SELF, "%");
         } else if (first >= 'a' && first <= 'z') {

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -232,6 +232,14 @@ final class Value {
         TERM,
 
         /**
+         * {@code I} — the identity object (§3.16), the one-glyph
+         * spelling of {@code x > [x]}. {@link Emissions} expands it
+         * into an anonymous formation binding a single void and
+         * decorating it.
+         */
+        IDENTITY,
+
+        /**
          * Paren group — {@code (expr)}. The {@code raw()} string holds
          * the bracketed text <em>including</em> the surrounding
          * parentheses; {@link Emissions} re-parses and emits the inner

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -391,6 +391,28 @@ final class EoTest {
     }
 
     @Test
+    void parsesIdentityObjectInsideFormation() {
+        MatcherAssert.assertThat(
+            "a bare I glyph inside a formation must expand into a formation binding one void and decorating it",
+            EoTest.render("[] > main", "  I > x"),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='main']/o[@name='x' and not(@base)][o[@base='∅' and @name='x']][o[@name='φ' and @base='x']]"
+            )
+        );
+    }
+
+    @Test
+    void parsesIdentityObjectAsHorizontalArgument() {
+        MatcherAssert.assertThat(
+            "an I glyph in argument position must expand into the same formation the spelled-out x > [x] emits",
+            EoTest.render("[] > main", "  foo I > x"),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='main']/o[@name='x']/o[not(@base)][o[@base='∅' and @name='x']][o[@name='φ' and @base='x']]"
+            )
+        );
+    }
+
+    @Test
     void parsesFragileHmethodInsideFormation() {
         MatcherAssert.assertThat(
             "a `?.` fragile dispatch must emit the method link with @fragile=''",

--- a/eo-parser/src/test/java/org/eolang/parser/KindTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/KindTest.java
@@ -39,13 +39,35 @@ final class KindTest {
         names = {
             "TOP_LEVEL", "HEAD", "HMETHOD", "BARE_FORMATION", "BARE_REVERSED",
             "COMPACT_TUPLE", "ONLY_PHI_FORMATION", "VAPPLICATION", "VMETHOD",
-            "TEXT_BLOCK"
+            "TEXT_BLOCK", "IDENTITY_OBJECT"
         }
     )
     void leavesOtherKindsOutOfHorizontallyCompletedSet(final Kind kind) {
         MatcherAssert.assertThat(
             "kinds outside Appendix A's horizontally-completed set must report false",
             kind.horizontallyCompleted(),
+            Matchers.is(false)
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = Kind.class,
+        names = {"BARE_FORMATION", "ONLY_PHI_FORMATION", "PIPE_APPLICATION", "IDENTITY_OBJECT"}
+    )
+    void acceptsPipeAfterFormationLikeKinds(final Kind kind) {
+        MatcherAssert.assertThat(
+            "a pipe must attach to every formation-like kind, the identity object included",
+            kind.pipeable(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void keepsIdentityObjectOutOfFormationSet() {
+        MatcherAssert.assertThat(
+            "an identity object binds no body, so its children stay arguments rather than bindings",
+            Kind.IDENTITY_OBJECT.formation(),
             Matchers.is(false)
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -55,7 +55,7 @@ final class ValueTest {
         MatcherAssert.assertThat(
             "Value.Kind must enumerate every kind the parser currently recognises",
             Value.Kind.values().length,
-            Matchers.equalTo(11)
+            Matchers.equalTo(12)
         );
     }
 
@@ -137,6 +137,15 @@ final class ValueTest {
             "TERM must be one of the recognised value kinds for the bottom term T",
             new Value(Value.Kind.TERM, "T", 0, 1).kind(),
             Matchers.equalTo(Value.Kind.TERM)
+        );
+    }
+
+    @Test
+    void retainsIdentityKind() {
+        MatcherAssert.assertThat(
+            "IDENTITY must be one of the recognised value kinds for the identity object I",
+            new Value(Value.Kind.IDENTITY, "I", 0, 1).kind(),
+            Matchers.equalTo(Value.Kind.IDENTITY)
         );
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/identity-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/identity-object.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The `I` glyph (#6834) is the one-character spelling of `x > [x]`, the
+# identity object. It expands into an anonymous formation binding a single
+# void and decorating it, wherever a value may stand: as a whole body line,
+# as a horizontal argument, and as a vertical one. Its void is always named
+# `x`, and a sibling attribute of that same name in the enclosing formation
+# does not capture it — the φ resolves to the identity's own void.
+sheets:
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/move-voids-up.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/parser/parse/mandatory-as.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[@base='∅' and @name='x'])=3]
+  - /object[count(//o[@name='φ' and @base='ξ.x'])=3]
+  - /object/o[@name='main']/o[@name='a' and not(@base)]/o[@base='ξ.x' and @name='φ']
+  - /object/o[@name='main']/o[@name='b' and @base='Φ.foo']/o[not(@base)]/o[@base='ξ.x' and @name='φ']
+  - /object/o[@name='main']/o[@name='c' and @base='Φ.bar']/o[not(@base)]/o[@base='ξ.x' and @name='φ']
+  - /object/o[@name='main']/o[@name='x' and @base='Φ.number']
+input: |
+  [] > main
+    I > a
+    foo I > b
+    bar > c
+      I
+    42 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The `I` glyph (#6834) names a formation, so a pipe may apply arguments to
+# it (R-3.14.2), exactly as it does to the `[x] > foo` the glyph stands for.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo' and not(@base)][o[@base='∅' and @name='x']][o[@name='φ' and @base='ξ.x']]
+  - //o[@name='foo5' and @base='ξ.foo']/o[@base='Φ.number']
+input: |
+  [] > app
+    I > foo
+    | 5 > foo5

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -131,6 +131,12 @@
   prints as the same one glyph. A φ that is applied to something, that
   is const, or that reaches any other name keeps the ordinary formation
   layout, since "I" cannot spell it.
+
+  The two tests that look over-tight are load-bearing. Exactly two
+  children: a third one is an argument applied to the formation, and the
+  glyph leaves nowhere to put it, so such an object must keep the long
+  layout. And the φ base rooted at "ξ": an unrooted name denotes some
+  other object entirely, not the void beside it.
   -->
   <xsl:function name="eo:identity" as="xs:boolean">
     <xsl:param name="o" as="element()"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -123,6 +123,19 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
+  <!--
+  Whether an object is an identity object (#6834) — an anonymous
+  formation that binds one void and decorates that very void, the shape
+  "x &gt; [x]" the "I" glyph spells. Nothing but the φ ever reads that
+  void, so its spelling carries no meaning and every spelling of it
+  prints as the same one glyph. A φ that is applied to something, that
+  is const, or that reaches any other name keeps the ordinary formation
+  layout, since "I" cannot spell it.
+  -->
+  <xsl:function name="eo:identity" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:sequence select="eo:abstract($o) and not(eo:has-data($o)) and count($o/o) = 2 and eo:void($o/o[1]) and empty($o/o[1]/(@local, @type, @args)) and $o/o[2]/@name = $eo:phi and empty($o/o[2]/o) and empty($o/o[2]/@const) and $o/o[2]/@base = concat($eo:xi, '.', $o/o[1]/@name)"/>
+  </xsl:function>
   <!-- PROGRAM -->
   <xsl:template match="object">
     <object>
@@ -241,6 +254,30 @@
         <xsl:sort select="if (not($sortable) or eo:void(.) or @name = $eo:phi) then '' else string((@local, @name)[1])"/>
       </xsl:apply-templates>
     </line>
+  </xsl:template>
+  <!-- IDENTITY OBJECT -->
+  <!--
+  An identity object is a leaf on the line tree: its void and its φ are
+  both spelled by the "I" glyph itself, so neither becomes a body line
+  and the node lays out exactly like a bare "T" — inlined as an
+  argument wherever the penalty allows it.
+  -->
+  <xsl:template match="o[eo:identity(.)]" mode="tree" priority="2">
+    <xsl:variable name="suffix">
+      <xsl:apply-templates select="." mode="tail"/>
+    </xsl:variable>
+    <line abstract="no" data="no" reversed="no">
+      <xsl:attribute name="base">
+        <xsl:apply-templates select="." mode="head"/>
+      </xsl:attribute>
+      <xsl:attribute name="tail" select="eo:printable(string($suffix))"/>
+      <xsl:attribute name="test">
+        <xsl:value-of select="if (eo:test-attr(.)) then 'yes' else 'no'"/>
+      </xsl:attribute>
+    </line>
+  </xsl:template>
+  <xsl:template match="o[eo:identity(.)]" mode="head" priority="2">
+    <xsl:text>I</xsl:text>
   </xsl:template>
   <!-- VOID AS A VERTICAL BODY LINE -->
   <!--

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -79,6 +79,27 @@ final class XmirTest {
         );
     }
 
+    @Test
+    void keepsArgumentsOfAnIdentityShapedFormation() {
+        MatcherAssert.assertThat(
+            "a formation that decorates its own void but also carries arguments cannot fold into the I glyph, which leaves nowhere for those arguments to go",
+            new Xsline(
+                new StClasspath("/org/eolang/printer/print/to-eo-tree.xsl")
+            ).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<object><metas/><o name='y'>",
+                        "<o base='∅' name='m'/><o base='ξ.m' name='φ'/>",
+                        "<o base='Φ.number'>5</o>",
+                        "</o></object>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("//line[@base='[m]']")
+        );
+    }
+
     @RepeatedTest(3)
     void printsSameEoInManyThreads() {
         final XML xml = new XMLDocument(

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-anonymous-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hybrid-phi-anonymous-argument.yaml
@@ -4,7 +4,10 @@
 # yamllint disable rule:line-length
 # The "tests-malloc-for-writes-first-init-value" test attribute from
 # malloc.eo: its phi (the reversed "eq.") applies regular arguments, one of
-# which is an anonymous formation "m > [m]" nested inside "malloc.for". The
+# which is an anonymous formation nested inside "malloc.for". The argument
+# is spelled "m.as-bytes > [m]" rather than the bare "m > [m]" malloc.eo
+# writes, because the latter is an identity object and prints as the "I"
+# glyph (#6834) — a leaf, which no longer nests an anonymous object here. The
 # only-phi fold used to be withheld because the recursive "nameless" guard
 # treated the anonymous object's inner " > @" phi decoratee as a name. A phi
 # decoratee is exactly what an only-phi formation binds, so a nested anonymous
@@ -29,7 +32,7 @@ origin: |
       eq. > @
         malloc.for
           42
-          m > [m]
+          m.as-bytes > [m]
         42
 
 printed: |
@@ -40,5 +43,5 @@ printed: |
     eq. ++> tests-malloc-for-writes-first-init-value
       malloc.for
         42
-        m > [m]
+        m.as-bytes > [m]
       42

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object-named.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object-named.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# A named identity object (#6834) keeps its name and loses its void's
+# spelling, so `uri > [uri] > sanitized` prints as `I > sanitized`.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -11,12 +13,8 @@ penalties:
   SPACE: 7
 origin: |
   [] > app
-    and > result
-      [x] > bar
-        x > @
-      | 5 > baz
+    uri > [uri] > sanitized
+
 printed: |
   [] > app
-    and baz > result
-    I > bar
-    | 5 > baz
+    I > sanitized

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object-phi.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object-phi.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# An identity object standing as the sole φ of a formation (#6834) folds
+# into the inline-phi form, just as a bare `T` decoratee does.
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -11,12 +13,7 @@ penalties:
   SPACE: 7
 origin: |
   [] > app
-    and > result
-      [x] > bar
-        x > @
-      | 5 > baz
+    m > [m] > @
+
 printed: |
-  [] > app
-    and baz > result
-    I > bar
-    | 5 > baz
+  I > [] > app

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/identity-object.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An identity object written the long way collapses to the `I` glyph
+# (#6834), whatever its void is called: nothing but the φ ever reads that
+# void, so its spelling carries no meaning. Being a leaf, the glyph inlines
+# as an argument wherever the penalty vote lets an argument inline.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    bar (error > [error]) > x
+    "hello".at 1.5 (m > [m]) > y
+
+printed: |
+  [] > app
+    bar I > x
+    "hello".at > y
+      1.5
+      I

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/star-tuple-with-pipe-continuation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/star-tuple-with-pipe-continuation.yaml
@@ -28,6 +28,6 @@ origin: |
 printed: |
   [] > foo
     seq * > @
-      q > [q] >> h
+      I >> h
       | walked
       ^

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-formation-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/unreferenced-formation-handle.yaml
@@ -25,4 +25,4 @@ origin: |
 printed: |
   [b] > array
     b > @
-    index > [index] >> slice-byte
+    I >> slice-byte

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -193,7 +193,7 @@
                                                                                 blah38 (x.plus 1) > @
                                                                                 [x] > blah38
                                                                                   blah39 (x.plus 1) > @
-                                                                                  x > [x] > blah39
+                                                                                  I > blah39
 
   ++> can-take-a-parent-object
     eq. > @
@@ -211,5 +211,5 @@
 
   --> stops-on-applying-to-a-closed-object
     closed true > @
-    x > [x] > a
+    I > a
     a false > closed

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -96,13 +96,13 @@
           hash >> objhash!
             obj 42
         number objhash
-    x > [x] > obj
+    I > obj
 
   ++> can-hash-equal-abstract-objects-alike
     eq. > @
       hash value
       hash value
-    x > [x] > obj
+    I > obj
     obj 42 > value
 
   ++> can-hash-different-abstract-objects-apart
@@ -112,7 +112,7 @@
           obj 42
         hash
           obj "42"
-    x > [x] > obj
+    I > obj
 
   ++> can-hash-a-float-into-an-integer
     1.eq > @

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -291,7 +291,7 @@
     "recovered"
     mktemp.tmpfile.deleted.open
       "r"
-      f > [f]
+      I
       "recovered" > [reason]
 
   ++> can-resolve-a-path-and-touch-it
@@ -438,11 +438,11 @@
 
   mktemp.tmpfile.deleted.open --> stops-on-reading-from-a-missing-file
     "r"
-    f > [f]
+    I
 
   mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
     "r+"
-    f > [f]
+    I
 
   tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
     @.

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -335,7 +335,7 @@
   eq. ++> can-write-the-initial-value
     malloc.for
       42
-      m > [m]
+      I
     42
 
   malloc.of --> stops-on-changing-the-size-to-a-fraction

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -109,7 +109,7 @@
     "Can't write a fixed-point decimal with -2.000000 fraction places"
     3.14159.as-fixed
       -2
-      message > [message]
+      I
 
   eq. ++> can-honour-custom-places
     "3.14"

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -79,7 +79,7 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           1
           10
           15
@@ -123,7 +123,7 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           0
           1
           1
@@ -145,7 +145,7 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           0
           10
           10
@@ -164,37 +164,37 @@
         value.neg
 
   integral --> stops-on-fractional-partitions
-    x > [x]
+    I
     0
     1
     1.5
 
   integral --> stops-on-nan-partitions
-    x > [x]
+    I
     0
     1
     nan
 
   integral --> stops-on-negative-partitions
-    x > [x]
+    I
     0
     1
     -1
 
   integral --> stops-on-negatively-infinite-partitions
-    x > [x]
+    I
     0
     1
     ninf
 
   integral --> stops-on-positively-infinite-partitions
-    x > [x]
+    I
     0
     1
     pinf
 
   integral --> stops-on-zero-partitions
-    x > [x]
+    I
     0
     1
     0

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -169,7 +169,7 @@
     "/" > separator
     [] > sys
       -- > [uri] > drive
-      uri > [uri] > sanitized
+      I > sanitized
       ^.separator > separator
   os.is-windows.if > separator
     win32.separator

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -44,11 +44,13 @@
 
   eq. ++> can-recover-from-a-multi-byte-character
     "recovered"
-    "Ж".as-ascii "recovered" > [message]
+    "Ж".as-ascii
+      "recovered" > [message]
 
   eq. ++> can-recover-from-an-empty-string
     "recovered"
-    "".as-ascii "recovered" > [message]
+    "".as-ascii
+      "recovered" > [message]
 
   "Ж".as-ascii --> stops-on-a-multi-byte-character
 

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -42,7 +42,7 @@
     "Given index 1.500000 is out of text bounds"
     "some".at
       1.5
-      message > [message]
+      I
 
   eq. ++> can-recover-from-a-fractional-index-in-bounds
     "recovered"

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -50,7 +50,7 @@
     "y".padded-left
       -1
       "x"
-      message > [message]
+      I
 
   eq. ++> can-pad-a-number-with-leading-spaces
     "   42"

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -49,7 +49,7 @@
     "y".padded-right
       -1
       "x"
-      message > [message]
+      I
 
   eq. ++> can-pad-a-text-with-trailing-spaces
     "x         "

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -58,7 +58,7 @@
     "Can't pad text to -4.000000 characters with zeros"
     "7".padded-zeros
       -4
-      message > [message]
+      I
 
   eq. ++> can-keep-a-minus-sign-in-front-of-the-zeros
     "-0042"

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -38,7 +38,7 @@
     "Can't repeat text -1.000000 times"
     "x".repeated
       -1
-      message > [message]
+      I
 
   eq. ++> can-recover-from-a-negative-count
     "recovered"

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -38,7 +38,7 @@
     "Can't truncate text to -3.000000 characters"
     "Jeff".truncated
       -3
-      message > [message]
+      I
 
   eq. ++> can-recover-from-a-negative-limit
     "recovered"

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -30,7 +30,7 @@
         1
         2
         3
-      x > [x]
+      I
     3
 
   ++> can-sum-many-numbers


### PR DESCRIPTION
`I` now means `x > [x]` — the formation that binds one void and decorates it. The parser expands the glyph into exactly the XMIR the long form emits, and the printer folds every long form back into `I`, whatever the void was called. Running the formatter over `eo-runtime` rewrites 27 of these across 14 files.

We write this object a lot, mostly as the fallback argument that just hands the error message back (`"some".at 1.5 I`), and the void's name is pure noise: nothing but the phi ever reads it, so every spelling of it means the same thing. One character says it better than seven.

Two things worth a look. A bare `I` line gets its own outer kind, so a pipe can still apply arguments to it (`I > foo` followed by `| 5`) while its own deeper-indent children stay arguments rather than bindings. And `hybrid-phi-anonymous-argument.yaml` had to change its fixture from `m > [m]` to `m.as-bytes > [m]`, because the bare form is now a leaf and would have quietly gutted what that pack regresses.

Closes #6834