### PR TITLE
fix(#6830): unlink symlinks even when they point to directories

### DIFF
--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -22,13 +22,31 @@
   called. > removed
     os.is-windows.if
       win32 *1
-        f.is-directory.if "_rmdir" "_unlink"
+        f.is-symlink.if
+          "_unlink"
+          f.is-directory.if "_rmdir" "_unlink"
         f.path
       posix *1
-        f.is-directory.if "rmdir" "unlink"
+        f.is-symlink.if
+          "unlink"
+          f.is-directory.if "rmdir" "unlink"
         f.path
 
   mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+
+  ++> can-delete-a-symlink-to-a-directory
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        link.as-file.deleted
+        link.as-file.exists.not
+        d.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "ссылка" > link
 
   ++> can-return-itself-after-deleting
     temp.deleted.path.eq temp.path > @


### PR DESCRIPTION
Fixes #6830.

## Problem

`file.deleted` picks the removal syscall from `f.is-directory`, which on POSIX uses `stat` and therefore follows a symbolic link. A symlink pointing to a directory is classified as a directory, so `file.deleted` calls `rmdir` on the link itself; `rmdir` rejects a symlink with `ENOTDIR` and the link stays in place. `directory.deleted` reaches the same failing path when it delegates the removal of a directory-symlink entry to `file.deleted`.

## Solution

Choose the syscall from `is-symlink` first: a symbolic link is removed with `unlink`, no matter what it points to; `rmdir` is reserved for an actual non-link directory. `is-symlink` already uses `lstat` on POSIX, which does not follow the link.

## Changes

- `eo-runtime/src/main/eo/file/deleted.eo` — the `removed` call now selects `unlink` for a symlink and falls back to `is-directory` (rmdir/unlink) only when the file is not a link.
- `eo-runtime/src/main/eo/file/deleted.eo` — regression test `can-delete-a-symlink-to-a-directory`.

## Verification

- Direct syscall check: for a symlink to a directory, `is-symlink` (lstat) is `true` while `is-directory` (stat) is `true`; `rmdir` returns `-1` (ENOTDIR, the bug) and `unlink` returns `0` (removes the link), leaving the target directory untouched.
- The regression test passes (it follows the existing symlink-test pattern in `file.eo`, which is likewise slower than the module's default `eo.deadline` and is skipped in the standard run).

@yegor256 please take a look.
