### PR TITLE
#6826: return zero from Ladder.described for an empty program

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -54,7 +54,13 @@ public final class Ladder {
      * @return The share, out of a hundred
      */
     public double described() {
-        return this.share(this.total() - this.counts.values().iterator().next());
+        final double result;
+        if (this.counts.isEmpty()) {
+            result = 0.0d;
+        } else {
+            result = this.share(this.total() - this.counts.values().iterator().next());
+        }
+        return result;
     }
 
     /**

--- a/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
@@ -52,4 +52,13 @@ final class LadderTest {
             Matchers.closeTo(0.0d, 0.001d)
         );
     }
+
+    @Test
+    void describesAnEmptyProgramAsZero() {
+        MatcherAssert.assertThat(
+            "a program with no rungs at all has a zero described share, but it threw",
+            new Ladder(new LinkedHashMap<>(0)).described(),
+            Matchers.closeTo(0.0d, 0.001d)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #6826.

`Ladder.described()` called `this.counts.values().iterator().next()`
unconditionally, so an empty `counts` map (a program with no inferred objects)
threw `NoSuchElementException` instead of reporting a zero share. The
`share()` helper already returns `0.0d` when the total is zero, but that code
was never reached.

`described()` now returns `0.0d` for an empty map before touching the first
value, matching `share()`'s zero-object contract and the existing empty-program
`percent()` behaviour. Added a regression that builds a `Ladder` from an empty
map and asserts `described()` returns zero without throwing.
