### PR TITLE
#6816: reject fractional slice bounds before recursion

### DIFF
--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -1,8 +1,10 @@
 # Takes a piece of the `text` as another `text`, counting characters and not
-# bytes. Here `start` must be a non-negative index to start slicing from, while
-# `len` must be a non-negative amount of characters to take. Both of them walk
-# the UTF-8 sequence character by character, so a multi-byte character counts
-# as one. An index outside the bounds of the `text` terminates the computation.
+# bytes. Here `start` must be a non-negative integer index to start slicing
+# from, while `len` must be a non-negative integer amount of characters to
+# take. A fractional, `nan` or infinite `start` or `len` terminates the
+# computation immediately. Both of them walk the UTF-8 sequence character by
+# character, so a multi-byte character counts as one. An index outside the
+# bounds of the `text` terminates the computation.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -14,14 +16,18 @@
 
 [text start len] > slice
   if. > @
-    nstart.lt 0
+    or.
+      nstart.lt 0
+      nstart.is-integer.not
     T
-      "Start index must be >= 0, but was %d".printf
+      "Start index must be a non-negative integer, but was %f".printf
         * nstart
     if.
-      nlen.lt 0
+      or.
+        nlen.lt 0
+        nlen.is-integer.not
       T
-        "Length to slice must be >= 0, but was %d".printf
+        "Length to slice must be a non-negative integer, but was %f".printf
           * nlen
       seq *
         recidx >> bstart!
@@ -188,6 +194,16 @@
       1
       2
     "ри"
+
+  slice. --> stops-on-a-fractional-length
+    "some"
+    0
+    1.5
+
+  slice. --> stops-on-a-fractional-start
+    "some"
+    0.5
+    1
 
   slice. --> stops-on-a-start-below-zero
     "some string"


### PR DESCRIPTION
`string.slice` checked only that `start` and `len` were non-negative, then compared the numeric inputs against an integer recursion counter while walking UTF-8 characters. A fraction can never equal that counter, so validation was deferred until a spurious out-of-bounds path at the end of the text, and the error templates used `%d`, which silently truncated the offending values.

```
"some".slice 0.5 1   -> "Start index (0) is out of string bounds"
"some".slice 0 1.5   -> "Start index + length to slice (1) is out of string bounds"
```

Both diagnostics describe the wrong condition and drop the fractional part.

Validated `nstart` and `nlen` with `is-integer` (which also excludes `nan` and infinite values) alongside the existing non-negative check, and switched the error format to `%f` so a rejected fractional value is preserved in the message instead of truncated.

```eo
if. > @
  or.
    nstart.lt 0
    nstart.is-integer.not
  T
    "Start index must be a non-negative integer, but was %f".printf
      * nstart
```

Added `stops-on-a-fractional-start` and `stops-on-a-fractional-length`, reproducing the issue's exact examples. Ran `EOsliceTest` locally, 18/18 passing.

Closes #6816
