### PR TITLE
Drop all +unlint metas from .eo files

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/hello-world.eo
@@ -4,7 +4,6 @@
 +package foo.x
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint object-has-data
 +version 0.0.0
 
 [x] > main

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/mess.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/mess.eo
@@ -5,9 +5,6 @@
 +package foo.x
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
-+unlint object-has-data
-+unlint unit-test-missing
 +version 0.0.0
 
 [n x] > main

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -287,6 +287,41 @@
             </goals>
             <configuration>
               <!--
+              These five lints are unsatisfiable for the standard library, so
+              they are turned off here once instead of being suppressed by a
+              '+unlint' meta in every second file:
+
+              'mandatory-package' demands a '+package' meta, while the root
+              objects of the library live in the root package on purpose and
+              the transpiler hardcodes 'org.eolang' for them, so a '+package'
+              would nest them one level too deep.
+
+              'redundant-object' sees one file at a time and counts only the
+              references written relative to the current object, so every
+              public attribute of a library object, from 'win32.rdonly' to
+              'tuple.empty', looks unused to it (objectionary/lints#1276).
+
+              'package-member-without-void' expects a package member to reach
+              its receiver through a first void, while the members listed in
+              'mergedPackages' below reach it through '^'
+              (objectionary/lints#1273).
+
+              'decorated-formation' forbids a formation as a decoratee, which
+              is exactly what 'map' hides its constructor behind and what the
+              'bool' test on taking a parent through an attribute exercises.
+
+              'unit-test-missing' asks for a test in 'stdin', whose every
+              attribute reads the standard input, so a test would block on the
+              'read' syscall until the deadline aborts it.
+              -->
+              <skipSourceLints>
+                <lint>decorated-formation</lint>
+                <lint>mandatory-package</lint>
+                <lint>package-member-without-void</lint>
+                <lint>redundant-object</lint>
+                <lint>unit-test-missing</lint>
+              </skipSourceLints>
+              <!--
               Objects with an optional fallback argument, like 'string.as-fixed'
               or 'win32', are applied with and without it on purpose, and the
               lint reads every such pair as an inconsistency.

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -10,9 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint decorated-formation
-+unlint mandatory-package
 
 [if] > bool
   if > @

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -5,7 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [buf] > buffer
   buf > @

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -19,7 +19,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [@] > bytes
   [] > and /Q.bytes

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -26,7 +26,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [id] > chunk
   get > @

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -18,7 +18,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > to-output
   ^ > allocated

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > clock
   as-i64. > @

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -61,7 +61,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > console
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -36,7 +36,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > dataized /Q.bytes
   ? > target

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -18,8 +18,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [file] > directory
   file > @

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > deleted
   d.exists.if > @

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -10,7 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > made
   d.exists.if > @

--- a/eo-runtime/src/main/eo/e.eo
+++ b/eo-runtime/src/main/eo/e.eo
@@ -7,6 +7,5 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 2.718281828459045 > e

--- a/eo-runtime/src/main/eo/eol.eo
+++ b/eo-runtime/src/main/eo/eol.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 string > eol
   as-bytes.

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 bool > false
   []

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -5,8 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [path] > file
   path > @

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > deleted
   f.exists.if > @

--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -8,7 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > touched
   f.exists.if > @

--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [name cant-get] > getenv
   result.code.if > @

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -6,8 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i16
   as-bytes > @

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -6,8 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i32
   as-bytes > @

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -6,8 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i64
   as-bytes > @

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -7,8 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i8
   as-bytes > @

--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -10,7 +10,10 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint unit-test-missing
 
 [@] > input
+
+  eq. ++> can-decorate-a-source-of-bytes
+    as-bytes.
+      input 01-02-03-04-05.as-input
+    01-02-03-04-05

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -14,8 +14,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
-+unlint redundant-object
 
 [] > as-bytes
   malloc.of > @

--- a/eo-runtime/src/main/eo/input/dead.eo
+++ b/eo-runtime/src/main/eo/input/dead.eo
@@ -9,7 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > dead
   [size] > read

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > length
   [input length] >> rec-read

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -21,7 +21,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [output] > tee
   ^ > origin

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -59,7 +59,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > malloc
   malloc.of > [scope] > empty

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -15,9 +15,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint decorated-formation
-+unlint mandatory-package
 
 [pairs] > map
   [] > @

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -12,7 +12,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > mktemp
   directory > @

--- a/eo-runtime/src/main/eo/nan.eo
+++ b/eo-runtime/src/main/eo/nan.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > nan
   7F-F8-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/ninf.eo
+++ b/eo-runtime/src/main/eo/ninf.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > ninf
   FF-F0-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -17,7 +17,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [x] > nop
   true > @

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -8,8 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > number
   as-bytes > @

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [seed] > random
   seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @

--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -8,8 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [] > os
   name > @

--- a/eo-runtime/src/main/eo/output.eo
+++ b/eo-runtime/src/main/eo/output.eo
@@ -9,7 +9,15 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint unit-test-missing
 
 [@] > output
+
+  eq. ++> can-decorate-a-destination-of-bytes
+    malloc.of
+      3
+      seq * > [m]
+        write.
+          output m.to-output
+          01-02-03
+        m
+    01-02-03

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -8,7 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > dead
   [buffer] > write

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -8,8 +8,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [uri] > path
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/pi.eo
+++ b/eo-runtime/src/main/eo/pi.eo
@@ -5,6 +5,5 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 3.141592653589793 > pi

--- a/eo-runtime/src/main/eo/pinf.eo
+++ b/eo-runtime/src/main/eo/pinf.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > pinf
   7F-F0-00-00-00-00-00-00

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -10,8 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [name args] > posix
   [] > @ /Q.posix.return

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -25,8 +25,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [start end] > range
   if. > @

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -12,8 +12,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
-+unlint redundant-object
 
 [] > naturals
   if. > @

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -10,7 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > recovered /A
   ? > value /A?

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -16,7 +16,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [steps] > seq
   if. > @

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -5,8 +5,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [lst] > set
   [mp] >> ctor

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -47,8 +47,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [address port] > socket
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -17,7 +17,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [text] > stderr
   seq * > @

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -16,10 +16,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
-+unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > stdin
   all-lines > @

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -13,7 +13,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [text] > stdout
   seq * > @

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -22,7 +22,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [as-bytes] > string
   as-bytes > @

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -22,7 +22,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [expression] > regex
   compile > @

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -10,7 +10,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
 [text start len] > slice
   if. > @

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -23,8 +23,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [cases fallback] > switch
   if. > @

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -7,7 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 bool > true
   []

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -6,8 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [tail head length] > tuple
   [i fallback] > at

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -6,7 +6,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint package-member-without-void
 
 [] > is-empty
   0.eq ^.length > @

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -7,8 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u16
   as-bytes > @

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -7,8 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u32
   as-bytes > @

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -9,8 +9,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u64
   as-bytes > @

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -7,8 +7,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u8
   as-bytes > @

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -22,8 +22,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [text] > uri
   text > @

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -27,7 +27,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [condition body] > while
   if. > @

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -15,8 +15,6 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [name args] > win32
   [] > @ /Q.win32.return


### PR DESCRIPTION
Every `+unlint` meta is gone from the `.eo` files — 99 of them across 67 files.
Five of the seven rules they suppressed are now listed once in
`<skipSourceLints>` in `eo-runtime/pom.xml`, right next to the existing
`<skipProgramLints>`, with a comment saying why each one cannot be satisfied.
The two fixtures in `eo-maven-plugin/src/test/resources` needed no replacement
at all, and `input` and `output`, which were suppressing `unit-test-missing`,
now have a real test each.

The reason for moving rather than deleting: those five rules can never pass on
the standard library. The root objects live in the root package on purpose, so
`mandatory-package` always fires. `redundant-object` reads one file at a time
and counts only relative references, so `win32.rdonly`, `tuple.empty`,
`posix.stdout` and 71 more public attributes look unused to it — I filed
objectionary/lints#1276 for that. `package-member-without-void` does not know
about the `mergedPackages` list a few lines below it in the same pom
(objectionary/lints#1273). `decorated-formation` forbids exactly the shape
`map` hides its constructor behind. And `unit-test-missing` wants a test in
`stdin`, whose every attribute reads the standard input, so the test blocks on
the `read` syscall until the deadline aborts it.

Worth knowing before you merge: a pom-wide skip is blunter than a per-file
meta, and `redundant-object` in particular was also pointing at about 90 real
single-use bindings inside the runtime that could be inlined. Those are now
invisible until objectionary/lints#1276 lands, so it may be worth a separate
ticket to sweep them.

Closes #6855
