### PR TITLE
Hold a type per row instead of a collection per form

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Data.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Data.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * An object that is a datum.
+ *
+ * <p>The bytes of a literal are the ground the whole program stands on, so
+ * this carries nothing: there is nothing to know about {@code 01-} beyond
+ * that it is what it is, and the bytes themselves are in the XMIR the row
+ * points at.</p>
+ *
+ * @since 0.69.0
+ */
+final class Data implements Type {
+
+    @Override
+    public Directives directives() {
+        return new Directives().add("data").up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Kept.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Kept.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import org.xembly.Directives;
+
+/**
+ * A type read from the table and written back as it was.
+ *
+ * <p>A pass that works out more than the table says has to write the table
+ * again, and it can only build the kinds of answer it knows about. Anything
+ * else would fall out of the document, silently and completely, the first
+ * time a later pass ran — a row saying an object is a datum vanishing
+ * because the pass that resolves dispatches has no business with data. So
+ * whatever is not rebuilt is kept exactly as it was found.</p>
+ *
+ * @since 0.69.0
+ */
+final class Kept implements Type {
+
+    /**
+     * The row, as the document keeps it.
+     */
+    private final XML row;
+
+    /**
+     * Ctor.
+     * @param written The row, as the document keeps it, rooted at the row
+     *  itself and not at a document of its own
+     */
+    Kept(final XML written) {
+        this.row = written;
+    }
+
+    @Override
+    public Directives directives() {
+        final Directives dirs = new Directives();
+        for (final XML held : this.row.nodes("*")) {
+            dirs.add(held.inner().getNodeName())
+                .append(Directives.copyOf(held.inner()))
+                .up();
+        }
+        return dirs;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -70,22 +70,21 @@ final class Links implements Clue {
             made.add(formation.xpath("@loc").get(0));
         }
         final Scope scope = new Scope(new HashSet<>(world.locators()), new HashSet<>(made));
-        final Map<String, String> found = new LinkedHashMap<>(0);
+        final Map<String, Type> found = new LinkedHashMap<>(0);
         for (final XML reference : world.references()) {
             final String from = reference.xpath("@loc").get(0);
             final String target = scope.target(from, reference.xpath("@base").get(0));
             if (!target.isEmpty()) {
-                found.put(from, target);
+                found.put(from, new Ref(target));
             }
         }
-        final Collection<String> ground = new ArrayList<>(0);
         for (final XML datum : world.data()) {
-            ground.add(datum.xpath("@loc").get(0));
+            found.put(datum.xpath("@loc").get(0), new Data());
         }
         Files.createDirectories(tables);
         Files.write(
             tables.resolve("links.xml"),
-            new Types(found, ground).asXml().toString().getBytes(StandardCharsets.UTF_8)
+            new Types(found).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -54,15 +54,28 @@ final class Pairs {
 
     /**
      * Every object of the table that is a datum.
-     *
-     * <p>A pass that reads the table and writes it again must put these back
-     * where it found them: a row saying an object is a datum is not a pair and
-     * would fall out of a document rebuilt from pairs alone.</p>
-     *
      * @return The locators
      */
     Collection<String> data() {
         return this.table.xpath("/links/type[data]/@id");
+    }
+
+    /**
+     * Every row of the table that is not a pair.
+     *
+     * <p>A pass that reads the table and writes it again can only build the
+     * kinds of answer it knows about, and it knows about pairs. Everything
+     * else comes back as {@link Kept}, to be written as it was found rather
+     * than dropped for being none of that pass's business.</p>
+     *
+     * @return The types, by the locator of the object they are about
+     */
+    Map<String, Type> others() {
+        final Map<String, Type> found = new LinkedHashMap<>(0);
+        for (final XML row : this.table.nodes("/links/type[not(ref)]")) {
+            found.put(row.xpath("@id").get(0), new Kept(row));
+        }
+        return found;
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Ref.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ref.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.Map;
+import org.xembly.Directives;
+
+/**
+ * An object that is a copy of another one.
+ *
+ * <p>The commonest answer there is, and the only one that carries anything
+ * with it: which voids of what it copies this copy has filled, and with
+ * what. A copy that has filled none is written the same way with nothing
+ * inside it, which is how a reader tells a saturated copy from one that is
+ * still waiting for arguments.</p>
+ *
+ * @since 0.69.0
+ */
+final class Ref implements Type {
+
+    /**
+     * The locator of what this object is a copy of.
+     */
+    private final String loc;
+
+    /**
+     * What this copy has put into the voids, by the locator of the void.
+     */
+    private final Map<String, String> filled;
+
+    /**
+     * Ctor.
+     * @param target The locator of what this object is a copy of
+     */
+    Ref(final String target) {
+        this(target, Collections.emptyMap());
+    }
+
+    /**
+     * Ctor.
+     * @param target The locator of what this object is a copy of
+     * @param binds What this copy has put into the voids, by the locator of
+     *  the void, in the order the voids were declared
+     */
+    Ref(final String target, final Map<String, String> binds) {
+        this.loc = target;
+        this.filled = binds;
+    }
+
+    @Override
+    public Directives directives() {
+        final Directives dirs = new Directives().add("ref").attr("loc", this.loc);
+        for (final Map.Entry<String, String> bind : this.filled.entrySet()) {
+            dirs.add("bind")
+                .attr("void", bind.getKey())
+                .add("ref")
+                .attr("loc", bind.getValue())
+                .up()
+                .up();
+        }
+        return dirs.up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Refs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Refs.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The pairs and the binds, as the rows of a table.
+ *
+ * <p>Two things are worked out apart and belong together in one row: what an
+ * object is a copy of, and which voids of that copy it has filled. Neither is
+ * of any use without the other — a copy nobody has given arguments to and a
+ * saturated one are the same pair and different types.</p>
+ *
+ * @since 0.69.0
+ */
+final class Refs {
+
+    /**
+     * The pairs, each object against the one it is a copy of.
+     */
+    private final Map<String, String> copies;
+
+    /**
+     * What every application put into the voids of what it copies.
+     */
+    private final Map<String, Map<String, String>> filled;
+
+    /**
+     * Ctor.
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @param binds What every application put into the voids of what it
+     *  copies, from {@link Bound}
+     */
+    Refs(final Map<String, String> pairs, final Map<String, Map<String, String>> binds) {
+        this.copies = pairs;
+        this.filled = binds;
+    }
+
+    /**
+     * These pairs as rows.
+     * @return The types, by the locator of the object they are about, in the
+     *  order the pairs came in
+     */
+    Map<String, Type> all() {
+        final Map<String, Type> found = new LinkedHashMap<>(this.copies.size());
+        for (final Map.Entry<String, String> pair : this.copies.entrySet()) {
+            found.put(
+                pair.getKey(),
+                new Ref(
+                    pair.getValue(),
+                    this.filled.getOrDefault(pair.getKey(), Collections.emptyMap())
+                )
+            );
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -77,13 +77,13 @@ public final class Resolved implements Clue {
             ).from(written.all())
         );
         final Map<String, String> names = new Ends(pairs).names();
+        final Map<String, Type> rows = new Refs(
+            pairs, new Bound(args, names, new Provided(given, names, voids)).all()
+        ).all();
+        rows.putAll(written.others());
         Files.write(
             links,
-            new Types(
-                pairs,
-                new Bound(args, names, new Provided(given, names, voids)).all(),
-                written.data()
-            ).asXml().toString().getBytes(StandardCharsets.UTF_8)
+            new Types(rows).asXml().toString().getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Type.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Type.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * What an object of a program turns out to be.
+ *
+ * <p>There are several kinds of answer and there will be more: an object is
+ * a copy of another one, or a datum, or a termination, or a choice between
+ * several objects. They have nothing in common except where they are written
+ * — inside the row of the object they are about — so that is all this says,
+ * and a new kind is a new class rather than another column of a table nobody
+ * can keep straight.</p>
+ *
+ * <p>What comes back leaves the cursor where it found it, since a row holds
+ * one type and the row that follows starts beside it.</p>
+ *
+ * @since 0.69.0
+ */
+@FunctionalInterface
+interface Type {
+
+    /**
+     * This type as the contents of a row.
+     * @return The directives
+     */
+    Directives directives();
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Types.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Types.java
@@ -6,8 +6,6 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -15,9 +13,7 @@ import org.xembly.Xembler;
 /**
  * What every object of a program turns out to be, as a document.
  *
- * <p>A row is keyed by the locator of an object and holds a type. There are
- * three forms of type so far — an object being a copy of another one, the
- * voids of that copy it has filled, and a datum — and every one of them is
+ * <p>A row is keyed by the locator of an object and holds one {@link Type},
  * written as an element rather than as a cell of the row:</p>
  *
  * <pre> &lt;type id="Φ.app.held"&gt;
@@ -34,9 +30,9 @@ import org.xembly.Xembler;
  * <p>A cell would have been shorter and is what this table used to write. It
  * cannot survive the other forms, though: an object is sometimes a datum,
  * sometimes a termination, sometimes a choice between several objects, and a
- * choice is not one answer. Since every one of those wants an element of its
- * own, the one form there was got an element too, and the ones that follow are
- * added beside it rather than by rewriting this.</p>
+ * choice is not one answer. Nor can a collection per form, which is what
+ * replaced it: three of them for three forms, and four more forms coming.
+ * A row holds one type, and so does this.</p>
  *
  * <p>The rows come out in the order they were worked out, so that two builds
  * of the same program can be compared as text.</p>
@@ -46,44 +42,16 @@ import org.xembly.Xembler;
 final class Types {
 
     /**
-     * The pairs, each object against the one it is a copy of.
+     * What every object turns out to be, by its locator.
      */
-    private final Map<String, String> copies;
-
-    /**
-     * What every application put into the voids of what it copies.
-     */
-    private final Map<String, Map<String, String>> filled;
-
-    /**
-     * The objects that are data.
-     */
-    private final Collection<String> ground;
+    private final Map<String, Type> rows;
 
     /**
      * Ctor.
-     * @param pairs The pairs, each object against the one it is a copy of
-     * @param data The objects that are data
+     * @param types What every object turns out to be, by its locator
      */
-    Types(final Map<String, String> pairs, final Collection<String> data) {
-        this(pairs, Collections.emptyMap(), data);
-    }
-
-    /**
-     * Ctor.
-     * @param pairs The pairs, each object against the one it is a copy of
-     * @param binds What every application put into the voids of what it
-     *  copies, from {@link Bound}
-     * @param data The objects that are data
-     */
-    Types(
-        final Map<String, String> pairs,
-        final Map<String, Map<String, String>> binds,
-        final Collection<String> data
-    ) {
-        this.copies = pairs;
-        this.filled = binds;
-        this.ground = data;
+    Types(final Map<String, Type> types) {
+        this.rows = types;
     }
 
     /**
@@ -92,38 +60,12 @@ final class Types {
      */
     XML asXml() {
         final Directives dirs = new Directives().add("links");
-        for (final Map.Entry<String, String> pair : this.copies.entrySet()) {
+        for (final Map.Entry<String, Type> row : this.rows.entrySet()) {
             dirs.add("type")
-                .attr("id", pair.getKey())
-                .add("ref")
-                .attr("loc", pair.getValue())
-                .append(this.binds(pair.getKey()))
-                .up()
+                .attr("id", row.getKey())
+                .append(row.getValue().directives())
                 .up();
-        }
-        for (final String datum : this.ground) {
-            dirs.add("type").attr("id", datum).add("data").up().up();
         }
         return new XMLDocument(new Xembler(dirs).domQuietly());
-    }
-
-    /**
-     * The voids this object has filled.
-     * @param id The locator of the object
-     * @return The directives that put them inside its type, empty when it
-     *  fills none
-     */
-    private Directives binds(final String id) {
-        final Directives dirs = new Directives();
-        for (final Map.Entry<String, String> bind
-            : this.filled.getOrDefault(id, Collections.emptyMap()).entrySet()) {
-            dirs.add("bind")
-                .attr("void", bind.getKey())
-                .add("ref")
-                .attr("loc", bind.getValue())
-                .up()
-                .up();
-        }
-        return dirs;
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/KeptTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/KeptTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Kept}.
+ * @since 0.69.0
+ */
+final class KeptTest {
+
+    @Test
+    void writesBackAFormItKnowsNothingAbout() {
+        MatcherAssert.assertThat(
+            "a form nobody here understands must come back as it was, but it didnt",
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("type").append(
+                        new Kept(
+                            new XMLDocument(
+                                "<links><type id='a'><union k='1'><data/></union></type></links>"
+                            ).nodes("/links/type").get(0)
+                        ).directives()
+                    )
+                ).domQuietly()
+            ),
+            XhtmlMatchers.hasXPath("/type/union[@k='1']/data")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Pairs}.
+ * @since 0.69.0
+ */
+final class PairsTest {
+
+    @Test
+    void carriesThroughEveryRowThatIsNotAPair() {
+        MatcherAssert.assertThat(
+            "a row a later pass does not rebuild must survive it, but it didnt",
+            new Types(
+                new Pairs(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<links><type id='a'><bottom/></type>",
+                            "<type id='b'><ref loc='x'/></type></links>"
+                        )
+                    )
+                ).others()
+            ).asXml(),
+            XhtmlMatchers.hasXPath("/links/type[@id='a']/bottom")
+        );
+    }
+}


### PR DESCRIPTION
`links.xml` has one row per object and every row holds one type. `Types` held three collections keyed by the same locators instead — the pairs, the binds, and the data — and the four remaining forms in the spec were each going to be another constructor argument.

A row now holds a `Type`. `Ref` is a copy and what it has put into the voids, `Data` is the ground a literal stands on, and a new form is a new class:

```java
final class Data implements Type {
    @Override
    public Directives directives() {
        return new Directives().add("data").up();
    }
}
```

The counting was the smaller half of the problem. `Resolved` reads the table and writes it again, and it can only rebuild the forms it knows about, so anything else had to be read back by name or it disappeared from the document with no test failing:

```java
new Types(pairs, binds, written.data())
```

Forget that third argument and every datum is gone on the second pass. `Kept` holds a row exactly as it was found, so the pass writes back what it does not rebuild without knowing what it is — which is what makes ⊥, `<unknown/>`, unions and variables cost one class each from here on rather than one class plus one thing to remember.

`Refs` turns the pairs and the binds into rows, since neither is any use without the other: a copy nobody has given arguments to and a saturated one are the same pair and different types.

The tables of `eo-runtime` come out **byte-identical** to the build before this — same 39,054 rows, same order, same md5. Two new tests cover the round trip, one of which fails against the first version of `Kept` I wrote.
