### PR TITLE
#6833: reject negative recv size on both platforms

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -7,6 +7,7 @@ package org.eolang.posix;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -33,6 +34,12 @@ public final class RecvSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure(
+                "Can't receive a negative number of bytes '%d'",
+                size
+            );
+        }
         final byte[] buf = new byte[size];
         final int received = CStdLib.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -34,6 +35,12 @@ public final class RecvFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
         final int size = new Dataized(params[1]).asNumber().intValue();
+        if (size < 0) {
+            throw new ExFailure(
+                "Can't receive a negative number of bytes '%d'",
+                size
+            );
+        }
         final byte[] buf = new byte[size];
         final int received = Winsock.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),

--- a/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
@@ -8,9 +8,11 @@ import java.util.Arrays;
 import java.util.List;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,6 +34,18 @@ final class RecvSyscallTest {
                 )
             ),
             Matchers.contains(-1, 0)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsNegativeSizeOnPosixRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(-7), new Data.ToPhi(0)
+            ),
+            "A negative posix recv size must fail with ExFailure, not NegativeArraySizeException"
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
@@ -8,9 +8,11 @@ import java.util.Arrays;
 import java.util.List;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,6 +34,18 @@ final class RecvFuncCallTest {
                 )
             ),
             Matchers.contains(-1, 0)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsNegativeSizeOnWindowsRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(-7), new Data.ToPhi(0)
+            ),
+            "A negative win32 recv size must fail with ExFailure, not NegativeArraySizeException"
         );
     }
 


### PR DESCRIPTION
Fixes #6833.

`RecvSyscall.make()` (POSIX) and `RecvFuncCall.make()` (Windows) allocated
`new byte[size]` directly from the requested size, so `socket.recv -1` leaked a
`java.lang.NegativeArraySizeException` instead of a normal EO failure.

Both wrappers now reject a negative size before allocating, with an explicit
`ExFailure`, exactly as `ReadSyscall` and `ReadFuncCall` already do. Added a
platform-guarded regression to each test that asserts an `ExFailure` for a
negative recv size.
