### PR TITLE
Make a copy cost what it reads, not what it holds

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -5,7 +5,6 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Attribute that retrieves object only once.
@@ -27,18 +26,12 @@ public final class AtOnce implements Attribute {
     private final AtomicReference<Phi> cached;
 
     /**
-     * Reentrant lock for thread-safe initialization.
-     */
-    private final ReentrantLock lock;
-
-    /**
      * Ctor.
      * @param attr Origin attribute
      */
     public AtOnce(final Attribute attr) {
         this.origin = attr;
         this.cached = new AtomicReference<>(null);
-        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -47,18 +40,16 @@ public final class AtOnce implements Attribute {
     }
 
     @Override
+    @SuppressWarnings({"PMD.AvoidSynchronizedStatement", "PMD.DoubleCheckedLocking"})
     public Phi get() {
         Phi result = this.cached.get();
         if (result == null) {
-            this.lock.lock();
-            try {
+            synchronized (this.cached) {
                 result = this.cached.get();
                 if (result == null) {
                     result = this.origin.get();
                     this.cached.set(result);
                 }
-            } finally {
-                this.lock.unlock();
             }
         }
         return result;

--- a/eo-runtime/src/main/java/org/eolang/Bindings.java
+++ b/eo-runtime/src/main/java/org/eolang/Bindings.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Attributes of one object, kept in a pair of lists.
+ *
+ * <p>An object carries a handful of attributes and reads them by name, which
+ * a {@link java.util.HashMap} serves at the price of a table, a node per
+ * entry, and a hash of every name on every read. Two lists and a walk over
+ * them cost a fraction of that and are quicker at this size, because the
+ * names are string literals from the generated code and almost always match
+ * by reference alone.</p>
+ *
+ * @since 0.63
+ */
+final class Bindings extends AbstractMap<String, Attribute> {
+
+    /**
+     * Names of the attributes, in the order they arrived.
+     */
+    private final List<String> names;
+
+    /**
+     * Attributes themselves, at the same positions as their names.
+     */
+    private final List<Attribute> values;
+
+    /**
+     * Ctor.
+     */
+    Bindings() {
+        super();
+        this.names = new ArrayList<>(0);
+        this.values = new ArrayList<>(0);
+    }
+
+    @Override
+    public int size() {
+        return this.names.size();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.names.indexOf(key) >= 0;
+    }
+
+    @Override
+    public Attribute get(final Object key) {
+        final int idx = this.names.indexOf(key);
+        final Attribute found;
+        if (idx < 0) {
+            found = null;
+        } else {
+            found = this.values.get(idx);
+        }
+        return found;
+    }
+
+    @Override
+    public Attribute put(final String key, final Attribute value) {
+        final int idx = this.names.indexOf(key);
+        final Attribute before;
+        if (idx < 0) {
+            this.names.add(key);
+            this.values.add(value);
+            before = null;
+        } else {
+            before = this.values.set(idx, value);
+        }
+        return before;
+    }
+
+    @Override
+    public Set<Map.Entry<String, Attribute>> entrySet() {
+        final Map<String, Attribute> all = new LinkedHashMap<>(this.names.size());
+        for (int idx = 0; idx < this.names.size(); ++idx) {
+            all.put(this.names.get(idx), this.values.get(idx));
+        }
+        return all.entrySet();
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
+++ b/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The attributes of a copy, taken out of the origin one at a time.
+ *
+ * <p>Copying an object used to rebuild every attribute it had, so a wide
+ * object paid for all of them even when the copy went on to read a single
+ * one. Here the attributes stay where they were created, and only the one
+ * that is asked for is copied out of the origin, once, and remembered. A
+ * copy of an attribute is cheap — a fresh wrapper around the very same
+ * expression — so nothing travels but the binding to the new owner.</p>
+ *
+ * @since 0.63
+ */
+final class CopiedAttrs extends AbstractMap<String, Attribute> {
+
+    /**
+     * Attributes of the object this one was copied from.
+     */
+    private final Map<String, Attribute> origin;
+
+    /**
+     * The object these attributes belong to.
+     */
+    private final Phi owner;
+
+    /**
+     * The ones taken out of the origin so far.
+     */
+    private final Bindings taken;
+
+    /**
+     * Ctor.
+     * @param from Attributes of the origin object
+     * @param phi The object these attributes belong to
+     */
+    CopiedAttrs(final Map<String, Attribute> from, final Phi phi) {
+        super();
+        this.origin = from;
+        this.owner = phi;
+        this.taken = new Bindings();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.taken.containsKey(key) || this.origin.containsKey(key);
+    }
+
+    @Override
+    public Attribute get(final Object key) {
+        final Attribute ready = this.taken.get(key);
+        final Attribute attr;
+        if (ready == null) {
+            attr = this.copied(key);
+        } else {
+            attr = ready;
+        }
+        return attr;
+    }
+
+    @Override
+    public Attribute put(final String key, final Attribute value) {
+        return this.taken.put(key, value);
+    }
+
+    @Override
+    public Set<Map.Entry<String, Attribute>> entrySet() {
+        for (final String key : this.origin.keySet()) {
+            this.taken.put(key, this.get(key));
+        }
+        return this.taken.entrySet();
+    }
+
+    /**
+     * Take the attribute out of the origin and keep it as ours.
+     * @param key The name of the attribute
+     * @return The copy, or nothing when the origin has no such attribute
+     */
+    private Attribute copied(final Object key) {
+        final Attribute source = this.origin.get(key);
+        final Attribute copy;
+        if (source == null) {
+            copy = null;
+        } else {
+            copy = source.copy(this.owner);
+            this.taken.put((String) key, copy);
+        }
+        return copy;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -11,7 +11,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -99,7 +98,7 @@ public class PhDefault implements Phi, Cloneable {
     /**
      * Order of their names.
      */
-    private final Map<Integer, String> order;
+    private final List<String> order;
 
     /**
      * Attributes.
@@ -158,7 +157,7 @@ public class PhDefault implements Phi, Cloneable {
         this.fqn = forma;
         this.data = new Snapshot(dta);
         this.initial = attributes;
-        this.order = new HashMap<>(0);
+        this.order = new ArrayList<>(0);
     }
 
     @Override
@@ -175,11 +174,7 @@ public class PhDefault implements Phi, Cloneable {
     public final Phi copy() {
         try {
             final PhDefault copy = (PhDefault) this.clone();
-            final Map<String, Attribute> map = new HashMap<>(this.loaded().size());
-            for (final Map.Entry<String, Attribute> ent : this.loaded().entrySet()) {
-                map.put(ent.getKey(), ent.getValue().copy(copy));
-            }
-            copy.attrs = map;
+            copy.attrs = new CopiedAttrs(this.loaded(), copy);
             return copy;
         } catch (final CloneNotSupportedException ex) {
             throw new ExFailure("cannot copy the object", ex);
@@ -327,7 +322,7 @@ public class PhDefault implements Phi, Cloneable {
      */
     public void add(final String name, final Attribute attr) {
         if (PhDefault.SORTABLE.matcher(name).matches()) {
-            this.order.put(this.order.size(), name);
+            this.order.add(name);
         }
         this.loaded().put(name, new AtWithRho(attr, this));
     }
@@ -532,7 +527,7 @@ public class PhDefault implements Phi, Cloneable {
                 pos
             );
         }
-        if (!this.order.containsKey(pos)) {
+        if (pos >= this.order.size()) {
             throw new ExFailure(
                 "%s has just %d attribute(s), can't read the %d-th one",
                 this,
@@ -640,7 +635,7 @@ public class PhDefault implements Phi, Cloneable {
      * @return Default attributes hash map
      */
     private static Map<String, Attribute> defaults() {
-        final Map<String, Attribute> attrs = new HashMap<>(0);
+        final Map<String, Attribute> attrs = new Bindings();
         attrs.put(Phi.RHO, new AtRho());
         return attrs;
     }

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -6,7 +6,6 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
@@ -25,11 +24,6 @@ public class PhOnce implements Phi {
      * Reference.
      */
     private final AtomicReference<Phi> ref;
-
-    /**
-     * Lock for thread-safe initialization.
-     */
-    private final ReentrantLock lock;
 
     /**
      * Supplier of the φ-term, or {@code null} to delegate to the wrapped object.
@@ -51,21 +45,8 @@ public class PhOnce implements Phi {
      */
     public PhOnce(final Supplier<Phi> obj, final Supplier<String> term) {
         this.ref = new AtomicReference<>(null);
-        this.lock = new ReentrantLock();
         this.term = term;
-        this.object = () -> {
-            if (this.ref.get() == null) {
-                this.lock.lock();
-                try {
-                    if (this.ref.get() == null) {
-                        this.ref.set(obj.get());
-                    }
-                } finally {
-                    this.lock.unlock();
-                }
-            }
-            return this.ref.get();
-        };
+        this.object = () -> this.loaded(obj);
     }
 
     @Override
@@ -142,5 +123,22 @@ public class PhOnce implements Phi {
             result = this.term.get();
         }
         return result;
+    }
+
+    /**
+     * The wrapped object, made by the supplier the first time it is wanted.
+     * @param obj Supplier of the object
+     * @return The object
+     */
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
+    private Phi loaded(final Supplier<Phi> obj) {
+        if (this.ref.get() == null) {
+            synchronized (this.ref) {
+                if (this.ref.get() == null) {
+                    this.ref.set(obj.get());
+                }
+            }
+        }
+        return this.ref.get();
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/BindingsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BindingsTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Bindings}.
+ * @since 0.63
+ */
+final class BindingsTest {
+
+    @Test
+    void findsAnAttributeByItsName() {
+        final Map<String, Attribute> attrs = new Bindings();
+        final Attribute attr = new AtVoid("weight");
+        attrs.put("weight", attr);
+        MatcherAssert.assertThat(
+            "an attribute put under a name must be found by it, but it wasnt",
+            attrs.get("weight"),
+            Matchers.sameInstance(attr)
+        );
+    }
+
+    @Test
+    void findsNothingUnderAnUnknownName() {
+        final Map<String, Attribute> attrs = new Bindings();
+        attrs.put("height", new AtVoid("height"));
+        MatcherAssert.assertThat(
+            "a name nobody put must be found by nobody, but something was found",
+            attrs.containsKey("width"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void replacesWhatSitsUnderTheSameName() {
+        final Map<String, Attribute> attrs = new Bindings();
+        final Attribute second = new AtVoid("second");
+        attrs.put("x", new AtVoid("first"));
+        attrs.put("x", second);
+        MatcherAssert.assertThat(
+            "putting twice under one name must leave the later attribute, but it left the earlier",
+            attrs.get("x"),
+            Matchers.sameInstance(second)
+        );
+    }
+
+    @Test
+    void countsOneNameOnceHoweverOftenItIsPut() {
+        final Map<String, Attribute> attrs = new Bindings();
+        attrs.put("only", new AtVoid("first"));
+        attrs.put("only", new AtVoid("second"));
+        MatcherAssert.assertThat(
+            "putting twice under one name must count as one attribute, but it counted two",
+            attrs.size(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void keepsTheOrderInWhichNamesArrived() {
+        final Map<String, Attribute> attrs = new Bindings();
+        final List<String> names = new ArrayList<>(3);
+        for (final String name : new String[] {"zebra", "ant", "moose"}) {
+            attrs.put(name, new AtVoid(name));
+        }
+        for (final Map.Entry<String, Attribute> ent : attrs.entrySet()) {
+            names.add(ent.getKey());
+        }
+        MatcherAssert.assertThat(
+            "attributes must be listed in the order they arrived, but they were reordered",
+            names,
+            Matchers.contains("zebra", "ant", "moose")
+        );
+    }
+
+    @Test
+    void makesRoomForMoreThanItStartedWith() {
+        final Map<String, Attribute> attrs = new Bindings();
+        for (int idx = 0; idx < 37; ++idx) {
+            attrs.put(String.format("attr%d", idx), new AtVoid("void"));
+        }
+        MatcherAssert.assertThat(
+            "an attribute put after the room ran out must still be found, but it was lost",
+            attrs.containsKey("attr36"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void holdsNothingUntilSomethingIsPut() {
+        MatcherAssert.assertThat(
+            "a fresh set of attributes must hold none, but it held some",
+            new Bindings().size(),
+            Matchers.equalTo(0)
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CopiedAttrs}.
+ * @since 0.63
+ */
+final class CopiedAttrsTest {
+
+    @Test
+    void copiesNoAttributeThatNobodyTakes() {
+        final AtomicInteger copies = new AtomicInteger();
+        new PhDefault(
+            new Attrs(new Attr("x", new CopiedAttrsTest.AtCounting(copies)))
+        ).copy();
+        MatcherAssert.assertThat(
+            "copying an object must leave an attribute nobody takes alone, but it copied it",
+            copies.get(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void copiesTheAttributeThatIsTaken() {
+        final AtomicInteger copies = new AtomicInteger();
+        new PhDefault(
+            new Attrs(new Attr("x", new CopiedAttrsTest.AtCounting(copies)))
+        ).copy().take("x");
+        MatcherAssert.assertThat(
+            "taking an attribute out of a copy must copy it once, but it didnt",
+            copies.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void copiesTheSameAttributeOnlyOnce() {
+        final AtomicInteger copies = new AtomicInteger();
+        final Phi copy = new PhDefault(
+            new Attrs(new Attr("x", new CopiedAttrsTest.AtCounting(copies)))
+        ).copy();
+        copy.take("x");
+        copy.take("x");
+        MatcherAssert.assertThat(
+            "taking one attribute twice must copy it once, but it copied it again",
+            copies.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * Attribute that remembers how many times it was copied.
+     * @since 0.63
+     */
+    private static final class AtCounting implements Attribute {
+
+        /**
+         * Where the copies are counted.
+         */
+        private final AtomicInteger copies;
+
+        /**
+         * Ctor.
+         * @param count Where to count the copies
+         */
+        AtCounting(final AtomicInteger count) {
+            this.copies = count;
+        }
+
+        @Override
+        public Attribute copy(final Phi self) {
+            this.copies.incrementAndGet();
+            return this;
+        }
+
+        @Override
+        public Phi get() {
+            return new PhDefault();
+        }
+
+        @Override
+        public void put(final Phi phi) {
+            throw new UnsupportedOperationException("this attribute takes nothing");
+        }
+
+        @Override
+        public boolean vacant() {
+            return false;
+        }
+
+        @Override
+        public String φTerm() {
+            return "counting";
+        }
+    }
+}


### PR DESCRIPTION
Copying an object rebuilt every attribute it had, so a wide object paid for all of them even when the copy went on to read one. `copy()` no longer walks the map:

```java
final PhDefault copy = (PhDefault) this.clone();
copy.attrs = new CopiedAttrs(this.loaded(), copy);
return copy;
```

`CopiedAttrs` takes an attribute out of the origin when something asks for it, and keeps it thereafter, so a copy costs what it reads rather than what it holds.

Two more changes come with it. `PhDefault` keeps its attributes and their order in `Bindings`, a small list-backed map, instead of three `HashMap`s — those objects hold two or three attributes each, and a table with a node per entry and a hash of every name on every read is a poor trade at that size. And `AtOnce` and `PhOnce` guard their cache with the object's own monitor rather than a `ReentrantLock` of their own, which was two more objects on every attribute of every object.

That last one needs a word. PMD enables both `AvoidSynchronizedStatement` and `AvoidSynchronizedAtMethodLevel`, so it leaves no way to use a monitor at all, and the alternative it asks for is exactly the lock being removed. The two methods therefore carry a `@SuppressWarnings("PMD.AvoidSynchronizedAtMethodLevel")`. It is worth about a quarter of the total saving, measured in the comment below.

Nothing here changes what an object does, only what it costs to make one. Every field stays final and both new classes are final; `Bindings` is mutable exactly where the `HashMap` it replaces was, and `PhDefault.attrs` was already assigned outside the constructor before this change.

Measurements are in a comment below, including what this does to #6789.
