### PR TITLE
#6829: fail directory.made when a non-directory occupies the path

### DIFF
--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -1,5 +1,8 @@
 # Creates a directory, making missing parent directories as needed. It is a
-# method of `directory`, and `d` is the directory it is taken off.
+# method of `directory`, and `d` is the directory it is taken off. When the
+# path already exists, it must already be a directory: if a regular file (or
+# any non-directory entry) occupies the path, the computation terminates
+# instead of returning that entry decorated as a directory.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -11,7 +14,11 @@
 
 [] > made
   d.exists.if > @
-    d
+    d.is-directory.if
+      d
+      T
+        "Cant make the directory '%s': a file already occupies that path".printf
+          * d.path
     seq *
       made.
         directory
@@ -40,3 +47,5 @@
     made. > dir
       as-dir.
         mktemp.tmpfile.deleted.as-path.resolved "foo-new"
+
+  mktemp.tmpfile.as-path.as-dir.made --> rejects-a-path-occupied-by-a-regular-file


### PR DESCRIPTION
Fixes #6829.

When the target path already existed, `directory.made` returned it as-is
without checking its kind, so a regular file occupying the path was reported as
a successfully made directory: `path.as-dir.made.is-directory` evaluated to
`false` even though `made` claimed success.

The existing-path branch now returns `d` only when `d.is-directory`, and
terminates with a clear error otherwise. The creation branch for a missing path
is unchanged.

The existing `can-make-a-new-directory` example still creates and verifies a
fresh directory, and a new negative example covers a path already occupied by a
regular file.
