### PR TITLE
#6848: reject horizontal args on a group wrapping an inline-phi

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -72,13 +72,7 @@ final class LnApplication implements Line {
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }
-        if (head.kind() == Value.Kind.GROUP
-            && chain.isEmpty() && args.isEmpty() && outer == null) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "redundant parentheses around a top-level expression — drop the outer `(` and `)`"
-            );
-        }
+        this.checkGroupHead(head, chain, args, outer);
         Comments.seal(globals, emit, this.span);
         final Kind kind = LnApplication.classify(head, chain, args);
         final Openness openness;
@@ -156,6 +150,70 @@ final class LnApplication implements Line {
             kind = Kind.HEAD;
         }
         return kind;
+    }
+
+    /**
+     * Reject a paren-group head that cannot carry what follows it: bare
+     * redundant parentheses around a whole top-level expression, or a
+     * horizontal argument list applied to an inline-phi formation the
+     * group wraps.
+     * @param head The head value
+     * @param chain Method-dispatch chain following the head (may be empty)
+     * @param args Horizontal arguments following the head (may be empty)
+     * @param outer The outer {@code :binding} label, or {@code null}
+     */
+    private void checkGroupHead(
+        final Value head, final List<MethodChain> chain, final List<Value> args,
+        final String outer
+    ) {
+        if (head.kind() == Value.Kind.GROUP
+            && chain.isEmpty() && args.isEmpty() && outer == null) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "redundant parentheses around a top-level expression — drop the outer `(` and `)`"
+            );
+        }
+        if (head.kind() == Value.Kind.GROUP && !args.isEmpty() && this.wrapsInlinePhi(head)) {
+            throw new ParseError(
+                this.span.line(), head.pos(),
+                "horizontal formation not allowed as argument"
+            );
+        }
+    }
+
+    /**
+     * Whether a paren-group head's own content is a top-level inline-phi
+     * expression ({@code body > [params]}, §3.10.10a) — the one paren-group
+     * shape that opens a formation without going through {@code [} at the
+     * head of {@link Tokens#readValue()}, so {@code ([x]) 5} is already
+     * rejected there but {@code (m > [m]) 5} is not (#6848). Scans depth-
+     * and string-aware, the same way {@code Emissions.topLevelInlinePhi}
+     * does for the group's own printing.
+     * @param head The paren-group head
+     * @return TRUE when the group wraps an inline-phi expression
+     * @checkstyle NonStaticMethodCheck (2 lines)
+     */
+    private boolean wrapsInlinePhi(final Value head) {
+        final String raw = head.raw();
+        final String inner = raw.substring(1, raw.length() - 1);
+        boolean found = false;
+        int depth = 0;
+        int idx = 0;
+        while (idx < inner.length() - 2 && !found) {
+            final char glyph = inner.charAt(idx);
+            if (glyph == '"') {
+                idx = Tokens.closingQuote(inner, idx);
+            } else if (glyph == '(') {
+                depth = depth + 1;
+            } else if (glyph == ')') {
+                depth = depth - 1;
+            } else if (depth == 0 && glyph == '>'
+                && inner.charAt(idx + 1) == ' ' && inner.charAt(idx + 2) == '[') {
+                found = true;
+            }
+            idx = idx + 1;
+        }
+        return found;
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/inline-phi-group-as-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/inline-phi-group-as-arg.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:2] error: 'horizontal formation not allowed as argument'
+    (m > [m]) 5 > y
+    ^
+input: |
+  [] > app
+    (m > [m]) 5 > y


### PR DESCRIPTION
`(m > [m]) 5` is accepted by the parser, but the arguments end up
inside the formation rather than applied to it:

```eo
[] > app
  (m > [m]) 5 > y
```

```xml
<o name="y">
  <o base="?" name="m"/>
  <o base="xi.m" name="phi"/>
  <o base="Phi.number" loc="Phi.app.y.a2">...</o>   <!-- no @name, no @as -->
</o>
```

`Emissions.inlinePhi` opens a base-less `<o>` for the formation and never
closes it, so the loop in `LnApplication.emit` appends every argument
as a child of that formation. Because the parent has no `@base`,
`mandatory-as` sees a formation body rather than an argument list and
leaves the child without `@as`.

A base-less `<o>` is a formation, and every child of a formation is an
attribute, so a child with neither `@name` nor `@as` is not
representable. The parser enforces exactly that rule on input, so it
accepts a program it cannot round-trip through eo-printer: printing
the tree back yields

```eo
[m] > y
  m > @
  5
```

which the parser then rejects with "object inside formation must have
a name". The sibling spellings are already rejected: `(foo) 5` gives
"redundant parentheses around a single token" and `([x]) 5` gives
"horizontal formation not allowed as argument". Only the inline-phi
flavour slipped through.

Fix (the smallest change the issue itself suggests): reject a
non-empty argument list on a group head whose own content is a
top-level inline-phi expression, with the same positioned error
`([x]) 5` already produces.

Fixes #6848
