### PR TITLE
#6862: reuse the settled print instead of printing twice

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -168,7 +169,10 @@ public final class MjFormat extends MjSafe {
      * structure out once with the configured weights. The settling is
      * bounded by {@link #SETTLE}; a
      * source that has not settled by then is laid out as-is and reported
-     * divergent, so it fails loudly instead of looping.</p>
+     * divergent, so it fails loudly instead of looping. When no weight is
+     * overridden, the default layout used to detect settling already is
+     * the final layout, so the last settling pass is reused instead of
+     * printing the same tree a second time.</p>
      *
      * @param path The path of the {@code .eo} file, for the error message
      * @param source The current text of the {@code .eo} file
@@ -178,15 +182,23 @@ public final class MjFormat extends MjSafe {
     private String canonical(final Path path, final String source) throws IOException {
         String structure = source;
         XML tree = MjFormat.parsed(path, structure);
+        Optional<String> settled = Optional.empty();
         for (int pass = 0; pass < MjFormat.SETTLE; ++pass) {
-            final String next = new Xmir(tree).toEO();
-            if (next.equals(structure)) {
+            final String printed = new Xmir(tree).toEO();
+            if (printed.equals(structure)) {
+                settled = Optional.of(printed);
                 break;
             }
-            structure = next;
+            structure = printed;
             tree = MjFormat.parsed(path, structure);
         }
-        return new Xmir(tree, this.weights()).toEO();
+        final String canon;
+        if (settled.isPresent() && this.weights().isEmpty()) {
+            canon = settled.get();
+        } else {
+            canon = new Xmir(tree, this.weights()).toEO();
+        }
+        return canon;
     }
 
     /**


### PR DESCRIPTION
`MjFormat.canonical()` settles a source's layout by repeatedly parsing and printing it with the default weights until the text stops changing, then, after the loop, prints the settled tree a second time with the configured weights:

```java
for (int pass = 0; pass < MjFormat.SETTLE; ++pass) {
    final String next = new Xmir(tree).toEO();
    if (next.equals(structure)) {
        break;
    }
    structure = next;
    tree = MjFormat.parsed(path, structure);
}
return new Xmir(tree, this.weights()).toEO();
```

When no penalty weight is overridden (`eo.penalty*`/`eo.width` unset, the common case for a default build), `this.weights()` is an empty map, so the final call reprints the exact same tree with the exact same default weights the loop already converged on. The value the loop already computed gets thrown away, and the same print work runs a second time.

Keep the last settling pass's text (`Optional<String> settled`, set only when the loop actually converges) and reuse it when no weight was overridden; only reprint when a weight genuinely differs from the default.

Measured by running the `format` goal over all 171 real `.eo` sources in `eo-runtime`, before and after:

```
before: 21.472s wall, 254.064s total CPU
after:  18.191s wall, 210.775s total CPU
```

About 15-17% off both wall time and total CPU for a full-module format run.

Ran `MjFormatTest` locally: 8/10 pass (the two directly relevant to this change, plus everything else); the other 2 failures (`failsWhenErrorRecoveredByDroppingABinding`, `doesNotOverwriteDroppedBindingRecoveryWhenAutoFixIsOn`) reproduce identically on a clean, unpatched master, confirmed by reverting this change locally and rerunning — pre-existing, unrelated to this change. `qulice` clean.

Closes #6862
