### PR TITLE
#6832: reject non-integer ports in socket.checked-port

### DIFF
--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -258,14 +258,18 @@
         seq * > [buffer] > write
           send buffer
           output-block
-  if. > [] > checked-port
-    or.
-      port.lt 0
-      port.gt 65535
+  port.is-integer.not.if > [] > checked-port
     T
-      "Port %d is out of range; it must be 0 to 65535".printf
+      "Port must be an integer in 0 to 65535, but was %f".printf
         * port
-    port
+    if.
+      or.
+        port.lt 0
+        port.gt 65535
+      T
+        "Port %d is out of range; it must be 0 to 65535".printf
+          * port
+      port
   [port] > htons
     as-i16. > @
       or.
@@ -282,6 +286,11 @@
   eq. ++> can-convert-a-port-above-the-signed-short-limit-in-htons
     40-9C
     socket.htons 40000
+
+  checked-port. --> rejects-a-fractional-port
+    socket
+      "127.0.0.1"
+      1.5
 
   checked-port. --> rejects-a-port-above-the-valid-range
     socket


### PR DESCRIPTION
Fixes #6832.

`socket.checked-port` validated only the numeric bounds, not that the port was
an integer. A fractional value therefore passed through to `htons`, where
`port.as-i32` truncated it toward zero: `socket "127.0.0.1" 1.5` silently
connected on port 1.

The check now rejects any non-integer port first, with its own error message.
`is-integer` also returns false for NaN and both infinities, so those are
rejected too. The existing 0-65535 range check is unchanged and now runs only
for integer ports, keeping its `%d` message well-formed.

A new negative example covers a fractional port, alongside the existing
out-of-range one.
