### PR TITLE
Say that an object never comes back

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bottom.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bottom.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * An object that never comes back with a value.
+ *
+ * <p>A termination is a complete answer and not a missing one, which is the
+ * whole of why it is written down: an expression that terminates fits
+ * wherever it is put, and an expression nothing is known about fits nowhere
+ * in particular. Leaving the row out says the second about the first.</p>
+ *
+ * <p>Whatever the termination was caused by is an object of its own with a
+ * row of its own, so nothing of it is carried here.</p>
+ *
+ * @since 0.69.0
+ */
+final class Bottom implements Type {
+
+    @Override
+    public Directives directives() {
+        return new Directives().add("bottom").up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -59,7 +59,7 @@ public final class Depth {
         final Rung rung = new Rung(
             new Ungrouped(given, Collections.emptyMap()).rows(),
             new HashSet<>(given.xpath("//attr[@void='true']/@type")),
-            new HashSet<>(pairs.data()),
+            new HashSet<>(pairs.certain()),
             new Ends(pairs.all()).names()
         );
         final Map<String, Integer> filled = pairs.binds();

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -45,10 +45,11 @@ import java.util.Map;
  *
  * <p>Which is why a row carries what an object is as an element of its own
  * rather than as a cell, and what {@link Types} makes of it. Being a copy is
- * one of the things an object turns out to be, and the second one arrives
- * here as well: a datum. It is a copy of nothing — the bytes of a literal are
- * the ground the program stands on — so it is the one row this clue writes
- * without a reference to look at.</p>
+ * one of the things an object turns out to be, and two more arrive here as
+ * well, both of them copies of nothing: a datum, the bytes of a literal being
+ * the ground the program stands on, and a termination, which comes back with
+ * no value at all. Those are the rows this clue writes without a reference to
+ * look at.</p>
  *
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
@@ -80,6 +81,9 @@ final class Links implements Clue {
         }
         for (final XML datum : world.data()) {
             found.put(datum.xpath("@loc").get(0), new Data());
+        }
+        for (final XML dead : world.bottoms()) {
+            found.put(dead.xpath("@loc").get(0), new Bottom());
         }
         Files.createDirectories(tables);
         Files.write(

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -53,11 +53,18 @@ final class Pairs {
     }
 
     /**
-     * Every object of the table that is a datum.
+     * Every object the table answers by itself.
+     *
+     * <p>A row holding a reference is an answer only once the reference has
+     * been followed, and where it leads may be a void or nothing at all. A
+     * datum and a termination are answers as they stand: the bytes of a
+     * literal are what they are, and an object that never comes back with a
+     * value has nothing further to say.</p>
+     *
      * @return The locators
      */
-    Collection<String> data() {
-        return this.table.xpath("/links/type[data]/@id");
+    Collection<String> certain() {
+        return this.table.xpath("/links/type[data or bottom]/@id");
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Rung.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rung.java
@@ -25,9 +25,10 @@ import java.util.Map;
  * it. A formation needs no rung of its own: it is a copy of itself that has
  * filled none of its own voids, and lands where that puts it.</p>
  *
- * <p>A datum goes straight to the top. The bytes of a literal are the ground
- * the program stands on, and asking what more there is to know about
- * {@code 01-} is asking nothing.</p>
+ * <p>A datum and a termination go straight to the top. The bytes of a literal
+ * are the ground the program stands on, and asking what more there is to know
+ * about {@code 01-} is asking nothing; an object that never comes back with a
+ * value has nothing further to say either.</p>
  *
  * @since 0.69.0
  */
@@ -44,7 +45,7 @@ final class Rung {
     private final Collection<String> hollows;
 
     /**
-     * The objects that are data.
+     * The objects the table answers by itself.
      */
     private final Collection<String> ground;
 
@@ -58,18 +59,19 @@ final class Rung {
      * @param rows The rows of the provides table, by the locator of their
      *  owner, from {@link Ungrouped}
      * @param voids The locator of every void
-     * @param data The objects that are data
+     * @param answered The objects the table answers by itself, from
+     *  {@link Pairs}
      * @param names Every chain of copies, walked to its end
      */
     Rung(
         final Map<String, Collection<Map<String, String>>> rows,
         final Collection<String> voids,
-        final Collection<String> data,
+        final Collection<String> answered,
         final Map<String, String> names
     ) {
         this.table = rows;
         this.hollows = voids;
-        this.ground = data;
+        this.ground = answered;
         this.ends = names;
     }
 

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -74,6 +74,22 @@ final class Xmirs {
     }
 
     /**
+     * Every termination of the program.
+     *
+     * <p>The {@code T} of the code, which the parser writes down as an
+     * object based on the bottom sign. It names no other object, so nothing
+     * looks for what it is a copy of: it is not a copy of anything, it is
+     * the one answer that fits everywhere.</p>
+     *
+     * @return The terminations, file by file, in the order they appear in
+     *  the code
+     * @throws IOException If a file cannot be read
+     */
+    Collection<XML> bottoms() throws IOException {
+        return this.matching("//o[@loc and @base='⊥']");
+    }
+
+    /**
      * The object every file of the program is about.
      *
      * <p>A file carries one object at the top and the package it declares

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-is-an-answer.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-is-an-answer.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `T` never comes back with a value, which is a thing we know about it and not
+# a thing we failed to find out. It is a copy of nothing, so its row holds no
+# reference to follow.
+eo:
+  app.eo: |
+    [] > app
+      T > dead
+links:
+  - "/links/type[@id='Φ.app.dead']/bottom"
+  - "/links/type[@id='Φ.app.dead'][not(ref)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-keeps-its-cause.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-keeps-its-cause.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What a termination was caused by is an object like any other and keeps the
+# row it would have had anyway, since nothing of it is carried in the row of
+# the termination itself.
+eo:
+  app.eo: |
+    [] > app
+      T > dead
+        why
+  why.eo: |
+    [] > why
+links:
+  - "/links/type[@id='Φ.app.dead']/bottom"
+  - "/links/type[@id='Φ.app.dead.α0']/ref[@loc='Φ.why']"


### PR DESCRIPTION
66 objects in `eo-runtime` were recorded as "nothing at all" when the XMIR says exactly what they are. Every one of them is a `T`:

```xml
<o base="⊥" loc="Φ.string.printf.a🌵113-2.φ">
  <o base="ξ.message" as="α0"/>
</o>
```

`Links` writes a row for an object whose base names another object, and this one names none, so nothing looked at it. Now there is a row:

```xml
<type id="Φ.string.printf.a🌵113-2.φ">
  <bottom/>
</type>
```

A termination is a complete answer, not a missing one, so it goes to the top rung of the ladder rather than the bottom — there is nothing further to find out about an object that never comes back with a value. That is also the whole reason for writing it down: an expression that terminates fits wherever it is put, and an expression nothing is known about fits nowhere in particular, so silence was saying the second about the first.

Two objects came along for free — `Φ.tuple.-stops-on-taking-the-tail-of-an-empty-tuple.φ` and its head twin — because a copy of a termination is a termination and the chain walk already knew how to follow that.

This is the first form added since #6853 made a row hold a type, and it cost what that PR promised: one class, plus the line in `Links` that writes it. `Pairs.data()` becomes `Pairs.certain()`, since the ladder now has two kinds of row that answer by themselves.

```
                        before    after
described                98.6%    98.8%
depth                    65.5%    65.7%
nothing at all             582      514
```

Worth being plain that the numbers barely move: 66 objects out of 43,083. The reason to do it is that the table was recording a definite fact as an absence, not that it fills a gap in coverage. What is left on the bottom rung is 514 objects: 431 dispatches whose receiver nothing describes, 56 names in scope resolving to nothing, the 25 `λ` markers of atoms, and two bare `ξ`.
