### PR TITLE
#6820: ignore trailing separators in path.posix basename/dirname

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -28,7 +28,7 @@
           or.
             pth.size.eq 0
             index.eq 0
-          uri >> pth!
+          trimmed >> pth!
           as-bytes.
             text.slice
               plus. >> index!
@@ -41,7 +41,7 @@
       string > @
         if.
           pth.size.eq 0
-          uri >> pth!
+          trimmed >> pth!
           if.
             len.eq -1
             "."
@@ -154,6 +154,19 @@
         as-bytes.
           sys.sanitized other
     sys.separator > separator
+    string > [] > trimmed
+      if.
+        or.
+          uri.size.eq 0
+          uri.eq separator
+        uri
+        if.
+          uri.ends-with separator
+          as-bytes.
+            uri.slice
+              0
+              uri.length.minus separator.length
+          uri
   [paths] > joined
     normalized. > @
       os.is-windows.if
@@ -404,7 +417,7 @@
       path.posix "/var/www/html/foo\\bar"
     "foo\\bar"
 
-  eq. ++> can-return-an-empty-basename-from-a-path-ending-with-a-separator
+  eq. ++> can-return-the-basename-ignoring-a-trailing-separator
     basename.
       path.joined
         *
@@ -412,7 +425,12 @@
           "www"
           "html"
           path.separator
-    ""
+    "html"
+
+  eq. ++> can-return-the-basename-of-a-root-relative-path-ending-with-a-separator
+    basename.
+      path.posix "/foo/"
+    "foo"
 
   eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
     dirname.
@@ -424,6 +442,11 @@
       path.posix "plain"
     "."
 
+  eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
+    dirname.
+      path.posix "foo/"
+    "."
+
   eq. ++> can-return-the-dirname-of-a-directory-path
     dirname.
       path.joined
@@ -431,8 +454,7 @@
           "var"
           "www"
           path.separator
-    path.joined
-      * "var" "www"
+    "var"
 
   eq. ++> can-return-the-dirname-of-a-file-path
     dirname.
@@ -462,6 +484,11 @@
   eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path
     dirname.
       path.posix "/foo"
+    "/"
+
+  eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path-ending-with-a-separator
+    dirname.
+      path.posix "/foo/"
     "/"
 
   eq. ++> can-return-the-same-string-without-a-separator


### PR DESCRIPTION
`path.eo`'s `basename` slices everything after the last separator, and `dirname` slices everything before it. For a path ending in that separator, the last separator found is the trailing one itself, so:

```
path.posix("/foo/").basename -> "" (empty, should be "foo")
path.posix("/foo/").dirname  -> "/foo" (should be "/")
path.posix("foo/").dirname   -> "foo" (should be ".")
```

Both disagree with the equivalent non-trailing path (`path.posix("/foo")` already gives the right answer for both).

Added a `trimmed` helper inside `impl`, shared by `basename` and `dirname`, that strips one trailing separator before either method runs its existing logic, so a path ending in a separator behaves exactly like its non-trailing equivalent. The root path (a bare separator) is left unstripped so it does not collapse to an empty string.

```eo
[] > trimmed
  string > @
    if.
      or.
        uri.size.eq 0
        uri.eq separator
      uri
      if.
        uri.ends-with separator
        as-bytes.
          uri.slice
            0
            uri.length.minus separator.length
        uri
```

Two existing tests encoded the same bug for a multi-segment path and asserted the old wrong values (`can-return-an-empty-basename-from-a-path-ending-with-a-separator` expected `""`, `can-return-the-dirname-of-a-directory-path` expected `"var/www"` instead of going up one level to `"var"`). Both are corrected, and I added regressions for the exact single-component cases from the issue, absolute and relative, each with and without the trailing separator.

Ran `EOpathTest` locally, 55/55 passing.

Closes #6820
