### PR TITLE
#6863: avoid a second HashMap lookup in take and put

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -204,7 +204,8 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public void put(final String name, final Phi object) {
-        if (!this.loaded().containsKey(name)) {
+        final Attribute attr = this.loaded().get(name);
+        if (attr == null) {
             throw new ExUnset(
                 String.format(
                     "Can't #put(\"%s\", %s) to %s, because the attribute is absent",
@@ -212,7 +213,7 @@ public class PhDefault implements Phi, Cloneable {
                 )
             );
         }
-        this.loaded().get(name).put(object);
+        attr.put(object);
     }
 
     @Override
@@ -231,8 +232,9 @@ public class PhDefault implements Phi, Cloneable {
         }
         try {
             final Phi resolved;
-            if (this.loaded().containsKey(name)) {
-                resolved = this.loaded().get(name).get();
+            final Attribute attr = this.loaded().get(name);
+            if (attr != null) {
+                resolved = attr.get();
             } else if (name.equals(Phi.LAMBDA)) {
                 resolved = new AtomTyped(
                     this, PhDefault.ATOMS.declared(this.forma())


### PR DESCRIPTION
`PhDefault.take(String)` and `PhDefault.put(String, Phi)` each did two `HashMap` lookups of the same key where one does:

```java
if (this.loaded().containsKey(name)) {
    resolved = this.loaded().get(name).get();
}
```

```java
if (!this.loaded().containsKey(name)) {
    throw new ExUnset(...);
}
this.loaded().get(name).put(object);
```

`take()` runs on every attribute resolution in the interpreter, so this is on the hottest path in the runtime.

Replaced both with a single `get()` call followed by a null check, which returns the same information as `containsKey()` plus `get()` without the second lookup:

```java
final Attribute attr = this.loaded().get(name);
if (attr != null) {
    resolved = attr.get();
}
```

Same change in `put()`. Ran `PhDefaultTest` locally, 55/55 passing, and `qulice` clean.

Closes #6863
