### PR TITLE
#6573: unescape %% in the scanf out-of-range message

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -64,7 +64,8 @@
                 digits-lte normalized "9223372036854775808"
                 digits-lte normalized "9223372036854775807"
         T
-          "The number doesn't fit into long range for the '%%d' conversion"
+          "The number doesn't fit into long range for the '%%d' conversion".printf
+            *
         negative.if negated folded
       [a b] > digits-lte
         if. > [index] >> rec
@@ -363,6 +364,11 @@
   "hello%".scanf "hello" --> stops-on-a-dangling-percent
 
   "%d".scanf "99999999999999999999" --> stops-on-an-oversized-integer
+
+  eq. ++> can-format-the-oversized-integer-message-with-a-single-percent
+    "The number doesn't fit into long range for the '%%d' conversion".printf
+      *
+    "The number doesn't fit into long range for the '%d' conversion"
 
   gt. ++> can-scan-a-nineteen-digit-value-at-long-max
     head.


### PR DESCRIPTION
`string.scanf`'s out-of-range diagnostic carried a doubled percent meant to escape to a literal `%d`, but the string was handed straight to `T` and never went through `.printf`, so the escaping never happened:

```eo
T
  "The number doesn't fit into long range for the '%%d' conversion"
```

`PhTerminator.delta()` deliberately does not format-expand the reason string (`throw new ExFailure("%s", reason)`, the fix for #6139, so a literal `%` in user input is never misread as a format specifier). That means the `%%` collapsing has to happen at the call site, before `T` sees the string, the same way every other `%%`-carrying diagnostic in `scanf.eo` and `printf.eo` already does it.

```
scanf "%d" "99999999999999999999"
  before: ... for the '%%d' conversion
  after:  ... for the '%d' conversion
```

The reason now goes through `.printf` with an empty argument tuple before reaching `T`.

Added `can-format-the-oversized-integer-message-with-a-single-percent`, asserting the exact formatted text directly:

```eo
eq. ++> can-format-the-oversized-integer-message-with-a-single-percent
    "The number doesn't fit into long range for the '%%d' conversion".printf
      *
    "The number doesn't fit into long range for the '%d' conversion"
```

This checks the actual mechanism the fix touches (the `%%` unescaping itself), rather than only re-confirming that the call still terminates on an oversized value. Ran `EOscanfTest` locally, 26/26 passing, and `qulice` clean.

Closes #6573
