### PR TITLE
#6813: reject malformed UTF-8 in string.slice

### DIFF
--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -3,6 +3,9 @@
 # `len` must be a non-negative amount of characters to take. Both of them walk
 # the UTF-8 sequence character by character, so a multi-byte character counts
 # as one. An index outside the bounds of the `text` terminates the computation.
+# The `text` must itself be well-formed UTF-8, validated the same way
+# `string.length` validates it; a malformed sequence anywhere in `text`
+# terminates the computation before any slicing happens.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -24,6 +27,7 @@
         "Length to slice must be >= 0, but was %d".printf
           * nlen
       seq *
+        text.length
         recidx >> bstart!
           0
           0
@@ -189,9 +193,19 @@
       2
     "ри"
 
+  slice. --> stops-on-a-broken-continuation-byte
+    string E1-80-41
+    0
+    1
+
   slice. --> stops-on-a-start-below-zero
     "some string"
     -1
+    1
+
+  slice. --> stops-on-a-surrogate-encoding
+    string ED-A0-80
+    0
     1
 
   slice. --> stops-on-an-end-below-the-start
@@ -203,3 +217,8 @@
     "some string"
     7
     5
+
+  slice. --> stops-on-an-overlong-two-byte-encoding
+    string C0-80
+    0
+    1


### PR DESCRIPTION
`string` is documented as UTF-8 text with Unicode-aware operations, but `string.slice` decided a character's byte width from its leading byte and never checked continuation bytes or the Unicode ranges. `string.length` already validates the same input against the full UTF-8 rule set (overlong encodings, surrogate code points, code points above U+10FFFF), so the two operations disagreed on the same malformed bytes:

```
(string C0-80).slice 0 1   -> "C0-80" (should fail: overlong two-byte encoding)
(string E1-80-41).slice 0 1 -> "E1-80-41" (should fail: broken continuation byte)
(string C0-80).length      -> fails correctly, as a control case
```

Instead of duplicating `string.length`'s ~90 lines of continuation-byte and range checking inside `slice`, `slice` now dataizes `text.length` as the first step of its recursion, before any character walking happens. A malformed sequence anywhere in `text` fails there, using the exact same validation `length` already implements.

```eo
seq *
  text.length
  recidx >> bstart!
    ...
```

Added `stops-on-a-broken-continuation-byte`, `stops-on-a-surrogate-encoding` and `stops-on-an-overlong-two-byte-encoding`, reproducing the issue's exact examples. Ran `EOsliceTest` locally, 19/19 passing.

Closes #6813
