### PR TITLE
#6822: preserve the win32 UNC prefix when normalizing a path

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -102,7 +102,9 @@
           concat.
             concat.
               drive.concat
-                is-absolute.if separator --
+                is-absolute.if
+                  unc.if (separator.concat separator) separator
+                  --
               string.joined >> body!
                 separator
                 reduced.
@@ -165,6 +167,10 @@
               0
               uri.length.minus separator.length
           uri
+    and. > unc
+      driveless.size.gt 1
+      driveless.starts-with
+        separator.concat separator
   [paths] > joined
     normalized. > @
       os.is-windows.if
@@ -279,6 +285,21 @@
     normalized.
       path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
     "..\\..\\foo\\x\\y\\"
+
+  eq. ++> can-normalize-a-root-relative-win32-path-keeping-a-single-separator
+    normalized.
+      path.win32 "\\server\\share"
+    "\\server\\share"
+
+  eq. ++> can-normalize-a-unc-win32-path-keeping-its-double-separator-prefix
+    normalized.
+      path.win32 "\\\\server\\share"
+    "\\\\server\\share"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-child-directory
+    normalized.
+      path.win32 "\\\\server\\share\\folder"
+    "\\\\server\\share\\folder"
 
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.


### PR DESCRIPTION
`path.win32.normalized` reduces empty segments while splitting the path and reconstructs every absolute path with a single leading separator. A UNC path's leading double backslash produces two empty segments when split by the separator, both get dropped by the reduction, and the reconstruction only ever adds one separator back:

```
(path.win32 "\\\\server\\share").normalized -> "\\server\\share" (should keep both backslashes)
```

That collapses a network share into a plain root-relative local path.

Added an `unc` flag next to the existing `is-absolute` flag, true when `driveless` starts with two separators, and used it to add the double separator prefix back when reconstructing:

```eo
and. > unc
  driveless.size.gt 1
  driveless.starts-with
    separator.concat separator
```

```eo
is-absolute.if
  unc.if (separator.concat separator) separator
  --
```

A root-relative path (single leading backslash) is unaffected, since it does not match the two-separator check.

Added `can-normalize-a-unc-win32-path-keeping-its-double-separator-prefix` and `can-normalize-a-unc-win32-path-with-a-child-directory`, reproducing the issue's exact examples, plus a control case for a root-relative path. Ran `EOpathTest` locally, 55/55 passing.

Closes #6822
