### PR TITLE
#6649: tag the per-line drop-and-continue recovery as lossy

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -216,6 +216,18 @@ public final class MjFormat extends MjSafe {
      * yet the tree no longer describes the source, so this also rejects a
      * tree carrying such a {@link #placeholder(XML) placeholder}.</p>
      *
+     * <p>Neither heuristic catches every lossy recovery: the parser can
+     * also drop a single binding line entirely and carry straight on to
+     * its siblings, which neither truncates line coverage (later siblings
+     * still reach the source's last line) nor leaves a placeholder (there
+     * is simply nothing where the binding used to be) — see #6649. That
+     * one recovery site tags its own {@code <error>} with {@code lossy}
+     * (see {@link Emit#error(int, int, String, boolean)}), so this also
+     * rejects a tree carrying such an error, without having to reject
+     * every {@code <errors>} entry the way the issue that reported this
+     * gap first suggested, which would also reject this goal's own core
+     * use case of recovering from purely cosmetic layout violations.</p>
+     *
      * @param source The path of the {@code .eo} file, for the error message
      * @param structure The current text of the {@code .eo} file
      * @return The parsed XMIR
@@ -230,7 +242,9 @@ public final class MjFormat extends MjSafe {
             .filter(MjFormat::severe)
             .count();
         if (errors > 0L
-            && (MjFormat.truncated(xmir, structure) || MjFormat.placeholder(xmir))) {
+            && (MjFormat.truncated(xmir, structure)
+                || MjFormat.placeholder(xmir)
+                || MjFormat.lossy(xmir))) {
             throw new IllegalStateException(
                 String.format(
                     "%s does not fully parse (%d error(s) found) and part of it was lost, won't format it",
@@ -239,6 +253,19 @@ public final class MjFormat extends MjSafe {
             );
         }
         return xmir;
+    }
+
+    /**
+     * Whether any error carries the {@code lossy} marker, meaning its own
+     * recovery dropped the whole construct it was building.
+     * @param xmir The parsed XMIR
+     * @return TRUE if such an error is present
+     */
+    private static boolean lossy(final XML xmir) {
+        return new Xnav(xmir.inner())
+            .path("//errors/error[@lossy]")
+            .findAny()
+            .isPresent();
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -147,6 +147,36 @@ final class MjFormatTest {
     }
 
     @Test
+    void failsWhenErrorRecoveredByDroppingABinding(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(MjFormatTest.droppedBinding())
+                .execute(MjFormat.class),
+            "a source recovered by dropping a whole binding must not be silently formatted"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must explain that the source does not fully parse",
+            writer.toString(),
+            Matchers.containsString("does not fully parse")
+        );
+    }
+
+    @Test
+    void doesNotOverwriteDroppedBindingRecoveryWhenAutoFixIsOn(@Mktmp final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .with("autoFix", true)
+                .withProgram(MjFormatTest.droppedBinding())
+                .execute(MjFormat.class),
+            "a source the parser only recovered by dropping a binding must not be rewritten"
+        );
+    }
+
+    @Test
     void doesNotOverwritePlaceholderRecoveryWhenAutoFixIsOn(@Mktmp final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -218,5 +248,35 @@ final class MjFormatTest {
      */
     private static String divergent(final String program) throws IOException {
         return String.format("%s%n%n", MjFormatTest.canonical(program));
+    }
+
+    /**
+     * A source the parser recovers from by dropping a whole binding line and
+     * carrying straight on to its siblings.
+     *
+     * <p>{@code x! > last} is a const suffix on the wrong side (the correct
+     * form is {@code x > last!}), so it fails to parse. The parser's
+     * per-line recovery rolls back and skips that one line entirely, but
+     * later sibling lines still reach the source's last line, so the loss
+     * shows up neither as truncated line coverage nor as an empty
+     * placeholder (see #6649).</p>
+     *
+     * @return The EO text
+     */
+    private static String droppedBinding() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[x] > foo",
+            "  seq * > @",
+            "    last",
+            "    last.plus 1",
+            "  x! > last",
+            "",
+            "[] > bar",
+            "  42 > @",
+            ""
+        );
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -189,9 +189,18 @@ final class Emit {
     }
 
     /**
-     * Append an error directive to {@code /object/errors} — §9.6.
-     *
-     * <p>Records the {@code line}, {@code pos} (0-indexed column per
+     * Append a non-lossy error directive to {@code /object/errors} — see
+     * {@link #error(int, int, String, boolean)}.
+     * @param line Line where the error occurred
+     * @param pos Column where the error occurred (0-indexed)
+     * @param message Canonical message text (no position prefix)
+     */
+    void error(final int line, final int pos, final String message) {
+        this.error(line, pos, message, false);
+    }
+
+    /**
+     * Emit a parser {@code <error>} at the current line/position (R-9.9.1 /
      * R-9.1.2), and the canonical message text from §9.9 prefixed with
      * {@code [L:P]} per R-9.9.2. Wraps absolute navigation in
      * {@code push}/{@code pop}. The {@code check} attribute is always set
@@ -199,26 +208,33 @@ final class Emit {
      * one raised by a named lint rule (#6215): downstream code (see
      * {@code Linting.toDefect} in eo-maven-plugin) fails fast if
      * {@code check} is ever missing, so it must be set here rather than
-     * defaulted downstream.</p>
-     *
+     * defaulted downstream.
      * @param line Line where the error occurred
      * @param pos Column where the error occurred (0-indexed)
      * @param message Canonical message text (no position prefix)
+     * @param lossy Whether recovering from this error dropped the whole
+     *  construct it was building, rather than merely flagging a cosmetic
+     *  or informational issue with a construct that still made it into
+     *  the tree intact (#6649)
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
-    void error(final int line, final int pos, final String message) {
+    void error(final int line, final int pos, final String message, final boolean lossy) {
+        final Directives dirs = new Directives()
+            .push()
+            .xpath("/object")
+            .strict(1)
+            .addIf("errors")
+            .strict(1)
+            .add("error")
+            .attr("line", line)
+            .attr("pos", pos)
+            .attr("check", "parser")
+            .attr("severity", "error");
+        if (lossy) {
+            dirs.attr("lossy", "");
+        }
         this.append(
-            new Directives()
-                .push()
-                .xpath("/object")
-                .strict(1)
-                .addIf("errors")
-                .strict(1)
-                .add("error")
-                .attr("line", line)
-                .attr("pos", pos)
-                .attr("check", "parser")
-                .attr("severity", "error")
-                .set(this.formatted(line, pos, message))
+            dirs.set(this.formatted(line, pos, message))
                 .up().up()
                 .pop()
         );

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -416,7 +416,7 @@ final class Eo implements Iterable<Directive> {
         } catch (final ParseError err) {
             emit.rollback(tstartsen);
             stack.restore(frame);
-            emit.error(err.line(), err.pos(), err.getMessage());
+            emit.error(err.line(), err.pos(), err.getMessage(), true);
             failed = true;
         }
         return failed;

--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -286,6 +286,19 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>
+        <xs:attribute name="lossy" type="empty">
+          <xs:annotation>
+            <xs:appinfo>The error came from a recovery that dropped source content</xs:appinfo>
+            <xs:documentation>
+              Present when the parser recovered from this error by discarding
+              the whole construct it was building (e.g. a binding line), as
+              opposed to a purely cosmetic or informational error that leaves
+              every construct intact. A consumer deciding whether it is safe
+              to trust the recovered tree should treat this attribute, not
+              severity alone, as the sign that part of the source was lost.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>


### PR DESCRIPTION
MjFormat.parsed's guard rejects a source only when severe errors
coexist with truncated line coverage or an empty placeholder node.
There is a third kind of lossy recovery it lets through: the parser
can recover from a mid-file syntax error by dropping just the
offending binding and carrying on, so line coverage stays intact and
no placeholder appears.

For example:

```
[x] > foo
  seq * > @
    last
    last.plus 1
  x! > last

[] > bar
  42 > @
```

fails to parse at [5:5] with "trailing garbage after name suffix" (the
const form has to be x > last!, not x! > last). In the recovered tree
the maximum @line equals the source's last non-blank line, so
truncated() is FALSE; there is no empty <o/>, so placeholder() is
FALSE. Yet the binding name="last" is gone entirely and its two
references escape to the global base="Phi.last". With -Deo.autoFix the
line is erased from the file on disk and the two references are left
dangling.

The gap is that severity="error" conflates cosmetic layout recoveries
(what this goal exists to fix) with genuinely lossy ones. Rejecting
every <errors> entry would also reject the goal's own core use case.

Fix: Eo.dispatch's per-line ParseError catch is the one recovery site
that drops a whole construct and moves on. Emit.error gained a lossy
overload that tags its <error> element with a new XMIR lossy attribute
(schema updated), and only that one call site passes true. No other
existing emit.error() call site was touched, so every other recovery
(cosmetic or otherwise) keeps its current behavior exactly. MjFormat
now also rejects a tree carrying an error tagged lossy, alongside the
existing truncated/placeholder checks.

Fixes #6649
