### PR TITLE
#6828: retry partial writes and fail on error in file.open write

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -161,14 +161,26 @@
             output-block.write buffer > @
             [] > output-block
               true > @
-              writable.not.if > [buffer] > write
-                T
-                  "Can't write to file with provided access mode '%s'".printf
-                    * access
-                seq *
-                  code.
-                    syscall.write
-                      * descriptor buffer buffer.size
+              [buffer] > write
+                writable.not.if > @
+                  T
+                    "Can't write to file with provided access mode '%s'".printf
+                      * access
+                  seq *
+                    if. >>!
+                      code.eq -1
+                      T
+                        "Failed to write to file"
+                      output-block
+                    code
+                    remainder
+                code. > code
+                  syscall.write
+                    * descriptor buffer buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  output-block.write
+                    buffer.slice code (buffer.size.minus code)
                   output-block
         truncate.if syscall.trunc 0 > trunc
     and. > readable


### PR DESCRIPTION
Fixes #6828.

The output block returned by `file.open(...).write` invoked `syscall.write`
once and discarded its result, so a `-1` error was reported as success and a
partial write silently dropped the unwritten suffix.

The block now follows the same pattern the `console` and `stderr` output blocks
already use: a `-1` result raises an EO failure, and when fewer than
`buffer.size` bytes are written it continues with
`buffer.slice written (buffer.size.minus written)` until the whole buffer is
accepted.

The existing write-and-size examples (`can-append-data-to-a-file` and the
`can-keep-the-size-*` ones) exercise the full-buffer path and stay green.
